### PR TITLE
Version ParallelCluster Stacks

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -22,6 +22,8 @@ from botocore.exceptions import NoCredentialsError
 
 from pcluster import easyconfig, pcluster
 
+LOGGER = logging.getLogger("pcluster.pcluster")
+
 
 def create(args):
     pcluster.create(args)
@@ -56,7 +58,8 @@ def update(args):
 
 
 def version(args):
-    pcluster.version(args)
+    version = pcluster.version()
+    LOGGER.info(version)
 
 
 def start(args):
@@ -162,7 +165,7 @@ Examples::
     # update command subparser
     pupdate = subparsers.add_parser(
         "update",
-        help="Updates a running cluster using the values in the config " "file or in a TEMPLATE_URL provided.",
+        help="Updates a running cluster using the values in the config file.",
         epilog="When the command is called and it begins polling for the status of that call, "
         'it is safe to "Ctrl-C" out. You can always return to that status by '
         'calling "pcluster status mycluster".',
@@ -178,7 +181,6 @@ Examples::
         default=False,
         help="Disable CloudFormation stack rollback on error.",
     )
-    pupdate.add_argument("-u", "--template-url", help="Specifies the URL for a custom CloudFormation template.")
     pupdate.add_argument("-t", "--cluster-template", help="Indicates which cluster template to use.")
     pupdate.add_argument("-p", "--extra-parameters", help="Adds extra parameters to the stack update.")
     pupdate.add_argument(
@@ -245,6 +247,7 @@ Examples::
         help="Displays a list of stacks associated with AWS ParallelCluster.",
         epilog="This command lists the names of any CloudFormation stacks named parallelcluster-*",
     )
+    plist.add_argument("--color", action="store_true", default=False, help="Display the cluster status in color.")
     _addarg_config(plist)
     _addarg_region(plist)
     plist.set_defaults(func=list_stacks)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -100,6 +100,8 @@ template_url
 """"""""""""
 Defines the path to the CloudFormation template used to create the cluster.
 
+Updates use the template the stack was created with.
+
 Defaults to
 ``https://s3.amazonaws.com/<aws_region_name>-aws-parallelcluster/templates/aws-parallelcluster-<version>.cfn.json``. ::
 


### PR DESCRIPTION
* Adds a version tag to newly created stacks
* Disable using a template **other** than the one used to create the
stack in an update
* List the version and status during `pcluster list`
* Color the output based on stack status

![image](https://user-images.githubusercontent.com/5545980/56781166-61378400-679f-11e9-88a0-12cb122ad8a7.png)


Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
