### PR TITLE
Fix to use empty AMI (not bootstrapped) at runtime

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2188,6 +2188,16 @@
                 "\n",
                 "  exit 1\n",
                 "}\n",
+                "function vendor_cookbook\n",
+                "{\n",
+                "  mkdir /tmp/cookbooks\n",
+                "  cd /tmp/cookbooks\n",
+                "  tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz\n",
+                "  HOME_BAK=\"${HOME}\"\n",
+                "  export HOME=\"/tmp\"\n",
+                "  . /tmp/proxy.sh; for d in `ls /tmp/cookbooks`; do cd /tmp/cookbooks/$d;LANG=en_US.UTF-8 /opt/chef/embedded/bin/berks vendor /etc/chef/cookbooks --delete; done;\n",
+                "  export HOME=\"${HOME_BAK}\"\n",
+                "}\n",
                 "function bootstrap_instance\n",
                 "{\n",
                 "  which yum 2>/dev/null; yum=$?\n",
@@ -2206,6 +2216,7 @@
                 "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${cookbook_url}\n",
                 "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${cookbook_url}.date\n",
                 "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.md5 ${cookbook_url}.md5\n",
+                "  vendor_cookbook\n",
                 "  mkdir /opt/parallelcluster && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped\n",
                 "}\n",
                 "proxy=",
@@ -2314,10 +2325,10 @@
                 "else\n",
                 "  bootstrap_instance\n",
                 "fi\n",
-                "mkdir /tmp/cookbooks\n",
-                "cd /tmp/cookbooks\n",
-                "curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz -z \"$(cat /etc/chef/aws-parallelcluster-cookbook.tgz.date)\" ${cookbook_url}\n",
-                "tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz\n",
+                "if [ \"${custom_cookbook}\" != \"NONE\" ]; then\n",
+                "  curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz -z \"$(cat /etc/chef/aws-parallelcluster-cookbook.tgz.date)\" ${cookbook_url}\n",
+                "  vendor_cookbook\n",
+                "fi\n",
                 "cd /tmp\n",
                 "# Call CloudFormation\n",
                 "cfn-init ${proxy_args} -s ",
@@ -2351,7 +2362,6 @@
           "configSets": {
             "default": [
               "deployConfigFiles",
-              "getCookbooks",
               "chefPrepEnv",
               "shellRunPreInstall",
               "chefConfig",
@@ -2534,35 +2544,6 @@
               },
               "jq": {
                 "command": "jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' > /etc/chef/dna.json || ( echo \"jq not installed\"; cp /tmp/dna.json /etc/chef/dna.json )"
-              }
-            }
-          },
-          "getCookbooks": {
-            "commands": {
-              "berk": {
-                "command": "if [ ! -f /opt/parallelcluster/.bootstrapped -o \"$(cat /opt/parallelcluster/.bootstrapped)\" != \"$parallelcluster_version\" -o \"$custom_cookbook\" != \"NONE\" ]; then . /tmp/proxy.sh; for d in `ls /tmp/cookbooks`; do cd /tmp/cookbooks/$d;LANG=en_US.UTF-8 /opt/chef/embedded/bin/berks vendor /etc/chef/cookbooks --delete; done; fi",
-                "cwd": "/tmp/cookbooks",
-                "env": {
-                  "HOME": "/tmp",
-                  "custom_cookbook": {
-                    "Ref": "CustomChefCookbook"
-                  },
-                  "parallelcluster_version": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "aws-parallelcluster-",
-                        {
-                          "Fn::FindInMap": [
-                            "PackagesVersions",
-                            "default",
-                            "parallelcluster"
-                          ]
-                        }
-                      ]
-                    ]
-                  }
-                }
               }
             }
           },
@@ -3029,6 +3010,16 @@
                 "\n",
                 "  exit 1\n",
                 "}\n",
+                "function vendor_cookbook\n",
+                "{\n",
+                "  mkdir /tmp/cookbooks\n",
+                "  cd /tmp/cookbooks\n",
+                "  tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz\n",
+                "  HOME_BAK=${HOME}\n",
+                "  export HOME=\"/tmp\"\n",
+                "  . /tmp/proxy.sh; for d in `ls /tmp/cookbooks`; do cd /tmp/cookbooks/$d;LANG=en_US.UTF-8 /opt/chef/embedded/bin/berks vendor /etc/chef/cookbooks --delete; done;\n",
+                "  export HOME=${HOME_BAK}\n",
+                "}\n",
                 "function bootstrap_instance\n",
                 "{\n",
                 "  which yum 2>/dev/null; yum=$?\n",
@@ -3047,6 +3038,7 @@
                 "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${cookbook_url}\n",
                 "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${cookbook_url}.date\n",
                 "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.md5 ${cookbook_url}.md5\n",
+                "  vendor_cookbook\n",
                 "  mkdir /opt/parallelcluster && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped\n",
                 "}\n",
                 "proxy=",
@@ -3155,10 +3147,10 @@
                 "else\n",
                 "  bootstrap_instance\n",
                 "fi\n",
-                "mkdir /tmp/cookbooks\n",
-                "cd /tmp/cookbooks\n",
-                "curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz -z \"$(cat /etc/chef/aws-parallelcluster-cookbook.tgz.date)\" ${cookbook_url}\n",
-                "tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz\n",
+                "if [ \"${custom_cookbook}\" != \"NONE\" ]; then\n",
+                "  curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz -z \"$(cat /etc/chef/aws-parallelcluster-cookbook.tgz.date)\" ${cookbook_url}\n",
+                "  vendor_cookbook\n",
+                "fi\n",
                 "cd /tmp\n",
                 "# Call CloudFormation\n",
                 "cfn-init ${proxy_args} -s ",
@@ -3192,7 +3184,6 @@
           "configSets": {
             "default": [
               "deployConfigFiles",
-              "getCookbooks",
               "chefPrepEnv",
               "shellRunPreInstall",
               "chefConfig",
@@ -3350,35 +3341,6 @@
               },
               "jq": {
                 "command": "jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' > /etc/chef/dna.json || ( echo \"jq not installed\"; cp /tmp/dna.json /etc/chef/dna.json )"
-              }
-            }
-          },
-          "getCookbooks": {
-            "commands": {
-              "berk": {
-                "command": "if [ ! -f /opt/parallelcluster/.bootstrapped -o \"$(cat /opt/parallelcluster/.bootstrapped)\" != \"$parallelcluster_version\" -o \"$custom_cookbook\" != \"NONE\" ]; then . /tmp/proxy.sh; for d in `ls /tmp/cookbooks`; do cd /tmp/cookbooks/$d;LANG=en_US.UTF-8 /opt/chef/embedded/bin/berks vendor /etc/chef/cookbooks --delete; done; fi",
-                "cwd": "/tmp/cookbooks",
-                "env": {
-                  "HOME": "/tmp",
-                  "custom_cookbook": {
-                    "Ref": "CustomChefCookbook"
-                  },
-                  "parallelcluster_version": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "aws-parallelcluster-",
-                        {
-                          "Fn::FindInMap": [
-                            "PackagesVersions",
-                            "default",
-                            "parallelcluster"
-                          ]
-                        }
-                      ]
-                    ]
-                  }
-                }
               }
             }
           },
@@ -3711,6 +3673,16 @@
                   "\n",
                   "  exit 1\n",
                   "}\n",
+                  "function vendor_cookbook\n",
+                  "{\n",
+                  "  mkdir /tmp/cookbooks\n",
+                  "  cd /tmp/cookbooks\n",
+                  "  tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz\n",
+                  "  HOME_BAK=${HOME}\n",
+                  "  export HOME=\"/tmp\"\n",
+                  "  . /tmp/proxy.sh; for d in `ls /tmp/cookbooks`; do cd /tmp/cookbooks/$d;LANG=en_US.UTF-8 /opt/chef/embedded/bin/berks vendor /etc/chef/cookbooks --delete; done;\n",
+                  "  export HOME=${HOME_BAK}\n",
+                  "}\n",
                   "function bootstrap_instance\n",
                   "{\n",
                   "  which yum 2>/dev/null; yum=$?\n",
@@ -3729,6 +3701,7 @@
                   "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${cookbook_url}\n",
                   "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${cookbook_url}.date\n",
                   "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.md5 ${cookbook_url}.md5\n",
+                  "  vendor_cookbook\n",
                   "  mkdir /opt/parallelcluster && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped\n",
                   "}\n",
                   "proxy=",
@@ -3837,10 +3810,10 @@
                   "else\n",
                   "  bootstrap_instance\n",
                   "fi\n",
-                  "mkdir /tmp/cookbooks\n",
-                  "cd /tmp/cookbooks\n",
-                  "curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz -z \"$(cat /etc/chef/aws-parallelcluster-cookbook.tgz.date)\" ${cookbook_url}\n",
-                  "tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz\n",
+                  "if [ \"${custom_cookbook}\" != \"NONE\" ]; then\n",
+                  "  curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz -z \"$(cat /etc/chef/aws-parallelcluster-cookbook.tgz.date)\" ${cookbook_url}\n",
+                  "  vendor_cookbook\n",
+                  "fi\n",
                   "cd /tmp\n",
                   "# Call CloudFormation\n",
                   "cfn-init ${proxy_args} -s ",
@@ -3876,7 +3849,6 @@
           "configSets": {
             "default": [
               "deployConfigFiles",
-              "getCookbooks",
               "chefPrepEnv",
               "shellRunPreInstall",
               "chefConfig",
@@ -4034,35 +4006,6 @@
               },
               "jq": {
                 "command": "jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' > /etc/chef/dna.json || ( echo \"jq not installed\"; cp /tmp/dna.json /etc/chef/dna.json )"
-              }
-            }
-          },
-          "getCookbooks": {
-            "commands": {
-              "berk": {
-                "command": "if [ ! -f /opt/parallelcluster/.bootstrapped -o \"$(cat /opt/parallelcluster/.bootstrapped)\" != \"$parallelcluster_version\" -o \"$custom_cookbook\" != \"NONE\" ]; then . /tmp/proxy.sh; for d in `ls /tmp/cookbooks`; do cd /tmp/cookbooks/$d;LANG=en_US.UTF-8 /opt/chef/embedded/bin/berks vendor /etc/chef/cookbooks --delete; done; fi",
-                "cwd": "/tmp/cookbooks",
-                "env": {
-                  "HOME": "/tmp",
-                  "custom_cookbook": {
-                    "Ref": "CustomChefCookbook"
-                  },
-                  "parallelcluster_version": {
-                    "Fn::Join": [
-                      "",
-                      [
-                        "aws-parallelcluster-",
-                        {
-                          "Fn::FindInMap": [
-                            "PackagesVersions",
-                            "default",
-                            "parallelcluster"
-                          ]
-                        }
-                      ]
-                    ]
-                  }
-                }
               }
             }
           },


### PR DESCRIPTION
The ParallelCluster cookbook needs to be vendored in two cases:
- using a empty AMI (not bootstrapped)
- using a custom cookbook at cluster creation time

In the other case of an already bootstrapped AMI, there is not even the
need to download the cookbook

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
