### PR TITLE
awsbstat: change datetime format to be ISO 8601 compliant

### DIFF
--- a/cli/awsbatch/utils.py
+++ b/cli/awsbatch/utils.py
@@ -17,6 +17,8 @@ import pipes
 import re
 from datetime import datetime
 
+from dateutil import tz
+
 
 def fail(error_message):
     """
@@ -50,14 +52,18 @@ def get_job_definition_name_by_arn(job_definition_arn, version=False):
     return re.search(pattern, job_definition_arn).group(1)
 
 
-def convert_to_date(timestamp):
+def convert_to_date(timestamp, timezone=None):
     """
     Convert timestamp to a readable date.
 
     :param timestamp: timestamp to convert
+    :param timezone: timezone to use when converting. Defaults to local.
     :return: the converted date
     """
-    return datetime.fromtimestamp(timestamp / 1000).strftime("%Y-%m-%d %H:%M:%S")
+    if not timezone:
+        timezone = tz.tzlocal()
+    # Forcing microsecond to 0 to avoid having them displayed.
+    return datetime.fromtimestamp(timestamp / 1000, tz=timezone).replace(microsecond=0).isoformat()
 
 
 def hide_keys(dictionary, keys_to_hide, new_value="xxx"):


### PR DESCRIPTION
```
jobId                                     jobName           status     startedAt                  stoppedAt                  exitCode
----------------------------------------  ----------------  ---------  -------------------------  -------------------------  ----------
ab2cd019-1d84-43c7-a016-9772dd963f3b      simple-succeeded  SUCCEEDED  2018-11-28T09:16:18+00:00  2018-11-28T09:16:49+00:00  0
3286a19c-68a9-47c9-8000-427d23ffc7ca [2]  array-succeeded   SUCCEEDED  -                          -                          -
3ec00225-8b85-48ba-a321-f61d005bec46      mnp-succeeded     SUCCEEDED  2018-11-28T09:17:46+00:00  2018-11-28T09:19:03+00:00  -
```

```
jobId                    : ab2cd019-1d84-43c7-a016-9772dd963f3b
jobName                  : simple-succeeded
createdAt                : 2018-11-28T09:15:50+00:00
startedAt                : 2018-11-28T09:16:18+00:00
stoppedAt                : 2018-11-28T09:16:49+00:00
status                   : SUCCEEDED
statusReason             : Essential container in task exited
jobDefinition            : parallelcluster-mnp-final:1
jobQueue                 : parallelcluster-mnp-final
command                  : /bin/bash -c 'aws s3 --region us-east-1 cp s3://parallelcluster-mnp-final-0ymk3bktyjgsbdmm/batch/job-simple-script-1543511352912.sh /tmp/batch/job-simple-script-1543511352912.sh; bash /tmp/batch/job-simple-script-1543511352912.sh '
exitCode                 : 0
reason                   : -
vcpus                    : 1
memory[MB]               : 128
nodes                    : 1
logStream                : parallelcluster-mnp-final/default/666cc3d4-bfc3-4720-b754-32c4b97b5d18
log                      : https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=parallelcluster-mnp-final/default/666cc3d4-bfc3-4720-b754-32c4b97b5d18
-------------------------

```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
