### PR TITLE
Support choosing the instance type

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -222,6 +222,8 @@ def main():
                            "Valid values are alinux, ubuntu1404, ubuntu1604, centos6 or centos7")
     pami.add_argument("--ami-name-prefix", "-ap", type=str, dest="custom_ami_name_prefix", default='custom-ami-',
                       help="specify the prefix name of the resulting AWS ParallelCluster AMI")
+    pami.add_argument("--instance-type", "-it", type=str, dest="instance_type", default='t2.large',
+                      help="Specify the instance type on which to build the ami. Defaults to t2.large.")
     pami.add_argument("--custom-cookbook", "-cc", type=str, dest="custom_ami_cookbook", default=None,
                       help="specify the cookbook to use to build the AWS ParallelCluster AMI")
     _addarg_config(pami)

--- a/cli/pcluster/pcluster.py
+++ b/cli/pcluster/pcluster.py
@@ -750,7 +750,6 @@ def create_ami(args):
     logger.debug('Building AMI based on args %s' % str(args))
     results = {}
 
-    instance_type = 't2.large'
     try:
         config = cfnconfig.ParallelClusterConfig(args)
 
@@ -758,7 +757,7 @@ def create_ami(args):
         master_subnet_id = config.parameters.get('MasterSubnetId')
 
         packer_env = {'CUSTOM_AMI_ID': args.base_ami_id,
-                      'AWS_FLAVOR_ID': instance_type,
+                      'AWS_FLAVOR_ID': args.instance_type,
                       'AMI_NAME_PREFIX': args.custom_ami_name_prefix,
                       'AWS_VPC_ID': vpc_id,
                       'AWS_SUBNET_ID': master_subnet_id}
@@ -775,7 +774,7 @@ def create_ami(args):
 
         logger.info('Base AMI ID: %s' % args.base_ami_id)
         logger.info('Base AMI OS: %s' % args.base_ami_os)
-        logger.info('Instance Type: %s' % instance_type)
+        logger.info('Instance Type: %s' % args.instance_type)
         logger.info('Region: %s' % config.region)
         logger.info('VPC ID: %s' % vpc_id)
         logger.info('Subnet ID: %s' % master_subnet_id)

--- a/docs/source/ami_customization.rst
+++ b/docs/source/ami_customization.rst
@@ -75,7 +75,7 @@ The command executes Packer, which does the following steps:
 
 To create your cluster enter the AMI id in the :ref:`custom_ami_section` field within your cluster configuration.
 
-.. note:: The instance type to build a custom AWS ParallelCluster AMI is a t2.xlarge and does not qualify for the AWS free tier. You are charged for any instances created when building this AMI.
+.. note:: The instance type to build a custom AWS ParallelCluster AMI is a t2.large and does not qualify for the AWS free tier. You are charged for any instances created when building this AMI.
 
 Use a Custom AMI at runtime
 ---------------------------


### PR DESCRIPTION
For certain device drivers such as cuda, you need an instance with that device. This adds a parameter that allows the customer to specify an instance type. Defaults to t2.large.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
