### PR TITLE
Don't specify python version for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,12 @@ python:
 matrix:
   include:
   - name: Code Checks
-    python: 3.6
     stage: linters
     env: TOXENV=code-linters
   - name: CloudFormation Templates Checks
-    python: 3.6
     stage: linters
     env: TOXENV=cfn-format-check,cfn-lint
   - name: Docs Checks
-    python: 3.6
     stage: linters
     env: TOXENV=docs-linters
     before_install:


### PR DESCRIPTION
This because in the test there is:
```
$ python --version
Python 3.7.1
...
execution failed:  -- pyenv: python3.6: command not found
```