### PR TITLE
awsbsub: fix submission when specifying 1 node within the nodes param

### DIFF
--- a/cli/awsbatch/awsbsub.py
+++ b/cli/awsbatch/awsbsub.py
@@ -630,19 +630,21 @@ def main():
         depends_on = _get_depends_on(args)
 
         # select submission (standard vs MNP)
-        if args.nodes:
+        if args.nodes and args.nodes > 1:
             if not hasattr(config, "job_definition_mnp"):
                 fail("Current cluster does not support MNP jobs submission")
             job_definition = config.job_definition_mnp
+            nodes = args.nodes
         else:
             job_definition = config.job_definition
+            nodes = None
 
         AWSBsubCommand(log, boto3_factory).run(
             job_definition=job_definition,
             job_name=job_name,
             job_queue=config.job_queue,
             command=command,
-            nodes=args.nodes,
+            nodes=nodes,
             vcpus=args.vcpus,
             memory=args.memory,
             array_size=args.array_size,


### PR DESCRIPTION
nodes == 1 means single job submission not multi node parallel submission.

The error was:
```
$ echo "sleep 10" | awsbsub -n 1
Error submitting job to AWS Batch. Failed with exception: An error occurred (ClientException) when calling the SubmitJob operation: NodeOverride targets should match job definition. Non matching targets - 0:0
```

