### PR TITLE
Patch to fix EFS Batch compatibility

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -131,7 +131,7 @@ class ParallelClusterConfig(object):
                     __temp_efs_options.append("Valid")
                 else:
                     __temp_efs_options.append("NONE")
-                self.parameters["EFSoptions"] = ",".join(__temp_efs_options)
+                self.parameters["EFSOptions"] = ",".join(__temp_efs_options)
         except AttributeError:
             pass
 

--- a/cli/pcluster/resources/batch/docker/scripts/entrypoint.sh
+++ b/cli/pcluster/resources/batch/docker/scripts/entrypoint.sh
@@ -14,7 +14,7 @@ echo "Mounting shared file system..."
 /parallelcluster/bin/mount_nfs.sh "${MASTER_IP}" "${SHARED_DIR}"
 
 # mount EFS via nfs
-if [[ ! -z "${EFS_FS_ID}" ]] && [[ ! -z "${AWS_REGION}" ]] && [[ "${EFS_SHARED_DIR}" != "NONE" ]]; then
+if [[ "${EFS_FS_ID}" != "NONE" ]] && [[ ! -z "${AWS_REGION}" ]] && [[ "${EFS_SHARED_DIR}" != "NONE" ]]; then
   /parallelcluster/bin/mount_efs.sh "${EFS_FS_ID}" "${AWS_REGION}" "${EFS_SHARED_DIR}"
 fi
 

--- a/cli/tests/pcluster/efs_test.py
+++ b/cli/tests/pcluster/efs_test.py
@@ -29,7 +29,7 @@ class TestEFSConfigParser(unittest.TestCase):
         global args
         args.func = create
         config = cfnconfig.ParallelClusterConfig(args)
-        efs_options = [opt.strip() for opt in config.parameters["EFSoptions"].split(",")]
+        efs_options = [opt.strip() for opt in config.parameters["EFSOptions"].split(",")]
         self.assertEqual(efs_options[0], "efs_shared", msg="Unexpected shared_dir")
         self.assertEqual(efs_options[1], "fs-12345", msg="Unexpected efs_fs_id")
         self.assertEqual(efs_options[2], "maxIO", msg="Unexpected performance_mode")
@@ -50,7 +50,7 @@ class TestEFSConfigParser(unittest.TestCase):
         global args
         args.func = update
         config = cfnconfig.ParallelClusterConfig(args)
-        efs_options = [opt.strip() for opt in config.parameters["EFSoptions"].split(",")]
+        efs_options = [opt.strip() for opt in config.parameters["EFSOptions"].split(",")]
         self.assertEqual(efs_options[0], "efs_shared", msg="Unexpected shared_dir")
         self.assertEqual(efs_options[1], "fs-12345", msg="Unexpected efs_fs_id")
         self.assertEqual(efs_options[2], "maxIO", msg="Unexpected performance_mode")

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -583,7 +583,7 @@
       "Type": "Number",
       "Default": "1"
     },
-    "EFSoptions": {
+    "EFSOptions": {
       "Description": "Comma separated list of efs related options, 8 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,valid_existing_MTorNot]",
       "Type": "String",
       "Default": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE"
@@ -601,7 +601,7 @@
                   "Fn::Split": [
                     ",",
                     {
-                      "Ref": "EFSoptions"
+                      "Ref": "EFSOptions"
                     }
                   ]
                 }
@@ -1281,8 +1281,8 @@
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
         "Parameters": {
-          "EFSoptions": {
-            "Ref": "EFSoptions"
+          "EFSOptions": {
+            "Ref": "EFSOptions"
           },
           "ComputeSecurityGroup": {
             "Fn::If": [
@@ -2178,7 +2178,7 @@
                       ]
                     },
                     "cfn_efs_shared_dir": {
-                      "Ref": "EFSoptions"
+                      "Ref": "EFSOptions"
                     },
                     "cfn_volume": {
                       "Fn::GetAtt": [
@@ -2933,7 +2933,7 @@
                       ]
                     },
                     "cfn_efs_shared_dir": {
-                      "Ref": "EFSoptions"
+                      "Ref": "EFSOptions"
                     },
                     "cfn_scheduler": {
                       "Ref": "Scheduler"
@@ -3599,7 +3599,7 @@
                       ]
                     },
                     "cfn_efs_shared_dir": {
-                      "Ref": "EFSoptions"
+                      "Ref": "EFSOptions"
                     },
                     "cfn_scheduler": {
                       "Ref": "Scheduler"
@@ -3958,7 +3958,7 @@
                 "Fn::Split": [
                   ",",
                   {
-                    "Ref": "EFSoptions"
+                    "Ref": "EFSOptions"
                   }
                 ]
               }

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -59,7 +59,8 @@
     },
     "EFSFSId": {
       "Description": "ID of EFS file system",
-      "Type": "String"
+      "Type": "String",
+      "Default": "NONE"
     }
   },
   "Conditions": {

--- a/cloudformation/efs-substack.cfn.json
+++ b/cloudformation/efs-substack.cfn.json
@@ -10,7 +10,7 @@
                   "Fn::Select": [
                     "0",
                     {
-                      "Ref": "EFSoptions"
+                      "Ref": "EFSOptions"
                     }
                   ]
                 },
@@ -25,7 +25,7 @@
               "Fn::Select": [
                 "1",
                 {
-                  "Ref": "EFSoptions"
+                  "Ref": "EFSOptions"
                 }
               ]
             },
@@ -44,7 +44,7 @@
                   "Fn::Select": [
                     "0",
                     {
-                      "Ref": "EFSoptions"
+                      "Ref": "EFSOptions"
                     }
                   ]
                 },
@@ -59,7 +59,7 @@
               "Fn::Select": [
                 "7",
                 {
-                  "Ref": "EFSoptions"
+                  "Ref": "EFSOptions"
                 }
               ]
             },
@@ -74,7 +74,7 @@
           "Fn::Select": [
             "5",
             {
-              "Ref": "EFSoptions"
+              "Ref": "EFSOptions"
             }
           ]
         },
@@ -94,7 +94,7 @@
                   "Fn::Select": [
                     "3",
                     {
-                      "Ref": "EFSoptions"
+                      "Ref": "EFSOptions"
                     }
                   ]
                 },
@@ -113,7 +113,7 @@
               "Fn::Select": [
                 "2",
                 {
-                  "Ref": "EFSoptions"
+                  "Ref": "EFSOptions"
                 }
               ]
             },
@@ -128,7 +128,7 @@
           "Fn::Select": [
             "6",
             {
-              "Ref": "EFSoptions"
+              "Ref": "EFSOptions"
             }
           ]
         },
@@ -148,7 +148,7 @@
                   "Fn::Select": [
                     "4",
                     {
-                      "Ref": "EFSoptions"
+                      "Ref": "EFSOptions"
                     }
                   ]
                 },
@@ -167,7 +167,7 @@
               "Fn::Select": [
                 "6",
                 {
-                  "Ref": "EFSoptions"
+                  "Ref": "EFSOptions"
                 }
               ]
             },
@@ -190,7 +190,7 @@
             "Fn::Select": [
               "1",
               {
-                "Ref": "EFSoptions"
+                "Ref": "EFSOptions"
               }
             ]
           }
@@ -203,7 +203,7 @@
       "Description": "SecurityGroup for Mount Target",
       "Type": "String"
     },
-    "EFSoptions": {
+    "EFSOptions": {
       "Description": "Comma separated list of efs related options, 8 parameters in total",
       "Type": "CommaDelimitedList"
     },
@@ -223,7 +223,7 @@
               "Fn::Select": [
                 "5",
                 {
-                  "Ref": "EFSoptions"
+                  "Ref": "EFSOptions"
                 }
               ]
             },
@@ -239,7 +239,7 @@
               "Fn::Select": [
                 "3",
                 {
-                  "Ref": "EFSoptions"
+                  "Ref": "EFSOptions"
                 }
               ]
             },
@@ -255,7 +255,7 @@
               "Fn::Select": [
                 "2",
                 {
-                  "Ref": "EFSoptions"
+                  "Ref": "EFSOptions"
                 }
               ]
             },
@@ -271,7 +271,7 @@
               "Fn::Select": [
                 "4",
                 {
-                  "Ref": "EFSoptions"
+                  "Ref": "EFSOptions"
                 }
               ]
             },
@@ -287,7 +287,7 @@
               "Fn::Select": [
                 "6",
                 {
-                  "Ref": "EFSoptions"
+                  "Ref": "EFSOptions"
                 }
               ]
             },
@@ -312,7 +312,7 @@
               "Fn::Select": [
                 "1",
                 {
-                  "Ref": "EFSoptions"
+                  "Ref": "EFSOptions"
                 }
               ]
             }

--- a/util/generate-efs-substack.py
+++ b/util/generate-efs-substack.py
@@ -9,7 +9,7 @@ def main():
     # 4 provisioned_throughput, 5 encrypted, 6 throughput_mode, 7 exists_valid_mt]
     efs_options = t.add_parameter(
         Parameter(
-            "EFSoptions",
+            "EFSOptions",
             Type="CommaDelimitedList",
             Description="Comma separated list of efs related options, " "8 parameters in total",
         )


### PR DESCRIPTION
- Modified batch-substack.cfn.json to include default value "NONE" for EFSFSId
- Modified entrypoint.sh to consider mounting EFS shared dir if EFS_FS_ID != "NONE"
- Modified stack templates and cfnconfig to change "EFSoptions" to "EFSOptions"

Signed-off-by: Rex Chen <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
