### PR TITLE
Implement support for Batch MNP

### DIFF
--- a/cli/awsbatch/awsbstat.py
+++ b/cli/awsbatch/awsbstat.py
@@ -249,14 +249,14 @@ class AWSBstatCommand(object):
 
                 for job in jobs_to_show:
                     nodes = 1
+                    container = {}
                     if "nodeProperties" in job:
                         # MNP job
-                        container = job["nodeProperties"]["nodeRangeProperties"][0]["container"]
+                        if "nodeRangeProperties" in job["nodeProperties"]:
+                            container = job["nodeProperties"]["nodeRangeProperties"][0]["container"]
                         nodes = job["nodeProperties"]["numNodes"]
                     elif "container" in job:
                         container = job["container"]
-                    else:
-                        container = {}
 
                     if is_job_array(job):
                         # parent job array

--- a/cli/awsbatch/awsbsub.py
+++ b/cli/awsbatch/awsbsub.py
@@ -94,6 +94,13 @@ def _get_parser():
         "if they have not finished. It must be at least 60 seconds",
         type=int,
     )
+    # MNP parameter
+    parser.add_argument(
+        "-n",
+        "--nodes",
+        help="The number of nodes to reserve for the job. It enables Multi-Node Parallel submission",
+        type=int,
+    )
     # array parameters
     parser.add_argument(
         "-a",
@@ -466,13 +473,18 @@ def main():
         # parse and validate depends_on parameter
         depends_on = _get_depends_on(args)
 
-        job_definition = config.job_definition
+        # select submission (standard vs MNP)
+        if args.nodes:
+            job_definition = config.job_definition_mnp
+        else:
+            job_definition = config.job_definition
 
         AWSBsubCommand(log, boto3_factory).run(
             job_definition=job_definition,
             job_name=job_name,
             job_queue=config.job_queue,
             command=command,
+            nodes=args.nodes,
             vcpus=args.vcpus,
             memory=args.memory,
             array_size=args.array_size,

--- a/cli/awsbatch/common.py
+++ b/cli/awsbatch/common.py
@@ -162,6 +162,7 @@ class AWSBatchCliConfig(object):
             log.debug("compute_environment = %s", self.compute_environment)
             log.debug("job_queue = %s", self.job_queue)
             log.debug("job_definition = %s", self.job_definition)
+            log.debug("job_definition_mnp = %s", self.job_definition_mnp)
             log.debug("master_ip = %s", self.master_ip)
             log.info(self)
         except AttributeError as e:
@@ -236,6 +237,7 @@ class AWSBatchCliConfig(object):
                 self.compute_environment = config.get(cluster_section, "compute_environment")
                 self.job_queue = config.get(cluster_section, "job_queue")
                 self.job_definition = config.get(cluster_section, "job_definition")
+                self.job_definition_mnp = config.get(cluster_section, "job_definition_mnp")
                 self.master_ip = config.get(cluster_section, "master_ip")
 
                 # get proxy
@@ -290,6 +292,8 @@ class AWSBatchCliConfig(object):
                         self.job_definition = output_value
                     elif output_key == "MasterPrivateIP":
                         self.master_ip = output_value
+                    elif output_key == "BatchJobDefinitionMnpArn":
+                        self.job_definition_mnp = output_value
 
                 for parameter in stack.get("Parameters", []):
                     if parameter.get("OutputKey") == "ProxyServer":

--- a/cli/awsbatch/examples/awsbatch-cli.cfg
+++ b/cli/awsbatch/examples/awsbatch-cli.cfg
@@ -33,6 +33,8 @@ compute_environment = arn:aws:batch:<region>:<account-id>:compute-environment/pa
 job_queue = arn:aws:batch:<region>:<account-id>:job-queue/parallelcluster-<cluster-name>
 # Job Definition ARN used for standard job submission
 job_definition = arn:aws:batch:<region>:<account-id>:job-definition/parallelcluster-<cluster-name>:1
+# Job Definition ARN used for Multi Node Parallel job submission
+job_definition_mnp = arn:aws:batch:<region>:<account-id>:job-definition/parallelcluster-<cluster-name>-mnp:1
 # HTTP(S) proxy server, typically http://x.x.x.x:8080, used for internal boto3 calls
 proxy = NONE
 # Private Master IP, used internally in the job submission phase.

--- a/cli/pcluster/resources/batch/custom_resources_code/deregister_batch_mnp_job_definitions.py
+++ b/cli/pcluster/resources/batch/custom_resources_code/deregister_batch_mnp_job_definitions.py
@@ -1,0 +1,111 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+import time
+
+import boto3
+from botocore.exceptions import ClientError
+
+import crhelper
+
+# initialise logger
+logger = crhelper.log_config({"RequestId": "CONTAINER_INIT"}, loglevel="info")
+logger.info("Logging configured")
+# set global to track init failures
+init_failed = False
+
+try:
+    # Place initialization code here
+    logger.info("Container initialization completed")
+    batch_client = boto3.client("batch")
+except Exception as e:
+    logger.error(e, exc_info=True)
+    init_failed = e
+
+
+def get_job_definition_name_by_arn(job_definition_arn):
+    """
+    Parse Job Definition arn and get name.
+
+    Args:
+        job_definition_arn: something like arn:aws:batch:<region>:<account-id>:job-definition/<name>:<version>
+
+    Returns: the job definition name
+    """
+    pattern = r".*/(.*):(.*)"
+    return re.search(pattern, job_definition_arn).group(1)
+
+
+def retrieve_job_definition_revisions(name):
+    """
+    Retrieve all revisions for a given job definition.
+
+    Args:
+        name: name of the job definition
+
+    Returns: an array containing all job definition revisions ARNs
+    """
+    next_token = ""
+    job_definitions = []
+    while next_token is not None:
+        response = batch_client.describe_job_definitions(jobDefinitionName=name, nextToken=next_token, status="ACTIVE")
+        if "jobDefinitions" in response:
+            for job_definition in response["jobDefinitions"]:
+                job_definitions.append(job_definition["jobDefinitionArn"])
+        next_token = response.get("nextToken")
+        # Since it's not a time critical operation, sleeping to avoid hitting API's TPS limit.
+        time.sleep(0.5)
+
+    return job_definitions
+
+
+def deregister_job_definition_revisions(name):
+    """
+    De-register all revisions belonging to a given job definition.
+
+    Args:
+        name: name of the job definition
+    """
+    job_definitions = retrieve_job_definition_revisions(name)
+    for job_definition in job_definitions:
+        try:
+            logger.info("De-registering job definition: %s" % job_definition)
+            batch_client.deregister_job_definition(jobDefinition=job_definition)
+        except ClientError:
+            logger.warning("job definition not found: %s. It was probably manually de-registered." % job_definition)
+        # Since it's not a time critical operation, sleeping to avoid hitting API's TPS limit.
+        time.sleep(0.5)
+
+
+def create(event, context):
+    """Noop."""
+    return "MNPJobDefinitionCleanupHandler", {}
+
+
+def update(event, context):
+    """Noop."""
+    return event["MNPJobDefinitionCleanupHandler"], {}
+
+
+def delete(event, context):
+    """Deregister all mnp job definitions."""
+    job_definition = get_job_definition_name_by_arn(event["ResourceProperties"]["JobDefinitionMNPArn"])
+    logger.info("Job definition %s deletion: STARTED" % job_definition)
+    deregister_job_definition_revisions(job_definition)
+    logger.info("Job definition %s deletion: COMPLETED" % job_definition)
+
+
+def handler(event, context):
+    """Main handler function, passes off it's work to crhelper's cfn_handler."""  # noqa: D401
+    # update the logger with event info
+    global logger
+    logger = crhelper.log_config(event, loglevel="info")
+    return crhelper.cfn_handler(event, context, create, update, delete, logger, init_failed)

--- a/cli/pcluster/resources/batch/docker/alinux/Dockerfile
+++ b/cli/pcluster/resources/batch/docker/alinux/Dockerfile
@@ -47,9 +47,6 @@ RUN echo "${USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
     && chmod -R 600 ${SSHDIR}/*  \
     && chown -R ${USER}:${USER} ${SSHDIR}/
 
-# check if ssh agent is running or not, if not, run
-RUN eval `ssh-agent -s` && ssh-add ${SSHDIR}/id_rsa
-
 # setup path
 ENV PATH "/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/usr/lib64/openmpi/bin/"
 

--- a/cli/pcluster/resources/batch/docker/scripts/entrypoint.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/entrypoint.sh
@@ -4,6 +4,11 @@ set -e
 echo "Job id: ${AWS_BATCH_JOB_ID}"
 echo "Initializing the environment..."
 
+# Starting ssh agents
+echo "Starting ssh agents..."
+eval `ssh-agent -s` && ssh-add ${SSHDIR}/id_rsa
+/usr/sbin/sshd -f /root/.ssh/sshd_config -h /root/.ssh/ssh_host_rsa_key
+
 # mount nfs
 echo "Mounting shared file system..."
 /parallelcluster/bin/mount_nfs.sh "${MASTER_IP}" "${SHARED_DIR}"

--- a/cli/pcluster/resources/batch/docker/scripts/entrypoint.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/entrypoint.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 set -e
 
-echo "Starting Job ${AWS_BATCH_JOB_ID}"
+echo "Job id: ${AWS_BATCH_JOB_ID}"
+echo "Initializing the environment..."
 
 # mount nfs
+echo "Mounting shared file system..."
 /parallelcluster/bin/mount_nfs.sh "${MASTER_IP}" "${SHARED_DIR}"
 
 # create hostfile if mnp job
 if [ -n "${AWS_BATCH_JOB_NUM_NODES}" ]; then
+  echo "Generating hostfile..."
   /parallelcluster/bin/generate_hostfile.sh "${SHARED_DIR}" "${HOME}"
 fi
 
 # run the user's script
+echo "Starting the job..."
 exec "$@"

--- a/cli/pcluster/resources/batch/docker/scripts/generate_hostfile.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/generate_hostfile.sh
@@ -97,11 +97,11 @@ read_compute_address() {
                 break
             fi
 
-            if ! [[ ${file} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} slots\=[0-9]+$ ]]; then
+            if ! [[ ${file} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
                 error_exit "Matched filename not in expected format on head node: ${file}"
             fi
 
-            echo "${file}" >> "${destination_dir}/hostfile"
+            cat "${fullfile}" >> "${destination_dir}/hostfile"
             rm -rf "${fullfile}"
             (( compute_nodes_read += 1 ))
         done
@@ -125,7 +125,7 @@ write_node_info() {
     error_exit "Matched IP Address not in expected format on compute node: ${ip_address}"
   fi
   available_cores=$(nproc --all)
-  touch "${shared_dir_temp}/${ip_address} slots=${available_cores}"
+  echo "${ip_address} slots=${available_cores}" > "${shared_dir_temp}/${ip_address}"
 }
 
 

--- a/cli/pcluster/resources/batch/docker/scripts/generate_hostfile.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/generate_hostfile.sh
@@ -18,12 +18,12 @@
 
 usage() {
     cat <<ENDUSAGE
-    This script generates a hostfile which contains the ip addresses of the compute nodes
+This script generates a hostfile which contains the ip addresses of the compute nodes
 
-    USAGE:
-    generate_hostfile <shared_dir> <destination_dir>
-    shared_dir: Shared directory on which compute and head instances have agreed upon for reading and writing the ip addresses. Directory needs to exist. A temporary directory is created inside this directory
-    destination_dir: Directory where hostfile should reside. Directory needs to exist
+USAGE:
+generate_hostfile <shared_dir> <destination_dir>
+shared_dir: Shared directory on which compute and head instances have agreed upon for reading and writing the ip addresses. Directory needs to exist. A temporary directory is created inside this directory
+destination_dir: Directory where hostfile should reside. Directory needs to exist
 ENDUSAGE
 
 }
@@ -81,7 +81,7 @@ check_batch_env_variables_exist() {
     fi
 }
 
-# On the head node populate the hostfile with the ip addresses of the compute nodes
+# On the head node populate the hostfile with the ip addresses and available cores of the compute nodes
 read_compute_address() {
     if [[ ! -f "${destination_dir}/hostfile" ]]; then
         touch "${destination_dir}/hostfile"
@@ -91,48 +91,48 @@ read_compute_address() {
 
     while [[ "${AWS_BATCH_JOB_NUM_NODES}" -gt ${compute_nodes_read} ]]; do
         for fullfile in "${shared_dir_temp}"/* ; do
-            file=$(basename ${fullfile})
+            file=$(basename "${fullfile}")
             if [[ ${file} = "*" ]]; then
-                echo "No files found in ${shared_dir_temp} yet"
+                # No files found in ${shared_dir_temp} yet
                 break
             fi
 
-            if ! [[ ${file} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            if ! [[ ${file} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3} slots\=[0-9]+$ ]]; then
                 error_exit "Matched filename not in expected format on head node: ${file}"
             fi
 
             echo "${file}" >> "${destination_dir}/hostfile"
-            rm -rf "${file}"
-            let "compute_nodes_read += 1"
+            rm -rf "${fullfile}"
+            (( compute_nodes_read += 1 ))
         done
-        echo "Expecting: ${AWS_BATCH_JOB_NUM_NODES}. Read: ${compute_nodes_read}"
+        echo "Detected ${compute_nodes_read}/${AWS_BATCH_JOB_NUM_NODES} compute nodes. Waiting for all compute nodes to start."
         sleep 15
     done
 
     if [[ "$(ls -A "${shared_dir_temp}")" ]]; then
         error_exit "head node failed to read some of the ip addresses while generating the hostfile. Shared temp directory is not empty"
-    elif [[ $(cat "${destination_dir}/hostfile" | wc -l) -ne ${AWS_BATCH_JOB_NUM_NODES} ]]; then
+    elif [[ $(wc -l < "${destination_dir}/hostfile") -ne ${AWS_BATCH_JOB_NUM_NODES} ]]; then
         error_exit "The number of entries in hostfile is not equal to the AWS_BATCH_JOB_NUM_NODES"
     else
         rmdir "${shared_dir_temp}"
     fi
 }
 
-# On the compute node touch a file with the ip address of the compute node
-write_compute_address() {
-  filename=$(curl "http://169.254.169.254/latest/meta-data/local-ipv4")
-  if ! [[ ${filename} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-    error_exit "Matched IP Address not in expected format on compute node: ${filename}"
+# Write a file in the shared dir with container ip address and available cores.
+write_node_info() {
+  ip_address=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+  if ! [[ ${ip_address} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+    error_exit "Matched IP Address not in expected format on compute node: ${ip_address}"
   fi
-
-  touch "${shared_dir_temp}/${filename}"
+  available_cores=$(nproc --all)
+  touch "${shared_dir_temp}/${ip_address} slots=${available_cores}"
 }
 
 
 main() {
 
-    if [ $# -eq 0 ]; then
-        error_exit_usage "No arguments provided"
+    if [ $# -ne 2 ]; then
+        error_exit_usage "Wrong number of arguments provided"
     fi
 
     # This is the shared directory on which compute and head instances have agreed upon for reading and writing the ip addresses
@@ -142,16 +142,16 @@ main() {
     check_arguments_valid
     check_batch_env_variables_exist
 
-    shared_dir_temp="${shared_dir}/${AWS_BATCH_JOB_ID}-${AWS_BATCH_JOB_ATTEMPT}"
+    # AWS_BATCH_JOB_ID is in the format job_id#node_id. Stripping #node_id.
+    shared_dir_temp="${shared_dir}/${AWS_BATCH_JOB_ID%#*}-${AWS_BATCH_JOB_ATTEMPT}"
 
     mkdir -p "${shared_dir_temp}"
 
+    write_node_info
     # If it is the head inspect the shared directory for the hostfile list
     if [[ "${AWS_BATCH_JOB_NODE_INDEX}" -eq  "${AWS_BATCH_JOB_MAIN_NODE_INDEX}" ]]; then
         read_compute_address
-    else
-        write_compute_address
     fi
 }
 
-main $@
+main "$@"

--- a/cli/pcluster/resources/batch/docker/scripts/mount_nfs.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/mount_nfs.sh
@@ -28,13 +28,13 @@ error_exit() {
 
 usage() {
     cat <<ENDUSAGE
-    This script mounts the shared dir from master instance on the nodes in the batch job.
-    The shared directory will be created if it does not exist.
+This script mounts the shared dir from master instance on the nodes in the batch job.
+The shared directory will be created if it does not exist.
 
-    USAGE:
-    mount_nfs <master_ip> <shared_dir>
-    master_ip: ip address of the main node
-    shared_dir: directory from master to be shared. If directory doesn't exist on compute, will be created
+USAGE:
+mount_nfs <master_ip> <shared_dir>
+master_ip: ip address of the main node
+shared_dir: directory from master to be shared. If directory doesn't exist on compute, will be created
 ENDUSAGE
 }
 

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -22,7 +22,7 @@ def readme():
 
 
 version = "2.0.2"
-requires = ["boto3>=1.7.33", "awscli>=1.11.175", "future>=0.16.0", "tabulate>=0.8.2"]
+requires = ["boto3>=1.9.48", "awscli>=1.11.175", "future>=0.16.0", "tabulate>=0.8.2"]
 
 if sys.version_info[:2] == (2, 6):
     # For python2.6 we have to require argparse since it

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1550,6 +1550,18 @@
               "Resource": [
                 "*"
               ]
+            },
+            {
+              "Sid": "BatchJobPassRole",
+              "Action": [
+                "iam:PassRole"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:role/parallelcluster-*"
+                }
+              ]
             }
           ]
         },
@@ -4242,6 +4254,15 @@
         "Fn::GetAtt": [
           "AWSBatchStack",
           "Outputs.JobDefinitionArn"
+        ]
+      },
+      "Condition": "CreateAWSBatchStack"
+    },
+    "BatchJobDefinitionMnpArn": {
+      "Value": {
+        "Fn::GetAtt": [
+          "AWSBatchStack",
+          "Outputs.MNPJobDefinitionArn"
         ]
       },
       "Condition": "CreateAWSBatchStack"

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -271,6 +271,46 @@
         }
       }
     },
+    "JobDefinitionMNP": {
+      "Type": "AWS::Batch::JobDefinition",
+      "Properties": {
+        "JobDefinitionName": {
+          "Fn::Sub": "${ClusterName}-mnp"
+        },
+        "Type": "multinode",
+        "NodeProperties": {
+          "NumNodes": 1,
+          "MainNode": 0,
+          "NodeRangeProperties": [
+            {
+              "TargetNodes": "0:",
+              "Container": {
+                "Image": {
+                  "Fn::Sub": "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${DockerImagesRepo}:${OS}"
+                },
+                "JobRoleArn": {
+                  "Fn::GetAtt": [
+                    "JobRole",
+                    "Arn"
+                  ]
+                },
+                "Memory": 512,
+                "Privileged": true,
+                "Vcpus": 1,
+                "Environment": [
+                  {
+                    "Name": "SHARED_DIR",
+                    "Value": {
+                      "Ref": "SharedDir"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
     "DockerImagesRepo": {
       "Type": "AWS::ECR::Repository"
     },
@@ -681,6 +721,99 @@
           }
         ]
       }
+    },
+    "DeregisterBatchMNPJobDefinitionsCustomResource": {
+      "Type": "AWS::CloudFormation::CustomResource",
+      "Properties": {
+        "JobDefinitionMNPArn": {
+          "Ref": "JobDefinitionMNP"
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "DeregisterBatchMNPJobDefinitionsFunction",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "DeregisterBatchMNPJobDefinitionsFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ResourcesS3Bucket"
+          },
+          "S3Key": "custom_resources_code/artifacts.zip"
+        },
+        "Handler": "deregister_batch_mnp_job_definitions.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "DeregisterBatchMNPJobDefinitionsFunctionExecutionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python3.6",
+        "Timeout": 120
+      }
+    },
+    "DeregisterBatchMNPJobDefinitionsFunctionExecutionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "arn:aws:logs:*:*:*",
+                  "Sid": "CloudWatchLogsPolicy"
+                },
+                {
+                  "Action": [
+                    "batch:*"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": "*",
+                  "Sid": "Batch"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "LambdaPolicy"
+          }
+        ]
+      }
+    },
+    "DeregisterBatchMNPJobDefinitionsFunctionLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": "/aws/lambda/${DeregisterBatchMNPJobDefinitionsFunction}"
+        },
+        "RetentionInDays": 1
+      }
     }
   },
   "Outputs": {
@@ -715,6 +848,11 @@
       "Description": "S3 user bucket where resources are stored",
       "Value": {
         "Ref": "ResourcesS3Bucket"
+      }
+    },
+    "MNPJobDefinitionArn": {
+      "Value": {
+        "Ref": "JobDefinitionMNP"
       }
     }
   }

--- a/docs/iam.rst
+++ b/docs/iam.rst
@@ -132,6 +132,18 @@ ParallelClusterInstancePolicy
               ],
               "Sid": "SQSList",
               "Effect": "Allow"
+          },
+          {
+            "Sid": "BatchJobPassRole",
+            "Action": [
+              "iam:PassRole"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+              {
+                "Fn::Sub": "arn:aws:iam::<AWS ACCOUNT ID>:role/<EC2 IAM ROLE NAME>"
+              }
+            ]
           }
       ]
   }


### PR DESCRIPTION
* Added back code to support MNP jobs
* Moved creation of MNP resources from CustomResource to CFN template.
* Created deregister_batch_mnp_job_definitions.py CustomResource that only deregisters all mnp job definitions created by the cli at stack deletion time.
* Starting `ssh-agent` in the entrypoint and not in the Dockerfile together with sshd daemon to allow ssh-ing between containers
* Small fixes to generate_hostfile script:
  * Added to hostfile information on the available CPUs (slots)
  * Changed the way ip address is retrieved to `ip_address=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)`. This is needed cause in case of MNP container ip is different from the host ip.
  * Strip the node number from the end of job id when creating the shared dir containing the ips of the compute nodes
  * Make the main node also write it's own IP to the hostfile
* Updated boto3 required version to boto3>=1.9.48. This is needed to support MNP features.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
