### PR TITLE
doc: fix commands names

### DIFF
--- a/docs/source/awsbhosts.rst
+++ b/docs/source/awsbhosts.rst
@@ -6,4 +6,4 @@ awsbhosts
 .. argparse::
     :filename: ../../cli/awsbatch/awsbhosts.py
     :func: _get_parser
-    :prog: awsbhosts.py
+    :prog: awsbhosts

--- a/docs/source/awsbkill.rst
+++ b/docs/source/awsbkill.rst
@@ -6,4 +6,4 @@ awsbkill
 .. argparse::
     :filename: ../../cli/awsbatch/awsbkill.py
     :func: _get_parser
-    :prog: awsbkill.py
+    :prog: awsbkill

--- a/docs/source/awsbout.rst
+++ b/docs/source/awsbout.rst
@@ -6,4 +6,4 @@ awsbout
 .. argparse::
     :filename: ../../cli/awsbatch/awsbout.py
     :func: _get_parser
-    :prog: awsbout.py
+    :prog: awsbout

--- a/docs/source/awsbqueues.rst
+++ b/docs/source/awsbqueues.rst
@@ -6,4 +6,4 @@ awsbqueues
 .. argparse::
     :filename: ../../cli/awsbatch/awsbqueues.py
     :func: _get_parser
-    :prog: awsbqueues.py
+    :prog: awsbqueues

--- a/docs/source/awsbstat.rst
+++ b/docs/source/awsbstat.rst
@@ -6,4 +6,4 @@ awsbstat
 .. argparse::
     :filename: ../../cli/awsbatch/awsbstat.py
     :func: _get_parser
-    :prog: awsbstat.py
+    :prog: awsbstat

--- a/docs/source/awsbsub.rst
+++ b/docs/source/awsbsub.rst
@@ -6,4 +6,4 @@ awsbsub
 .. argparse::
     :filename: ../../cli/awsbatch/awsbsub.py
     :func: _get_parser
-    :prog: awsbsub.py
+    :prog: awsbsub


### PR DESCRIPTION
The commands to show in the guide are without the `.py` suffix

