### PR TITLE
Improve integration tests for the scaling process

### DIFF
--- a/tests/cluster-check.sh
+++ b/tests/cluster-check.sh
@@ -83,17 +83,10 @@ submit_launch() {
 
     submit_init ${scheduler}
 
-    ${scheduler}_submit
+    echo "$(date +%s)" > jobs_start_time
 
-    done=0
-    while test $done = 0 ; do
-        if test -f job1.done -a -f job2.done -a -f job3.done; then
-            done=1
-        else
-            sleep 1
-        fi
-    done
-     echo "Scaleup successful"
+    ${scheduler}_submit
+    echo "Jobs submitted successfully"
 }
 
 submit_init() {
@@ -123,18 +116,18 @@ slurm_submit() {
     cat > job1.sh <<EOF
 #!/bin/bash
 srun sleep ${_sleepjob1}
-touch job1.done
+echo "\$(date +%s)" > job1.done
 EOF
     cat > job2.sh <<EOF
 #!/bin/bash
 srun sleep ${_sleepjob2}
-touch job2.done
+echo "\$(date +%s)" > job2.done
 EOF
 
     cat > job3.sh <<EOF
 #!/bin/bash
 srun sleep ${_sleepjob3}
-touch job3.done
+echo "\$(date +%s)" > job3.done
 EOF
 
     chmod +x job1.sh job2.sh job3.sh
@@ -154,7 +147,7 @@ sge_submit() {
 #$ -R y
 
 sleep ${_sleepjob1}
-touch job1.done
+echo "\$(date +%s)" > job1.done
 EOF
     cat > job2.sh <<EOF
 #!/bin/bash
@@ -162,7 +155,7 @@ EOF
 #$ -R y
 
 sleep ${_sleepjob2}
-touch job2.done
+echo "\$(date +%s)" > job2.done
 EOF
 
     cat > job3.sh <<EOF
@@ -171,7 +164,7 @@ EOF
 #$ -R y
 
 sleep ${_sleepjob3}
-touch job3.done
+echo "\$(date +%s)" > job3.done
 EOF
 
     chmod +x job1.sh job2.sh job3.sh
@@ -186,18 +179,18 @@ torque_submit() {
     cat > job1.sh <<EOF
 #!/bin/bash
 sleep ${_sleepjob1}
-touch job1.done
+echo "\$(date +%s)" > job1.done
 EOF
     cat > job2.sh <<EOF
 #!/bin/bash
 sleep ${_sleepjob2}
-touch job2.done
+echo "\$(date +%s)" > job2.done
 EOF
 
     cat > job3.sh <<EOF
 #!/bin/bash
 sleep ${_sleepjob3}
-touch job3.done
+echo "\$(date +%s)" > job3.done
 EOF
 
     chmod +x job1.sh job2.sh job3.sh

--- a/tests/parallelcluster-release-check.py
+++ b/tests/parallelcluster-release-check.py
@@ -460,7 +460,7 @@ def run_test(
             key_path=extra_args["key_path"],
             key_name=key_name,
             master_node="",
-            scaledown_idletime=2,
+            scaledown_idletime=4,
         )
 
         _write_pcluster_config(cluster_config=cluster_config, extra_args=extra_args)

--- a/tests/parallelcluster-release-check.py
+++ b/tests/parallelcluster-release-check.py
@@ -157,8 +157,8 @@ def _get_desired_asg_capacity(cluster_config):
         asg_capacity: the desired capacity of the autoscaling group.
     """
     asg_conn = boto3.client("autoscaling", region_name=cluster_config.region)
-    r = asg_conn.describe_tags(Filters=[{"Name": "value", "Values": [cluster_config.stack_name]}])
-    asg_name = r.get("Tags")[0].get("ResourceId")
+    tags = asg_conn.describe_tags(Filters=[{"Name": "value", "Values": [cluster_config.stack_name]}])
+    asg_name = tags.get("Tags")[0].get("ResourceId")
     response = asg_conn.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
     return response["AutoScalingGroups"][0]["DesiredCapacity"]
 


### PR DESCRIPTION
Add to the integration tests defined in cfncluster-release-check
a more granular test to verify that scale-up and scale-down features
work correctly. The integration tests are now able to verify that
the cluster is correctly scaled-up and that all created nodes are
available to the scheduler. It is also possible to customize the
scaling range of the cluster and make sure that, when some of the
compute nodes are configured to be retained in absence of jobs, this
condition is verified.
The change also refactors the integration tests structure by moving all
tests defined in cluster-check bash script into the
cfncluster-release-check python script. This was done in order to
increase the cohesion and future extensibility of integration tests.
Also scaledown_idletime has been increased to 4 minutes in integration tests
in order to minimize the chance that compute nodes are released even 
before the cluster completes its creation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
