### PR TITLE
fix util path

### DIFF
--- a/docs/custom_cookbook.rst
+++ b/docs/custom_cookbook.rst
@@ -21,7 +21,7 @@ Steps
 
 #. Upload the cookbook, changing ``[your_bucket]`` to a bucket you own ::
 
-        $ cd aws-parallelcluster-cookbook/utils
+        $ cd aws-parallelcluster-cookbook
         $ /bin/bash util/uploadCookbook.sh --bucket [your_bucket] --srcdir .
 
 #. From the output above, add the following variable to the AWS ParallelCluster config file, under the ``[cluster ...]`` section ::


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fix util path, there's no `utils` under `aws-parallelcluster-cookbook`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
