### PR TITLE
fix flake8 warns and per-file-ignores config

### DIFF
--- a/cli/.flake8
+++ b/cli/.flake8
@@ -11,10 +11,10 @@ ignore =
 # D102 Missing docstring in public method
 per-file-ignores =
     pcluster/*.py: D103
-    pcluster/config_sanity.py: E402
-    pcluster/easyconfig.py: E402
-    pcluster/cfnconfig.py: E402
-    tests/pcluster/pcluster-unittest.py: D101, D102
+    pcluster/config_sanity.py: E402, D103
+    pcluster/easyconfig.py: E402, D103
+    pcluster/cfnconfig.py: E402, D103
+    tests/pcluster/pcluster-unittest.py: D101, D102, D103
     tests/awsbatch/test_*.py: D101, D102
 exclude =
     .tox,

--- a/cli/pcluster/easyconfig.py
+++ b/cli/pcluster/easyconfig.py
@@ -243,7 +243,7 @@ def configure(args):  # noqa: C901 FIXME!!!
             pass
         for key, value in section.items():
             # Only update configuration if not set
-            if value is not None and key is not "__name__":
+            if value is not None and key != "__name__":
                 config.set(section["__name__"], key, value)
 
     # ensure that the directory for the config file exists (because

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -103,7 +103,6 @@ deps =
     # flake8-import-order # delegated to isort
     flake8-colors
     pep8-naming
-    flake8-per-file-ignores
 commands =
     flake8 \
         setup.py \


### PR DESCRIPTION
flake8 started officially supporting per-file-ignores option with slightly different behaviour.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
