### PR TITLE
Clarify wording on -t flag

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -157,7 +157,7 @@ Examples::
         "--template-url",
         help="Specifies the URL for a custom CloudFormation template, " "if it was used at creation time.",
     )
-    pcreate.add_argument("-t", "--cluster-template", help="Indicates which cluster template to use.")
+    pcreate.add_argument("-t", "--cluster-template", help="Indicates which section of the cluster template to use.")
     pcreate.add_argument("-p", "--extra-parameters", type=json.loads, help="Adds extra parameters to the stack create.")
     pcreate.add_argument("-g", "--tags", type=json.loads, help="Specifies additional tags to be added to the stack.")
     pcreate.set_defaults(func=create)
@@ -181,7 +181,7 @@ Examples::
         default=False,
         help="Disable CloudFormation stack rollback on error.",
     )
-    pupdate.add_argument("-t", "--cluster-template", help="Indicates which cluster template to use.")
+    pupdate.add_argument("-t", "--cluster-template", help="Indicates which section of the cluster template to use.")
     pupdate.add_argument("-p", "--extra-parameters", help="Adds extra parameters to the stack update.")
     pupdate.add_argument(
         "-rd",


### PR DESCRIPTION
In https://github.com/aws/aws-parallelcluster/pull/1019 I removed the `-u` flag. This commit updates the wording so the `-t` flag, which is used to select a specific cluster section in the parallelcluster config isn't confused with the old `-u` flag which was removed from `pcluster update`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
