### PR TITLE
 Integ tests: add support to automatically create VPCs needed by tests 

### DIFF
--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -1,0 +1,140 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+import boto3
+from botocore.exceptions import ClientError
+from retrying import retry
+
+from utils import random_alphanumeric, retrieve_cfn_outputs
+
+
+class CfnStack:
+    """Identify a CloudFormation stack."""
+
+    def __init__(self, name, region, template):
+        self.name = name
+        self.region = region
+        self.template = template
+        self.__cfn_outputs = None
+
+    @property
+    def cfn_outputs(self):
+        """
+        Return the CloudFormation stack outputs for the stack.
+        Outputs are retrieved only once and then cached.
+        """
+        if self.__cfn_outputs:
+            return self.__cfn_outputs
+        self.__cfn_outputs = retrieve_cfn_outputs(self.name, self.region)
+        return self.__cfn_outputs
+
+
+class CfnStacksFactory:
+    """Manage creation and deletion of CloudFormation stacks."""
+
+    def __init__(self):
+        self.__created_stacks = {}
+
+    def create_stack(self, region, template, name=None):
+        """
+        Create a cfn stack with a given template.
+        :param template: template to use for stack creation.
+        :param name: name of the stack. If not specified it defaults to "integ-tests-" + random_alphanumeric()
+        :return:
+        """
+        if not name:
+            name = "integ-tests-" + random_alphanumeric()
+
+        if self.__get_stack_internal_id(name, region) in self.__created_stacks:
+            raise ValueError("Stack {0} already exists in region {1}".format(name, region))
+
+        # create the cluster
+        logging.info("Creating stack {0} in region {1}".format(name, region))
+        id = self.__get_stack_internal_id(name, region)
+        self.__created_stacks[id] = CfnStack(name, region, template)
+        try:
+            cfn_client = boto3.client("cloudformation", region_name=region)
+            cfn_client.create_stack(StackName=name, TemplateBody=template)
+            final_status = self.__wait_for_stack_creation(name, cfn_client)
+            self.__assert_stack_status(final_status, "CREATE_COMPLETE")
+        except Exception as e:
+            logging.error("Creation of stack {0} in region {1} failed with exception: {2}".format(name, region, e))
+            raise
+
+        logging.info("Cluster {0} created successfully in region {1}".format(name, region))
+        return self.__created_stacks[id]
+
+    @retry(
+        stop_max_attempt_number=10,
+        wait_fixed=5000,
+        retry_on_exception=lambda exception: isinstance(exception, ClientError),
+    )
+    def delete_stack(self, name, region):
+        """Destroy a created cfn stack."""
+        id = self.__get_stack_internal_id(name, region)
+        if id in self.__created_stacks:
+            logging.info("Destroying stack {0} in region {1}".format(name, region))
+            try:
+                stack = self.__created_stacks[id]
+                cfn_client = boto3.client("cloudformation", region_name=stack.region)
+                cfn_client.delete_stack(StackName=stack.name)
+                final_status = self.__wait_for_stack_deletion(name, cfn_client)
+                self.__assert_stack_status(final_status, "DELETE_COMPLETE")
+            except Exception as e:
+                logging.error("Deletion of stack {0} in region {1} failed with exception: {2}".format(name, region, e))
+                raise
+            del self.__created_stacks[id]
+            logging.info("Cluster {0} deleted successfully in region {1}".format(name, region))
+        else:
+            logging.warning("Couldn't find cluster with name {0} in region. Skipping deletion.".format(name, region))
+
+    def delete_all_stacks(self):
+        """Destroy all created stacks."""
+        logging.debug("Destroying all cfn stacks")
+        for _, value in dict(self.__created_stacks).items():
+            try:
+                self.delete_stack(value.name, value.region)
+            except Exception as e:
+                logging.error(
+                    "Failed when destroying stack {0} in region {1} with exception {2}.".format(
+                        value.name, value.region, e
+                    )
+                )
+
+    @retry(
+        retry_on_result=lambda result: result == "CREATE_IN_PROGRESS",
+        wait_fixed=5000,
+        retry_on_exception=lambda e: False,
+    )
+    def __wait_for_stack_creation(self, name, cfn_client):
+        return self.__get_stack_status(name, cfn_client)
+
+    @retry(
+        retry_on_result=lambda result: result == "DELETE_IN_PROGRESS",
+        wait_fixed=5000,
+        retry_on_exception=lambda e: False,
+    )
+    def __wait_for_stack_deletion(self, name, cfn_client):
+        return self.__get_stack_status(name, cfn_client)
+
+    @staticmethod
+    def __get_stack_status(name, cfn_client):
+        return cfn_client.describe_stacks(StackName=name).get("Stacks")[0].get("StackStatus")
+
+    @staticmethod
+    def __assert_stack_status(status, expected_status):
+        if status != expected_status:
+            raise Exception("Stack status {0} differs from expected one {1}".format(status, expected_status))
+
+    @staticmethod
+    def __get_stack_internal_id(name, region):
+        return name + "-" + region

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -32,9 +32,8 @@ class CfnStack:
         Return the CloudFormation stack outputs for the stack.
         Outputs are retrieved only once and then cached.
         """
-        if self.__cfn_outputs:
-            return self.__cfn_outputs
-        self.__cfn_outputs = retrieve_cfn_outputs(self.name, self.region)
+        if not self.__cfn_outputs:
+            self.__cfn_outputs = retrieve_cfn_outputs(self.name, self.region)
         return self.__cfn_outputs
 
 

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -223,7 +223,13 @@ def cfn_stacks_factory():
 @pytest.fixture(scope="session", autouse=True)
 def vpc_stacks(cfn_stacks_factory, request):
     """Create VPC used by integ tests in all configured regions."""
-    public_subnet = SubnetConfig()
+    public_subnet = SubnetConfig(
+        name="PublicSubnet",
+        cidr="10.0.0.0/24",
+        map_public_ip_on_launch=True,
+        has_nat_gateway=True,
+        default_gateway=Gateways.INTERNET_GATEWAY,
+    )
     private_subnet = SubnetConfig(
         name="PrivateSubnet",
         cidr="10.0.1.0/24",

--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -9,3 +9,4 @@ retrying
 junitparser
 Jinja2
 boto3
+troposphere

--- a/tests/integration-tests/tests/test_awsbatch.py
+++ b/tests/integration-tests/tests/test_awsbatch.py
@@ -20,7 +20,7 @@ from remote_command_executor import RemoteCommandExecutor
 @pytest.mark.instances(["c5.xlarge", "t2.large"])
 @pytest.mark.dimensions("*", "*", "alinux", "awsbatch")
 def test_job_submission(region, os, instance, scheduler, pcluster_config_reader, clusters_factory, test_datadir):
-    cluster_config = pcluster_config_reader(vpc_id="aaa", master_subnet_id="bbb", compute_subnet_id="ccc")
+    cluster_config = pcluster_config_reader()
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
     result = remote_command_executor.run_remote_command("env")

--- a/tests/integration-tests/tests/test_awsbatch/test_job_submission/pcluster.config.ini
+++ b/tests/integration-tests/tests/test_awsbatch/test_job_submission/pcluster.config.ini
@@ -16,5 +16,5 @@ max_vcpus = 24
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
-master_subnet_id = {{ master_subnet_id }}
-compute_subnet_id = {{ compute_subnet_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 import random
+import re
 import shlex
 import string
 import subprocess
@@ -61,3 +62,9 @@ def retrieve_cfn_outputs(stack_name, region):
     except Exception as e:
         logging.warning("Failed retrieving stack outputs for stack {} with exception: {}".format(stack_name, e))
         raise
+
+
+def to_snake_case(input):
+    """Convert a string into its snake case representation."""
+    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", input)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()

--- a/tests/integration-tests/vpc_builder.py
+++ b/tests/integration-tests/vpc_builder.py
@@ -42,7 +42,10 @@ class SubnetConfig(NamedTuple):
     map_public_ip_on_launch: bool = True
     has_nat_gateway: bool = True
     default_gateway: Gateways = Gateways.INTERNET_GATEWAY
-    tags: Tags = Tags(Name=Sub("${AWS::StackName}-" + name + "_subnet"), Stack=Ref("AWS::StackId"))
+
+    def tags(self):
+        """Get the tags for the subnet"""
+        return Tags(Name=Sub("${AWS::StackName}-" + self.name + "_subnet"), Stack=Ref("AWS::StackId"))
 
 
 class VPCConfig(NamedTuple):
@@ -115,7 +118,7 @@ class VPCTemplateBuilder:
                 CidrBlock=subnet_config.cidr,
                 VpcId=Ref(vpc),
                 MapPublicIpOnLaunch=subnet_config.map_public_ip_on_launch,
-                Tags=subnet_config.tags,
+                Tags=subnet_config.tags(),
             )
         )
         self.__template.add_output(Output(subnet_config.name + "Id", Value=Ref(subnet)))

--- a/tests/integration-tests/vpc_builder.py
+++ b/tests/integration-tests/vpc_builder.py
@@ -1,0 +1,171 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+from enum import Enum, auto
+from typing import List, NamedTuple
+
+from troposphere import GetAtt, Output, Ref, Sub, Tags, Template
+from troposphere.ec2 import (
+    EIP,
+    VPC,
+    InternetGateway,
+    NatGateway,
+    Route,
+    RouteTable,
+    Subnet,
+    SubnetRouteTableAssociation,
+    VPCGatewayAttachment,
+)
+
+
+class Gateways(Enum):
+    """Define gateways to use for default traffic in a subnet."""
+
+    INTERNET_GATEWAY = auto()
+    NAT_GATEWAY = auto()
+    PROXY = auto()
+
+
+class SubnetConfig(NamedTuple):
+    """Configuration of a VPC Subnet"""
+
+    name: str = "PublicSubnet"
+    cidr: str = "10.0.0.0/24"
+    map_public_ip_on_launch: bool = True
+    has_nat_gateway: bool = True
+    default_gateway: Gateways = Gateways.INTERNET_GATEWAY
+    tags: Tags = Tags(Name=Sub("${AWS::StackName}-" + name + "_subnet"), Stack=Ref("AWS::StackId"))
+
+
+class VPCConfig(NamedTuple):
+    """Configuration of a VPC"""
+
+    name: str = "vpc"
+    cidr: str = "10.0.0.0/16"
+    enable_dns_support: bool = True
+    enable_dns_hostnames: bool = True
+    has_internet_gateway: bool = True
+    subnets: List[SubnetConfig] = [SubnetConfig()]
+    tags: Tags = Tags(Name=Ref("AWS::StackName"), Stack=Ref("AWS::StackId"))
+
+
+class VPCTemplateBuilder:
+    """Build troposphere CFN templates for VPC creation."""
+
+    def __init__(self, vpc_config, description="VPC built by VPCBuilder"):
+        self.__template = Template()
+        self.__template.set_version("2010-09-09")
+        self.__template.set_description(description)
+        self.__vpc_config = vpc_config
+
+    def build(self):
+        """Build the template."""
+        self.__build_template()
+        return self.__template
+
+    def __build_template(self):
+        vpc = self.__build_vpc()
+        internet_gateway = self.__build_internet_gateway(vpc)
+        nat_gateway = None
+        subnet_refs = []
+        for subnet in self.__vpc_config.subnets:
+            subnet_ref = self.__build_subnet(subnet, vpc)
+            subnet_refs.append(subnet_ref)
+            if subnet.has_nat_gateway:
+                nat_gateway = self.__build_nat_gateway(subnet, subnet_ref)
+
+        for subnet, subnet_ref in zip(self.__vpc_config.subnets, subnet_refs):
+            self.__build_route_table(subnet, subnet_ref, vpc, internet_gateway, nat_gateway)
+
+    def __build_vpc(self):
+        vpc_config = self.__vpc_config
+        vpc = self.__template.add_resource(
+            VPC(
+                vpc_config.name,
+                CidrBlock=vpc_config.cidr,
+                EnableDnsSupport=vpc_config.enable_dns_support,
+                EnableDnsHostnames=vpc_config.enable_dns_hostnames,
+                Tags=vpc_config.tags,
+            )
+        )
+        self.__template.add_output(Output("VpcId", Value=Ref(vpc), Description="VPC Id"))
+        return vpc
+
+    def __build_internet_gateway(self, vpc: VPC):
+        internet_gateway = self.__template.add_resource(
+            InternetGateway("InternetGateway", Tags=Tags(Name=Ref("AWS::StackName"), Stack=Ref("AWS::StackId")))
+        )
+        self.__template.add_resource(
+            VPCGatewayAttachment("VPCGatewayAttachment", VpcId=Ref(vpc), InternetGatewayId=Ref(internet_gateway))
+        )
+        return internet_gateway
+
+    def __build_subnet(self, subnet_config: SubnetConfig, vpc: VPC):
+        subnet = self.__template.add_resource(
+            Subnet(
+                subnet_config.name,
+                CidrBlock=subnet_config.cidr,
+                VpcId=Ref(vpc),
+                MapPublicIpOnLaunch=subnet_config.map_public_ip_on_launch,
+                Tags=subnet_config.tags,
+            )
+        )
+        self.__template.add_output(Output(subnet_config.name + "Id", Value=Ref(subnet)))
+        return subnet
+
+    def __build_nat_gateway(self, subnet_config: SubnetConfig, subnet_ref: Subnet):
+        nat_eip = self.__template.add_resource(EIP("NatEIP" + subnet_config.name, Domain="vpc"))
+        return self.__template.add_resource(
+            NatGateway(
+                "NatGateway" + subnet_config.name,
+                AllocationId=GetAtt(nat_eip, "AllocationId"),
+                SubnetId=Ref(subnet_ref),
+            )
+        )
+
+    def __build_route_table(
+        self,
+        subnet_config: SubnetConfig,
+        subnet_ref: Subnet,
+        vpc: VPC,
+        internet_gateway: InternetGateway,
+        nat_gateway: NatGateway,
+    ):
+        route_table = self.__template.add_resource(
+            RouteTable(
+                "RouteTable" + subnet_config.name,
+                VpcId=Ref(vpc),
+                Tags=Tags(Name=Sub("${AWS::StackName}_route_table_" + subnet_config.name), Stack=Ref("AWS::StackId")),
+            )
+        )
+        self.__template.add_resource(
+            SubnetRouteTableAssociation(
+                "RouteAssociation" + subnet_config.name, SubnetId=Ref(subnet_ref), RouteTableId=Ref(route_table)
+            )
+        )
+        if subnet_config.default_gateway == Gateways.INTERNET_GATEWAY:
+            self.__template.add_resource(
+                Route(
+                    "DefaultRoute" + subnet_config.name,
+                    RouteTableId=Ref(route_table),
+                    DestinationCidrBlock="0.0.0.0/0",
+                    GatewayId=Ref(internet_gateway),
+                )
+            )
+        elif subnet_config.default_gateway == Gateways.NAT_GATEWAY:
+            self.__template.add_resource(
+                Route(
+                    "NatRoute" + subnet_config.name,
+                    RouteTableId=Ref(route_table),
+                    DestinationCidrBlock="0.0.0.0/0",
+                    NatGatewayId=Ref(nat_gateway),
+                )
+            )


### PR DESCRIPTION
See README with docs: https://github.com/demartinofra/aws-parallelcluster/blob/0f9523477229388905bfbd205eceb4f3f1ccc094/tests/integration-tests/README.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
