### PR TITLE
Revert "integ tests: disabling tests for centos7-torque until bug is solved

### DIFF
--- a/tests/integration-tests/tests/test_scaling.py
+++ b/tests/integration-tests/tests/test_scaling.py
@@ -23,7 +23,6 @@ from time_utils import minutes
 @pytest.mark.skip_schedulers(["awsbatch"])
 @pytest.mark.skip_dimensions("cn-northwest-1", "*", "ubuntu1404", "*")  # aws-cfn-bootstrap missing in Ningxia region
 @pytest.mark.skip_dimensions("cn-northwest-1", "*", "ubuntu1604", "*")  # aws-cfn-bootstrap missing in Ningxia region
-@pytest.mark.skip_dimensions("*", "*", "centos7", "torque")  # https://github.com/aws/aws-parallelcluster/issues/875
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):
     scaledown_idletime = 4


### PR DESCRIPTION
Re-enabling tests since we have a fix for this issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
