### PR TITLE
Remove sanity check on policy not needed

### DIFF
--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -184,7 +184,6 @@ def check_resource(  # noqa: C901 FIXME!!!
                 ),
                 (["s3:GetObject"], "arn:%s:s3:::%s-aws-parallelcluster/*" % (partition, region)),
                 (["sqs:ListQueues"], "*"),
-                (["logs:*"], "arn:%s:logs:*:*:*" % partition),
             ]
 
             for actions, resource_arn in iam_policy:


### PR DESCRIPTION
The policy (and associated resources) was removed since commit
https://github.com/aws/aws-parallelcluster/commit/bcf11b22769eccbf38de54dbff7fb5779bb622e2

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
