### PR TITLE
Implement integration tests for EBS

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -10,6 +10,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
+import time
 
 import configparser
 from retrying import retry
@@ -85,6 +86,11 @@ class ClustersFactory:
             logging.error(error)
             raise Exception(error)
         logging.info("Cluster {0} created successfully".format(name))
+
+        # FIXME: temporary workaround since in certain circumstances the cluster isn't ready for
+        # job submission right after creation. We need to investigate this further.
+        logging.info("Sleeping for 60 seconds in case cluster is not ready yet")
+        time.sleep(60)
 
     @retry(stop_max_attempt_number=10, wait_fixed=5000, retry_on_exception=retry_if_subprocess_error)
     def destroy_cluster(self, name):

--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -2,9 +2,9 @@ argparse
 assertpy
 aws-parallelcluster
 boto3
+fabric
 jinja2
 junitparser
-paramiko
 pytest
 pytest-datadir
 pytest-html

--- a/tests/integration-tests/tests/common/__init__.py
+++ b/tests/integration-tests/tests/common/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -1,0 +1,147 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from abc import ABCMeta, abstractmethod
+
+from retrying import retry
+
+from assertpy import assert_that
+from time_utils import minutes, seconds
+
+
+class SchedulerCommands(metaclass=ABCMeta):
+    """Define common scheduler commands."""
+
+    @abstractmethod
+    def __init__(self, remote_command_executor):
+        self._remote_command_executor = remote_command_executor
+
+    @abstractmethod
+    def assert_job_submitted(self, submit_output):
+        """
+        Assert that a job is successfully submitted.
+
+        :param submit_output: stdout from the submit command.
+        :return: the job id
+        """
+        pass
+
+    @abstractmethod
+    def wait_job_completed(self, job_id):
+        """
+        Wait for job completion.
+
+        :param job_id: id of the job to wait for.
+        :return: status of the job.
+        """
+        pass
+
+    @abstractmethod
+    def get_job_exit_status(self, job_id):
+        """
+        Retrieve the job exist status.
+
+        :param job_id: id of the job.
+        :return: the job exist status.
+        """
+        pass
+
+    @abstractmethod
+    def submit_command(self, command):
+        """
+        Submit a job to the scheduler.
+
+        :param command: command to submit.
+        :return: result from remote command execution.
+        """
+        pass
+
+    @abstractmethod
+    def assert_job_succeeded(self, job_id, children_number=0):
+        """
+        Assert that the job succeeded.
+
+        :param job_id: id of the job to check.
+        :param children_number: number of expected children. (e.g. array, multi-node)
+        """
+        pass
+
+
+class AWSBatchCommands(SchedulerCommands):
+    """Implement commands for awsbatch scheduler."""
+
+    def __init__(self, remote_command_executor):
+        super().__init__(remote_command_executor)
+
+    @retry(
+        retry_on_result=lambda result: "FAILED" not in result and any(status != "SUCCEEDED" for status in result),
+        wait_fixed=seconds(7),
+        stop_max_delay=minutes(15),
+    )
+    def wait_job_completed(self, job_id):  # noqa: D102
+        result = self._remote_command_executor.run_remote_command("awsbstat -d {0}".format(job_id))
+        return re.findall(r"status\s+: (.+)", result.stdout)
+
+    def get_job_exit_status(self, job_id):  # noqa: D102
+        return self.wait_job_completed(job_id)
+
+    def assert_job_submitted(self, awsbsub_output):  # noqa: D102
+        __tracebackhide__ = True
+        match = re.match(r"Job ([a-z0-9\-]{36}) \(.+\) has been submitted.", awsbsub_output)
+        assert_that(match).is_not_none()
+        return match.group(1)
+
+    def submit_command(self, command):  # noqa: D102
+        return self._remote_command_executor.run_remote_command('echo "{0}" | awsbsub'.format(command))
+
+    def assert_job_succeeded(self, job_id, children_number=0):  # noqa: D102
+        __tracebackhide__ = True
+        status = self.get_job_exit_status(job_id)
+        assert_that(status).is_length(1 + children_number)
+        assert_that(status).contains_only("SUCCEEDED")
+
+
+class SgeCommands(SchedulerCommands):
+    """Implement commands for sge scheduler."""
+
+    def __init__(self, remote_command_executor):
+        super().__init__(remote_command_executor)
+
+    @retry(retry_on_result=lambda result: result != 0, wait_fixed=seconds(7), stop_max_delay=minutes(5))
+    def wait_job_completed(self, job_id):  # noqa: D102
+        result = self._remote_command_executor.run_remote_command("qacct -j {0}".format(job_id), raise_on_error=False)
+        return result.return_code
+
+    def get_job_exit_status(self, job_id):  # noqa: D102
+        result = self._remote_command_executor.run_remote_command("qacct -j {0}".format(job_id))
+        match = re.search(r"exit_status\s+([0-9]+)", result.stdout)
+        assert_that(match).is_not_none()
+        return match.group(1)
+
+    def assert_job_submitted(self, qsub_output):  # noqa: D102
+        __tracebackhide__ = True
+        match = re.search(r"Your job ([0-9]+) \(.+\) has been submitted", qsub_output)
+        assert_that(match).is_not_none()
+        return match.group(1)
+
+    def submit_command(self, command):  # noqa: D102
+        return self._remote_command_executor.run_remote_command("echo '{0}' | qsub".format(command).format(command))
+
+    def assert_job_succeeded(self, job_id, children_number=0):  # noqa: D102
+        __tracebackhide__ = True
+        status = self.get_job_exit_status(job_id)
+        assert_that(status).is_equal_to("0")
+
+
+def get_scheduler_commands(scheduler, remote_command_executor):
+    scheduler_commands = {"awsbatch": AWSBatchCommands, "sge": SgeCommands}
+    return scheduler_commands[scheduler](remote_command_executor)

--- a/tests/integration-tests/tests/test_ebs.py
+++ b/tests/integration-tests/tests/test_ebs.py
@@ -19,7 +19,7 @@ from tests.common.schedulers_common import get_scheduler_commands
 
 
 @pytest.mark.regions(["us-east-1", "eu-west-1", "cn-north-1", "us-gov-west-1"])
-@pytest.mark.instances(["c5.xlarge"])
+@pytest.mark.instances(["c4.xlarge", "c5.xlarge"])
 @pytest.mark.schedulers(["sge", "awsbatch"])
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_ebs_single(scheduler, pcluster_config_reader, clusters_factory):

--- a/tests/integration-tests/tests/test_ebs.py
+++ b/tests/integration-tests/tests/test_ebs.py
@@ -1,0 +1,76 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+
+import pytest
+
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+from tests.common.schedulers_common import get_scheduler_commands
+
+
+@pytest.mark.regions(["us-east-1", "eu-west-1", "cn-north-1", "us-gov-west-1"])
+@pytest.mark.instances(["c5.xlarge"])
+@pytest.mark.schedulers(["sge", "awsbatch"])
+@pytest.mark.usefixtures("region", "os", "instance")
+def test_ebs_single(scheduler, pcluster_config_reader, clusters_factory):
+    mount_dir = "ebs_mount_dir"
+    cluster_config = pcluster_config_reader(mount_dir=mount_dir)
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    mount_dir = "/" + mount_dir
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+    _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size=20)
+    _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
+
+
+@pytest.mark.regions(["us-east-1", "eu-west-1", "cn-north-1", "us-gov-west-1"])
+@pytest.mark.instances(["c5.xlarge"])
+@pytest.mark.schedulers(["sge", "awsbatch"])
+@pytest.mark.usefixtures("region", "os", "instance")
+def test_ebs_multiple(scheduler, pcluster_config_reader, clusters_factory):
+    mount_dirs = ["/ebs_mount_dir_{0}".format(i) for i in range(0, 5)]
+    volume_sizes = [15 + 5 * i for i in range(0, 5)]
+    cluster_config = pcluster_config_reader(mount_dirs=mount_dirs, volume_sizes=volume_sizes)
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+    for mount_dir, volume_size in zip(mount_dirs, volume_sizes):
+        _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size)
+        _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
+
+
+def _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size):
+    logging.info("Testing ebs {0} is correctly mounted".format(mount_dir))
+    result = remote_command_executor.run_remote_command(
+        "df -h -t ext4 | tail -n +2 | awk '{{print $2, $6}}' | grep '{0}'".format(mount_dir)
+    )
+    assert_that(result.stdout).matches(r"{size}G {mount_dir}".format(size=volume_size, mount_dir=mount_dir))
+
+    result = remote_command_executor.run_remote_command("cat /etc/fstab")
+    assert_that(result.stdout).matches(
+        r"/dev/disk/by-ebs-volumeid/vol-[a-z0-9]{{17}} {mount_dir} ext4 _netdev 0 0".format(mount_dir=mount_dir)
+    )
+
+
+def _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands):
+    logging.info("Testing ebs correctly mounted on compute nodes")
+    remote_command_executor.run_remote_command("touch {mount_dir}/test_file".format(mount_dir=mount_dir))
+    job_command = "cat {mount_dir}/test_file " "&& touch {mount_dir}/compute_output".format(mount_dir=mount_dir)
+
+    result = scheduler_commands.submit_command(job_command)
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)
+    remote_command_executor.run_remote_command("cat {mount_dir}/compute_output".format(mount_dir=mount_dir))

--- a/tests/integration-tests/tests/test_ebs/test_ebs_multiple/pcluster.config.ini
+++ b/tests/integration-tests/tests/test_ebs/test_ebs_multiple/pcluster.config.ini
@@ -1,0 +1,54 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+compute_instance_type = {{ instance }}
+{% if scheduler == "awsbatch" %}
+min_vcpus = 4
+desired_vcpus = 4
+{% else %}
+initial_queue_size = 1
+maintain_initial_size = true
+{% endif %}
+ebs_settings = ebs1, ebs2, ebs3, ebs4, ebs5
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+
+[ebs ebs1]
+shared_dir = {{ mount_dirs[0] }}
+volume_type = io1
+volume_size = {{ volume_sizes[0] }}
+volume_iops = 100
+encrypted = true
+
+[ebs ebs2]
+shared_dir = {{ mount_dirs[1] }}
+volume_size = {{ volume_sizes[1] }}
+volume_iops = 125
+encrypted = false
+
+[ebs ebs3]
+shared_dir = {{ mount_dirs[2] }}
+volume_size = {{ volume_sizes[2] }}
+volume_iops = 150
+
+[ebs ebs4]
+shared_dir = {{ mount_dirs[3] }}
+volume_size = {{ volume_sizes[3] }}
+
+[ebs ebs5]
+shared_dir = {{ mount_dirs[4] }}
+volume_size = {{ volume_sizes[4] }}
+volume_type = io1
+volume_iops = 200
+encrypted = false

--- a/tests/integration-tests/tests/test_ebs/test_ebs_single/pcluster.config.ini
+++ b/tests/integration-tests/tests/test_ebs/test_ebs_single/pcluster.config.ini
@@ -1,0 +1,31 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+compute_instance_type = {{ instance }}
+{% if scheduler == "awsbatch" %}
+min_vcpus = 4
+desired_vcpus = 4
+{% else %}
+initial_queue_size = 1
+maintain_initial_size = true
+{% endif %}
+ebs_settings = ebs
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+
+[ebs ebs]
+shared_dir = {{ mount_dir }}
+volume_type = io1
+volume_iops = 210
+encrypted = true


### PR DESCRIPTION
Following tests are implemented:
* single EBS volume
* multiple EBS volumes

Additional changes:
* reorganize common scheduler commands that are shared across several test cases in dedicated classes
* replace paramiko with fabric (a higher level library built on top of paramiko). This simplifies the logic in the remote_command_executor
* wait for 60 seconds after cluster creation since under certain circumstances the cluster seems not to be ready right after stack completion. Waiting for additional 60 seconds as temporary workaround.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
