### PR TITLE
Change OrderedDict Initialization

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -460,10 +460,13 @@ class ParallelClusterConfig(object):
         self.parameters["MaxSize"] = "10"
 
         size_parameters = OrderedDict(
-            initial_queue_size=("InitialQueueSize", None),
-            maintain_initial_size=("MaintainInitialSize", None),
-            max_queue_size=("MaxQueueSize", None),
+            [
+                ("initial_queue_size", ("InitialQueueSize", None)),
+                ("maintain_initial_size", ("MaintainInitialSize", None)),
+                ("max_queue_size", ("MaxQueueSize", None)),
+            ]
         )
+
         for key in size_parameters:
             try:
                 __temp__ = self.__config.get(self.__cluster_section, key)


### PR DESCRIPTION
Fixes https://github.com/aws/aws-parallelcluster/issues/1016

This is the only occurrence of `OrderedDict` that's initialized using parameters rather than a list. This commit unifies the code base by using the all the same initialization method.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
