### PR TITLE
Extended pcluster configure to speed up the configuration

### DIFF
--- a/cli/.flake8
+++ b/cli/.flake8
@@ -19,6 +19,7 @@ per-file-ignores =
     pcluster/cfnconfig.py: E402, D103
     tests/pcluster/pcluster-unittest.py: D101, D102, D103
     tests/awsbatch/test_*.py: D101, D102
+    tests/pcluster/configure/test_*.py: D101, D102, D103
     ../tests/integration-tests/tests/*: D103
     ../tests/integration-tests/*: D205, D400, D401
 exclude =

--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -368,3 +368,7 @@ def main():
     except Exception as e:
         logger.error("Unexpected error of type %s: %s", type(e).__name__, e)
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/pcluster/easyconfig.py
+++ b/cli/pcluster/easyconfig.py
@@ -29,7 +29,7 @@ import boto3
 import configparser
 from botocore.exceptions import BotoCoreError, ClientError
 
-from pcluster.utils import get_supported_os, get_supported_schedulers
+from pcluster.utils import NumberedList, get_supported_os, get_supported_schedulers
 
 from . import cfnconfig
 
@@ -63,32 +63,70 @@ def handle_client_exception(func):
     return wrapper
 
 
-def prompt(message, default_value=None, hidden=False, options=None, check_validity=False):
-    if hidden and default_value is not None:
-        user_prompt = message + " [*******" + default_value[-4:] + "]: "
-    else:
-        user_prompt = message + " ["
-        if default_value is not None:
-            user_prompt = user_prompt + default_value + "]: "
-        else:
-            user_prompt = user_prompt + "]: "
+def prompt(message, default_value=None, options=None):
+    """
+    Prompt the user a message and return the acquired value.
 
-    if isinstance(options, (list, tuple)):
+    Example:
+
+    prompt("vpc", "vpc-id1", [("vpc-id1", "nome-1"), ("vpc-id2", "nome-2")])
+
+    result:
+    __________________
+    Acceptable value for vpc:
+    1) vpc-id1 | sasso
+    2) vpc-id2 | cavolo
+
+    vpc[vpc-id1] = xxx
+    __________________
+
+    :param message: the message to show to the user
+    :param default_value: the value to return if user does not input anything
+    :param options: a list of items (can also be list of list or tuple of tuple) containing the options
+    to show to the user.
+    Only the first element of the tuple, if you pass a tuple will be considered as acceptable.
+    The user can then choose one of the option or write something that is not in them.
+    :raise ValueError if options is not a list of tuple
+    :return: the id of the option selected by the user.
+    """
+    user_prompt = "{0} [{1}]: ".format(message, default_value or "")
+    if options:
+        if not (isinstance(options, (tuple, list))):
+            # Should never been thrown, DEBUGGING
+            raise ValueError("options is not a list nor a tuple")
+        if not (isinstance(options[0], (tuple, list))):
+            # Convert a list to a list of tuple
+            options = [(item,) for item in options]
         print("Acceptable Values for %s: " % message)
-        for o in options:
-            print("    %s" % o)
+        allowed_values = set([item[0] for item in options])
+        numbered_items = NumberedList(options)
+        for key, value in numbered_items.get().items():
+            print("{0}. {1}".format(key, " | ".join(value)))
 
-    var = input(user_prompt).strip()
-
-    if var == "":
-        return default_value
+        result = get_correct_answer(allowed_values, default_value, message, numbered_items, user_prompt)
     else:
-        if check_validity and options is not None and var not in options:
-            print("ERROR: The value (%s) is not valid " % var)
-            print("Please select one of the Acceptable Values listed above.")
-            sys.exit(1)
-        else:
-            return var
+        user_input = input(user_prompt).strip()
+        result = user_input or default_value
+    return result
+
+
+def get_correct_answer(allowed_values, default_value, message, numbered_items, user_prompt):
+    user_input = input(user_prompt).strip()
+    if user_input == "":
+        result = default_value
+    else:
+        # We give the user the possibility to try again if wrong
+        while True:
+            result = numbered_items.get_item_by_index(int(user_input))[0] if user_input.isdigit() else user_input
+            if result in allowed_values:
+                break
+            else:
+                print("WARNING: {0} is not an acceptable value for {1}".format(user_input, message))
+                if input("Press q if you want to exit, or any other character to try again: ").strip() == "q":
+                    print("Aborted by the user")
+                    sys.exit(1)
+            user_input = input(user_prompt).strip()
+    return result
 
 
 @handle_client_exception
@@ -115,52 +153,47 @@ def ec2_conn(aws_region_name):
     return ec2
 
 
+def extract_tag_from_resource(resource, tag_name):
+    tags = resource.get("Tags", [])
+    return next((item.get("Value") for item in tags if item.get("Key") == tag_name), None)
+
+
+def _list_resource(resource, aws_region_name, resource_name, resource_id_name):
+    resource_options = []
+    for key in resource.get(resource_name):
+        keyid = key.get(resource_id_name)
+        name = extract_tag_from_resource(key, tag_name="Name")
+        resource_options.append((keyid, name)) if name else resource_options.append((keyid,))
+
+    if not resource_options:
+        print("ERROR: No {0} found in region  {1}".format(resource_name, aws_region_name))
+        print("Please create a {0} before continuing".format(resource_name[:-1]))
+        sys.exit(1)
+    return resource_options
+
+
 @handle_client_exception
-def list_keys(aws_region_name):
+def _list_keys(aws_region_name):
+    """Return a list of keys as a list of tuple of type (key-name,)."""
     conn = ec2_conn(aws_region_name)
     keypairs = conn.describe_key_pairs()
-    keynames = []
-    for key in keypairs.get("KeyPairs"):
-        keynames.append(key.get("KeyName"))
-
-    if not keynames:
-        print("ERROR: No Key Pairs found in region " + aws_region_name)
-        print("Please create an EC2 Key Pair before continuing")
-        sys.exit(1)
-
-    return keynames
+    return _list_resource(keypairs, aws_region_name, "KeyPairs", "KeyName")
 
 
 @handle_client_exception
-def list_vpcs(aws_region_name):
+def _list_vpcs(aws_region_name):
+    """Return a list of vpcs as a list of tuple of type (vpc-id, vpc-name (if present))."""
     conn = ec2_conn(aws_region_name)
     vpcs = conn.describe_vpcs()
-    vpcids = []
-    for vpc in vpcs.get("Vpcs"):
-        vpcids.append(vpc.get("VpcId"))
-
-    if not vpcids:
-        print("ERROR: No VPCs found in region " + aws_region_name)
-        print("Please create a VPC before continuing")
-        sys.exit(1)
-
-    return vpcids
+    return _list_resource(vpcs, aws_region_name, "Vpcs", "VpcId")
 
 
 @handle_client_exception
-def list_subnets(aws_region_name, vpc_id):
+def _list_subnets(aws_region_name, vpc_id):
+    """Return a list of subnet as a list of tuple of type (subnet-id, subnet-name (if present))."""
     conn = ec2_conn(aws_region_name)
     subnets = conn.describe_subnets(Filters=[{"Name": "vpcId", "Values": [vpc_id]}])
-    subnetids = []
-    for subnet in subnets.get("Subnets"):
-        subnetids.append(subnet.get("SubnetId"))
-
-    if not subnetids:
-        print("ERROR: No Subnets found in region " + aws_region_name)
-        print("Please create a VPC Subnet before continuing")
-        sys.exit(1)
-
-    return subnetids
+    return _list_resource(subnets, aws_region_name, "Subnets", "SubnetId")
 
 
 def configure(args):  # noqa: C901 FIXME!!!
@@ -193,7 +226,6 @@ def configure(args):  # noqa: C901 FIXME!!!
             config, section="aws", parameter_name="aws_region_name", default_value=DEFAULT_VALUES["aws_region_name"]
         ),
         options=get_regions(),
-        check_validity=True,
     )
 
     scheduler = prompt(
@@ -202,7 +234,6 @@ def configure(args):  # noqa: C901 FIXME!!!
             config, section=cluster_label, parameter_name="scheduler", default_value=DEFAULT_VALUES["scheduler"]
         ),
         options=get_supported_schedulers(),
-        check_validity=True,
     )
     scheduler_info = scheduler_handler(scheduler)
     is_aws_batch = scheduler == "awsbatch"
@@ -216,7 +247,6 @@ def configure(args):  # noqa: C901 FIXME!!!
                 config, section=cluster_label, parameter_name="base_os", default_value=DEFAULT_VALUES["os"]
             ),
             options=get_supported_os(scheduler),
-            check_validity=True,
         )
 
     max_queue_size = prompt(
@@ -249,27 +279,20 @@ def configure(args):  # noqa: C901 FIXME!!!
     )
     vpc_label = "vpc " + vpc_name
 
-    keys = list_keys(aws_region_name)
-    key_name = prompt(
-        "Key Name",
-        get_config_parameter(config, section=cluster_label, parameter_name="key_name", default_value=keys[0]),
-        options=keys,
-        check_validity=True,
-    )
+    keys = _list_keys(aws_region_name)
+    default_key = keys[0]
+    default_key_id = default_key[0]
+    key_name = prompt("Key Name", default_key_id, options=keys)
 
-    vpc_id = prompt(
-        "VPC ID",
-        get_config_parameter(config, section=vpc_label, parameter_name="vpc_id", default_value=None),
-        options=list_vpcs(aws_region_name),
-        check_validity=True,
-    )
+    vpcs = _list_vpcs(aws_region_name)
+    default_vpc = vpcs[0]
+    default_vpc_id = default_vpc[0]
+    vpc_id = prompt("VPC ID", default_vpc_id, options=vpcs)
 
-    master_subnet_id = prompt(
-        "Master Subnet ID",
-        get_config_parameter(config, section=vpc_label, parameter_name="master_subnet_id", default_value=None),
-        options=list_subnets(aws_region_name, vpc_id),
-        check_validity=True,
-    )
+    subnets = _list_subnets(aws_region_name, vpc_id)
+    default_subnet = subnets[0]
+    default_subnet_id = default_subnet[0]
+    master_subnet_id = prompt("Master Subnet ID", default_subnet_id, options=subnets)
 
     global_parameters = {
         "__name__": "global",
@@ -294,8 +317,10 @@ def configure(args):  # noqa: C901 FIXME!!!
     sections = [aws_parameters, cluster_parameters, vpc_parameters, global_parameters, aliases_parameters]
 
     # We first remove unnecessary parameters from the past configurations
-    for par in scheduler_info["parameters_to_remove"]:
-        config.remove_option(cluster_label, par)
+    if config.has_section(cluster_label):
+        for par in scheduler_info["parameters_to_remove"]:
+            config.remove_option(cluster_label, par)
+
     # Loop through the configuration sections we care about
     for section in sections:
         try:

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 from __future__ import absolute_import, print_function
 
+import collections
 import json
 import os
 import zipfile
@@ -199,3 +200,41 @@ def get_supported_schedulers():
     :return: a tuple of strings of the supported scheduler
     """
     return "sge", "torque", "slurm", "awsbatch"
+
+
+class NumberedList:
+    """
+    This class associates numbers to a list or a tuple of items.
+
+    It can be used to help a user decide an option faster.
+    """
+
+    def __init__(self, items):
+        """
+        Initialize the object with the list of object in which you want to add number.
+
+        :param items: the list of object in which number will be added
+        """
+        self.numbered_items = collections.OrderedDict()
+        for index, item in enumerate(items, start=1):
+            self.numbered_items[index] = item
+
+    def get(self):
+        """
+        Return an ordered dict of the items with the numbers added.
+
+        :return: the ordered dict
+        """
+        return self.numbered_items.copy()
+
+    def get_item_by_index(self, index):
+        """
+        Return the string associated with the number.
+
+        :param index: the number
+        :return: the associate string
+        :raise ValueError: If the number is not present or it is not a number
+        """
+        if index not in self.numbered_items:
+            raise ValueError
+        return self.numbered_items[index]

--- a/cli/tests/pcluster/configure/test_numbers_to_list.py
+++ b/cli/tests/pcluster/configure/test_numbers_to_list.py
@@ -1,0 +1,48 @@
+import collections
+
+import pytest
+
+from pcluster.utils import NumberedList
+
+
+def inizialize_non_empty():
+    return NumberedList(("a", "b", "c", "d", "e", "f"))
+
+
+def ordered_dict():
+    return collections.OrderedDict({1: "a", 2: "b", 3: "c"})
+
+
+def test_empty():
+    with pytest.raises(TypeError):
+        assert NumberedList()
+
+
+def test_iterable():
+    using_tuple = NumberedList(("a", "b", "c"))
+    assert using_tuple.get().items() == ordered_dict().items()
+    using_list = NumberedList(["a", "b", "c"])
+    assert using_list.get().items() == ordered_dict().items()
+
+
+def test_value_errors():
+    with pytest.raises(ValueError):
+        assert inizialize_non_empty().get_item_by_index(-1)
+        assert inizialize_non_empty().get_item_by_index("jon snow")
+        assert inizialize_non_empty().get_item_by_index(0)
+        assert inizialize_non_empty().get_item_by_index(7)
+
+
+def test_order():
+    using_tuple = NumberedList(("a", "c", "b"))
+    assert using_tuple.get().items() != ordered_dict().items()
+
+
+def test_defensive_copy():
+    obj = inizialize_non_empty().get()
+    obj[1] = "nothing should happen"
+    assert inizialize_non_empty().get_item_by_index(1) == "a"
+
+
+def test_size():
+    assert len(inizialize_non_empty().get()) == 6


### PR DESCRIPTION
Extended the pcluster configure command to also show vpc and subnets name. Added also the option to select an option with numbers on the left.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
