### PR TITLE
cli: speed up version evaluation in pcluster list command

### DIFF
--- a/cli/pcluster/pcluster.py
+++ b/cli/pcluster/pcluster.py
@@ -379,8 +379,7 @@ def get_version(stack):
     :param stack: stack object
     :return: version or empty string
     """
-    tags = filter(lambda x: x.get("Key") == "Version", stack.get("Tags"))
-    return list(tags)[0].get("Value") if len(list(tags)) > 0 else ""
+    return next((tag.get("Value") for tag in stack.get("Tags") if tag.get("Key") == "Version"), "")
 
 
 def colorize(stack_status, args):


### PR DESCRIPTION
We are avoiding to create a list multiple times, the iteration can stop once the match is found and we also have a default value.

Tested with both python 3.7 and 2.7