### PR TITLE
FSx Amazon Linux Support

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -804,7 +804,14 @@ class ParallelClusterConfig(object):
             return
 
         # Check that the base_os is supported
-        self.__validate_os("FSx", self.__get_os(), ["centos7"])
+        self.__validate_os("FSx", self.__get_os(), ["centos7", "alinux"])
+
+        # Validate scheduler is not awsbatch
+        if self.parameters.get("Scheduler") == "awsbatch":
+            self.__fail(
+                "FSx isn't supported with awsbatch as the scheduler, please submit a feature request"
+                " if you need it: https://github.com/aws/aws-parallelcluster/issues/new"
+            )
 
         # Dictionary list of all FSx options
         fsx_options = OrderedDict(

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -989,7 +989,9 @@ FSx
 Configuration for an attached FSx Lustre file system. See `FSx CreateFileSystem
 <https://docs.aws.amazon.com/fsx/latest/APIReference/API_CreateFileSystem.html>`_ for more information.
 
-FSx Lustre is only supported when ``base_os = centos7``.
+FSx Lustre is supported when ``base_os = centos7 | alinux``.
+
+Note FSx is not currently supported when using ``awsbatch`` as a scheduler.
 
 If using an existing file system, it must be associated to a security group that allows inbound and outbound
 TCP traffic from ``0.0.0.0/0`` through port ``988``. This is done by automatically when not using


### PR DESCRIPTION
* Allows the user to specify `base_os = alinux` when using Amazon FSx for Lustre

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
