### PR TITLE
Fix link to Getting Started Guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ You can view the running compute hosts:
 
 For more information on any of these steps see the `Getting Started Guide`_.
 
-.. _`Getting Started Guide`: https://aws-parallelcluster.readthedocs.io/en/latest/getting_started.html
+.. _`Getting Started Guide`: https://aws-parallelcluster.readthedocs.io/en/latest/source/getting_started.html
 
 Documentation
 -------------
@@ -93,7 +93,7 @@ Documentation
 Documentation is part of the project and is published to -
 https://aws-parallelcluster.readthedocs.io/. Of most interest to new users is
 the Getting Started Guide -
-https://aws-parallelcluster.readthedocs.io/en/latest/getting_started.html.
+https://aws-parallelcluster.readthedocs.io/en/latest/source/getting_started.html.
 
 Issues
 ------


### PR DESCRIPTION
*Description of changes:*
It looks like the Getting Started Guide link was broken, so I fixed it based on the links from the docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
