### PR TITLE
EFA

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -518,6 +518,7 @@ class ParallelClusterConfig(object):
             custom_chef_runlist=("CustomChefRunList", None),
             additional_cfn_template=("AdditionalCfnTemplate", None),
             custom_awsbatch_template_url=("CustomAWSBatchTemplateURL", None),
+            enable_efa=("EFA", None),
         )
         for key in cluster_options:
             try:

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 import boto3
 from botocore.exceptions import ClientError
 
-from pcluster.utils import get_instance_vcpus, get_supported_batch_instances
+from pcluster.utils import get_instance_vcpus, get_supported_features
 
 
 class ResourceValidator(object):
@@ -221,6 +221,57 @@ class ResourceValidator(object):
             # 1,024 MiB (1 GiB) and can go as high as 512,000 MiB
             if not (1 <= int(resource_value[0]) <= 512000):
                 self.__fail(resource_type, "has a minimum size of 1 MiB, and max size of 512,000 MiB")
+
+    def __validate_efa_sg(self, resource_type, sg_id):
+        try:
+            ec2 = boto3.client(
+                "ec2",
+                region_name=self.region,
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+            )
+            sg = ec2.describe_security_groups(GroupIds=[sg_id]).get("SecurityGroups")[0]
+            in_rules = sg.get("IpPermissions")
+            out_rules = sg.get("IpPermissionsEgress")
+
+            allowed_in = False
+            allowed_out = False
+            for rule in in_rules:
+                # UserIdGroupPairs is always of length 1, so grabbing 0th object is ok
+                if (
+                    rule.get("IpProtocol") == "-1"
+                    and len(rule.get("UserIdGroupPairs")) > 0
+                    and rule.get("UserIdGroupPairs")[0].get("GroupId") == sg_id
+                ):
+                    allowed_in = True
+                    break
+            for rule in out_rules:
+                if (
+                    rule.get("IpProtocol") == "-1"
+                    and len(rule.get("UserIdGroupPairs")) > 0
+                    and rule.get("UserIdGroupPairs")[0].get("GroupId") == sg_id
+                ):
+                    allowed_out = True
+                    break
+            if not (allowed_in and allowed_out):
+                self.__fail(
+                    resource_type,
+                    "VPC Security Group %s must allow all traffic in and out from itself. "
+                    "See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security" % sg_id,
+                )
+        except ClientError as e:
+            self.__fail(resource_type, e.response.get("Error").get("Message"))
+
+    def __validate_efa_parameters(self, resource_type, resource_value):
+        supported_features = get_supported_features(self.region, "efa")
+        valid_instances = supported_features.get("instances")
+        if resource_value.get("ComputeInstanceType", None) not in valid_instances:
+            self.__fail(resource_type, "Compute Instance needs to be one of %s" % valid_instances)
+        if resource_value.get("PlacementGroup", "NONE") == "NONE":
+            self.__fail(resource_type, "Placement group is required, set placement_group.")
+        if "VPCSecurityGroupId" in resource_value:
+            sg_id = resource_value.get("VPCSecurityGroupId")
+            self.__validate_efa_sg(resource_type, sg_id)
 
     def validate(self, resource_type, resource_value):  # noqa: C901 FIXME
         """
@@ -530,6 +581,9 @@ class ResourceValidator(object):
         # FSX FS Id check
         elif resource_type in ["fsx_fs_id", "FSx_storage_capacity", "FSx_imported_file_chunk_size", "FSx_export_path"]:
             self.__validate_fsx_parameters(resource_type, resource_value)
+        elif resource_type == "EFA":
+            self.__validate_efa_parameters(resource_type, resource_value)
+
         # Batch Parameters
         elif resource_type == "AWSBatch_Parameters":
             # Check region
@@ -566,7 +620,7 @@ class ResourceValidator(object):
             if "ComputeInstanceType" in resource_value:
                 compute_instance_type = resource_value["ComputeInstanceType"]
                 try:
-                    supported_instances = get_supported_batch_instances(self.region)
+                    supported_instances = get_supported_features(self.region, "batch").get("instances")
                     if supported_instances:
                         for instance in compute_instance_type.split(","):
                             if not instance.strip() in supported_instances:

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1202,11 +1202,15 @@
       ]
     },
     "EnableEFA": {
-      "Fn::Equals": [
+      "Fn::Not": [
         {
-          "Ref": "EFA"
-        },
-        "compute"
+          "Fn::Equals": [
+            {
+              "Ref": "EFA"
+            },
+            "NONE"
+          ]
+        }
       ]
     }
   },
@@ -3431,7 +3435,7 @@
               "InterfaceType": {
                 "Fn::If": [
                   "EnableEFA",
-                  "EFA",
+                  "efa",
                   {
                     "Ref": "AWS::NoValue"
                   }
@@ -4222,6 +4226,34 @@
             "ToPort": 65535
           }
         ]
+      },
+      "Condition": "CreateSecurityGroups"
+    },
+    "ComputeSecurityGroupEgress": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties": {
+        "IpProtocol": "-1",
+        "FromPort": 0,
+        "ToPort": 65535,
+        "DestinationSecurityGroupId": {
+          "Ref": "ComputeSecurityGroup"
+        },
+        "GroupId": {
+          "Ref": "ComputeSecurityGroup"
+        }
+      },
+      "Condition": "CreateSecurityGroups"
+    },
+    "ComputeSecurityGroupNormalEgress": {
+      "Type": "AWS::EC2::SecurityGroupEgress",
+      "Properties": {
+        "IpProtocol": "-1",
+        "FromPort": 0,
+        "ToPort": 65535,
+        "CidrIp": "0.0.0.0/0",
+        "GroupId": {
+          "Ref": "ComputeSecurityGroup"
+        }
       },
       "Condition": "CreateSecurityGroups"
     },

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -598,6 +598,11 @@
       "Description": "Comma separated list of efs related options, 8 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,valid_existing_MTorNot]",
       "Type": "String",
       "Default": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE"
+    },
+    "EFA": {
+      "Description": "Enable EFA on the compute nodes, enable_efa = compute",
+      "Type": "String",
+      "Default": "NONE"
     }
   },
   "Conditions": {
@@ -1194,6 +1199,14 @@
             "NONE"
           ]
         }
+      ]
+    },
+    "EnableEFA": {
+      "Fn::Equals": [
+        {
+          "Ref": "EFA"
+        },
+        "compute"
       ]
     }
   },
@@ -3415,6 +3428,15 @@
           "NetworkInterfaces": [
             {
               "DeviceIndex": 0,
+              "InterfaceType": {
+                "Fn::If": [
+                  "EnableEFA",
+                  "EFA",
+                  {
+                    "Ref": "AWS::NoValue"
+                  }
+                ]
+              },
               "Groups": [
                 {
                   "Fn::If": [


### PR DESCRIPTION
### Background

This add the `enable_efa = compute` flag and validates the parameters to make sure they're sane.

### Validates

```ini
[cluster efa]
base_os = [alinux | centos7]
enable_efa = compute
placement_group != NONE
compute_instance_type = [c5n.18xlarge | p3dn.24xlarge]

[vpc public]
vpc_security_group_id = sg-00b54f8b1f050a52e # if set, checks ingress and egress allow all traffic to itself [1]
```

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
