### PR TITLE
Change Placement Default

### DIFF
--- a/cli/pcluster/examples/config
+++ b/cli/pcluster/examples/config
@@ -91,8 +91,8 @@ key_name = mykey
 # (defaults to NONE)
 #placement_group = NONE
 # Cluster placement logic. This enables the whole cluster or only compute to use the placement group
-# (defaults to cluster)
-#placement = cluster
+# (defaults to compute)
+#placement = compute
 # Path/mountpoint for ephemeral drives
 # (defaults to /scratch)
 #ephemeral_dir = /scratch

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -414,7 +414,7 @@
     "Placement": {
       "Description": "Type of placement requird in AWS ParallelCluster, it can either be cluster or compute.",
       "Type": "String",
-      "Default": "cluster",
+      "Default": "compute",
       "AllowedValues": [
         "cluster",
         "compute"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -335,9 +335,9 @@ Can be ``cluster`` or ``compute``.
 
 This does not apply to awsbatch.
 
-Defaults to ``cluster``. ::
+Defaults to ``compute``. ::
 
-    placement = cluster
+    placement = compute
 
 ephemeral_dir
 """""""""""""


### PR DESCRIPTION
* By setting `placement = compute`, customers will be more likely to get
capacity in their placement group
* Setting master instance type and compute as different instance types
is a common paradigm, this combined with setting `placement_group = DYNAMIC`
makes insufficient capacity errors more common.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
