### PR TITLE
Handle NoCredentialsError correctly in pcluster

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -18,6 +18,7 @@ import sys
 import textwrap
 
 import argparse
+from botocore.exceptions import NoCredentialsError
 
 from pcluster import easyconfig, pcluster
 
@@ -341,11 +342,16 @@ def main():
     parser = _get_parser()
     args, extra_args = parser.parse_known_args()
     logger.debug(args)
-    if args.func.__name__ == "command":
-        args.func(args, extra_args)
-    else:
-        if extra_args:
-            parser.print_usage()
-            print("Invalid arguments %s..." % extra_args)
-            sys.exit(1)
-        args.func(args)
+
+    try:
+        if args.func.__name__ == "command":
+            args.func(args, extra_args)
+        else:
+            if extra_args:
+                parser.print_usage()
+                print("Invalid arguments %s..." % extra_args)
+                sys.exit(1)
+            args.func(args)
+    except NoCredentialsError:
+        logger.error("AWS Credentials not found.")
+        sys.exit(1)


### PR DESCRIPTION
When no AWS credentials are configured pcluster commands were failing with:

```
pcluster list
Traceback (most recent call last):
  File "/Users/fdm/.pyenv/versions/parallelcluster/bin/pcluster", line 11, in <module>
    load_entry_point('aws-parallelcluster==2.1.1', 'console_scripts', 'pcluster')()
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/pcluster/cli.py", line 351, in main
    args.func(args)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/pcluster/cli.py", line 42, in list_stacks
    pcluster.list_stacks(args)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/pcluster/pcluster.py", line 382, in list_stacks
    stacks = cfn.describe_stacks().get("Stacks")
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/client.py", line 648, in _make_api_call
    operation_model, request_dict, request_context)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/client.py", line 667, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/endpoint.py", line 102, in make_request
    return self._send_request(request_dict, operation_model)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/endpoint.py", line 132, in _send_request
    request = self.create_request(request_dict, operation_model)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/endpoint.py", line 116, in create_request
    operation_name=operation_model.name)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/hooks.py", line 356, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/hooks.py", line 228, in emit
    return self._emit(event_name, kwargs)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/hooks.py", line 211, in _emit
    response = handler(**kwargs)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/signers.py", line 90, in handler
    return self.sign(operation_name, request)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/signers.py", line 157, in sign
    auth.add_auth(request)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/parallelcluster/lib/python3.7/site-packages/botocore/auth.py", line 357, in add_auth
    raise NoCredentialsError
botocore.exceptions.NoCredentialsError: Unable to locate credentials
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
