### PR TITLE
Patch for stringify errors

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import
 
 from future import standard_library
 standard_library.install_aliases()
-from builtins import str
 from builtins import object
 import configparser
 import os
@@ -80,7 +79,7 @@ class ParallelClusterConfig(object):
                     if not __temp_shared_dir:
                         print("ERROR: shared_dir defined but not set")
                         sys.exit(1)
-                    self.parameters['SharedDir'] = str(__temp_shared_dir)
+                    self.parameters['SharedDir'] = __temp_shared_dir
                 except configparser.NoOptionError:
                     pass
             else:
@@ -93,7 +92,7 @@ class ParallelClusterConfig(object):
                 if not __temp_shared_dir:
                     print("ERROR: shared_dir defined but not set")
                     sys.exit(1)
-                self.parameters['SharedDir'] = str(__temp_shared_dir)
+                self.parameters['SharedDir'] = __temp_shared_dir
             except configparser.NoOptionError:
                 pass
 
@@ -108,12 +107,12 @@ class ParallelClusterConfig(object):
                       % self.__cluster_section)
                 sys.exit(1)
             # Modify list
-            self.__ebs_section = str(self.__ebs_settings).split(',')
+            self.__ebs_section = self.__ebs_settings.split(',')
             if (len(self.__ebs_section) > self.__MAX_EBS_VOLUMES):
                 print("ERROR: number of EBS volumes requested is greater than the MAX.\n"
                       "Max number of EBS volumes supported is currently %s" % self.__MAX_EBS_VOLUMES)
                 sys.exit(1)
-            self.parameters["NumberOfEBSVol"] = str(len(self.__ebs_section))
+            self.parameters["NumberOfEBSVol"] = '%s' % len(self.__ebs_section)
             for i, item in enumerate(self.__ebs_section):
                 item = ('ebs %s' % item.strip())
                 self.__ebs_section[i] = item
@@ -150,7 +149,7 @@ class ParallelClusterConfig(object):
                     # Fill the rest of the parameter with NONE
                     while len(__temp_parameter_list) < self.__MAX_EBS_VOLUMES:
                         __temp_parameter_list.append("NONE")
-                    self.parameters[self.__ebs_options.get(key)[0]] = ",".join(str(x) for x in __temp_parameter_list)
+                    self.parameters[self.__ebs_options.get(key)[0]] = ",".join(x for x in __temp_parameter_list)
 
         except AttributeError:
             pass

--- a/cli/pcluster/pcluster.py
+++ b/cli/pcluster/pcluster.py
@@ -156,6 +156,12 @@ def create(args):
     except KeyboardInterrupt:
         logger.info('\nExiting...')
         sys.exit(0)
+    except KeyError as e:
+        logger.critical("ERROR: KeyError - reason:")
+        logger.critical(e)
+        if batch_temporary_bucket:
+            utils.delete_s3_bucket(bucket_name=batch_temporary_bucket, aws_client_config=aws_client_config)
+        sys.exit(1)
     except Exception as e:
         logger.critical(e)
         if batch_temporary_bucket:


### PR DESCRIPTION
Error description: str() on strings will sometimes cause a KeyError problem

- Modified cfnconfig.py to remove all occurances of stringify and use python string interpolation instead, remove str package
- Modified pcluster.py to catch KeyError separately so we can better identify the problem in the future

Signed-off-by: Rex Chen <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
