### PR TITLE
integ tests: run FSx tests in us-east-1

### DIFF
--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -19,7 +19,7 @@ from remote_command_executor import RemoteCommandExecutor
 from tests.common.schedulers_common import SgeCommands
 
 
-@pytest.mark.regions(["eu-central-1"])
+@pytest.mark.regions(["us-east-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.oss(["centos7", "alinux"])
 @pytest.mark.schedulers(["sge"])


### PR DESCRIPTION
FSx Lustre not available in eu-central-1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
