### PR TITLE
Fix awsbhosts that fails when info not available

### DIFF
--- a/cli/awsbatch/awsbhosts.py
+++ b/cli/awsbatch/awsbhosts.py
@@ -163,9 +163,9 @@ class AWSBhostsCommand(object):
                 ec2_instance=container_instance["ec2InstanceId"],
                 instance_type=instance_type,
                 private_ip_address=ec2_instance["PrivateIpAddress"],
-                public_ip_address=ec2_instance["PublicIpAddress"] if ec2_instance["PublicIpAddress"] != "" else "-",
+                public_ip_address=ec2_instance["PublicIpAddress"] if ec2_instance.get("PublicIpAddress") else "-",
                 private_dns_name=ec2_instance["PrivateDnsName"],
-                public_dns_name=ec2_instance["PublicDnsName"] if ec2_instance["PublicDnsName"] != "" else "-",
+                public_dns_name=ec2_instance["PublicDnsName"] if ec2_instance.get("PublicDnsName") else "-",
                 running_jobs=container_instance["runningTasksCount"],
                 pending_jobs=container_instance["pendingTasksCount"],
             )


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
