### PR TITLE
DynamoDB BillingMode property is not supported in govcloud

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1563,7 +1563,9 @@
         "BillingMode": {
           "Fn::If": [
             "GovCloudRegion",
-            "PROVISIONED",
+            {
+              "Ref": "AWS::NoValue"
+            },
             "PAY_PER_REQUEST"
           ]
         },
@@ -1574,7 +1576,9 @@
               "ReadCapacityUnits": 5,
               "WriteCapacityUnits": 5
             },
-            { "Ref": "AWS::NoValue" }
+            {
+              "Ref": "AWS::NoValue"
+            }
           ]
         }
       }


### PR DESCRIPTION
`AWS::NoValue` removes the corresponding resource property when specified as a return value in the `Fn::If` intrinsic function.
