### PR TITLE
integ tests: test compute replacement when not attached to scheduler

### DIFF
--- a/tests/integration-tests/tests/common/compute_logs_common.py
+++ b/tests/integration-tests/tests/common/compute_logs_common.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from retrying import retry
+
+from remote_command_executor import RemoteCommandExecutionError
+from time_utils import minutes, seconds
+
+
+@retry(
+    retry_on_exception=lambda exception: isinstance(exception, RemoteCommandExecutionError),
+    wait_fixed=seconds(30),
+    stop_max_delay=minutes(10),
+)
+def wait_compute_log(remote_command_executor):
+    remote_command_executor.run_remote_command("test -d /home/logs/compute", log_error=False)
+    # return instance-id
+    return remote_command_executor.run_remote_command(
+        "find /home/logs/compute/ -type f -printf '%f\n' -quit  | head -1 | cut -d. -f1", log_error=False
+    ).stdout

--- a/tests/integration-tests/tests/test_scaling/test_nodewatcher_terminates_failing_node/pcluster.config.ini
+++ b/tests/integration-tests/tests/test_scaling/test_nodewatcher_terminates_failing_node/pcluster.config.ini
@@ -1,0 +1,19 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+initial_queue_size = 1
+maintain_initial_size = true
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}

--- a/tests/integration-tests/tests/test_scaling/test_nodewatcher_terminates_failing_node/slurm_kill_scheduler_job.sh
+++ b/tests/integration-tests/tests/test_scaling/test_nodewatcher_terminates_failing_node/slurm_kill_scheduler_job.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+sudo kill $(ps aux | grep '[s]lurm' | awk '{print $2}')


### PR DESCRIPTION
Tests that nodewatcher correctly terminates a faulty node. The failures is injected by submitting a job that kills the scheduler

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
