### PR TITLE
Integ tests minor fixes

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -216,12 +216,12 @@ def pcluster_config_reader(test_datadir, vpc_stacks, region, request):
 
     def _config_renderer(**kwargs):
         config_file_path = test_datadir / config_file
-        _add_custom_packages_configs(config_file_path, request)
         default_values = _get_default_template_values(vpc_stacks, region, request)
         file_loader = FileSystemLoader(str(test_datadir))
         env = Environment(loader=file_loader)
         rendered_template = env.get_template(config_file).render(**{**kwargs, **default_values})
         config_file_path.write_text(rendered_template)
+        _add_custom_packages_configs(config_file_path, request)
         return config_file_path
 
     return _config_renderer

--- a/tests/integration-tests/conftest_markers.py
+++ b/tests/integration-tests/conftest_markers.py
@@ -25,6 +25,7 @@ UNSUPPORTED_DIMENSIONS = [
     ("cn-northwest-1", "*", "*", "awsbatch"),
     ("us-gov-west-1", "*", "*", "awsbatch"),
     ("us-gov-east-1", "*", "*", "awsbatch"),
+    ("us-gov-east-1", "*", "c4.xlarge", "*"),
 ]
 
 

--- a/tests/integration-tests/conftest_markers.py
+++ b/tests/integration-tests/conftest_markers.py
@@ -21,6 +21,10 @@ UNSUPPORTED_DIMENSIONS = [
     ("*", "*", "centos7", "awsbatch"),
     ("*", "*", "ubuntu1604", "awsbatch"),
     ("*", "*", "ubuntu1404", "awsbatch"),
+    ("cn-north-1", "*", "*", "awsbatch"),
+    ("cn-northwest-1", "*", "*", "awsbatch"),
+    ("us-gov-west-1", "*", "*", "awsbatch"),
+    ("us-gov-east-1", "*", "*", "awsbatch"),
 ]
 
 

--- a/tests/integration-tests/conftest_markers.py
+++ b/tests/integration-tests/conftest_markers.py
@@ -14,7 +14,14 @@ import logging
 import pytest
 
 DIMENSIONS_MARKER_ARGS = ["region", "instance", "os", "scheduler"]
-UNSUPPORTED_DIMENSIONS = [("eu-north-1", "c4.xlarge", "*", "*"), ("eu-west-3", "c4.xlarge", "*", "*")]
+UNSUPPORTED_DIMENSIONS = [
+    ("eu-north-1", "c4.xlarge", "*", "*"),
+    ("eu-west-3", "c4.xlarge", "*", "*"),
+    ("*", "*", "centos6", "awsbatch"),
+    ("*", "*", "centos7", "awsbatch"),
+    ("*", "*", "ubuntu1604", "awsbatch"),
+    ("*", "*", "ubuntu1404", "awsbatch"),
+]
 
 
 class InvalidMarkerError(Exception):

--- a/tests/integration-tests/tests/test_awsbatch.py
+++ b/tests/integration-tests/tests/test_awsbatch.py
@@ -20,7 +20,7 @@ from remote_command_executor import RemoteCommandExecutor
 from time_utils import minutes, seconds
 
 
-@pytest.mark.regions(["us-east-1", "eu-west-1", "cn-north-1", "us-gov-west-1"])
+@pytest.mark.regions(["us-east-1", "eu-west-1"])
 @pytest.mark.instances(["c5.xlarge", "t2.large"])
 @pytest.mark.dimensions("*", "*", "alinux", "awsbatch")
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")

--- a/tests/integration-tests/tests/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/test_fsx_lustre.py
@@ -48,7 +48,7 @@ def test_fsx_lustre(region, pcluster_config_reader, clusters_factory, s3_bucket_
 
 def _test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir):
     logging.info("Testing fsx lustre is correctly mounted")
-    result = remote_command_executor.run_remote_command("df -h -t lustre --output=source,size,target | tail -n +2")
+    result = remote_command_executor.run_remote_command("df -h -t lustre | tail -n +2 | awk '{print $1, $2, $6}'")
     assert_that(result.stdout).matches(r"[0-9\.]+@tcp:/fsx\s+3\.4T\s+{mount_dir}".format(mount_dir=mount_dir))
 
     result = remote_command_executor.run_remote_command("cat /etc/fstab")

--- a/tests/integration-tests/tests/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
+++ b/tests/integration-tests/tests/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
@@ -10,8 +10,13 @@ key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
 compute_instance_type = {{ instance }}
+{% if scheduler == "awsbatch" %}
+min_vcpus = 4
+desired_vcpus = 4
+{% else %}
 initial_queue_size = 1
 maintain_initial_size = true
+{% endif %}
 fsx_settings = fsx
 s3_read_resource = arn:aws:s3:::{{ bucket_name }}/*
 


### PR DESCRIPTION
Several minor fixes:
* set custom packages config after jinja rendering otherwise the templated config can't be correctly parsed
* add unsupported awsbatch oss in the default unsupported dimensions list
* make fsx lustre config compatible with awsbatch (although unused at the moment)
* make df command compatible with centos 6 in fsx tests (although unused at the moment)
* awsbatch exclude unsupported regions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
