### PR TITLE
Fix doc about choosing the ami list from where to start building AMI

### DIFF
--- a/docs/tutorials/02_ami_customization.rst
+++ b/docs/tutorials/02_ami_customization.rst
@@ -34,8 +34,12 @@ This is the safest method as the base AWS ParallelCluster AMI is often updated w
 the components required for AWS ParallelCluster to function installed and configured and you can start with this as the
 base.
 
-    #. Find the AMI which corresponds with the region you will be utilizing in the list here:
-       https://github.com/aws/aws-parallelcluster/blob/master/amis.txt.
+    #. Find the AMI which corresponds to the region you will be utilizing from the AMI list.
+       The AMI list to use must match the version of the product e.g.
+
+       - for ParallelCluster 2.0.2 -> https://github.com/aws/aws-parallelcluster/blob/v2.0.2/amis.txt
+       - for CfnCluster 1.6.1 -> https://github.com/aws/aws-parallelcluster/blob/v1.6.1/amis.txt
+
     #. Within the EC2 Console, choose "Launch Instance".
     #. Navigate to "Community AMIs", and enter the AMI id for your region into the search box.
     #. Select the AMI, choose your instance type and properties, and launch your instance.


### PR DESCRIPTION
The AMI to choose when start building a custom AMI must match
the version of the product used

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
