### PR TITLE
Speed up cluster creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,9 +89,9 @@ Documentation
 -------------
 
 We've been working hard to greatly improve the `Documentation <https://docs.aws.amazon.com/parallelcluster/latest/ug/>`_, it's now published in 10 languages, one of the many benefits of being hosted on AWS Docs. Of most interest to new users is
-the `Getting Started Guide <https://docs.aws.amazon.com/parallelcluster/latest/ug/getting_started.html>`_. 
+the `Getting Started Guide <https://docs.aws.amazon.com/parallelcluster/latest/ug/getting_started.html>`_.
 
-If you have changes you would like to see in the docs, please either submit feedback using the feedback link at the bottom 
+If you have changes you would like to see in the docs, please either submit feedback using the feedback link at the bottom
 of each page or create an issue or pull request for the project at:
 https://github.com/awsdocs/aws-parallelcluster-user-guide.
 

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -355,7 +355,8 @@ class ResourceValidator(object):
                     ),
                     (
                         ["cloudformation:DescribeStacks"],
-                        "arn:%s:cloudformation:%s:%s:stack/parallelcluster-*" % (partition, self.region, account_id),
+                        ["cloudformation:DescribeStackResource"],
+                        "arn:%s:cloudformation:%s:%s:stack/parallelcluster-*/*" % (partition, self.region, account_id),
                     ),
                     (["s3:GetObject"], "arn:%s:s3:::%s-aws-parallelcluster/*" % (partition, self.region)),
                     (["sqs:ListQueues"], "*"),

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1726,7 +1726,8 @@
             {
               "Sid": "Cloudformation",
               "Action": [
-                "cloudformation:DescribeStacks"
+                "cloudformation:DescribeStacks",
+                "cloudformation:DescribeStackResource"
               ],
               "Effect": "Allow",
               "Resource": [
@@ -2383,7 +2384,7 @@
                 {
                   "Ref": "AWS::StackName"
                 },
-                " --resource=MasterServer --region=",
+                " --resource=MasterServerWaitCondition --region=",
                 {
                   "Ref": "AWS::Region"
                 },
@@ -2629,7 +2630,13 @@
             }
           }
         }
-      },
+      }
+    },
+    "MasterServerWaitCondition": {
+      "Type": "AWS::CloudFormation::WaitCondition",
+      "DependsOn": [
+        "MasterServer"
+      ],
       "CreationPolicy": {
         "ResourceSignal": {
           "Count": "1",
@@ -2794,7 +2801,6 @@
           ]
         }
       },
-      "DependsOn": "MasterServer",
       "CreationPolicy": {
         "ResourceSignal": {
           "Timeout": "PT30M",
@@ -3217,6 +3223,21 @@
                 "  vendor_cookbook\n",
                 "fi\n",
                 "cd /tmp\n",
+                "\n",
+                "while [ \"${masterServerStatus}\" != \"CREATE_COMPLETE\" ] && [ \"${masterServerStatus}\" != \"UPDATE_COMPLETE\" ]\n",
+                "do\n",
+                "sleep 3\n",
+                "masterServerStatus=$(aws cloudformation describe-stack-resource --stack-name ",
+                {
+                  "Ref": "AWS::StackName"
+                },
+                " --logical-resource-id MasterServerWaitCondition --region ",
+                {
+                  "Ref": "AWS::Region"
+                },
+                " --query StackResourceDetail.ResourceStatus --output text 2>/dev/null)\n",
+                "done\n",
+                "\n",
                 "# Call CloudFormation\n",
                 "cfn-init ${proxy_args} -s ",
                 {
@@ -3900,6 +3921,21 @@
                   "  vendor_cookbook\n",
                   "fi\n",
                   "cd /tmp\n",
+                  "\n",
+                  "while [ \"${masterServerStatus}\" != \"CREATE_COMPLETE\" ] && [ \"${masterServerStatus}\" != \"UPDATE_COMPLETE\" ]\n",
+                  "do\n",
+                  "sleep 3\n",
+                  "masterServerStatus=$(aws cloudformation describe-stack-resource --stack-name ",
+                  {
+                    "Ref": "AWS::StackName"
+                  },
+                  " --logical-resource-id MasterServerWaitCondition --region ",
+                  {
+                    "Ref": "AWS::Region"
+                  },
+                  " --query StackResourceDetail.ResourceStatus --output text 2>/dev/null)\n",
+                  "done\n",
+                  "\n",
                   "# Call CloudFormation\n",
                   "cfn-init ${proxy_args} -s ",
                   {

--- a/docs/iam.rst
+++ b/docs/iam.rst
@@ -118,10 +118,11 @@ In case you are using SGE, Slurm or Torque as a scheduler:
           },
           {
               "Resource": [
-                  "arn:aws:cloudformation:<REGION>:<AWS ACCOUNT ID>:stack/parallelcluster-*"
+                  "arn:aws:cloudformation:<REGION>:<AWS ACCOUNT ID>:stack/parallelcluster-*/*"
               ],
               "Action": [
-                  "cloudformation:DescribeStacks"
+                  "cloudformation:DescribeStacks",
+                  "cloudformation:DescribeStackResource"
               ],
               "Sid": "CloudFormationDescribe",
               "Effect": "Allow"


### PR DESCRIPTION
Separate the provisioning process of the ComputeNode
into two steps, boot and init. Then start provisioning (boot phase) both
MasterNode and ComputeNode at the same time, but wait to start the
init step for the ComputeNode until the Master has finished.

The technique used is described here
https://aws.amazon.com/it/blogs/devops/optimize-aws-cloudformation-templates/

No gain when initial_queue_size = 0

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
