### PR TITLE
Disable Dynamo OnDemand in GovCloud regions

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1560,7 +1560,23 @@
             "KeyType": "HASH"
           }
         ],
-        "BillingMode": "PAY_PER_REQUEST"
+        "BillingMode": {
+          "Fn::If": [
+            "GovCloudRegion",
+            "PROVISIONED",
+            "PAY_PER_REQUEST"
+          ]
+        },
+        "ProvisionedThroughput": {
+          "Fn::If": [
+            "GovCloudRegion",
+            {
+              "ReadCapacityUnits": 5,
+              "WriteCapacityUnits": 5
+            },
+            { "Ref": "AWS::NoValue" }
+          ]
+        }
       }
     },
     "RootRole": {


### PR DESCRIPTION
### Background
Dynamo doesn't support `PAY_PER_REQUEST` yet in GovCloud regions. This commit conditionally disables this feature in govcloud regions.

See:
* [ProvisionedThroughput](https://docs.aws.amazon.com/en_us/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-provisionedthroughput)
* [BillingMode](https://docs.aws.amazon.com/en_us/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-billingmode)

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
