### PR TITLE
cfn-lint: disable iE3008 because of a cfn-python-lint issue

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -209,9 +209,10 @@ deps = cfn-lint
 # E2504 disabled since does not allow two-digit numbers in ephemeral(n)
 # W2507 disabled since we want to have nullable String type parameters
 # E2523 disabled since we have both a Launch Template and Launch Configuration
+# iE3008 disabled because of https://github.com/awslabs/cfn-python-lint/issues/564
 commands =
     cfn-lint -iE2504 -iW2507 -iE2523 aws-parallelcluster.cfn.json
-    cfn-lint batch-substack.cfn.json
+    cfn-lint -iE3008 batch-substack.cfn.json
     cfn-lint ebs-substack.cfn.json
     cfn-lint efs-substack.cfn.json
     cfn-lint raid-substack.cfn.json


### PR DESCRIPTION
The latest release 0.18.0 re-opened the bug:
https://github.com/awslabs/cfn-python-lint/issues/564
