### PR TITLE
 docs: fix css and js overrides

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -209,18 +209,13 @@ html_theme_options = {
     "base_url": "https://aws-parallelcluster.readthedocs.io/latest/"
 }
 
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css'
-    ]
-}
 
-html_js_files = [
-    'custom.js'
-]
+def setup(app):
+    app.add_css_file('theme_overrides.css')
+    app.add_javascript('custom.js')
+
 
 # -- Options for LaTeX output ---------------------------------------------
-
 latex_elements = {
 # The paper size ('letterpaper' or 'a4paper').
 #'papersize': 'letterpaper',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>=1.8.0
 sphinx-argparse
 tabulate
 boto3


### PR DESCRIPTION
Append custom css and js files to existing ones instead of replacing them.

https://docs.readthedocs.io/en/latest/guides/adding-custom-css.html

Test: https://aws-parallelcluster-fdm.readthedocs.io/en/wip-docs-overrides/awsbatchcli.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
