### PR TITLE
integ tests - cfn_init: make log assertion work cross OSs

### DIFF
--- a/tests/integration-tests/tests/cfn-init/test_cfn_init.py
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init.py
@@ -54,7 +54,9 @@ def _assert_compute_logs(remote_command_executor, instance_id):
         "tar -xf /home/logs/compute/{0}.tar.gz --directory /tmp".format(instance_id)
     )
     remote_command_executor.run_remote_command("test -f /tmp/var/log/cfn-init.log")
-    messages_log = remote_command_executor.run_remote_command("cat /tmp/var/log/messages", hide=True).stdout
-    assert_that(messages_log).contains(
-        "Reporting instance as unhealthy and dumping logs to /home/logs/compute/{0}.tar.gz".format(instance_id)
-    )
+    output = remote_command_executor.run_remote_command(
+        'find /tmp/var/log -type f | xargs grep "Reporting instance as unhealthy and dumping logs to"',
+        hide=True,
+        login_shell=False,
+    ).stdout
+    assert_that(output).is_not_empty()

--- a/tests/integration-tests/tests/common/compute_logs_common.py
+++ b/tests/integration-tests/tests/common/compute_logs_common.py
@@ -23,5 +23,5 @@ def wait_compute_log(remote_command_executor):
     remote_command_executor.run_remote_command("test -d /home/logs/compute", log_error=False)
     # return instance-id
     return remote_command_executor.run_remote_command(
-        "find /home/logs/compute/ -type f -printf '%f\n' -quit  | head -1 | cut -d. -f1", log_error=False
+        "find /home/logs/compute/ -type f -printf '%f\\n' -quit  | head -1 | cut -d. -f1", log_error=False
     ).stdout

--- a/tests/integration-tests/tests/common/scaling_common.py
+++ b/tests/integration-tests/tests/common/scaling_common.py
@@ -130,5 +130,7 @@ def assert_instance_replaced_or_terminating(instance_id, region):
         InstanceIds=[instance_id]
     )
     assert_that(
-        not response["AutoScalingInstances"] or response["AutoScalingInstances"][0]["LifecycleState"] == "Terminating"
+        not response["AutoScalingInstances"]
+        or response["AutoScalingInstances"][0]["LifecycleState"] == "Terminating"
+        or response["AutoScalingInstances"][0]["HealthStatus"] == "UNHEALTHY"
     ).is_true()


### PR DESCRIPTION
Based on the OS the userdata stdout logs are saved  to a different file. Making the assertion more generic.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
