### PR TITLE
Changes to support EFS file system

### DIFF
--- a/cli/pcluster/examples/config
+++ b/cli/pcluster/examples/config
@@ -125,6 +125,8 @@ vpc_settings = public
 #ebs_settings = custom1, custom2, ...
 # Settings section relation to scaling
 #scaling_settings = custom
+# Settings section relation to EFS file system
+#efs_settings = customfs
 
 ## VPC Settings
 [vpc public]
@@ -197,3 +199,25 @@ master_subnet_id = subnet-
 # Amount of time in minutes without a job after which the compute node will terminate
 # Defaults to 10
 #scaledown_idletime = 10
+
+## EFS Settings
+#[efs customfs]
+# Shared directory for the file system. REQUIRED if using EFS file system. Below example mounts to /efs
+#shared_dir = efs
+# Use encrypted file system
+# (defaults to false)
+#encrypted = false
+# Performance Mode of the file system; generalPurpose or maxIO (case sensitive)
+# (defaults to generalPurpose)
+#performance_mode = generalPurpose
+# Throughput mode of the file system; bursting or provisioned (case sensitive)
+# (defaults to bursting)
+#throughput_mode = provisioned
+# The throughput, measured in MiB/s, that you want to provision for a file system that you're creating. The limit on throughput is 0.0 - 1024 MiB/s. You can get these limits increased by contacting AWS Support.
+# Can only be used when throughput_mode is set to provisioned
+# (defaults to NONE)
+#provisioned_throughput = 1024
+# File system ID of an existing EFS file system to use. Specifying this option will void all EFS options but shared_dir
+# Requires the given file system to: not have a mount target in the stack's availability zone OR have a mount target with inbound and outbound permissions for NFS traffic from 0.0.0.0/0
+# (defaults to NONE)
+#efs_fs_id = fs-12faea3

--- a/cli/pcluster/resources/batch/docker/scripts/entrypoint.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/entrypoint.sh
@@ -13,6 +13,11 @@ eval `ssh-agent -s` && ssh-add ${SSHDIR}/id_rsa
 echo "Mounting shared file system..."
 /parallelcluster/bin/mount_nfs.sh "${MASTER_IP}" "${SHARED_DIR}"
 
+# mount EFS via nfs
+if [[ ! -z "${EFS_FS_ID}" ]] && [[ ! -z "${AWS_REGION}" ]] && [[ "${EFS_SHARED_DIR}" != "NONE" ]]; then
+  /parallelcluster/bin/mount_efs.sh "${EFS_FS_ID}" "${AWS_REGION}" "${EFS_SHARED_DIR}"
+fi
+
 # create hostfile if mnp job
 if [ -n "${AWS_BATCH_JOB_NUM_NODES}" ]; then
   echo "Generating hostfile..."

--- a/cli/pcluster/resources/batch/docker/scripts/mount_efs.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/mount_efs.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy
+# of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+# Usage: mount_filesystem.sh efs_fs_id aws_region shared_dir
+
+error_exit_usage() {
+    echo "Error executing script: $1"
+    usage
+    exit 1
+}
+
+error_exit() {
+    echo "Error executing script: $1"
+    exit 1
+}
+
+usage() {
+    cat <<ENDUSAGE
+    This script mounts EFS filesystem on shared dir on the nodes in the batch job.
+    The shared directory will be created if it does not exist.
+
+    USAGE:
+    mount_nfs <efs_fs_id> <aws_region> <shared_dir>
+    efs_fs_id: if of EFS file system
+    aws_region: AWS region of the stack
+    shared_dir: directory for EFS file system to be mounted on. If directory doesn't exist on compute, will be created
+ENDUSAGE
+}
+
+# Check that the arguments are valid
+check_arguments_valid(){
+    if [ -z "${efs_fs_id}" ]; then
+        error_exit_usage "EFS FS Id is a required argument"
+    fi
+
+    if [ -z "${aws_region}" ]; then
+        error_exit_usage "AWS region is a required argument"
+    fi
+
+    if [ -z "${shared_dir}" ]; then
+        error_exit_usage "The directory to be shared via nfs is a required argument"
+    fi
+}
+
+# mount nfs
+mount_nfs() {
+
+    error_message=$(rpcinfo &> /dev/null || rpcbind 2>&1)
+    if [[ $? -ne 0 ]]; then
+        error_exit "Failed to run rpcbind with error_message: ${error_message}"
+    fi
+
+    mkdir -p ${shared_dir}
+    error_message=$(mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev "${efs_dir}" "${shared_dir}" 2>&1)
+    if [[ $? -ne 0 ]]; then
+        error_exit "Failed to mount nfs volume from ${efs_dir} with error_message: ${error_message}"
+    fi
+
+    # Check that the filesystem is mounted as appropriate
+    mount_line=$(mount | grep "${efs_dir}")
+    if [[ -z "${mount_line}" ]]; then
+        error_exit "mount succeeded but nfs volume from ${efs_dir} was not mounted as expected"
+    fi
+}
+
+
+# main function
+main() {
+    efs_fs_id=${1}
+    aws_region=${2}
+    efs_dir="${efs_fs_id}.efs.${aws_region}.amazonaws.com:/"
+    shared_dir="/${3}"
+
+    check_arguments_valid
+    mount_nfs
+}
+
+main $@

--- a/cli/tests/pcluster/config_efs
+++ b/cli/tests/pcluster/config_efs
@@ -1,0 +1,41 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = false
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+key_name = id_rsa
+vpc_settings = public
+efs_settings = fs
+
+[cluster unittest]
+base_os = alinux
+key_name = id_rsa
+vpc_settings = public
+efs_settings = fs_unittest
+
+[vpc public]
+vpc_id = vpc-12345
+master_subnet_id = subnet-12345
+
+[efs fs]
+shared_dir = efs
+#efs_fs_id =
+encrypted = true
+performance_mode = generalPurpose
+provisioned_throughput = 1024
+throughput_mode = provisioned
+
+[efs fs_unittest]
+shared_dir = efs_shared
+efs_fs_id = fs-12345
+efs_kms_key_id = key1
+encrypted = true
+performance_mode = maxIO
+provisioned_throughput = 1020
+throughput_mode = provisioned
+
+

--- a/cli/tests/pcluster/efs-unitttest.py
+++ b/cli/tests/pcluster/efs-unitttest.py
@@ -1,0 +1,71 @@
+import unittest
+
+import argparse
+
+from pcluster import cfnconfig
+
+config_file = "cli/tests/pcluster/config_efs"
+test_cluster_template = "unittest"
+args = argparse.Namespace()
+args.config_file = config_file
+args.cluster_template = test_cluster_template
+
+
+def create():
+    """Empty function to simulate the create function in pcluster."""
+    return
+
+
+def update():
+    """Empty function to simulate the update function in pcluster."""
+    return
+
+
+class TestEFSConfigParser(unittest.TestCase):
+    """Unit testing module for parsing EFS related options."""
+
+    def test_efs_create(self):
+        """Unit tests for parsing EFS related options when pcluster create is called."""
+        global args
+        args.func = create
+        config = cfnconfig.ParallelClusterConfig(args)
+        efs_options = [opt.strip() for opt in config.parameters["EFSoptions"].split(",")]
+        self.assertEqual(efs_options[0], "efs_shared", msg="Unexpected shared_dir")
+        self.assertEqual(efs_options[1], "fs-12345", msg="Unexpected efs_fs_id")
+        self.assertEqual(efs_options[2], "maxIO", msg="Unexpected performance_mode")
+        self.assertEqual(efs_options[3], "key1", msg="Unexpected efs_kms_key_id")
+        self.assertEqual(efs_options[4], "1020", msg="Unexpected provisioned_throughput")
+        self.assertEqual(efs_options[5], "true", msg="Unexpected encrypted")
+        self.assertEqual(efs_options[6], "provisioned", msg="Unexpected throughput_mode")
+        self.assertEqual(
+            len(efs_options),
+            8,
+            "Unexpected number of EFS parameters: %s "
+            "\nExpected 8 parameters, 7 configurable parameters"
+            "and 1 parameter reserved for passing mount point state to stack" % len(efs_options),
+        )
+
+    def test_efs_update(self):
+        """Unit tests for parsing EFS related options when pcluster update is called."""
+        global args
+        args.func = update
+        config = cfnconfig.ParallelClusterConfig(args)
+        efs_options = [opt.strip() for opt in config.parameters["EFSoptions"].split(",")]
+        self.assertEqual(efs_options[0], "efs_shared", msg="Unexpected shared_dir")
+        self.assertEqual(efs_options[1], "fs-12345", msg="Unexpected efs_fs_id")
+        self.assertEqual(efs_options[2], "maxIO", msg="Unexpected performance_mode")
+        self.assertEqual(efs_options[3], "key1", msg="Unexpected efs_kms_key_id")
+        self.assertEqual(efs_options[4], "1020", msg="Unexpected provisioned_throughput")
+        self.assertEqual(efs_options[5], "true", msg="Unexpected encrypted")
+        self.assertEqual(efs_options[6], "provisioned", msg="Unexpected throughput_mode")
+        self.assertEqual(
+            len(efs_options),
+            8,
+            "Unexpected number of EFS parameters: %s "
+            "\nExpected 8 parameters, 7 configurable parameters"
+            "and 1 parameter reserved for passing mount point state to stack" % len(efs_options),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -582,9 +582,36 @@
       "Description": "Number of EBS Volumes the user requested, up to 5",
       "Type": "Number",
       "Default": "1"
+    },
+    "EFSoptions": {
+      "Description": "Comma separated list of efs related options, 8 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,valid_existing_MTorNot]",
+      "Type": "String",
+      "Default": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE"
     }
   },
   "Conditions": {
+    "CreateEFSSubstack": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "0",
+                {
+                  "Fn::Split": [
+                    ",",
+                    {
+                      "Ref": "EFSoptions"
+                    }
+                  ]
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
     "IsMasterInstanceEbsOpt": {
       "Fn::Not": [
         {
@@ -1250,6 +1277,54 @@
     }
   },
   "Resources": {
+    "EFSSubstack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "Parameters": {
+          "EFSoptions": {
+            "Ref": "EFSoptions"
+          },
+          "ComputeSecurityGroup": {
+            "Fn::If": [
+              "CreateSecurityGroups",
+              {
+                "Ref": "ComputeSecurityGroup"
+              },
+              {
+                "Ref": "VPCSecurityGroupId"
+              }
+            ]
+          },
+          "SubnetId": {
+            "Ref": "MasterSubnetId"
+          }
+        },
+        "TemplateURL": {
+          "Fn::Sub": [
+            "https://${s3_domain}/${AWS::Region}-aws-parallelcluster/templates/efs-substack-${version}.cfn.json",
+            {
+              "s3_domain": {
+                "Fn::If": [
+                  "GovCloudRegion",
+                  {
+                    "Fn::Sub": "s3-${AWS::Region}.amazonaws.com"
+                  },
+                  "s3.amazonaws.com"
+                ]
+              },
+              "version": {
+                "Fn::FindInMap": [
+                  "PackagesVersions",
+                  "default",
+                  "cfncluster"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "CreateEFSSubstack"
+    },
     "SQS": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
@@ -2090,6 +2165,21 @@
                     "cfn_region": {
                       "Ref": "AWS::Region"
                     },
+                    "cfn_efs": {
+                      "Fn::If": [
+                        "CreateEFSSubstack",
+                        {
+                          "Fn::GetAtt": [
+                            "EFSSubstack",
+                            "Outputs.FileSystemId"
+                          ]
+                        },
+                        ""
+                      ]
+                    },
+                    "cfn_efs_shared_dir": {
+                      "Ref": "EFSoptions"
+                    },
                     "cfn_volume": {
                       "Fn::GetAtt": [
                         "EBSCfnStack",
@@ -2830,6 +2920,21 @@
                     "cfn_region": {
                       "Ref": "AWS::Region"
                     },
+                    "cfn_efs": {
+                      "Fn::If": [
+                        "CreateEFSSubstack",
+                        {
+                          "Fn::GetAtt": [
+                            "EFSSubstack",
+                            "Outputs.FileSystemId"
+                          ]
+                        },
+                        ""
+                      ]
+                    },
+                    "cfn_efs_shared_dir": {
+                      "Ref": "EFSoptions"
+                    },
                     "cfn_scheduler": {
                       "Ref": "Scheduler"
                     },
@@ -3481,6 +3586,21 @@
                     "cfn_region": {
                       "Ref": "AWS::Region"
                     },
+                    "cfn_efs": {
+                      "Fn::If": [
+                        "CreateEFSSubstack",
+                        {
+                          "Fn::GetAtt": [
+                            "EFSSubstack",
+                            "Outputs.FileSystemId"
+                          ]
+                        },
+                        ""
+                      ]
+                    },
+                    "cfn_efs_shared_dir": {
+                      "Ref": "EFSoptions"
+                    },
                     "cfn_scheduler": {
                       "Ref": "Scheduler"
                     },
@@ -3831,6 +3951,33 @@
       ],
       "Properties": {
         "Parameters": {
+          "EFSSharedDir": {
+            "Fn::Select": [
+              "0",
+              {
+                "Fn::Split": [
+                  ",",
+                  {
+                    "Ref": "EFSoptions"
+                  }
+                ]
+              }
+            ]
+          },
+          "EFSFSId": {
+            "Fn::If": [
+              "CreateEFSSubstack",
+              {
+                "Fn::GetAtt": [
+                  "EFSSubstack",
+                  "Outputs.FileSystemId"
+                ]
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          },
           "MinvCpus": {
             "Ref": "MinSize"
           },

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -52,6 +52,14 @@
     "SharedDir": {
       "Description": "The path/mountpoint for the shared drive",
       "Type": "String"
+    },
+    "EFSSharedDir": {
+      "Description": "The path/mountpoint for the EFS file system",
+      "Type": "String"
+    },
+    "EFSFSId": {
+      "Description": "ID of EFS file system",
+      "Type": "String"
     }
   },
   "Conditions": {
@@ -262,9 +270,27 @@
           "Privileged": true,
           "Environment": [
             {
+              "Name": "AWS_REGION",
+              "Value": {
+                "Ref": "AWS::Region"
+              }
+            },
+            {
               "Name": "SHARED_DIR",
               "Value": {
                 "Ref": "SharedDir"
+              }
+            },
+            {
+              "Name": "EFS_SHARED_DIR",
+              "Value": {
+                "Ref": "EFSSharedDir"
+              }
+            },
+            {
+              "Name": "EFS_FS_ID",
+              "Value": {
+                "Ref": "EFSFSId"
               }
             }
           ]

--- a/cloudformation/efs-substack.cfn.json
+++ b/cloudformation/efs-substack.cfn.json
@@ -1,0 +1,333 @@
+{
+  "Conditions": {
+    "CreateEFS": {
+      "Fn::And": [
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "0",
+                    {
+                      "Ref": "EFSoptions"
+                    }
+                  ]
+                },
+                "NONE"
+              ]
+            }
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "1",
+                {
+                  "Ref": "EFSoptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "CreateMT": {
+      "Fn::And": [
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "0",
+                    {
+                      "Ref": "EFSoptions"
+                    }
+                  ]
+                },
+                "NONE"
+              ]
+            }
+          ]
+        },
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "7",
+                {
+                  "Ref": "EFSoptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "UseEFSEncryption": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "5",
+            {
+              "Ref": "EFSoptions"
+            }
+          ]
+        },
+        "true"
+      ]
+    },
+    "UseEFSKMSKey": {
+      "Fn::And": [
+        {
+          "Condition": "UseEFSEncryption"
+        },
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "3",
+                    {
+                      "Ref": "EFSoptions"
+                    }
+                  ]
+                },
+                "NONE"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "UsePerformanceMode": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "2",
+                {
+                  "Ref": "EFSoptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "UseProvisioned": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "6",
+            {
+              "Ref": "EFSoptions"
+            }
+          ]
+        },
+        "provisioned"
+      ]
+    },
+    "UseProvisionedThroughput": {
+      "Fn::And": [
+        {
+          "Condition": "UseProvisioned"
+        },
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "4",
+                    {
+                      "Ref": "EFSoptions"
+                    }
+                  ]
+                },
+                "NONE"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "UseThroughputMode": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "6",
+                {
+                  "Ref": "EFSoptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    }
+  },
+  "Outputs": {
+    "FileSystemId": {
+      "Description": "ID of the FileSystem",
+      "Value": {
+        "Fn::If": [
+          "CreateEFS",
+          {
+            "Ref": "EFSFS"
+          },
+          {
+            "Fn::Select": [
+              "1",
+              {
+                "Ref": "EFSoptions"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "Parameters": {
+    "ComputeSecurityGroup": {
+      "Description": "SecurityGroup for Mount Target",
+      "Type": "String"
+    },
+    "EFSoptions": {
+      "Description": "Comma separated list of efs related options, 8 parameters in total",
+      "Type": "CommaDelimitedList"
+    },
+    "SubnetId": {
+      "Description": "SubnetId for Mount Target",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "EFSFS": {
+      "Condition": "CreateEFS",
+      "Properties": {
+        "Encrypted": {
+          "Fn::If": [
+            "UseEFSEncryption",
+            {
+              "Fn::Select": [
+                "5",
+                {
+                  "Ref": "EFSoptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "KmsKeyId": {
+          "Fn::If": [
+            "UseEFSKMSKey",
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "EFSoptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "PerformanceMode": {
+          "Fn::If": [
+            "UsePerformanceMode",
+            {
+              "Fn::Select": [
+                "2",
+                {
+                  "Ref": "EFSoptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "ProvisionedThroughputInMibps": {
+          "Fn::If": [
+            "UseProvisionedThroughput",
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "EFSoptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "ThroughputMode": {
+          "Fn::If": [
+            "UseThroughputMode",
+            {
+              "Fn::Select": [
+                "6",
+                {
+                  "Ref": "EFSoptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::EFS::FileSystem"
+    },
+    "EFSMT": {
+      "Condition": "CreateMT",
+      "Properties": {
+        "FileSystemId": {
+          "Fn::If": [
+            "CreateEFS",
+            {
+              "Ref": "EFSFS"
+            },
+            {
+              "Fn::Select": [
+                "1",
+                {
+                  "Ref": "EFSoptions"
+                }
+              ]
+            }
+          ]
+        },
+        "SecurityGroups": [
+          {
+            "Ref": "ComputeSecurityGroup"
+          }
+        ],
+        "SubnetId": {
+          "Ref": "SubnetId"
+        }
+      },
+      "Type": "AWS::EFS::MountTarget"
+    }
+  }
+}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -450,6 +450,14 @@ See :ref:`Scaling Section <scaling_section>`. ::
 
     scaling_settings = custom
 
+efs_settings
+""""""""""""
+Settings section relating to EFS filesystem
+
+See :ref:`EFS Section <efs_section>`. ::
+
+    efs_settings = customfs
+
 tags
 """"
 Defines tags to be used in CloudFormation.
@@ -702,3 +710,78 @@ minutes. ::
     url
     vcpus
     vpc
+
+.. _efs_section:
+
+EFS
+^^^
+EFS file system configuration settings for the EFS mounted on the master node and compute nodes via nfs4. ::
+
+
+    [efs customfs]
+    shared_dir = efs
+    encrypted = false
+    performance_mode = generalPurpose
+
+shared_dir
+""""""""""
+Shared directory that the file system will be mounted to on the master and compute nodes.
+
+This parameter is REQUIRED, the EFS section will only be used if this parameter is specified.
+The below example mounts to /efs. Do not use NONE or /NONE as the shared directory.::
+
+    shared_dir = efs
+
+encrypted
+"""""""""
+Whether or not the file system will be encrypted.
+
+Defaults to false. ::
+
+    encrypted = false
+
+performance_mode
+""""""""""""""""
+Performance Mode of the file system. We recommend generalPurpose performance mode for most file systems.
+File systems using the maxIO performance mode can scale to higher levels of aggregate throughput
+and operations per second with a trade-off of slightly higher latencies for most file operations.
+This can't be changed after the file system has been created.
+
+Defaults generalPurpose. Valid Values are generalPurpose | maxIO (case sensitive). ::
+
+    performance_mode = generalPurpose
+
+throughput_mode
+"""""""""""""""
+The throughput mode for the file system to be created.
+There are two throughput modes to choose from for your file system: bursting and provisioned.
+
+Valid Values are provisioned | bursting ::
+
+    throughput_mode = provisioned
+
+provisioned_throughput
+""""""""""""""""""""""
+The throughput, measured in MiB/s, that you want to provision for a file system that you're creating.
+The limit on throughput is 1024 MiB/s. You can get these limits increased by contacting AWS Support.
+
+Valid Range: Min of 0.0. To use this option, must specify throughput_mode to provisioned ::
+
+    provisioned_throughput = 1024
+
+efs_fs_id
+"""""""""
+File system ID for an existing file system. Specifying this option will void all other EFS options but shared_dir.
+Config sanity will only allow file systems that: have no mount target in the stack's availability zone
+OR have existing mount target in stack's availability zone with inbound and outbound NFS traffic allowed from 0.0.0.0/0.
+
+CAUTION: having mount target with inbound and outbound NFS traffic allowed from 0.0.0.0/0 will expose the file system
+to any NFS mounting request anywhere. We recommend not to have a mount target in stack's availability zone and let us
+create the mount target. If you must have a mount target in stack's availability zone, consider using a
+custom security group by providing a vpc_security_group_id option under the vpc section, adding that security group
+to the mount target, and turning off config sanity to create the cluster.
+
+Defaults to NONE. Needs to be an available EFS file system::
+
+    efs_fs_id = fs-1dsaf3
+

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -44,3 +44,10 @@ vCPUs
 workflow
 workflows
 xlarge
+efs
+nfs
+kms
+generalPurpose
+maxIO
+MiB
+fs

--- a/tests/config_efs
+++ b/tests/config_efs
@@ -1,0 +1,33 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = true
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+base_os = alinux
+key_name = id_rsa
+#scheduler = awsbatch
+initial_queue_size = 1
+vpc_settings = public
+efs_settings = fs
+#custom_awsbatch_template_url = 
+template_url = 
+custom_chef_cookbook = 
+
+[vpc public]
+vpc_id = 
+master_subnet_id = 
+
+[efs fs]
+shared_dir = efs
+#efs_fs_id =
+encrypted = true
+performance_mode = generalPurpose
+provisioned_throughput = 1024
+throughput_mode = provisioned
+
+
+

--- a/tests/efs-check.sh
+++ b/tests/efs-check.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+paths=${1}
+fs_id=${2}
+paths=$(echo ${paths} | tr "," " ")
+status=0
+
+pathCount=$(cat /etc/fstab | grep -E "$(echo ${paths} | tr " " "|")" | wc -l | xargs)
+fsGrep=$(cat /etc/fstab | grep -E "fs-" | wc -l | xargs)
+truePathCount=$(echo ${paths} | tr " " "\n"| wc -l |xargs)
+
+if [ ${pathCount} == ${truePathCount} ] && [ ${fsGrep} == ${truePathCount} ]; then
+    echo "found the file system"
+else
+    echo "error: file system not found"
+    exit 1
+fi
+
+if [[ ${fs_id} ]]; then
+    fsCount=$(cat /etc/fstab | grep -E "${fs_id}" | wc -l | xargs)
+    if [[ ${fsCount} == "0" ]]; then
+        echo "Error: the given ${fs_id} was not attached"
+        exit 1
+    else
+        echo "Success: the given ${fs_id} is attached"
+    fi
+fi
+
+computeIP=$(qhost | grep "ip-" | cut -d " " -f 1)
+
+for path in ${paths}
+do
+    touch ${path}/master_file
+    scp ${path}/master_file ${computeIP}:${path}/compute_file
+
+    computeCheck=$(ls ${path} | grep "compute_file")
+
+    if [[ ${computeCheck} ]]; then
+        echo "${path} is correctly mounted on compute"
+        rm ${path}/compute_file
+    else
+        echo "error: ${path} is not found on compute"
+        status=1
+    fi
+
+    rm ${path}/master_file
+done
+
+exit ${status}

--- a/tests/efs-test.py
+++ b/tests/efs-test.py
@@ -1,0 +1,621 @@
+import argparse
+import datetime
+import os
+import Queue
+import re
+import signal
+import subprocess as sub
+import sys
+import threading
+import time
+from builtins import exit
+
+import boto3
+import process_helper as prochelp
+
+UNSUPPORTED_REGIONS = set(["ap-northeast-3", "eu-west-3"])
+
+
+class ReleaseCheckException(Exception):
+    pass
+
+
+#
+# configuration
+#
+username_map = {
+    "alinux": "ec2-user",
+    "centos6": "centos",
+    "centos7": "centos",
+    "ubuntu1404": "ubuntu",
+    "ubuntu1604": "ubuntu",
+}
+efs_path = "/efs"
+
+#
+# global variables (sigh)
+#
+
+
+results_lock = threading.Lock()
+failure = 0
+success = 0
+
+# PID of the actual test process
+_child = 0
+# True if parent process has been asked to terminate
+_termination_caught = False
+
+_TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
+_timestamp = datetime.datetime.now().strftime(_TIMESTAMP_FORMAT)
+
+
+def prepare_testfiles(distro, vpc_id, subnets, key_name, region, extra_args):
+    rfile = open("./config_efs", "r").read().split("\n")
+    template_url = extra_args["templateURL"]
+    cookbook_url = extra_args["cookbookURL"]
+    batch_url = extra_args["batchTemplateURL"]
+    for index, line in enumerate(rfile):
+        r = re.search("aws_region_name", line)
+        if r:
+            rfile[index] = "aws_region_name = %s" % region
+        o = re.search("base_os", line)
+        if o:
+            rfile[index] = "base_os = %s" % distro
+        k = re.search("key_name", line)
+        if k:
+            rfile[index] = "key_name = %s" % key_name
+        v = re.search("vpc_id", line)
+        if v:
+            rfile[index] = "vpc_id = %s" % vpc_id
+        s = re.search("master_subnet_id", line)
+        if s:
+            rfile[index] = "master_subnet_id = %s" % subnets["a1"]
+        t = re.search("template_url", line)
+        if t:
+            if template_url:
+                rfile[index] = "template_url = %s" % template_url
+            else:
+                rfile[index] = "#template_url ="
+        c = re.search("custom_chef_cookbook", line)
+        if c:
+            if cookbook_url:
+                rfile[index] = "custom_chef_cookbook = %s" % cookbook_url
+            else:
+                rfile[index] = "#custom_chef_cookbook ="
+        b = re.search("custom_awsbatch_template_url", line)
+        if b:
+            if batch_url:
+                rfile[index] = "custom_awsbatch_template_url = %s" % batch_url
+            else:
+                rfile[index] = "#custom_awsbatch_template_url ="
+    wfile = open("./config-%s-%s" % (region, distro), "w")
+    wfile.write("\n".join(rfile))
+    wfile.close()
+
+
+def prepare_vpc(region):
+    vpcrelated = {}
+    ec2 = boto3.client("ec2", region_name=region)
+    response_vpc = ec2.create_vpc(CidrBlock="177.31.0.0/16")
+    vpcrelated["vpc_id"] = response_vpc["Vpc"]["VpcId"]
+
+    time.sleep(5)
+    ec2.modify_vpc_attribute(EnableDnsHostnames={"Value": True}, VpcId=vpcrelated["vpc_id"])
+
+    response_gateway = ec2.create_internet_gateway()
+    vpcrelated["gatewayId"] = response_gateway["InternetGateway"]["InternetGatewayId"]
+
+    ec2.attach_internet_gateway(InternetGatewayId=vpcrelated["gatewayId"], VpcId=vpcrelated["vpc_id"])
+
+    response_rt = ec2.create_route_table(VpcId=vpcrelated["vpc_id"])
+    vpcrelated["routetableId"] = response_rt["RouteTable"]["RouteTableId"]
+
+    ec2.create_route(
+        DestinationCidrBlock="0.0.0.0/0", RouteTableId=vpcrelated["routetableId"], GatewayId=vpcrelated["gatewayId"]
+    )
+
+    return vpcrelated
+
+
+def prepare_subnets(vpcrelated, region):
+    subnets = {}
+
+    ec2 = boto3.client("ec2", region_name=region)
+    response_a1 = ec2.create_subnet(
+        AvailabilityZone=region + "a", CidrBlock="177.31.0.0/25", VpcId=vpcrelated["vpc_id"]
+    )
+    subnets["a1"] = response_a1["Subnet"]["SubnetId"]
+
+    response_a2 = ec2.create_subnet(
+        AvailabilityZone=region + "a", CidrBlock="177.31.0.128/25", VpcId=vpcrelated["vpc_id"]
+    )
+    subnets["a2"] = response_a2["Subnet"]["SubnetId"]
+
+    response_b = ec2.create_subnet(
+        AvailabilityZone=region + "b", CidrBlock="177.31.16.0/20", VpcId=vpcrelated["vpc_id"]
+    )
+    subnets["b"] = response_b["Subnet"]["SubnetId"]
+
+    for key in subnets:
+        ec2.associate_route_table(RouteTableId=vpcrelated["routetableId"], SubnetId=subnets[key])
+        ec2.modify_subnet_attribute(MapPublicIpOnLaunch={"Value": True}, SubnetId=subnets[key])
+    return subnets
+
+
+def create_invalid_rules(group_id, sourceg, ec2):
+    # create invalid ingress rules
+    ec2.authorize_security_group_ingress(
+        GroupId=group_id, IpPermissions=[{"IpProtocol": "-1", "IpRanges": [{"CidrIp": "111.111.0.0/20"}]}]
+    )
+    ec2.authorize_security_group_ingress(
+        GroupId=group_id, IpPermissions=[{"IpProtocol": "-1", "UserIdGroupPairs": [{"GroupId": sourceg}]}]
+    )
+    # create invalid egress rules
+    ec2.authorize_security_group_egress(
+        GroupId=group_id,
+        IpPermissions=[
+            {"FromPort": 2049, "IpProtocol": "tcp", "IpRanges": [{"CidrIp": "111.111.0.0/20"}], "ToPort": 2049}
+        ],
+    )
+    ec2.authorize_security_group_egress(
+        GroupId=group_id, IpPermissions=[{"IpProtocol": "-1", "IpRanges": [{"CidrIp": "111.111.0.0/20"}]}]
+    )
+    ec2.authorize_security_group_egress(
+        GroupId=group_id, IpPermissions=[{"IpProtocol": "-1", "UserIdGroupPairs": [{"GroupId": sourceg}]}]
+    )
+
+
+def prepare_test_sg(vpc_id, region):
+    sg = {}
+    ec2 = boto3.client("ec2", region_name=region)
+    response_source = ec2.create_security_group(GroupName="sourceGroup", VpcId=vpc_id, Description="SourceGroup")
+    sg["sourceGroup"] = response_source["GroupId"]
+
+    response_bad = ec2.create_security_group(GroupName="badSG", VpcId=vpc_id, Description="No public NFS access")
+    sg["badSG"] = response_bad["GroupId"]
+
+    response_good = ec2.create_security_group(GroupName="goodSG", VpcId=vpc_id, Description="Public NFS access")
+    sg["goodSG"] = response_good["GroupId"]
+
+    ec2.authorize_security_group_ingress(
+        GroupId=sg["badSG"],
+        IpPermissions=[
+            {"FromPort": 2049, "IpProtocol": "tcp", "IpRanges": [{"CidrIp": "111.111.0.0/20"}], "ToPort": 2049}
+        ],
+    )
+    create_invalid_rules(sg["badSG"], sg["sourceGroup"], ec2)
+
+    create_invalid_rules(sg["goodSG"], sg["sourceGroup"], ec2)
+    # create Valid ingress rules
+    ec2.authorize_security_group_ingress(
+        GroupId=sg["goodSG"],
+        IpPermissions=[{"FromPort": 2049, "IpProtocol": "tcp", "IpRanges": [{"CidrIp": "0.0.0.0/0"}], "ToPort": 2049}],
+    )
+    # create Valid egress rules
+    ec2.authorize_security_group_egress(
+        GroupId=sg["goodSG"],
+        IpPermissions=[{"FromPort": 2049, "IpProtocol": "tcp", "IpRanges": [{"CidrIp": "0.0.0.0/0"}], "ToPort": 2049}],
+    )
+    return sg
+
+
+def prepare_test_fs(case, subnets, sg, distro, region):
+    fsrelated = {}
+    efs = boto3.client("efs", region_name=region)
+    response_fs = efs.create_file_system(CreationToken="OnlyEFS_%s_%s" % (region, distro))
+    fsrelated["fsid"] = response_fs["FileSystemId"]
+    while True:
+        response_fs_state = efs.describe_file_systems(FileSystemId=fsrelated["fsid"])
+        life_cycle = response_fs_state["FileSystems"][0]["LifeCycleState"]
+        if life_cycle == "available":
+            print("FS is good to go!")
+            break
+        time.sleep(5)
+    if case == "createMT":
+        response_mt = efs.create_mount_target(
+            FileSystemId=fsrelated["fsid"], SubnetId=subnets["b"], SecurityGroups=[sg["badSG"]]
+        )
+
+    elif case == "useGoodMT":
+        response_mt = efs.create_mount_target(
+            FileSystemId=fsrelated["fsid"], SubnetId=subnets["a2"], SecurityGroups=[sg["badSG"], sg["goodSG"]]
+        )
+    else:
+        response_mt = efs.create_mount_target(
+            FileSystemId=fsrelated["fsid"], SubnetId=subnets["a2"], SecurityGroups=[sg["badSG"]]
+        )
+    fsrelated["mtid"] = response_mt["MountTargetId"]
+    while True:
+        response_mt_state = efs.describe_mount_targets(MountTargetId=fsrelated["mtid"])
+        life_cycle = response_mt_state["MountTargets"][0]["LifeCycleState"]
+        if life_cycle == "available":
+            print("MT is good to go!")
+            break
+        time.sleep(5)
+    time.sleep(5)
+    return fsrelated
+
+
+def clean_up_fs(fsrelated, region):
+    try:
+        efs = boto3.client("efs", region_name=region)
+        efs.delete_mount_target(MountTargetId=fsrelated["mtid"])
+        while True:
+            # This should return an exception because the mount target id should be not found at this point
+            response_mt_state = efs.describe_mount_targets(MountTargetId=fsrelated["mtid"])
+            life_cycle = response_mt_state["MountTargets"][0]["LifeCycleState"]
+            if life_cycle != "deleted":
+                print("Delete MT failed!")
+                break
+            time.sleep(5)
+    except Exception as e:
+        print("MT successfully deleted!")
+        pass
+    try:
+        efs.delete_file_system(FileSystemId=fsrelated["fsid"])
+        while True:
+            # This should return an exception because the file system id should be not found at this point
+            response_fs_state = efs.describe_file_systems(FileSystemId=fsrelated["fsid"])
+            life_cycle = response_fs_state["FileSystems"][0]["LifeCycleState"]
+            if life_cycle == "deleted":
+                print("Delete FS failed!")
+                break
+            time.sleep(5)
+    except Exception as e:
+        print("FS successfully deleted!")
+        pass
+
+
+def clean_up_testfiles(distro, region):
+    os.remove("./config-%s-%s" % (region, distro))
+
+
+def _dirname():
+    return os.path.dirname(os.path.realpath(sys.argv[0]))
+
+
+def _time():
+    return datetime.datetime.now()
+
+
+def _double_writeln(fileo, message):
+    print(message)
+    fileo.write(message + "\n")
+
+
+def run_test(distro, case, subnets, sg, region):
+    testname = "%s-%s-%s" % (region, distro, case)
+    out_f = open("%s-out.txt" % testname, "w")
+    username = username_map[distro]
+    _create_done = False
+    _create_interrupted = False
+
+    fsrelated = {}
+    try:
+        if case == "createAll":
+            rfile = open("./config-%s-%s" % (region, distro), "r").read().split("\n")
+            for index, line in enumerate(rfile):
+                m = re.search("efs_fs_id", line)
+                if m:
+                    rfile[index] = "#efs_fs_id = "
+
+            wfile = open("./config-%s-%s" % (region, distro), "w")
+            wfile.write("\n".join(rfile))
+            wfile.close()
+        else:
+            fsrelated = prepare_test_fs(case, subnets, sg, distro, region)
+            rfile = open("./config-%s-%s" % (region, distro), "r").read().split("\n")
+            for index, line in enumerate(rfile):
+                m = re.search("efs_fs_id", line)
+                if m:
+                    rfile[index] = "efs_fs_id = %s" % fsrelated["fsid"]
+
+            wfile = open("./config-%s-%s" % (region, distro), "w")
+            wfile.write("\n".join(rfile))
+            wfile.close()
+
+        print("Creating cluster...")
+        prochelp.exec_command(
+            ["pcluster", "create", "autoTest-%s" % testname, "--config", "./config-%s-%s" % (region, distro)],
+            stdout=out_f,
+            stderr=sub.STDOUT,
+            universal_newlines=True,
+        )
+        _create_done = True
+        dump = prochelp.exec_command(
+            ["pcluster", "status", "autoTest-%s" % testname, "--config", "./config-%s-%s" % (region, distro)],
+            stderr=sub.STDOUT,
+            universal_newlines=True,
+        )
+        dump_array = dump.splitlines()
+        master_ip = ""
+        for line in dump_array:
+            m = re.search("MasterPublicIP: (.+)$", line)
+            if m:
+                master_ip = m.group(1)
+                break
+        if master_ip == "":
+            _double_writeln(out_f, "!! %s: Master IP not found; exiting !!" % testname)
+            raise ReleaseCheckException("--> %s: Master IP not found!" % testname)
+        _double_writeln(out_f, "--> %s Master IP: %s" % (testname, master_ip))
+
+        time.sleep(10)
+
+        # run test on the cluster...
+        ssh_params = ["-o", "StrictHostKeyChecking=no"]
+        ssh_params += ["-o", "BatchMode=yes"]
+        ssh_params += ["-o", "ConnectTimeout=60"]
+        ssh_params += ["-o", "ServerAliveCountMax=5"]
+        ssh_params += ["-o", "ServerAliveInterval=30"]
+
+        prochelp.exec_command(
+            ["scp"] + ssh_params + [os.path.join(_dirname(), "efs-check.sh"), "%s@%s:." % (username, master_ip)],
+            stdout=out_f,
+            stderr=sub.STDOUT,
+            universal_newlines=True,
+        )
+
+        time.sleep(5)
+
+        if case == "createAll":
+            prochelp.exec_command(
+                ["ssh", "-n"]
+                + ssh_params
+                + ["%s@%s" % (username, master_ip), "/bin/bash --login efs-check.sh %s" % efs_path],
+                stdout=out_f,
+                stderr=sub.STDOUT,
+                universal_newlines=True,
+            )
+        else:
+            prochelp.exec_command(
+                ["ssh", "-n"]
+                + ssh_params
+                + [
+                    "%s@%s" % (username, master_ip),
+                    "/bin/bash --login efs-check.sh %s %s" % (efs_path, fsrelated["fsid"]),
+                ],
+                stdout=out_f,
+                stderr=sub.STDOUT,
+                universal_newlines=True,
+            )
+        print("Test passed!!")
+    except prochelp.ProcessHelperError as exc:
+        if not _create_done and isinstance(exc, prochelp.KilledProcessError):
+            _create_interrupted = True
+            _double_writeln(out_f, "--> %s: Interrupting pcluster create!" % testname)
+        _double_writeln(out_f, "!! ABORTED: %s!!" % testname)
+        open("%s.aborted" % testname, "w").close()
+        raise exc
+    except Exception as exc:
+        if not _create_done:
+            _create_interrupted = True
+        _double_writeln(out_f, "Unexpected exception %s: %s" % (str(type(exc)), str(exc)))
+        _double_writeln(out_f, "!! FAILURE: %s!!" % testname)
+        open("%s.failed" % testname, "w").close()
+        raise exc
+
+    finally:
+        if _create_interrupted or _create_done:
+            # if the create process was interrupted it may take few seconds for the stack id to be actually registered
+            _max_del_iters = _del_iters = 10
+        else:
+            # No delete is necessary if cluster creation wasn't started (process_helper.AbortedProcessError)
+            _del_iters = 0
+        if _del_iters > 0:
+            _del_done = False
+            _double_writeln(out_f, "--> %s: Deleting - max iterations: %s" % (testname, _del_iters))
+            while not _del_done and _del_iters > 0:
+                try:
+                    time.sleep(2)
+                    # clean up the cluster
+                    _del_output = sub.check_output(
+                        [
+                            "pcluster",
+                            "delete",
+                            "autoTest-%s" % testname,
+                            "--config",
+                            "./config-%s-%s" % (region, distro),
+                        ],
+                        stderr=sub.STDOUT,
+                        universal_newlines=True,
+                    )
+                    _del_done = "DELETE_IN_PROGRESS" in _del_output or "DELETE_COMPLETE" in _del_output
+                    out_f.write(_del_output + "\n")
+                except sub.CalledProcessError as exc:
+                    out_f.write(
+                        "CalledProcessError exception launching 'pcluster delete': %s - Output:\n%s\n"
+                        % (str(exc), exc.output)
+                    )
+                except Exception as exc:
+                    out_f.write(
+                        "Unexpected exception launching 'pcluster delete' %s: %s\n" % (str(type(exc)), str(exc))
+                    )
+                finally:
+                    _double_writeln(
+                        out_f,
+                        "--> %s: Deleting - iteration: %s - successfully submitted: %s"
+                        % (testname, (_max_del_iters - _del_iters + 1), _del_done),
+                    )
+                    _del_iters -= 1
+
+            try:
+                prochelp.exec_command(
+                    ["pcluster", "status", "autoTest-%s" % testname, "--config", "./config-%s-%s" % (region, distro)],
+                    stdout=out_f,
+                    stderr=sub.STDOUT,
+                    universal_newlines=True,
+                )
+            except (prochelp.ProcessHelperError, sub.CalledProcessError):
+                # Should terminates with exit status 1 since at the end of the delete operation the stack is not found.
+                pass
+            except Exception as exc:
+                out_f.write("Unexpected exception launching 'pcluster status' %s: %s\n" % (str(type(exc)), str(exc)))
+        if fsrelated:
+            clean_up_fs(fsrelated, region)
+        out_f.close()
+    print("--> %s: Finished" % testname)
+
+
+def _killme_gently():
+    os.kill(os.getpid(), signal.SIGTERM)
+
+
+def _proc_alive(pid):
+    if pid <= 1:
+        return False
+    alive = False
+    try:
+        # No real signal is sent but error checking is performed
+        os.kill(pid, 0)
+        alive = True
+    except OSError as ose:
+        pass
+    except Exception as exc:
+        print("Unexpected exception checking process %s, %s: %s" % (pid, str(type(exc)), str(exc)))
+
+    return alive
+
+
+def test_runner(q, subnets, sgs, region):
+    global failure
+    global success
+    global results_lock
+
+    while True:
+        item = q.get()
+
+        retval = 1
+        try:
+            if not prochelp.termination_caught():
+                run_test(distro=item["distro"], case=item["case"], subnets=subnets, sg=sgs, region=region)
+                retval = 0
+        except (prochelp.ProcessHelperError, sub.CalledProcessError):
+            pass
+        except Exception as exc:
+            print("[test_runner] Unexpected exception %s: %s\n" % (str(type(exc)), str(exc)))
+            retval = 1
+            pass
+
+        results_lock.acquire(True)
+        if retval == 0:
+            success += 1
+        else:
+            failure += 1
+        results_lock.release()
+        q.task_done()
+
+
+def clean_up_resources(vpcrelated, subnets, sg, region):
+    ec2 = boto3.client("ec2", region_name=region)
+    try:
+        for key in sg:
+            ec2.delete_security_group(GroupId=sg[key])
+        for key in subnets:
+            ec2.delete_subnet(SubnetId=subnets[key])
+        ec2.delete_route_table(RouteTableId=vpcrelated["routetableId"])
+        ec2.detach_internet_gateway(InternetGatewayId=vpcrelated["gatewayId"], VpcId=vpcrelated["vpc_id"])
+        ec2.delete_internet_gateway(InternetGatewayId=vpcrelated["gatewayId"])
+        ec2.delete_vpc(VpcId=vpcrelated["vpc_id"])
+    except Exception as exc:
+        pass
+
+
+def get_all_aws_regions():
+    ec2 = boto3.client("ec2")
+    return set(sorted(r.get("RegionName") for r in ec2.describe_regions().get("Regions"))) - UNSUPPORTED_REGIONS
+
+
+def main(args):
+    global failure
+    global success
+
+    for region in args.regions:
+        print("Starting work for region %s" % region)
+        vpcrelated = prepare_vpc(region)
+        subnets = prepare_subnets(vpcrelated, region)
+        sgs = prepare_test_sg(vpcrelated["vpc_id"], region)
+        parent = os.getppid()
+        num_parallel = args.numparallel if args.numparallel else 1
+        extra_args = {
+            "templateURL": args.templateURL,
+            "cookbookURL": args.cookbookURL,
+            "batchTemplateURL": args.batchTemplateURL,
+        }
+
+        case_list = ["useBadMT", "createAll", "createMT", "useGoodMT"]
+        distro_list = args.distros if args.distros else ["alinux", "centos6", "centos7", "ubuntu1404", "ubuntu1604"]
+
+        work_queues = {}
+        for distro in distro_list:
+            if args.keyname:
+                prepare_testfiles(distro, vpcrelated["vpc_id"], subnets, args.keyname, region, extra_args)
+            else:
+                prepare_testfiles(distro, vpcrelated["vpc_id"], subnets, "id_rsa", region, extra_args)
+            work_queues[distro] = Queue.Queue()
+            for case in case_list:
+                work_item = {"distro": distro, "case": case}
+                work_queues[distro].put(work_item)
+
+        for distro in distro_list:
+            for i in range(num_parallel):
+                t = threading.Thread(target=test_runner, args=(work_queues[distro], subnets, sgs, region))
+                t.daemon = True
+                t.start()
+
+        all_finished = False
+        self_killed = False
+        while not all_finished:
+            time.sleep(1)
+            all_finished = True
+            for queue in work_queues.values():
+                all_finished = all_finished and queue.unfinished_tasks == 0
+            # In the case parent process was SIGKILL-ed
+            if not _proc_alive(parent) and not self_killed:
+                print("Parent process with pid %s died - terminating..." % parent)
+                _killme_gently()
+                self_killed = True
+
+        print("%s - Regions workers queues all done: %s" % (_time(), all_finished))
+
+        for distro in distro_list:
+            clean_up_testfiles(distro, region)
+        # print status...
+        clean_up_resources(vpcrelated, subnets, sgs, region)
+
+    print(
+        "%s success %s failure, expected %s success and %s failure"
+        % (success, failure, 3 * len(args.distros) * len(args.regions), len(args.distros) * len(args.regions))
+    )
+    if failure != len(args.distros) * len(args.regions) or success != 3 * len(args.distros) * len(args.regions):
+        exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Take in test related parameters")
+    parser.add_argument("--keyname", type=str, help="Keyname, default is id_rsa", required=False)
+    parser.add_argument(
+        "--regions", type=str, help="Comma separated list of regions to test, defaults to all", required=False
+    )
+    parser.add_argument(
+        "--distros", type=str, help="Comma separated list of distributions to test, defaults to all", required=False
+    )
+    parser.add_argument("--templateURL", type=str, help="Custom template URL", required=False)
+    parser.add_argument("--cookbookURL", type=str, help="Custom cookbook URL", required=False)
+    parser.add_argument("--batchTemplateURL", type=str, help="Custom batch substack template URL", required=False)
+    parser.add_argument(
+        "--numparallel",
+        type=int,
+        help="number of threads to run in parallel per distribution, " "total number of threads will be 5*numparallel",
+        required=False,
+    )
+    args = parser.parse_args()
+    if not args.regions:
+        args.regions = get_all_aws_regions()
+    else:
+        args.regions = args.regions.split(",")
+
+    if args.distros:
+        args.distros = args.distros.split(",")
+
+    main(args)

--- a/util/generate-efs-substack.py
+++ b/util/generate-efs-substack.py
@@ -1,0 +1,79 @@
+from troposphere import And, Condition, Equals, If, Not, NoValue, Output, Parameter, Ref, Select, Template
+from troposphere.efs import FileSystem, MountTarget
+
+
+def main():
+    t = Template()
+
+    # [0 shared_dir, 1 efs_fs_id, 2 performance_mode, 3 efs_kms_key_id,
+    # 4 provisioned_throughput, 5 encrypted, 6 throughput_mode, 7 exists_valid_mt]
+    efs_options = t.add_parameter(
+        Parameter(
+            "EFSoptions",
+            Type="CommaDelimitedList",
+            Description="Comma separated list of efs related options, " "8 parameters in total",
+        )
+    )
+    compute_security_group = t.add_parameter(
+        Parameter("ComputeSecurityGroup", Type="String", Description="SecurityGroup for Mount Target")
+    )
+    subnet_id = t.add_parameter(Parameter("SubnetId", Type="String", Description="SubnetId for Mount Target"))
+    create_efs = t.add_condition(
+        "CreateEFS",
+        And(Not(Equals(Select(str(0), Ref(efs_options)), "NONE")), Equals(Select(str(1), Ref(efs_options)), "NONE")),
+    )
+    create_mt = t.add_condition(
+        "CreateMT",
+        And(Not(Equals(Select(str(0), Ref(efs_options)), "NONE")), Equals(Select(str(7), Ref(efs_options)), "NONE")),
+    )
+    use_performance_mode = t.add_condition("UsePerformanceMode", Not(Equals(Select(str(2), Ref(efs_options)), "NONE")))
+    use_efs_encryption = t.add_condition("UseEFSEncryption", Equals(Select(str(5), Ref(efs_options)), "true"))
+    use_efs_kms_key = t.add_condition(
+        "UseEFSKMSKey", And(Condition(use_efs_encryption), Not(Equals(Select(str(3), Ref(efs_options)), "NONE")))
+    )
+    use_throughput_mode = t.add_condition("UseThroughputMode", Not(Equals(Select(str(6), Ref(efs_options)), "NONE")))
+    use_provisioned = t.add_condition("UseProvisioned", Equals(Select(str(6), Ref(efs_options)), "provisioned"))
+    use_provisioned_throughput = t.add_condition(
+        "UseProvisionedThroughput",
+        And(Condition(use_provisioned), Not(Equals(Select(str(4), Ref(efs_options)), "NONE"))),
+    )
+
+    fs = t.add_resource(
+        FileSystem(
+            "EFSFS",
+            PerformanceMode=If(use_performance_mode, Select(str(2), Ref(efs_options)), NoValue),
+            ProvisionedThroughputInMibps=If(use_provisioned_throughput, Select(str(4), Ref(efs_options)), NoValue),
+            ThroughputMode=If(use_throughput_mode, Select(str(6), Ref(efs_options)), NoValue),
+            Encrypted=If(use_efs_encryption, Select(str(5), Ref(efs_options)), NoValue),
+            KmsKeyId=If(use_efs_kms_key, Select(str(3), Ref(efs_options)), NoValue),
+            Condition=create_efs,
+        )
+    )
+
+    mt = t.add_resource(
+        MountTarget(
+            "EFSMT",
+            FileSystemId=If(create_efs, Ref(fs), Select(str(1), Ref(efs_options))),
+            SecurityGroups=[Ref(compute_security_group)],
+            SubnetId=Ref(subnet_id),
+            Condition=create_mt,
+        )
+    )
+
+    t.add_output(
+        Output(
+            "FileSystemId",
+            Description="ID of the FileSystem",
+            Value=If(create_efs, Ref(fs), Select("1", Ref(efs_options))),
+        )
+    )
+
+    # Specify output file path
+    json_file_path = "TargetPath"
+    output_file = open(json_file_path, "w")
+    output_file.write(t.to_json())
+    output_file.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tested on all 5 distribution in us-east-2. AWS Batch support is manually tested.

If merged, the following changes will be made:
- Modified cfnconfig.py to take in EFS related parameters, and combines into a single comma separated list to be used in cloud formation template
- Modified config_sanity.py to check if the provided EFS file system id is valid and the mount targets are good for mounting
- Modified cfncluster.cfn.json to incorporate new EFS substack
- Created generate-efs-substack.py, which generates EFS substack template using troposphere
- Created efs-substack.cfn.json, the EFS substack templated generated with generate-efs-substack.py. Currently supports 1 EFS file system, and creates file system and mount target for FS depending on the given EFS inputs
- Created efs-test.py, efs-check.sh, tests/config for EFS automated tests, which tests the 4 cases of: creating file system and mount target, use existing FS and create a new MT, use existing FS and its valid MT, trying to mount existing FS with an invalid MT
- Modified configuration.rst and examples/config to reflect the EFS related changes

Signed-off-by: Rex Chen <shuningc@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
