### PR TITLE
Remove AWS Credentials from ParallelCluster Config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,6 @@ Then, run pcluster configure:
 
   $ pcluster configure
   Cluster Template [default]:
-  AWS Access Key ID []:
-  AWS Secret Access Key ID []:
   Acceptable Values for AWS Region ID:
       ap-south-1
       ...

--- a/cli/pcluster/examples/config
+++ b/cli/pcluster/examples/config
@@ -8,13 +8,6 @@ update_check = true
 sanity_check = true
 
 [aws]
-# This is the AWS credentials section (required).
-# These settings apply to all clusters
-# replace these with your AWS keys
-# If not defined, boto will attempt to use a) environment
-# or b) EC2 IAM role.
-#aws_access_key_id = #your_aws_access_key_id
-#aws_secret_access_key = #your_secret_access_key
 # Uncomment to specify a different Amazon AWS region  (OPTIONAL)
 # (Defaults to us-east-1 if not defined in environment or below)
 #aws_region_name = #region

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -55,16 +55,10 @@ Attempt to validate the existence of the resources defined in parameters. ::
 
 aws
 ^^^
-AWS credentials/region section.
+AWS Region section.
 
-These settings apply to all clusters and are REQUIRED.
-
-For security purposes, AWS highly recommends using the environment, EC2 IAM Roles, or the
-`AWS CLI <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html>`_ to store credentials rather than saving into the AWS ParallelCluster config file. ::
-
-    [aws]
-    aws_access_key_id = #your_aws_access_key_id
-    aws_secret_access_key = #your_secret_access_key
+To store credentials, you can use environment variables, IAM roles, or the preferred way, the
+`AWS CLI <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html>`_ ::
 
     # Defaults to us-east-1 if not defined in environment or below
     aws_region_name = #region

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -65,6 +65,16 @@ was originally installed:
 Configuring AWS ParallelCluster
 ===============================
 
+First you'll need to setup your IAM credentials, see `AWS CLI <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html>`_.
+for more information.
+
+::
+    $ aws configure
+    AWS Access Key ID [None]: AKIAIOSFODNN7EXAMPLE
+    AWS Secret Access Key [None]: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    Default region name [us-east-1]: us-east-1
+    Default output format [None]:
+
 Once installed you will need to setup some initial config. The easiest way to do this is below:
 
 ::
@@ -78,15 +88,6 @@ cluster from.
 ::
 
         Cluster Template [mycluster]:
-
-Next, you will be prompted for your AWS Access & Secret Keys. Enter the keys for an IAM user with administrative
-privileges.
-These can also be read from your environment variables or the AWS CLI config.
-
-::
-
-        AWS Access Key ID []:
-        AWS Secret Access Key ID []:
 
 Now, you will be presented with a list of valid AWS region identifiers. Choose the region in which you'd like your
 cluster to run.
@@ -234,3 +235,6 @@ to allow Inbound connection to the port 80 from your Public IP.
 
 .. spelling::
    aws
+   wJalrXUtnFEMI
+   MDENG
+   bPxRfiCYEXAMPLEKEY


### PR DESCRIPTION
For a better security posture, we're removing AWS credentials from the
parallelcluster config file. Credentials can be setup from the aws cli,
for example:

```bash
$ aws configure
AWS Access Key ID [None]: AKIAI44QH8DHBEXAMPLE
AWS Secret Access Key [None]: je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY
Default region name [None]: us-east-1
Default output format [None]: text
```

See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
