### PR TITLE
Display Public IP's for SSH

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -4753,8 +4753,7 @@
           "MasterServer",
           "PublicIp"
         ]
-      },
-      "Condition": "MasterPublicIp"
+      }
     },
     "GangliaPrivateURL": {
       "Description": "Private URL to access Ganglia (disabled by default)",
@@ -4790,8 +4789,7 @@
             "/ganglia/"
           ]
         ]
-      },
-      "Condition": "MasterPublicIp"
+      }
     },
     "ResourcesS3Bucket": {
       "Description": "S3 user bucket where AWS ParallelCluster resources are stored",


### PR DESCRIPTION
The configuration option `use_public_ips = true`, is used to toggle
allocation of elastic ip's. Many customers don't want to have to use
an elastic ip, but they still want too ssh into their instance. This
patch allows users to `pcluster ssh cluster` when `use_public_ips = false`.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
