### PR TITLE
awsbstat: add space between job-array id and bracket

### DIFF
--- a/cli/awsbatch/awsbstat.py
+++ b/cli/awsbatch/awsbstat.py
@@ -260,7 +260,7 @@ class AWSBstatCommand(object):
 
                     if is_job_array(job):
                         # parent job array
-                        job_id = "{0}[{1}]".format(job["jobId"], job["arrayProperties"]["size"])
+                        job_id = "{0} [{1}]".format(job["jobId"], job["arrayProperties"]["size"])
                         log_stream = "-"
                         log_stream_url = "-"
                     else:


### PR DESCRIPTION
Before:
```
jobId                                     jobName           status     startedAt            stoppedAt            exitCode
----------------------------------------  ----------------  ---------  -------------------  -------------------  ----------
3286a19c-68a9-47c9-8000-427d23ffc7ca[2]  array-succeeded   SUCCEEDED  -                    -                    -
```

After:
```
jobId                                     jobName           status     startedAt            stoppedAt            exitCode
----------------------------------------  ----------------  ---------  -------------------  -------------------  ----------
3286a19c-68a9-47c9-8000-427d23ffc7ca [2]  array-succeeded   SUCCEEDED  -                    -                    -
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
