### PR TITLE
update sanity check to solve cidr_value and public_ips conflicts

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -354,6 +354,11 @@ class ParallelClusterConfig(object):
                     "VPC section [%s] used in [%s] section is not defined" % (vpc_section, self.__cluster_section)
                 )
 
+        # Check that cidr and public ips are not both set
+        cidr_value = self.__config.get(vpc_section, "compute_subnet_cidr", fallback=None)
+        public_ips = self.__config.getboolean(vpc_section, "use_public_ips", fallback=True)
+        ResourceValidator.validate_vpc_coherence(cidr_value, public_ips)
+
     def __check_account_capacity(self):
         """Try to launch the requested number of instances to verify Account limits."""
         if self.parameters.get("Scheduler") == "awsbatch" or self.parameters.get("ClusterType", "ondemand") == "spot":

--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -47,6 +47,17 @@ class ResourceValidator(object):
         return "aws"
 
     @staticmethod
+    def validate_vpc_coherence(cidr_value, public_ip):
+        """
+        Check that cidr_value and public_ip parameters are not conflicting.
+
+        :param cidr_value: the value of compute_subnet_cidr set by the user (default should be None)
+        :param public_ip: the value of use_public_ips set by the user (default should be True)
+        """
+        if cidr_value and public_ip is False:
+            ResourceValidator.__fail("VPC COHERENCE", "compute_subnet_cidr needs use_public_ips to be true")
+
+    @staticmethod
     def __check_sg_rules_for_port(rule, port_to_check):
         """
         Verify if the security group rule accepts connections on the given port.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -593,6 +593,9 @@ If true, an Elastic IP will be associated to the Master instance.
 If false, the Master instance will have a Public IP (or not) according to the value
 of the "Auto-assign Public IP" subnet configuration parameter.
 
+.. note::
+    This parameter can't be set to false if :code:`compute_subnet_cidr` is specified.
+
 See :ref:`networking configuration <networking>` for some examples.
 
 Defaults to true. ::


### PR DESCRIPTION
I verified with a test that for compute_subnet_cidr public_ips has to be
set to true, so I added the check into the code.
