### PR TITLE
AWS Batch GPU Support

### DIFF
--- a/docs/awsbatchcli/awsbsub.rst
+++ b/docs/awsbatchcli/awsbsub.rst
@@ -17,3 +17,4 @@ awsbsub
     startedAt
     subfolder
     utf
+    gpus


### PR DESCRIPTION
### AWS Batch GPU Jobs 
To submit a GPU job, just do:

```
$ awsbsub --gpus 1 nvidia-smi
```
For this to work, there's three requirements:

1. **AMI** - AWS Batch uses the ecs GPU-optimized ami for any P Family instance. See [1]
2. **Container** - nvidia-docker or deep learning container needs to be used here. See [2] and [3]. Container will be a separate PR.
3. **Instance** - Needs to be one of `p2`, `p3` families

[1] https://docs.aws.amazon.com/batch/latest/userguide/batch-gpu-ami.html
[2] https://docs.aws.amazon.com/dlami/latest/devguide/deep-learning-containers-images.html
[3] https://github.com/NVIDIA/nvidia-docker

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
