### PR TITLE
Fix cfn-format tox target

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -224,7 +224,7 @@ skip_install = true
 changedir =
     ../cloudformation
 commands =
-    python utils/json_formatter.py -c *.cfn.json
+    python utils/json_formatter.py *.cfn.json
 
 # Runs tests for cfn templates.
 [testenv:cfn-tests]


### PR DESCRIPTION
Removed the -c option that only performs a check of the formatting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
