### PR TITLE
Use random names for AWSBatch CFN resources

### DIFF
--- a/cli/pcluster/pcluster.py
+++ b/cli/pcluster/pcluster.py
@@ -189,7 +189,15 @@ def _print_stack_outputs(stack):
 
     :param stack: the stack dictionary
     """
-    whitelisted_outputs = ["ClusterUser", "MasterPrivateIP", "MasterPublicIP"]
+    whitelisted_outputs = [
+        "ClusterUser",
+        "MasterPrivateIP",
+        "MasterPublicIP",
+        "BatchComputeEnvironmentArn",
+        "BatchJobQueueArn",
+        "BatchJobDefinitionArn",
+        "BatchJobDefinitionMnpArn",
+    ]
     if is_ganglia_enabled(stack.get("Parameters")):
         whitelisted_outputs.extend(["GangliaPrivateURL", "GangliaPublicURL"])
 

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -173,9 +173,6 @@
         "ServiceRole": {
           "Ref": "BatchServiceRole"
         },
-        "ComputeEnvironmentName": {
-          "Ref": "ClusterName"
-        },
         "ComputeResources": {
           "Type": {
             "Fn::If": [
@@ -234,9 +231,6 @@
     "JobQueue": {
       "Type": "AWS::Batch::JobQueue",
       "Properties": {
-        "JobQueueName": {
-          "Ref": "ClusterName"
-        },
         "Priority": 1,
         "ComputeEnvironmentOrder": [
           {
@@ -251,9 +245,6 @@
     "JobDefinitionSerial": {
       "Type": "AWS::Batch::JobDefinition",
       "Properties": {
-        "JobDefinitionName": {
-          "Ref": "ClusterName"
-        },
         "Type": "container",
         "ContainerProperties": {
           "JobRoleArn": {
@@ -300,9 +291,6 @@
     "JobDefinitionMNP": {
       "Type": "AWS::Batch::JobDefinition",
       "Properties": {
-        "JobDefinitionName": {
-          "Fn::Sub": "${ClusterName}-mnp"
-        },
         "Type": "multinode",
         "NodeProperties": {
           "NumNodes": 1,


### PR DESCRIPTION
Issue: If a cluster gets created with the same name of a previously deleted one, Batch resources will have the same name and it'll be possible to see jobs submitted by the old cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
