### PR TITLE
Tox: add target to build and live reload docs

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-toxworkdir=..
+toxworkdir=../.tox
 envlist =
     py{26,27,34,35,36,37}
     code-linters
@@ -270,6 +270,19 @@ changedir = ../docs/build/html
 deps =
 commands =
     python -m http.server {posargs}
+
+# Automatically builds the docs on every change. It also includes a livereload enabled web server.
+# https://github.com/GaretJax/sphinx-autobuild
+[testenv:docs-autobuild]
+basepython = python3
+whitelist_externals =
+    make
+deps =
+    -r../docs/requirements.txt
+    sphinx-autobuild
+changedir = ../docs
+setenv = SPHINXOPTS=-E -W -B
+commands = make livehtml
 
 # sphinxcontrib-spelling is a spelling checker for Sphinx-based documentation:
 # https://github.com/sphinx-contrib/spelling.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext spelling
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext spelling livehtml
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -46,6 +46,7 @@ help:
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 	@echo "  spelling   to check for typos in documentation"
+	@echo "  livehtml   to rebuild docs when a change is detected"
 
 
 clean:
@@ -183,3 +184,8 @@ spelling:
 	@echo
 	@echo "Check finished. Wrong words can be found in " \
 		"$(BUILDDIR)/spelling/output.txt."
+
+livehtml:
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. Auto-reloading enabled."

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -38,6 +38,7 @@ if "%1" == "help" (
 	echo.  linkcheck  to check all external links for integrity
 	echo.  doctest    to run all doctests embedded in the documentation if enabled
 	echo.  spelling   to check for typos in documentation
+	echo.  livehtml   to rebuild docs when a change is detected
 	goto end
 )
 
@@ -245,6 +246,14 @@ if "%1" == "spelling" (
 	if errorlevel 1 exit /b 1
 	echo.
 	echo.Check finished. Wrong words can be found in %BUILDDIR%/spelling/output.txt.
+	goto end
+)
+
+if "%1" == "livehtml" (
+	sphinx-autobuild -b html %ALLSPHINXOPTS% %BUILDDIR%/html
+	if errorlevel 1 exit /b 1
+	echo.
+	echo.Build finished. Auto-reloading enabled.
 	goto end
 )
 


### PR DESCRIPTION
Running `tox -e docs-autobuild` will automatically build the docs on every file change and serve it with a livereload enabled web server.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
