### PR TITLE
doc: remove extra space from configuration file from vpc section name

### DIFF
--- a/docs/tutorials/code_samples/batch_mpi/cluster_config.ini
+++ b/docs/tutorials/code_samples/batch_mpi/cluster_config.ini
@@ -15,7 +15,7 @@ min_vcpus = 2
 desired_vcpus = 2
 max_vcpus = 24
 
-[vpc  my-vpc]
+[vpc my-vpc]
 # Replace with the id of the vpc you intend to use.
 vpc_id = vpc-#######
 # Replace with id of the subnet for the Master node.


### PR DESCRIPTION
The extra space breaks the ConfigParser because we are searching for the string "vpc myvpc".
