### PR TITLE
Add possibility to use S3 job folder as stage in/out area for the job

### DIFF
--- a/cli/awsbatch/awsbstat.py
+++ b/cli/awsbatch/awsbstat.py
@@ -101,6 +101,7 @@ class Job(object):
         nodes,
         log_stream,
         log_stream_url,
+        s3_folder_url,
     ):
         """Constructor."""
         self.id = job_id
@@ -120,6 +121,7 @@ class Job(object):
         self.nodes = nodes
         self.log_stream = log_stream
         self.log_stream_url = log_stream_url
+        self.s3_folder_url = s3_folder_url
 
 
 class AWSBstatCommand(object):
@@ -152,6 +154,7 @@ class AWSBstatCommand(object):
                 ("nodes", "nodes"),
                 ("logStream", "log_stream"),
                 ("log", "log_stream_url"),
+                ("s3FolderUrl", "s3_folder_url"),
             ]
         )
         self.output = Output(mapping=mapping)
@@ -285,6 +288,11 @@ class AWSBstatCommand(object):
                             log_stream_url = "-"
 
                     command = container.get("command", [])
+                    s3_folder_url = "-"
+                    for env_var in container.get("environment", []):
+                        if env_var.get("name") == "PCLUSTER_JOB_S3_URL":
+                            s3_folder_url = env_var.get("value")
+                            break
                     self.log.debug("Adding job to the output (%s)", job)
                     job = Job(
                         job_id=job_id,
@@ -306,6 +314,7 @@ class AWSBstatCommand(object):
                         nodes=nodes,
                         log_stream=log_stream,
                         log_stream_url=log_stream_url,
+                        s3_folder_url=s3_folder_url,
                     )
                     self.output.add(job)
         except KeyError as e:

--- a/cli/awsbatch/awsbsub.py
+++ b/cli/awsbatch/awsbsub.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and limitations under the License.
 from __future__ import print_function
 
-import datetime
 import os
 import pipes
 import re
@@ -25,7 +24,7 @@ import time
 import argparse
 
 from awsbatch.common import AWSBatchCliConfig, Boto3ClientFactory, config_logger
-from awsbatch.utils import fail, get_job_definition_name_by_arn, shell_join
+from awsbatch.utils import S3Uploader, fail, get_job_definition_name_by_arn, shell_join
 
 
 def _get_parser():
@@ -56,6 +55,25 @@ def _get_parser():
         "--command-file",
         help="Identifies that the command is a file to be transferred to the compute instances",
         action="store_true",
+    )
+    parser.add_argument(
+        "-w",
+        "--working-dir",
+        help="The folder to use as job working directory. "
+        "If not specified the job will be executed in the job-<AWS_BATCH_JOB_ID> subfolder of the user's home",
+    )
+    parser.add_argument(
+        "-pw",
+        "--parent-working-dir",
+        help="Parent folder for the job working directory. If not specified it is the user's home. "
+        "A subfolder named job-<AWS_BATCH_JOB_ID> will be created in it. Alternative to the --working-dir parameter",
+    )
+    parser.add_argument(
+        "-if",
+        "--input-file",
+        help="File to be transferred to the compute instances, in the job working directory. "
+        "It can be expressed multiple times",
+        action="append",
     )
     parser.add_argument(
         "-p",
@@ -163,86 +181,69 @@ def _validate_parameters(args):
     if args.env_blacklist and (not args.env or args.env != "all"):
         fail('--env-blacklist parameter can be used only associated with --env "all"')
 
+    if args.working_dir and args.parent_working_dir:
+        fail("--parent-working-dir and --working-dir parameters cannot be used at the same time")
 
-def _get_job_folder(job_id):
+
+def _generate_unique_job_key(job_name):
     """
-    Get relative folder path to use for the given job_id.
+    Generate an unique job key to use as identifier.
 
-    :param job_id: the job_id will be the subfolder name
-    :return: batch/<job_id>/
+    :param job_name: job name
+    :return: "job-<job_name>-<timestamp>"
     """
-    return "batch/{0}/".format(job_id)
+    return "job-{0}-{1}".format(job_name, int(time.time() * 1000))
 
 
-class S3Uploader(object):
-    """S3 uploader."""
-
-    def __init__(self, boto3_factory, s3_bucket):
-        """Constructor.
-
-        :param boto3_factory: initialized Boto3ClientFactory object
-        :param s3_bucket: S3 bucket to use
-        """
-        self.boto3_factory = boto3_factory
-        self.s3_bucket = s3_bucket
-
-    def put_file(self, file_path, key_name, timeout):
-        """
-        Upload a file to an s3 bucket.
-
-        :param file_path: file to upload
-        :param key_name: S3 key to create
-        :param timeout: S3 expiration time in seconds
-        """
-        default_expiration = 30  # minutes
-        expires = datetime.datetime.now() + datetime.timedelta(minutes=default_expiration)
-        if timeout:
-            expires += datetime.timedelta(seconds=timeout)
-
-        s3_client = self.boto3_factory.get_client("s3")
-        s3_client.upload_file(file_path, self.s3_bucket, key_name, ExtraArgs={"Expires": expires})
-
-
-def _upload_and_get_command(boto3_factory, args, job_name, config, log):
+def _upload_and_get_command(boto3_factory, args, job_s3_folder, job_key, config, log):
     """
     Get command by parsing args and config.
 
     The function will also perform an s3 upload, if needed.
     :param boto3_factory: initialized Boto3ClientFactory object
     :param args: input arguments
-    :param job_name: job name
+    :param job_s3_folder: S3 folder for the job files
+    :param job_key: internal job_key
     :param config: config object
     :param log: log
     :return: command to submit
     """
+    # create S3 folder for the job
+    s3_uploader = S3Uploader(boto3_factory, config.s3_bucket, job_s3_folder)
+
+    # upload input files, if there
+    if args.input_file:
+        for file in args.input_file:
+            s3_uploader.put_file(file, file)
+
+    # upload command, if needed
     if args.command_file or not sys.stdin.isatty() or args.env:
         # define job script name
-        job_id = "job-{0}-{1}".format(job_name, int(time.time() * 1000))
-        job_folder = _get_job_folder(job_id)
-        job_script = job_id + ".sh"
+        job_script = job_key + ".sh"
         log.info("Using command-file option or stdin. Job script name: %s" % job_script)
 
-        s3_uploader = S3Uploader(boto3_factory, config.s3_bucket)
         env_file = None
         if args.env:
-            env_file = job_id + ".env.sh"
+            env_file = job_key + ".env.sh"
             # get environment variables and upload file used to extend the submission environment
             env_blacklist = args.env_blacklist if args.env_blacklist else config.env_blacklist
-            _get_env_and_upload(s3_uploader, args.env, env_blacklist, job_folder, env_file, args.timeout, log)
+            _get_env_and_upload(s3_uploader, args.env, env_blacklist, env_file, log)
 
         # upload job script
         if args.command_file:
             # existing script file
             try:
-                s3_uploader.put_file(args.command, job_folder + job_script, args.timeout)
+                s3_uploader.put_file(args.command, job_script)
             except Exception as e:
                 fail("Error creating job script. Failed with exception: %s" % e)
         elif not sys.stdin.isatty():
             # stdin
-            _get_stdin_and_upload(s3_uploader, job_folder, job_script, args.timeout)
+            _get_stdin_and_upload(s3_uploader, job_script)
 
         # define command to execute
-        bash_command = _compose_bash_command(args, config.s3_bucket, config.region, job_folder, job_script, env_file)
+        bash_command = _compose_bash_command(
+            args, config.s3_bucket, config.region, job_s3_folder, job_key, job_script, env_file
+        )
         command = ["/bin/bash", "-c", bash_command]
     elif type(args.command) == str:
         log.info("Using command parameter")
@@ -253,35 +254,32 @@ def _upload_and_get_command(boto3_factory, args, job_name, config, log):
     return command
 
 
-def _get_stdin_and_upload(s3_uploader, job_folder, job_script, timeout):
+def _get_stdin_and_upload(s3_uploader, job_script):
     """
     Create file from STDIN and upload to S3.
 
     :param s3_uploader: S3Uploader object
-    :param job_folder: S3 bucket subfolder
     :param job_script: job script name
-    :param timeout: S3 expiration time in seconds
     """
     try:
         # copy stdin to temporary file and upload
         with os.fdopen(sys.stdin.fileno(), "rb") as src:
             with tempfile.NamedTemporaryFile() as dst:
                 shutil.copyfileobj(src, dst)
-                s3_uploader.put_file(dst.name, job_folder + job_script, timeout)
+                dst.flush()
+                s3_uploader.put_file(dst.name, job_script)
     except Exception as e:
         fail("Error creating job script. Failed with exception: %s" % e)
 
 
-def _get_env_and_upload(s3_uploader, env, env_blacklist, job_folder, env_file, timeout, log):
+def _get_env_and_upload(s3_uploader, env, env_blacklist, env_file, log):
     """
     Get environment variables, create a file containing the list of the exported env variables and upload to S3.
 
     :param s3_uploader: S3Uploader object
     :param env: comma separated list of environment variables
     :param env_blacklist: comma separated list of blacklisted environment variables
-    :param job_folder: S3 bucket subfolder
     :param env_file: environment file name
-    :param timeout: S3 expiration time in seconds
     :param log: log
     """
     key_value_list = _get_env_key_value_list(env, log, env_blacklist)
@@ -289,48 +287,62 @@ def _get_env_and_upload(s3_uploader, env, env_blacklist, job_folder, env_file, t
         # copy env to temporary file
         with tempfile.NamedTemporaryFile() as dst:
             dst.write("\n".join(key_value_list) + "\n")
-            s3_uploader.put_file(dst.name, job_folder + env_file, timeout)
+            dst.flush()
+            s3_uploader.put_file(dst.name, env_file)
     except Exception as e:
         fail("Error creating environment file. Failed with exception: %s" % e)
 
 
-def _compose_bash_command(args, s3_bucket, region, job_folder, job_script, env_file):
+def _compose_bash_command(args, s3_bucket, region, job_s3_folder, job_key, job_script, env_file):
     """
     Define bash command to execute.
 
     :param args: input arguments
     :param s3_bucket: S3 bucket
     :param region: AWS region
-    :param job_folder: S3 bucket subfolder
+    :param job_s3_folder: S3 job folder
+    :param job_key: job key identifier
     :param job_script: job script file
     :param env_file: environment file
     :return: composed bash command
     """
     command_args = shell_join(args.arguments)
     # download awscli, if required.
-    bash_command = (
-        "curl -O https://bootstrap.pypa.io/get-pip.py >/dev/null 2>&1 && "
-        "python get-pip.py --user >/dev/null 2>&1 && "
-        "export PATH=~/.local/bin:$PATH >/dev/null 2>&1 && "
-        "pip install awscli --upgrade --user >/dev/null 2>&1; "
-        if args.awscli
-        else ""
-    )
-    # download all job files to a tmp subfolder
-    bash_command += (
-        "mkdir -p /tmp/{FOLDER} && "
-        "aws s3 --region {REGION} sync s3://{BUCKET}/{FOLDER} /tmp/{FOLDER}; ".format(
-            REGION=region, BUCKET=s3_bucket, FOLDER=job_folder
+    bash_command = []
+    if args.awscli:
+        bash_command.append(
+            "curl -O https://bootstrap.pypa.io/get-pip.py >/dev/null 2>&1 && "
+            "python get-pip.py --user >/dev/null 2>&1 && "
+            "export PATH=~/.local/bin:$PATH >/dev/null 2>&1 && "
+            "pip install awscli --upgrade --user >/dev/null 2>&1"
+        )
+
+    # set working directory
+    if args.working_dir:
+        # create and move to the working dir specified by the user
+        bash_command.append('mkdir -p "{JOB_WD}" && cd "{JOB_WD}"'.format(JOB_WD=args.working_dir))
+    else:
+        if args.parent_working_dir:
+            # create and move to the parent working dir specified by the user
+            bash_command.append(
+                'mkdir -p "{JOB_PARENT_WD}" && cd "{JOB_PARENT_WD}"'.format(JOB_PARENT_WD=args.parent_working_dir)
+            )
+
+        # create subfolder named job-<$AWS_BATCH_JOB_ID>
+        bash_command.append("mkdir -p job-${AWS_BATCH_JOB_ID} && cd job-${AWS_BATCH_JOB_ID}")
+
+    # download all job files to the job folder
+    bash_command.append(
+        "aws s3 --region {REGION} sync s3://{BUCKET}/{S3_FOLDER} . >/dev/null".format(
+            REGION=region, BUCKET=s3_bucket, S3_FOLDER=job_s3_folder
         )
     )
-    if env_file:
-        # source the environment file
-        bash_command += "source /tmp/{FOLDER}{ENV_FILE}; ".format(FOLDER=job_folder, ENV_FILE=env_file)
+    if env_file:  # source the environment file
+        bash_command.append("source {ENV_FILE}".format(ENV_FILE=env_file))
+
     # execute the job script + arguments
-    bash_command += "chmod +x /tmp/{FOLDER}{SCRIPT} && /tmp/{FOLDER}{SCRIPT} {ARGS}".format(
-        FOLDER=job_folder, SCRIPT=job_script, ARGS=command_args
-    )
-    return bash_command
+    bash_command.append("chmod +x {SCRIPT} && ./{SCRIPT} {ARGS}".format(SCRIPT=job_script, ARGS=command_args))
+    return " && ".join(bash_command)
 
 
 def _get_env_key_value_list(env_vars, log, env_blacklist_vars=None):
@@ -437,7 +449,7 @@ class AWSBsubCommand(object):
         retry_attempts=1,
         timeout=None,
         dependencies=None,
-        master_ip=None,
+        env=None,
     ):
         """Submit the job."""
         try:
@@ -458,8 +470,8 @@ class AWSBsubCommand(object):
                 container_overrides.update(memory=memory)
             # populate environment variables
             environment = []
-            if master_ip:
-                environment.append({"name": "MASTER_IP", "value": master_ip})
+            for env_var in env:
+                environment.append({"name": env_var[0], "value": env_var[1]})
             container_overrides.update(environment=environment)
 
             # common submission arguments
@@ -612,8 +624,11 @@ def main():
                 job_name = re.sub(r"\W+", "_", os.path.basename(args.command))
             log.info("Job name not specified, setting it to (%s)" % job_name)
 
+        # generate an internal unique job-id
+        job_key = _generate_unique_job_key(job_name)
+        job_s3_folder = "batch/{0}/".format(job_key)
         # upload script, if needed, and get related command
-        command = _upload_and_get_command(boto3_factory, args, job_name, config, log)
+        command = _upload_and_get_command(boto3_factory, args, job_s3_folder, job_key, config, log)
         # parse and validate depends_on parameter
         depends_on = _get_depends_on(args)
 
@@ -637,7 +652,10 @@ def main():
             dependencies=depends_on,
             retry_attempts=args.retry_attempts,
             timeout=args.timeout,
-            master_ip=config.master_ip,
+            env=[
+                ("MASTER_IP", config.master_ip),
+                ("PCLUSTER_JOB_S3_URL", "s3://{0}/{1}".format(config.s3_bucket, job_s3_folder)),
+            ],
         )
     except KeyboardInterrupt:
         print("Exiting...")

--- a/cli/awsbatch/utils.py
+++ b/cli/awsbatch/utils.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and limitations under the License.
 from __future__ import print_function
 
+import datetime
 import pipes
 import re
 import sys
-from datetime import datetime
 
 from dateutil import tz
 
@@ -64,7 +64,7 @@ def convert_to_date(timestamp, timezone=None):
     if not timezone:
         timezone = tz.tzlocal()
     # Forcing microsecond to 0 to avoid having them displayed.
-    return datetime.fromtimestamp(timestamp / 1000, tz=timezone).replace(microsecond=0).isoformat()
+    return datetime.datetime.fromtimestamp(timestamp / 1000, tz=timezone).replace(microsecond=0).isoformat()
 
 
 def hide_keys(dictionary, keys_to_hide, new_value="xxx"):
@@ -89,7 +89,7 @@ def shell_join(array):
     :param array: input array
     :return: the shell-quoted string
     """
-    return " ".join(pipes.quote(arg) for arg in array)
+    return " ".join(pipes.quote(item) for item in array)
 
 
 def is_job_array(job):
@@ -100,3 +100,42 @@ def is_job_array(job):
     :return: true if the job is an array, false otherwise
     """
     return "arrayProperties" in job and "size" in job["arrayProperties"]
+
+
+class S3Uploader(object):
+    """S3 uploader."""
+
+    def __init__(self, boto3_factory, s3_bucket, default_folder=""):
+        """Constructor.
+
+        :param boto3_factory: initialized Boto3ClientFactory object
+        :param s3_bucket: S3 bucket to use
+        :param default_folder: S3 folder on which put the files (optional)
+        """
+        self.s3_client = boto3_factory.get_client("s3")
+        self.s3_bucket = s3_bucket
+        self.default_folder = default_folder
+        if default_folder:
+            self.__create_folder(default_folder)
+
+    def __create_folder(self, folder):
+        """
+        Create an empty pseudo-folder in the S3 bucket.
+
+        :param folder: the path to create
+        """
+        if not folder.endswith("/"):
+            folder = folder + "/"
+
+        self.s3_client.put_object(Bucket=self.s3_bucket, Key=folder, Body="")
+
+    def put_file(self, file_path, key_name, folder=None):
+        """
+        Upload a file to an s3 bucket.
+
+        :param file_path: file to upload
+        :param key_name: S3 key to create
+        :param folder: S3 folder on which put the files (optional)
+        """
+        s3_folder = folder if folder else self.default_folder
+        self.s3_client.upload_file(file_path, self.s3_bucket, s3_folder + key_name)

--- a/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_FAILED.json
+++ b/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_FAILED.json
@@ -37,6 +37,10 @@
                 {
                   "name": "MASTER_IP",
                   "value": "10.0.0.47"
+                },
+                {
+                  "name": "PCLUSTER_JOB_S3_URL",
+                  "value": "s3://parallelcluster-xxx/batch/job-xxx"
                 }
               ],
               "vcpus": 1,
@@ -75,6 +79,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,
@@ -132,6 +140,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,

--- a/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_PENDING.json
+++ b/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_PENDING.json
@@ -13,6 +13,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,

--- a/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_RUNNABLE.json
+++ b/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_RUNNABLE.json
@@ -25,6 +25,10 @@
                 {
                   "name": "MASTER_IP",
                   "value": "10.0.0.47"
+                },
+                {
+                  "name": "PCLUSTER_JOB_S3_URL",
+                  "value": "s3://parallelcluster-xxx/batch/job-xxx"
                 }
               ],
               "vcpus": 1,
@@ -61,6 +65,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,

--- a/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_RUNNING.json
+++ b/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_RUNNING.json
@@ -25,6 +25,10 @@
                 {
                   "name": "MASTER_IP",
                   "value": "10.0.0.47"
+                },
+                {
+                  "name": "PCLUSTER_JOB_S3_URL",
+                  "value": "s3://parallelcluster-xxx/batch/job-xxx"
                 }
               ],
               "vcpus": 1,
@@ -64,6 +68,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,

--- a/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_STARTING.json
+++ b/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_STARTING.json
@@ -16,6 +16,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,
@@ -68,6 +72,10 @@
                 {
                   "name": "MASTER_IP",
                   "value": "10.0.0.47"
+                },
+                {
+                  "name": "PCLUSTER_JOB_S3_URL",
+                  "value": "s3://parallelcluster-xxx/batch/job-xxx"
                 }
               ],
               "vcpus": 1,

--- a/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_SUBMITTED.json
+++ b/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_SUBMITTED.json
@@ -13,6 +13,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,
@@ -65,6 +69,10 @@
                 {
                   "name": "MASTER_IP",
                   "value": "10.0.0.47"
+                },
+                {
+                  "name": "PCLUSTER_JOB_S3_URL",
+                  "value": "s3://parallelcluster-xxx/batch/job-xxx"
                 }
               ],
               "vcpus": 1,

--- a/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_SUCCEEDED.json
+++ b/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_SUCCEEDED.json
@@ -13,6 +13,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,
@@ -68,6 +72,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,
@@ -145,6 +153,10 @@
                 {
                   "name": "MASTER_IP",
                   "value": "10.0.0.47"
+                },
+                {
+                  "name": "PCLUSTER_JOB_S3_URL",
+                  "value": "s3://parallelcluster-xxx/batch/job-xxx"
                 }
               ],
               "vcpus": 1,

--- a/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_single_array_job.json
+++ b/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_single_array_job.json
@@ -13,6 +13,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,

--- a/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_single_array_job_children.json
+++ b/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_single_array_job_children.json
@@ -16,6 +16,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,
@@ -80,6 +84,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,

--- a/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_single_job.json
+++ b/cli/tests/awsbatch/data/aws_api_responses/batch_describe-jobs_single_job.json
@@ -16,6 +16,10 @@
           {
             "name": "MASTER_IP",
             "value": "10.0.0.47"
+          },
+          {
+            "name": "PCLUSTER_JOB_S3_URL",
+            "value": "s3://parallelcluster-xxx/batch/job-xxx"
           }
         ],
         "vcpus": 1,

--- a/cli/tests/awsbatch/test_awsbstat/TestOutput/test_all_status_detailed/expected_output.txt
+++ b/cli/tests/awsbatch/test_awsbstat/TestOutput/test_all_status_detailed/expected_output.txt
@@ -15,6 +15,7 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : 3c6ee190-9121-464e-a0ac-62e4084e6bf1
 jobName                  : mnp-submitted
@@ -33,6 +34,7 @@ memory[MB]               : 128
 nodes                    : 2
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : 11aa9096-1e98-4a7c-a44b-5ac3442df177 [2]
 jobName                  : array-pending
@@ -51,6 +53,7 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : 77712b12-71eb-4007-a865-85f05de13a71
 jobName                  : mnp-runnable
@@ -69,6 +72,7 @@ memory[MB]               : 128
 nodes                    : 2
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : 46a77495-55af-461c-ab5b-7f4e16de34d9
 jobName                  : simple-runnable
@@ -87,6 +91,7 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : aaaaabd2-4174-47be-8636-8f6e6da4b544
 jobName                  : simple-starting
@@ -105,6 +110,7 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : parallelcluster-mnp-final/default/0ce8cb55-579e-40bb-bded-d675270d95a6
 log                      : https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=parallelcluster-mnp-final/default/0ce8cb55-579e-40bb-bded-d675270d95a6
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : bbbbbcbc-2647-4d8b-a1ef-da65bffe0dd0
 jobName                  : mnp-script-starting
@@ -123,6 +129,7 @@ memory[MB]               : 128
 nodes                    : 2
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : qwerfcbc-2647-4d8b-a1ef-da65bffe0dd0
 jobName                  : mnp-running
@@ -141,6 +148,7 @@ memory[MB]               : 128
 nodes                    : 2
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : 12300bd2-4174-47be-8636-8f6e6da4b544
 jobName                  : simple-running
@@ -159,6 +167,7 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : parallelcluster-mnp-final/default/0ce8cb55-579e-40bb-bded-d675270d95a6
 log                      : https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=parallelcluster-mnp-final/default/0ce8cb55-579e-40bb-bded-d675270d95a6
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : 3286a19c-68a9-47c9-8000-427d23ffc7ca [2]
 jobName                  : array-succeeded
@@ -177,6 +186,7 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : ab2cd019-1d84-43c7-a016-9772dd963f3b
 jobName                  : simple-succeeded
@@ -195,6 +205,7 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : parallelcluster-mnp-final/default/666cc3d4-bfc3-4720-b754-32c4b97b5d18
 log                      : https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=parallelcluster-mnp-final/default/666cc3d4-bfc3-4720-b754-32c4b97b5d18
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : 3ec00225-8b85-48ba-a321-f61d005bec46
 jobName                  : mnp-succeeded
@@ -213,6 +224,7 @@ memory[MB]               : 128
 nodes                    : 2
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : 7a712b12-71eb-4007-a865-85f05de13a71
 jobName                  : mnp-failed
@@ -231,6 +243,7 @@ memory[MB]               : 128
 nodes                    : 2
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : 44db07a9-f8a2-48d9-8d67-dcb04ceca54c [2]
 jobName                  : array-failed
@@ -249,6 +262,7 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : -
 log                      : -
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : a9ef6970-2edc-4d0d-b561-cfc48369ed51
 jobName                  : simple-failed
@@ -267,4 +281,5 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : parallelcluster-mnp-final/default/13f0668b-cd9f-493a-8c14-5c3848a53b1c
 log                      : https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=parallelcluster-mnp-final/default/13f0668b-cd9f-493a-8c14-5c3848a53b1c
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------

--- a/cli/tests/awsbatch/test_awsbstat/TestOutput/test_single_array_job_detailed/expected_output.txt
+++ b/cli/tests/awsbatch/test_awsbstat/TestOutput/test_single_array_job_detailed/expected_output.txt
@@ -15,6 +15,7 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : parallelcluster-mnp-final/default/4086671a-6a65-4666-ae18-931e63187271
 log                      : https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=parallelcluster-mnp-final/default/4086671a-6a65-4666-ae18-931e63187271
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------
 jobId                    : 3286a19c-68a9-47c9-8000-427d23ffc7ca:0
 jobName                  : array-succeeded
@@ -33,4 +34,5 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : parallelcluster-mnp-final/default/8f049b3a-9fab-400a-acbe-135337ec4c17
 log                      : https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=parallelcluster-mnp-final/default/8f049b3a-9fab-400a-acbe-135337ec4c17
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------

--- a/cli/tests/awsbatch/test_awsbstat/TestOutput/test_single_job_detailed/expected_output.txt
+++ b/cli/tests/awsbatch/test_awsbstat/TestOutput/test_single_job_detailed/expected_output.txt
@@ -15,4 +15,5 @@ memory[MB]               : 128
 nodes                    : 1
 logStream                : parallelcluster-mnp-final/default/666cc3d4-bfc3-4720-b754-32c4b97b5d18
 log                      : https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=parallelcluster-mnp-final/default/666cc3d4-bfc3-4720-b754-32c4b97b5d18
+s3FolderUrl              : s3://parallelcluster-xxx/batch/job-xxx
 -------------------------

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -121,8 +121,31 @@
           ]
         },
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
-          "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonS3ReadOnlyAccess"
+          },
+          {
+            "Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+          }
+        ],
+        "Policies": [
+          {
+            "PolicyName": "s3PutObject",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": "s3:PutObject",
+                  "Resource": [
+                    {
+                      "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/batch/*"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         ]
       }
     },

--- a/docs/awsbsub.rst
+++ b/docs/awsbsub.rst
@@ -15,4 +15,5 @@ awsbsub
     io
     jobId
     startedAt
+    subfolder
     utf


### PR DESCRIPTION
+ At submission time an S3 folder is created for the job,
  containing the command file (if there) and the environment (if there).
+ The s3 bucket folder is available in the `awsbstat -d` command.
+ We are adding `PutObject` permission to the Job Role.

+ We are exporting in the job environment the `PCLUSTER_JOB_S3_URL`, to be used for stage-in/out by the job.
+ Added `--input-file file1 --input-file file2` option to the awsbsub to stage-in input files from the client.
+ Added `--working-dir` to give the user the possibility to specify the working-directory for the job in the compute instance
+ Added `--parent-working-dir` to give the user the possibility to specify the parent-working-directory for the job in the compute instance it is an alternative to the previous


Examples:
```
$ awsbsub -cf test.sh --> pwd: /job-08f80690-947d-40e5-9bc7-5ad78b729991

$ awsbsub -pw /custom/ -cf test.sh --> pwd: /custom/job-cfc1faa6-554a-46d9-84a2-5a2c16c8297a

$ awsbsub -w /customwd/ -cf test.sh --> pwd: /customwd
```

