### PR TITLE
integ tests: skipping ubuntu tests in cn-northwest-1 globally

### DIFF
--- a/tests/integration-tests/conftest_markers.py
+++ b/tests/integration-tests/conftest_markers.py
@@ -26,6 +26,8 @@ UNSUPPORTED_DIMENSIONS = [
     ("us-gov-west-1", "*", "*", "awsbatch"),
     ("us-gov-east-1", "*", "*", "awsbatch"),
     ("us-gov-east-1", "*", "c4.xlarge", "*"),
+    ("cn-northwest-1", "*", "ubuntu1404", "*"),  # aws-cfn-bootstrap missing in Ningxia region
+    ("cn-northwest-1", "*", "ubuntu1604", "*"),  # aws-cfn-bootstrap missing in Ningxia region
 ]
 
 

--- a/tests/integration-tests/tests/test_scaling.py
+++ b/tests/integration-tests/tests/test_scaling.py
@@ -21,8 +21,6 @@ from time_utils import minutes
 
 
 @pytest.mark.skip_schedulers(["awsbatch"])
-@pytest.mark.skip_dimensions("cn-northwest-1", "*", "ubuntu1404", "*")  # aws-cfn-bootstrap missing in Ningxia region
-@pytest.mark.skip_dimensions("cn-northwest-1", "*", "ubuntu1604", "*")  # aws-cfn-bootstrap missing in Ningxia region
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):
     scaledown_idletime = 4


### PR DESCRIPTION
Due to aws-cfn-bootstrap missing in Ningxia region

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
