### PR TITLE
Added @tcp to Integration Tests

### DIFF
--- a/tests/integration-tests/tests/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/test_fsx_lustre.py
@@ -53,7 +53,7 @@ def _test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir):
 
     result = remote_command_executor.run_remote_command("cat /etc/fstab")
     assert_that(result.stdout).matches(
-        r"fs-[0-9a-z]+\.fsx\.[a-z1-9\-]+\.amazonaws\.com:/fsx {mount_dir} lustre defaults,_netdev 0 0".format(
+        r"fs-[0-9a-z]+\.fsx\.[a-z1-9\-]+\.amazonaws\.com@tcp:/fsx {mount_dir} lustre defaults,_netdev 0 0".format(
             mount_dir=mount_dir
         )
     )


### PR DESCRIPTION
I added `@tcp` in the mount command in https://github.com/aws/aws-parallelcluster-cookbook/pull/258

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
