### PR TITLE
Several minor improvements to integration tests

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_awsbatch.py
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch.py
@@ -18,7 +18,7 @@ from remote_command_executor import RemoteCommandExecutor
 from tests.common.schedulers_common import AWSBatchCommands
 
 
-@pytest.mark.regions(["us-east-1", "eu-west-1"])
+@pytest.mark.regions(["eu-west-1"])
 @pytest.mark.instances(["c5.xlarge", "t2.large"])
 @pytest.mark.dimensions("*", "*", "alinux", "awsbatch")
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
@@ -9,6 +9,7 @@ base_os = {{ os }}
 key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = awsbatch
+master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 min_vcpus = 2
 desired_vcpus = 2

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -41,7 +41,7 @@ def test_slurm(region, pcluster_config_reader, clusters_factory):
     _test_slurm_version(remote_command_executor)
     _test_dynamic_max_cluster_size(remote_command_executor, region, cluster.asg)
     _test_cluster_limits(remote_command_executor, max_queue_size, region, cluster.asg)
-    _test_job_dependencies(remote_command_executor, region, cluster.cfn_name, scaledown_idletime)
+    _test_job_dependencies(remote_command_executor, region, cluster.cfn_name, scaledown_idletime, max_queue_size)
     _test_dynamic_dummy_nodes(remote_command_executor, max_queue_size)
 
 
@@ -82,7 +82,7 @@ def _test_dynamic_dummy_nodes(remote_command_executor, max_queue_size):
     _assert_dummy_nodes(remote_command_executor, max_queue_size - 1)
 
 
-def _test_job_dependencies(remote_command_executor, region, stack_name, scaledown_idletime):
+def _test_job_dependencies(remote_command_executor, region, stack_name, scaledown_idletime, max_queue_size):
     logging.info("Testing cluster doesn't scale when job dependencies are not satisfied")
     slurm_commands = SlurmCommands(remote_command_executor)
     result = slurm_commands.submit_command("sleep 60", nodes=1)
@@ -113,6 +113,8 @@ def _test_job_dependencies(remote_command_executor, region, stack_name, scaledow
     assert_that(max(compute_nodes_time_series)).is_equal_to(1)
     assert_that(asg_capacity_time_series[-1]).is_equal_to(0)
     assert_that(compute_nodes_time_series[-1]).is_equal_to(0)
+    _assert_dummy_nodes(remote_command_executor, max_queue_size)
+    assert_that(_retrieve_slurm_nodes_from_config(remote_command_executor)).is_empty()
 
 
 def _test_cluster_limits(remote_command_executor, max_queue_size, region, asg_name):
@@ -133,6 +135,11 @@ def _test_cluster_limits(remote_command_executor, max_queue_size, region, asg_na
 
 def _retrieve_slurm_dummy_nodes_from_config(remote_command_executor):
     retrieve_dummy_nodes_command = "sudo cat /opt/slurm/etc/slurm_parallelcluster_nodes.conf | head -n 1"
+    return remote_command_executor.run_remote_command(retrieve_dummy_nodes_command).stdout
+
+
+def _retrieve_slurm_nodes_from_config(remote_command_executor):
+    retrieve_dummy_nodes_command = "sudo tail -n +2 /opt/slurm/etc/slurm_parallelcluster_nodes.conf"
     return remote_command_executor.run_remote_command(retrieve_dummy_nodes_command).stdout
 
 

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -100,6 +100,7 @@ def _test_job_dependencies(remote_command_executor, region, stack_name, scaledow
 
     jobs_execution_time = 1
     estimated_scaleup_time = 5
+    max_scaledown_time = 10
     asg_capacity_time_series, compute_nodes_time_series, timestamps = get_compute_nodes_allocation(
         scheduler_commands=slurm_commands,
         region=region,
@@ -107,7 +108,7 @@ def _test_job_dependencies(remote_command_executor, region, stack_name, scaledow
         max_monitoring_time=minutes(jobs_execution_time)
         + minutes(scaledown_idletime)
         + minutes(estimated_scaleup_time)
-        + minutes(10),
+        + minutes(max_scaledown_time),
     )
     assert_that(max(asg_capacity_time_series)).is_equal_to(1)
     assert_that(max(compute_nodes_time_series)).is_equal_to(1)

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -100,7 +100,6 @@ def _test_job_dependencies(remote_command_executor, region, stack_name, scaledow
 
     jobs_execution_time = 1
     estimated_scaleup_time = 5
-    estimated_scaledown_time = 20
     asg_capacity_time_series, compute_nodes_time_series, timestamps = get_compute_nodes_allocation(
         scheduler_commands=slurm_commands,
         region=region,
@@ -108,7 +107,7 @@ def _test_job_dependencies(remote_command_executor, region, stack_name, scaledow
         max_monitoring_time=minutes(jobs_execution_time)
         + minutes(scaledown_idletime)
         + minutes(estimated_scaleup_time)
-        + minutes(estimated_scaledown_time),
+        + minutes(10),
     )
     assert_that(max(asg_capacity_time_series)).is_equal_to(1)
     assert_that(max(compute_nodes_time_series)).is_equal_to(1)

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -19,7 +19,7 @@ from tests.common.schedulers_common import get_scheduler_commands
 from tests.storage.storage_common import verify_directory_correctly_shared
 
 
-@pytest.mark.regions(["us-east-1", "eu-west-1", "cn-north-1", "us-gov-west-1"])
+@pytest.mark.regions(["us-west-2", "cn-north-1", "us-gov-west-1"])
 @pytest.mark.instances(["c4.xlarge", "c5.xlarge"])
 @pytest.mark.schedulers(["sge", "awsbatch"])
 @pytest.mark.usefixtures("region", "os", "instance")
@@ -35,7 +35,7 @@ def test_ebs_single(scheduler, pcluster_config_reader, clusters_factory):
     _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
 
-@pytest.mark.regions(["us-east-1", "eu-west-1", "cn-north-1", "us-gov-west-1"])
+@pytest.mark.regions(["us-east-1", "cn-north-1", "us-gov-east-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["sge", "awsbatch"])
 @pytest.mark.usefixtures("region", "os", "instance")
@@ -52,7 +52,7 @@ def test_ebs_multiple(scheduler, pcluster_config_reader, clusters_factory):
         _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
 
-@pytest.mark.regions(["us-east-1", "cn-north-1", "us-gov-west-1"])
+@pytest.mark.regions(["eu-west-2", "cn-northwest-1", "us-gov-west-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["sge", "awsbatch"])
 @pytest.mark.usefixtures("region", "os", "instance")

--- a/tests/integration-tests/tests/storage/test_ebs/test_default_ebs/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_default_ebs/pcluster.config.ini
@@ -9,6 +9,7 @@ base_os = {{ os }}
 key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 {% if scheduler == "awsbatch" %}
 min_vcpus = 4

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.ini
@@ -9,6 +9,7 @@ base_os = {{ os }}
 key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 {% if scheduler == "awsbatch" %}
 min_vcpus = 4

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.ini
@@ -9,6 +9,7 @@ base_os = {{ os }}
 key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 {% if scheduler == "awsbatch" %}
 min_vcpus = 4

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -19,7 +19,7 @@ from remote_command_executor import RemoteCommandExecutor
 from tests.common.schedulers_common import SgeCommands
 
 
-@pytest.mark.regions(["us-east-1", "eu-west-1"])
+@pytest.mark.regions(["eu-central-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.oss(["centos7", "alinux"])
 @pytest.mark.schedulers(["sge"])

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
@@ -9,6 +9,7 @@ base_os = {{ os }}
 key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 {% if scheduler == "awsbatch" %}
 min_vcpus = 4

--- a/tests/integration-tests/tests/storage/test_raid.py
+++ b/tests/integration-tests/tests/storage/test_raid.py
@@ -19,7 +19,7 @@ from tests.common.schedulers_common import get_scheduler_commands
 from tests.storage.storage_common import verify_directory_correctly_shared
 
 
-@pytest.mark.regions(["us-east-1", "eu-west-1", "cn-north-1", "us-gov-west-1"])
+@pytest.mark.regions(["ap-south-1", "cn-northwest-1", "us-gov-east-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["sge", "awsbatch"])
 @pytest.mark.usefixtures("region", "os", "instance")
@@ -35,7 +35,7 @@ def test_raid_performance_mode(scheduler, pcluster_config_reader, clusters_facto
     _test_raid_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
 
-@pytest.mark.regions(["us-east-1", "eu-west-1", "cn-north-1", "us-gov-west-1"])
+@pytest.mark.regions(["us-east-2", "cn-north-1", "us-gov-west-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["sge", "awsbatch"])
 @pytest.mark.usefixtures("region", "os", "instance")

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.ini
@@ -9,6 +9,7 @@ base_os = {{ os }}
 key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 {% if scheduler == "awsbatch" %}
 min_vcpus = 4

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.ini
@@ -9,6 +9,7 @@ base_os = {{ os }}
 key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 {% if scheduler == "awsbatch" %}
 min_vcpus = 4


### PR DESCRIPTION
* Revert workaround commit "Double the estimated scaledown time"
* Use same parametrized instance type for master and compute 
* redistribute tests that are running in a single AWS region across several regions to avoid overloading a single one 
* add succeeded tests count to json report 
* verify compute nodes correctly scale-down with Slurm. This would have caught the following bug: https://github.com/aws/aws-parallelcluster-node/pull/121

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
