### PR TITLE
Migrate parallelcluster release-check to the new testing framework

### DIFF
--- a/tests/integration-tests/tests/test_scaling.py
+++ b/tests/integration-tests/tests/test_scaling.py
@@ -1,0 +1,184 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+import time
+
+import boto3
+import pytest
+from retrying import RetryError, retry
+
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
+from tests.common.schedulers_common import get_scheduler_commands
+from time_utils import minutes, seconds
+
+
+@pytest.mark.skip_schedulers(["awsbatch"])
+@pytest.mark.usefixtures("region", "os", "instance")
+def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):
+    scaledown_idletime = 4
+    # Test jobs should take at most 9 minutes to be executed.
+    # These guarantees that the jobs are executed in parallel.
+    max_jobs_execution_time = 9
+
+    cluster_config = pcluster_config_reader(scaledown_idletime=scaledown_idletime)
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+
+    logging.info("Executing test jobs on cluster")
+    remote_command_executor.run_remote_script(test_datadir / "cluster-check.sh", args=["submit", scheduler])
+
+    logging.info("Monitoring asg capacity and compute nodes")
+    asg_capacity_time_series, compute_nodes_time_series, timestamps = _get_compute_nodes_allocation(
+        scheduler_commands=scheduler_commands,
+        region=region,
+        stack_name=cluster.cfn_name,
+        max_monitoring_time=minutes(max_jobs_execution_time) + minutes(scaledown_idletime) + minutes(5),
+    )
+
+    logging.info("Verifying test jobs completed successfully and in the expected time")
+    _assert_test_jobs_completed(remote_command_executor, max_jobs_execution_time * 60)
+
+    logging.info("Verifying auto-scaling worked correctly")
+    _assert_scaling_works(
+        asg_capacity_time_series=asg_capacity_time_series,
+        compute_nodes_time_series=compute_nodes_time_series,
+        expected_asg_capacity=(0, 3),
+        expected_compute_nodes=(0, 3),
+    )
+
+
+def _get_compute_nodes_allocation(scheduler_commands, region, stack_name, max_monitoring_time):
+    """
+    Watch periodically the number of compute nodes in the cluster.
+
+    :return: (asg_capacity_time_series, compute_nodes_time_series, timestamps): three lists describing
+        the variation over time in the number of compute nodes and the timestamp when these fluctuations occurred.
+        asg_capacity_time_series describes the variation in the desired asg capacity. compute_nodes_time_series
+        describes the variation in the number of compute nodes seen by the scheduler. timestamps describes the
+        time since epoch when the variations occurred.
+    """
+    asg_capacity_time_series = []
+    compute_nodes_time_series = []
+    timestamps = []
+
+    @retry(
+        # Retry until ASG and Scheduler capacities scale down to 0
+        # Also make sure cluster scaled up before scaling down
+        retry_on_result=lambda _: asg_capacity_time_series[-1] != 0
+        or compute_nodes_time_series[-1] != 0
+        or max(asg_capacity_time_series) == 0
+        or max(compute_nodes_time_series) == 0,
+        wait_fixed=seconds(20),
+        stop_max_delay=max_monitoring_time,
+    )
+    def _watch_compute_nodes_allocation():
+        compute_nodes = scheduler_commands.compute_nodes_count()
+        asg_capacity = _get_desired_asg_capacity(region, stack_name)
+        timestamp = time.time()
+
+        # add values only if there is a transition.
+        if (
+            len(asg_capacity_time_series) == 0
+            or asg_capacity_time_series[-1] != asg_capacity
+            or compute_nodes_time_series[-1] != compute_nodes
+        ):
+            asg_capacity_time_series.append(asg_capacity)
+            compute_nodes_time_series.append(compute_nodes)
+            timestamps.append(timestamp)
+
+    try:
+        _watch_compute_nodes_allocation()
+    except RetryError:
+        # ignoring this error in order to perform assertions on the collected data.
+        pass
+
+    logging.info(
+        "Monitoring completed: %s, %s, %s",
+        "asg_capacity_time_series [" + " ".join(map(str, asg_capacity_time_series)) + "]",
+        "compute_nodes_time_series [" + " ".join(map(str, compute_nodes_time_series)) + "]",
+        "timestamps [" + " ".join(map(str, timestamps)) + "]",
+    )
+    return asg_capacity_time_series, compute_nodes_time_series, timestamps
+
+
+def _get_desired_asg_capacity(region, stack_name):
+    """Retrieve the desired capacity of the autoscaling group for a specific cluster."""
+    asg_conn = boto3.client("autoscaling", region_name=region)
+    tags = asg_conn.describe_tags(Filters=[{"Name": "value", "Values": [stack_name]}])
+    asg_name = tags.get("Tags")[0].get("ResourceId")
+    response = asg_conn.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
+    return response["AutoScalingGroups"][0]["DesiredCapacity"]
+
+
+def _assert_scaling_works(
+    asg_capacity_time_series, compute_nodes_time_series, expected_asg_capacity, expected_compute_nodes
+):
+    """
+    Verify that cluster scaling-up and scaling-down features work correctly.
+
+    :param asg_capacity_time_series: list describing the fluctuations over time in the asg capacity
+    :param compute_nodes_time_series: list describing the fluctuations over time in the compute nodes
+    :param expected_asg_capacity: pair containing the expected asg capacity (min_asg_capacity, max_asg_capacity)
+    :param expected_compute_nodes: pair containing the expected compute nodes (min_compute_nodes, max_compute_nodes)
+    """
+    assert_that(asg_capacity_time_series).described_as("asg_capacity_time_series cannot be empty").is_not_empty()
+    assert_that(compute_nodes_time_series).described_as("compute_nodes_time_series cannot be empty").is_not_empty()
+
+    expected_asg_capacity_min, expected_asg_capacity_max = expected_asg_capacity
+    expected_compute_nodes_min, expected_compute_nodes_max = expected_compute_nodes
+    actual_asg_capacity_max = max(asg_capacity_time_series)
+    actual_asg_capacity_min = min(
+        asg_capacity_time_series[asg_capacity_time_series.index(actual_asg_capacity_max) :]  # noqa E203
+    )
+    actual_compute_nodes_max = max(compute_nodes_time_series)
+    actual_compute_nodes_min = min(
+        compute_nodes_time_series[compute_nodes_time_series.index(actual_compute_nodes_max) :]  # noqa E203
+    )
+    assert_that(actual_asg_capacity_min).described_as(
+        "actual asg min capacity does not match the expected one"
+    ).is_equal_to(expected_asg_capacity_min)
+    assert_that(actual_asg_capacity_max).described_as(
+        "actual asg max capacity does not match the expected one"
+    ).is_equal_to(expected_asg_capacity_max)
+    assert_that(actual_compute_nodes_min).described_as(
+        "actual number of min compute nodes does not match the expected one"
+    ).is_equal_to(expected_compute_nodes_min)
+    assert_that(actual_compute_nodes_max).described_as(
+        "actual number of max compute nodes does not match the expected one"
+    ).is_equal_to(expected_compute_nodes_max)
+
+
+def _assert_test_jobs_completed(remote_command_executor, max_jobs_exec_time):
+    """
+    Verify that test jobs started by cluster-check.sh script were successfully executed and in a timely manner.
+
+    In order to do this the function checks that some files (jobN.done), which denote the fact
+    that a job has been correctly executed, are present in the shared cluster file-system.
+    Additionally, the function uses the timestamp contained in those files, that indicates
+    the end time of each job, to verify that all jobs were executed within the max expected time.
+    """
+    try:
+        remote_command_executor.run_remote_command("test -f job1.done -a -f job2.done -a -f job3.done")
+    except RemoteCommandExecutionError:
+        raise AssertionError("Not all test jobs completed in the max allowed time")
+
+    jobs_start_time = int(remote_command_executor.run_remote_command("cat jobs_start_time").stdout.split()[-1])
+    jobs_completion_time = int(
+        remote_command_executor.run_remote_command(
+            "cat job1.done job2.done job3.done | sort -n | tail -1"
+        ).stdout.split()[-1]
+    )
+    jobs_execution_time = jobs_completion_time - jobs_start_time
+    logging.info("Test jobs completed in %d seconds", jobs_execution_time)
+    assert_that(jobs_execution_time).is_less_than(max_jobs_exec_time)

--- a/tests/integration-tests/tests/test_scaling/test_multiple_jobs_submission/cluster-check.sh
+++ b/tests/integration-tests/tests/test_scaling/test_multiple_jobs_submission/cluster-check.sh
@@ -1,0 +1,265 @@
+#!/bin/bash
+#
+# Copyright 2018      Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy
+# of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+#
+# Script executed on clusters from parallelcluster-release-check.py.  This
+# script attempts to submit two jobs which must complete in 10
+# minutes, one of which (hopefully) requires scaling (note that
+# scaling is currently not tested on Torque, because it's too big of a
+# pain to determine how many slots per node are on a Torque compute
+# node from the master node).
+#
+
+# Usage:
+#   cluster-check.sh {submit | scaledown_check} <scheduler>
+#
+set -e
+
+sge_get_slots() {
+    local -- ppn i=0
+    ppn=$(qhost | grep 'lx-' | head -n 1 | sed -n -e 's/[^[:space:]]*[[:space:]]\+[^[:space:]]*[[:space:]]\+\([0-9]\+\).*/\1/p')
+    # wait 15 secs before giving up retrieving the slots per host
+    while [ -z "${ppn}" -a $i -lt 15 ]; do
+        sleep 1
+        i=$((i+1))
+        ppn=$(qhost | grep 'lx-' | head -n 1 | sed -n -e 's/[^[:space:]]*[[:space:]]\+[^[:space:]]*[[:space:]]\+\([0-9]\+\).*/\1/p')
+    done
+
+    echo ${ppn}
+}
+
+slurm_get_slots() {
+    local -- ppn i=0
+    ppn=$(scontrol show nodes -o | head -n 1 | sed -n -e 's/^.* CPUTot=\([0-9]\+\) .*$/\1/p')
+    # wait 15 secs before giving up retrieving the slots per host
+    while [ -z "${ppn}" -a $i -lt 15 ]; do
+        sleep 1
+        i=$((i+1))
+        ppn=$(scontrol show nodes -o | head -n 1 | sed -n -e 's/^.* CPUTot=\([0-9]\+\) .*$/\1/p')
+    done
+
+    echo ${ppn}
+}
+
+torque_get_slots() {
+    local -- chost ppn i=0
+
+    chost=$({ pbsnodes -l free ; pbsnodes -l job-exclusive; } | head -n 1 | cut -d ' ' -f1)
+    # wait 15 secs before giving up retrieving the slots per host
+    while [ -z "${chost}" -a $i -lt 15 ]; do
+        sleep 1
+        i=$((i+1))
+        chost=$({ pbsnodes -l free ; pbsnodes -l job-exclusive; } | head -n 1 | cut -d ' ' -f1)
+    done
+    [ -n "${chost}" ] && ppn=$(pbsnodes ${chost} | tr -d '\t ' | sed -n '/np=/{s/^np=\([0-9]\+\)/\1/;p;}')
+
+    echo ${ppn}
+}
+
+submit_launch() {
+    # in case the scheduler goes nuts, wrap ourselves in a timeout so
+    # there's a bounded completion time
+    if test "$CHECK_CLUSTER_SUBPROCESS" = ""; then
+        export CHECK_CLUSTER_SUBPROCESS=1
+        timeout -s KILL 9m /bin/bash ./cluster-check.sh "$@"
+        exit $?
+    fi
+
+    scheduler="$2"
+
+    echo "--> scheduler: $scheduler"
+
+    submit_init ${scheduler}
+
+    echo "$(date +%s)" > jobs_start_time
+
+    ${scheduler}_submit
+    echo "Jobs submitted successfully"
+}
+
+submit_init() {
+    # we submit 3 1-node jobs, each of which are a sleep.
+    # The whole thing has to run in 9 minutes (higher of the three sleep times + buffer),
+    # or the kill in submit_launch will fail the job, which means that the jobs must run at the same time.
+    # The initial cluster is 1 nodes, so we'll need to scale up 2 further nodes simultaneously
+    # and bootstrap in less than 7 minutes and run the job that needs 105 seconds
+    # in order for the test to succeed.
+
+    # job1: 7m45s
+    export _sleepjob1=465
+    # job2: 1m45s
+    export _sleepjob2=105
+    # job3: 1m45s
+    export _sleepjob3=105
+
+    scheduler=$1
+    export _ppn=$(${scheduler}_get_slots)
+    if [ -z "${_ppn}" ]; then
+        >&2 echo "The number of slots per instance couldn't be retrieved, no compute nodes available in ${scheduler} cluster"
+        exit 1
+    fi
+}
+
+slurm_submit() {
+    cat > job1.sh <<EOF
+#!/bin/bash
+srun sleep ${_sleepjob1}
+echo "\$(date +%s)" > job1.done
+EOF
+    cat > job2.sh <<EOF
+#!/bin/bash
+srun sleep ${_sleepjob2}
+echo "\$(date +%s)" > job2.done
+EOF
+
+    cat > job3.sh <<EOF
+#!/bin/bash
+srun sleep ${_sleepjob3}
+echo "\$(date +%s)" > job3.done
+EOF
+
+    chmod +x job1.sh job2.sh job3.sh
+    rm -f job1.done job2.done job3.done
+
+    sbatch -N 1 -n ${_ppn} ./job1.sh
+    sbatch -N 1 -n ${_ppn} ./job2.sh
+    sbatch -N 1 -n ${_ppn} ./job3.sh
+}
+
+sge_submit() {
+    count=$((_ppn))
+
+    cat > job1.sh <<EOF
+#!/bin/bash
+#$ -pe mpi $count
+#$ -R y
+
+sleep ${_sleepjob1}
+echo "\$(date +%s)" > job1.done
+EOF
+    cat > job2.sh <<EOF
+#!/bin/bash
+#$ -pe mpi $count
+#$ -R y
+
+sleep ${_sleepjob2}
+echo "\$(date +%s)" > job2.done
+EOF
+
+    cat > job3.sh <<EOF
+#!/bin/bash
+#$ -pe mpi $count
+#$ -R y
+
+sleep ${_sleepjob3}
+echo "\$(date +%s)" > job3.done
+EOF
+
+    chmod +x job1.sh job2.sh job3.sh
+    rm -f job1.done job2.done job3.done
+
+    qsub ./job1.sh
+    qsub ./job2.sh
+    qsub ./job3.sh
+}
+
+torque_submit() {
+    cat > job1.sh <<EOF
+#!/bin/bash
+sleep ${_sleepjob1}
+echo "\$(date +%s)" > job1.done
+EOF
+    cat > job2.sh <<EOF
+#!/bin/bash
+sleep ${_sleepjob2}
+echo "\$(date +%s)" > job2.done
+EOF
+
+    cat > job3.sh <<EOF
+#!/bin/bash
+sleep ${_sleepjob3}
+echo "\$(date +%s)" > job3.done
+EOF
+
+    chmod +x job1.sh job2.sh job3.sh
+    rm -f job1.done job2.done job3.done
+
+    echo "qsub -l nodes=1:ppn=${_ppn} ./job1.sh"
+    qsub -l nodes=1:ppn=${_ppn} ./job1.sh
+    echo "qsub -l nodes=1:ppn=${_ppn} ./job2.sh"
+    qsub -l nodes=1:ppn=${_ppn} ./job2.sh
+    echo "qsub -l nodes=1:ppn=${_ppn} ./job3.sh"
+    qsub -l nodes=1:ppn=${_ppn} ./job3.sh
+}
+
+scaledown_check_launch() {
+    # bounded completion time
+    if test "$CHECK_CLUSTER_SUBPROCESS" = ""; then
+        export CHECK_CLUSTER_SUBPROCESS=1
+        timeout -s KILL 5m /bin/bash ./cluster-check.sh "$@"
+        exit $?
+    fi
+
+    scheduler="$2"
+
+    echo "--> scheduler: $scheduler"
+
+    scaledown_complete=0
+    while test $scaledown_complete = 0 ; do
+        ${scheduler}_scaledown_check
+        sleep 10
+    done
+    echo "Scaledown successful"
+}
+
+has_zero_active_instances(){
+    instances=$1
+    if [[ ${instances} ]]; then
+        echo "instances have not scaled down yet"
+        scaledown_complete=0
+    else
+        echo "instances have scaled down; exiting"
+        scaledown_complete=1
+    fi
+}
+
+slurm_scaledown_check() {
+    has_zero_active_instances $(sinfo --noheader | awk '$4 != "0"')
+}
+
+sge_scaledown_check() {
+    has_zero_active_instances $(qhost | grep ip-)
+}
+
+torque_scaledown_check() {
+    has_zero_active_instances $(pbsnodes | grep status)
+}
+
+main() {
+    case "$1" in
+        submit)
+            submit_launch "$@"
+            ;;
+        scaledown_check)
+            scaledown_check_launch "$@"
+            ;;
+        *)
+            echo "!! Unknown command $1 !!"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/tests/integration-tests/tests/test_scaling/test_multiple_jobs_submission/pcluster.config.ini
+++ b/tests/integration-tests/tests/test_scaling/test_multiple_jobs_submission/pcluster.config.ini
@@ -1,0 +1,23 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+initial_queue_size = 1
+maintain_initial_size = false
+scaling_settings = custom
+
+[scaling custom]
+scaledown_idletime = {{ scaledown_idletime }}
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}


### PR DESCRIPTION
Old version of the release-check: https://github.com/aws/aws-parallelcluster/blob/develop/tests/parallelcluster-release-check.py

Diff between Old and New version: https://gist.github.com/demartinofra/b28d4a34452fb0d859529e712a74fe42

cluster-check.sh was only moved.

From 872 lines to 180 lines!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
