### PR TITLE
cli: correctly handle boto exception in set_asg_limits function

### DIFF
--- a/cli/cfncluster/cfncluster.py
+++ b/cli/cfncluster/cfncluster.py
@@ -345,7 +345,7 @@ def set_asg_limits(asg, min, max, desired):
     asg.desired_capacity = desired
     try:
         return asg.update()
-    except:
+    except boto.exception.BotoServerError as e:
         raise e
 
 def get_asg_ids(stack, config):


### PR DESCRIPTION
The exception "e" was raised but not defined.

Signed-off-by: Enrico Usai <usai@amazon.com>