### PR TITLE
Run efs unittests as part of the CI workflow

### DIFF
--- a/cli/tests/pcluster/efs_test.py
+++ b/cli/tests/pcluster/efs_test.py
@@ -4,7 +4,7 @@ import argparse
 
 from pcluster import cfnconfig
 
-config_file = "cli/tests/pcluster/config_efs"
+config_file = "tests/pcluster/config_efs"
 test_cluster_template = "unittest"
 args = argparse.Namespace()
 args.config_file = config_file

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -2,4 +2,4 @@ pytest
 pytest-cov
 pytest-html
 pytest-mock
-moto
+discover # Needed for Python 2.6 compatibility

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -12,8 +12,11 @@ envlist =
 # deps = -rtests/requirements.txt  TODO: ADD UNIT TESTS
 whitelist_externals:
     bash
+deps = -rtests/requirements.txt
 commands =
     bash ./tests/pcluster/test.sh
+    # Running with discover and not unittest discover for Python 2.6 compatibility
+    python -m discover -s tests/pcluster -p "*_test.py"
     # TODO: ADD UNIT TESTS
     # py.test -l --basetemp={envtmpdir} --html=report.html --cov=pcluster tests/
 


### PR DESCRIPTION
Automatically run efs unittests as part of the Travis build and for all supported python versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
