### PR TITLE
 integ tests - cfn_init: fix log file assertion

### DIFF
--- a/tests/integration-tests/tests/cfn-init/test_cfn_init.py
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init.py
@@ -53,7 +53,7 @@ def _assert_compute_logs(remote_command_executor, instance_id):
     remote_command_executor.run_remote_command(
         "tar -xf /home/logs/compute/{0}.tar.gz --directory /tmp".format(instance_id)
     )
-    remote_command_executor.run_remote_command("test -f /tmp/var/log/nodewatcher")
+    remote_command_executor.run_remote_command("test -f /tmp/var/log/cfn-init.log")
     messages_log = remote_command_executor.run_remote_command("cat /tmp/var/log/messages", hide=True).stdout
     assert_that(messages_log).contains(
         "Reporting instance as unhealthy and dumping logs to /home/logs/compute/{0}.tar.gz".format(instance_id)


### PR DESCRIPTION
nodewatcher log is not present if failures happen during userdata

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
