### PR TITLE
Please allow more characters in KeyName

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -7,8 +7,8 @@
       "Type" : "String",
       "MinLength" : "1",
       "MaxLength" : "64",
-      "AllowedPattern" : "[-_ a-zA-Z0-9]*",
-      "ConstraintDescription" : "can contain only alphanumeric characters, spaces, dashes and underscores."
+      "AllowedPattern" : "[-+_.@ a-zA-Z0-9]+",
+      "ConstraintDescription" : "can contain only alphanumeric characters, spaces, dashes, plusses, underscores, dots, and at signs."
     },
     "MasterInstanceType" : {
       "Description" : "Master Server EC2 instance type",


### PR DESCRIPTION
Hi, my EC2 keys have names that are like e-mail addresses, like:

  jwm+ec2-foo@example.com

so I can easily keep track of the different keys I use for various services. The CloudFormation template doesn't allow [+.@], but it seems (after an admittedly quick glance at the code) that allowing those characters shouldn't be a problem.
