### PR TITLE
Support for resizing the shared drive snapshot

### DIFF
--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -769,7 +769,7 @@
       "Default" : "NONE"
     },
     "VolumeSize" : {
-      "Description" : "Size of EBS volume in GB, if creating a new one",
+      "Description" : "Size of EBS volume in GB",
       "Type" : "Number",
       "Default" : "20"
     },
@@ -3872,15 +3872,7 @@
           "Ref" : "VolumeType"
         },
         "Size" : {
-          "Fn::If" : [
-            "UseEBSSnapshot",
-            {
-              "Ref" : "AWS::NoValue"
-            },
-            {
-              "Ref" : "VolumeSize"
-            }
-          ]
+          "Ref" : "VolumeSize"
         },
         "SnapshotId" : {
           "Fn::If" : [

--- a/cloudformation/cfncluster.cfn.yaml
+++ b/cloudformation/cfncluster.cfn.yaml
@@ -564,7 +564,7 @@ Parameters:
     Type: String
     Default: NONE
   VolumeSize:
-    Description: Size of EBS volume in GB, if creating a new one
+    Description: Size of EBS volume in GB
     Type: Number
     Default: '20'
   VolumeType:
@@ -2413,7 +2413,7 @@ Resources:
     Properties:
       AvailabilityZone: !Ref 'AvailabilityZone'
       VolumeType: !Ref 'VolumeType'
-      Size: !If [UseEBSSnapshot, !Ref 'AWS::NoValue', !Ref 'VolumeSize']
+      Size: !Ref 'VolumeSize'
       SnapshotId: !If [UseEBSSnapshot, !Ref 'EBSSnapshotId', !Ref 'AWS::NoValue']
       Iops: !If [UseEBSPIOPS, !Ref 'VolumeIOPS', !Ref 'AWS::NoValue']
       Encrypted: !If [UseEBSEncryption, !Ref 'EBSEncryption', !Ref 'AWS::NoValue']


### PR DESCRIPTION
Updating CloudFormation templates to support resizing the shared drive when created from a snapshot. Previously the volume_size parameter was ignored when creating from a snapshot. With this change, the user can specify volume size that is larger than the original snapshot. If the user specifies a volume size that is smaller than the snapshot, the snapshot size is used instead. It does not cause an error. NOTE: There is a side effect to take into account when reviewing this PR.  If the user has created a snapshot that is smaller than 20GB and does not specify a VolumeSize, the default value of 20GB will be used.

Why is this important? I am working a WRF cluster that is run for different size simulations. We are running pIOPS and storage is a significant cost driver. During a normal day, we run many small (4 node) clusters every few hours. These simulations are low resolution and only need a small volume. Occasionally (e.g. when a storm is coming) we run a much larger simulation and need lots more storage. Managing multiple snapshots for various simulation sizes is a hassle and this would make life better.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
