### PR TITLE
Get config section before listing instances

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -212,7 +212,7 @@ class ParallelClusterConfig(object):
             self.aws_secret_access_key=None
 
         # Determine which cluster template will be used
-        if __args_func in ['start', 'stop']:
+        if __args_func in ['start', 'stop', 'instances']:
             # Starting and stopping a cluster is unique in that we would want to prevent the
             # customer from inadvertently using a different template than what
             # the cluster was created with, so we do not support the -t


### PR DESCRIPTION
### before
```
$ pcluster instances sge
MasterServer         i-08a78d2f9f3f8c886
Run 'awsbhosts --cluster sge2' to list the compute instances
```
### after
```
$ pcluster instances sge
MasterServer         i-08a78d2f9f3f8c886
ComputeFleet         i-05b2385e79442afe4
ComputeFleet         i-0cf246779ab22fdc5
```
Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
