### PR TITLE
Fix Tox Warning

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -932,14 +932,21 @@
       ]
     },
     "UseS3ReadPolicy": {
-      "Fn::Not": [
+      "Fn::And": [
         {
-          "Fn::Equals": [
+          "Fn::Not": [
             {
-              "Ref": "S3ReadResource"
-            },
-            "NONE"
+              "Fn::Equals": [
+                {
+                  "Ref": "S3ReadResource"
+                },
+                "NONE"
+              ]
+            }
           ]
+        },
+        {
+          "Condition": "CreateEC2IAMRole"
         }
       ]
     },
@@ -971,14 +978,21 @@
       ]
     },
     "UseS3ReadWritePolicy": {
-      "Fn::Not": [
+      "Fn::And": [
         {
-          "Fn::Equals": [
+          "Fn::Not": [
             {
-              "Ref": "S3ReadWriteResource"
-            },
-            "NONE"
+              "Fn::Equals": [
+                {
+                  "Ref": "S3ReadWriteResource"
+                },
+                "NONE"
+              ]
+            }
           ]
+        },
+        {
+          "Condition": "CreateEC2IAMRole"
         }
       ]
     },


### PR DESCRIPTION
Fixes:
```
W1001 Ref to resource "RootRole" that many not be available when when condition "UseS3ReadPolicy" is True and when condition "CreateEC2IAMRole" is False at Resources/S3ReadRolePolicies/Properties/Roles/0/Ref

W1001 Ref to resource "RootRole" that many not be available when when condition "UseS3ReadWritePolicy" is True and when condition "CreateEC2IAMRole" is False at Resources/S3ReadWriteRolePolicies/Properties/Roles/0/Ref
```

I changed the `UseS3Read[Write]Policy` condtion so it checks if the `CreateEC2IAMRole` is true before creating the S3 Policices. This ensures it'll never reference a non-existant RootRole.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
