### PR TITLE
Added check for snapshot state in config_sanity

### DIFF
--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -157,7 +157,10 @@ def check_resource(region, aws_access_key_id, aws_secret_access_key, resource_ty
             ec2 = boto3.client('ec2', region_name=region,
                                aws_access_key_id=aws_access_key_id,
                                aws_secret_access_key=aws_secret_access_key)
-            test = ec2.describe_snapshots(SnapshotIds=[resource_value])
+            test = ec2.describe_snapshots(SnapshotIds=[resource_value]).get('Snapshots')[0]
+            if test.get('State') != 'completed':
+                print('Snapshot %s is in state \'%s\' not \'completed\'' % (resource_value, test.get('State')))
+                sys.exit(1)
         except ClientError as e:
             print('Config sanity error on resource %s: %s' % (resource_type, e.response.get('Error').get('Message')))
             sys.exit(1)


### PR DESCRIPTION
- In response to customer issue: https://github.com/aws/aws-parallelcluster/issues/639 , modified config_sanity to check for state of the snapshot before stack creation.

Signed-off-by: Rex Chen <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
