### PR TITLE
Remove skip-numeric-underscore-normalization option from black

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -43,7 +43,7 @@ skip_install = true
 deps =
     black
 commands =
-    black -l 120 -N  \
+    black -l 120 \
         {[vars]code_dirs} \
         {posargs}
 


### PR DESCRIPTION
The `-N | --skip-numeric-underscore-normalization` option used to preserve underscores in numeric literals has been removed from Black.

Black no longer normalizes numeric literals to include _ separators.

See:
https://github.com/ambv/black/issues/549
https://github.com/ambv/black/pull/696
