### PR TITLE
Add possibility to export environment variables in the job environment

### DIFF
--- a/cli/awsbatch/common.py
+++ b/cli/awsbatch/common.py
@@ -136,6 +136,7 @@ class AWSBatchCliConfig(object):
         self.aws_access_key_id = None
         self.aws_secret_access_key = None
         self.region = None
+        self.env_blacklist = None
         parallelcluster_config_file = os.path.expanduser(os.path.join("~", ".parallelcluster", "config"))
         if os.path.isfile(parallelcluster_config_file):
             self.__init_from_parallelcluster_config(parallelcluster_config_file, log)
@@ -201,7 +202,7 @@ class AWSBatchCliConfig(object):
             except (NoOptionError, NoSectionError):
                 pass
 
-    def __init_from_config(self, cli_config_file, cluster, log):
+    def __init_from_config(self, cli_config_file, cluster, log):  # noqa: C901 FIXME
         """
         Init object attributes from awsbatch-cli configuration file.
 
@@ -227,6 +228,10 @@ class AWSBatchCliConfig(object):
             cluster_section = "cluster {0}".format(cluster_name)
             try:
                 self.region = config.get("main", "region")
+            except NoOptionError:
+                pass
+            try:
+                self.env_blacklist = config.get("main", "env_blacklist")
             except NoOptionError:
                 pass
 

--- a/cli/awsbatch/examples/awsbatch-cli.cfg
+++ b/cli/awsbatch/examples/awsbatch-cli.cfg
@@ -39,6 +39,9 @@ job_definition_mnp = arn:aws:batch:<region>:<account-id>:job-definition/parallel
 proxy = NONE
 # Private Master IP, used internally in the job submission phase.
 master_ip = x.x.x.x
+# Environment blacklist variables
+# Comma separated list of environment variable names to not export when submitting a job with "--env all" parameter
+#env_blacklist = HOME,PWD,USER,PATH,LD_LIBRARY_PATH,TERM,TERMCAP
 
 # NOTE: the CLI will also search for the credentials in the [aws] section of the AWS ParallelCluster config file
 # If not defined, boto3 will attempt to use environment or EC2 IAM role.

--- a/docs/awsbsub.rst
+++ b/docs/awsbsub.rst
@@ -11,6 +11,7 @@ awsbsub
 .. spelling::
     MiB
     TextIOWrapper
+    env
     io
     jobId
     startedAt


### PR DESCRIPTION
Usage:

```
  $ echo "env | sort" | awsbsub -jn test-env -e CUSTOM1,CUSTOM2
  $ echo "env | sort" | awsbsub -jn test-all-env -e all
  $ echo "env | sort" | awsbsub -jn test-blacklisted-env -e all -eb CUSTOM1,CUSTOM2
```

I also changed the s3 folder for the uploaded script from: `s3_bucket/batch/` to `s3_bucket/batch/jobid/`
This because now we have two files, one for the exported environment and the user script.