### PR TITLE
Do not check Account limits for spot and awsbatch clusters

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -359,6 +359,9 @@ class ParallelClusterConfig(object):
         if instance_type == "optimal":
             return
 
+        if self.parameters.get("ClusterType", "ondemand") == "spot":
+            return
+
         max_size = self.__get_max_number_of_instances(instance_type)
         try:
             # Check for insufficient Account capacity

--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -353,15 +353,10 @@ class ParallelClusterConfig(object):
 
     def __check_account_capacity(self):
         """Try to launch the requested number of instances to verify Account limits."""
-        test_ami_id = self.__get_latest_alinux_ami_id()
+        if self.parameters.get("Scheduler") == "awsbatch" or self.parameters.get("ClusterType", "ondemand") == "spot":
+            return
 
         instance_type = self.parameters.get("ComputeInstanceType", "t2.micro")
-        if instance_type == "optimal":
-            return
-
-        if self.parameters.get("ClusterType", "ondemand") == "spot":
-            return
-
         max_size = self.__get_max_number_of_instances(instance_type)
         try:
             # Check for insufficient Account capacity
@@ -370,6 +365,8 @@ class ParallelClusterConfig(object):
             subnet_id = self.parameters.get("ComputeSubnetId")
             if not subnet_id:
                 subnet_id = self.parameters.get("MasterSubnetId")
+
+            test_ami_id = self.__get_latest_alinux_ami_id()
 
             ec2.run_instances(
                 InstanceType=instance_type,


### PR DESCRIPTION
We were testing the on-demand capacity also when the cluster type was set to "spot".

We cannot test the limits with a [spot instances request](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html) since is not a synchronous event.
If the capacity is not available, EC2 waits until your request can be fulfilled or until you cancel the request.

With this patch we are also skipping the test for awsbatch scheduler.
