### PR TITLE
Refactor and cleanup of the configuration sanity modules

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -278,6 +278,7 @@ class ParallelClusterConfig(object):
 
         :param resource_type: Resource type
         :param resource_value: Resource value
+        :return True or False (for the EFSFSId resource type only), nothing in the other cases
         """
         if self.__sanity_check:
             self.__resource_validator.validate(resource_type, resource_value)
@@ -623,7 +624,8 @@ class ParallelClusterConfig(object):
                             __throughput_mode = __temp__
                         # Separate sanity_check for fs_id, need to pass in fs_id and subnet_id
                         if self.__efs_options.get(key)[1] == "EFSFSId":
-                            __valid_mt = self.__validate_resource("EFSFSId", (__temp__, self.__master_subnet))
+                            self.__validate_resource("EFSFSId", (__temp__, self.__master_subnet))
+                            __valid_mt = True
                         elif self.__efs_options.get(key)[1] is not None:
                             self.__validate_resource(self.__efs_options.get(key)[1], __temp__)
                         __temp_efs_options.append(__temp__)

--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -32,26 +32,36 @@ from botocore.exceptions import ClientError
 from . import config_sanity
 
 
-def get_stack_template(region, aws_access_key_id, aws_secret_access_key, stack):
+def get_stack_template(region, aws_access_key_id, aws_secret_access_key, cluster_name):
+    """
+    Get stack template corresponding to the given cluster name.
+
+    :param region: AWS Region
+    :param aws_access_key_id: AWS access key
+    :param aws_secret_access_key: AWS secret access key
+    :param cluster_name: The cluster name to search for
+    :return: the corresponding stack template
+    """
     cfn = boto3.client(
         "cloudformation",
         region_name=region,
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
     )
-    __stack_name = "parallelcluster-" + stack
+    stack_name = "parallelcluster-" + cluster_name
 
     try:
-        __stack = cfn.describe_stacks(StackName=__stack_name).get("Stacks")[0]
+        stack = cfn.describe_stacks(StackName=stack_name).get("Stacks")[0]
     except ClientError as e:
         print(e.response.get("Error").get("Message"))
         sys.stdout.flush()
         sys.exit(1)
-    __cli_template = [
-        p.get("ParameterValue") for p in __stack.get("Parameters") if p.get("ParameterKey") == "CLITemplate"
-    ][0]
 
-    return __cli_template
+    cli_template = [p.get("ParameterValue") for p in stack.get("Parameters") if p.get("ParameterKey") == "CLITemplate"][
+        0
+    ]
+
+    return cli_template
 
 
 class ParallelClusterConfig(object):

--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -218,17 +218,20 @@ class ParallelClusterConfig(object):
             )
         else:
             try:
-                if self.args.cluster_template is not None:
-                    cluster_template = self.args.cluster_template
-                else:
-                    if args_func == "update":
+                try:
+                    if self.args.cluster_template is not None:
+                        cluster_template = self.args.cluster_template
+                    elif args_func == "update":
                         cluster_template = get_stack_template(
                             self.region, self.aws_access_key_id, self.aws_secret_access_key, self.args.cluster_name
                         )
                     else:
                         cluster_template = self.__config.get("global", "cluster_template")
-            except AttributeError:
-                cluster_template = self.__config.get("global", "cluster_template")
+                except AttributeError:
+                    cluster_template = self.__config.get("global", "cluster_template")
+            except configparser.NoOptionError:
+                print("ERROR: Missing 'cluster_template' option in [global] section.")
+                sys.exit(1)
 
         return cluster_template
 

--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -240,7 +240,7 @@ class ParallelClusterConfig(object):
         if update_check is True:
             try:
                 latest = json.loads(
-                    urllib.request.urlopen("http://pypi.python.org/pypi/aws-parallelcluster/json").read()
+                    urllib.request.urlopen("https://pypi.python.org/pypi/aws-parallelcluster/json").read()
                 )["info"]["version"]
                 if self.version < latest:
                     print("warning: There is a newer version %s of AWS ParallelCluster available." % latest)

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -104,8 +104,6 @@ class ResourceValidator(object):
                         "Please modify the Mount Target's security group, or delete the Mount Target."
                         % (mt_id, availability_zone, resource_value[0]),
                     )
-
-                return True
         except ClientError as e:
             self.__fail("EFSFSId", e.response.get("Error").get("Message"))
 
@@ -115,7 +113,6 @@ class ResourceValidator(object):
 
         :param resource_type: Resource type
         :param resource_value: Resource value
-        :return True or False (for the EFSFSId resource type only), nothing in the other cases
         """
         # Loop over all supported resource checks
         if resource_type == "EC2KeyPair":
@@ -360,7 +357,7 @@ class ResourceValidator(object):
                     aws_access_key_id=self.aws_access_key_id,
                     aws_secret_access_key=self.aws_secret_access_key,
                 )
-                return self.__check_efs_fs_id(ec2, efs, resource_value)
+                self.__check_efs_fs_id(ec2, efs, resource_value)
             except ClientError as e:
                 self.__fail(resource_type, e.response.get("Error").get("Message"))
         # EFS Performance Mode check

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -25,424 +25,457 @@ import boto3
 from botocore.exceptions import ClientError
 
 
-def get_partition(region):
-    if region.startswith("us-gov"):
-        return "aws-us-gov"
-    return "aws"
+class ResourceValidator(object):
+    """Utility class to check resource sanity."""
 
+    def __init__(self, region, aws_access_key_id, aws_secret_access_key):
+        """
+        Initialize a ResourceValidator object.
 
-def check_sg_rules_for_port(rule, port_to_check):
-    port = rule.get("FromPort")
-    ip_rules = rule.get("IpRanges")
-    group = rule.get("UserIdGroupPairs")
-    for ip_rule in ip_rules:
-        ip = ip_rule.get("CidrIp")
-        # An existing rule is valid for EFS if, it allows all traffic(0.0.0.0/0)
-        # from all ports or NFS(port 2049), and does not have a security group restriction
-        if (not port or port == port_to_check) and ip == "0.0.0.0/0" and not group:
-            return True
+        :param region: AWS Region
+        :param aws_access_key_id: AWS access key
+        :param aws_secret_access_key: AWS secret access key
+        """
+        self.region = region
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
 
+    def __get_partition(self):
+        if self.region.startswith("us-gov"):
+            return "aws-us-gov"
+        return "aws"
 
-def check_efs_fs_id(ec2, efs, resource_value):  # noqa: C901 FIXME!!!
-    try:
-        # Check to see if there is any existing mt on the fs
-        mt = efs.describe_mount_targets(FileSystemId=resource_value[0])
-        # Get the availability zone of the stack
-        availability_zone = (
-            ec2.describe_subnets(SubnetIds=[resource_value[1]]).get("Subnets")[0].get("AvailabilityZone")
-        )
-        mt_id = None
-        for item in mt.get("MountTargets"):
-            # Check to see if there is an existing mt in the az of the stack
-            mt_subnet = item.get("SubnetId")
-            if availability_zone == ec2.describe_subnets(SubnetIds=[mt_subnet]).get("Subnets")[0].get(
-                "AvailabilityZone"
-            ):
-                mt_id = item.get("MountTargetId")
-        # If there is an existing mt in the az, need to check the inbound and outbound rules of the security groups
-        if mt_id:
-            nfs_access = False
-            in_access = False
-            out_access = False
-            # Get list of security group IDs of the mount target
-            sg_ids = efs.describe_mount_target_security_groups(MountTargetId=mt_id).get("SecurityGroups")
-            for sg in ec2.describe_security_groups(GroupIds=sg_ids).get("SecurityGroups"):
-                # Check all inbound rules
-                in_rules = sg.get("IpPermissions")
-                for rule in in_rules:
-                    if check_sg_rules_for_port(rule, 2049):
-                        in_access = True
+    @staticmethod
+    def __check_sg_rules_for_port(rule, port_to_check):
+        port = rule.get("FromPort")
+        ip_rules = rule.get("IpRanges")
+        group = rule.get("UserIdGroupPairs")
+
+        for ip_rule in ip_rules:
+            ip = ip_rule.get("CidrIp")
+            # An existing rule is valid for EFS if, it allows all traffic(0.0.0.0/0)
+            # from all ports or NFS(port 2049), and does not have a security group restriction
+            if (not port or port == port_to_check) and ip == "0.0.0.0/0" and not group:
+                return True
+
+    def __check_efs_fs_id(self, ec2, efs, resource_value):  # noqa: C901 FIXME!!!
+        try:
+            # Check to see if there is any existing mt on the fs
+            mt = efs.describe_mount_targets(FileSystemId=resource_value[0])
+            # Get the availability zone of the stack
+            availability_zone = (
+                ec2.describe_subnets(SubnetIds=[resource_value[1]]).get("Subnets")[0].get("AvailabilityZone")
+            )
+            mt_id = None
+            for item in mt.get("MountTargets"):
+                # Check to see if there is an existing mt in the az of the stack
+                mt_subnet = item.get("SubnetId")
+                if availability_zone == ec2.describe_subnets(SubnetIds=[mt_subnet]).get("Subnets")[0].get(
+                    "AvailabilityZone"
+                ):
+                    mt_id = item.get("MountTargetId")
+            # If there is an existing mt in the az, need to check the inbound and outbound rules of the security groups
+            if mt_id:
+                nfs_access = False
+                in_access = False
+                out_access = False
+                # Get list of security group IDs of the mount target
+                sg_ids = efs.describe_mount_target_security_groups(MountTargetId=mt_id).get("SecurityGroups")
+                for sg in ec2.describe_security_groups(GroupIds=sg_ids).get("SecurityGroups"):
+                    # Check all inbound rules
+                    in_rules = sg.get("IpPermissions")
+                    for rule in in_rules:
+                        if self.__check_sg_rules_for_port(rule, 2049):
+                            in_access = True
+                            break
+                    out_rules = sg.get("IpPermissionsEgress")
+                    for rule in out_rules:
+                        if self.__check_sg_rules_for_port(rule, 2049):
+                            out_access = True
+                            break
+                    if in_access and out_access:
+                        nfs_access = True
                         break
-                out_rules = sg.get("IpPermissionsEgress")
-                for rule in out_rules:
-                    if check_sg_rules_for_port(rule, 2049):
-                        out_access = True
-                        break
-                if in_access and out_access:
-                    nfs_access = True
-                    break
-            if not nfs_access:
-                _fail(
-                    "EFSFSId",
-                    "There is an existing Mount Target %s in the Availability Zone %s for EFS %s, "
-                    "and it does not have a security group with inbound and outbound rules that support NFS. "
-                    "Please modify the Mount Target's security group, or delete the Mount Target."
-                    % (mt_id, availability_zone, resource_value[0])
-                )
+                if not nfs_access:
+                    self.__fail(
+                        "EFSFSId",
+                        "There is an existing Mount Target %s in the Availability Zone %s for EFS %s, "
+                        "and it does not have a security group with inbound and outbound rules that support NFS. "
+                        "Please modify the Mount Target's security group, or delete the Mount Target."
+                        % (mt_id, availability_zone, resource_value[0]),
+                    )
 
-            return True
-    except ClientError as e:
-        _fail("EFSFSId", e.response.get("Error").get("Message"))
-
-
-def check_resource(region, aws_access_key_id, aws_secret_access_key, resource_type, resource_value):  # noqa: C901 FIXME
-    # Loop over all supported resource checks
-    # EC2 KeyPair
-    if resource_type == "EC2KeyPair":
-        try:
-            ec2 = boto3.client(
-                "ec2",
-                region_name=region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
-            test = ec2.describe_key_pairs(KeyNames=[resource_value])
+                return True
         except ClientError as e:
-            _fail(resource_type, e.response.get("Error").get("Message"))
-    if resource_type == "EC2IAMRoleName":
-        try:
-            iam = boto3.client(
-                "iam",
-                region_name=region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
+            self.__fail("EFSFSId", e.response.get("Error").get("Message"))
 
-            arn = iam.get_role(RoleName=resource_value).get("Role").get("Arn")
-            accountid = (
-                boto3.client(
-                    "sts",
-                    region_name=region,
-                    aws_access_key_id=aws_access_key_id,
-                    aws_secret_access_key=aws_secret_access_key,
-                )
-                .get_caller_identity()
-                .get("Account")
-            )
+    def validate(self, resource_type, resource_value):  # noqa: C901 FIXME
+        """
+        Validate the given resource. Print an error and exit in case of error.
 
-            partition = get_partition(region)
-
-            iam_policy = [
-                (
-                    [
-                        "ec2:DescribeVolumes",
-                        "ec2:AttachVolume",
-                        "ec2:DescribeInstanceAttribute",
-                        "ec2:DescribeInstanceStatus",
-                        "ec2:DescribeInstances",
-                    ],
-                    "*",
-                ),
-                (["dynamodb:ListTables"], "*"),
-                (
-                    [
-                        "sqs:SendMessage",
-                        "sqs:ReceiveMessage",
-                        "sqs:ChangeMessageVisibility",
-                        "sqs:DeleteMessage",
-                        "sqs:GetQueueUrl",
-                    ],
-                    "arn:%s:sqs:%s:%s:parallelcluster-*" % (partition, region, accountid),
-                ),
-                (
-                    [
-                        "autoscaling:DescribeAutoScalingGroups",
-                        "autoscaling:TerminateInstanceInAutoScalingGroup",
-                        "autoscaling:SetDesiredCapacity",
-                        "autoscaling:DescribeTags",
-                        "autoScaling:UpdateAutoScalingGroup",
-                    ],
-                    "*",
-                ),
-                (
-                    [
-                        "dynamodb:PutItem",
-                        "dynamodb:Query",
-                        "dynamodb:GetItem",
-                        "dynamodb:DeleteItem",
-                        "dynamodb:DescribeTable",
-                    ],
-                    "arn:%s:dynamodb:%s:%s:table/parallelcluster-*" % (partition, region, accountid),
-                ),
-                (
-                    ["cloudformation:DescribeStacks"],
-                    "arn:%s:cloudformation:%s:%s:stack/parallelcluster-*" % (partition, region, accountid),
-                ),
-                (["s3:GetObject"], "arn:%s:s3:::%s-aws-parallelcluster/*" % (partition, region)),
-                (["sqs:ListQueues"], "*"),
-            ]
-
-            for actions, resource_arn in iam_policy:
-                response = iam.simulate_principal_policy(
-                    PolicySourceArn=arn, ActionNames=actions, ResourceArns=[resource_arn]
-                )
-                for decision in response.get("EvaluationResults"):
-                    if decision.get("EvalDecision") != "allowed":
-                        print(
-                            "IAM role error on user provided role %s: action %s is %s"
-                            % (resource_value, decision.get("EvalActionName"), decision.get("EvalDecision"))
-                        )
-                        print("See https://aws-parallelcluster.readthedocs.io/en/latest/iam.html")
-                        sys.exit(1)
-        except ClientError as e:
-            _fail(resource_type, e.response.get("Error").get("Message"))
-    # VPC Id
-    elif resource_type == "VPC":
-        try:
-
-            ec2 = boto3.client(
-                "ec2",
-                region_name=region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
-            test = ec2.describe_vpcs(VpcIds=[resource_value])
-        except ClientError as e:
-            _fail(resource_type, e.response.get("Error").get("Message"))
-        # Check for DNS support in the VPC
-        if (
-            not ec2.describe_vpc_attribute(VpcId=resource_value, Attribute="enableDnsSupport")
-            .get("EnableDnsSupport")
-            .get("Value")
-        ):
-            _fail(resource_type, "DNS Support is not enabled in %s" % resource_value)
-        if (
-            not ec2.describe_vpc_attribute(VpcId=resource_value, Attribute="enableDnsHostnames")
-            .get("EnableDnsHostnames")
-            .get("Value")
-        ):
-            _fail(resource_type, "DNS Hostnames not enabled in %s" % resource_value)
-    # VPC Subnet Id
-    elif resource_type == "VPCSubnet":
-        try:
-            ec2 = boto3.client(
-                "ec2",
-                region_name=region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
-            test = ec2.describe_subnets(SubnetIds=[resource_value])
-        except ClientError as e:
-            _fail(resource_type, e.response.get("Error").get("Message"))
-    # VPC Security Group
-    elif resource_type == "VPCSecurityGroup":
-        try:
-            ec2 = boto3.client(
-                "ec2",
-                region_name=region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
-            test = ec2.describe_security_groups(GroupIds=[resource_value])
-        except ClientError as e:
-            _fail(resource_type, e.response.get("Error").get("Message"))
-    # EC2 AMI Id
-    elif resource_type == "EC2Ami":
-        try:
-            ec2 = boto3.client(
-                "ec2",
-                region_name=region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
-            test = ec2.describe_images(ImageIds=[resource_value])
-        except ClientError as e:
-            _fail(resource_type, e.response.get("Error").get("Message"))
-    # EC2 Placement Group
-    elif resource_type == "EC2PlacementGroup":
-        if resource_value == "DYNAMIC":
-            pass
-        else:
+        :param resource_type: Resource type
+        :param resource_value: Resource value
+        :return True or False (for the EFSFSId resource type only), nothing in the other cases
+        """
+        # Loop over all supported resource checks
+        if resource_type == "EC2KeyPair":
             try:
                 ec2 = boto3.client(
                     "ec2",
-                    region_name=region,
-                    aws_access_key_id=aws_access_key_id,
-                    aws_secret_access_key=aws_secret_access_key,
+                    region_name=self.region,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
                 )
-                test = ec2.describe_placement_groups(GroupNames=[resource_value])
+                ec2.describe_key_pairs(KeyNames=[resource_value])
             except ClientError as e:
-                _fail(resource_type, e.response.get("Error").get("Message"))
-    # URL
-    elif resource_type == "URL":
-        scheme = urlparse(resource_value).scheme
-        if scheme == "s3":
-            pass
-        else:
+                self.__fail(resource_type, e.response.get("Error").get("Message"))
+        if resource_type == "EC2IAMRoleName":
             try:
-                urllib.request.urlopen(resource_value)
-            except urllib.error.HTTPError as e:
-                _fail(resource_type, "%s %s %s" % (resource_value, e.code, e.reason))
-            except urllib.error.URLError as e:
-                _fail(resource_type, "%s %s" (resource_value, e.reason))
-    # EC2 EBS Snapshot Id
-    elif resource_type == "EC2Snapshot":
-        try:
-            ec2 = boto3.client(
-                "ec2",
-                region_name=region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
-            test = ec2.describe_snapshots(SnapshotIds=[resource_value]).get("Snapshots")[0]
-            if test.get("State") != "completed":
-                _fail(
-                    resource_type,
-                    "Snapshot %s is in state '%s' not 'completed'" % (resource_value, test.get("State"))
+                iam = boto3.client(
+                    "iam",
+                    region_name=self.region,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
                 )
-        except ClientError as e:
-            _fail(resource_type, e.response.get("Error").get("Message"))
-    # EC2 EBS Volume Id
-    elif resource_type == "EC2Volume":
-        try:
-            ec2 = boto3.client(
-                "ec2",
-                region_name=region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
-            test = ec2.describe_volumes(VolumeIds=[resource_value]).get("Volumes")[0]
-            if test.get("State") != "available":
-                _fail(resource_type, "Volume %s is in state '%s' not 'available'" % (resource_value, test.get("State")))
-        except ClientError as e:
-            if e.response.get("Error").get("Message").endswith("parameter volumes is invalid. Expected: 'vol-...'."):
-                _fail(resource_type, "Volume %s does not exist." % resource_value)
 
-            _fail(resource_type, e.response.get("Error").get("Message"))
-    # EFS file system Id
-    elif resource_type == "EFSFSId":
-        try:
-            ec2 = boto3.client(
-                "ec2",
-                region_name=region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
-            efs = boto3.client(
-                "efs",
-                region_name=region,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-            )
-            return check_efs_fs_id(ec2, efs, resource_value)
-        except ClientError as e:
-            _fail(resource_type, e.response.get("Error").get("Message"))
-    # EFS Performance Mode check
-    elif resource_type == "EFSPerfMode":
-        if resource_value != "generalPurpose" and resource_value != "maxIO":
-            _fail(
-                resource_type,
-                "Invalid value for 'performance_mode'! "
-                "Acceptable values for 'performance_mode' are generalPurpose and maxIO"
-            )
-    # EFS Throughput check
-    elif resource_type == "EFSThroughput":
-        throughput_mode = resource_value[0]
-        provisioned_throughput = resource_value[1]
-        if throughput_mode and (throughput_mode != "provisioned" and throughput_mode != "bursting"):
-            _fail(
-                resource_type,
-                "Invalid value for 'throughput_mode'! "
-                "Acceptable values for 'throughput_mode' are bursting and provisioned"
-            )
-        if provisioned_throughput is not None:
-            if throughput_mode != "provisioned":
-                _fail(
-                    resource_type,
-                    "When specifying 'provisioned_throughput', the 'throughput_mode' must be set to provisioned"
+                arn = iam.get_role(RoleName=resource_value).get("Role").get("Arn")
+                account_id = (
+                    boto3.client(
+                        "sts",
+                        region_name=self.region,
+                        aws_access_key_id=self.aws_access_key_id,
+                        aws_secret_access_key=self.aws_secret_access_key,
+                    )
+                    .get_caller_identity()
+                    .get("Account")
                 )
-        else:
-            if throughput_mode == "provisioned":
-                _fail(
-                    resource_type,
-                    "When specifying 'throughput_mode' to provisioned, "
-                    "the 'provisioned_throughput' option must be specified"
-                )
-    # RAID EBS IOPS
-    elif resource_type == "RAIDIOPS":
-        raid_iops = float(resource_value[0])
-        raid_vol_size = float(resource_value[1])
-        if raid_iops > raid_vol_size * 50:
-            _fail(
-                resource_type,
-                "IOPS to volume size ratio of %s is too high; maximum is 50." % (raid_iops / raid_vol_size)
-            )
-    # RAID Array Type
-    elif resource_type == "RAIDType":
-        if resource_value != "0" and resource_value != "1":
-            _fail(resource_type, "Invalid raid_type, only RAID 0 and RAID 1 are currently supported.")
-    # Number of RAID Volumes Requested
-    elif resource_type == "RAIDNumVol":
-        if int(resource_value) > 5 or int(resource_value) < 2:
-            _fail(
-                resource_type,
-                "Invalid num_of_raid_volumes. "
-                "Needs min of 2 volumes for RAID and max of 5 EBS volumes are currently supported."
-            )
-    # Batch Parameters
-    elif resource_type == "AWSBatch_Parameters":
-        # Check region
-        if region in ["ap-northeast-3", "eu-north-1", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1"]:
-            _fail(resource_type, "Region %s is not supported with batch scheduler" % region)
 
-        # Check compute instance types
-        if "ComputeInstanceType" in resource_value:
+                partition = self.__get_partition()
+
+                iam_policy = [
+                    (
+                        [
+                            "ec2:DescribeVolumes",
+                            "ec2:AttachVolume",
+                            "ec2:DescribeInstanceAttribute",
+                            "ec2:DescribeInstanceStatus",
+                            "ec2:DescribeInstances",
+                        ],
+                        "*",
+                    ),
+                    (["dynamodb:ListTables"], "*"),
+                    (
+                        [
+                            "sqs:SendMessage",
+                            "sqs:ReceiveMessage",
+                            "sqs:ChangeMessageVisibility",
+                            "sqs:DeleteMessage",
+                            "sqs:GetQueueUrl",
+                        ],
+                        "arn:%s:sqs:%s:%s:parallelcluster-*" % (partition, self.region, account_id),
+                    ),
+                    (
+                        [
+                            "autoscaling:DescribeAutoScalingGroups",
+                            "autoscaling:TerminateInstanceInAutoScalingGroup",
+                            "autoscaling:SetDesiredCapacity",
+                            "autoscaling:DescribeTags",
+                            "autoScaling:UpdateAutoScalingGroup",
+                        ],
+                        "*",
+                    ),
+                    (
+                        [
+                            "dynamodb:PutItem",
+                            "dynamodb:Query",
+                            "dynamodb:GetItem",
+                            "dynamodb:DeleteItem",
+                            "dynamodb:DescribeTable",
+                        ],
+                        "arn:%s:dynamodb:%s:%s:table/parallelcluster-*" % (partition, self.region, account_id),
+                    ),
+                    (
+                        ["cloudformation:DescribeStacks"],
+                        "arn:%s:cloudformation:%s:%s:stack/parallelcluster-*" % (partition, self.region, account_id),
+                    ),
+                    (["s3:GetObject"], "arn:%s:s3:::%s-aws-parallelcluster/*" % (partition, self.region)),
+                    (["sqs:ListQueues"], "*"),
+                ]
+
+                for actions, resource_arn in iam_policy:
+                    response = iam.simulate_principal_policy(
+                        PolicySourceArn=arn, ActionNames=actions, ResourceArns=[resource_arn]
+                    )
+                    for decision in response.get("EvaluationResults"):
+                        if decision.get("EvalDecision") != "allowed":
+                            print(
+                                "IAM role error on user provided role %s: action %s is %s"
+                                % (resource_value, decision.get("EvalActionName"), decision.get("EvalDecision"))
+                            )
+                            print("See https://aws-parallelcluster.readthedocs.io/en/latest/iam.html")
+                            sys.exit(1)
+            except ClientError as e:
+                self.__fail(resource_type, e.response.get("Error").get("Message"))
+        # VPC Id
+        elif resource_type == "VPC":
             try:
-                s3 = boto3.resource("s3", region_name=region)
-                bucket_name = "%s-aws-parallelcluster" % region
-                file_name = "instances/batch_instances.json"
+                ec2 = boto3.client(
+                    "ec2",
+                    region_name=self.region,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
+                )
+                ec2.describe_vpcs(VpcIds=[resource_value])
+            except ClientError as e:
+                self.__fail(resource_type, e.response.get("Error").get("Message"))
+            # Check for DNS support in the VPC
+            if (
+                not ec2.describe_vpc_attribute(VpcId=resource_value, Attribute="enableDnsSupport")
+                .get("EnableDnsSupport")
+                .get("Value")
+            ):
+                self.__fail(resource_type, "DNS Support is not enabled in %s" % resource_value)
+            if (
+                not ec2.describe_vpc_attribute(VpcId=resource_value, Attribute="enableDnsHostnames")
+                .get("EnableDnsHostnames")
+                .get("Value")
+            ):
+                self.__fail(resource_type, "DNS Hostnames not enabled in %s" % resource_value)
+        # VPC Subnet Id
+        elif resource_type == "VPCSubnet":
+            try:
+                ec2 = boto3.client(
+                    "ec2",
+                    region_name=self.region,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
+                )
+                ec2.describe_subnets(SubnetIds=[resource_value])
+            except ClientError as e:
+                self.__fail(resource_type, e.response.get("Error").get("Message"))
+        # VPC Security Group
+        elif resource_type == "VPCSecurityGroup":
+            try:
+                ec2 = boto3.client(
+                    "ec2",
+                    region_name=self.region,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
+                )
+                ec2.describe_security_groups(GroupIds=[resource_value])
+            except ClientError as e:
+                self.__fail(resource_type, e.response.get("Error").get("Message"))
+        # EC2 AMI Id
+        elif resource_type == "EC2Ami":
+            try:
+                ec2 = boto3.client(
+                    "ec2",
+                    region_name=self.region,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
+                )
+                ec2.describe_images(ImageIds=[resource_value])
+            except ClientError as e:
+                self.__fail(resource_type, e.response.get("Error").get("Message"))
+        # EC2 Placement Group
+        elif resource_type == "EC2PlacementGroup":
+            if resource_value == "DYNAMIC":
+                pass
+            else:
                 try:
-                    file_contents = s3.Object(bucket_name, file_name).get()["Body"].read().decode("utf-8")
-                    supported_instances = json.loads(file_contents)
-                    for instance in resource_value["ComputeInstanceType"].split(","):
-                        if not instance.strip() in supported_instances:
-                            _fail(resource_type, "Instance type %s not supported by batch in this region" % instance)
+                    ec2 = boto3.client(
+                        "ec2",
+                        region_name=self.region,
+                        aws_access_key_id=self.aws_access_key_id,
+                        aws_secret_access_key=self.aws_secret_access_key,
+                    )
+                    ec2.describe_placement_groups(GroupNames=[resource_value])
                 except ClientError as e:
-                    _fail(resource_type, e.response.get("Error").get("Message"))
+                    self.__fail(resource_type, e.response.get("Error").get("Message"))
+        # URL
+        elif resource_type == "URL":
+            scheme = urlparse(resource_value).scheme
+            if scheme == "s3":
+                pass
+            else:
+                try:
+                    urllib.request.urlopen(resource_value)
+                except urllib.error.HTTPError as e:
+                    self.__fail(resource_type, "%s %s %s" % (resource_value, e.code, e.reason))
+                except urllib.error.URLError as e:
+                    self.__fail(resource_type, "%s %s" % (resource_value, e.reason))
+        # EC2 EBS Snapshot Id
+        elif resource_type == "EC2Snapshot":
+            try:
+                ec2 = boto3.client(
+                    "ec2",
+                    region_name=self.region,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
+                )
+                test = ec2.describe_snapshots(SnapshotIds=[resource_value]).get("Snapshots")[0]
+                if test.get("State") != "completed":
+                    self.__fail(
+                        resource_type,
+                        "Snapshot %s is in state '%s' not 'completed'" % (resource_value, test.get("State")),
+                    )
             except ClientError as e:
-                _fail(resource_type, e.response.get("Error").get("Message"))
+                self.__fail(resource_type, e.response.get("Error").get("Message"))
+        # EC2 EBS Volume Id
+        elif resource_type == "EC2Volume":
+            try:
+                ec2 = boto3.client(
+                    "ec2",
+                    region_name=self.region,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
+                )
+                test = ec2.describe_volumes(VolumeIds=[resource_value]).get("Volumes")[0]
+                if test.get("State") != "available":
+                    self.__fail(
+                        resource_type,
+                        "Volume %s is in state '%s' not 'available'" % (resource_value, test.get("State")),
+                    )
+            except ClientError as e:
+                if (
+                    e.response.get("Error")
+                    .get("Message")
+                    .endswith("parameter volumes is invalid. Expected: 'vol-...'.")
+                ):
+                    self.__fail(resource_type, "Volume %s does not exist." % resource_value)
 
-        # Check spot bid percentage
-        if "SpotPrice" in resource_value:
-            if int(resource_value["SpotPrice"]) > 100 or int(resource_value["SpotPrice"]) < 0:
-                _fail(resource_type, "Spot bid percentage needs to be between 0 and 100")
+                self.__fail(resource_type, e.response.get("Error").get("Message"))
+        # EFS file system Id
+        elif resource_type == "EFSFSId":
+            try:
+                ec2 = boto3.client(
+                    "ec2",
+                    region_name=self.region,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
+                )
+                efs = boto3.client(
+                    "efs",
+                    region_name=self.region,
+                    aws_access_key_id=self.aws_access_key_id,
+                    aws_secret_access_key=self.aws_secret_access_key,
+                )
+                return self.__check_efs_fs_id(ec2, efs, resource_value)
+            except ClientError as e:
+                self.__fail(resource_type, e.response.get("Error").get("Message"))
+        # EFS Performance Mode check
+        elif resource_type == "EFSPerfMode":
+            if resource_value != "generalPurpose" and resource_value != "maxIO":
+                self.__fail(
+                    resource_type,
+                    "Invalid value for 'performance_mode'! "
+                    "Acceptable values for 'performance_mode' are generalPurpose and maxIO",
+                )
+        # EFS Throughput check
+        elif resource_type == "EFSThroughput":
+            throughput_mode = resource_value[0]
+            provisioned_throughput = resource_value[1]
+            if throughput_mode and (throughput_mode != "provisioned" and throughput_mode != "bursting"):
+                self.__fail(
+                    resource_type,
+                    "Invalid value for 'throughput_mode'! "
+                    "Acceptable values for 'throughput_mode' are bursting and provisioned",
+                )
+            if provisioned_throughput is not None:
+                if throughput_mode != "provisioned":
+                    self.__fail(
+                        resource_type,
+                        "When specifying 'provisioned_throughput', the 'throughput_mode' must be set to provisioned",
+                    )
+            else:
+                if throughput_mode == "provisioned":
+                    self.__fail(
+                        resource_type,
+                        "When specifying 'throughput_mode' to provisioned, "
+                        "the 'provisioned_throughput' option must be specified",
+                    )
+        # RAID EBS IOPS
+        elif resource_type == "RAIDIOPS":
+            raid_iops = float(resource_value[0])
+            raid_vol_size = float(resource_value[1])
+            if raid_iops > raid_vol_size * 50:
+                self.__fail(
+                    resource_type,
+                    "IOPS to volume size ratio of %s is too high; maximum is 50." % (raid_iops / raid_vol_size),
+                )
+        # RAID Array Type
+        elif resource_type == "RAIDType":
+            if resource_value != "0" and resource_value != "1":
+                self.__fail(resource_type, "Invalid raid_type, only RAID 0 and RAID 1 are currently supported.")
+        # Number of RAID Volumes Requested
+        elif resource_type == "RAIDNumVol":
+            if int(resource_value) > 5 or int(resource_value) < 2:
+                self.__fail(
+                    resource_type,
+                    "Invalid num_of_raid_volumes. "
+                    "Needs min of 2 volumes for RAID and max of 5 EBS volumes are currently supported.",
+                )
+        # Batch Parameters
+        elif resource_type == "AWSBatch_Parameters":
+            # Check region
+            if self.region in [
+                "ap-northeast-3",
+                "eu-north-1",
+                "cn-north-1",
+                "cn-northwest-1",
+                "us-gov-east-1",
+                "us-gov-west-1",
+            ]:
+                self.__fail(resource_type, "Region %s is not supported with batch scheduler" % self.region)
 
-        # Check sanity on desired, min and max vcpus
-        if "DesiredSize" in resource_value and "MinSize" in resource_value:
-            if int(resource_value["DesiredSize"]) < int(resource_value["MinSize"]):
-                _fail(resource_type, "Desired vcpus must be greater than or equal to min vcpus")
+            # Check compute instance types
+            if "ComputeInstanceType" in resource_value:
+                try:
+                    s3 = boto3.resource("s3", region_name=self.region)
+                    bucket_name = "%s-aws-parallelcluster" % self.region
+                    file_name = "instances/batch_instances.json"
+                    try:
+                        file_contents = s3.Object(bucket_name, file_name).get()["Body"].read().decode("utf-8")
+                        supported_instances = json.loads(file_contents)
+                        for instance in resource_value["ComputeInstanceType"].split(","):
+                            if not instance.strip() in supported_instances:
+                                self.__fail(
+                                    resource_type, "Instance type %s not supported by batch in this region" % instance
+                                )
+                    except ClientError as e:
+                        self.__fail(resource_type, e.response.get("Error").get("Message"))
+                except ClientError as e:
+                    self.__fail(resource_type, e.response.get("Error").get("Message"))
 
-        if "DesiredSize" in resource_value and "MaxSize" in resource_value:
-            if int(resource_value["DesiredSize"]) > int(resource_value["MaxSize"]):
-                _fail(resource_type, "Desired vcpus must be fewer than or equal to max vcpus")
+            # Check spot bid percentage
+            if "SpotPrice" in resource_value:
+                if int(resource_value["SpotPrice"]) > 100 or int(resource_value["SpotPrice"]) < 0:
+                    self.__fail(resource_type, "Spot bid percentage needs to be between 0 and 100")
 
-        if "MaxSize" in resource_value and "MinSize" in resource_value:
-            if int(resource_value["MaxSize"]) < int(resource_value["MinSize"]):
-                _fail(resource_type, "Max vcpus must be greater than or equal to min vcpus")
+            # Check sanity on desired, min and max vcpus
+            if "DesiredSize" in resource_value and "MinSize" in resource_value:
+                if int(resource_value["DesiredSize"]) < int(resource_value["MinSize"]):
+                    self.__fail(resource_type, "Desired vcpus must be greater than or equal to min vcpus")
 
-        # Check custom batch url
-        if "CustomAWSBatchTemplateURL" in resource_value:
-            check_resource(
-                region, aws_access_key_id, aws_secret_access_key, "URL", resource_value["CustomAWSBatchTemplateURL"]
-            )
+            if "DesiredSize" in resource_value and "MaxSize" in resource_value:
+                if int(resource_value["DesiredSize"]) > int(resource_value["MaxSize"]):
+                    self.__fail(resource_type, "Desired vcpus must be fewer than or equal to max vcpus")
 
+            if "MaxSize" in resource_value and "MinSize" in resource_value:
+                if int(resource_value["MaxSize"]) < int(resource_value["MinSize"]):
+                    self.__fail(resource_type, "Max vcpus must be greater than or equal to min vcpus")
 
-def _fail(resource_type, message):
-    """
-    Print an error and exit.
+            # Check custom batch url
+            if "CustomAWSBatchTemplateURL" in resource_value:
+                self.validate("URL", resource_value["CustomAWSBatchTemplateURL"])
 
-    :param resource_type: Resource on which the config sanity check failed
-    :param message: the message to print
-    """
-    print("Config sanity error on resource %s: %s" % (resource_type, message))
-    sys.exit(1)
+    @staticmethod
+    def __fail(resource_type, message):
+        """
+        Print an error and exit.
+
+        :param resource_type: Resource on which the config sanity check failed
+        :param message: the message to print
+        """
+        print("Config sanity error on resource %s: %s" % (resource_type, message))
+        sys.exit(1)

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -82,23 +82,20 @@ def check_efs_fs_id(ec2, efs, resource_value):  # noqa: C901 FIXME!!!
                     nfs_access = True
                     break
             if not nfs_access:
-                print(
-                    "Config sanity error: There is an existing Mount Target %s in the Availability Zone %s for EFS %s, "
+                _fail(
+                    "EFSFSId",
+                    "There is an existing Mount Target %s in the Availability Zone %s for EFS %s, "
                     "and it does not have a security group with inbound and outbound rules that support NFS. "
                     "Please modify the Mount Target's security group, or delete the Mount Target."
                     % (mt_id, availability_zone, resource_value[0])
                 )
-                sys.exit(1)
+
             return True
     except ClientError as e:
-        print("Config sanity error: %s" % e.response.get("Error").get("Message"))
-        sys.exit(1)
+        _fail("EFSFSId", e.response.get("Error").get("Message"))
 
 
-def check_resource(  # noqa: C901 FIXME!!!
-    region, aws_access_key_id, aws_secret_access_key, resource_type, resource_value
-):
-
+def check_resource(region, aws_access_key_id, aws_secret_access_key, resource_type, resource_value):  # noqa: C901 FIXME
     # Loop over all supported resource checks
     # EC2 KeyPair
     if resource_type == "EC2KeyPair":
@@ -111,8 +108,7 @@ def check_resource(  # noqa: C901 FIXME!!!
             )
             test = ec2.describe_key_pairs(KeyNames=[resource_value])
         except ClientError as e:
-            print("Config sanity error on resource %s: %s" % (resource_type, e.response.get("Error").get("Message")))
-            sys.exit(1)
+            _fail(resource_type, e.response.get("Error").get("Message"))
     if resource_type == "EC2IAMRoleName":
         try:
             iam = boto3.client(
@@ -199,8 +195,7 @@ def check_resource(  # noqa: C901 FIXME!!!
                         print("See https://aws-parallelcluster.readthedocs.io/en/latest/iam.html")
                         sys.exit(1)
         except ClientError as e:
-            print("Config sanity error on resource %s: %s" % (resource_type, e.response.get("Error").get("Message")))
-            sys.exit(1)
+            _fail(resource_type, e.response.get("Error").get("Message"))
     # VPC Id
     elif resource_type == "VPC":
         try:
@@ -213,23 +208,20 @@ def check_resource(  # noqa: C901 FIXME!!!
             )
             test = ec2.describe_vpcs(VpcIds=[resource_value])
         except ClientError as e:
-            print("Config sanity error on resource %s: %s" % (resource_type, e.response.get("Error").get("Message")))
-            sys.exit(1)
+            _fail(resource_type, e.response.get("Error").get("Message"))
         # Check for DNS support in the VPC
         if (
             not ec2.describe_vpc_attribute(VpcId=resource_value, Attribute="enableDnsSupport")
             .get("EnableDnsSupport")
             .get("Value")
         ):
-            print("DNS Support is not enabled in %s" % resource_value)
-            sys.exit(1)
+            _fail(resource_type, "DNS Support is not enabled in %s" % resource_value)
         if (
             not ec2.describe_vpc_attribute(VpcId=resource_value, Attribute="enableDnsHostnames")
             .get("EnableDnsHostnames")
             .get("Value")
         ):
-            print("DNS Hostnames not enabled in %s" % resource_value)
-            sys.exit(1)
+            _fail(resource_type, "DNS Hostnames not enabled in %s" % resource_value)
     # VPC Subnet Id
     elif resource_type == "VPCSubnet":
         try:
@@ -241,8 +233,7 @@ def check_resource(  # noqa: C901 FIXME!!!
             )
             test = ec2.describe_subnets(SubnetIds=[resource_value])
         except ClientError as e:
-            print("Config sanity error on resource %s: %s" % (resource_type, e.response.get("Error").get("Message")))
-            sys.exit(1)
+            _fail(resource_type, e.response.get("Error").get("Message"))
     # VPC Security Group
     elif resource_type == "VPCSecurityGroup":
         try:
@@ -254,8 +245,7 @@ def check_resource(  # noqa: C901 FIXME!!!
             )
             test = ec2.describe_security_groups(GroupIds=[resource_value])
         except ClientError as e:
-            print("Config sanity error on resource %s: %s" % (resource_type, e.response.get("Error").get("Message")))
-            sys.exit(1)
+            _fail(resource_type, e.response.get("Error").get("Message"))
     # EC2 AMI Id
     elif resource_type == "EC2Ami":
         try:
@@ -267,8 +257,7 @@ def check_resource(  # noqa: C901 FIXME!!!
             )
             test = ec2.describe_images(ImageIds=[resource_value])
         except ClientError as e:
-            print("Config sanity error on resource %s: %s" % (resource_type, e.response.get("Error").get("Message")))
-            sys.exit(1)
+            _fail(resource_type, e.response.get("Error").get("Message"))
     # EC2 Placement Group
     elif resource_type == "EC2PlacementGroup":
         if resource_value == "DYNAMIC":
@@ -283,10 +272,7 @@ def check_resource(  # noqa: C901 FIXME!!!
                 )
                 test = ec2.describe_placement_groups(GroupNames=[resource_value])
             except ClientError as e:
-                print(
-                    "Config sanity error on resource %s: %s" % (resource_type, e.response.get("Error").get("Message"))
-                )
-                sys.exit(1)
+                _fail(resource_type, e.response.get("Error").get("Message"))
     # URL
     elif resource_type == "URL":
         scheme = urlparse(resource_value).scheme
@@ -296,11 +282,9 @@ def check_resource(  # noqa: C901 FIXME!!!
             try:
                 urllib.request.urlopen(resource_value)
             except urllib.error.HTTPError as e:
-                print("Config sanity error:", resource_value, e.code, e.reason)
-                sys.exit(1)
+                _fail(resource_type, "%s %s %s" % (resource_value, e.code, e.reason))
             except urllib.error.URLError as e:
-                print("Config sanity error:", resource_value, e.reason)
-                sys.exit(1)
+                _fail(resource_type, "%s %s" (resource_value, e.reason))
     # EC2 EBS Snapshot Id
     elif resource_type == "EC2Snapshot":
         try:
@@ -312,11 +296,12 @@ def check_resource(  # noqa: C901 FIXME!!!
             )
             test = ec2.describe_snapshots(SnapshotIds=[resource_value]).get("Snapshots")[0]
             if test.get("State") != "completed":
-                print("Snapshot %s is in state '%s' not 'completed'" % (resource_value, test.get("State")))
-                sys.exit(1)
+                _fail(
+                    resource_type,
+                    "Snapshot %s is in state '%s' not 'completed'" % (resource_value, test.get("State"))
+                )
         except ClientError as e:
-            print("Config sanity error on resource %s: %s" % (resource_type, e.response.get("Error").get("Message")))
-            sys.exit(1)
+            _fail(resource_type, e.response.get("Error").get("Message"))
     # EC2 EBS Volume Id
     elif resource_type == "EC2Volume":
         try:
@@ -328,14 +313,12 @@ def check_resource(  # noqa: C901 FIXME!!!
             )
             test = ec2.describe_volumes(VolumeIds=[resource_value]).get("Volumes")[0]
             if test.get("State") != "available":
-                print("Volume %s is in state '%s' not 'available'" % (resource_value, test.get("State")))
-                sys.exit(1)
+                _fail(resource_type, "Volume %s is in state '%s' not 'available'" % (resource_value, test.get("State")))
         except ClientError as e:
             if e.response.get("Error").get("Message").endswith("parameter volumes is invalid. Expected: 'vol-...'."):
-                print("Config sanity error: volume %s does not exist." % resource_value)
-                sys.exit(1)
-            print("Config sanity error on resource %s: %s" % (resource_type, e.response.get("Error").get("Message")))
-            sys.exit(1)
+                _fail(resource_type, "Volume %s does not exist." % resource_value)
+
+            _fail(resource_type, e.response.get("Error").get("Message"))
     # EFS file system Id
     elif resource_type == "EFSFSId":
         try:
@@ -353,69 +336,64 @@ def check_resource(  # noqa: C901 FIXME!!!
             )
             return check_efs_fs_id(ec2, efs, resource_value)
         except ClientError as e:
-            print("Config sanity error: %s" % e.response.get("Error").get("Message"))
-            sys.exit(1)
+            _fail(resource_type, e.response.get("Error").get("Message"))
     # EFS Performance Mode check
     elif resource_type == "EFSPerfMode":
         if resource_value != "generalPurpose" and resource_value != "maxIO":
-            print(
-                "Config sanity error: Invalid value for 'performance_mode'! "
+            _fail(
+                resource_type,
+                "Invalid value for 'performance_mode'! "
                 "Acceptable values for 'performance_mode' are generalPurpose and maxIO"
             )
-            sys.exit(1)
     # EFS Throughput check
     elif resource_type == "EFSThroughput":
         throughput_mode = resource_value[0]
         provisioned_throughput = resource_value[1]
         if throughput_mode and (throughput_mode != "provisioned" and throughput_mode != "bursting"):
-            print(
-                "Config sanity error: Invalid value for 'throughput_mode'! "
+            _fail(
+                resource_type,
+                "Invalid value for 'throughput_mode'! "
                 "Acceptable values for 'throughput_mode' are bursting and provisioned"
             )
-            sys.exit(1)
         if provisioned_throughput is not None:
             if throughput_mode != "provisioned":
-                print(
-                    "Config sanity error: When specifying 'provisioned_throughput', "
-                    "the 'throughput_mode' must be set to provisioned"
+                _fail(
+                    resource_type,
+                    "When specifying 'provisioned_throughput', the 'throughput_mode' must be set to provisioned"
                 )
-                sys.exit(1)
         else:
             if throughput_mode == "provisioned":
-                print(
-                    "Config sanity error: When specifying 'throughput_mode' to provisioned, "
+                _fail(
+                    resource_type,
+                    "When specifying 'throughput_mode' to provisioned, "
                     "the 'provisioned_throughput' option must be specified"
                 )
-                sys.exit(1)
     # RAID EBS IOPS
     elif resource_type == "RAIDIOPS":
         raid_iops = float(resource_value[0])
         raid_vol_size = float(resource_value[1])
         if raid_iops > raid_vol_size * 50:
-            print(
-                "Config sanity error: IOPS to volume size ratio of %s is too high; maximum is 50."
-                % (raid_iops / raid_vol_size)
+            _fail(
+                resource_type,
+                "IOPS to volume size ratio of %s is too high; maximum is 50." % (raid_iops / raid_vol_size)
             )
-            sys.exit(1)
     # RAID Array Type
     elif resource_type == "RAIDType":
         if resource_value != "0" and resource_value != "1":
-            print("Config sanity error: invalid raid_type, only RAID 0 and RAID 1 are currently supported.")
-            sys.exit(1)
+            _fail(resource_type, "Invalid raid_type, only RAID 0 and RAID 1 are currently supported.")
     # Number of RAID Volumes Requested
     elif resource_type == "RAIDNumVol":
         if int(resource_value) > 5 or int(resource_value) < 2:
-            print(
-                "Config sanity error: invalid num_of_raid_volumes. "
+            _fail(
+                resource_type,
+                "Invalid num_of_raid_volumes. "
                 "Needs min of 2 volumes for RAID and max of 5 EBS volumes are currently supported."
             )
-            sys.exit(1)
     # Batch Parameters
     elif resource_type == "AWSBatch_Parameters":
         # Check region
         if region in ["ap-northeast-3", "eu-north-1", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1"]:
-            print("ERROR: %s region is not supported with awsbatch" % region)
-            sys.exit(1)
+            _fail(resource_type, "Region %s is not supported with batch scheduler" % region)
 
         # Check compute instance types
         if "ComputeInstanceType" in resource_value:
@@ -428,44 +406,43 @@ def check_resource(  # noqa: C901 FIXME!!!
                     supported_instances = json.loads(file_contents)
                     for instance in resource_value["ComputeInstanceType"].split(","):
                         if not instance.strip() in supported_instances:
-                            print("Instance type %s not supported by batch in this region" % instance)
-                            sys.exit(1)
+                            _fail(resource_type, "Instance type %s not supported by batch in this region" % instance)
                 except ClientError as e:
-                    print(
-                        "Config sanity error on resource %s: %s"
-                        % (resource_type, e.response.get("Error").get("Message"))
-                    )
-                    sys.exit(1)
+                    _fail(resource_type, e.response.get("Error").get("Message"))
             except ClientError as e:
-                print(
-                    "Config sanity error on resource %s: %s" % (resource_type, e.response.get("Error").get("Message"))
-                )
-                sys.exit(1)
+                _fail(resource_type, e.response.get("Error").get("Message"))
 
         # Check spot bid percentage
         if "SpotPrice" in resource_value:
             if int(resource_value["SpotPrice"]) > 100 or int(resource_value["SpotPrice"]) < 0:
-                print("ERROR: Spot bid percentage needs to be between 0 and 100")
-                sys.exit(1)
+                _fail(resource_type, "Spot bid percentage needs to be between 0 and 100")
 
         # Check sanity on desired, min and max vcpus
         if "DesiredSize" in resource_value and "MinSize" in resource_value:
             if int(resource_value["DesiredSize"]) < int(resource_value["MinSize"]):
-                print("ERROR: Desired vcpus must be greater than or equal to min vcpus")
-                sys.exit(1)
+                _fail(resource_type, "Desired vcpus must be greater than or equal to min vcpus")
 
         if "DesiredSize" in resource_value and "MaxSize" in resource_value:
             if int(resource_value["DesiredSize"]) > int(resource_value["MaxSize"]):
-                print("ERROR: Desired vcpus must be fewer than or equal to max vcpus")
-                sys.exit(1)
+                _fail(resource_type, "Desired vcpus must be fewer than or equal to max vcpus")
 
         if "MaxSize" in resource_value and "MinSize" in resource_value:
             if int(resource_value["MaxSize"]) < int(resource_value["MinSize"]):
-                print("ERROR: Max vcpus must be greater than or equal to min vcpus")
-                sys.exit(1)
+                _fail(resource_type, "Max vcpus must be greater than or equal to min vcpus")
 
         # Check custom batch url
         if "CustomAWSBatchTemplateURL" in resource_value:
             check_resource(
                 region, aws_access_key_id, aws_secret_access_key, "URL", resource_value["CustomAWSBatchTemplateURL"]
             )
+
+
+def _fail(resource_type, message):
+    """
+    Print an error and exit.
+
+    :param resource_type: Resource on which the config sanity check failed
+    :param message: the message to print
+    """
+    print("Config sanity error on resource %s: %s" % (resource_type, message))
+    sys.exit(1)

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -47,16 +47,27 @@ class ResourceValidator(object):
 
     @staticmethod
     def __check_sg_rules_for_port(rule, port_to_check):
+        """
+        Verify if the security group rule accepts connections to the given port.
+
+        :param rule: The rule to check
+        :param port_to_check: The port to check
+        :return: True if the rule accepts connection, False otherwise
+        """
         port = rule.get("FromPort")
         ip_rules = rule.get("IpRanges")
         group = rule.get("UserIdGroupPairs")
 
+        is_valid = False
         for ip_rule in ip_rules:
             ip = ip_rule.get("CidrIp")
             # An existing rule is valid for EFS if, it allows all traffic(0.0.0.0/0)
-            # from all ports or NFS(port 2049), and does not have a security group restriction
+            # from all ports or the given port, and does not have a security group restriction
             if (not port or port == port_to_check) and ip == "0.0.0.0/0" and not group:
-                return True
+                is_valid = True
+                break
+
+        return is_valid
 
     def __check_efs_fs_id(self, ec2, efs, resource_value):  # noqa: C901 FIXME!!!
         try:


### PR DESCRIPTION
Please take a look commit by commit, since there are a lot of changes, but I tried to keep them isolated.

1. _Move initialization specific function after the main init_
   In the first commit I just moved the `__init_*` specific function after the `__init` one. 
   It is a safe commit but in the PR there are a lot of "fake" differences.
1.  _Add documentation and rename internal variables_
  Very simple and safe commit.
1. _Simplify init method of ParalleClusterConfig class_
  I'm defining a set of internal functions to initialize internal attributes and parameters items, by grouping them by context. It is invasive but I put the new functions in the same order of the old code so it should be easy to see that there are no too many differences.
1. _Define a fail function for the config sanity module_
  Simple commit to have a single point to manage the error and the exit in case of errors.
1. _Create ResourceValidator object and use it to validate resources_
  As described in the commit title.

I tested it locally with Python 3.6 by putting some errors in the configuration file.
E.g. raid type, num or faid volumes, desired size, fake vpc id, fake key name, etc