### PR TITLE
docs: Improve mpi example to work when using multiple shared dirs

### DIFF
--- a/docs/tutorials/code_samples/batch_mpi/submit_mpi.sh
+++ b/docs/tutorials/code_samples/batch_mpi/submit_mpi.sh
@@ -3,11 +3,15 @@ echo "ip container: $(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/
 echo "ip host: $(curl -s "http://169.254.169.254/latest/meta-data/local-ipv4")"
 
 if [[ "${AWS_BATCH_JOB_NODE_INDEX}" -eq  "${AWS_BATCH_JOB_MAIN_NODE_INDEX}" ]]; then
+    # get shared dir
+    IFS=',' _shared_dirs=(${PCLUSTER_SHARED_DIRS})
+    _shared_dir=${_shared_dirs[0]}
+
     echo "Compiling..."
-    /usr/lib64/openmpi/bin/mpicc -o /shared/mpi_hello_world /shared/mpi_hello_world.c
+    /usr/lib64/openmpi/bin/mpicc -o "${_shared_dir}/mpi_hello_world" "${_shared_dir}/mpi_hello_world.c"
 
     echo "Hello I'm the main node! I run the mpi job!"
-    /usr/lib64/openmpi/bin/mpirun --mca btl_tcp_if_include eth0 --allow-run-as-root --machinefile "${HOME}/hostfile" /shared/mpi_hello_world
+    /usr/lib64/openmpi/bin/mpirun --mca btl_tcp_if_include eth0 --allow-run-as-root --machinefile "${HOME}/hostfile" "${_shared_dir}/mpi_hello_world"
 else
     echo "Hello I'm a compute note! I let the main node orchestrate the mpi execution!"
     # Since mpi orchestration happens on the main node, we need to make sure the containers representing the compute


### PR DESCRIPTION
The mount point for the shared EBS volume could be different from `/shared`.

I'm improving the example to show the customers that `PCLUSTER_SHARED_DIRS` contains the list of shared dirs.
