### PR TITLE
awsbsub: check if cluster supports mnp before submission

### DIFF
--- a/cli/awsbatch/awsbsub.py
+++ b/cli/awsbatch/awsbsub.py
@@ -619,6 +619,8 @@ def main():
 
         # select submission (standard vs MNP)
         if args.nodes:
+            if not hasattr(config, "job_definition_mnp"):
+                fail("Current cluster does not support MNP jobs submission")
             job_definition = config.job_definition_mnp
         else:
             job_definition = config.job_definition

--- a/cli/awsbatch/common.py
+++ b/cli/awsbatch/common.py
@@ -166,7 +166,6 @@ class AWSBatchCliConfig(object):
             log.debug("compute_environment = %s", self.compute_environment)
             log.debug("job_queue = %s", self.job_queue)
             log.debug("job_definition = %s", self.job_definition)
-            log.debug("job_definition_mnp = %s", self.job_definition_mnp)
             log.debug("master_ip = %s", self.master_ip)
             log.info(self)
         except AttributeError as e:
@@ -245,7 +244,10 @@ class AWSBatchCliConfig(object):
                 self.compute_environment = config.get(cluster_section, "compute_environment")
                 self.job_queue = config.get(cluster_section, "job_queue")
                 self.job_definition = config.get(cluster_section, "job_definition")
-                self.job_definition_mnp = config.get(cluster_section, "job_definition_mnp")
+                try:
+                    self.job_definition_mnp = config.get(cluster_section, "job_definition_mnp")
+                except NoOptionError:
+                    pass
                 self.master_ip = config.get(cluster_section, "master_ip")
 
                 # get proxy


### PR DESCRIPTION
Allows compatibility of the new version of the cli with older clusters that do not have MNP resources configured.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
