### PR TITLE
Fix cluster name in warning message

### DIFF
--- a/cli/pcluster/pcluster.py
+++ b/cli/pcluster/pcluster.py
@@ -730,7 +730,7 @@ def delete(args):
             sys.stdout.write("\n")
             sys.stdout.flush()
         if status == "DELETE_FAILED":
-            LOGGER.info("Cluster did not delete successfully. Run 'pcluster delete %s' again", stack)
+            LOGGER.info("Cluster did not delete successfully. Run 'pcluster delete %s' again", args.cluster_name)
     except ClientError as e:
         if e.response.get("Error").get("Message").endswith("does not exist"):
             if saw_update:


### PR DESCRIPTION
The message was `Run 'pcluster delete parallelcluster-batchS3' again`, 
it must be instead `Run 'pcluster delete batchS3' again`.

