### PR TITLE
awsbstat: optimize calls to describe-jobs in detailed mode

### DIFF
--- a/cli/awsbatch/awsbstat.py
+++ b/cli/awsbatch/awsbstat.py
@@ -205,7 +205,8 @@ class AWSBstatCommand(object):
                 self.__populate_output_by_array_ids(job_status, job_array_ids, details)
 
                 # add single jobs to the output
-                self.__add_jobs(single_jobs, details)
+                # forcing details to be False since already retrieved.
+                self.__add_jobs(single_jobs, details=False)
         except Exception as e:
             fail("Error describing jobs from AWS Batch. Failed with exception: %s" % e)
 

--- a/cli/awsbatch/common.py
+++ b/cli/awsbatch/common.py
@@ -50,11 +50,12 @@ class Output(object):
         else:
             self.items.append(items)
 
-    def show_table(self, keys=None):
+    def show_table(self, keys=None, sort_keys_function=None):
         """
         Print the items table.
 
         :param keys: show a specific list of keys (optional)
+        :param sort_keys_function: function to sort table rows (optional)
         """
         rows = []
         output_keys = keys or self.keys
@@ -63,6 +64,8 @@ class Output(object):
             for output_key in output_keys:
                 row.append(getattr(item, self.mapping[output_key]))
             rows.append(row)
+        if sort_keys_function:
+            rows = sorted(rows, key=sort_keys_function)
         print(tabulate(rows, output_keys))
 
     def show(self, keys=None):


### PR DESCRIPTION
The patch contains 3 optimisations:

1. Reduce the amount of calls to describe-jobs when awsbstat is used in detailed mode by calling __add_jobs function only after all jobs are retrieved.
In order to keep jobs sorted by status in the output table, output is now sorted right before being displayed rather than relying on the order given by the api calls performed.

2. Avoid a duplicate call to describe-jobs when awsbstat is called with a list of job ids.

3. Replace list_jobs calls with a single call to describe_jobs when expanding arrays.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
