### PR TITLE
Make stop use correct cluster section

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -212,8 +212,8 @@ class ParallelClusterConfig(object):
             self.aws_secret_access_key=None
 
         # Determine which cluster template will be used
-        if __args_func == 'start':
-            # Starting a cluster is unique in that we would want to prevent the
+        if __args_func in ['start', 'stop']:
+            # Starting and stopping a cluster is unique in that we would want to prevent the
             # customer from inadvertently using a different template than what
             # the cluster was created with, so we do not support the -t
             # parameter. We always get the template to use from CloudFormation.


### PR DESCRIPTION
With the addition of awsbatch, stop needs to know the scheduler type in order to decide if it's stopping a compute environment or ASG.

If the customer sets their default cluster to `scheduler = awsbatch` on a cluster with a traditional scheduler then runs `pcluster stop`, it'll attempt to disable a non-existent compute environment and error out.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
