### PR TITLE
Fix cloud-config script

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2159,7 +2159,7 @@
                     "_none_"
                   ]
                 },
-                "\" >> /etc/yum.conf' ]\n",
+                "\" >> /etc/yum.conf || echo \"Not yum system\"' ]\n",
                 " - [ sh, -c, 'which apt-get && echo \"Acquire::http::Proxy \\\"",
                 {
                   "Fn::If": [
@@ -2170,7 +2170,7 @@
                     "false"
                   ]
                 },
-                "\\\";\" >> /etc/apt/apt.conf' ]\n",
+                "\\\";\" >> /etc/apt/apt.conf || echo \"Not apt system\"' ]\n",
                 "--==BOUNDARY==\n",
                 "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
                 "MIME-Version: 1.0\n\n",
@@ -3000,7 +3000,7 @@
                     "_none_"
                   ]
                 },
-                "\" >> /etc/yum.conf' ]\n",
+                "\" >> /etc/yum.conf || echo \"Not yum system\"' ]\n",
                 " - [ sh, -c, 'which apt-get && echo \"Acquire::http::Proxy \\\"",
                 {
                   "Fn::If": [
@@ -3011,7 +3011,7 @@
                     "false"
                   ]
                 },
-                "\\\";\" >> /etc/apt/apt.conf' ]\n",
+                "\\\";\" >> /etc/apt/apt.conf || echo \"Not apt system\"' ]\n",
                 "--==BOUNDARY==\n",
                 "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
                 "MIME-Version: 1.0\n\n",
@@ -3682,7 +3682,7 @@
                       "_none_"
                     ]
                   },
-                  "\" >> /etc/yum.conf' ]\n",
+                  "\" >> /etc/yum.conf || echo \"Not yum system\"' ]\n",
                   " - [ sh, -c, 'which apt-get && echo \"Acquire::http::Proxy \\\"",
                   {
                     "Fn::If": [
@@ -3693,7 +3693,7 @@
                       "false"
                     ]
                   },
-                  "\\\";\" >> /etc/apt/apt.conf' ]\n",
+                  "\\\";\" >> /etc/apt/apt.conf || echo \"Not apt system\"' ]\n",
                   "--==BOUNDARY==\n",
                   "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
                   "MIME-Version: 1.0\n\n",


### PR DESCRIPTION
The cloud-config script was always terminating with exit code 1, because it's not possible to have a system with both yum and apt

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

Before patch:
in cloud-init.log
```
Mar 15 18:29:07 cloud-init[19576]: util.py[DEBUG]: Running command ['/var/lib/cloud/instance/scripts/runcmd'] with allowed return codes [0] (shell=True, capture=False)
Mar 15 18:29:07 cloud-init[19576]: util.py[WARNING]: Failed running /var/lib/cloud/instance/scripts/runcmd [1]
Mar 15 18:29:07 cloud-init[19576]: util.py[DEBUG]: Failed running /var/lib/cloud/instance/scripts/runcmd [1]
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/cloudinit/util.py", line 645, in runparts
    subp(prefix + [exe_path], capture=False, shell=True)
  File "/usr/lib/python2.7/dist-packages/cloudinit/util.py", line 1626, in subp
    cmd=args)
ProcessExecutionError: Unexpected error while running command.
Command: ['/var/lib/cloud/instance/scripts/runcmd']
Exit code: 1
Reason: -
Stdout: ''
Stderr: ''
Mar 15 18:29:07 cloud-init[19576]: cc_scripts_user.py[WARNING]: Failed to run module scripts-user (scripts in /var/lib/cloud/instance/scripts)
Mar 15 18:29:07 cloud-init[19576]: util.py[WARNING]: Running module scripts-user (<module 'cloudinit.config.cc_scripts_user' from '/usr/lib/python2.7/dist-packages/cloudinit/config/cc_scripts_user.pyc'>) failed
Mar 15 18:29:07 cloud-init[19576]: util.py[DEBUG]: Running module scripts-user (<module 'cloudinit.config.cc_scripts_user' from '/usr/lib/python2.7/dist-packages/cloudinit/config/cc_scripts_user.pyc'>) failed
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/cloudinit/stages.py", line 660, in _run_modules
    cc.run(run_name, mod.handle, func_args, freq=freq)
  File "/usr/lib/python2.7/dist-packages/cloudinit/cloud.py", line 63, in run
    return self._runners.run(name, functor, args, freq, clear_on_fail)
  File "/usr/lib/python2.7/dist-packages/cloudinit/helpers.py", line 197, in run
    results = functor(*args)
  File "/usr/lib/python2.7/dist-packages/cloudinit/config/cc_scripts_user.py", line 38, in handle
    util.runparts(runparts_path)
  File "/usr/lib/python2.7/dist-packages/cloudinit/util.py", line 652, in runparts
    % (len(failed), len(attempted)))
RuntimeError: Runparts: 1 failures in 2 attempted commands
```
in cloud-init-output.log
```
+ cfn-signal --exit-code=0 '--reason=MasterServer setup complete' --stack=parallelcluster-brokenCloudInit --resource=MasterServer --region=us-east-1
/usr/bin/yum
which: no apt-get in (/sbin:/usr/sbin:/bin:/usr/bin)
Mar 15 18:29:07 cloud-init[19576]: util.py[WARNING]: Failed running /var/lib/cloud/instance/scripts/runcmd [1]
Mar 15 18:29:07 cloud-init[19576]: cc_scripts_user.py[WARNING]: Failed to run module scripts-user (scripts in /var/lib/cloud/instance/scripts)
Mar 15 18:29:07 cloud-init[19576]: util.py[WARNING]: Running module scripts-user (<module 'cloudinit.config.cc_scripts_user' from '/usr/lib/python2.7/dist-packages/cloudinit/config/cc_scripts_user.pyc'>) failed
Cloud-init v. 0.7.6 finished at Fri, 15 Mar 2019 18:29:07 +0000. Datasource DataSourceEc2.  Up 135.14 seconds
```
After patch:
in cloud-init.log
```
Mar 15 12:11:14 cloud-init[19595]: util.py[DEBUG]: Running command ['/var/lib/cloud/instance/scripts/runcmd'] with allowed return codes [0] (shell=True, capture=False)
```
in cloud-init-output.log
```
+ cfn-signal --exit-code=0 '--reason=MasterServer setup complete' --stack=parallelcluster-customTemp --resource=MasterServer --region=us-east-1
/usr/bin/yum
which: no apt-get in (/sbin:/usr/sbin:/bin:/usr/bin)
Not apt system
Cloud-init v. 0.7.6 finished at Fri, 15 Mar 2019 12:11:14 +0000. Datasource DataSourceEc2.  Up 125.58 seconds
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
