### PR TITLE
Fix broken links in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -356,3 +356,6 @@ epub_exclude_files = ['search.html']
 
 # If false, no index is generated.
 #epub_use_index = True
+
+# A list of regular expressions that match URIs that should not be checked when doing a linkcheck build.
+linkcheck_ignore = [r'http://x\.x\.x\.x:\d+', r'http://hostname/']

--- a/docs/source/aws_services.rst
+++ b/docs/source/aws_services.rst
@@ -15,6 +15,8 @@ The following Amazon Web Services (AWS) services are used in AWS ParallelCluster
 * Amazon S3
 * Amazon DynamoDB
 
+.. _aws_services_cloudformation:
+
 AWS CloudFormation
 ------------------
 

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -14,7 +14,7 @@ Most commands provided are just wrappers around CloudFormation functions.
 create
 ======
 
-Creates a CloudFormation stack with the name :code:`parallelcluster-[stack_name]`. To read more about CloudFormation see `AWS CloudFormation <https://aws-parallelcluster.readthedocs.io/en/latest/aws_services.html#aws-cloudformation>`_.
+Creates a CloudFormation stack with the name :code:`parallelcluster-[stack_name]`. To read more about CloudFormation see :ref:`AWS CloudFormation <aws_services_cloudformation>`.
 
 positional arguments:
   cluster_name          create a cluster with the provided name.
@@ -106,10 +106,8 @@ start
 =====
 
 Starts a cluster. This sets the Auto Scaling Group parameters to either the
-initial configuration values (`max_queue_size
-<https://aws-parallelcluster.readthedocs.io/en/latest/configuration.html#max-queue-size>`_
-and `initial_queue_size
-<https://aws-parallelcluster.readthedocs.io/en/latest/configuration.html#initial-queue-size>`_)
+initial configuration values (:ref:`max_queue_size <configuration_max_queue_size>`
+and :ref:`initial_queue_size <configuration_initial_queue_size>`)
 from the template that was used to create the cluster or to the configuration
 values that were used to update the cluster since creation.
 
@@ -184,7 +182,7 @@ status
 ======
 
 Pull the current status of the cluster. Polls if the status is not CREATE_COMPLETE or UPDATE_COMPLETE.
-For more info on possible statuses see the `Stack Status Codes <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html#d0e9320>`_ page.
+For more info on possible statuses see the `Stack Status Codes <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html#w2ab1c15c15c17c11>`_ page.
 
 positional arguments:
   cluster_name  show the status of the cluster with the provided name.
@@ -239,7 +237,7 @@ optional arguments:
 configure
 =========
 
-Configures the cluster. See `Configuring AWS ParallelCluster <https://aws-parallelcluster.readthedocs.io/en/latest/getting_started.html#configuring-parallelcluster>`_.
+Configures the cluster. See :ref:`Configuring AWS ParallelCluster <getting_started_configuring_parallelcluster>`.
 
 optional arguments:
   -h, --help  show this help message and exit

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -119,6 +119,8 @@ This defaults to t2.micro. ::
 
     master_instance_type = t2.micro
 
+.. _configuration_initial_queue_size:
+
 initial_queue_size
 """"""""""""""""""
 The initial number of EC2 instances to launch as compute nodes in the cluster for traditional schedulers.
@@ -128,6 +130,8 @@ If you're using awsbatch, use :ref:`min_vcpus <min_vcpus>`.
 The default is 2. ::
 
     initial_queue_size = 2
+
+.. _configuration_max_queue_size:
 
 max_queue_size
 """"""""""""""
@@ -501,7 +505,7 @@ If true, an Elastic Ip will be associated to the Master instance.
 If false, the Master instance will have a Public IP or not according to the value
 of the "Auto-assign Public IP" subnet configuration parameter.
 
-See `networking configuration <https://aws-parallelcluster.readthedocs.io/en/latest/networking.html>`_ for some examples.
+See :ref:`networking configuration <networking>` for some examples.
 
 Defaults to true. ::
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -53,6 +53,8 @@ To upgrade an older version of AWS ParallelCluster, you can use either of the fo
 
 **Remember when upgrading to check that the exiting config is compatible with the latest version installed.**
 
+.. _getting_started_configuring_parallelcluster:
+
 Configuring AWS ParallelCluster
 ===============================
 
@@ -143,7 +145,7 @@ Once all of those settings contain valid values, you can launch the cluster by r
     $ pcluster create mycluster
 
 Once the cluster reaches the "CREATE_COMPLETE" status, you can connect using your normal SSH client/settings.
-For more details on connecting to EC2 instances, check the `EC2 User Guide <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-connect-to-instance-linux.html#using-ssh-client>`_.
+For more details on connecting to EC2 instances, check the `EC2 User Guide <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html#ec2-connect-to-instance-linux>`_.
 
 
 Moving from CfnCluster to AWS ParallelCluster


### PR DESCRIPTION
Broken links detected by running: `tox -e docs-linkcheck`

Tested locally with `tox -e docs` and `tox -e serve-docs`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
