### PR TITLE
Multiple EBS volumes

### DIFF
--- a/cli/cfncluster/examples/config
+++ b/cli/cfncluster/examples/config
@@ -86,9 +86,10 @@ key_name = mykey
 # Path/mountpoint for ephemeral drives
 # (defaults to /scratch in the default template)
 #ephemeral_dir = /scratch
-# Path/mountpoint for shared EBS volume
-# (defaults to /shared in the default template)
-#shared_dir = /shared
+# Path/mountpoint for shared EBS volume.
+# Do not use this option when using multiple EBS volumes, specify shared_dir under EBS section instead
+# (defaults to /shared in the default template) Example below mounts to /myshared
+#shared_dir = myshared
 # Encrypted ephemeral drives. In-memory keys, non-recoverable.
 # (defaults to false in default template)
 #encrypted_ephemeral = false
@@ -117,8 +118,8 @@ key_name = mykey
 #additional_cfn_template = NONE
 # Settings section relating to VPC to be used
 vpc_settings = public
-# Settings section relating to EBS volume
-#ebs_settings = custom
+# Settings section relating to EBS volumes. Enter multiple sections as a comma separated list. Up to 5 EBS volumes are supported
+#ebs_settings = custom1, custom2, ...
 # Settings section relation to scaling
 #scaling_settings = custom
 
@@ -155,8 +156,10 @@ master_subnet_id = subnet-
 # CIDR for new backend subnet i.e. 10.0.100.0/24
 #compute_subnet_id = subnet-
 
-## EBS Settings
-#[ebs custom]
+## First EBS Settings
+#[ebs custom1]
+# Path/mountpoint for shared EBS volume. REQUIRED when using > 1 EBS volumes. Example below mounts to /vol1
+#shared_dir = vol1
 # Id of EBS snapshot if using snapshot as source for volume
 # (defaults to NONE for default template)
 #ebs_snapshot_id = snap-
@@ -174,6 +177,17 @@ master_subnet_id = subnet-
 # Existing EBS volume to be attached to the MasterServer
 # (defaults to NONE in the default template)
 #ebs_volume_id = NONE
+
+## Second EBS Settings
+#[ebs custom2]
+# Path/mountpoint for shared EBS volume. REQUIRED when using > 1 EBS volumes. Example below mounts to /vol2
+#shared_dir = vol2
+# ... More EBS options if needed
+
+## More EBS settings if needed. Supports up to 5 volumes in total
+#[ebs ...]
+#shared_dir = ...
+# ... More EBS options if needed
 
 ## Scaling settings
 #[scaling custom]

--- a/cloudformation/cfncluster.cfn.json
+++ b/cloudformation/cfncluster.cfn.json
@@ -94,7 +94,8 @@
             "VolumeIOPS",
             "EBSEncryption",
             "EBSKMSKeyId",
-            "EBSVolumeId"
+            "EBSVolumeId",
+            "NumberOfEBSVol"
           ]
         },
         {
@@ -733,22 +734,16 @@
       "Default": "NONE"
     },
     "VolumeSize": {
-      "Description": "Size of EBS volume in GB, if creating a new one",
-      "Type": "Number",
-      "Default": "20"
+      "Description": "Comma delimited list of size of EBS volume in GB, if creating a new one",
+      "Type": "String",
+      "Default": "20, 20, 20, 20, 20"
     },
     "VolumeType": {
-      "Description": "Type of volume to create either new or from snapshot",
+      "Description": "Comma delimited list of type of volume to create either new or from snapshot",
       "Type": "String",
-      "Default": "gp2",
+      "Default": "gp2, gp2, gp2, gp2, gp2",
       "ConstraintDescription": "must be a supported volume type: standard, io1, gp2, st1, sc1",
-      "AllowedValues": [
-        "standard",
-        "gp2",
-        "io1",
-        "st1",
-        "sc1"
-      ]
+      "AllowedPattern": "^(NONE|standard|io1|gp2|st1|sc1)((,|, )(NONE|standard|io1|gp2|st1|sc1)){4}$"
     },
     "MasterSubnetId": {
       "Description": "ID of the Subnet you want to provision the Master server into",
@@ -759,10 +754,10 @@
       "Type": "AWS::EC2::AvailabilityZone::Name"
     },
     "EBSSnapshotId": {
-      "Description": "Id of EBS snapshot if using snapshot as source for volume",
+      "Description": "Comma delimited list of Id of EBS snapshot if using snapshot as source for volume",
       "Type": "String",
-      "Default": "NONE",
-      "AllowedPattern": "(NONE|^snap-[0-9a-z]{8}$|^snap-[0-9a-z]{17}$)"
+      "Default": "NONE, NONE, NONE, NONE, NONE",
+      "AllowedPattern" : "^(NONE|snap-[0-9a-z]{8}|snap-[0-9a-z]{17})((,|, )(NONE|snap-[0-9a-z]{8}|snap-[0-9a-z]{17})){4}$"
     },
     "CustomAMI": {
       "Description": "ID of a Custom AMI, to use instead of published AMI's",
@@ -811,9 +806,9 @@
       ]
     },
     "VolumeIOPS": {
-      "Description": "Number of IOPS for volume type io1. Not used for other volume types.",
-      "Type": "Number",
-      "Default": "100"
+      "Description": "Comma delimited list of number of IOPS for volume type io1. Not used for other volume types.",
+      "Type": "String",
+      "Default": "100, 100, 100, 100, 100"
     },
     "PreInstallScript": {
       "Description": "Preinstall script URL. This is run before any host configuration.",
@@ -875,14 +870,11 @@
       "Default": "NONE"
     },
     "EBSEncryption": {
-      "Description": "Boolean flag to use EBS encryption for /shared volume. (Not to be used for snapshots)",
+      "Description": "Comma delimited list of boolean flag to use EBS encryption for /shared volume. (Not to be used for snapshots)",
       "Type": "String",
-      "Default": "false",
+      "Default": "false, false, false, false, false",
       "ConstraintDescription": "true/false",
-      "AllowedValues": [
-        "true",
-        "false"
-      ]
+      "AllowedPattern": "^(NONE|true|false)((,|, )(NONE|true|false)){4}$"
     },
     "EphemeralDir": {
       "Description": "The path/mountpoint for the ephemeral drive",
@@ -970,9 +962,9 @@
       ]
     },
     "EBSKMSKeyId": {
-      "Description": "KMS ARN for customer created master key, will be used for EBS encryption",
+      "Description": "Comma delimited list of KMS ARN for customer created master key, will be used for EBS encryption",
       "Type": "String",
-      "Default": "NONE"
+      "Default": "NONE, NONE, NONE, NONE, NONE"
     },
     "EphemeralKMSKeyId": {
       "Description": "KMS ARN for customer created master key, will be used for ephemeral encryption",
@@ -1008,15 +1000,20 @@
       "AllowedPattern": "(NONE|^sg-[0-9a-z]{8}$|^sg-[0-9a-z]{17}$)"
     },
     "EBSVolumeId": {
-      "Description": "Existing EBS volume Id",
+      "Description": "Comma delimited list of existing EBS volume Id",
       "Type": "String",
-      "Default": "NONE",
-      "AllowedPattern": "(NONE|^vol-[0-9a-z]{8}$|^vol-[0-9a-z]{17}$)"
+      "Default": "NONE, NONE, NONE, NONE, NONE",
+      "AllowedPattern": "^(NONE|vol-[0-9a-z]{8}|vol-[0-9a-z]{17})((,|, )(NONE|vol-[0-9a-z]{8}|vol-[0-9a-z]{17})){4}$"
     },
     "AdditionalCfnTemplate": {
       "Description": "A second CloudFormation template to launch with the cluster",
       "Type": "String",
       "Default": "NONE"
+    },
+    "NumberOfEBSVol": {
+      "Description": "Number of EBS Volumes the user requested, up to 5",
+      "Type": "Number",
+      "Default": "1"
     }
   },
   "Conditions": {
@@ -1276,18 +1273,6 @@
         }
       ]
     },
-    "UseEBSSnapshot": {
-      "Fn::Not": [
-        {
-          "Fn::Equals": [
-            {
-              "Ref": "EBSSnapshotId"
-            },
-            "NONE"
-          ]
-        }
-      ]
-    },
     "UseCustomRunList": {
       "Fn::Not": [
         {
@@ -1355,14 +1340,6 @@
         }
       ]
     },
-    "UseEBSPIOPS": {
-      "Fn::Equals": [
-        {
-          "Ref": "VolumeType"
-        },
-        "io1"
-      ]
-    },
     "UseS3ReadPolicy": {
       "Fn::Not": [
         {
@@ -1400,14 +1377,6 @@
         {
           "Condition": "UsePlacementGroup"
         }
-      ]
-    },
-    "UseEBSEncryption": {
-      "Fn::Equals": [
-        {
-          "Ref": "EBSEncryption"
-        },
-        "true"
       ]
     },
     "UseS3ReadWritePolicy": {
@@ -1459,25 +1428,6 @@
             },
             "NONE"
           ]
-        }
-      ]
-    },
-    "UseEBSKMSKey": {
-      "Fn::And": [
-        {
-          "Fn::Not": [
-            {
-              "Fn::Equals": [
-                {
-                  "Ref": "EBSKMSKeyId"
-                },
-                "NONE"
-              ]
-            }
-          ]
-        },
-        {
-          "Condition": "UseEBSEncryption"
         }
       ]
     },
@@ -1545,26 +1495,6 @@
         }
       ]
     },
-    "UseExistingEBSVolume": {
-      "Fn::Not": [
-        {
-          "Fn::Equals": [
-            {
-              "Ref": "EBSVolumeId"
-            },
-            "NONE"
-          ]
-        }
-      ]
-    },
-    "CreateEBSVolume": {
-      "Fn::Equals": [
-        {
-          "Ref": "EBSVolumeId"
-        },
-        "NONE"
-      ]
-    },
     "CreateSecurityGroups": {
       "Fn::Equals": [
         {
@@ -1598,6 +1528,14 @@
         {
           "Condition": "UsePlacementGroup"
         }
+      ]
+    },
+    "GovCloudRegion": {
+      "Fn::Equals": [
+        {
+          "Ref": "AWS::Partition"
+        },
+        "aws-us-gov"
       ]
     }
   },
@@ -2632,14 +2570,9 @@
                       "Ref": "AWS::Region"
                     },
                     "cfn_volume": {
-                      "Fn::If": [
-                        "UseExistingEBSVolume",
-                        {
-                          "Ref": "EBSVolumeId"
-                        },
-                        {
-                          "Ref": "SharedVolume"
-                        }
+                      "Fn::GetAtt":[
+                        "EBSCfnStack",
+                        "Outputs.Volumeids"
                       ]
                     },
                     "cfn_scheduler": {
@@ -2943,9 +2876,9 @@
             "AssociatePublicIpAddress" : {
               "Fn::If": [
                 "ComputePublicIps",
-                true,
-                false
-              ],
+                "true",
+                "false"
+              ]
             }
           }],
           "InstanceType": {
@@ -2974,10 +2907,10 @@
               "UseSpotInstances",
               {
                 "SpotOptions" : {
-                    "SpotInstanceType" : "one-time",
-                    "InstanceInterruptionBehavior" : "terminate",
-                    "MaxPrice" : {
-                      "Fn::If": [
+                  "SpotInstanceType" : "one-time",
+                  "InstanceInterruptionBehavior" : "terminate",
+                  "MaxPrice" : {
+                    "Fn::If": [
                       "UseSpotPrice",
                       { "Ref": "SpotPrice" },
                       { "Ref": "AWS::NoValue" }
@@ -3343,10 +3276,10 @@
                 "\n",
                 "# End of file\n",
                 "--==BOUNDARY==\n"
+                ]
               ]
-            ]
+            }
           }
-        }
         }
       },
       "Metadata": {
@@ -3784,78 +3717,6 @@
       },
       "Condition": "CreateSubStack"
     },
-    "SharedVolume": {
-      "Type": "AWS::EC2::Volume",
-      "Properties": {
-        "AvailabilityZone": {
-          "Ref": "AvailabilityZone"
-        },
-        "VolumeType": {
-          "Ref": "VolumeType"
-        },
-        "Size": {
-          "Fn::If": [
-            "UseEBSSnapshot",
-            {
-              "Ref": "AWS::NoValue"
-            },
-            {
-              "Ref": "VolumeSize"
-            }
-          ]
-        },
-        "SnapshotId": {
-          "Fn::If": [
-            "UseEBSSnapshot",
-            {
-              "Ref": "EBSSnapshotId"
-            },
-            {
-              "Ref": "AWS::NoValue"
-            }
-          ]
-        },
-        "Iops": {
-          "Fn::If": [
-            "UseEBSPIOPS",
-            {
-              "Ref": "VolumeIOPS"
-            },
-            {
-              "Ref": "AWS::NoValue"
-            }
-          ]
-        },
-        "Encrypted": {
-          "Fn::If": [
-            "UseEBSEncryption",
-            {
-              "Ref": "EBSEncryption"
-            },
-            {
-              "Ref": "AWS::NoValue"
-            }
-          ]
-        },
-        "KmsKeyId": {
-          "Fn::If": [
-            "UseEBSKMSKey",
-            {
-              "Ref": "EBSKMSKeyId"
-            },
-            {
-              "Ref": "AWS::NoValue"
-            }
-          ]
-        }
-      },
-      "Condition": "CreateEBSVolume",
-      "Metadata": {
-        "AWS::CloudFormation::Designer": {
-          "id": "c8d3da13-fd27-4377-b606-0f41728c17e1"
-        }
-      }
-    },
     "AssociateEIP": {
       "Type": "AWS::EC2::EIPAssociation",
       "Properties": {
@@ -3885,6 +3746,97 @@
       "Metadata": {
         "AWS::CloudFormation::Designer": {
           "id": "ee5f3006-419e-4786-b527-e9503a662e5e"
+        }
+      }
+    },
+    "EBSCfnStack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "Parameters":{
+          "AvailabilityZone": {
+            "Ref":"AvailabilityZone"
+          },
+          "VolumeSize": {
+            "Ref" : "VolumeSize"
+          },
+          "VolumeType": {
+            "Ref" : "VolumeType"
+          },
+          "VolumeIOPS": {
+            "Ref" : "VolumeIOPS"
+          },
+          "EBSEncryption":{
+            "Ref" : "EBSEncryption"
+          },
+          "EBSKMSKeyId": {
+            "Ref" : "EBSKMSKeyId"
+          },
+          "EBSVolumeId": {
+            "Ref" : "EBSVolumeId"
+          },
+          "EBSSnapshotId": {
+            "Ref" : "EBSSnapshotId"
+          },
+          "NumberOfEBSVol": {
+            "Ref" : "NumberOfEBSVol"
+          }
+        },
+
+        "TemplateURL":{
+          "Fn::If": [
+            "GovCloudRegion",
+            { "Fn::Join": [
+              "",
+              [
+                "https://s3-",
+                { "Ref": "AWS::Region" },
+                ".amazonaws.com/",
+                { "Ref": "AWS::Region" },
+                "-cfncluster/templates/ebs_vol_substack-",
+                { "Fn::Select" : [
+                  "1",
+                  { "Fn::Split": [
+                    "-",
+                    {
+                      "Fn::FindInMap": [
+                        "CfnClusterVersions",
+                        "default",
+                        "cfncluster"
+                      ]
+                    }
+                  ]}
+                ]},
+                ".cfn.json"
+              ]
+            ]},
+            { "Fn::Join": [
+              "",
+              [
+                "https://s3.amazonaws.com/",
+                { "Ref": "AWS::Region" },
+                "-cfncluster/templates/ebs_vol_substack-",
+                { "Fn::Select" : [
+                  "1",
+                  { "Fn::Split": [
+                    "-",
+                    {
+                      "Fn::FindInMap": [
+                        "CfnClusterVersions",
+                        "default",
+                        "cfncluster"
+                      ]
+                    }
+                  ]}
+                ]},
+                ".cfn.json"
+              ]
+            ]}
+          ]
+        }
+      },
+      "Metadata": {
+        "AWS::CloudFormation::Designer": {
+          "id": "73e68f93-f470-4ec8-9fcc-fca1bc20b673"
         }
       }
     }

--- a/cloudformation/ebs_vol_substack.cfn.json
+++ b/cloudformation/ebs_vol_substack.cfn.json
@@ -1,0 +1,1634 @@
+{
+    "Conditions": {
+        "UseVol2": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "NumberOfEBSVol"
+                        },
+                        "1"
+                    ]
+                }
+            ]
+        },
+        "UseVol3": {
+            "Fn::And": [
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Ref": "NumberOfEBSVol"
+                                },
+                                "2"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Condition": "UseVol2"
+                }
+            ]
+        },
+        "UseVol4": {
+            "Fn::And": [
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Ref": "NumberOfEBSVol"
+                                },
+                                "3"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Condition": "UseVol3"
+                }
+            ]
+        },
+        "UseVol5": {
+            "Fn::And": [
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Ref": "NumberOfEBSVol"
+                                },
+                                "4"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Condition": "UseVol4"
+                }
+            ]
+        },
+        "Vol1_CreateEBSVolume": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "0",
+                        {
+                            "Ref": "EBSVolumeId"
+                        }
+                    ]
+                },
+                "NONE"
+            ]
+        },
+        "Vol1_UseEBSEncryption": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "0",
+                        {
+                            "Ref": "EBSEncryption"
+                        }
+                    ]
+                },
+                "true"
+            ]
+        },
+        "Vol1_UseEBSKMSKey": {
+            "Fn::And": [
+                {
+                    "Condition": "Vol1_UseEBSEncryption"
+                },
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Fn::Select": [
+                                        "0",
+                                        {
+                                            "Ref": "EBSKMSKeyId"
+                                        }
+                                    ]
+                                },
+                                "NONE"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "Vol1_UseEBSPIOPS": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "0",
+                        {
+                            "Ref": "VolumeType"
+                        }
+                    ]
+                },
+                "io1"
+            ]
+        },
+        "Vol1_UseEBSSnapshot": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "0",
+                                {
+                                    "Ref": "EBSSnapshotId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol1_UseExistingEBSVolume": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "0",
+                                {
+                                    "Ref": "EBSVolumeId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol1_UseVolumeSize": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "0",
+                                {
+                                    "Ref": "VolumeSize"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol1_UseVolumeType": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "0",
+                                {
+                                    "Ref": "VolumeType"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol2_CreateEBSVolume": {
+            "Fn::And": [
+                {
+                    "Condition": "UseVol2"
+                },
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "1",
+                                {
+                                    "Ref": "EBSVolumeId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol2_UseEBSEncryption": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "1",
+                        {
+                            "Ref": "EBSEncryption"
+                        }
+                    ]
+                },
+                "true"
+            ]
+        },
+        "Vol2_UseEBSKMSKey": {
+            "Fn::And": [
+                {
+                    "Condition": "Vol2_UseEBSEncryption"
+                },
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Fn::Select": [
+                                        "1",
+                                        {
+                                            "Ref": "EBSKMSKeyId"
+                                        }
+                                    ]
+                                },
+                                "NONE"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "Vol2_UseEBSPIOPS": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "1",
+                        {
+                            "Ref": "VolumeType"
+                        }
+                    ]
+                },
+                "io1"
+            ]
+        },
+        "Vol2_UseEBSSnapshot": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "1",
+                                {
+                                    "Ref": "EBSSnapshotId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol2_UseExistingEBSVolume": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "1",
+                                {
+                                    "Ref": "EBSVolumeId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol2_UseVolumeSize": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "1",
+                                {
+                                    "Ref": "VolumeSize"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol2_UseVolumeType": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "1",
+                                {
+                                    "Ref": "VolumeType"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol3_CreateEBSVolume": {
+            "Fn::And": [
+                {
+                    "Condition": "UseVol3"
+                },
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "2",
+                                {
+                                    "Ref": "EBSVolumeId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol3_UseEBSEncryption": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "2",
+                        {
+                            "Ref": "EBSEncryption"
+                        }
+                    ]
+                },
+                "true"
+            ]
+        },
+        "Vol3_UseEBSKMSKey": {
+            "Fn::And": [
+                {
+                    "Condition": "Vol3_UseEBSEncryption"
+                },
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Fn::Select": [
+                                        "2",
+                                        {
+                                            "Ref": "EBSKMSKeyId"
+                                        }
+                                    ]
+                                },
+                                "NONE"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "Vol3_UseEBSPIOPS": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "2",
+                        {
+                            "Ref": "VolumeType"
+                        }
+                    ]
+                },
+                "io1"
+            ]
+        },
+        "Vol3_UseEBSSnapshot": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "2",
+                                {
+                                    "Ref": "EBSSnapshotId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol3_UseExistingEBSVolume": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "2",
+                                {
+                                    "Ref": "EBSVolumeId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol3_UseVolumeSize": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "2",
+                                {
+                                    "Ref": "VolumeSize"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol3_UseVolumeType": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "2",
+                                {
+                                    "Ref": "VolumeType"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol4_CreateEBSVolume": {
+            "Fn::And": [
+                {
+                    "Condition": "UseVol4"
+                },
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "3",
+                                {
+                                    "Ref": "EBSVolumeId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol4_UseEBSEncryption": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "3",
+                        {
+                            "Ref": "EBSEncryption"
+                        }
+                    ]
+                },
+                "true"
+            ]
+        },
+        "Vol4_UseEBSKMSKey": {
+            "Fn::And": [
+                {
+                    "Condition": "Vol4_UseEBSEncryption"
+                },
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Fn::Select": [
+                                        "3",
+                                        {
+                                            "Ref": "EBSKMSKeyId"
+                                        }
+                                    ]
+                                },
+                                "NONE"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "Vol4_UseEBSPIOPS": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "3",
+                        {
+                            "Ref": "VolumeType"
+                        }
+                    ]
+                },
+                "io1"
+            ]
+        },
+        "Vol4_UseEBSSnapshot": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "3",
+                                {
+                                    "Ref": "EBSSnapshotId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol4_UseExistingEBSVolume": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "3",
+                                {
+                                    "Ref": "EBSVolumeId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol4_UseVolumeSize": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "3",
+                                {
+                                    "Ref": "VolumeSize"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol4_UseVolumeType": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "3",
+                                {
+                                    "Ref": "VolumeType"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol5_CreateEBSVolume": {
+            "Fn::And": [
+                {
+                    "Condition": "UseVol5"
+                },
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "4",
+                                {
+                                    "Ref": "EBSVolumeId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol5_UseEBSEncryption": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "4",
+                        {
+                            "Ref": "EBSEncryption"
+                        }
+                    ]
+                },
+                "true"
+            ]
+        },
+        "Vol5_UseEBSKMSKey": {
+            "Fn::And": [
+                {
+                    "Condition": "Vol5_UseEBSEncryption"
+                },
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Fn::Select": [
+                                        "4",
+                                        {
+                                            "Ref": "EBSKMSKeyId"
+                                        }
+                                    ]
+                                },
+                                "NONE"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "Vol5_UseEBSPIOPS": {
+            "Fn::Equals": [
+                {
+                    "Fn::Select": [
+                        "4",
+                        {
+                            "Ref": "VolumeType"
+                        }
+                    ]
+                },
+                "io1"
+            ]
+        },
+        "Vol5_UseEBSSnapshot": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "4",
+                                {
+                                    "Ref": "EBSSnapshotId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol5_UseExistingEBSVolume": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "4",
+                                {
+                                    "Ref": "EBSVolumeId"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol5_UseVolumeSize": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "4",
+                                {
+                                    "Ref": "VolumeSize"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        },
+        "Vol5_UseVolumeType": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Select": [
+                                "4",
+                                {
+                                    "Ref": "VolumeType"
+                                }
+                            ]
+                        },
+                        "NONE"
+                    ]
+                }
+            ]
+        }
+    },
+    "Outputs": {
+        "Volumeids": {
+            "Description": "Volume IDs of the resulted EBS volumes",
+            "Value": {
+                "Fn::If": [
+                    "UseVol5",
+                    {
+                        "Fn::Join": [
+                            ",",
+                            [
+                                {
+                                    "Fn::If": [
+                                        "Vol1_UseExistingEBSVolume",
+                                        {
+                                            "Fn::Select": [
+                                                "0",
+                                                {
+                                                    "Ref": "EBSVolumeId"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Ref": "Volume1"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Fn::If": [
+                                        "Vol2_UseExistingEBSVolume",
+                                        {
+                                            "Fn::Select": [
+                                                "1",
+                                                {
+                                                    "Ref": "EBSVolumeId"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Ref": "Volume2"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Fn::If": [
+                                        "Vol3_UseExistingEBSVolume",
+                                        {
+                                            "Fn::Select": [
+                                                "2",
+                                                {
+                                                    "Ref": "EBSVolumeId"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Ref": "Volume3"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Fn::If": [
+                                        "Vol4_UseExistingEBSVolume",
+                                        {
+                                            "Fn::Select": [
+                                                "3",
+                                                {
+                                                    "Ref": "EBSVolumeId"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Ref": "Volume4"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "Fn::If": [
+                                        "Vol5_UseExistingEBSVolume",
+                                        {
+                                            "Fn::Select": [
+                                                "4",
+                                                {
+                                                    "Ref": "EBSVolumeId"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Ref": "Volume5"
+                                        }
+                                    ]
+                                }
+                            ]
+                        ]
+                    },
+                    {
+                        "Fn::If": [
+                            "UseVol4",
+                            {
+                                "Fn::Join": [
+                                    ",",
+                                    [
+                                        {
+                                            "Fn::If": [
+                                                "Vol1_UseExistingEBSVolume",
+                                                {
+                                                    "Fn::Select": [
+                                                        "0",
+                                                        {
+                                                            "Ref": "EBSVolumeId"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "Ref": "Volume1"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Fn::If": [
+                                                "Vol2_UseExistingEBSVolume",
+                                                {
+                                                    "Fn::Select": [
+                                                        "1",
+                                                        {
+                                                            "Ref": "EBSVolumeId"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "Ref": "Volume2"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Fn::If": [
+                                                "Vol3_UseExistingEBSVolume",
+                                                {
+                                                    "Fn::Select": [
+                                                        "2",
+                                                        {
+                                                            "Ref": "EBSVolumeId"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "Ref": "Volume3"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "Fn::If": [
+                                                "Vol4_UseExistingEBSVolume",
+                                                {
+                                                    "Fn::Select": [
+                                                        "3",
+                                                        {
+                                                            "Ref": "EBSVolumeId"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "Ref": "Volume4"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                ]
+                            },
+                            {
+                                "Fn::If": [
+                                    "UseVol3",
+                                    {
+                                        "Fn::Join": [
+                                            ",",
+                                            [
+                                                {
+                                                    "Fn::If": [
+                                                        "Vol1_UseExistingEBSVolume",
+                                                        {
+                                                            "Fn::Select": [
+                                                                "0",
+                                                                {
+                                                                    "Ref": "EBSVolumeId"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "Ref": "Volume1"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "Fn::If": [
+                                                        "Vol2_UseExistingEBSVolume",
+                                                        {
+                                                            "Fn::Select": [
+                                                                "1",
+                                                                {
+                                                                    "Ref": "EBSVolumeId"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "Ref": "Volume2"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "Fn::If": [
+                                                        "Vol3_UseExistingEBSVolume",
+                                                        {
+                                                            "Fn::Select": [
+                                                                "2",
+                                                                {
+                                                                    "Ref": "EBSVolumeId"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "Ref": "Volume3"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        ]
+                                    },
+                                    {
+                                        "Fn::If": [
+                                            "UseVol2",
+                                            {
+                                                "Fn::Join": [
+                                                    ",",
+                                                    [
+                                                        {
+                                                            "Fn::If": [
+                                                                "Vol1_UseExistingEBSVolume",
+                                                                {
+                                                                    "Fn::Select": [
+                                                                        "0",
+                                                                        {
+                                                                            "Ref": "EBSVolumeId"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "Ref": "Volume1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "Fn::If": [
+                                                                "Vol2_UseExistingEBSVolume",
+                                                                {
+                                                                    "Fn::Select": [
+                                                                        "1",
+                                                                        {
+                                                                            "Ref": "EBSVolumeId"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "Ref": "Volume2"
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "Vol1_UseExistingEBSVolume",
+                                                    {
+                                                        "Fn::Select": [
+                                                            "0",
+                                                            {
+                                                                "Ref": "EBSVolumeId"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "Ref": "Volume1"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "Parameters": {
+        "AvailabilityZone": {
+            "Description": "Availability Zone the cluster will launch into. THIS IS REQUIRED",
+            "Type": "String"
+        },
+        "EBSEncryption": {
+            "Description": "Boolean flag to use EBS encryption for /shared volume. (Not to be used for snapshots)",
+            "Type": "CommaDelimitedList"
+        },
+        "EBSKMSKeyId": {
+            "Description": "KMS ARN for customer created master key, will be used for EBS encryption",
+            "Type": "CommaDelimitedList"
+        },
+        "EBSSnapshotId": {
+            "Description": "Id of EBS snapshot if using snapshot as source for volume",
+            "Type": "CommaDelimitedList"
+        },
+        "EBSVolumeId": {
+            "Description": "Existing EBS volume Id",
+            "Type": "CommaDelimitedList"
+        },
+        "NumberOfEBSVol": {
+            "Description": "Number of EBS Volumes the user requested, up to 5",
+            "Type": "Number"
+        },
+        "VolumeIOPS": {
+            "Description": "Number of IOPS for volume type io1. Not used for other volume types.",
+            "Type": "CommaDelimitedList"
+        },
+        "VolumeSize": {
+            "Description": "Size of EBS volume in GB, if creating a new one",
+            "Type": "CommaDelimitedList"
+        },
+        "VolumeType": {
+            "Description": "Type of volume to create either new or from snapshot",
+            "Type": "CommaDelimitedList"
+        }
+    },
+    "Resources": {
+        "Volume1": {
+            "Condition": "Vol1_CreateEBSVolume",
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "AvailabilityZone"
+                },
+                "Encrypted": {
+                    "Fn::If": [
+                        "Vol1_UseEBSEncryption",
+                        {
+                            "Fn::Select": [
+                                "0",
+                                {
+                                    "Ref": "EBSEncryption"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Iops": {
+                    "Fn::If": [
+                        "Vol1_UseEBSPIOPS",
+                        {
+                            "Fn::Select": [
+                                "0",
+                                {
+                                    "Ref": "VolumeIOPS"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "KmsKeyId": {
+                    "Fn::If": [
+                        "Vol1_UseEBSKMSKey",
+                        {
+                            "Fn::Select": [
+                                "0",
+                                {
+                                    "Ref": "EBSKMSKeyId"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Size": {
+                    "Fn::If": [
+                        "Vol1_UseEBSSnapshot",
+                        {
+                            "Ref": "AWS::NoValue"
+                        },
+                        {
+                            "Fn::If": [
+                                "Vol1_UseVolumeSize",
+                                {
+                                    "Fn::Select": [
+                                        "0",
+                                        {
+                                            "Ref": "VolumeSize"
+                                        }
+                                    ]
+                                },
+                                "20"
+                            ]
+                        }
+                    ]
+                },
+                "SnapshotId": {
+                    "Fn::If": [
+                        "Vol1_UseEBSSnapshot",
+                        {
+                            "Fn::Select": [
+                                "0",
+                                {
+                                    "Ref": "EBSSnapshotId"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "VolumeType": {
+                    "Fn::If": [
+                        "Vol1_UseVolumeType",
+                        {
+                            "Fn::Select": [
+                                "0",
+                                {
+                                    "Ref": "VolumeType"
+                                }
+                            ]
+                        },
+                        "gp2"
+                    ]
+                }
+            },
+            "Type": "AWS::EC2::Volume"
+        },
+        "Volume2": {
+            "Condition": "Vol2_CreateEBSVolume",
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "AvailabilityZone"
+                },
+                "Encrypted": {
+                    "Fn::If": [
+                        "Vol2_UseEBSEncryption",
+                        {
+                            "Fn::Select": [
+                                "1",
+                                {
+                                    "Ref": "EBSEncryption"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Iops": {
+                    "Fn::If": [
+                        "Vol2_UseEBSPIOPS",
+                        {
+                            "Fn::Select": [
+                                "1",
+                                {
+                                    "Ref": "VolumeIOPS"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "KmsKeyId": {
+                    "Fn::If": [
+                        "Vol2_UseEBSKMSKey",
+                        {
+                            "Fn::Select": [
+                                "1",
+                                {
+                                    "Ref": "EBSKMSKeyId"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Size": {
+                    "Fn::If": [
+                        "Vol2_UseEBSSnapshot",
+                        {
+                            "Ref": "AWS::NoValue"
+                        },
+                        {
+                            "Fn::If": [
+                                "Vol2_UseVolumeSize",
+                                {
+                                    "Fn::Select": [
+                                        "1",
+                                        {
+                                            "Ref": "VolumeSize"
+                                        }
+                                    ]
+                                },
+                                "20"
+                            ]
+                        }
+                    ]
+                },
+                "SnapshotId": {
+                    "Fn::If": [
+                        "Vol2_UseEBSSnapshot",
+                        {
+                            "Fn::Select": [
+                                "1",
+                                {
+                                    "Ref": "EBSSnapshotId"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "VolumeType": {
+                    "Fn::If": [
+                        "Vol2_UseVolumeType",
+                        {
+                            "Fn::Select": [
+                                "1",
+                                {
+                                    "Ref": "VolumeType"
+                                }
+                            ]
+                        },
+                        "gp2"
+                    ]
+                }
+            },
+            "Type": "AWS::EC2::Volume"
+        },
+        "Volume3": {
+            "Condition": "Vol3_CreateEBSVolume",
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "AvailabilityZone"
+                },
+                "Encrypted": {
+                    "Fn::If": [
+                        "Vol3_UseEBSEncryption",
+                        {
+                            "Fn::Select": [
+                                "2",
+                                {
+                                    "Ref": "EBSEncryption"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Iops": {
+                    "Fn::If": [
+                        "Vol3_UseEBSPIOPS",
+                        {
+                            "Fn::Select": [
+                                "2",
+                                {
+                                    "Ref": "VolumeIOPS"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "KmsKeyId": {
+                    "Fn::If": [
+                        "Vol3_UseEBSKMSKey",
+                        {
+                            "Fn::Select": [
+                                "2",
+                                {
+                                    "Ref": "EBSKMSKeyId"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Size": {
+                    "Fn::If": [
+                        "Vol3_UseEBSSnapshot",
+                        {
+                            "Ref": "AWS::NoValue"
+                        },
+                        {
+                            "Fn::If": [
+                                "Vol3_UseVolumeSize",
+                                {
+                                    "Fn::Select": [
+                                        "2",
+                                        {
+                                            "Ref": "VolumeSize"
+                                        }
+                                    ]
+                                },
+                                "20"
+                            ]
+                        }
+                    ]
+                },
+                "SnapshotId": {
+                    "Fn::If": [
+                        "Vol3_UseEBSSnapshot",
+                        {
+                            "Fn::Select": [
+                                "2",
+                                {
+                                    "Ref": "EBSSnapshotId"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "VolumeType": {
+                    "Fn::If": [
+                        "Vol3_UseVolumeType",
+                        {
+                            "Fn::Select": [
+                                "2",
+                                {
+                                    "Ref": "VolumeType"
+                                }
+                            ]
+                        },
+                        "gp2"
+                    ]
+                }
+            },
+            "Type": "AWS::EC2::Volume"
+        },
+        "Volume4": {
+            "Condition": "Vol4_CreateEBSVolume",
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "AvailabilityZone"
+                },
+                "Encrypted": {
+                    "Fn::If": [
+                        "Vol4_UseEBSEncryption",
+                        {
+                            "Fn::Select": [
+                                "3",
+                                {
+                                    "Ref": "EBSEncryption"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Iops": {
+                    "Fn::If": [
+                        "Vol4_UseEBSPIOPS",
+                        {
+                            "Fn::Select": [
+                                "3",
+                                {
+                                    "Ref": "VolumeIOPS"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "KmsKeyId": {
+                    "Fn::If": [
+                        "Vol4_UseEBSKMSKey",
+                        {
+                            "Fn::Select": [
+                                "3",
+                                {
+                                    "Ref": "EBSKMSKeyId"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Size": {
+                    "Fn::If": [
+                        "Vol4_UseEBSSnapshot",
+                        {
+                            "Ref": "AWS::NoValue"
+                        },
+                        {
+                            "Fn::If": [
+                                "Vol4_UseVolumeSize",
+                                {
+                                    "Fn::Select": [
+                                        "3",
+                                        {
+                                            "Ref": "VolumeSize"
+                                        }
+                                    ]
+                                },
+                                "20"
+                            ]
+                        }
+                    ]
+                },
+                "SnapshotId": {
+                    "Fn::If": [
+                        "Vol4_UseEBSSnapshot",
+                        {
+                            "Fn::Select": [
+                                "3",
+                                {
+                                    "Ref": "EBSSnapshotId"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "VolumeType": {
+                    "Fn::If": [
+                        "Vol4_UseVolumeType",
+                        {
+                            "Fn::Select": [
+                                "3",
+                                {
+                                    "Ref": "VolumeType"
+                                }
+                            ]
+                        },
+                        "gp2"
+                    ]
+                }
+            },
+            "Type": "AWS::EC2::Volume"
+        },
+        "Volume5": {
+            "Condition": "Vol5_CreateEBSVolume",
+            "Properties": {
+                "AvailabilityZone": {
+                    "Ref": "AvailabilityZone"
+                },
+                "Encrypted": {
+                    "Fn::If": [
+                        "Vol5_UseEBSEncryption",
+                        {
+                            "Fn::Select": [
+                                "4",
+                                {
+                                    "Ref": "EBSEncryption"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Iops": {
+                    "Fn::If": [
+                        "Vol5_UseEBSPIOPS",
+                        {
+                            "Fn::Select": [
+                                "4",
+                                {
+                                    "Ref": "VolumeIOPS"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "KmsKeyId": {
+                    "Fn::If": [
+                        "Vol5_UseEBSKMSKey",
+                        {
+                            "Fn::Select": [
+                                "4",
+                                {
+                                    "Ref": "EBSKMSKeyId"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "Size": {
+                    "Fn::If": [
+                        "Vol5_UseEBSSnapshot",
+                        {
+                            "Ref": "AWS::NoValue"
+                        },
+                        {
+                            "Fn::If": [
+                                "Vol5_UseVolumeSize",
+                                {
+                                    "Fn::Select": [
+                                        "4",
+                                        {
+                                            "Ref": "VolumeSize"
+                                        }
+                                    ]
+                                },
+                                "20"
+                            ]
+                        }
+                    ]
+                },
+                "SnapshotId": {
+                    "Fn::If": [
+                        "Vol5_UseEBSSnapshot",
+                        {
+                            "Fn::Select": [
+                                "4",
+                                {
+                                    "Ref": "EBSSnapshotId"
+                                }
+                            ]
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "VolumeType": {
+                    "Fn::If": [
+                        "Vol5_UseVolumeType",
+                        {
+                            "Fn::Select": [
+                                "4",
+                                {
+                                    "Ref": "VolumeType"
+                                }
+                            ]
+                        },
+                        "gp2"
+                    ]
+                }
+            },
+            "Type": "AWS::EC2::Volume"
+        }
+    }
+}

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -271,11 +271,11 @@ Defaults to /scratch in the default template. ::
 
 shared_dir
 """"""""""
-Path/mountpoint for shared EBS volume
+Path/mountpoint for shared EBS volume. Do not use this option when using multiple EBS volumes; provide shared_dir under each EBS section instead
 
-Defaults to /shared in the default template. See :ref:`EBS Section <ebs_section>` for details on working with EBS volumes::
+Defaults to /shared in the default template. The example below mounts to /myshared. See :ref:`EBS Section <ebs_section>` for details on working with multiple EBS volumes::
 
-    shared_dir = /shared
+    shared_dir = myshared
 
 encrypted_ephemeral
 """""""""""""""""""
@@ -355,11 +355,11 @@ See :ref:`VPC Section <vpc_section>`. ::
 
 ebs_settings
 """"""""""""
-Settings section relating to EBS volume mounted on the master.
+Settings section relating to EBS volume mounted on the master. When using multiple EBS volumes, enter multiple settings as a comma separated list. Up to 5 EBS volumes are supported.
 
 See :ref:`EBS Section <ebs_section>`. ::
 
-  ebs_settings = custom
+  ebs_settings = custom1, custom2, ...
 
 scaling_settings
 """"""""""""""""
@@ -463,12 +463,26 @@ Defaults to NONE in the default template. ::
 
 ebs
 ^^^
-EBS Volume configuration settings for the volume mounted on the master node and shared via NFS to compute nodes. ::
+EBS Volume configuration settings for the volumes mounted on the master node and shared via NFS to compute nodes. ::
 
-    [ebs custom]
+    [ebs custom1]
+    shared_dir = vol1
     ebs_snapshot_id = snap-xxxxx
     volume_type = io1
     volume_iops = 200
+    ...
+
+    [ebs custom2]
+    shared_dir = vol2
+    ...
+
+    ...
+
+shared_dir
+""""""""""
+Path/mountpoint for shared EBS volume. Required when using multiple EBS volumes. When using 1 ebs volume, this option will overwrite the shared_dir specified under the cluster section. The example below mounts to /vol1 ::
+
+    shared_dir = vol1
 
 ebs_snapshot_id
 """""""""""""""

--- a/util/generate-ebs-substack.py
+++ b/util/generate-ebs-substack.py
@@ -1,0 +1,97 @@
+import troposphere.ec2 as ec2
+
+from troposphere import Parameter, Condition, Ref, Template, Select, If, Equals, And, Not, NoValue, Join, Output
+
+
+numberOfVol = 5
+
+
+t = Template()
+AvailabilityZone = t.add_parameter(Parameter("AvailabilityZone",
+                                             Type="String",
+                                             Description="Availability Zone the cluster will launch into. THIS IS REQUIRED"))
+VolumeSize = t.add_parameter(Parameter("VolumeSize",
+                                       Type="CommaDelimitedList",
+                                       Description = "Size of EBS volume in GB, if creating a new one"))
+VolumeType = t.add_parameter(Parameter("VolumeType",
+                                       Type="CommaDelimitedList",
+                                       Description="Type of volume to create either new or from snapshot"))
+VolumeIOPS = t.add_parameter(Parameter("VolumeIOPS",
+                                       Type="CommaDelimitedList",
+                                       Description= "Number of IOPS for volume type io1. Not used for other volume types."))
+EBSEncryption = t.add_parameter(Parameter("EBSEncryption",
+                                          Type="CommaDelimitedList",
+                                          Description="Boolean flag to use EBS encryption for /shared volume. "
+                                                      "(Not to be used for snapshots)"))
+EBSKMSKeyId = t.add_parameter(Parameter("EBSKMSKeyId",
+                                        Type="CommaDelimitedList",
+                                        Description="KMS ARN for customer created master key, will be used for EBS encryption"))
+EBSVolumeId = t.add_parameter(Parameter("EBSVolumeId",
+                                        Type="CommaDelimitedList",
+                                        Description="Existing EBS volume Id"))
+EBSSnapshotId = t.add_parameter(Parameter("EBSSnapshotId",
+                                          Type="CommaDelimitedList",
+                                          Description="Id of EBS snapshot if using snapshot as source for volume"))
+EBSVolumeNum = t.add_parameter(Parameter("NumberOfEBSVol",
+                                         Type="Number",
+                                         Description= "Number of EBS Volumes the user requested, up to %s" %numberOfVol))
+
+UseVol = [None]*numberOfVol
+UseExistingEBSVolume = [None]*numberOfVol
+v = [None]*numberOfVol
+
+for i in range(numberOfVol):
+    if i == 0:
+        CreateVol = t.add_condition("Vol%s_CreateEBSVolume" % (i + 1),
+                                    Equals(Select(str(i), Ref(EBSVolumeId)), "NONE"))
+    elif i == 1:
+        UseVol[i] = t.add_condition("UseVol%s" % (i + 1), Not(Equals(Ref(EBSVolumeNum), str(i))))
+        CreateVol = t.add_condition("Vol%s_CreateEBSVolume" % (i + 1),
+                                    And(Condition(UseVol[i]), Equals(Select(str(i), Ref(EBSVolumeId)), "NONE")))
+    else:
+        UseVol[i] = t.add_condition("UseVol%s" % (i + 1), And(Not(Equals(Ref(EBSVolumeNum), str(i))), Condition(UseVol[i-1])))
+        CreateVol = t.add_condition("Vol%s_CreateEBSVolume" % (i + 1),
+                                    And(Condition(UseVol[i]), Equals(Select(str(i), Ref(EBSVolumeId)), "NONE")))
+
+    UseEBSPIOPS = t.add_condition("Vol%s_UseEBSPIOPS" % (i + 1),
+                                  Equals(Select(str(i), Ref(VolumeType)), "io1"))
+    UseVolumeSize = t.add_condition("Vol%s_UseVolumeSize" % (i + 1),
+                                    Not(Equals(Select(str(i), Ref(VolumeSize)), "NONE")))
+    UseVolumeType = t.add_condition("Vol%s_UseVolumeType" % (i + 1),
+                                    Not(Equals(Select(str(i), Ref(VolumeType)), "NONE")))
+    UseEBSEncryption = t.add_condition("Vol%s_UseEBSEncryption" % (i + 1),
+                                       Equals(Select(str(i), Ref(EBSEncryption)), "true"))
+    UseEBSKMSKey = t.add_condition("Vol%s_UseEBSKMSKey" % (i + 1),
+                                   And(Condition(UseEBSEncryption), Not(Equals(Select(str(i), Ref(EBSKMSKeyId)), "NONE"))))
+    UseEBSSnapshot = t.add_condition("Vol%s_UseEBSSnapshot" % (i + 1),
+                                     Not(Equals(Select(str(i), Ref(EBSSnapshotId)), "NONE")))
+    UseExistingEBSVolume[i] = t.add_condition("Vol%s_UseExistingEBSVolume" % (i + 1),
+                                              Not(Equals(Select(str(i), Ref(EBSVolumeId)), "NONE")))
+    v[i] = t.add_resource(ec2.Volume("Volume%s" % (i + 1),
+                                     AvailabilityZone=Ref(AvailabilityZone),
+                                     VolumeType=If(UseVolumeType, Select(str(i), Ref(VolumeType)), "gp2"),
+                                     Size=If(UseEBSSnapshot, NoValue, If(UseVolumeSize, Select(str(i), Ref(VolumeSize)), "20")),
+                                     SnapshotId=If(UseEBSSnapshot, Select(str(i), Ref(EBSSnapshotId)), NoValue),
+                                     Iops=If(UseEBSPIOPS, Select(str(i), Ref(VolumeIOPS)), NoValue),
+                                     Encrypted=If(UseEBSEncryption, Select(str(i), Ref(EBSEncryption)), NoValue),
+                                     KmsKeyId=If(UseEBSKMSKey, Select(str(i), Ref(EBSKMSKeyId)), NoValue),
+                                     Condition=CreateVol
+                                     ))
+
+outputs = [None]*numberOfVol
+volToReturn = [None]*numberOfVol
+for i in range(numberOfVol):
+    volToReturn[i] = If(UseExistingEBSVolume[i], Select(str(i), Ref(EBSVolumeId)), Ref(v[i]))
+    if i == 0:
+        outputs[i] = volToReturn[i]
+    else:
+        outputs[i] = If(UseVol[i], Join(",", volToReturn[:(i+1)]), outputs[i-1])
+
+t.add_output(Output("Volumeids",
+                    Description= "Volume IDs of the resulted EBS volumes",
+                    Value=outputs[numberOfVol-1]))
+
+jsonFilePath = "targetPath"
+outputfile = open(jsonFilePath, "w")
+outputfile.write(t.to_json())
+outputfile.close()


### PR DESCRIPTION
- Modified cfnconfig.py to take in the new format of the config file, with multiple ebs sections
- Modified config_sanity.py to add validation for VolumeType and EBSEncryption, as those can no longer be checked in the cloudformation template
- Modified cfncluster.cfn.json to handle multiple EBS volumes; added 1 additional parameter: NumberOfEBSVol, added new resource EBSCfnStack, took out all EBS related conditions, and changed all EBS related parameters to comma separated lists
- Added ebs_vol_substack.cfn.json, the new template for EBS substack, which supports up to 5 EBS volume
- Added generate-ebs-substack.py, which can be used to generate template for EBS substack via troposphere

Signed-off-by: Rex Chen <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
