### PR TITLE
Check AWS Account limits before cluster creation

### DIFF
--- a/docs/iam.rst
+++ b/docs/iam.rst
@@ -420,6 +420,14 @@ In case you are using SGE, Slurm or Torque as a scheduler:
               ],
               "Effect": "Allow",
               "Resource": "*"
+          },
+          {
+              "Sid": "SSMDescribe",
+              "Action": [
+                  "ssm:GetParametersByPath"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
           }
       ]
   }


### PR DESCRIPTION
At cluster creation/update/configuration time the AWS account capacity
will be verified by trying to instantiate a number of instances
equal to the configured `max_queue_size`.

I added the `ssm:GetParametersByPath` policy to the documentation, since
it is required to get the latest amazon linux ami id to use for the test.

In the _awsbatch_ case we are calculating the number of instances for the
test according to the instance_type, the number of vcpus for the instance_type
and the selected `max_vcpus` parameter.
The test will be skipped if the compute instance type is set to "_optimal_".


### Tests

I tested both python 3.6 and 2.7, awsbatch (with optimal and standard instance_type) and the other schedulers.

**Examples:**
```
$ pcluster create test-limit --cluster-template sge-centos6
Beginning cluster creation for cluster: test-limit
ERROR: The configured max size parameter 1000 exceeds the AWS Account limit in the eu-west-1 region.
Your quota allows for 27 more running instance(s). You requested at least 1000

$ pcluster create test-limit --cluster-template batch-mnp
Beginning cluster creation for cluster: test-limit
ERROR: The configured max size parameter 1000 exceeds the number of free private IP addresses available in the Compute Subnet.
```