### PR TITLE
ParallelCluster Documentation Updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,23 +10,13 @@ AWS ParallelCluster - HPC for the Cloud
 .. |Version| image:: https://badge.fury.io/py/aws-parallelcluster.png
     :target: https://badge.fury.io/py/aws-parallelcluster
 
-AWS ParallelCluster is an AWS-supported Open Source cluster management tool that makes it easy to deploy and
-manage High Performance Computing (HPC) clusters in the AWS cloud.
-
-AWS ParallelCluster supports the following features:
-
-- Multiple Linux flavors including Amazon Linux, CentOS, and Ubuntu.
-- Configurable autoscaling of compute resources.
-- Custom AMIs.
-- Shared file systems built from EBS, EFS, and FSxL (Lustre) volumes.
-- EBS RAID functionality.
-- Private subnet deployments.
-- Multiple HPC schedulers including AWS Batch, Grid Engine, Torque, and Slurm.
-
-AWS ParallelCluster facilitates both quick start proof-of-concepts (POCs) and massive production deployments.
-It can be used to orchestrate higher level workflow use cases such as automated DNA sequencing pipelines,
-global weather forecasting, cryptography, fluid dynamics simulations, jet engine design, credit card fraud
-detection, insurance risk modeling, and protein-ligand docking analysis.
+AWS ParallelCluster is an AWS supported Open Source cluster management tool that makes it easy for you to deploy and
+manage High Performance Computing (HPC) clusters in the AWS cloud. Built on the Open Source CfnCluster project,
+AWS ParallelCluster enables you to quickly build an HPC compute environment in AWS.  It automatically sets up the
+required compute resources and a shared filesystem and offers a variety of batch schedulers such as AWS Batch, SGE,
+Torque, and Slurm.  AWS ParallelCluster facilitates both quick start proof of concepts (POCs) and production
+deployments.  You can build higher level workflows, such as a Genomics portal that automates the entire DNA sequencing
+workflow, on top of AWS ParallelCluster.
 
 -----------
 Quick Start
@@ -128,7 +118,7 @@ Changes
 
 CfnCluster 1.6 IAM Change
 =========================
-Between CfnCluster 1.5.4 and 1.6.0, we made a change to the CfnClusterInstancePolicy that adds “s3:GetObject” permissions
+Between CfnCluster 1.5.4 and 1.6.0, we made a change to the CfnClusterInstancePolicy that adds "s3:GetObject" permissions
 on objects in <REGION>-cfncluster bucket, "autoscaling:SetDesiredCapacity", "autoscaling:DescribeTags" permissions, and
 "cloudformation:DescribeStacks" permissions on <REGION>:<ACCOUNT_ID>:stack/cfncluster-*.
 
@@ -137,7 +127,7 @@ For more detailed information, please visit: https://aws-parallelcluster.readthe
 
 CfnCluster 1.5 IAM Change
 =========================
-Between CfnCluster 1.4.2 and 1.5.0, we made a change to the CfnClusterInstancePolicy that adds “ec2:DescribeVolumes” permissions. If you are using a custom policy (e.g. "ec2_iam_role" is specified in your config), please be sure it includes this new permission.
+Between CfnCluster 1.4.2 and 1.5.0, we made a change to the CfnClusterInstancePolicy that adds "ec2:DescribeVolumes" permissions. If you are using a custom policy (e.g. "ec2_iam_role" is specified in your config), please be sure it includes this new permission.
 For more detailed information, please visit: https://aws-parallelcluster.readthedocs.io/en/latest/iam.html
 
 CfnCluster 1.2 and Earlier

--- a/README.rst
+++ b/README.rst
@@ -10,22 +10,35 @@ AWS ParallelCluster - HPC for the Cloud
 .. |Version| image:: https://badge.fury.io/py/aws-parallelcluster.png
     :target: https://badge.fury.io/py/aws-parallelcluster
 
-AWS ParallelCluster is an AWS supported Open Source cluster management tool that makes it easy for you to deploy and
+AWS ParallelCluster is an AWS-supported Open Source cluster management tool that makes it easy to deploy and
 manage High Performance Computing (HPC) clusters in the AWS cloud.
-Built on the Open Source CfnCluster project, AWS ParallelCluster enables you to quickly build an HPC compute environment in AWS.
-It automatically sets up the required compute resources and a shared filesystem and offers a variety of batch schedulers such as AWS Batch, SGE, Torque, and Slurm.
-AWS ParallelCluster facilitates both quick start proof of concepts (POCs) and production deployments.
-You can build higher level workflows, such as a Genomics portal that automates the entire DNA sequencing workflow, on top of AWS ParallelCluster.\
 
+AWS ParallelCluster supports the following features:
+
+- Multiple Linux flavors including Amazon Linux, CentOS, and Ubuntu.
+- Configurable autoscaling of compute resources.
+- Custom AMIs.
+- Shared file systems built from EBS, EFS, and FSxL (Lustre) volumes.
+- EBS RAID functionality.
+- Private subnet deployments.
+- Multiple HPC schedulers including AWS Batch, Grid Engine, Torque, and Slurm.
+
+AWS ParallelCluster facilitates both quick start proof-of-concepts (POCs) and massive production deployments.
+It can be used to orchestrate higher level workflow use cases such as automated DNA sequencing pipelines,
+global weather forecasting, cryptography, fluid dynamics simulations, jet engine design, credit card fraud
+detection, insurance risk modeling, and protein-ligand docking analysis.
+
+-----------
 Quick Start
 -----------
-First, install the library:
+
+Install the library using pip:
 
 .. code-block:: sh
 
     $ pip install aws-parallelcluster
 
-Next, configure your aws credentials and default region:
+Configure your AWS credentials and default region:
 
 .. code-block:: sh
 
@@ -35,7 +48,7 @@ Next, configure your aws credentials and default region:
     Default region name [us-east-1]:
     Default output format [None]:
 
-Then, run pcluster configure:
+Initialize the pcluster environment:
 
 .. code-block:: ini
 
@@ -64,64 +77,69 @@ Then, run pcluster configure:
     subnet-b921nv04
   Master Subnet ID []:
 
-Now you can create your first cluster;
+Now create your first cluster stack:
 
 .. code-block:: sh
 
   $ pcluster create myfirstcluster
 
-
-After the cluster finishes creating, log in:
+After the cluster creation process finishes, login to the head node:
 
 .. code-block:: sh
 
   $ pcluster ssh myfirstcluster
 
-You can view the running compute hosts:
+View the running compute hosts based on the selected scheduler:
 
 .. code-block:: sh
 
-  $ qhost
+  $ qhost                              [ Grid Engine ]
+  $ pbsnodes -a                        [ Torque ]
+  $ sinfo -N                           [ Slurm ]
+  $ awsbhosts -c myfirstcluster -d     [ AWS Batch ]
 
-For more information on any of these steps see the `Getting Started Guide`_.
+For more information on any of these steps, please refer to the `Getting Started Guide`_.
 
 .. _`Getting Started Guide`: https://aws-parallelcluster.readthedocs.io/en/latest/getting_started.html
 
+-------------
 Documentation
 -------------
 
-Documentation is part of the project and is published to -
-https://aws-parallelcluster.readthedocs.io/. Of most interest to new users is
-the Getting Started Guide -
-https://aws-parallelcluster.readthedocs.io/en/latest/getting_started.html.
+Documentation for AWS ParallelCluster can be found by visiting the project page:
+https://aws-parallelcluster.readthedocs.io/
 
+New users are strongly encouraged to review the Getting Started Guide:
+https://aws-parallelcluster.readthedocs.io/en/latest/getting_started.html
+
+------
 Issues
 ------
 
-Please open a GitHub issue for any feedback or issues:
-https://github.com/aws/aws-parallelcluster.  There is also an active AWS
-HPC forum which may be helpful:https://forums.aws.amazon.com/forum.jspa?forumID=192.
+Please visit the AWS ParallelCluster Github project site to provide feedback, request new features, or report bugs:
+https://github.com/aws/aws-parallelcluster.
 
+The AWS HPC Forum is monitored by the ParallelCluster development team and may also be helpful:
+https://forums.aws.amazon.com/forum.jspa?forumID=192.
+
+-------
 Changes
 -------
 
 CfnCluster 1.6 IAM Change
 =========================
-Between CfnCluster 1.5.4 and 1.6.0 we made a change to the CfnClusterInstancePolicy that adds “s3:GetObject” permissions
-on objects in <REGION>-cfncluster bucket, "autoscaling:SetDesiredCapacity", "autoscaling:DescribeTags" permissions and
+Between CfnCluster 1.5.4 and 1.6.0, we made a change to the CfnClusterInstancePolicy that adds “s3:GetObject” permissions
+on objects in <REGION>-cfncluster bucket, "autoscaling:SetDesiredCapacity", "autoscaling:DescribeTags" permissions, and
 "cloudformation:DescribeStacks" permissions on <REGION>:<ACCOUNT_ID>:stack/cfncluster-*.
 
-If you’re using a custom policy (e.g. you specify "ec2_iam_role" in your config) be sure it includes this new permission. See https://aws-parallelcluster.readthedocs.io/en/latest/iam.html
+If you are using a custom policy (e.g. "ec2_iam_role" is specified in your config), please be sure it includes this new permission.
+For more detailed information, please visit: https://aws-parallelcluster.readthedocs.io/en/latest/iam.html
 
 CfnCluster 1.5 IAM Change
 =========================
-Between CfnCluster 1.4.2 and 1.5.0 we made a change to the CfnClusterInstancePolicy that adds “ec2:DescribeVolumes” permissions. If you’re using a custom policy (e.g. you specify "ec2_iam_role" in your config) be sure it includes this new permission. See https://aws-parallelcluster.readthedocs.io/en/latest/iam.html
+Between CfnCluster 1.4.2 and 1.5.0, we made a change to the CfnClusterInstancePolicy that adds “ec2:DescribeVolumes” permissions. If you are using a custom policy (e.g. "ec2_iam_role" is specified in your config), please be sure it includes this new permission.
+For more detailed information, please visit: https://aws-parallelcluster.readthedocs.io/en/latest/iam.html
 
 CfnCluster 1.2 and Earlier
 ==========================
-
-For various security (on our side) and maintenance reasons, CfnCluster
-1.2 and earlier have been deprecated.  AWS-side resources necessary to
-create a cluster with CfnCluster 1.2 or earlier are no longer
-available.  Existing clusters will continue to operate, but new
-clusters can not be created.
+For various maintenance and security reasons (on our side), CfnCluster 1.2 and earlier have been deprecated.  AWS-side resources necessary to create a cluster with CfnCluster 1.2 or earlier are no longer available.  Existing clusters will continue to operate, but new clusters cannot be created.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -23,7 +23,7 @@ the directory containing the AWS ParallelCluster source code documentation:
 
 .. code-block:: sh
 
-    $ cd ~/src/aws-parallelcluster/docs
+    $ cd docs
     $ make html
 
 When the build process concludes, the finalized documentation will be available in the :code:`build/html` folder.
@@ -33,13 +33,14 @@ tox
 ===
 
 tox is a generic virtualenv management and test command line tool used for checking package installations against
-different Python versions and interpreters, testing in each of these environments, and avoiding boilerplate and platform-specific build-step hacks.
+different Python versions and interpreters, testing in each of these environments, and avoiding boilerplate
+and platform-specific build-step hacks.
 
 To build the AWS ParallelCluster documentation with tox:
 
 .. code-block:: sh
 
-    $ cd ~/src/aws-parallelcluster/cli
+    $ cd cli
     $ tox -e docs
     $ tox -e serve-docs
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,27 +1,47 @@
-==============================================
 How to build AWS ParallelCluster documentation
-==============================================
+##############################################
 
-First, install the libraries needed to build Sphinx doc:
+AWS ParallelCluster documentation can be constructed using Sphinx (http://www.sphinx-doc.org/en/master/) or
+tox (https://tox.readthedocs.io/en/latest/index.html).
+
+To begin, install the required libraries:
 
 .. code-block:: sh
 
     $ pip install -r docs/requirements.txt
 
-Next, execute the :code:`make html` command.
+Select your preferred tool of choice and build the documentation using the guidelines outlined below:
+
+Sphinx
+======
+
+Sphinx was originally created to facilitate Python documentation creation.  It has excellent facilities for
+documentation of software projects for a range of languages.
+
+To build the AWS ParallelCluster documentation using Sphinx, run the :code:`make html` command from the
+the directory containing the AWS ParallelCluster source code documentation:
 
 .. code-block:: sh
 
+    $ cd ~/src/aws-parallelcluster/docs
     $ make html
 
-The documentation will be available in the :code:`build/html` folder.
-See Makefile for other available targets.
+When the build process concludes, the finalized documentation will be available in the :code:`build/html` folder.
+Please consult the Makefile for additonal guidance on building for other supported targets.
 
-Alternatively you can also use tox to build and serve the documentation.
-In this case you don't need to install any library since tox takes care of it:
+tox
+===
+
+tox is a generic virtualenv management and test command line tool used for checking package installations against
+different Python versions and interpreters, testing in each of these environments, and avoiding boilerplate and platform-specific build-step hacks.
+
+To build the AWS ParallelCluster documentation with tox:
 
 .. code-block:: sh
 
-    $ cd cli
+    $ cd ~/src/aws-parallelcluster/cli
     $ tox -e docs
     $ tox -e serve-docs
+
+When the build process concludes, the finalized documentation will be available in the :code:`build/html` folder.
+Please consult :code:`~/src/aws-parallelcluster/cli/tox.ini` for additional guidance on customizing the tox build environment.

--- a/docs/autoscaling.rst
+++ b/docs/autoscaling.rst
@@ -1,21 +1,18 @@
 .. _autoscaling:
 
-================================
 AWS ParallelCluster Auto Scaling
 ================================
 
-The auto scaling strategy described here applies to HPC clusters deployed with one of the
-supported traditional job scheduler, either SGE, Slurm or Torque.
-In these cases AWS ParallelCluster directly implements the scaling capabilities by managing
-the `Auto Scaling Group`_ (ASG) of the compute nodes and changing the scheduler configuration
-accordingly.
-For HPC clusters based on AWS Batch, ParallelCluster relies on the elastic scaling capabilities
-provided by the AWS-managed job scheduler.
+The auto scaling strategy described here applies to HPC clusters deployed with one of the supported traditional
+job schedulers (Grid Engine, Slurm, or Torque).
+For these cases, AWS ParallelCluster implements auto scaling by managing the `Auto Scaling Group`_ (ASG) of the
+compute nodes and changing the scheduler configuration accordingly.
+For HPC clusters based on AWS Batch, ParallelCluster relies on the elastic scaling capabilities provided by
+the AWS-managed job scheduler.
 
-Clusters deployed with AWS ParallelCluster are elastic in several ways. The first is by
-simply setting the ``initial_queue_size`` and ``max_queue_size`` parameters of a cluster
-settings. The ``initial_queue_size`` sets the minimum size value of the ComputeFleet ASG and also
-the desired capacity value.
+Clusters deployed with AWS ParallelCluster are elasticized by setting the ``initial_queue_size`` and ``max_queue_size``
+parameters in the cluster configuration settings.
+The ``initial_queue_size`` sets the minimum size value of the ComputeFleet ASG and the desired capacity value.
 The ``max_queue_size`` sets the maximum size value of the ComputeFleet ASG.
 
 .. image:: images/as-basic-diagram.png
@@ -23,55 +20,52 @@ The ``max_queue_size`` sets the maximum size value of the ComputeFleet ASG.
 Scaling Up
 ==========
 
-Every minute, a process called jobwatcher_ runs on the master instance and evaluates
-the current number of instances required by the pending jobs in the queue.
-If the total number of busy nodes and requested nodes is greater than the current desired value in the ASG,
-it adds more instances.
-If you submit more jobs, the queue will get re-evaluated and the ASG updated up to the ``max_queue_size``.
+Every minute, a process called jobwatcher_ runs on the master instance and evaluates the current number of instances
+required by the pending jobs in the queue.
+If the total number of busy nodes and requested nodes is greater than the current desired value in the ASG, more instances
+are added.
+If additional jobs are submitted, the queue will be re-evaluated and the ASG will be updated up to the ``max_queue_size``.
 
-With SGE each job requires a number of slots to run (one slot corresponds to one processing unit, e.g. a vCPU).
-When evaluating the number of instances required to serve the currently pending jobs, the jobwatcher
-divides the total number of requested slots by the capacity of a single compute node.
-The capacity of a compute node that is the number of available vCPUs depends on the EC2 instance type selected
-in the cluster configuration.
+With Grid Engine, each job requires a number of slots to run (one slot corresponds to one processing unit, e.g. a vCPU).
+When evaluating the number of instances required to serve currently pending jobs that are queued, the jobwatcher divides
+the total number of requested slots by the capacity of a single compute node.
+The capacity of a compute node that is the number of available vCPUs depends on the EC2 instance type selected in
+the cluster configuration.
 
-With Slurm and Torque schedulers each job can require both a number of nodes and a number of slots per node.
-The jobwatcher takes into account the request of each job and determines the number of compute nodes to fulfill
-the new computational requirements.
-For example, assuming a cluster with c5.2xlarge (8 vCPU) as compute instance type, and three queued pending jobs
-with the following requirements: job1 2 nodes / 4 slots each, job2 3 nodes / 2 slots and job3 1 node / 4 slots,
-the jobwatcher will require three new compute instances to the ASG to serve the three jobs.
+With Slurm and Torque, each job can require both a number of nodes and a number of slots per node.
+The jobwatcher takes into account the resources requested by each job and determines the number of compute nodes to
+fulfill the new computational requirements.
+For example, assuming a cluster with c5.2xlarge (8 vCPU) as the compute instance type, and three queued pending jobs
+with the following requirements: job1 (2 nodes / 4 slots per job), job2 (3 nodes / 2 slots per job) and
+job3 (1 node / 4 slots per job), the jobwatcher will require adding three new compute instances to the ASG to
+serve the three jobs.
 
-*Current limitation*: the auto scale up logic does not consider partially loaded busy nodes, i.e. each node running
-a job is considered busy even if there are empty slots.
+*Current limitation*: the auto scale-up logic does not consider partially loaded busy nodes.  Each node running a job
+is considered busy even if there are empty slots.
 
 Scaling Down
 ============
 
-On each compute node, a process called nodewatcher_ runs and evaluates the idle time of
-the node. If an instance had no jobs for longer than ``scaledown_idletime``
-(which defaults to 10 minutes) and currently there are no pending jobs in the cluster,
-the instance is terminated.
+Each compute node runs a process called nodewatcher_ which evaluates the idle time of the node. If an instance had
+no jobs for longer than ``scaledown_idletime`` (which defaults to 10 minutes) and there are no pending jobs currently
+queued by the cluster, the instance is terminated.
 
-It specifically calls the TerminateInstanceInAutoScalingGroup_ API call,
-which will remove an instance as long as the size of the ASG is at least the
-minimum ASG size. That handles scale down of the cluster, without
-affecting running jobs and also enables an elastic cluster with a fixed base
-number of instances.
+nodewatcher_ calls the TerminateInstanceInAutoScalingGroup_ API call to remove an as long as the size of the ASG is
+equal to the minimum ASG size. This permits the cluster to scale down without affecting running jobs and also enables
+an elastic cluster with a fixed base number of instances.
 
-Static Cluster
-==============
+===============
+Static Clusters
+===============
 
-The value of the auto scaling is the same for HPC as with any other workloads,
-the only difference here is AWS ParallelCluster has code to specifically make it interact
-in a more intelligent manner. If a static cluster is required, this can be
-achieved by setting ``initial_queue_size`` and ``max_queue_size`` parameters to the size
-of cluster required and also setting the ``maintain_initial_size`` parameter to
-true. This will cause the ComputeFleet ASG to have the same value for minimum,
-maximum and desired capacity.
+The value of auto scaling is the same for HPC as with any other cloud-based workload.  The only difference is that
+AWS ParallelCluster has code to specifically make it interact in a more intelligent manner.  If a static cluster is
+required, this can be achieved by setting ``initial_queue_size`` and ``max_queue_size`` to the required size of the
+cluster and ``maintain_initial_size`` parameter to
+``true.`` This will configure the ComputeFleet ASG to have the same value for minimum, maximum, and desired capacity.
 
 .. _`Auto Scaling Group`: https://docs.aws.amazon.com/autoscaling/ec2/userguide/what-is-amazon-ec2-auto-scaling.html
-.. _nodewatcher: https://github.com/aws/aws-parallelcluster-node/tree/develop/nodewatcher
 .. _jobwatcher: https://github.com/aws/aws-parallelcluster-node/tree/develop/jobwatcher
+.. _nodewatcher: https://github.com/aws/aws-parallelcluster-node/tree/develop/nodewatcher
 .. _TerminateInstanceInAutoScalingGroup:
    http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_TerminateInstanceInAutoScalingGroup.html

--- a/docs/autoscaling.rst
+++ b/docs/autoscaling.rst
@@ -22,9 +22,10 @@ Scaling Up
 
 Every minute, a process called jobwatcher_ runs on the master instance and evaluates the current number of instances
 required by the pending jobs in the queue.
-If the total number of busy nodes and requested nodes is greater than the current desired value in the ASG, more instances
-are added.
-If additional jobs are submitted, the queue will be re-evaluated and the ASG will be updated up to the ``max_queue_size``.
+If the total number of busy nodes and requested nodes is greater than the current desired value in the ASG,
+more instances will be added.
+If additional jobs are submitted, the queue will be re-evaluated by jobwatcher_ and the ASG will be increased
+up to the ``max_queue_size``.
 
 With Grid Engine, each job requires a number of slots to run (one slot corresponds to one processing unit, e.g. a vCPU).
 When evaluating the number of instances required to serve currently pending jobs that are queued, the jobwatcher divides

--- a/docs/aws_services.rst
+++ b/docs/aws_services.rst
@@ -1,162 +1,165 @@
 .. _aws_services:
 
-AWS Services used in AWS ParallelCluster
+AWS Services Used in AWS ParallelCluster
 ========================================
 
-The following Amazon Web Services (AWS) services are used in AWS ParallelCluster.
+The following AWS services are used in AWS ParallelCluster:
 
 * AWS CloudFormation
 * AWS Identity and Access Management (IAM)
 * Amazon SNS
 * Amazon SQS
 * Amazon EC2
-* Auto Scaling
+* AWS Auto Scaling
 * Amazon EBS
 * Amazon S3
 * Amazon DynamoDB
+* AWS Batch
+* AWS CodeBuild
+* AWS Lambda
+* Amazon Elastic Container Registry (ECR)
+* Amazon Cloudwatch
 
 .. _aws_services_cloudformation:
 
 AWS CloudFormation
 ------------------
 
-AWS CloudFormation is the core service used by AWS ParallelCluster. Each cluster is represented as a stack. All
-resources required by the cluster are defined within the AWS ParallelCluster CloudFormation template. AWS
-ParallelCluster CLI commands typically map to CloudFormation stack commands, such as create, update and delete.
-Instances launched within a cluster make HTTPS calls to the CloudFormation Endpoint for the region the cluster is
-launched in.
+AWS CloudFormation is the core service used by AWS ParallelCluster.  Each cluster is represented as a stack.
+All resources required by the cluster are defined within the AWS ParallelCluster CloudFormation template.
+AWS ParallelCluster CLI commands typically map to CloudFormation stack commands, such as create, update and delete.
+Instances launched within a cluster make HTTPS calls to the CloudFormation endpoint for the region
+in which the cluster is launched.
 
-For more details about AWS CloudFormation, see http://aws.amazon.com/cloudformation/
+For more details about AWS CloudFormation, please visit: http://aws.amazon.com/cloudformation/
 
 AWS Identity and Access Management (IAM)
 ----------------------------------------
 
-AWS IAM is used within AWS ParallelCluster to provide an Amazon EC2 IAM Role for the instances. This role is a least
-privileged role specifically created for each cluster. AWS ParallelCluster instances are given access only to the
+AWS IAM is used within AWS ParallelCluster to provide a least privileged Amazon EC2 IAM Role for the instances
+that is specific to each invividual cluster.  AWS ParallelCluster instances are given access only to the
 specific API calls that are required to deploy and manage the cluster.
 
 With AWS Batch clusters, IAM Roles are also created for the components involved with the Docker image building process
 at cluster creation time.
-These components include the Lambda functions allowed to add and delete Docker images to/from the ECR repository and to
-delete the S3 bucket created for the cluster and CodeBuild project. Then there are roles for the AWS Batch resources,
-instance, job.
+These components include the Lambda functions allowed to add and delete Docker images to and from the ECR repository,
+and to delete the S3 bucket created for the cluster and its CodeBuild project.
+There are also roles for the AWS Batch resources, instances, and jobs.
 
-For more details about AWS Identity and Access Management, see http://aws.amazon.com/iam/
+For more details about AWS Identity and Access Management, please visit: http://aws.amazon.com/iam/
 
 Amazon Simple Notification Service (SNS)
 ----------------------------------------
 
-Amazon SNS is used to receive notifications from Auto Scaling. These events are called life cycle events, and are
-generated when an instance launches or terminates in an Autoscaling Group. Within AWS ParallelCluster, the Amazon SNS
-topic for the Autoscaling Group is subscribed to an Amazon SQS queue.
+Amazon SNS is used to receive notifications whenever an instance launches or terminates in an Autoscaling Group.
+Within AWS ParallelCluster, the Amazon SNS topic for the Autoscaling Group is subscribed to an Amazon SQS queue.
 
 The service is not used with AWS Batch clusters.
 
-For more details about Amazon SNS, see http://aws.amazon.com/sns/
+For more details about Amazon SNS, please visit: http://aws.amazon.com/sns/
 
 Amazon Simple Queuing Service (SQS)
 -----------------------------------
 
-Amazon SQS is used to hold notifications(messages) from Auto Scaling, sent through Amazon SNS and notifications from
-the ComputeFleet instances. This decouples the sending of notifications from the receiving and allows the Master to
-handle them through polling. The MasterServer runs Amazon SQSwatcher and polls the queue. AutoScaling and the
+Amazon SQS is used to hold notifications (messages) from Auto Scaling evnts sent through Amazon SNS and notifications
+from the ComputeFleet instances.  This decouples the sending of notifications from the receiving and allows the Master
+to handle them through polling.  The MasterServer runs Amazon SQSwatcher and polls the queue. AutoScaling and the
 ComputeFleet instances post messages to the queue.
 
 The service is not used with AWS Batch clusters.
 
-For more details about Amazon SQS, see http://aws.amazon.com/sqs/
+For more details about Amazon SQS, please visit: http://aws.amazon.com/sqs/
 
 Amazon EC2
 ----------
 
-Amazon EC2 provides the compute for AWS ParallelCluster. The MasterServer and ComputeFleet are EC2 instances. Any
-instance type that support HVM can be selected. The MasterServer and ComputeFleet can be different instance types and
-the ComputeFleet can also be launched as Spot instances. Instance store volumes found on the instances are mounted as a
-striped LVM volume.
+Amazon EC2 provides the compute for AWS ParallelCluster.  The MasterServer and ComputeFleet are EC2 instances.
+Any instance type that supports HVM can be selected. The MasterServer and ComputeFleet can be different instance types.
+The ComputeFleet can also be launched using Spot instances.
+Instance store volumes found on the instances are mounted as a striped LVM volume.
 
-For more details about Amazon EC2, see http://aws.amazon.com/ec2/
+For more details about Amazon EC2, please visit: http://aws.amazon.com/ec2/
 
 AWS Auto Scaling
 ----------------
 
-AWS Auto Scaling is used to manage the ComputeFleet instances. These instances are managed as an AutoScaling Group and
-can either be elastically driven by workload or static and driven by the config.
+AWS Auto Scaling is used to manage the ComputeFleet instances.  These instances are managed as an AutoScaling Group and
+can either be elastically driven by workload or statically configured in the base cluster configuration.
 
 The service is not used with AWS Batch clusters.
 
-For more details about Auto Scaling, see http://aws.amazon.com/autoscaling/
+For more details about Auto Scaling, please visit: http://aws.amazon.com/autoscaling/
 
 Amazon Elastic Block Store (EBS)
 --------------------------------
 
-Amazon EBS provides the persistent storage for the shared volumes. Any EBS settings can be passed through the config.
+Amazon EBS provides persistent storage for the shared volumes.  Any EBS settings can be passed through the config.
 EBS volumes can either be initialized empty or from an existing EBS snapshot.
+RAID configurations are also supported.
 
-For more details about Amazon EBS, see http://aws.amazon.com/ebs/
+For more details about Amazon EBS, please visit: http://aws.amazon.com/ebs/
 
 Amazon S3
 ---------
 
-Amazon S3 is used to store the AWS ParallelCluster templates. Each region has a bucket with all templates. AWS
-ParallelCluster can be configured to allow allow CLI/SDK tools to use S3.
+Amazon S3 is used to store the AWS ParallelCluster templates.  Each region has a bucket with all templates.
+AWS ParallelCluster can be configured to allow the CLI/SDK tools to use S3.
 
-With an AWS Batch cluster, an S3 bucket in the customer's account is created to store artifacts used by the Docker
-image creation and the jobs scripts when submitting jobs from the user's machine.
+With AWS Batch, an S3 bucket in the customer's account is created to store artifacts used by the Docker
+image creation process and the jobs scripts generated jobs are submitted from the user's machine.
 
-For more details, see http://aws.amazon.com/s3/
+For more details, please visit: http://aws.amazon.com/s3/
 
 Amazon DynamoDB
 ---------------
 
-Amazon DynamoDB is used to store minimal state of the cluster. The MasterServer tracks provisioned instances in a
-DynamoDB table.
+Amazon DynamoDB is used to maintain cluster state.  The MasterServer tracks provisioned instances in a DynamoDB table.
 
-The service is not used with AWS Batch clusters.
+This service is not used with AWS Batch clusters.
 
-For more details, see http://aws.amazon.com/dynamodb/
+For more details, please visit: http://aws.amazon.com/dynamodb/
 
 AWS Batch
 ---------
-AWS Batch is the AWS managed job scheduler that dynamically provisions the optimal quantity and type of compute
+AWS Batch is an AWS-managed job scheduler that dynamically provisions the optimal quantity and type of compute
 resources (e.g., CPU or memory optimized instances) based on the volume and specific resource requirements of the batch
-jobs submitted. With AWS Batch, there is no need to install and manage batch computing software or server clusters that
-you use to run your jobs.
+jobs submitted.  With AWS Batch, there is no need to install and manage batch computing software or server clusters that
+are used to run jobs.
 
-The service is only used with AWS Batch clusters.
+This service is only used with AWS Batch clusters.
 
-For more details, see https://aws.amazon.com/batch/
+For more details, please visit: https://aws.amazon.com/batch/
 
 AWS CodeBuild
 -------------
 AWS CodeBuild is used to automatically and transparently build Docker images at cluster creation time.
 
-The service is only used with AWS Batch clusters.
+This service is only used with AWS Batch clusters.
 
-For more details, see https://aws.amazon.com/codebuild/
+For more details, please visit: https://aws.amazon.com/codebuild/
 
 AWS Lambda
 ----------
-AWS Lambda service runs the functions that orchestrate the Docker image creation and manage custom cluster resources
-cleanup, that are the created Docker images stored in the ECR repository and the S3 bucket for the cluster.
+AWS Lambda runs functions that orchestrate the Docker image creation and custom cluster resource cleanup processes.
 
-The service is only used with AWS Batch clusters.
+This service is only used with AWS Batch clusters.
 
-For more details, see https://aws.amazon.com/lambda/
+For more details, please visit: https://aws.amazon.com/lambda/
 
 Amazon Elastic Container Registry (ECR)
 ---------------------------------------
 
-Amazon ECR stores the Docker images built at cluster creation time. The Docker images are then used by AWS Batch to run
+Amazon ECR stores the Docker images built at cluster creation time.  The Docker images are then used by AWS Batch to run
 the containers for the submitted jobs.
 
 The service is only used with AWS Batch clusters.
 
-For more details, see https://aws.amazon.com/ecr/
+For more details, please visit: https://aws.amazon.com/ecr/
 
 Amazon CloudWatch
 -----------------
-Amazon CloudWatch is used to log Docker image build steps and the standard output and error of the AWS Batch jobs.
+Amazon CloudWatch is used to log Docker image build steps and the standard output and error of AWS Batch jobs.
 
 The service is only used with AWS Batch clusters.
 
-For more details, see https://aws.amazon.com/cloudwatch/
+For more details, please visit: https://aws.amazon.com/cloudwatch/

--- a/docs/aws_services.rst
+++ b/docs/aws_services.rst
@@ -18,7 +18,7 @@ The following AWS services are used in AWS ParallelCluster:
 * AWS CodeBuild
 * AWS Lambda
 * Amazon Elastic Container Registry (ECR)
-* Amazon Cloudwatch
+* Amazon CloudWatch
 
 .. _aws_services_cloudformation:
 
@@ -37,7 +37,7 @@ AWS Identity and Access Management (IAM)
 ----------------------------------------
 
 AWS IAM is used within AWS ParallelCluster to provide a least privileged Amazon EC2 IAM Role for the instances
-that is specific to each invividual cluster.  AWS ParallelCluster instances are given access only to the
+that is specific to each individual cluster.  AWS ParallelCluster instances are given access only to the
 specific API calls that are required to deploy and manage the cluster.
 
 With AWS Batch clusters, IAM Roles are also created for the components involved with the Docker image building process
@@ -61,7 +61,7 @@ For more details about Amazon SNS, please visit: http://aws.amazon.com/sns/
 Amazon Simple Queuing Service (SQS)
 -----------------------------------
 
-Amazon SQS is used to hold notifications (messages) from Auto Scaling evnts sent through Amazon SNS and notifications
+Amazon SQS is used to hold notifications (messages) from Auto Scaling events sent through Amazon SNS and notifications
 from the ComputeFleet instances.  This decouples the sending of notifications from the receiving and allows the Master
 to handle them through polling.  The MasterServer runs Amazon SQSwatcher and polls the queue. AutoScaling and the
 ComputeFleet instances post messages to the queue.
@@ -163,3 +163,6 @@ Amazon CloudWatch is used to log Docker image build steps and the standard outpu
 The service is only used with AWS Batch clusters.
 
 For more details, please visit: https://aws.amazon.com/cloudwatch/
+
+.. spelling::
+   CloudWatch

--- a/docs/awsbatchcli.rst
+++ b/docs/awsbatchcli.rst
@@ -4,10 +4,11 @@
 AWS ParallelCluster Batch CLI Commands
 ######################################
 
-The AWS ParallelCluster Batch CLI commands will be automatically installed in the AWS ParallelCluster Master Node
-when the selected scheduler is awsbatch.
-The CLI uses AWS Batch APIs and permits to submit and manage jobs
-and to monitor jobs, queues, hosts, mirroring traditional schedulers commands.
+The AWS ParallelCluster Batch CLI commands will be automatically installed on the AWS ParallelCluster Master Node
+when the selected scheduler is ``awsbatch.``
+
+The CLI uses AWS Batch APIs to mirror traditional scheduler commands that are used to to submit, manage, and monitor
+jobs, queues, and hosts.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'AWS ParallelCluster'
-copyright = u'2014-2018, Amazon Web Services'
+copyright = u'2014-2019, Amazon Web Services'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -299,7 +299,7 @@ texinfo_documents = [
 epub_title = u'AWS ParallelCluster'
 epub_author = u'Amazon Web Services'
 epub_publisher = u'Amazon Web Services'
-epub_copyright = u'2014-2018, Amazon Web Services'
+epub_copyright = u'2014-2019, Amazon Web Services'
 
 # The basename for the epub file. It defaults to the project name.
 #epub_basename = u'aws-parallelcluster'

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -14,7 +14,7 @@ Configuration is defined in multiple sections.
 
 Required sections are "global" and "aws".
 
-At least one "cluster" and one "subnet" section must be included.
+At least one "cluster" and one "subnet" section must also be included.
 
 A section starts with the section name in brackets, followed by parameters and configuration. ::
 

--- a/docs/custom_cookbook.rst
+++ b/docs/custom_cookbook.rst
@@ -5,32 +5,31 @@ Setting Up a Custom AWS ParallelCluster Cookbook
 ################################################
 
 .. warning::
-    The following are instructions for use a custom version of the AWS ParallelCluster cookbook recipes.
-    This is an advanced method of customizing AWS ParallelCluster, with many hard to debug pitfalls.
-    The AWS ParallelCluster team highly recommends using :doc:`pre_post_install` scripts for customization,
-    as post install hooks are generally easier to debug and more portable across releases of AWS ParallelCluster.
+    These instructions are used to define custom versions of the AWS ParallelCluster Cookbook recipes.
+    This is an advanced method of customizing AWS ParallelCluster with many hard-to-debug pitfalls.
+    The AWS ParallelCluster team strongly recommends using :doc:`pre_post_install` scripts for customization,
+    as post install hooks are usually easier to debug and port across future releases of AWS ParallelCluster.
 
 Steps
 =====
 
-#.  Identify the AWS ParallelCluster Cookbook working directory where you have cloned the AWS ParallelCluster Cookbook
-    code ::
+#.  Identify the working directory where the AWS ParallelCluster Cookbook code has been cloned::
 
         _cookbookDir=<path to cookbook>
 
-#.  Detect the current version of the AWS ParallelCluster Cookbook ::
+#.  Determine the current version of the AWS ParallelCluster Cookbook ::
 
         _version=$(grep version ${_cookbookDir}/metadata.rb|awk '{print $2}'| tr -d \')
 
-#.  Create an archive of the AWS ParallelCluster Cookbook and calculate its md5 ::
+#.  Create an archive of the AWS ParallelCluster Cookbook and calculate its md5 checksum ::
 
         cd "${_cookbookDir}"
         _stashName=$(git stash create)
         git archive --format tar --prefix="aws-parallelcluster-cookbook-${_version}/" "${_stashName:-HEAD}" | gzip > "aws-parallelcluster-cookbook-${_version}.tgz"
         md5sum "aws-parallelcluster-cookbook-${_version}.tgz" > "aws-parallelcluster-cookbook-${_version}.md5"
 
-#.  Create an S3 bucket and upload the archive, its md5 and its last modified date into the bucket, giving public
-    readable permission through a public-read ACL ::
+#.  Create an S3 bucket and upload the archive, its md5 checksum, and its last modified date into the bucket.
+    Provide public readable permission through a public-read ACL ::
 
         _bucket=<the bucket name>
         aws s3 cp --acl public-read aws-parallelcluster-cookbook-${_version}.tgz s3://${_bucket}/cookbooks/aws-parallelcluster-cookbook-${_version}.tgz
@@ -38,11 +37,9 @@ Steps
         aws s3api head-object --bucket ${_bucket} --key cookbooks/aws-parallelcluster-cookbook-${_version}.tgz --output text --query LastModified > aws-parallelcluster-cookbook-${_version}.tgz.date
         aws s3 cp --acl public-read aws-parallelcluster-cookbook-${_version}.tgz.date s3://${_bucket}/cookbooks/aws-parallelcluster-cookbook-${_version}.tgz.date
 
-
-#.  Add the following variable to the AWS ParallelCluster config file, under the `[cluster ...]` section" ::
+#.  Add this variable to the AWS ParallelCluster config file, under the `[cluster ...]` section" ::
 
         custom_chef_cookbook = https://s3.<the bucket region>.amazonaws.com/${_bucket}/cookbooks/aws-parallelcluster-cookbook-${_version}.tgz
-
 
 .. spelling::
     md

--- a/docs/custom_node_package.rst
+++ b/docs/custom_node_package.rst
@@ -5,19 +5,19 @@ Setting Up a Custom AWS ParallelCluster Node Package
 ####################################################
 
 .. warning::
-    The following are instructions for use a custom version of the AWS ParallelCluster Node package.
-    This is an advanced method of customizing AWS ParallelCluster, with many hard to debug pitfalls.
-    The AWS ParallelCluster team highly recommends using :doc:`pre_post_install` scripts for customization, as post
-    install hooks are generally easier to debug and more portable across releases of AWS ParallelCluster.
+    These instructions are used to define custom versions of the AWS ParallelCluster Node package.
+    This is an advanced method of customizing AWS ParallelCluster with many hard-to-debug pitfalls.
+    The AWS ParallelCluster team strongly recommends using :doc:`pre_post_install` scripts for customization,
+    as post install hooks are usually easier to debug and port across future releases of AWS ParallelCluster.
 
 Steps
 =====
 
-#.  Identify the AWS ParallelCluster Node working directory where you have cloned the AWS ParallelCluster Node code ::
+#.  Identify the working directory where the AWS ParallelCluster Node code has been cloned ::
 
         _nodeDir=<path to node package>
 
-#.  Detect the current version of the AWS ParallelCluster Node ::
+#.  Determine the current version of the AWS ParallelCluster Node ::
 
         _version=$(grep "version = \"" ${_nodeDir}/setup.py |awk '{print $3}' | tr -d \")
 
@@ -27,14 +27,13 @@ Steps
         _stashName=$(git stash create)
         git archive --format tar --prefix="aws-parallelcluster-node-${_version}/" "${_stashName:-HEAD}" | gzip > "aws-parallelcluster-node-${_version}.tgz"
 
-#.  Create an S3 bucket and upload the archive into the bucket, giving public readable permission through a public-read
-    ACL ::
+#.  Create an S3 bucket and upload the archive into the bucket.
+    Provide public readable permission through a public-read ACL ::
 
         _bucket=<the bucket name>
         aws s3 cp --acl public-read aws-parallelcluster-node-${_version}.tgz s3://${_bucket}/node/aws-parallelcluster-node-${_version}.tgz
 
 
-#.  Add the following variable to the AWS ParallelCluster config file, under the `[cluster ...]` section" ::
+#.  Add the following variable to the AWS ParallelCluster config file under the `[cluster ...]` section" ::
 
         extra_json = { "cluster" : { "custom_node_package" : "https://s3.<the bucket region>.amazonaws.com/${_bucket}/node/aws-parallelcluster-node-${_version}.tgz" } }
-

--- a/docs/detailed_description.rst
+++ b/docs/detailed_description.rst
@@ -1,0 +1,22 @@
+..
+    This is a detailed description of the AWS ParallelCluster service.
+
+
+AWS ParallelCluster is an AWS-supported Open Source cluster management tool that makes it easy to deploy and
+manage High Performance Computing (HPC) clusters in the AWS cloud.
+
+AWS ParallelCluster supports the following features:
+
+- Multiple Linux flavors including Amazon Linux, CentOS, and Ubuntu.
+- Configurable autoscaling of compute resources.
+- Custom AMIs.
+- Shared file systems built from EBS, EFS, and FSxL (Lustre) volumes.
+- EBS RAID functionality.
+- Private subnet deployments.
+- Multiple HPC schedulers including AWS Batch, Grid Engine, Torque, and Slurm.
+
+AWS ParallelCluster facilitates both quick start proof-of-concepts (POCs) and massive production deployments.
+It can be used to orchestrate higher level workflow use cases such as automated DNA sequencing pipelines,
+global weather forecasting, cryptography, fluid dynamics simulations, jet engine design, credit card fraud
+detection, insurance risk modeling, and protein-ligand docking analysis.
+

--- a/docs/detailed_description.rst
+++ b/docs/detailed_description.rst
@@ -20,3 +20,6 @@ It can be used to orchestrate higher level workflow use cases such as automated 
 global weather forecasting, cryptography, fluid dynamics simulations, jet engine design, credit card fraud
 detection, insurance risk modeling, and protein-ligand docking analysis.
 
+.. spelling::
+   FSxL
+   Boto

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -3,14 +3,14 @@
 Development
 ###########
 
-Here you can find guides for getting started with the development of AWS ParallelCluster.
+This document provides guidance for getting started with AWS ParallelCluster development.
 
 .. warning::
-    The following guides are instructions for use a custom version of the cookbook recipes or a custom AWS
-    ParallelCluster Node package.
-    These are advanced method of customizing AWS ParallelCluster, with many hard to debug pitfalls.
-    The AWS ParallelCluster team highly recommends using :doc:`pre_post_install` scripts for customization, as post
-    install hooks are generally easier to debug and more portable across releases of AWS ParallelCluster.
+    The following guidelines provide instructions for using custom versions of the cookbook recipes
+    or a custom AWS ParallelCluster Node package.
+    These are advanced method of customizing AWS ParallelCluster with many hard-to-debug pitfalls.
+    The AWS ParallelCluster team strongly recommends using :doc:`pre_post_install` scripts for customization, as post
+    install hooks are generally easier to debug and port across releases of AWS ParallelCluster.
 
 .. toctree::
 

--- a/docs/functional.rst
+++ b/docs/functional.rst
@@ -3,7 +3,8 @@
 How AWS ParallelCluster Works
 #############################
 
-AWS ParallelCluster was built as a way to manage clusters and to provide a reference for leveraging AWS services to construct an HPC environment in the cloud.
+AWS ParallelCluster was built as a way to manage clusters and to provide a reference for leveraging AWS services
+to construct an HPC environment in the cloud.
 
 .. toctree::
 

--- a/docs/functional.rst
+++ b/docs/functional.rst
@@ -3,8 +3,7 @@
 How AWS ParallelCluster Works
 #############################
 
-AWS ParallelCluster was built not only as a way to manage clusters, but as a reference on how to use AWS services to
-build your HPC environment
+AWS ParallelCluster was built as a way to manage clusters and to provide a reference for leveraging AWS services to construct an HPC environment in the cloud.
 
 .. toctree::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -143,7 +143,7 @@ correct :code:`domain-name` for the region.
 Please refer to the `VPC DHCP Options <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html>`_
 documentation for further guidance.
 
-Once these paraeters contain valid values, the cluster can be launched by running the create command:
+Once these parameters contain valid values, the cluster can be launched by running the create command:
 
 ::
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -7,22 +7,30 @@
 Getting started with AWS ParallelCluster
 ########################################
 
-AWS ParallelCluster is an AWS supported Open Source cluster management tool that makes it easy for you to deploy and
+AWS ParallelCluster is an AWS-supported Open Source cluster management tool that makes it easy to deploy and
 manage High Performance Computing (HPC) clusters in the AWS cloud.
-Built on the Open Source CfnCluster project, AWS ParallelCluster enables you to quickly build an HPC compute
-environment in AWS.
-It automatically sets up the required compute resources and a shared filesystem and offers a variety of batch
-schedulers such as AWS Batch, SGE, Torque, and Slurm.
-AWS ParallelCluster facilitates both quick start proof of concepts (POCs) and production deployments.
-You can build higher level workflows, such as a Genomics portal that automates the entire DNA sequencing workflow, on
-top of AWS ParallelCluster.
+
+AWS ParallelCluster supports the following features:
+
+- Multiple Linux flavors including Amazon Linux, CentOS, and Ubuntu.
+- Configurable autoscaling of compute resources.
+- Custom AMIs.
+- Shared file systems built from EBS, EFS, and FSxL (Lustre) volumes.
+- EBS RAID functionality.
+- Private subnet deployments.
+- Multiple HPC schedulers including AWS Batch, Grid Engine, Torque, and Slurm.
+
+AWS ParallelCluster facilitates both quick start proof-of-concepts (POCs) and massive production deployments.
+It can be used to orchestrate higher level workflow use cases such as automated DNA sequencing pipelines, 
+global weather forecasting, cryptography, fluid dynamics simulations, jet engine design, credit card fraud
+detection, insurance risk modeling, and protein-ligand docking analysis.
 
 Installing AWS ParallelCluster
 ==============================
 
-The current working version is aws-parallelcluster-|version|. The CLI is written in Python and uses BOTO for AWS
-actions.
-You can install the CLI with the following commands, depending on your OS.
+The current working version is aws-parallelcluster-|version|. The CLI is written in Python and uses the Boto library
+to perform AWS actions.
+The CLI can be installed with the following commands:
 
 Linux/OSX
 ---------
@@ -32,17 +40,17 @@ Linux/OSX
 
 Windows
 -------
-Windows support is experimental!!
+NOTE - Windows support is experimental!!
 
 Install the following packages:
 
 * Python3.6 - https://www.python.org/download/
 * pip - https://pip.pypa.io/en/stable/installing/
 
-Once installed, you should update the Environment Variables to have the Python install directory and Python Scripts
+Once installed, update the Environment Variables to have the Python install directory and Python Scripts
 directory in the PATH, for example: ``C:\Python36-32;C:\Python36-32\Scripts``
 
-Now it should be possible to run the following within a command prompt window:
+It should now be possible to run the following within a command prompt window:
 
 ::
 
@@ -51,45 +59,42 @@ Now it should be possible to run the following within a command prompt window:
 Upgrading
 ---------
 
-To upgrade an older version of AWS ParallelCluster, you can use either of the following commands, depending on how it
-was originally installed:
+To upgrade an older version of AWS ParallelCluster:
 
 ::
 
   $ sudo pip install --upgrade aws-parallelcluster
 
-**Remember when upgrading to check that the existing config is compatible with the latest version installed.**
+**Please remember to check that the existing configuration is compatible with the version of ParallelCluster being installed.**
 
 .. _getting_started_configuring_parallelcluster:
 
 Configuring AWS ParallelCluster
 ===============================
 
-Once installed you will need to setup some initial config. The easiest way to do this is below:
+Once installed, you will need to perform some initial configuration steps.  The easiest way to do this is:
 
 ::
 
     $ pcluster configure
 
-This configure wizard will prompt you for everything you need to create your cluster.
-You will first be prompted for your cluster template name, which is the logical name of the template you will create a
-cluster from.
+The pcluster configure wizard will prompt for all information required to create your cluster.
+
+You must first provide the name of the cluster template:
 
 ::
 
         Cluster Template [mycluster]:
 
-Next, you will be prompted for your AWS Access & Secret Keys. Enter the keys for an IAM user with administrative
-privileges.
-These can also be read from your environment variables or the AWS CLI config.
+You will then be prompted to provide AWS Access and Secret Keys.  Enter the keys for an IAM user with administrative
+privileges.  These can also be read from your environment variables or the AWS CLI config:
 
 ::
 
         AWS Access Key ID []:
         AWS Secret Access Key ID []:
 
-Now, you will be presented with a list of valid AWS region identifiers. Choose the region in which you'd like your
-cluster to run.
+A list of valid AWS region identifiers will then be provided.  Choose the region that the cluster will deployed into:
 
 ::
 
@@ -108,15 +113,15 @@ cluster to run.
             sa-east-1
         AWS Region ID []:
 
-Choose a descriptive name for your VPC. Typically, this will be something like :code:`production` or :code:`test`.
+Choose a descriptive name for your VPC.  Typically, this will be something like :code:`production`, :code:`test`, or :code:`dev`.
 
 ::
 
         VPC Name [myvpc]:
 
-Next, you will need to choose a key pair that already exists in EC2 in order to log into your master instance.
-If you do not already have a key pair, refer to the EC2 documentation on `EC2 Key Pairs
-<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html>`_.
+Now choose a key pair that already exists in EC2 in order to log into your master instance.
+If you do not already have a key pair, please refer to the EC2 documentation on `EC2 Key Pairs
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html>`_ for additional guidance.
 
 ::
 
@@ -126,7 +131,7 @@ If you do not already have a key pair, refer to the EC2 documentation on `EC2 Ke
             production-key
         Key Name []:
 
-Choose the VPC ID into which you'd like your cluster launched.
+Choose the VPC ID that the cluster will be launched from:
 
 ::
 
@@ -135,7 +140,7 @@ Choose the VPC ID into which you'd like your cluster launched.
             vpc-blk4982d
         VPC ID []:
 
-Finally, choose the subnet in which you'd like your master server to run.
+Choose the subnet into which the master server will be created:
 
 ::
 
@@ -146,19 +151,19 @@ Finally, choose the subnet in which you'd like your master server to run.
         Master Subnet ID []:
 
 
-Next, a simple cluster launches into a VPC and uses an existing subnet which supports public IP's i.e. the route table
+The cluster will launch from a VPC and use an existing subnet which supports public IP's i.e. the route table
 for the subnet is :code:`0.0.0.0/0 => igw-xxxxxx`.
 The VPC must have :code:`DNS Resolution = yes` and :code:`DNS Hostnames = yes`.
-It should also have DHCP options with the correct :code:`domain-name` for the region, as defined in the docs: `VPC DHCP
+It should also have DHCP options with the correct :code:`domain-name` for the region, as defined in the documentation: `VPC DHCP
 Options <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html>`_.
 
-Once all of those settings contain valid values, you can launch the cluster by running the create command:
+Once all of these settings contain valid values, the cluster can be launched by running the create command:
 
 ::
 
     $ pcluster create mycluster
 
-Once the cluster reaches the "CREATE_COMPLETE" status, you can connect using your normal SSH client/settings.
+Once the cluster reaches the "CREATE_COMPLETE" status, connect using your normal SSH client/settings.
 For more details on connecting to EC2 instances, check the `EC2 User Guide
 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html#ec2-connect-to-instance-linux>`_.
 
@@ -168,11 +173,11 @@ Moving from CfnCluster to AWS ParallelCluster
 
 AWS ParallelCluster is an enhanced and productized version of CfnCluster.
 
-If you are a previous CfnCluster user, we encourage you to start using and creating new clusters only with AWS
-ParallelCluster.
+If you are a previous CfnCluster user, we encourage you to start using and creating new clusters using only
+AWS ParallelCluster.
 Although you can still use CfnCluster, it will no longer be developed.
 
-The main differences between CfnCluster and AWS ParallelCluster are listed below.
+The primary differences between CfnCluster and AWS ParallelCluster are described below.
 
 |
 
@@ -186,30 +191,30 @@ The following commands will no longer work on clusters created by CfnCluster::
      pcluster start cluster_name
      pcluster status cluster_name
 
-You need to use the :code:`cfncluster` CLI to manage your old clusters.
+You must use the :code:`cfncluster` CLI to manage your old clusters.
 
-If you need an old CfnCluster package to manage your old clusters, we recommend you install and use it
-from a `Python Virtual Environment <https://docs.python.org/3/tutorial/venv.html>`_.
+If an old CfnCluster package is still required to manage your legacy clusters, we recommend installing and using
+CfnCluster from a `Python Virtual Environment <https://docs.python.org/3/tutorial/venv.html>`_.
 
 |
 
 **Distinct IAM Custom Policies**
 
-Custom IAM Policies, previously used for CfnCluster cluster creation, cannot be used with AWS ParallelCluster.
-If you require custom policies you need to create the new ones by following :ref:`IAM in AWS ParallelCluster <iam>`
+Custom IAM Policies cannot be used with AWS ParallelCluster.
+If your environment requires custom IAM policies, you must create the new ones by following the :ref:`IAM in AWS ParallelCluster <iam>`
 guide.
 
 |
 
 **Different configuration files**
 
-The AWS ParallelCluster configuration file resides in the :code:`~/.parallelcluster` folder, unlike the CfnCluster one
-that was created in the :code:`~/.cfncluster` folder.
+The AWS ParallelCluster configuration file resides in the :code:`~/.parallelcluster` folder, unlike the CfnCluster one,
+which was created in the :code:`~/.cfncluster` folder.
 
-You can still use your existing configuration file but this needs to be moved from :code:`~/.cfncluster/config` to
+You can still use your existing configuration file by moving or copying from :code:`~/.cfncluster/config` to
 :code:`~/.parallelcluster/config`.
 
-If you use the :code:`extra_json` configuration parameter, it must be changed as described below:
+The :code:`extra_json` configuration parameter must be changed as described below:
 
 :code:`extra_json = { "cfncluster" : { } }`
 
@@ -221,16 +226,15 @@ has been changed to
 
 **Ganglia disabled by default**
 
-Ganglia is disabled by default.
+Ganglia is disabled by default in ParallelCluster.
 You can enable it by setting the :code:`extra_json` parameter as described below:
 
 :code:`extra_json = { "cluster" : { "ganglia_enabled" : "yes" } }`
 
-and changing the Master SG to allow connections to port 80.
-The :code:`parallelcluster-<CLUSTER_NAME>-MasterSecurityGroup-<xxx>` Security Group has to be modified by
+The :code:`parallelcluster-<CLUSTER_NAME>-MasterSecurityGroup-<xxx>` Security Group must also be modified by
 `adding a new Security Group Rule
 <https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/using-network-security.html#adding-security-group-rule>`_
-to allow Inbound connection to the port 80 from your Public IP.
+to allow Inbound connection to port 80 from the "public" IP block that needs to access Ganglia.
 
 .. spelling::
    aws

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -7,23 +7,8 @@
 Getting started with AWS ParallelCluster
 ########################################
 
-AWS ParallelCluster is an AWS-supported Open Source cluster management tool that makes it easy to deploy and
-manage High Performance Computing (HPC) clusters in the AWS cloud.
+.. include:: detailed_description.rst
 
-AWS ParallelCluster supports the following features:
-
-- Multiple Linux flavors including Amazon Linux, CentOS, and Ubuntu.
-- Configurable autoscaling of compute resources.
-- Custom AMIs.
-- Shared file systems built from EBS, EFS, and FSxL (Lustre) volumes.
-- EBS RAID functionality.
-- Private subnet deployments.
-- Multiple HPC schedulers including AWS Batch, Grid Engine, Torque, and Slurm.
-
-AWS ParallelCluster facilitates both quick start proof-of-concepts (POCs) and massive production deployments.
-It can be used to orchestrate higher level workflow use cases such as automated DNA sequencing pipelines, 
-global weather forecasting, cryptography, fluid dynamics simulations, jet engine design, credit card fraud
-detection, insurance risk modeling, and protein-ligand docking analysis.
 
 Installing AWS ParallelCluster
 ==============================
@@ -65,7 +50,7 @@ To upgrade an older version of AWS ParallelCluster:
 
   $ sudo pip install --upgrade aws-parallelcluster
 
-**Please remember to check that the existing configuration is compatible with the version of ParallelCluster being installed.**
+**Verify compatibility of the existing configuration with the new version of ParallelCluster being installed!**
 
 .. _getting_started_configuring_parallelcluster:
 
@@ -113,7 +98,7 @@ A list of valid AWS region identifiers will then be provided.  Choose the region
             sa-east-1
         AWS Region ID []:
 
-Choose a descriptive name for your VPC.  Typically, this will be something like :code:`production`, :code:`test`, or :code:`dev`.
+Choose a descriptive name for the VPC. Typically, this will be :code:`production`, :code:`test`, or :code:`dev`.
 
 ::
 
@@ -151,20 +136,26 @@ Choose the subnet into which the master server will be created:
         Master Subnet ID []:
 
 
-The cluster will launch from a VPC and use an existing subnet which supports public IP's i.e. the route table
-for the subnet is :code:`0.0.0.0/0 => igw-xxxxxx`.
-The VPC must have :code:`DNS Resolution = yes` and :code:`DNS Hostnames = yes`.
-It should also have DHCP options with the correct :code:`domain-name` for the region, as defined in the documentation: `VPC DHCP
-Options <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html>`_.
+The cluster will launch from a VPC and use an existing subnet that supports public IP's i.e. the route table for the
+subnet is :code:`0.0.0.0/0 => igw-xxxxxx`.
+The VPC must also have :code:`DNS Resolution = yes`, :code:`DNS Hostnames = yes`, and DHCP options set to the
+correct :code:`domain-name` for the region.
+Please refer to the `VPC DHCP Options <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html>`_
+documentation for further guidance.
 
-Once all of these settings contain valid values, the cluster can be launched by running the create command:
+Once these paraeters contain valid values, the cluster can be launched by running the create command:
 
 ::
 
     $ pcluster create mycluster
 
-Once the cluster reaches the "CREATE_COMPLETE" status, connect using your normal SSH client/settings.
-For more details on connecting to EC2 instances, check the `EC2 User Guide
+Once the cluster reaches the "CREATE_COMPLETE" status, connect using the pcluster ssh command:
+
+::
+
+    $ pcluster ssh mycluster
+
+For more details on connecting to EC2 instances, please refer to the `EC2 User Guide
 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html#ec2-connect-to-instance-linux>`_.
 
 
@@ -198,15 +189,15 @@ CfnCluster from a `Python Virtual Environment <https://docs.python.org/3/tutoria
 
 |
 
-**Distinct IAM Custom Policies**
+**Custom IAM policies are no longer supported**
 
 Custom IAM Policies cannot be used with AWS ParallelCluster.
-If your environment requires custom IAM policies, you must create the new ones by following the :ref:`IAM in AWS ParallelCluster <iam>`
-guide.
+If your environment requires custom IAM policies, please create them by following the guidelines detailed in
+the :ref:`IAM in AWS ParallelCluster <iam>` guide.
 
 |
 
-**Different configuration files**
+**ParallelCluster uses different configuration files**
 
 The AWS ParallelCluster configuration file resides in the :code:`~/.parallelcluster` folder, unlike the CfnCluster one,
 which was created in the :code:`~/.cfncluster` folder.
@@ -224,7 +215,7 @@ has been changed to
 
 |
 
-**Ganglia disabled by default**
+**Ganglia is disabled by default**
 
 Ganglia is disabled by default in ParallelCluster.
 You can enable it by setting the :code:`extra_json` parameter as described below:

--- a/docs/iam.rst
+++ b/docs/iam.rst
@@ -3,8 +3,8 @@
 IAM in AWS ParallelCluster
 ==========================
 
-AWS ParallelCluster utilizes multiple AWS services to deploy and operate HPC clusters.  The services used are listed in the
-:ref:`AWS Services used in AWS ParallelCluster <aws_services>` section of the documentation.
+AWS ParallelCluster utilizes multiple AWS services to deploy and operate HPC clusters.  The services used are
+listed in the :ref:`AWS Services used in AWS ParallelCluster <aws_services>` section of the documentation.
 
 AWS ParallelCluster uses EC2 IAM roles to enable instances access to AWS services for the deployment and operation of
 the cluster. By default, the EC2 IAM role is created as part of the cluster creation process by CloudFormation.
@@ -138,7 +138,7 @@ When using SGE, Slurm or Torque as a scheduler:
       ]
   }
 
-When using awsbatch as a scheduler, you must include the same policies as those assigned to the BatchUserRole
+When using AWS Batch as a scheduler, you must include the same policies as those assigned to the BatchUserRole
 defined in the Batch CloudFormation nested stack.
 The BatchUserRole ARN is provided as a stack output.  Here is an overview of the required permissions:
 

--- a/docs/iam.rst
+++ b/docs/iam.rst
@@ -3,35 +3,35 @@
 IAM in AWS ParallelCluster
 ==========================
 
-AWS ParallelCluster utilizes multiple AWS services to deploy and operate a cluster. The services used are listed in the
+AWS ParallelCluster utilizes multiple AWS services to deploy and operate HPC clusters.  The services used are listed in the
 :ref:`AWS Services used in AWS ParallelCluster <aws_services>` section of the documentation.
 
 AWS ParallelCluster uses EC2 IAM roles to enable instances access to AWS services for the deployment and operation of
-the cluster. By default the EC2 IAM role is created as part of the cluster creation by CloudFormation. This means that
-the user creating the cluster must have the appropriate level of permissions
+the cluster. By default, the EC2 IAM role is created as part of the cluster creation process by CloudFormation.
+This requires the user creating the cluster to have the appropriate level of permissions.
 
 Defaults
 --------
 
-When using defaults, during cluster launch an EC2 IAM Role is created by the cluster, as well as all the resources
-required to launch the cluster. The user calling the create call must have the right level of permissions to create all
-the resources including an EC2 IAM Role. This level of permissions is typically an IAM user with the
+When using defaults, an EC2 IAM Role will be created along with all other resources required to launch the cluster.
+The user performing the stack creation must have the right level of permissions to create all
+necessary resources, including an EC2 IAM Role. This level of permissions is typically provided to IAM users with the
 `AdministratorAccess` managed policy. More details on managed policies can be found here:
 http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#aws-managed-policies
 
 Using an existing EC2 IAM role
 ------------------------------
 
-When using AWS ParallelCluster with an existing EC2 IAM role, you must first define the IAM policy and role before
-attempting to launch the cluster. Typically the reason for using an existing EC2 IAM role within AWS ParallelCluster is
-to reduce the permissions granted to users launching clusters. Below is an example IAM policy for both the EC2 IAM role
-and the AWS ParallelCluster IAM user. You should create both as individual policies in IAM and then attach to the
-appropriate resources. In both policies, you should replace REGION and AWS ACCOUNT ID with the appropriate values.
+When using AWS ParallelCluster with an existing EC2 IAM role, the IAM policy and role must be already defined before
+attempting to launch the cluster. Typically, the reason for using an existing EC2 IAM role within AWS ParallelCluster is
+to reduce permissions granted to users launching clusters. Below is an example IAM policy for both the EC2 IAM role
+and the AWS ParallelCluster IAM user.  You should create both as individual policies in IAM and then attach to the
+appropriate resources, replacing REGION and AWS ACCOUNT ID with the appropriate values.
 
 ParallelClusterInstancePolicy
 -----------------------------
 
-In case you are using SGE, Slurm or Torque as a scheduler:
+When using SGE, Slurm or Torque as a scheduler:
 
 ::
 
@@ -138,10 +138,9 @@ In case you are using SGE, Slurm or Torque as a scheduler:
       ]
   }
 
-In case you are using awsbatch as a scheduler, you need to include the same policies
-as the ones assigned to the BatchUserRole that is defined in the Batch CloudFormation nested stack.
-The BatchUserRole ARN is provided as a stack output.
-Here is an overview of the required permissions:
+When using awsbatch as a scheduler, you must include the same policies as those assigned to the BatchUserRole
+defined in the Batch CloudFormation nested stack.
+The BatchUserRole ARN is provided as a stack output.  Here is an overview of the required permissions:
 
 ::
 
@@ -205,10 +204,10 @@ Here is an overview of the required permissions:
 ParallelClusterUserPolicy
 -------------------------
 
-In case you are using SGE, Slurm or Torque as a scheduler:
+Note: if you use a custom role, ``ec2_iam_role = role_name``, the IAM resource must be changed to include
+the name of this custom role.
 
-Note, if you use a custom role, ``ec2_iam_role = role_name``, you'll need to change the IAM resource to include
-the name of that role.
+When using SGE, Slurm or Torque as a scheduler:
 
 From: ::
 
@@ -443,7 +442,7 @@ To: ::
       ]
   }
 
-In case you are using awsbatch as a scheduler:
+When using awsbatch as a scheduler:
 
 ::
 
@@ -655,4 +654,3 @@ In case you are using awsbatch as a scheduler:
       }
     ]
   }
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,15 +8,23 @@
 AWS ParallelCluster
 ###################
 
-AWS ParallelCluster is an AWS supported Open Source cluster management tool that makes it easy for you to deploy and
+AWS ParallelCluster is an AWS-supported Open Source cluster management tool that makes it easy to deploy and
 manage High Performance Computing (HPC) clusters in the AWS cloud.
-Built on the Open Source CfnCluster project, AWS ParallelCluster enables you to quickly build an HPC compute
-environment in AWS.
-It automatically sets up the required compute resources and a shared filesystem and offers a variety of batch
-schedulers such as AWS Batch, SGE, Torque, and Slurm.
-AWS ParallelCluster facilitates both quick start proof of concepts (POCs) and production deployments.
-You can build higher level workflows, such as a Genomics portal that automates the entire DNA sequencing workflow, on
-top of AWS ParallelCluster.
+
+AWS ParallelCluster supports the following features:
+
+- Multiple Linux flavors including Amazon Linux, CentOS, and Ubuntu.
+- Configurable autoscaling of compute resources.
+- Custom AMIs.
+- Shared file systems built from EBS, EFS, and FSxL (Lustre) volumes.
+- EBS RAID functionality.
+- Private subnet deployments.
+- Multiple HPC schedulers including AWS Batch, Grid Engine, Torque, and Slurm.
+
+AWS ParallelCluster facilitates both quick start proof-of-concepts (POCs) and massive production deployments.
+It can be used to orchestrate higher level workflow use cases such as automated DNA sequencing pipelines,
+global weather forecasting, cryptography, fluid dynamics simulations, jet engine design, credit card fraud
+detection, insurance risk modeling, and protein-ligand docking analysis.
 
 .. toctree::
     :maxdepth: 2
@@ -31,8 +39,8 @@ top of AWS ParallelCluster.
 Getting Started
 ---------------
 
-If you've never used ``AWS ParallelCluster`` before, you should read the :doc:`Getting Started with AWS ParallelCluster
-<getting_started>` guide to get familiar with ``pcluster`` & its usage.
+If you have never used ``AWS ParallelCluster`` before, please read the :doc:`Getting Started with AWS ParallelCluster
+<getting_started>` guide to get familiar with ``pcluster`` and its usage.
 
 Additional Docs
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,26 +5,11 @@
     contain the root `toctree` directive.
 
 
-AWS ParallelCluster
-###################
+About AWS ParallelCluster
+#########################
 
-AWS ParallelCluster is an AWS-supported Open Source cluster management tool that makes it easy to deploy and
-manage High Performance Computing (HPC) clusters in the AWS cloud.
+.. include:: detailed_description.rst
 
-AWS ParallelCluster supports the following features:
-
-- Multiple Linux flavors including Amazon Linux, CentOS, and Ubuntu.
-- Configurable autoscaling of compute resources.
-- Custom AMIs.
-- Shared file systems built from EBS, EFS, and FSxL (Lustre) volumes.
-- EBS RAID functionality.
-- Private subnet deployments.
-- Multiple HPC schedulers including AWS Batch, Grid Engine, Torque, and Slurm.
-
-AWS ParallelCluster facilitates both quick start proof-of-concepts (POCs) and massive production deployments.
-It can be used to orchestrate higher level workflow use cases such as automated DNA sequencing pipelines,
-global weather forecasting, cryptography, fluid dynamics simulations, jet engine design, credit card fraud
-detection, insurance risk modeling, and protein-ligand docking analysis.
 
 .. toctree::
     :maxdepth: 2
@@ -35,6 +20,7 @@ detection, insurance risk modeling, and protein-ligand docking analysis.
     functional
     tutorials
     development
+
 
 Getting Started
 ---------------

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
 
-REM Command file for Sphinx documentation
+REM Command file for building AWS ParallelCluster documentation with Sphinx
 
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build

--- a/docs/networking.rst
+++ b/docs/networking.rst
@@ -3,19 +3,19 @@
 Network Configurations
 ======================
 
-AWS ParallelCluster leverages Amazon Virtual Private Cloud (VPC) for networking. This provides a very flexible and
-configurable networking platform to deploy clusters within. AWS ParallelCluster support the following high-level
-configurations:
+AWS ParallelCluster leverages Amazon Virtual Private Cloud (VPC) for networking. This provides a flexible and
+configurable networking platform for deploying HPC clusters.
+AWS ParallelCluster support the following high-level configurations:
 
 * Single subnet for both master and compute instances
 * Two subnets, master in one public subnet and compute instances in a private subnet (new or already existing)
 
 All of these configurations can operate with or without public IP addressing.
-It can also be deployed to leverage an HTTP proxy for all AWS requests.
+ParallelCluster can also leverage an HTTP proxy for all AWS requests.
 The combinations of these configurations result in many different deployment scenarios, ranging from a single public
 subnet with all access over the Internet, to fully private via AWS Direct Connect and HTTP proxy for all traffic.
 
-Below are some architecture diagrams for some of those scenarios:
+Below are some architecture diagrams for some of these scenarios:
 
 AWS ParallelCluster in a single public subnet
 ---------------------------------------------
@@ -57,9 +57,9 @@ The configuration to use an existing private network requires the following sett
   master_subnet_id = subnet-<public>
   compute_subnet_id = subnet-<private>
 
-Both these configuration require to have a `NAT Gateway
+Both of these configuration require a `NAT Gateway
 <https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html>`_
-or an internal PROXY to enable web access for compute instances.
+or an internal PROXY to enable web access for the compute instances.
 
 AWS ParallelCluster in a single private subnet connected using Direct Connect
 -----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ The configuration for this architecture requires the following settings:
   master_subnet_id = subnet-<private>
   use_public_ips = false
 
-With use_public_ips set to false The VPC must be correctly setup to use the Proxy for all traffic.
+Set use_public_ips set to false.  The VPC must be correctly configured to use the Proxy for all traffic.
 Web access is required for both Master and Compute instances.
 
 .. _awsbatch_networking:
@@ -87,29 +87,28 @@ Web access is required for both Master and Compute instances.
 AWS ParallelCluster with awsbatch scheduler
 -------------------------------------------
 
-When using ``awsbatch`` as scheduler type, ParallelCluster creates an AWS Batch Managed Compute Environment which takes
-care of managing ECS container instances, launched in the ``compute_subnet``. In order for AWS Batch to function
-correctly, Amazon ECS container instances need external network access to communicate with the Amazon ECS service
+When using ``awsbatch`` as the scheduler, ParallelCluster creates an AWS Batch Managed Compute Environment which
+takes care of managing ECS container instances launched in the ``compute_subnet``. In order for AWS Batch to function
+correctly, Amazon ECS container instances require external network access to communicate with the Amazon ECS service
 endpoint. This translates into the following scenarios:
 
-* The ``compute_subnet`` uses a NAT Gateway to access the Internet. (Recommended approach)
+* The ``compute_subnet`` uses a NAT Gateway to access the Internet (this is the recommended approach).
 * Instances launched in the ``compute_subnet`` have public IP addresses and can reach the Internet through an
   Internet Gateway.
 
 Additionally, if you are interested in Multi-node Parallel jobs (according to AWS Batch docs):
 
- AWS Batch multi-node parallel jobs use the Amazon ECS awsvpc network mode, which gives your multi-node parallel job
- containers the same networking properties as Amazon EC2 instances. Each multi-node parallel job container gets its own
- elastic network interface, a primary private IP address, and an internal DNS hostname. The network interface is created
- in the same VPC subnet as its host compute resource. Any security groups that are applied to your compute resources are
- also applied to it.
+AWS Batch multi-node parallel jobs use the Amazon ECS awsvpc network mode, giving your multi-node parallel job
+containers the same networking properties as Amazon EC2 instances. Each multi-node parallel job container gets its own
+elastic network interface, a primary private IP address, and an internal DNS hostname. The network interface is created
+in the same VPC subnet as its host compute resource. Any security groups that are applied to your compute resources are
+also applied to it.
 
 When using ECS Task Networking, the awsvpc network mode does not provide task elastic network interfaces with public IP
-addresses for tasks that use the EC2 launch type. To access the Internet, tasks that use the EC2 launch type must be
+addresses for tasks that use the EC2 launch type.  To access the Internet, tasks that use the EC2 launch type must be
 launched in a private subnet that is configured to use a NAT Gateway.
 
-This leaves us with the only option of configuring a NAT Gateway in order to enable the cluster to execute
-Multi-node Parallel Jobs.
+This requires configuring a NAT Gateway to enable the cluster to execute Multi-node Parallel Jobs.
 
 .. figure:: images/networking_batch.jpg
    :alt: AWS ParallelCluster networking with awsbatch scheduler

--- a/docs/pre_post_install.rst
+++ b/docs/pre_post_install.rst
@@ -3,28 +3,30 @@
 Custom Bootstrap Actions
 ========================
 
-AWS ParallelCluster can execute arbitrary code either before(pre) or after(post) the main bootstrap action during
-cluster creation. This code is typically stored in S3 and accessed via HTTP(S) during cluster creation. The code will
-be executed as root and can be in any script language supported by the cluster OS, typically `bash` or `python`.
+AWS ParallelCluster can execute arbitrary code from an S3 bucket either before (pre) or after (post) the main
+bootstrap action during cluster creation.  The pre- and post-install scripts will be executed as root and
+can be written in any script language supported by the cluster operating system.
+This is typically `bash` or `python`.
 
-pre-install actions are called before any cluster deployment bootstrap such as configuring NAT, EBS and the scheduler.
-Typical pre-install actions may include modifying storage, adding extra users or packages.
+The pre-install script is executed before any cluster deployment bootstrap action such as configuring NAT,
+building EBS volumes, and enabling the chosen scheduler.
+Typical pre-install actions may include modifying storage, adding extra users, or installing additional packages.
 
-post-install actions are called after cluster bootstrap is complete, as the last action before an instance is
-considered complete. Typical post-install actions may include changing scheduler settings, modifying storage or
-packages.
+post-install actions are invoked after the cluster bootstrap process is complete as the last action before an instance is
+considered complete. Typical post-install actions may include changing scheduler settings, modifying shared storage,
+or installing addiitonal packages.
 
-Arguments can be passed to scripts by specifying them in the config. These will be passed double-quoted to the
+Arguments can be passed to scripts by specifying them in the config.  They must be passed double-quoted to the
 pre/post-install actions.
 
-If a pre/post-install actions fails, then the instance bootstrap will be considered failed and it will not continue.
-Success is signalled with an exit code of 0, any other exit code will be considered a fail.
+If a pre/post-install actions fails, the instance bootstrap will be considered failed and will not continue.
+Success is signalled with an exit code of 0.  Any other exit code will be considered a failure.
 
 Configuration
 -------------
 
-The following config settings are used to define pre/post-install actions and arguments. All options are optional and
-are not required for basic cluster install.
+The following config settings are used to define pre/post-install actions and arguments.  All parameters are optional and
+are *not* required for basic cluster install.
 
 ::
 
@@ -54,9 +56,9 @@ The first two arguments ``$0`` and ``$1`` are reserved for the script name and u
 Example
 -------
 
-The following are some steps to create a simple post install script that installs the R packages in a cluster.
+Here is an example of how to create a simple post-install script to install some R packages on a cluster.
 
-1. Create a script. For the R example, see below
+1. Create a script. For the R example, see below:
 
 ::
 
@@ -64,11 +66,14 @@ The following are some steps to create a simple post install script that install
 
     yum -y install --enablerepo=epel R
 
-2. Upload the script with the correct permissions to S3
+2. Upload the script with the correct permissions to S3:
 
-``aws s3 cp --acl public-read /path/to/myscript.sh s3://<bucket-name>/myscript.sh``
+::
 
-3. Update AWS ParallelCluster config to include the new post install action.
+$ chmod 0755 myscript.sh
+$ aws s3 cp --acl public-read /path/to/myscript.sh s3://<bucket-name>/myscript.sh
+
+3. Update the AWS ParallelCluster configuration file to include the new post install action:
 
 ::
 
@@ -76,7 +81,7 @@ The following are some steps to create a simple post install script that install
     ...
     post_install = https://<bucket-name>.s3.amazonaws.com/myscript.sh
 
-If the bucket does not have public-read permission use ``s3`` as URL scheme.
+If the bucket does not have public-read permission, use ``s3`` as the URL scheme.
 
 ::
 
@@ -85,6 +90,6 @@ If the bucket does not have public-read permission use ``s3`` as URL scheme.
     post_install = s3://<bucket-name>/myscript.sh
 
 
-4. Launch a cluster
+4. Launch a new cluster stack:
 
 ``pcluster create mycluster``

--- a/docs/pre_post_install.rst
+++ b/docs/pre_post_install.rst
@@ -14,7 +14,7 @@ Typical pre-install actions may include modifying storage, adding extra users, o
 
 post-install actions are invoked after the cluster bootstrap process is complete as the last action before an
 instance is considered complete. Typical post-install actions may include changing scheduler settings, modifying
-shared storage, or installing addiitonal packages.
+shared storage, or installing additional packages.
 
 Arguments can be passed to scripts by specifying them in the config.  They must be passed double-quoted to the
 pre/post-install actions.

--- a/docs/pre_post_install.rst
+++ b/docs/pre_post_install.rst
@@ -12,9 +12,9 @@ The pre-install script is executed before any cluster deployment bootstrap actio
 building EBS volumes, and enabling the chosen scheduler.
 Typical pre-install actions may include modifying storage, adding extra users, or installing additional packages.
 
-post-install actions are invoked after the cluster bootstrap process is complete as the last action before an instance is
-considered complete. Typical post-install actions may include changing scheduler settings, modifying shared storage,
-or installing addiitonal packages.
+post-install actions are invoked after the cluster bootstrap process is complete as the last action before an
+instance is considered complete. Typical post-install actions may include changing scheduler settings, modifying
+shared storage, or installing addiitonal packages.
 
 Arguments can be passed to scripts by specifying them in the config.  They must be passed double-quoted to the
 pre/post-install actions.

--- a/docs/pre_post_install.rst
+++ b/docs/pre_post_install.rst
@@ -25,8 +25,8 @@ Success is signalled with an exit code of 0.  Any other exit code will be consid
 Configuration
 -------------
 
-The following config settings are used to define pre/post-install actions and arguments.  All parameters are optional and
-are *not* required for basic cluster install.
+The following config settings are used to define pre/post-install actions and arguments.  All parameters are optional
+and are *not* required for a basic cluster installation.
 
 ::
 

--- a/docs/processes.rst
+++ b/docs/processes.rst
@@ -48,7 +48,8 @@ online or are terminated, so they can be added or removed from the queue accordi
 
 nodewatcher
 -----------
-nodewatcher runs on each node in the compute fleet.  After the user defined ``scaledown_idletime`` period, the instance is terminated.
+nodewatcher runs on each node in the compute fleet.  After the user-defined ``scaledown_idletime`` period has
+elapsed, the instance will be terminated.
 
 .. image:: images/nodewatcher.svg
     :align: center

--- a/docs/processes.rst
+++ b/docs/processes.rst
@@ -3,24 +3,24 @@
 AWS ParallelCluster Processes
 =============================
 
-This section applies only to HPC clusters deployed with one of the supported traditional job scheduler,
-either SGE, Slurm or Torque.
-In these cases AWS ParallelCluster manages the compute node provisioning and removal
+This section applies only to HPC clusters deployed with one of the supported traditional job schedulers
+(Grid Engine, Slurm or Torque).
+In these cases, AWS ParallelCluster manages the compute node provisioning and removal
 by interacting with both the Auto Scaling Group (ASG) and the underlying job scheduler.
-For HPC clusters based on AWS Batch, ParallelCluster totally relies on the capabilities
-provided by the AWS Batch for the compute node management.
+
+For HPC clusters based on AWS Batch, ParallelCluster instead relies on the capabilities provided by the AWS Batch
+for management of the compute nodes.
 
 .. toctree::
 
 General Overview
 ----------------
-A cluster's life cycle begins after it is created by a user.
+The life cycle of a cluster begins after it is created by a user.
 Typically, this is done from the Command Line Interface (CLI).
-Once created, a cluster will exist until it's deleted.
-There are then AWS ParallelCluster daemons running on the cluster nodes mainly
-aimed to manage the HPC cluster elasticity.
-Here below a diagram representing the user's workflow and the cluster life cycle, while the next sections
-describe the AWS ParallelClustr daemons used to manage the cluster.
+Once created, a cluster will exist until it is deleted.
+The AWS ParallelCluster daemons run on the cluster nodes and are mainly aimed at managing elasticity.
+The diagram below represents a typical user workflow and cluster life cycle, while the next sections
+describe the AWS ParallelCluster daemons used to manage the cluster:
 
 .. image:: images/workflow.svg
     :align: center
@@ -28,8 +28,8 @@ describe the AWS ParallelClustr daemons used to manage the cluster.
 
 jobwatcher
 ----------
-Once a cluster is running, a process owned by the root user will monitor the configured scheduler (SGE, Torque, Slurm,
-etc) and each minute, it'll evaluate the queue in order to decide when to scale up.
+jobwatcher is a root-owned process that monitors the configured scheduler (Grid Engine, Torque, or Slurm).
+Once per minute, it will evaluate the queue to determine if scaling up is necessary.
 
 .. image:: images/jobwatcher.svg
     :align: center
@@ -37,9 +37,9 @@ etc) and each minute, it'll evaluate the queue in order to decide when to scale 
 
 sqswatcher
 ----------
-The sqswatcher process monitors for SQS messages emitted by Auto Scaling which notifies of state changes within the
-cluster.  When an instance comes online, it will submit an "instance ready" message to SQS, which is picked up by
-sqs_watcher running on the master server.  These messages are used to notify the queue manager when new instances come
+sqswatcher monitors SQS messages emitted by Auto Scaling when state changes occur within the cluster.
+When an new instance comes online, an "instance ready" message is submitted to SQS which is picked up by
+sqswatcher running on the master server.  These messages are used to notify the queue manager when new instances come
 online or are terminated, so they can be added or removed from the queue accordingly.
 
 .. image:: images/sqswatcher.svg
@@ -48,8 +48,7 @@ online or are terminated, so they can be added or removed from the queue accordi
 
 nodewatcher
 -----------
-The nodewatcher process runs on each node in the compute fleet.  After the user defined ``scaledown_idletime`` period,
-the instance is terminated.
+nodewatcher runs on each node in the compute fleet.  After the user defined ``scaledown_idletime`` period, the instance is terminated.
 
 .. image:: images/nodewatcher.svg
     :align: center

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,9 @@
+boto3
+configparser
+future
+doc8
 sphinx>=1.8.0
 sphinx-argparse
-tabulate
-boto3
-future
-configparser
 sphinxcontrib-spelling
-doc8
+tabulate
+tox

--- a/docs/s3_resources.rst
+++ b/docs/s3_resources.rst
@@ -3,7 +3,7 @@
 Working with S3
 ===============
 
-Accessing S3 within AWS ParallelCluster can be controlled through two parameters in the AWS ParallelCluster config.
+Accessing S3 within AWS ParallelCluster is controlled through two parameters in the AWS ParallelCluster config:
 
 ::
 
@@ -14,20 +14,21 @@ Accessing S3 within AWS ParallelCluster can be controlled through two parameters
   # (defaults to NONE)
   s3_read_write_resource = NONE
 
-Both parameters accept either ``*`` or a valid S3 ARN. For details of how to specify S3 ARNs, please see
+Both parameters accept either ``*`` or a valid S3 ARN. For details of how to specify S3 ARNs, please visit:
 http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-s3
 
 Examples
 --------
 
-The following example gives you read access to any object in the bucket `my_corporate_bucket`.
+This example provides read access to any object in the bucket `my_corporate_bucket`.
 
 ::
 
   s3_read_resource = arn:aws:s3:::my_corporate_bucket/*
 
-This next example gives you read access to the bucket. This does **not** let you read items from the bucket.
+This example provides read access to the bucket `my_corporate_bucket`.  This does **not** provide read access to objects stored in the bucket.
 
 ::
 
   s3_read_resource = arn:aws:s3:::my_corporate_bucket
+

--- a/docs/s3_resources.rst
+++ b/docs/s3_resources.rst
@@ -26,7 +26,8 @@ This example provides read access to any object in the bucket `my_corporate_buck
 
   s3_read_resource = arn:aws:s3:::my_corporate_bucket/*
 
-This example provides read access to the bucket `my_corporate_bucket`.  This does **not** provide read access to objects stored in the bucket.
+This example provides read access to the bucket `my_corporate_bucket`.  Please note that this does **not**
+provide read access to any objects stored in the bucket.
 
 ::
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -3,7 +3,7 @@
 Tutorials
 #########
 
-Here you can find tutorials for best practices guides for getting started with AWS ParallelCluster.
+These tutorials provide guidance for enabling best practices when getting started with AWS ParallelCluster.
 
 .. toctree::
    :glob:


### PR DESCRIPTION
*Description of changes:*

   Updated the ParallelCluster documentation to fix some spelling errors and
    improve overall readability.  Updated the requirements.txt file so that
    tox and Sphinx are both installed in a single "pip install" statement.
    This change is now reflected in docs/README.rst and makes it easier for
    users to build ParallelCluster documentation.

   Unified the ParallelCluster introductory paragraph for consistency
    throughout the documentation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
