### PR TITLE
Keep DynamoDB from updating

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1535,6 +1535,7 @@
     },
     "DynamoDBTable": {
       "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Retain",
       "Properties": {
         "AttributeDefinitions": [
           {


### PR DESCRIPTION
### Overview

DynamoDB (in provisioned mode) is limited to (1) update each day, preventing a `pcluster update`.

To fix this, we're adding `"UpdateReplacePolicy" : "Retain",`, which disables updates to this resource.

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html

### Testing

To test, I created a stack and then updated it twice. Confirmed on the cloudformation console DynamoDB table wasn't updated.

```bash
$ pcluster create test
...
$ pcluster update test
...
$ pcluster update test
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
