### PR TITLE
batch: validate max vcpus size against vpcus of the compute instance type

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -30,7 +30,7 @@ import pkg_resources
 from botocore.exceptions import ClientError
 
 from pcluster.config_sanity import ResourceValidator
-from pcluster.utils import get_vcpus_from_pricing_file
+from pcluster.utils import get_instance_vcpus
 
 
 class ParallelClusterConfig(object):
@@ -412,7 +412,7 @@ class ParallelClusterConfig(object):
         try:
             max_size = int(self.parameters.get("MaxSize"))
             if self.parameters.get("Scheduler") == "awsbatch":
-                vcpus = get_vcpus_from_pricing_file(self.region, instance_type)
+                vcpus = get_instance_vcpus(self.region, instance_type)
                 max_size = -(-max_size // vcpus)
         except ValueError:
             self.__fail("Unable to convert max size parameter to an integer")

--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -112,6 +112,11 @@ class ParallelClusterConfig(object):
             pass
 
     @staticmethod
+    def __warn(message):
+        """Print a warning message."""
+        print("WARNING: {0}".format(message))
+
+    @staticmethod
     def __fail(message):
         """Print an error message and exit."""
         print("ERROR: {0}".format(message))
@@ -358,6 +363,10 @@ class ParallelClusterConfig(object):
 
         instance_type = self.parameters.get("ComputeInstanceType", "t2.micro")
         max_size = self.__get_max_number_of_instances(instance_type)
+        if max_size < 0:
+            self.__warn("Unable to check AWS account capacity. Skipping limits validation")
+            return
+
         try:
             # Check for insufficient Account capacity
             ec2 = boto3.client("ec2", region_name=self.region)

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -539,15 +539,6 @@ class ResourceValidator(object):
                 if spot_price > 100 or spot_price < 0:
                     self.__fail(resource_type, "Spot bid percentage needs to be between 0 and 100")
 
-            # Check sanity on desired, min and max vcpus
-            if (
-                "DesiredSize" not in resource_value
-                or "MinSize" not in resource_value
-                or "MaxSize" not in resource_value
-            ):
-                # this should never occur
-                self.__fail(resource_type, "Both min, desired and max vcpus parameters must be set")
-
             min_size = int(resource_value["MinSize"])
             desired_size = int(resource_value["DesiredSize"])
             max_size = int(resource_value["MaxSize"])

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -553,21 +553,31 @@ class ResourceValidator(object):
 
             # Check spot bid percentage
             if "SpotPrice" in resource_value:
-                if int(resource_value["SpotPrice"]) > 100 or int(resource_value["SpotPrice"]) < 0:
+                spot_price = int(resource_value["SpotPrice"])
+                if spot_price > 100 or spot_price < 0:
                     self.__fail(resource_type, "Spot bid percentage needs to be between 0 and 100")
 
             # Check sanity on desired, min and max vcpus
-            if "DesiredSize" in resource_value and "MinSize" in resource_value:
-                if int(resource_value["DesiredSize"]) < int(resource_value["MinSize"]):
-                    self.__fail(resource_type, "Desired vcpus must be greater than or equal to min vcpus")
+            if (
+                "DesiredSize" not in resource_value
+                or "MinSize" not in resource_value
+                or "MaxSize" not in resource_value
+            ):
+                # this should never occur
+                self.__fail(resource_type, "Both min, desired and max vcpus parameters must be set")
 
-            if "DesiredSize" in resource_value and "MaxSize" in resource_value:
-                if int(resource_value["DesiredSize"]) > int(resource_value["MaxSize"]):
-                    self.__fail(resource_type, "Desired vcpus must be fewer than or equal to max vcpus")
+            min_size = int(resource_value["MinSize"])
+            desired_size = int(resource_value["DesiredSize"])
+            max_size = int(resource_value["MaxSize"])
 
-            if "MaxSize" in resource_value and "MinSize" in resource_value:
-                if int(resource_value["MaxSize"]) < int(resource_value["MinSize"]):
-                    self.__fail(resource_type, "Max vcpus must be greater than or equal to min vcpus")
+            if desired_size < min_size:
+                self.__fail(resource_type, "Desired vcpus must be greater than or equal to min vcpus")
+
+            if desired_size > max_size:
+                self.__fail(resource_type, "Desired vcpus must be fewer than or equal to max vcpus")
+
+            if max_size < min_size:
+                self.__fail(resource_type, "Max vcpus must be greater than or equal to min vcpus")
 
             # Check custom batch url
             if "CustomAWSBatchTemplateURL" in resource_value:

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -566,16 +566,14 @@ class ResourceValidator(object):
                     s3 = boto3.resource("s3", region_name=self.region)
                     bucket_name = "%s-aws-parallelcluster" % self.region
                     file_name = "instances/batch_instances.json"
-                    try:
-                        file_contents = s3.Object(bucket_name, file_name).get()["Body"].read().decode("utf-8")
-                        supported_instances = json.loads(file_contents)
-                        for instance in resource_value["ComputeInstanceType"].split(","):
-                            if not instance.strip() in supported_instances:
-                                self.__fail(
-                                    resource_type, "Instance type %s not supported by batch in this region" % instance
-                                )
-                    except ClientError as e:
-                        self.__fail(resource_type, e.response.get("Error").get("Message"))
+
+                    file_contents = s3.Object(bucket_name, file_name).get()["Body"].read().decode("utf-8")
+                    supported_instances = json.loads(file_contents)
+                    for instance in resource_value["ComputeInstanceType"].split(","):
+                        if not instance.strip() in supported_instances:
+                            self.__fail(
+                                resource_type, "Instance type %s not supported by batch in this region" % instance
+                            )
                 except ClientError as e:
                     self.__fail(resource_type, e.response.get("Error").get("Message"))
 

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -532,25 +532,6 @@ class ResourceValidator(object):
             ]:
                 self.__fail(resource_type, "Region %s is not supported with batch scheduler" % self.region)
 
-            # Check compute instance types
-            if "ComputeInstanceType" in resource_value:
-                try:
-                    s3 = boto3.resource("s3", region_name=self.region)
-                    bucket_name = "%s-aws-parallelcluster" % self.region
-                    file_name = "instances/batch_instances.json"
-                    try:
-                        file_contents = s3.Object(bucket_name, file_name).get()["Body"].read().decode("utf-8")
-                        supported_instances = json.loads(file_contents)
-                        for instance in resource_value["ComputeInstanceType"].split(","):
-                            if not instance.strip() in supported_instances:
-                                self.__fail(
-                                    resource_type, "Instance type %s not supported by batch in this region" % instance
-                                )
-                    except ClientError as e:
-                        self.__fail(resource_type, e.response.get("Error").get("Message"))
-                except ClientError as e:
-                    self.__fail(resource_type, e.response.get("Error").get("Message"))
-
             # Check spot bid percentage
             if "SpotPrice" in resource_value:
                 spot_price = int(resource_value["SpotPrice"])
@@ -578,6 +559,25 @@ class ResourceValidator(object):
 
             if max_size < min_size:
                 self.__fail(resource_type, "Max vcpus must be greater than or equal to min vcpus")
+
+            # Check compute instance types
+            if "ComputeInstanceType" in resource_value:
+                try:
+                    s3 = boto3.resource("s3", region_name=self.region)
+                    bucket_name = "%s-aws-parallelcluster" % self.region
+                    file_name = "instances/batch_instances.json"
+                    try:
+                        file_contents = s3.Object(bucket_name, file_name).get()["Body"].read().decode("utf-8")
+                        supported_instances = json.loads(file_contents)
+                        for instance in resource_value["ComputeInstanceType"].split(","):
+                            if not instance.strip() in supported_instances:
+                                self.__fail(
+                                    resource_type, "Instance type %s not supported by batch in this region" % instance
+                                )
+                    except ClientError as e:
+                        self.__fail(resource_type, e.response.get("Error").get("Message"))
+                except ClientError as e:
+                    self.__fail(resource_type, e.response.get("Error").get("Message"))
 
             # Check custom batch url
             if "CustomAWSBatchTemplateURL" in resource_value:

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -114,35 +114,53 @@ def upload_resources_artifacts(bucket_name, root, aws_client_config):
             bucket.upload_file(os.path.join(root, res), res)
 
 
-def get_instances_from_pricing_file(region):
+def _get_json_from_s3(region, file_name):
     """
-    Get pricing file and get supported instances.
+    Get pricing file (if none) and parse content as json.
 
     :param region: AWS Region
-    :return: a json object representing the pricing file content.
-    :raises ClientError if unable to download the pricing file.
+    :param file_name the object name to get
+    :return: a json object representing the file content
+    :raises ClientError if unable to download the file
+    :raises ValueError if unable to decode the file content
     """
     s3 = boto3.resource("s3", region_name=region)
-    bucket_name = "%s-aws-parallelcluster" % region
-    file_name = "instances/instances.json"
+    bucket_name = "{0}-aws-parallelcluster".format(region)
 
     file_contents = s3.Object(bucket_name, file_name).get()["Body"].read().decode("utf-8")
     return json.loads(file_contents)
 
 
-def get_vcpus_from_pricing_file(region, instance_type):
+def get_supported_batch_instances(region):
     """
-    Read instances json object (fetching it if None) and get number of vcpus for the given instance type.
+    Get a json object containing the instances supported by batch.
+
+    :param region: AWS Region
+    :param instance_type: the instance type to search for.
+    :return: json object containing the instances supported by batch
+    or an empty object if unable to parse/get the instance list file
+    """
+    try:
+        instances = _get_json_from_s3(region, "instances/batch_instances.json")
+    except (ValueError, ClientError):
+        instances = ""
+
+    return instances
+
+
+def get_instance_vcpus(region, instance_type):
+    """
+    Get number of vcpus for the given instance type.
 
     :param region: AWS Region
     :param instance_type: the instance type to search for.
     :return: the number of vcpus or -1 if the instance type cannot be found
-    :raises ClientError if unable to download the pricing file.
+    or the pricing file cannot be retrieved/parsed
     """
     try:
-        instances = get_instances_from_pricing_file(region)
+        instances = _get_json_from_s3(region, "instances/instances.json")
         vcpus = int(instances[instance_type]["vcpus"])
-    except KeyError:
+    except (KeyError, ValueError, ClientError):
         vcpus = -1
 
     return vcpus


### PR DESCRIPTION
`max_vcpus` must be greater than or equal to the number of vcpus available for the selected `compute_instance_type`.

I'm skipping the test for _optimal_, instance families or instances list.

Without this patch if you have a configuration like the following, the batch jobs remain _RUNNABLE_ forever:
```
[cluster batch]
scheduler = awsbatch
compute_instance_type = c4.8xlarge
min_vcpus = 0
desired_vcpus = 18
max_vcpus = 18
...
```

From now, the creation will be stopped with the message:
```
$ pcluster create batch-test
Beginning cluster creation for cluster: batch-test
Config sanity error on resource AWSBatch_Parameters: Max vcpus must be greater than or equal to 36, that is the number of vcpus available for the c4.8xlarge you selected as compute instance type
```

I also improved the code to avoid a failure if the instance type cannot be found in the pricing file or in the batch instances file or if the files are not available.