### PR TITLE
Changes to support RAID

### DIFF
--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -387,6 +387,29 @@ def check_resource(  # noqa: C901 FIXME!!!
                     "the 'provisioned_throughput' option must be specified"
                 )
                 sys.exit(1)
+    # RAID EBS IOPS
+    elif resource_type == "RAIDIOPS":
+        raid_iops = float(resource_value[0])
+        raid_vol_size = float(resource_value[1])
+        if raid_iops > raid_vol_size * 50:
+            print(
+                "Config sanity error: IOPS to volume size ratio of %s is too high; maximum is 50."
+                % (raid_iops / raid_vol_size)
+            )
+            sys.exit(1)
+    # RAID Array Type
+    elif resource_type == "RAIDType":
+        if resource_value != "0" and resource_value != "1":
+            print("Config sanity error: invalid raid_type, only RAID 0 and RAID 1 are currently supported.")
+            sys.exit(1)
+    # Number of RAID Volumes Requested
+    elif resource_type == "RAIDNumVol":
+        if int(resource_value) > 5 or int(resource_value) < 2:
+            print(
+                "Config sanity error: invalid num_of_raid_volumes. "
+                "Needs min of 2 volumes for RAID and max of 5 EBS volumes are currently supported."
+            )
+            sys.exit(1)
     # Batch Parameters
     elif resource_type == "AWSBatch_Parameters":
         # Check region

--- a/cli/pcluster/examples/config
+++ b/cli/pcluster/examples/config
@@ -125,8 +125,10 @@ vpc_settings = public
 #ebs_settings = custom1, custom2, ...
 # Settings section relation to scaling
 #scaling_settings = custom
-# Settings section relation to EFS file system
+# Settings section relating to EFS file system
 #efs_settings = customfs
+# Settings section relating to RAID drive
+#raid_settings = rs
 
 ## VPC Settings
 [vpc public]
@@ -221,3 +223,24 @@ master_subnet_id = subnet-
 # Requires the given file system to: not have a mount target in the stack's availability zone OR have a mount target with inbound and outbound permissions for NFS traffic from 0.0.0.0/0
 # (defaults to NONE)
 #efs_fs_id = fs-12faea3
+
+## RAID Settings
+#[raid rs]
+# Shared directory for the RAID drive. REQUIRED if using RAID drive.  Below example mounts to /raid
+#shared_dir = raid
+# RAID type for the drive. REQUIRED if using RAID drive. Allowed values are 0 and 1.
+#raid_type = 1
+# Number of EBS volumes to use with RAID, min of 2 and max of 5
+# (defaults to 2)
+#num_of_raid_volumes = 4
+# Type of volume for the RAID volumes
+# (defaults to gp2)
+#volume_type = io1
+# Size of volumes to be created
+# (defaults to 20GB)
+#volume_size = 20
+# Number of IOPS for io1 type volumes
+#volume_iops = 500
+# Use encrypted volume
+# (defaults to false)
+#encrypted = false

--- a/cli/pcluster/resources/batch/docker/scripts/entrypoint.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/entrypoint.sh
@@ -39,6 +39,11 @@ if [[ "${PCLUSTER_EFS_FS_ID}" != "NONE" ]] && [[ ! -z "${PCLUSTER_AWS_REGION}" ]
   /parallelcluster/bin/mount_efs.sh "${PCLUSTER_EFS_FS_ID}" "${PCLUSTER_AWS_REGION}" "${PCLUSTER_EFS_SHARED_DIR}"
 fi
 
+# mount RAID via nfs
+if [[ ${PCLUSTER_RAID_SHARED_DIR} != "NONE" ]]; then
+  /parallelcluster/bin/mount_nfs.sh "${_master_ip}" "${PCLUSTER_RAID_SHARED_DIR}"
+fi
+
 # create hostfile if mnp job
 if [ -n "${AWS_BATCH_JOB_NUM_NODES}" ]; then
   /parallelcluster/bin/generate_hostfile.sh "${first_ebs_shared_dir}" "${HOME}"

--- a/cli/tests/config
+++ b/cli/tests/config
@@ -1,0 +1,16 @@
+[aws]
+aws_region_name = us-east-1
+
+[cluster default]
+vpc_settings = public
+key_name = test
+
+[vpc public]
+master_subnet_id = subnet-5eb7e481
+vpc_id = vpc-d4fc4ad0
+
+[global]
+update_check = true
+sanity_check = true
+cluster_template = default
+

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -578,6 +578,12 @@
       "Type": "String",
       "Default": "NONE"
     },
+    "RAIDOptions": {
+      "Description": "Comma Separated List of RAID options",
+      "Type": "String",
+      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+      "AllowedPattern": "^(NONE|.+)(,|, )(NONE|\\d)(,|, )(NONE|\\d)(,|, )(NONE|standard|io1|gp2|st1|sc1)(,|, )(NONE|\\d+)(,|, )(NONE|\\d+)(,|, )(NONE|true|false)(,|, )(NONE|.+)$"
+    },
     "NumberOfEBSVol": {
       "Description": "Number of EBS Volumes the user requested, up to 5",
       "Type": "Number",
@@ -608,6 +614,28 @@
               ]
             },
             "NONE"
+          ]
+        }
+      ]
+    },
+    "CreateRAIDSubstack": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            "NONE",
+            {
+              "Fn::Select": [
+                "0",
+                {
+                  "Fn::Split": [
+                    ",",
+                    {
+                      "Ref": "RAIDOptions"
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
@@ -2149,6 +2177,26 @@
                     "stack_name": {
                       "Ref": "AWS::StackName"
                     },
+                    "cfn_raid_vol_ids": {
+                      "Fn::If": [
+                        "CreateRAIDSubstack",
+                        {
+                          "Fn::GetAtt": [
+                            "RAIDSubstack",
+                            "Outputs.Volumeids"
+                          ]
+                        },
+                        {
+                          "Ref": "AWS::NoValue"
+                        }
+                      ]
+                    },
+                    "cfn_raid_parameters": {
+                      "Ref": "RAIDOptions"
+                    },
+                    "cfn_base_os": {
+                      "Ref": "BaseOS"
+                    },
                     "cfn_preinstall": {
                       "Ref": "PreInstallScript"
                     },
@@ -2896,6 +2944,9 @@
                     "stack_name": {
                       "Ref": "AWS::StackName"
                     },
+                    "cfn_raid_parameters": {
+                      "Ref": "RAIDOptions"
+                    },
                     "cfn_preinstall": {
                       "Ref": "PreInstallScript"
                     },
@@ -3552,6 +3603,9 @@
                     "stack_name": {
                       "Ref": "AWS::StackName"
                     },
+                    "cfn_raid_parameters": {
+                      "Ref": "RAIDOptions"
+                    },
                     "cfn_preinstall": {
                       "Ref": "PreInstallScript"
                     },
@@ -4058,6 +4112,19 @@
           },
           "SharedDir": {
             "Ref": "SharedDir"
+          },
+          "RAIDSharedDir": {
+            "Fn::Select": [
+              "0",
+              {
+                "Fn::Split": [
+                  ",",
+                  {
+                    "Ref": "RAIDOptions"
+                  }
+                ]
+              }
+            ]
           }
         },
         "TemplateURL": {
@@ -4224,6 +4291,43 @@
         "RetentionInDays": 1
       },
       "Condition": "HasResourcesS3Bucket"
+    },
+    "RAIDSubstack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "Parameters": {
+          "RAIDOptions": {
+            "Ref": "RAIDOptions"
+          },
+          "AvailabilityZone": {
+            "Ref": "AvailabilityZone"
+          }
+        },
+        "TemplateURL": {
+          "Fn::Sub": [
+            "https://${s3_domain}/${AWS::Region}-aws-parallelcluster/templates/raid-substack-${version}.cfn.json",
+            {
+              "s3_domain": {
+                "Fn::If": [
+                  "GovCloudRegion",
+                  {
+                    "Fn::Sub": "s3-${AWS::Region}.amazonaws.com"
+                  },
+                  "s3.amazonaws.com"
+                ]
+              },
+              "version": {
+                "Fn::FindInMap": [
+                  "PackagesVersions",
+                  "default",
+                  "cfncluster"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "Condition": "CreateRAIDSubstack"
     },
     "EBSCfnStack": {
       "Type": "AWS::CloudFormation::Stack",

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -61,6 +61,10 @@
       "Description": "ID of EFS file system",
       "Type": "String",
       "Default": "NONE"
+    },
+    "RAIDSharedDir": {
+      "Description": "The path/mountpoint for the shared RAID drive",
+      "Type": "String"
     }
   },
   "Conditions": {
@@ -332,6 +336,12 @@
               "Value": {
                 "Ref": "EFSFSId"
               }
+            },
+            {
+              "Name": "PCLUSTER_RAID_SHARED_DIR",
+              "Value": {
+                "Ref": "RAIDSharedDir"
+              }
             }
           ]
         }
@@ -389,6 +399,12 @@
                     "Name": "PCLUSTER_EFS_FS_ID",
                     "Value": {
                       "Ref": "EFSFSId"
+                    }
+                  },
+                  {
+                    "Name": "PCLUSTER_RAID_SHARED_DIR",
+                    "Value": {
+                      "Ref": "RAIDSharedDir"
                     }
                   }
                 ]

--- a/cloudformation/raid-substack.cfn.json
+++ b/cloudformation/raid-substack.cfn.json
@@ -1,0 +1,1078 @@
+{
+  "Conditions": {
+    "UseVol1": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "0",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "UseVol2": {
+      "Fn::And": [
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "2",
+                    {
+                      "Ref": "RAIDOptions"
+                    }
+                  ]
+                },
+                "1"
+              ]
+            }
+          ]
+        },
+        {
+          "Condition": "UseVol1"
+        }
+      ]
+    },
+    "UseVol3": {
+      "Fn::And": [
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "2",
+                    {
+                      "Ref": "RAIDOptions"
+                    }
+                  ]
+                },
+                "2"
+              ]
+            }
+          ]
+        },
+        {
+          "Condition": "UseVol2"
+        }
+      ]
+    },
+    "UseVol4": {
+      "Fn::And": [
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "2",
+                    {
+                      "Ref": "RAIDOptions"
+                    }
+                  ]
+                },
+                "3"
+              ]
+            }
+          ]
+        },
+        {
+          "Condition": "UseVol3"
+        }
+      ]
+    },
+    "UseVol5": {
+      "Fn::And": [
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "2",
+                    {
+                      "Ref": "RAIDOptions"
+                    }
+                  ]
+                },
+                "4"
+              ]
+            }
+          ]
+        },
+        {
+          "Condition": "UseVol4"
+        }
+      ]
+    },
+    "Vol1_UseEBSEncryption": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "6",
+            {
+              "Ref": "RAIDOptions"
+            }
+          ]
+        },
+        "true"
+      ]
+    },
+    "Vol1_UseEBSKMSKey": {
+      "Fn::And": [
+        {
+          "Condition": "Vol1_UseEBSEncryption"
+        },
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "7",
+                    {
+                      "Ref": "RAIDOptions"
+                    }
+                  ]
+                },
+                "NONE"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Vol1_UseEBSPIOPS": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "3",
+            {
+              "Ref": "RAIDOptions"
+            }
+          ]
+        },
+        "io1"
+      ]
+    },
+    "Vol1_UseVolumeSize": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "Vol1_UseVolumeType": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "Vol2_UseEBSEncryption": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "6",
+            {
+              "Ref": "RAIDOptions"
+            }
+          ]
+        },
+        "true"
+      ]
+    },
+    "Vol2_UseEBSKMSKey": {
+      "Fn::And": [
+        {
+          "Condition": "Vol2_UseEBSEncryption"
+        },
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "7",
+                    {
+                      "Ref": "RAIDOptions"
+                    }
+                  ]
+                },
+                "NONE"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Vol2_UseEBSPIOPS": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "3",
+            {
+              "Ref": "RAIDOptions"
+            }
+          ]
+        },
+        "io1"
+      ]
+    },
+    "Vol2_UseVolumeSize": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "Vol2_UseVolumeType": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "Vol3_UseEBSEncryption": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "6",
+            {
+              "Ref": "RAIDOptions"
+            }
+          ]
+        },
+        "true"
+      ]
+    },
+    "Vol3_UseEBSKMSKey": {
+      "Fn::And": [
+        {
+          "Condition": "Vol3_UseEBSEncryption"
+        },
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "7",
+                    {
+                      "Ref": "RAIDOptions"
+                    }
+                  ]
+                },
+                "NONE"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Vol3_UseEBSPIOPS": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "3",
+            {
+              "Ref": "RAIDOptions"
+            }
+          ]
+        },
+        "io1"
+      ]
+    },
+    "Vol3_UseVolumeSize": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "Vol3_UseVolumeType": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "Vol4_UseEBSEncryption": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "6",
+            {
+              "Ref": "RAIDOptions"
+            }
+          ]
+        },
+        "true"
+      ]
+    },
+    "Vol4_UseEBSKMSKey": {
+      "Fn::And": [
+        {
+          "Condition": "Vol4_UseEBSEncryption"
+        },
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "7",
+                    {
+                      "Ref": "RAIDOptions"
+                    }
+                  ]
+                },
+                "NONE"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Vol4_UseEBSPIOPS": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "3",
+            {
+              "Ref": "RAIDOptions"
+            }
+          ]
+        },
+        "io1"
+      ]
+    },
+    "Vol4_UseVolumeSize": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "Vol4_UseVolumeType": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "Vol5_UseEBSEncryption": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "6",
+            {
+              "Ref": "RAIDOptions"
+            }
+          ]
+        },
+        "true"
+      ]
+    },
+    "Vol5_UseEBSKMSKey": {
+      "Fn::And": [
+        {
+          "Condition": "Vol5_UseEBSEncryption"
+        },
+        {
+          "Fn::Not": [
+            {
+              "Fn::Equals": [
+                {
+                  "Fn::Select": [
+                    "7",
+                    {
+                      "Ref": "RAIDOptions"
+                    }
+                  ]
+                },
+                "NONE"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "Vol5_UseEBSPIOPS": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "3",
+            {
+              "Ref": "RAIDOptions"
+            }
+          ]
+        },
+        "io1"
+      ]
+    },
+    "Vol5_UseVolumeSize": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "Vol5_UseVolumeType": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    }
+  },
+  "Outputs": {
+    "Volumeids": {
+      "Description": "Volume IDs of the resulted RAID EBS volumes",
+      "Value": {
+        "Fn::If": [
+          "UseVol5",
+          {
+            "Fn::Join": [
+              ",",
+              [
+                {
+                  "Ref": "Volume1"
+                },
+                {
+                  "Ref": "Volume2"
+                },
+                {
+                  "Ref": "Volume3"
+                },
+                {
+                  "Ref": "Volume4"
+                },
+                {
+                  "Ref": "Volume5"
+                }
+              ]
+            ]
+          },
+          {
+            "Fn::If": [
+              "UseVol4",
+              {
+                "Fn::Join": [
+                  ",",
+                  [
+                    {
+                      "Ref": "Volume1"
+                    },
+                    {
+                      "Ref": "Volume2"
+                    },
+                    {
+                      "Ref": "Volume3"
+                    },
+                    {
+                      "Ref": "Volume4"
+                    }
+                  ]
+                ]
+              },
+              {
+                "Fn::If": [
+                  "UseVol3",
+                  {
+                    "Fn::Join": [
+                      ",",
+                      [
+                        {
+                          "Ref": "Volume1"
+                        },
+                        {
+                          "Ref": "Volume2"
+                        },
+                        {
+                          "Ref": "Volume3"
+                        }
+                      ]
+                    ]
+                  },
+                  {
+                    "Fn::If": [
+                      "UseVol2",
+                      {
+                        "Fn::Join": [
+                          ",",
+                          [
+                            {
+                              "Ref": "Volume1"
+                            },
+                            {
+                              "Ref": "Volume2"
+                            }
+                          ]
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseVol1",
+                          {
+                            "Ref": "Volume1"
+                          },
+                          "NONE"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "Parameters": {
+    "AvailabilityZone": {
+      "Description": "Availability Zone the cluster will launch into. THIS IS REQUIRED",
+      "Type": "String"
+    },
+    "RAIDOptions": {
+      "Description": "Comma separated list of RAID related options, 8 parameters in total, [0 shared_dir,1 raid_type,2 num_of_vols,3 vol_type,4 vol_size,5 vol_IOPS,6 encrypted, 7 ebs_kms_key]",
+      "Type": "CommaDelimitedList"
+    }
+  },
+  "Resources": {
+    "Volume1": {
+      "Condition": "UseVol1",
+      "Properties": {
+        "AvailabilityZone": {
+          "Ref": "AvailabilityZone"
+        },
+        "Encrypted": {
+          "Fn::If": [
+            "Vol1_UseEBSEncryption",
+            {
+              "Fn::Select": [
+                "6",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "Iops": {
+          "Fn::If": [
+            "Vol1_UseEBSPIOPS",
+            {
+              "Fn::Select": [
+                "5",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "KmsKeyId": {
+          "Fn::If": [
+            "Vol1_UseEBSKMSKey",
+            {
+              "Fn::Select": [
+                "7",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "Size": {
+          "Fn::If": [
+            "Vol1_UseVolumeSize",
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            20
+          ]
+        },
+        "VolumeType": {
+          "Fn::If": [
+            "Vol1_UseVolumeType",
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "gp2"
+          ]
+        }
+      },
+      "Type": "AWS::EC2::Volume"
+    },
+    "Volume2": {
+      "Condition": "UseVol2",
+      "Properties": {
+        "AvailabilityZone": {
+          "Ref": "AvailabilityZone"
+        },
+        "Encrypted": {
+          "Fn::If": [
+            "Vol2_UseEBSEncryption",
+            {
+              "Fn::Select": [
+                "6",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "Iops": {
+          "Fn::If": [
+            "Vol2_UseEBSPIOPS",
+            {
+              "Fn::Select": [
+                "5",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "KmsKeyId": {
+          "Fn::If": [
+            "Vol2_UseEBSKMSKey",
+            {
+              "Fn::Select": [
+                "7",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "Size": {
+          "Fn::If": [
+            "Vol2_UseVolumeSize",
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            20
+          ]
+        },
+        "VolumeType": {
+          "Fn::If": [
+            "Vol2_UseVolumeType",
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "gp2"
+          ]
+        }
+      },
+      "Type": "AWS::EC2::Volume"
+    },
+    "Volume3": {
+      "Condition": "UseVol3",
+      "Properties": {
+        "AvailabilityZone": {
+          "Ref": "AvailabilityZone"
+        },
+        "Encrypted": {
+          "Fn::If": [
+            "Vol3_UseEBSEncryption",
+            {
+              "Fn::Select": [
+                "6",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "Iops": {
+          "Fn::If": [
+            "Vol3_UseEBSPIOPS",
+            {
+              "Fn::Select": [
+                "5",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "KmsKeyId": {
+          "Fn::If": [
+            "Vol3_UseEBSKMSKey",
+            {
+              "Fn::Select": [
+                "7",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "Size": {
+          "Fn::If": [
+            "Vol3_UseVolumeSize",
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            20
+          ]
+        },
+        "VolumeType": {
+          "Fn::If": [
+            "Vol3_UseVolumeType",
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "gp2"
+          ]
+        }
+      },
+      "Type": "AWS::EC2::Volume"
+    },
+    "Volume4": {
+      "Condition": "UseVol4",
+      "Properties": {
+        "AvailabilityZone": {
+          "Ref": "AvailabilityZone"
+        },
+        "Encrypted": {
+          "Fn::If": [
+            "Vol4_UseEBSEncryption",
+            {
+              "Fn::Select": [
+                "6",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "Iops": {
+          "Fn::If": [
+            "Vol4_UseEBSPIOPS",
+            {
+              "Fn::Select": [
+                "5",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "KmsKeyId": {
+          "Fn::If": [
+            "Vol4_UseEBSKMSKey",
+            {
+              "Fn::Select": [
+                "7",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "Size": {
+          "Fn::If": [
+            "Vol4_UseVolumeSize",
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            20
+          ]
+        },
+        "VolumeType": {
+          "Fn::If": [
+            "Vol4_UseVolumeType",
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "gp2"
+          ]
+        }
+      },
+      "Type": "AWS::EC2::Volume"
+    },
+    "Volume5": {
+      "Condition": "UseVol5",
+      "Properties": {
+        "AvailabilityZone": {
+          "Ref": "AvailabilityZone"
+        },
+        "Encrypted": {
+          "Fn::If": [
+            "Vol5_UseEBSEncryption",
+            {
+              "Fn::Select": [
+                "6",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "Iops": {
+          "Fn::If": [
+            "Vol5_UseEBSPIOPS",
+            {
+              "Fn::Select": [
+                "5",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "KmsKeyId": {
+          "Fn::If": [
+            "Vol5_UseEBSKMSKey",
+            {
+              "Fn::Select": [
+                "7",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
+        "Size": {
+          "Fn::If": [
+            "Vol5_UseVolumeSize",
+            {
+              "Fn::Select": [
+                "4",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            20
+          ]
+        },
+        "VolumeType": {
+          "Fn::If": [
+            "Vol5_UseVolumeType",
+            {
+              "Fn::Select": [
+                "3",
+                {
+                  "Ref": "RAIDOptions"
+                }
+              ]
+            },
+            "gp2"
+          ]
+        }
+      },
+      "Type": "AWS::EC2::Volume"
+    }
+  }
+}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -458,6 +458,14 @@ See :ref:`EFS Section <efs_section>`. ::
 
     efs_settings = customfs
 
+raid_settings
+"""""""""""""
+Settings section relating to RAID drive configuration.
+
+See :ref:`RAID Section <raid_section>`. ::
+
+  raid_settings = rs
+
 tags
 """"
 Defines tags to be used in CloudFormation.
@@ -788,4 +796,77 @@ vpc section, adding that security group to the mount target, and turning off con
 Defaults to NONE. Needs to be an available EFS file system::
 
     efs_fs_id = fs-12345
+
+
+.. _raid_section:
+
+RAID
+^^^^
+RAID drive configuration settings for creating a RAID array from a number of identical EBS volumes. The RAID drive
+is mounted on the master node, and exported to compute nodes via nfs. ::
+
+
+    [raid rs]
+    shared_dir = raid
+    raid_type = 1
+    num_of_raid_volumes = 2
+    encrypted = true
+
+shared_dir
+""""""""""
+Shared directory that the RAID drive will be mounted to on the master and compute nodes.
+
+This parameter is REQUIRED, the RAID drive will only be created if this parameter is specified.
+The below example mounts to /raid. Do not use NONE or /NONE as the shared directory.::
+
+    shared_dir = raid
+
+raid_type
+"""""""""
+RAID type for the RAID array. Currently only support RAID 0 or RAID 1. For more information on RAID types,
+see: `RAID info <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/raid-config.html>`_
+
+This parameter is REQUIRED, the RAID drive will only be created if this parameter is specified.
+The below example will create a RAID 0 array::
+
+    raid_type = 0
+
+num_of_raid_volumes
+"""""""""""""""""""
+The number of EBS volumes to assemble the RAID array from. Currently supports max of 5 volumes and minimum of 2.
+
+Defaults to 2. ::
+
+    num_of_raid_volumes = 2
+
+volume_type
+"""""""""""
+The the type of volume you wish to launch.
+See: `Volume type <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html>`_ for detail
+
+Defaults to gp2. ::
+
+    volume_type = io1
+
+volume_size
+"""""""""""
+Size of volume to be created.
+
+Defaults to 20GB. ::
+
+    volume_size = 20
+
+volume_iops
+"""""""""""
+Number of IOPS for io1 type volumes. ::
+
+    volume_iops = 500
+
+encrypted
+"""""""""
+Whether or not the file system will be encrypted.
+
+Defaults to false. ::
+
+    encrypted = false
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -57,3 +57,4 @@ DescribeMountTargets
 DescribeMountTargetSecurityGroups
 DescribeSubnets
 DescribeSecurityGroups
+num

--- a/tests/config_raid
+++ b/tests/config_raid
@@ -1,0 +1,114 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = true
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+base_os = ubuntu1404
+key_name = id_rsa
+vpc_settings = public
+maintain_initial_size = true
+initial_queue_size = 1
+template_url = https://s3.us-east-2.amazonaws.com/shuningc-raid/aws-parallelcluster.cfn.json
+custom_chef_cookbook = https://s3.us-east-2.amazonaws.com/shuningc-raid/cookbooks/cfncluster-cookbook-2.0.2.tgz
+
+[cluster raid2Vol]
+base_os = ubuntu1604
+key_name = id_rsa
+vpc_settings = public
+maintain_initial_size = true
+initial_queue_size = 1
+raid_settings = rs2
+template_url = https://s3.us-east-2.amazonaws.com/shuningc-raid/aws-parallelcluster.cfn.json
+custom_chef_cookbook = https://s3.us-east-2.amazonaws.com/shuningc-raid/cookbooks/cfncluster-cookbook-2.0.2.tgz
+
+[cluster raid5Vol]
+base_os = ubuntu1604
+key_name = id_rsa
+vpc_settings = public
+maintain_initial_size = true
+initial_queue_size = 1
+raid_settings = rs5
+template_url = https://s3.us-east-2.amazonaws.com/shuningc-raid/cfncluster.cfn.json
+custom_chef_cookbook = https://s3.us-east-2.amazonaws.com/shuningc-raid/cookbooks/cfncluster-cookbook-2.0.0.tgz
+
+[cluster raid1Vol]
+base_os = ubuntu1604
+key_name = id_rsa
+vpc_settings = public
+maintain_initial_size = true
+initial_queue_size = 1
+raid_settings = rs1
+template_url = https://s3.us-east-2.amazonaws.com/shuningc-raid/cfncluster.cfn.json
+custom_chef_cookbook = https://s3.us-east-2.amazonaws.com/shuningc-raid/cookbooks/cfncluster-cookbook-1.6.0.tgz
+
+[cluster raid6Vol]
+base_os = ubuntu1604
+key_name = id_rsa
+vpc_settings = public
+maintain_initial_size = true
+initial_queue_size = 1
+raid_settings = rs6
+template_url = https://s3.us-east-2.amazonaws.com/shuningc-raid/cfncluster.cfn.json
+custom_chef_cookbook = https://s3.us-east-2.amazonaws.com/shuningc-raid/cookbooks/cfncluster-cookbook-1.6.0.tgz
+
+[cluster raidIOPS]
+base_os = ubuntu1604
+key_name = id_rsa
+vpc_settings = public
+maintain_initial_size = true
+initial_queue_size = 1
+raid_settings = rsIOPS
+template_url = https://s3.us-east-2.amazonaws.com/shuningc-raid/cfncluster.cfn.json
+custom_chef_cookbook = https://s3.us-east-2.amazonaws.com/shuningc-raid/cookbooks/cfncluster-cookbook-1.6.0.tgz
+
+[cluster raidType]
+base_os = ubuntu1604
+key_name = id_rsa
+vpc_settings = public
+maintain_initial_size = true
+initial_queue_size = 1
+raid_settings = rsT
+template_url = https://s3.us-east-2.amazonaws.com/shuningc-raid/cfncluster.cfn.json
+custom_chef_cookbook = https://s3.us-east-2.amazonaws.com/shuningc-raid/cookbooks/cfncluster-cookbook-1.6.0.tgz
+
+[vpc public]
+vpc_id = vpc-f9cff091
+master_subnet_id = subnet-898cabe1
+
+[raid rs2]
+shared_dir = /raid
+raid_type = 1
+
+[raid rs5]
+shared_dir = /raid
+raid_type = 0
+num_of_raid_volumes = 5
+volume_type = io1
+volume_size = 30
+volume_iops = 1500
+encrypted = false
+
+[raid rs1]
+shared_dir = /raid
+raid_type = 1
+num_of_raid_volumes = 1
+
+[raid rs6]
+shared_dir = /raid
+raid_type = 0
+num_of_raid_volumes = 6
+
+[raid rsIOPS]
+shared_dir = /raid
+raid_type = 0
+num_of_raid_volumes = 3
+volume_iops = 1500
+
+[raid rsT]
+shared_dir = /raid
+raid_type = 5
+num_of_raid_volumes = 3

--- a/tests/raid-check.sh
+++ b/tests/raid-check.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+path=${1}
+status=0
+
+mount_point_grep=$(cat /etc/fstab | grep "md0";echo $?)
+
+if [[ ! -z ${path} ]]
+then
+  path_exist=$(cat /etc/fstab | grep "${path}";echo $?)
+
+  if [[ ${path_exist} != 1 ]] && [[ ${mount_point_grep} != 1 ]]
+  then
+    echo "Success: found the RAID array"
+  else
+    echo "Error: RAID array not found"
+    exit 1
+  fi
+
+  compute_ip=$(qhost | grep "ip-" | cut -d " " -f 1)
+
+  touch ${path}/master_file
+  scp ${path}/master_file ${compute_ip}:${path}/compute_file
+
+  compute_check=$(ls ${path} | grep "compute_file";echo $?)
+
+  if [[ ${compute_check} != 1 ]]
+  then
+    echo "Success: ${path} is correctly mounted on compute"
+    rm ${path}/compute_file
+  else
+    echo "Error: ${path} is not found on compute"
+    status=1
+  fi
+
+  rm ${path}/master_file
+else
+  if [[ ${mount_point_grep} == 1 ]]
+  then
+    echo "Success: RAID array does not exist in default case"
+  else
+    echo "Error: RAID found in default case"
+    exit 1
+  fi
+fi
+
+exit ${status}

--- a/tests/raid-test.py
+++ b/tests/raid-test.py
@@ -1,0 +1,519 @@
+import argparse
+import datetime
+import os
+import Queue
+import random
+import re
+import signal
+import string
+import subprocess as sub
+import sys
+import threading
+import time
+from builtins import exit
+
+import boto3
+import process_helper as prochelp
+
+UNSUPPORTED_REGIONS = set(["ap-northeast-3", "eu-west-3"])
+
+
+class ReleaseCheckException(Exception):
+    pass
+
+
+#
+# configuration
+#
+username_map = {
+    "alinux": "ec2-user",
+    "centos6": "centos",
+    "centos7": "centos",
+    "ubuntu1404": "ubuntu",
+    "ubuntu1604": "ubuntu",
+}
+
+#
+# global variables (sigh)
+#
+setup = {}
+
+raid_path = "/raid"
+
+results_lock = threading.Lock()
+failure = 0
+success = 0
+
+# PID of the actual test process
+_child = 0
+# True if parent process has been asked to terminate
+_termination_caught = False
+
+_TIMESTAMP_FORMAT = "%Y%m%d%H%M%S"
+_timestamp = datetime.datetime.now().strftime(_TIMESTAMP_FORMAT)
+
+
+def prepare_testfiles(distro, key_name, extra_args):
+    rfile = open("./config_raid", "r").read().split("\n")
+    template_url = extra_args["templateURL"]
+    cookbook_url = extra_args["cookbookURL"]
+    vpc = extra_args["vpc"]
+    master_subnet = extra_args["master_subnet"]
+    region = extra_args["region"]
+    for index, line in enumerate(rfile):
+        r = re.search("aws_region_name", line)
+        if r:
+            rfile[index] = "aws_region_name = %s" % region
+
+        o = re.search("base_os", line)
+        if o:
+            rfile[index] = "base_os = %s" % distro
+        k = re.search("key_name", line)
+        if k:
+            rfile[index] = "key_name = %s" % key_name
+        t = re.search("template_url", line)
+        if t:
+            if template_url:
+                rfile[index] = "template_url = %s" % template_url
+            else:
+                rfile[index] = "#template_url ="
+        c = re.search("custom_chef_cookbook", line)
+        if c:
+            if cookbook_url:
+                rfile[index] = "custom_chef_cookbook = %s" % cookbook_url
+            else:
+                rfile[index] = "#custom_chef_cookbook ="
+        if vpc:
+            v = re.search("vpc_id", line)
+            if v:
+                rfile[index] = "vpc_id = %s" % vpc
+        m = re.search("master_subnet_id = (.+)", line)
+        if m:
+            if master_subnet:
+                rfile[index] = "master_subnet_id = %s" % master_subnet
+            else:
+                extra_args["master_subnet"] = m.group(1)
+
+    wfile = open("./config-%s-%s" % (region, distro), "w")
+    wfile.write("\n".join(rfile))
+    wfile.close()
+
+
+def clean_up_testfiles(region, distro):
+    os.remove("./config-%s-%s" % (region, distro))
+
+
+def _dirname():
+    return os.path.dirname(os.path.realpath(sys.argv[0]))
+
+
+def _time():
+    return datetime.datetime.now()
+
+
+def _double_writeln(fileo, message):
+    print(message)
+    fileo.write(message + "\n")
+
+
+def _get_az(subnet_id, region):
+    ec2 = boto3.resource("ec2", region_name=region)
+    subnet = ec2.Subnet(subnet_id)
+
+    az = subnet.availability_zone
+    print(subnet_id)
+    print(az)
+
+    return az
+
+
+def run_test(distro, clustername, mastersubnet, region):
+    testname = ("%s-%s" % (distro, clustername)) + "".join(
+        random.choice(string.ascii_uppercase + string.digits) for _ in range(8)
+    )
+    print(testname)
+    out_f = open("%s-out.txt" % testname, "w")
+    username = username_map[distro]
+    _create_done = False
+    _create_interrupted = False
+    _volume_id = ""
+    _az = _get_az(mastersubnet, region)
+    _region = _az[:-1]
+
+    try:
+
+        print("Creating cluster...")
+        prochelp.exec_command(
+            [
+                "pcluster",
+                "create",
+                "autoTest-%s" % testname,
+                "--config",
+                "./config-%s-%s" % (_region, distro),
+                "--cluster-template",
+                "%s" % clustername,
+            ],
+            stdout=out_f,
+            stderr=sub.STDOUT,
+            universal_newlines=True,
+        )
+        _create_done = True
+        dump = prochelp.exec_command(
+            ["pcluster", "status", "autoTest-%s" % testname, "--config", "./config-%s-%s" % (_region, distro)],
+            stderr=sub.STDOUT,
+            universal_newlines=True,
+        )
+        dump_array = dump.splitlines()
+        for line in dump_array:
+            m = re.search("MasterPublicIP: (.+)$", line)
+            if m:
+                master_ip = m.group(1)
+                break
+        if master_ip == "":
+            _double_writeln(out_f, "!! %s: Master IP not found; exiting !!" % (testname))
+            raise ReleaseCheckException("--> %s: Master IP not found!" % testname)
+        _double_writeln(out_f, "--> %s Master IP: %s" % (testname, master_ip))
+
+        time.sleep(10)
+
+        # run test on the cluster...
+        ssh_params = ["-o", "StrictHostKeyChecking=no"]
+        ssh_params += ["-o", "BatchMode=yes"]
+        # ssh_params += ['-o', 'ConnectionAttempts=30']
+        ssh_params += ["-o", "ConnectTimeout=60"]
+        ssh_params += ["-o", "ServerAliveCountMax=5"]
+        ssh_params += ["-o", "ServerAliveInterval=30"]
+
+        print("Running tests...")
+        prochelp.exec_command(
+            ["scp"] + ssh_params + [os.path.join(_dirname(), "raid-check.sh"), "%s@%s:." % (username, master_ip)],
+            stdout=out_f,
+            stderr=sub.STDOUT,
+            universal_newlines=True,
+        )
+
+        time.sleep(5)
+
+        if clustername == "default":
+            prochelp.exec_command(
+                ["ssh", "-n"] + ssh_params + ["%s@%s" % (username, master_ip), "/bin/bash --login raid-check.sh"],
+                stdout=out_f,
+                stderr=sub.STDOUT,
+                universal_newlines=True,
+            )
+        else:
+            prochelp.exec_command(
+                ["ssh", "-n"]
+                + ssh_params
+                + ["%s@%s" % (username, master_ip), "/bin/bash --login raid-check.sh %s" % raid_path],
+                stdout=out_f,
+                stderr=sub.STDOUT,
+                universal_newlines=True,
+            )
+        print("Test passed...")
+
+    except prochelp.ProcessHelperError as exc:
+        if not _create_done and isinstance(exc, prochelp.KilledProcessError):
+            _create_interrupted = True
+            _double_writeln(out_f, "--> %s: Interrupting AWS ParallelCluster create!" % testname)
+        _double_writeln(out_f, "!! ABORTED: %s!!" % (testname))
+        open("%s.aborted" % testname, "w").close()
+        raise exc
+    except Exception as exc:
+        if not _create_done:
+            _create_interrupted = True
+        _double_writeln(out_f, "Unexpected exception %s: %s" % (str(type(exc)), str(exc)))
+        _double_writeln(out_f, "!! FAILURE: %s!!" % (testname))
+        open("%s.failed" % testname, "w").close()
+        raise exc
+
+    finally:
+        print("Cleaning up!")
+        if _create_interrupted or _create_done:
+            # if the create process was interrupted it may take few seconds for the stack id to be actually registered
+            _max_del_iters = _del_iters = 10
+        else:
+            # No delete is necessary if cluster creation wasn't started (process_helper.AbortedProcessError)
+            _del_iters = 0
+        if _del_iters > 0:
+            _del_done = False
+            _double_writeln(out_f, "--> %s: Deleting - max iterations: %s" % (testname, _del_iters))
+            while not _del_done and _del_iters > 0:
+                try:
+                    time.sleep(2)
+                    # clean up the cluster
+                    _del_output = sub.check_output(
+                        [
+                            "pcluster",
+                            "delete",
+                            "autoTest-%s" % testname,
+                            "--config",
+                            "./config-%s-%s" % (_region, distro),
+                        ],
+                        stderr=sub.STDOUT,
+                        universal_newlines=True,
+                    )
+                    _del_done = "DELETE_IN_PROGRESS" in _del_output or "DELETE_COMPLETE" in _del_output
+                    out_f.write(_del_output + "\n")
+                except sub.CalledProcessError as exc:
+                    out_f.write(
+                        "CalledProcessError exception launching 'pcluster delete': %s - Output:\n%s\n"
+                        % (str(exc), exc.output)
+                    )
+                except Exception as exc:
+                    out_f.write(
+                        "Unexpected exception launching 'pcluster delete' %s: %s\n" % (str(type(exc)), str(exc))
+                    )
+                finally:
+                    _double_writeln(
+                        out_f,
+                        "--> %s: Deleting - iteration: %s - successfully submitted: %s"
+                        % (testname, (_max_del_iters - _del_iters + 1), _del_done),
+                    )
+                    _del_iters -= 1
+
+            try:
+                prochelp.exec_command(
+                    ["pcluster", "status", "autoTest-%s" % testname, "--config", "./config-%s-%s" % (region, distro)],
+                    stdout=out_f,
+                    stderr=sub.STDOUT,
+                    universal_newlines=True,
+                )
+            except (prochelp.ProcessHelperError, sub.CalledProcessError):
+                # Usually terminates with exit status 1 since at the end of the delete operation the stack is not found
+                pass
+            except Exception as exc:
+                out_f.write("Unexpected exception launching 'pcluster status' %s: %s\n" % (str(type(exc)), str(exc)))
+        out_f.close()
+    print("--> %s: Finished" % (testname))
+
+
+def _killme_gently():
+    os.kill(os.getpid(), signal.SIGTERM)
+
+
+def _proc_alive(pid):
+    if pid <= 1:
+        return False
+    alive = False
+    try:
+        # No real signal is sent but error checking is performed
+        os.kill(pid, 0)
+        alive = True
+    except OSError as ose:
+        # ose.errno == errno.EINVAL - Invalid signal number (this shouldn't happen)
+        # ose.errno == errno.ESRCH - No such process
+        # ose.errno == errno.EPERM - No permissions to check 'pid' process.
+        pass
+    except Exception as exc:
+        print("Unexpected exception checking process %s, %s: %s" % (pid, str(type(exc)), str(exc)))
+
+    return alive
+
+
+def test_runner(q, extra_args):
+    global failure
+    global success
+    global results_lock
+
+    while True:
+        item = q.get()
+
+        retval = 1
+        try:
+            if not prochelp.termination_caught():
+                run_test(
+                    distro=item["distro"],
+                    clustername=item["clustername"],
+                    mastersubnet=extra_args["master_subnet"],
+                    region=extra_args["region"],
+                )
+                retval = 0
+        except (prochelp.ProcessHelperError, sub.CalledProcessError):
+            pass
+        except Exception as exc:
+            print("[test_runner] Unexpected exception %s: %s\n" % (str(type(exc)), str(exc)))
+
+        results_lock.acquire(True)
+        if retval == 0:
+            success += 1
+        else:
+            failure += 1
+        results_lock.release()
+        q.task_done()
+
+
+def get_all_aws_regions():
+    ec2 = boto3.client("ec2")
+    return set(sorted(r.get("RegionName") for r in ec2.describe_regions().get("Regions"))) - UNSUPPORTED_REGIONS
+
+
+def main(args):
+    global failure
+    global success
+    total_success = 0
+    total_failure = 0
+
+    for region in args.regions:
+        print("Starting work for region %s" % region)
+        failure = 0
+        success = 0
+        client = boto3.client("ec2", region_name=region)
+        response = client.describe_tags(
+            Filters=[{"Name": "key", "Values": ["ParallelClusterTestSubnet"]}], MaxResults=16
+        )
+        if not args.mastersubnet:
+            if len(response["Tags"]) == 0:
+                print("Could not find subnet in %s with ParallelClusterTestSubnet tag.  Aborting." % (region))
+                exit(1)
+            subnetid = response["Tags"][0]["ResourceId"]
+            if subnetid is None:
+                print("Error: Subnet ID is None")
+
+            response = client.describe_subnets(SubnetIds=[subnetid])
+            if len(response) == 0:
+                print("Could not find subnet info for %s" % (subnetid))
+                exit(1)
+            vpcid = response["Subnets"][0]["VpcId"]
+
+            if vpcid is None:
+                print("Error: VPC ID is None")
+
+            print("VPCId: %s; SubnetId %s" % (vpcid, subnetid))
+            setup[region] = {"vpc": vpcid, "subnet": subnetid}
+
+        key_name = args.keyname
+        parent = os.getppid()
+        num_parallel = args.numparallel if args.numparallel else 1
+        extra_args = {
+            "templateURL": args.templateURL,
+            "cookbookURL": args.cookbookURL,
+            "vpc": args.vpcid if args.vpcid else setup[region]["vpc"],
+            "master_subnet": args.mastersubnet if args.mastersubnet else setup[region]["subnet"],
+            "region": region,
+        }
+        success_cluster_list = ["raid2Vol", "raid5Vol", "default"]
+        failure_cluster_list = ["raid1Vol", "raid6Vol", "raidIOPS", "raidType"]
+        distro_list = args.distros if args.distros else ["alinux", "centos6", "centos7", "ubuntu1404", "ubuntu1604"]
+        success_work_queues = {}
+        failure_work_queues = {}
+        for distro in distro_list:
+            if key_name:
+                prepare_testfiles(distro, key_name, extra_args)
+            else:
+                prepare_testfiles(distro, "id_rsa", extra_args)
+            success_work_queues[distro] = Queue.Queue()
+            failure_work_queues[distro] = Queue.Queue()
+            for clustername in success_cluster_list:
+                work_item = {"distro": distro, "clustername": clustername}
+                success_work_queues[distro].put(work_item)
+            for clustername in failure_cluster_list:
+                work_item = {"distro": distro, "clustername": clustername}
+                failure_work_queues[distro].put(work_item)
+
+        for distro in distro_list:
+            for i in range(num_parallel):
+                t = threading.Thread(target=test_runner, args=(success_work_queues[distro], extra_args))
+                t.daemon = True
+                t.start()
+
+        all_finished = False
+        self_killed = False
+        while not all_finished:
+            time.sleep(1)
+            all_finished = True
+            for queue in success_work_queues.values():
+                all_finished = all_finished and queue.unfinished_tasks == 0
+            # In the case parent process was SIGKILL-ed
+            if not _proc_alive(parent) and not self_killed:
+                print("Parent process with pid %s died - terminating..." % parent)
+                _killme_gently()
+                self_killed = True
+
+        print("%s - Distributions workers queues all done: %s" % (_time(), all_finished))
+        if success != len(success_cluster_list) * len(distro_list) or failure != 0:
+            print(
+                "ERROR: expected %s success 0 failure, got %s success %s failure"
+                % (len(success_cluster_list) * len(distro_list), success, failure)
+            )
+
+        for distro in distro_list:
+            for i in range(num_parallel):
+                t = threading.Thread(target=test_runner, args=(failure_work_queues[distro], extra_args))
+                t.daemon = True
+                t.start()
+
+        all_finished = False
+        self_killed = False
+        while not all_finished:
+            time.sleep(1)
+            all_finished = True
+            for queue in failure_work_queues.values():
+                all_finished = all_finished and queue.unfinished_tasks == 0
+            # In the case parent process was SIGKILL-ed
+            if not _proc_alive(parent) and not self_killed:
+                print("Parent process with pid %s died - terminating..." % parent)
+                _killme_gently()
+                self_killed = True
+
+        print("%s - Distributions workers queues all done: %s" % (_time(), all_finished))
+        if failure != len(failure_cluster_list) * len(distro_list):
+            print(
+                "ERROR: expected %s failure, got %s failure" % (len(failure_cluster_list) * len(distro_list), failure)
+            )
+
+        for distro in distro_list:
+            clean_up_testfiles(region, distro)
+        # print status...
+
+        print("Region %s test finished" % region)
+
+        total_success += success
+        total_failure += failure
+
+    print(
+        "Expected %s success and %s failure, got %s success and %s failure"
+        % (
+            len(success_cluster_list) * len(distro_list) * len(args.regions),
+            len(failure_cluster_list) * len(distro_list) * len(args.regions),
+            total_success,
+            total_failure,
+        )
+    )
+    if total_success == len(success_cluster_list) * len(distro_list) * len(args.regions) and total_failure == len(
+        failure_cluster_list
+    ) * len(distro_list) * len(args.regions):
+        print("Test finished")
+    else:
+        print("FAILURE!")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Take in test related parameters")
+    parser.add_argument("--keyname", type=str, help="Keyname, default is id_rsa", required=False)
+    parser.add_argument(
+        "--regions", type=str, help="Comma separated list of regions to test, defaults to all", required=False
+    )
+    parser.add_argument(
+        "--distros", type=str, help="Comma separated list of distributions to test, defaults to all", required=False
+    )
+    parser.add_argument("--templateURL", type=str, help="Custom template URL", required=False)
+    parser.add_argument("--cookbookURL", type=str, help="Custom cookbook URL", required=False)
+    parser.add_argument("--vpcid", type=str, help="VPC ID for testing", required=False)
+    parser.add_argument("--mastersubnet", type=str, help="Master Subnet ID for testing", required=False)
+    parser.add_argument(
+        "--numparallel",
+        type=int,
+        help="number of threads to run in parallel per distribution, " "total number of threads will be 5*numparallel",
+        required=False,
+    )
+    args = parser.parse_args()
+    if not args.regions:
+        args.regions = get_all_aws_regions()
+    else:
+        args.regions = args.regions.split(",")
+
+    if args.distros:
+        args.distros = args.distros.split(",")
+
+    main(args)

--- a/util/generate-raid-substack.py
+++ b/util/generate-raid-substack.py
@@ -1,0 +1,99 @@
+import argparse
+
+import troposphere.ec2 as ec2
+from troposphere import And, Condition, Equals, If, Join, Not, NoValue, Output, Parameter, Ref, Select, Template
+
+
+def main(args):
+    number_of_vol = 5
+
+    t = Template()
+    availability_zone = t.add_parameter(
+        Parameter(
+            "AvailabilityZone",
+            Type="String",
+            Description="Availability Zone the cluster will launch into. " "THIS IS REQUIRED",
+        )
+    )
+    raid_options = t.add_parameter(
+        Parameter(
+            "RAIDOptions",
+            Type="CommaDelimitedList",
+            Description="Comma separated list of RAID related options, "
+            "8 parameters in total, "
+            "["
+            "0 shared_dir,"
+            "1 raid_type,"
+            "2 num_of_vols,"
+            "3 vol_type,"
+            "4 vol_size,"
+            "5 vol_IOPS,"
+            "6 encrypted, "
+            "7 ebs_kms_key]",
+        )
+    )
+    use_vol = [None] * number_of_vol
+    v = [None] * number_of_vol
+
+    for i in range(number_of_vol):
+        if i == 0:
+            use_vol[i] = t.add_condition("UseVol%s" % (i + 1), Not(Equals(Select("0", Ref(raid_options)), "NONE")))
+        else:
+            use_vol[i] = t.add_condition(
+                "UseVol%s" % (i + 1),
+                And(Not(Equals(Select("2", Ref(raid_options)), str(i))), Condition(use_vol[i - 1])),
+            )
+
+        use_ebs_iops = t.add_condition("Vol%s_UseEBSPIOPS" % (i + 1), Equals(Select("3", Ref(raid_options)), "io1"))
+        use_volume_size = t.add_condition(
+            "Vol%s_UseVolumeSize" % (i + 1), Not(Equals(Select("4", Ref(raid_options)), "NONE"))
+        )
+        use_volume_type = t.add_condition(
+            "Vol%s_UseVolumeType" % (i + 1), Not(Equals(Select("3", Ref(raid_options)), "NONE"))
+        )
+        use_ebs_encryption = t.add_condition(
+            "Vol%s_UseEBSEncryption" % (i + 1), Equals(Select("6", Ref(raid_options)), "true")
+        )
+        use_ebs_kms_key = t.add_condition(
+            "Vol%s_UseEBSKMSKey" % (i + 1),
+            And(Condition(use_ebs_encryption), Not(Equals(Select("7", Ref(raid_options)), "NONE"))),
+        )
+        v[i] = t.add_resource(
+            ec2.Volume(
+                "Volume%s" % (i + 1),
+                AvailabilityZone=Ref(availability_zone),
+                VolumeType=If(use_volume_type, Select("3", Ref(raid_options)), "gp2"),
+                Size=If(use_volume_size, Select("4", Ref(raid_options)), 20),
+                Iops=If(use_ebs_iops, Select("5", Ref(raid_options)), NoValue),
+                Encrypted=If(use_ebs_encryption, Select("6", Ref(raid_options)), NoValue),
+                KmsKeyId=If(use_ebs_kms_key, Select("7", Ref(raid_options)), NoValue),
+                Condition=use_vol[i],
+            )
+        )
+
+    outputs = [None] * number_of_vol
+    vol_to_return = [None] * number_of_vol
+    for i in range(number_of_vol):
+        vol_to_return[i] = Ref(v[i])
+        if i == 0:
+            outputs[i] = If(use_vol[i], vol_to_return[i], "NONE")
+        else:
+            outputs[i] = If(use_vol[i], Join(",", vol_to_return[: (i + 1)]), outputs[i - 1])
+
+    t.add_output(
+        Output("Volumeids", Description="Volume IDs of the resulted RAID EBS volumes", Value=outputs[number_of_vol - 1])
+    )
+
+    json_file_path = args.target_path
+    output_file = open(json_file_path, "w")
+    output_file.write(t.to_json())
+    output_file.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Take in generator related parameters")
+    parser.add_argument(
+        "--target-path", type=str, help="The target path for generated substack template", required=True
+    )
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
If merged, the following changes will take place:
- Changed cfnconfig.py to parse all RAID related variables
- Changed config_sanity.py to check RAID related constraints
- Changed aws-parallelcluster.cfn.json to add new parameter RAIDoptions, with allowed pattern to validate input, and new substack RAIDSubstack, output RAID shared directory via dna.json to master and compute nodes, output RAID volume ids to master. Added new parameter RAIDSharedDir to Batch substack resource
- Changed batch-substack.cfn.json to set RAIDSharedDir as an environment variable so the RAID directory can be mounted
- Added util/generate-raid-substack.py, which generates raid substack template with troposphere
- Added raid-substack.cfn.json, generated with generate-raid-substack.py, supports creating up to 5 volumes
- Changed entrypoint.sh to include RAID directory mounting call
- Added integration test raid-test.py and test files config_raid and raid-check.sh, which tests edge cases of creating with the minimum number of 2 volumes and max number of 5 volumes, as well as the default case of not using RAID at all.
- Batch compatibility is manually tested by submitting a job under RAID shared directory

Signed-off-by: Rex Chen <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
