### PR TITLE
cfn-lint: re-enable iE3008 since linter issue got fixed

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -208,10 +208,9 @@ changedir =
 deps = cfn-lint
 # E2504 disabled since does not allow two-digit numbers in ephemeral(n)
 # W2507 disabled since we want to have nullable String type parameters
-# iE3008 disabled because of https://github.com/awslabs/cfn-python-lint/issues/564
 commands =
     cfn-lint -iE2504 -iW2507 aws-parallelcluster.cfn.json
-    cfn-lint -iE3008 batch-substack.cfn.json
+    cfn-lint batch-substack.cfn.json
     cfn-lint ebs-substack.cfn.json
     cfn-lint efs-substack.cfn.json
     cfn-lint raid-substack.cfn.json


### PR DESCRIPTION
cfn-lint issue was fixed: https://github.com/awslabs/cfn-python-lint/issues/564

Tested locally with `tox -e cfn-lint -r`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
