### PR TITLE
Patch for mounting multiple EBS volumes on Batch

### DIFF
--- a/cli/pcluster/resources/batch/docker/scripts/generate_hostfile.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/generate_hostfile.sh
@@ -136,7 +136,10 @@ main() {
     fi
 
     # This is the shared directory on which compute and head instances have agreed upon for reading and writing the ip addresses
-    shared_dir=${1}
+    shared_dir="${1}"
+    if [[ "${shared_dir:0:1}" != '/' ]]; then
+      shared_dir="/${shared_dir}"
+    fi
     destination_dir=${2}
 
     check_arguments_valid

--- a/cli/pcluster/resources/batch/docker/scripts/mount_nfs.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/mount_nfs.sh
@@ -75,6 +75,9 @@ mount_nfs() {
 main() {
     master_ip=${1}
     shared_dir=${2}
+    if [[ "${shared_dir:0:1}" != '/' ]]; then
+      shared_dir="/${shared_dir}"
+    fi
 
     check_arguments_valid
     mount_nfs

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -316,7 +316,7 @@
               }
             },
             {
-              "Name": "PCLUSTER_SHARED_DIR",
+              "Name": "PCLUSTER_SHARED_DIRS",
               "Value": {
                 "Ref": "SharedDir"
               }
@@ -374,7 +374,7 @@
                     }
                   },
                   {
-                    "Name": "PCLUSTER_SHARED_DIR",
+                    "Name": "PCLUSTER_SHARED_DIRS",
                     "Value": {
                       "Ref": "SharedDir"
                     }


### PR DESCRIPTION
- Modified entrypoint.sh to parse the comma separated list of SHARED_DIR into a list, and recursively run mount nfs script
- Modified mount_nfs script to add a '/' in front of all directory to prevent possible failure
- Manually tested

Signed-off-by: Rex Chen <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
