### PR TITLE
Integ tests: improve sge and slurm specific tests

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -29,3 +29,11 @@ def assert_asg_desired_capacity(region, asg_name, expected):
     asg_client = boto3.client("autoscaling", region_name=region)
     asg = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name]).get("AutoScalingGroups")[0]
     assert_that(asg.get("DesiredCapacity")).is_equal_to(expected)
+
+
+def assert_no_errors_in_logs(remote_command_executor, log_files):
+    __tracebackhide__ = True
+    for log_file in log_files:
+        log = remote_command_executor.run_remote_command("cat {0}".format(log_file), hide=True).stdout
+        for error_level in ["CRITICAL", "ERROR"]:
+            assert_that(log).does_not_contain(error_level)

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -151,9 +151,13 @@ class SgeCommands(SchedulerCommands):
         assert_that(match).is_not_none()
         return match.group(1)
 
-    def assert_job_submitted(self, qsub_output):  # noqa: D102
+    def assert_job_submitted(self, qsub_output, is_array=False):  # noqa: D102
         __tracebackhide__ = True
-        match = re.search(r"Your job ([0-9]+) \(.+\) has been submitted", qsub_output)
+        if is_array:
+            regex = r"Your job-array ([0-9]+)\.[0-9\-:]+ \(.+\) has been submitted"
+        else:
+            regex = r"Your job ([0-9]+) \(.+\) has been submitted"
+        match = re.search(regex, qsub_output)
         assert_that(match).is_not_none()
         return match.group(1)
 
@@ -186,7 +190,8 @@ class SgeCommands(SchedulerCommands):
         return int(result.stdout.split()[-1])
 
     def get_compute_nodes(self):  # noqa: D102
-        raise NotImplementedError
+        result = self._remote_command_executor.run_remote_command("qhost | grep ip- | awk '{print $1}'")
+        return result.stdout.splitlines()
 
 
 class SlurmCommands(SchedulerCommands):

--- a/tests/integration-tests/tests/schedulers/test_sge/test_sge/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_sge/test_sge/pcluster.config.ini
@@ -22,3 +22,5 @@ scaledown_idletime = {{ scaledown_idletime }}
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.ini
@@ -22,3 +22,5 @@ scaledown_idletime = {{ scaledown_idletime }}
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/test_scaling.py
+++ b/tests/integration-tests/tests/test_scaling.py
@@ -12,14 +12,15 @@
 import logging
 
 import pytest
+from retrying import retry
 
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
-from tests.common.assertions import assert_instance_replaced_or_terminating
+from tests.common.assertions import assert_instance_replaced_or_terminating, assert_no_errors_in_logs
 from tests.common.compute_logs_common import wait_compute_log
 from tests.common.scaling_common import get_compute_nodes_allocation, get_desired_asg_capacity
 from tests.common.schedulers_common import get_scheduler_commands
-from time_utils import minutes
+from time_utils import minutes, seconds
 
 
 @pytest.mark.skip_schedulers(["awsbatch"])
@@ -58,7 +59,7 @@ def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clu
     )
 
     logging.info("Verifying no error in logs")
-    _assert_no_errors_in_logs(remote_command_executor, ["/var/log/sqswatcher", "/var/log/jobwatcher"])
+    assert_no_errors_in_logs(remote_command_executor, ["/var/log/sqswatcher", "/var/log/jobwatcher"])
 
 
 @pytest.mark.regions(["sa-east-1"])
@@ -72,6 +73,8 @@ def test_nodewatcher_terminates_failing_node(scheduler, region, pcluster_config_
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
 
+    compute_nodes = scheduler_commands.get_compute_nodes()
+
     # submit a job that kills the slurm daemon so that the node enters a failing state
     scheduler_commands.submit_script(str(test_datadir / "{0}_kill_scheduler_job.sh".format(scheduler)))
     instance_id = wait_compute_log(remote_command_executor)
@@ -80,6 +83,14 @@ def test_nodewatcher_terminates_failing_node(scheduler, region, pcluster_config_
     assert_instance_replaced_or_terminating(instance_id, region)
     # verify that desired capacity is still 1
     assert_that(get_desired_asg_capacity(region, cluster.cfn_name)).is_equal_to(1)
+    _assert_nodes_removed_from_scheduler(scheduler_commands, compute_nodes)
+
+    assert_no_errors_in_logs(remote_command_executor, ["/var/log/sqswatcher", "/var/log/jobwatcher"])
+
+
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))
+def _assert_nodes_removed_from_scheduler(scheduler_commands, nodes):
+    assert_that(scheduler_commands.get_compute_nodes()).does_not_contain(*nodes)
 
 
 def _assert_compute_logs(remote_command_executor, instance_id):
@@ -153,11 +164,3 @@ def _assert_test_jobs_completed(remote_command_executor, max_jobs_exec_time):
     jobs_execution_time = jobs_completion_time - jobs_start_time
     logging.info("Test jobs completed in %d seconds", jobs_execution_time)
     assert_that(jobs_execution_time).is_less_than(max_jobs_exec_time)
-
-
-def _assert_no_errors_in_logs(remote_command_executor, log_files):
-    __tracebackhide__ = True
-    for log_file in log_files:
-        log = remote_command_executor.run_remote_command("cat {0}".format(log_file), hide=True).stdout
-        for error_level in ["CRITICAL", "ERROR"]:
-            assert_that(log).does_not_contain(error_level)

--- a/tests/integration-tests/tests/test_scaling/test_nodewatcher_terminates_failing_node/sge_kill_scheduler_job.sh
+++ b/tests/integration-tests/tests/test_scaling/test_nodewatcher_terminates_failing_node/sge_kill_scheduler_job.sh
@@ -11,3 +11,5 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 sudo /etc/init.d/sgeexecd.p6444 stop
+# keep job up and running
+sleep infinity

--- a/tests/integration-tests/tests/test_scaling/test_nodewatcher_terminates_failing_node/slurm_kill_scheduler_job.sh
+++ b/tests/integration-tests/tests/test_scaling/test_nodewatcher_terminates_failing_node/slurm_kill_scheduler_job.sh
@@ -11,3 +11,5 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 sudo kill $(ps aux | grep '[s]lurm' | awk '{print $2}')
+# keep job up and running
+sleep infinity


### PR DESCRIPTION
- add additional checks to verify node is correctly removed from scheduler when nodewatcher terminates the node due to errors. This also checks that node cleanup on SGE is correctly performed when a job is still running on a faulty node.

- add array and parallel jobs tests for SGE and Slurm


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
