### PR TITLE
Mount nfs with the latest supported version

### DIFF
--- a/cli/pcluster/resources/batch/docker/scripts/mount_nfs.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/mount_nfs.sh
@@ -58,7 +58,7 @@ mount_nfs() {
     fi
 
     mkdir -p ${shared_dir}
-    error_message=$(mount -t nfs -o hard,intr,noatime,vers=3,_netdev "${master_ip}":"${shared_dir}" "${shared_dir}" 2>&1)
+    error_message=$(mount -t nfs -o hard,intr,noatime,_netdev "${master_ip}":"${shared_dir}" "${shared_dir}" 2>&1)
     if [[ $? -ne 0 ]]; then
         error_exit "Failed to mount nfs volume from ${master_ip}:${shared_dir} with error_message: ${error_message}"
     fi


### PR DESCRIPTION
Avoid enforcing version when mounting NFS in docker containers. When vers is not specified, the latest version supported by the NFS server is used when mounting the shared dir.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
