### PR TITLE
integ tests - scaling: check there are no errors in logs

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -9,7 +9,6 @@ envlist =
 
 # Default testenv. Used to run tests on all python versions.
 [testenv]
-# deps = -rtests/requirements.txt  TODO: ADD UNIT TESTS
 whitelist_externals =
     bash
 deps = -rtests/requirements.txt
@@ -61,7 +60,9 @@ commands =
 [testenv:isort]
 basepython = python3
 skip_install = true
-deps = isort
+deps =
+    isort
+    seed-isort-config
 commands =
     isort -rc -w 120 \
         {[vars]code_dirs} \


### PR DESCRIPTION
- improve scaling tests by checking that no errors are present in the logs
- seed-isort-config helps recognising third party packages when sorting the import

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
