### PR TITLE
Add a catch all in the cli entrypoint to avoid printing stack trace

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -355,3 +355,6 @@ def main():
     except NoCredentialsError:
         logger.error("AWS Credentials not found.")
         sys.exit(1)
+    except Exception as e:
+        logger.error("Unexpected error of type %s: %s", type(e).__name__, e)
+        sys.exit(1)


### PR DESCRIPTION
Example of error caused by invalid region in config (note this is not validated in pcluster but out of scope for this patch):

Before patch:

```
Beginning cluster creation for cluster: test
Traceback (most recent call last):
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/urllib3/connection.py", line 159, in _new_conn
    (self._dns_host, self.port), self.timeout, **extra_kw)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/urllib3/util/connection.py", line 57, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "/Users/fdm/.pyenv/versions/3.7.1/lib/python3.7/socket.py", line 748, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno 8] nodename nor servname provided, or not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/httpsession.py", line 258, in send
    decode_content=False,
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/urllib3/connectionpool.py", line 638, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/urllib3/util/retry.py", line 343, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/urllib3/packages/six.py", line 686, in reraise
    raise value
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/urllib3/connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/urllib3/connectionpool.py", line 343, in _make_request
    self._validate_conn(conn)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/urllib3/connectionpool.py", line 839, in _validate_conn
    conn.connect()
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/urllib3/connection.py", line 301, in connect
    conn = self._new_conn()
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/urllib3/connection.py", line 168, in _new_conn
    self, "Failed to establish a new connection: %s" % e)
urllib3.exceptions.NewConnectionError: <botocore.awsrequest.AWSHTTPSConnection object at 0x106fd1630>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/fdm/.pyenv/versions/pcluster2.2.1/bin/pcluster", line 11, in <module>
    load_entry_point('aws-parallelcluster', 'console_scripts', 'pcluster')()
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/cli.py", line 354, in main
    args.func(args)
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/cli.py", line 27, in create
    pcluster.create(args)
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/pcluster.py", line 76, in create
    config = cfnconfig.ParallelClusterConfig(args)
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/cfnconfig.py", line 65, in __init__
    self.__init_key_name()
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/cfnconfig.py", line 288, in __init_key_name
    self.__validate_resource("EC2KeyPair", self.key_name)
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/cfnconfig.py", line 280, in __validate_resource
    self.__resource_validator.validate(resource_type, resource_value)
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/config_sanity.py", line 226, in validate
    ec2.describe_key_pairs(KeyNames=[resource_value])
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/client.py", line 648, in _make_api_call
    operation_model, request_dict, request_context)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/client.py", line 667, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/endpoint.py", line 102, in make_request
    return self._send_request(request_dict, operation_model)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/endpoint.py", line 137, in _send_request
    success_response, exception):
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/endpoint.py", line 231, in _needs_retry
    caught_exception=caught_exception, request_dict=request_dict)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/hooks.py", line 356, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/hooks.py", line 228, in emit
    return self._emit(event_name, kwargs)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/hooks.py", line 211, in _emit
    response = handler(**kwargs)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/retryhandler.py", line 183, in __call__
    if self._checker(attempts, response, caught_exception):
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/retryhandler.py", line 251, in __call__
    caught_exception)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/retryhandler.py", line 277, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/retryhandler.py", line 317, in __call__
    caught_exception)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/retryhandler.py", line 223, in __call__
    attempt_number, caught_exception)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/retryhandler.py", line 359, in _check_caught_exception
    raise caught_exception
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/endpoint.py", line 200, in _do_get_response
    http_response = self._send(request)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/endpoint.py", line 244, in _send
    return self.http_session.send(request)
  File "/Users/fdm/.pyenv/versions/3.7.1/envs/pcluster2.2.1/lib/python3.7/site-packages/botocore/httpsession.py", line 278, in send
    raise EndpointConnectionError(endpoint_url=request.url, error=e)
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "https://ec2.eu-west-11.amazonaws.com/"
```

After patch:

```
Beginning cluster creation for cluster: test
Unexpected error of type EndpointConnectionError: Could not connect to the endpoint URL: "https://ec2.eu-west-11.amazonaws.com/"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
