### PR TITLE
Integ tests: add first tests for "pcluster update" command

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -11,6 +11,8 @@ config generation.
 
 ## Run Integration Tests
 
+To run the integration tests you have to use Python 3.7.
+
 Before executing integration tests it is required to install all the python dependencies required by the framework.
 In order to do that simply run the following command:
 ```bash

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -176,11 +176,11 @@ def clusters_factory(request):
 def _write_cluster_config_to_outdir(request, cluster_config):
     out_dir = request.config.getoption("output_dir")
     os.makedirs(
-        "{out_dir}/clusters_configs/{test_dir}".format(out_dir=out_dir, test_dir=os.path.dirname(request.node.nodeid)),
+        "{out_dir}/clusters_configs/{test_dir}".format(out_dir=out_dir, test_dir=os.path.dirname(request.node.name)),
         exist_ok=True,
     )
     cluster_config_dst = "{out_dir}/clusters_configs/{test_name}.config".format(
-        out_dir=out_dir, test_name=request.node.nodeid
+        out_dir=out_dir, test_name=request.node.name
     )
     copyfile(cluster_config, cluster_config_dst)
     return cluster_config_dst

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -167,7 +167,7 @@ def clusters_factory(request):
             ssh_key=request.config.getoption("key_path"),
         )
         factory.create_cluster(cluster)
-        return cluster
+        return cluster, factory
 
     yield _cluster_factory
     factory.destroy_all_clusters()

--- a/tests/integration-tests/tests/common/scaling_common.py
+++ b/tests/integration-tests/tests/common/scaling_common.py
@@ -71,10 +71,20 @@ def get_compute_nodes_allocation(scheduler_commands, region, stack_name, max_mon
     return asg_capacity_time_series, compute_nodes_time_series, timestamps
 
 
-def _get_desired_asg_capacity(region, stack_name):
-    """Retrieve the desired capacity of the autoscaling group for a specific cluster."""
+def _get_asg(region, stack_name):
+    """Retrieve the autoscaling group for a specific cluster."""
     asg_conn = boto3.client("autoscaling", region_name=region)
     tags = asg_conn.describe_tags(Filters=[{"Name": "value", "Values": [stack_name]}])
     asg_name = tags.get("Tags")[0].get("ResourceId")
     response = asg_conn.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
-    return response["AutoScalingGroups"][0]["DesiredCapacity"]
+    return response["AutoScalingGroups"][0]
+
+
+def _get_desired_asg_capacity(region, stack_name):
+    """Retrieve the desired capacity of the autoscaling group for a specific cluster."""
+    return _get_asg(region, stack_name)["DesiredCapacity"]
+
+
+def get_max_asg_capacity(region, stack_name):
+    """Retrieve the max capacity of the autoscaling group for a specific cluster."""
+    return _get_asg(region, stack_name)["MaxSize"]

--- a/tests/integration-tests/tests/schedulers/test_awsbatch.py
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch.py
@@ -29,7 +29,7 @@ def test_awsbatch(pcluster_config_reader, clusters_factory, test_datadir):
     Grouped all tests in a single function so that cluster can be reused for all of them.
     """
     cluster_config = pcluster_config_reader()
-    cluster = clusters_factory(cluster_config)
+    cluster, _ = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     _test_simple_job_submission(remote_command_executor, test_datadir)

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -35,7 +35,7 @@ def test_slurm(region, pcluster_config_reader, clusters_factory):
     scaledown_idletime = 3
     max_queue_size = 5
     cluster_config = pcluster_config_reader(scaledown_idletime=scaledown_idletime, max_queue_size=max_queue_size)
-    cluster = clusters_factory(cluster_config)
+    cluster, _ = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     _test_slurm_version(remote_command_executor)

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -26,7 +26,7 @@ from tests.storage.storage_common import verify_directory_correctly_shared
 def test_ebs_single(scheduler, pcluster_config_reader, clusters_factory):
     mount_dir = "ebs_mount_dir"
     cluster_config = pcluster_config_reader(mount_dir=mount_dir)
-    cluster = clusters_factory(cluster_config)
+    cluster, _ = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     mount_dir = "/" + mount_dir
@@ -43,7 +43,7 @@ def test_ebs_multiple(scheduler, pcluster_config_reader, clusters_factory):
     mount_dirs = ["/ebs_mount_dir_{0}".format(i) for i in range(0, 5)]
     volume_sizes = [15 + 5 * i for i in range(0, 5)]
     cluster_config = pcluster_config_reader(mount_dirs=mount_dirs, volume_sizes=volume_sizes)
-    cluster = clusters_factory(cluster_config)
+    cluster, _ = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
@@ -58,7 +58,7 @@ def test_ebs_multiple(scheduler, pcluster_config_reader, clusters_factory):
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_default_ebs(scheduler, pcluster_config_reader, clusters_factory):
     cluster_config = pcluster_config_reader()
-    cluster = clusters_factory(cluster_config)
+    cluster, _ = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     mount_dir = "/shared"

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -35,7 +35,7 @@ def test_fsx_lustre(region, pcluster_config_reader, clusters_factory, s3_bucket_
     bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
     bucket.upload_file(str(test_datadir / "s3_test_file"), "s3_test_file")
     cluster_config = pcluster_config_reader(bucket_name=bucket_name, mount_dir=mount_dir)
-    cluster = clusters_factory(cluster_config)
+    cluster, _ = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     _test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir)

--- a/tests/integration-tests/tests/storage/test_raid.py
+++ b/tests/integration-tests/tests/storage/test_raid.py
@@ -25,7 +25,7 @@ from tests.storage.storage_common import verify_directory_correctly_shared
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_raid_performance_mode(scheduler, pcluster_config_reader, clusters_factory):
     cluster_config = pcluster_config_reader()
-    cluster = clusters_factory(cluster_config)
+    cluster, _ = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
@@ -41,7 +41,7 @@ def test_raid_performance_mode(scheduler, pcluster_config_reader, clusters_facto
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_raid_fault_tolerance_mode(scheduler, pcluster_config_reader, clusters_factory):
     cluster_config = pcluster_config_reader()
-    cluster = clusters_factory(cluster_config)
+    cluster, _ = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)

--- a/tests/integration-tests/tests/test_scaling.py
+++ b/tests/integration-tests/tests/test_scaling.py
@@ -29,7 +29,7 @@ def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clu
     max_jobs_execution_time = 9
 
     cluster_config = pcluster_config_reader(scaledown_idletime=scaledown_idletime)
-    cluster = clusters_factory(cluster_config)
+    cluster, _ = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
 

--- a/tests/integration-tests/tests/update/__init__.py
+++ b/tests/integration-tests/tests/update/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -11,8 +11,12 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import boto3
 import pytest
+
 from assertpy import assert_that
-from tests.common.scaling_common import get_max_asg_capacity
+from remote_command_executor import RemoteCommandExecutor
+from tests.common.scaling_common import get_max_asg_capacity, watch_compute_nodes
+from tests.common.schedulers_common import SlurmCommands
+from time_utils import minutes
 
 
 @pytest.mark.regions(["us-west-1"])
@@ -30,25 +34,59 @@ def test_update(region, pcluster_config_reader, clusters_factory):
 
     cluster_config = pcluster_config_reader(max_queue_size=max_queue_size, compute_instance=compute_instance)
     cluster, factory = clusters_factory(cluster_config)
-    _test_asg_size(region, cluster.cfn_name, max_queue_size)
+    # Verify initial settings
+    _test_max_queue(region, cluster.cfn_name, max_queue_size)
+    _test_compute_instance_type(cluster.cfn_name, compute_instance)
 
-    _test_update_max_queue(region, cluster, factory)
+    # Configuration parameters for the update test
+    new_max_queue_size = 10
+    new_compute_instance = "c4.xlarge"
 
-
-def _test_update_max_queue(region, cluster, factory):
-    new_queue_size = 10
-    _update_cluster_property(cluster, "max_queue_size", str(new_queue_size))
-
+    # change config settings
+    _update_cluster_property(cluster, "max_queue_size", str(new_max_queue_size))
+    _update_cluster_property(cluster, "compute_instance_type", new_compute_instance)
+    # update configuration file
+    cluster.update()
+    # update cluster
     factory.update_cluster(cluster)
-    _test_asg_size(region, cluster.cfn_name, new_queue_size)
+
+    # test update
+    _test_max_queue(region, cluster.cfn_name, new_max_queue_size)
+    _test_update_compute_instance_type(cluster, new_compute_instance)
 
 
-def _test_asg_size(region, stack_name, queue_size):
+def _test_max_queue(region, stack_name, queue_size):
     asg_max_size = get_max_asg_capacity(region, stack_name)
     assert_that(asg_max_size).is_equal_to(queue_size)
 
 
+def _test_update_compute_instance_type(cluster, new_compute_instance):
+    # submit a job to perform a scaling up action and have a new instance
+    number_of_nodes = 2
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    slurm_commands = SlurmCommands(remote_command_executor)
+    result = slurm_commands.submit_command("sleep 60", nodes=number_of_nodes)
+    slurm_commands.assert_job_submitted(result.stdout)
+
+    estimated_scaleup_time = 5
+    watch_compute_nodes(
+        scheduler_commands=slurm_commands,
+        max_monitoring_time=minutes(estimated_scaleup_time),
+        number_of_nodes=number_of_nodes,
+    )
+    _test_compute_instance_type(cluster.cfn_name, new_compute_instance)
+
+
+def _test_compute_instance_type(stack_name, compute_instance_type):
+    ec2_client = boto3.resource("ec2")
+    instance_ids = []
+    instance_types = []
+    for instance in ec2_client.instances.filter(Filters=[{"Name": "tag:Application", "Values": [stack_name]}]):
+        instance_ids.append(instance.instance_id)
+        instance_types.append(instance.instance_type)
+
+    assert_that(instance_types).contains(compute_instance_type)
+
+
 def _update_cluster_property(cluster, property_name, property_value):
     cluster.config.set("cluster default", property_name, property_value)
-    # update configuration file
-    cluster.update()

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1,0 +1,54 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import boto3
+import pytest
+from assertpy import assert_that
+from tests.common.scaling_common import get_max_asg_capacity
+
+
+@pytest.mark.regions(["us-west-1"])
+@pytest.mark.schedulers(["slurm"])
+@pytest.mark.oss(["alinux"])
+@pytest.mark.usefixtures("os", "scheduler")
+def test_update(region, pcluster_config_reader, clusters_factory):
+    """
+    Test 'pcluster update' command.
+
+    Grouped all tests in a single function so that cluster can be reused for all of them.
+    """
+    max_queue_size = 5
+    compute_instance = "c5.xlarge"
+
+    cluster_config = pcluster_config_reader(max_queue_size=max_queue_size, compute_instance=compute_instance)
+    cluster, factory = clusters_factory(cluster_config)
+    _test_asg_size(region, cluster.cfn_name, max_queue_size)
+
+    _test_update_max_queue(region, cluster, factory)
+
+
+def _test_update_max_queue(region, cluster, factory):
+    new_queue_size = 10
+    _update_cluster_property(cluster, "max_queue_size", str(new_queue_size))
+
+    factory.update_cluster(cluster)
+    _test_asg_size(region, cluster.cfn_name, new_queue_size)
+
+
+def _test_asg_size(region, stack_name, queue_size):
+    asg_max_size = get_max_asg_capacity(region, stack_name)
+    assert_that(asg_max_size).is_equal_to(queue_size)
+
+
+def _update_cluster_property(cluster, property_name, property_value):
+    cluster.config.set("cluster default", property_name, property_value)
+    # update configuration file
+    cluster.update()

--- a/tests/integration-tests/tests/update/test_update/test_update/pcluster.config.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update/pcluster.config.ini
@@ -1,0 +1,24 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = slurm
+master_instance_type = c5.xlarge
+compute_instance_type = {{ compute_instance }}
+initial_queue_size = 1
+max_queue_size = {{ max_queue_size }}
+maintain_initial_size = true
+scaling_settings = custom
+
+[scaling custom]
+scaledown_idletime = 3
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}


### PR DESCRIPTION
Preliminary changes:
+ add required python version to readme
+ use `node.name` in place of `node.id` for test_name (fixes gitbash execution)
    + node.id = `tests_outputs/.../test_slurm.py::test_slurm[c5.xlarge-us-west-1-alinux-slurm].config`
    + node.name = `tests_outputs/.../test_slurm[c5.xlarge-us-west-1-alinux-slurm].config`


Changes required for the update integration tests:
+ extend `clusters_factory` fixture to return the `factory` (required to update an existing cluster)
+ add `get_max_asg_capacity` function 

Integration tests:
+ verify `max_queue_size` and `compute_instance_type` after an update