### PR TITLE
Remove upper-bound version limit for boto3 and awscli

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -22,12 +22,7 @@ def readme():
 
 
 VERSION = "2.1.1"
-REQUIRES = [
-    "boto3>=1.9.48,<=1.9.85",
-    "awscli>=1.11.175,<=1.16.95",
-    "future>=0.16.0,<=0.17.1",
-    "tabulate>=0.8.2,<=0.8.3",
-]
+REQUIRES = ["boto3>=1.9.48", "awscli>=1.11.175", "future>=0.16.0,<=0.17.1", "tabulate>=0.8.2,<=0.8.3"]
 
 if sys.version_info[:2] == (2, 6):
     # For python2.6 we have to require argparse since it


### PR DESCRIPTION
This was causing an incompatible version of botocore to get installed. 

After creating a virtualenv and running `pip install cli/` here is what happens:
```
pip install cli/
Processing ./cli
Collecting boto3<=1.9.85,>=1.9.48 (from aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/d7/0c/ab877fa34bebf8aba5af6e822c081972d11194be026a247997de3764ade4/boto3-1.9.85-py2.py3-none-any.whl
Collecting awscli<=1.16.95,>=1.11.175 (from aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/0d/21/684544fb0fc52f86149740ecc8bcfef6e705d0ce3799424c9c76cf95de4f/awscli-1.16.95-py2.py3-none-any.whl
Collecting future<=0.17.1,>=0.16.0 (from aws-parallelcluster==2.1.1)
Collecting tabulate<=0.8.3,>=0.8.2 (from aws-parallelcluster==2.1.1)
Collecting s3transfer<0.2.0,>=0.1.10 (from boto3<=1.9.85,>=1.9.48->aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/d7/14/2a0004d487464d120c9fb85313a75cd3d71a7506955be458eebfe19a6b1d/s3transfer-0.1.13-py2.py3-none-any.whl
Collecting jmespath<1.0.0,>=0.7.1 (from boto3<=1.9.85,>=1.9.48->aws-parallelcluster==2.1.1)
  Downloading https://files.pythonhosted.org/packages/83/94/7179c3832a6d45b266ddb2aac329e101367fbdb11f425f13771d27f225bb/jmespath-0.9.4-py2.py3-none-any.whl
Collecting botocore<1.13.0,>=1.12.85 (from boto3<=1.9.85,>=1.9.48->aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/d2/c1/bba75ff036a9363d32f597cddd0fbb6b6166a51f896631c4f57e56aacf65/botocore-1.12.101-py2.py3-none-any.whl
Collecting docutils>=0.10 (from awscli<=1.16.95,>=1.11.175->aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/36/fa/08e9e6e0e3cbd1d362c3bbee8d01d0aedb2155c4ac112b19ef3cae8eed8d/docutils-0.14-py3-none-any.whl
Collecting PyYAML<=3.13,>=3.10 (from awscli<=1.16.95,>=1.11.175->aws-parallelcluster==2.1.1)
Collecting rsa<=3.5.0,>=3.1.2 (from awscli<=1.16.95,>=1.11.175->aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/e1/ae/baedc9cb175552e95f3395c43055a6a5e125ae4d48a1d7a924baca83e92e/rsa-3.4.2-py2.py3-none-any.whl
Collecting colorama<=0.3.9,>=0.2.5 (from awscli<=1.16.95,>=1.11.175->aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/db/c8/7dcf9dbcb22429512708fe3a547f8b6101c0d02137acbd892505aee57adf/colorama-0.3.9-py2.py3-none-any.whl
Collecting urllib3<1.25,>=1.20; python_version >= "3.4" (from botocore<1.13.0,>=1.12.85->boto3<=1.9.85,>=1.9.48->aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/62/00/ee1d7de624db8ba7090d1226aebefab96a2c71cd5cfa7629d6ad3f61b79e/urllib3-1.24.1-py2.py3-none-any.whl
Collecting python-dateutil<3.0.0,>=2.1; python_version >= "2.7" (from botocore<1.13.0,>=1.12.85->boto3<=1.9.85,>=1.9.48->aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/41/17/c62faccbfbd163c7f57f3844689e3a78bae1f403648a6afb1d0866d87fbb/python_dateutil-2.8.0-py2.py3-none-any.whl
Collecting pyasn1>=0.1.3 (from rsa<=3.5.0,>=3.1.2->awscli<=1.16.95,>=1.11.175->aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/7b/7c/c9386b82a25115cccf1903441bba3cbadcfae7b678a20167347fa8ded34c/pyasn1-0.4.5-py2.py3-none-any.whl
Collecting six>=1.5 (from python-dateutil<3.0.0,>=2.1; python_version >= "2.7"->botocore<1.13.0,>=1.12.85->boto3<=1.9.85,>=1.9.48->aws-parallelcluster==2.1.1)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
awscli 1.16.95 has requirement botocore==1.12.85, but you'll have botocore 1.12.101 which is incompatible.
Installing collected packages: urllib3, docutils, jmespath, six, python-dateutil, botocore, s3transfer, boto3, PyYAML, pyasn1, rsa, colorama, awscli, future, tabulate, aws-parallelcluster
  Running setup.py install for aws-parallelcluster ... done
Successfully installed PyYAML-3.13 aws-parallelcluster-2.1.1 awscli-1.16.95 boto3-1.9.85 botocore-1.12.101 colorama-0.3.9 docutils-0.14 future-0.17.1 jmespath-0.9.4 pyasn1-0.4.5 python-dateutil-2.8.0 rsa-3.4.2 s3transfer-0.1.13 six-1.12.0 tabulate-0.8.3 urllib3-1.24.1
```

```
pipdeptree
Warning!!! Possibly conflicting dependencies found:
* awscli==1.16.95
 - botocore [required: ==1.12.85, installed: 1.12.101]
------------------------------------------------------------------------
aws-parallelcluster==2.1.1
  - awscli [required: >=1.11.175,<=1.16.95, installed: 1.16.95]
    - botocore [required: ==1.12.85, installed: 1.12.101]
      - docutils [required: >=0.10, installed: 0.14]
      - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
      - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.0]
        - six [required: >=1.5, installed: 1.12.0]
      - urllib3 [required: >=1.20,<1.25, installed: 1.24.1]
    - colorama [required: >=0.2.5,<=0.3.9, installed: 0.3.9]
    - docutils [required: >=0.10, installed: 0.14]
    - PyYAML [required: >=3.10,<=3.13, installed: 3.13]
    - rsa [required: >=3.1.2,<=3.5.0, installed: 3.4.2]
      - pyasn1 [required: >=0.1.3, installed: 0.4.5]
    - s3transfer [required: >=0.1.12,<0.2.0, installed: 0.1.13]
      - botocore [required: >=1.3.0,<2.0.0, installed: 1.12.101]
        - docutils [required: >=0.10, installed: 0.14]
        - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
        - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.0]
          - six [required: >=1.5, installed: 1.12.0]
        - urllib3 [required: >=1.20,<1.25, installed: 1.24.1]
  - boto3 [required: >=1.9.48,<=1.9.85, installed: 1.9.85]
    - botocore [required: >=1.12.85,<1.13.0, installed: 1.12.101]
      - docutils [required: >=0.10, installed: 0.14]
      - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
      - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.0]
        - six [required: >=1.5, installed: 1.12.0]
      - urllib3 [required: >=1.20,<1.25, installed: 1.24.1]
    - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
    - s3transfer [required: >=0.1.10,<0.2.0, installed: 0.1.13]
      - botocore [required: >=1.3.0,<2.0.0, installed: 1.12.101]
        - docutils [required: >=0.10, installed: 0.14]
        - jmespath [required: >=0.7.1,<1.0.0, installed: 0.9.4]
        - python-dateutil [required: >=2.1,<3.0.0, installed: 2.8.0]
          - six [required: >=1.5, installed: 1.12.0]
        - urllib3 [required: >=1.20,<1.25, installed: 1.24.1]
  - future [required: >=0.16.0,<=0.17.1, installed: 0.17.1]
  - tabulate [required: >=0.8.2,<=0.8.3, installed: 0.8.3]
pipdeptree==0.13.2
  - pip [required: >=6.0.0, installed: 10.0.1]
setuptools==39.0.1

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
