### PR TITLE
Run integ tests against a given custom AMI

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -124,14 +124,17 @@ not marked with `@pytest.mark.advanced` are executed.
 It is a good practice to mark test cases with a series of markers that allow to identify the feature under test.
 Every test is marked by default with a marker matching its filename with the `test_` prefix or `_test` suffix removed.
 
-### Custom Templates And Packages
+### Custom Templates, Packages and AMI
 
-To use custom templates or packages URLs the following options are available:
+To use custom templates or packages URLs or to run tests against a given custom AMI
+use the following options:
 * `--custom-node-url`: URL to a custom node package.
 * `--custom-cookbook-url`: URL to a custom cookbook package.
 * `--custom-template-url`: URL to a custom cfn template.
 * `--custom-awsbatch-template-url`: URL to a custom awsbatch cfn template.
 * `--custom-awsbatchcli-url`: URL to a custom awsbatch cli package.
+* `--custom-ami`: custom AMI to use for all tests. Note that this custom AMI will be used
+  for all tests, no matter the region.
 
 The configuration for the custom templates and packages are automatically injected into
 all cluster configs when these are rendered. In case any of these parameters is already set

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -56,7 +56,6 @@ class CfnStacksFactory:
         if id in self.__created_stacks:
             raise ValueError("Stack {0} already exists in region {1}".format(name, region))
 
-        # create the cluster
         logging.info("Creating stack {0} in region {1}".format(name, region))
         self.__created_stacks[id] = stack
         try:
@@ -69,7 +68,7 @@ class CfnStacksFactory:
             logging.error("Creation of stack {0} in region {1} failed with exception: {2}".format(name, region, e))
             raise
 
-        logging.info("Cluster {0} created successfully in region {1}".format(name, region))
+        logging.info("Stack {0} created successfully in region {1}".format(name, region))
 
     @retry(
         stop_max_attempt_number=10,
@@ -91,9 +90,9 @@ class CfnStacksFactory:
                 logging.error("Deletion of stack {0} in region {1} failed with exception: {2}".format(name, region, e))
                 raise
             del self.__created_stacks[id]
-            logging.info("Cluster {0} deleted successfully in region {1}".format(name, region))
+            logging.info("Stack {0} deleted successfully in region {1}".format(name, region))
         else:
-            logging.warning("Couldn't find cluster with name {0} in region. Skipping deletion.".format(name, region))
+            logging.warning("Couldn't find stack with name {0} in region. Skipping deletion.".format(name, region))
 
     def delete_all_stacks(self):
         """Destroy all created stacks."""

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -54,6 +54,7 @@ def pytest_addoption(parser):
     parser.addoption("--template-url", help="url to a custom cfn template")
     parser.addoption("--custom-awsbatchcli-package", help="url to a custom awsbatch cli package")
     parser.addoption("--custom-node-package", help="url to a custom node package")
+    parser.addoption("--custom-ami", help="custom AMI to use in the tests")
 
 
 def pytest_generate_tests(metafunc):
@@ -236,7 +237,7 @@ def _add_custom_packages_configs(cluster_config, request):
     config.read(cluster_config)
     cluster_template = "cluster {0}".format(config.get("global", "cluster_template", fallback="default"))
 
-    for custom_option in ["template_url", "custom_awsbatch_template_url", "custom_chef_cookbook"]:
+    for custom_option in ["template_url", "custom_awsbatch_template_url", "custom_chef_cookbook", "custom_ami"]:
         if request.config.getoption(custom_option) and custom_option not in config[cluster_template]:
             config[cluster_template][custom_option] = request.config.getoption(custom_option)
 

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -62,6 +62,7 @@ TEST_DEFAULTS = {
     "custom_template_url": None,
     "custom_awsbatch_template_url": None,
     "custom_awsbatchcli_url": None,
+    "custom_ami": None,
 }
 
 
@@ -148,6 +149,9 @@ def _init_argparser():
         help="URL to a custom awsbatch cli package.",
         default=TEST_DEFAULTS.get("custom_awsbatchcli_url"),
     )
+    parser.add_argument(
+        "--custom-ami", help="custom AMI to use for all tests.", default=TEST_DEFAULTS.get("custom_ami")
+    )
 
     return parser
 
@@ -214,6 +218,9 @@ def _set_custom_packages_args(args, pytest_args):
 
     if args.custom_awsbatchcli_url:
         pytest_args.extend(["--custom-awsbatchcli-package", args.custom_awsbatchcli_url])
+
+    if args.custom_ami:
+        pytest_args.extend(["--custom-ami", args.custom_ami])
 
 
 def _get_pytest_regionalized_args(region, args):


### PR DESCRIPTION
You can now use --custom-ami to run tests against a given AMI id. See README for further details

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
