### PR TITLE
cfn-lint: fix warnings and disable bugged rule

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -207,9 +207,14 @@ changedir =
     ../cloudformation
 deps = cfn-lint
 # E2504 disabled since does not allow two-digit numbers in ephemeral(n)
-# E2502 disabled since was not working correctly in the substack
 # W2507 disabled since we want to have nullable String type parameters
-commands = cfn-lint -iE2504 -iE2502 -iW2507 *.cfn.json
+# iE3008 disabled because of https://github.com/awslabs/cfn-python-lint/issues/564
+commands =
+    cfn-lint -iE2504 -iW2507 aws-parallelcluster.cfn.json
+    cfn-lint -iE3008 batch-substack.cfn.json
+    cfn-lint ebs-substack.cfn.json
+    cfn-lint efs-substack.cfn.json
+    cfn-lint raid-substack.cfn.json
 
 # Validates that cfn json templates are correctly formatted.
 [testenv:cfn-format-check]

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -375,7 +375,10 @@
       "Properties": {
         "Type": "MANAGED",
         "ServiceRole": {
-          "Ref": "BatchServiceRole"
+          "Fn::GetAtt": [
+            "BatchServiceRole",
+            "Arn"
+          ]
         },
         "ComputeResources": {
           "Type": {
@@ -421,7 +424,10 @@
             "Fn::If": [
               "UseSpot",
               {
-                "Ref": "SpotIamFleetRole"
+                "Fn::GetAtt": [
+                  "SpotIamFleetRole",
+                  "Arn"
+                ]
               },
               {
                 "Ref": "AWS::NoValue"
@@ -627,7 +633,10 @@
           "Fn::Sub": "${ClusterName}-build-docker-images-project"
         },
         "ServiceRole": {
-          "Ref": "CodeBuildRole"
+          "Fn::GetAtt": [
+            "CodeBuildRole",
+            "Arn"
+          ]
         },
         "Source": {
           "Location": {


### PR DESCRIPTION
* Fixed warnings by using ARN instead of Role name
* iE3008 disabled because of https://github.com/awslabs/cfn-python-lint/issues/564

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
