### PR TITLE
Integ tests: filter tests at collection time

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -60,8 +60,8 @@ def pytest_addoption(parser):
 
 def pytest_generate_tests(metafunc):
     """Generate (multiple) parametrized calls to a test function."""
-    _parametrize_from_option(metafunc, "instance", "instances")
     _parametrize_from_option(metafunc, "region", "regions")
+    _parametrize_from_option(metafunc, "instance", "instances")
     _parametrize_from_option(metafunc, "os", "oss")
     _parametrize_from_option(metafunc, "scheduler", "schedulers")
 
@@ -90,24 +90,24 @@ def pytest_configure(config):
 def pytest_runtest_call(item):
     """Called to execute the test item."""
     _add_properties_to_report(item)
-    add_default_markers(item)
-
-    check_marker_list(item, "instances", "instance")
-    check_marker_list(item, "regions", "region")
-    check_marker_list(item, "oss", "os")
-    check_marker_list(item, "schedulers", "scheduler")
-    check_marker_skip_list(item, "skip_instances", "instance")
-    check_marker_skip_list(item, "skip_regions", "region")
-    check_marker_skip_list(item, "skip_oss", "os")
-    check_marker_skip_list(item, "skip_schedulers", "scheduler")
-    check_marker_dimensions(item)
-    check_marker_skip_dimensions(item)
-
     logging.info("Running test " + item.name)
 
 
 def pytest_collection_modifyitems(items):
     """Called after collection has been performed, may filter or re-order the items in-place."""
+    add_default_markers(items)
+
+    check_marker_list(items, "instances", "instance")
+    check_marker_list(items, "regions", "region")
+    check_marker_list(items, "oss", "os")
+    check_marker_list(items, "schedulers", "scheduler")
+    check_marker_skip_list(items, "skip_instances", "instance")
+    check_marker_skip_list(items, "skip_regions", "region")
+    check_marker_skip_list(items, "skip_oss", "os")
+    check_marker_skip_list(items, "skip_schedulers", "scheduler")
+    check_marker_dimensions(items)
+    check_marker_skip_dimensions(items)
+
     _add_filename_markers(items)
 
 

--- a/tests/integration-tests/conftest_markers.py
+++ b/tests/integration-tests/conftest_markers.py
@@ -35,17 +35,18 @@ class InvalidMarkerError(Exception):
     pass
 
 
-def add_default_markers(item):
+def add_default_markers(items):
     """
     Add default markers for dimensions that need to be skipped by default for all tests.
 
-    :param item: pytest Item object markers are applied to.
+    :param items: pytest Item object markers are applied to.
     """
-    for dimensions in UNSUPPORTED_DIMENSIONS:
-        item.add_marker(pytest.mark.skip_dimensions(*dimensions))
+    for item in items:
+        for dimensions in UNSUPPORTED_DIMENSIONS:
+            item.add_marker(pytest.mark.skip_dimensions(*dimensions))
 
 
-def check_marker_list(item, marker_name, arg_name):
+def check_marker_list(items, marker_name, arg_name):
     """
     Skip all tests that are annotated with marker marker_name and have the arg value corresponding to arg_name
     not listed in the list passed as first argument to the marker.
@@ -56,33 +57,34 @@ def check_marker_list(item, marker_name, arg_name):
 
         The test is executed only if arg_name is equal to "value1" or "value2".
 
-    :param item: pytest Item object annotated with markers.
+    :param items: pytest Item objects annotated with markers.
     :param marker_name: name of the marker to process.
     :param arg_name: arg name the marker values should be compared to.
     """
-    arg_value = item.funcargs.get(arg_name)
-    allowed_values = []
-    for marker in item.iter_markers(name=marker_name):
-        _validate_marker(marker_name, [marker_name + "_list"], len(marker.args))
-        allowed_values.extend(marker.args[0])
+    for item in list(items):
+        arg_value = item.callspec.params.get(arg_name)
+        allowed_values = []
+        for marker in item.iter_markers(name=marker_name):
+            _validate_marker(marker_name, [marker_name + "_list"], len(marker.args))
+            allowed_values.extend(marker.args[0])
 
-    if not allowed_values or arg_value in allowed_values:
-        return
-    skip_message = (
-        "Skipping test {test_name} because {arg_name} {arg_value} is not in {marker} allowed values: "
-        "{allowed_values}".format(
-            test_name=item.name,
-            arg_name=arg_name,
-            arg_value=arg_value,
-            marker=marker_name,
-            allowed_values=allowed_values,
+        if not allowed_values or arg_value in allowed_values:
+            continue
+        skip_message = (
+            "Skipping test {test_name} because {arg_name} {arg_value} is not in {marker} allowed values: "
+            "{allowed_values}".format(
+                test_name=item.name,
+                arg_name=arg_name,
+                arg_value=arg_value,
+                marker=marker_name,
+                allowed_values=allowed_values,
+            )
         )
-    )
-    logging.info(skip_message)
-    pytest.skip(skip_message)
+        logging.info(skip_message)
+        items.remove(item)
 
 
-def check_marker_skip_list(item, marker_name, arg_name):
+def check_marker_skip_list(items, marker_name, arg_name):
     """
     Skip all tests that are annotated with marker marker_name and have the arg value corresponding to arg_name
     listed in the list passed as first argument to the marker.
@@ -93,30 +95,31 @@ def check_marker_skip_list(item, marker_name, arg_name):
 
         The test is executed only if arg_name is not equal to "value1" or "value2".
 
-    :param item: pytest Item object annotated with markers.
+    :param items: pytest Item objects annotated with markers.
     :param marker_name: name of the marker to process.
     :param arg_name: arg name the marker values should be compared to.
     """
-    arg_value = item.funcargs.get(arg_name)
-    for marker in item.iter_markers(name=marker_name):
-        _validate_marker(marker_name, [marker_name + "_skip_list"], len(marker.args))
-        skip_values = marker.args[0]
-        if arg_value in skip_values:
-            skip_message = (
-                "Skipping test {test_name} because {arg_name} {arg_value} is in {marker} allowed values:"
-                "{skip_values}".format(
-                    test_name=item.name,
-                    arg_name=arg_name,
-                    arg_value=arg_value,
-                    marker=marker_name,
-                    skip_values=skip_values,
+    for item in list(items):
+        arg_value = item.callspec.params.get(arg_name)
+        for marker in item.iter_markers(name=marker_name):
+            _validate_marker(marker_name, [marker_name + "_skip_list"], len(marker.args))
+            skip_values = marker.args[0]
+            if arg_value in skip_values:
+                skip_message = (
+                    "Skipping test {test_name} because {arg_name} {arg_value} is in {marker} allowed values:"
+                    "{skip_values}".format(
+                        test_name=item.name,
+                        arg_name=arg_name,
+                        arg_value=arg_value,
+                        marker=marker_name,
+                        skip_values=skip_values,
+                    )
                 )
-            )
-            logging.info(skip_message)
-            pytest.skip(skip_message)
+                logging.info(skip_message)
+                items.remove(item)
 
 
-def check_marker_skip_dimensions(item):
+def check_marker_skip_dimensions(items):
     """
     Skip all tests that are annotated with @pytest.mark.skip_dimensions and have the args
     (region, instance, os, scheduler) match those specified in the marker.
@@ -130,34 +133,35 @@ def check_marker_skip_dimensions(item):
         The test is executed only if the test args (region, instance, os, scheduler) do not match
         ("a", "b", "*", "d")
 
-    :param item: pytest Item object annotated with markers.
+    :param items: pytest Item objects annotated with markers.
     """
     marker_name = "skip_dimensions"
-    args_values = []
-    for dimension in DIMENSIONS_MARKER_ARGS:
-        args_values.append(item.funcargs.get(dimension))
-    for marker in item.iter_markers(name=marker_name):
-        _validate_marker(marker_name, DIMENSIONS_MARKER_ARGS, len(marker.args))
-        if len(marker.args) != len(DIMENSIONS_MARKER_ARGS):
-            logging.error(
-                "Marker {marker_name} requires the following args: {args}".format(
-                    marker_name=marker_name, args=DIMENSIONS_MARKER_ARGS
+    for item in list(items):
+        args_values = []
+        for dimension in DIMENSIONS_MARKER_ARGS:
+            args_values.append(item.callspec.params.get(dimension))
+        for marker in item.iter_markers(name=marker_name):
+            _validate_marker(marker_name, DIMENSIONS_MARKER_ARGS, len(marker.args))
+            if len(marker.args) != len(DIMENSIONS_MARKER_ARGS):
+                logging.error(
+                    "Marker {marker_name} requires the following args: {args}".format(
+                        marker_name=marker_name, args=DIMENSIONS_MARKER_ARGS
+                    )
                 )
-            )
-            raise ValueError
-        dimensions_match = _compare_dimension_lists(args_values, marker.args)
-        if dimensions_match:
-            skip_message = (
-                "Skipping test {test_name} because dimensions {args_values} match {marker}: "
-                "{skip_values}".format(
-                    test_name=item.name, args_values=args_values, marker=marker_name, skip_values=marker.args
+                raise ValueError
+            dimensions_match = _compare_dimension_lists(args_values, marker.args)
+            if dimensions_match:
+                skip_message = (
+                    "Skipping test {test_name} because dimensions {args_values} match {marker}: "
+                    "{skip_values}".format(
+                        test_name=item.name, args_values=args_values, marker=marker_name, skip_values=marker.args
+                    )
                 )
-            )
-            logging.info(skip_message)
-            pytest.skip(skip_message)
+                logging.info(skip_message)
+                items.remove(item)
 
 
-def check_marker_dimensions(item):
+def check_marker_dimensions(items):
     """
     Execute all tests that are annotated with @pytest.mark.dimensions and have the args
     (region, instance, os, scheduler) match those specified in the marker.
@@ -170,29 +174,33 @@ def check_marker_dimensions(item):
 
         The test is executed only if the test args (region, instance, os, scheduler) match ("a", "b", "*", "d")
 
-    :param item: pytest Item object annotated with markers.
+    :param items: pytest Item objects annotated with markers.
     """
     marker_name = "dimensions"
-    test_args_value = []
-    for dimension in DIMENSIONS_MARKER_ARGS:
-        test_args_value.append(item.funcargs.get(dimension))
-    allowed_values = []
-    for marker in item.iter_markers(name=marker_name):
-        _validate_marker(marker_name, DIMENSIONS_MARKER_ARGS, len(marker.args))
-        allowed_values.append(marker.args)
-        dimensions_match = _compare_dimension_lists(test_args_value, marker.args)
-        if dimensions_match:
-            return
+    for item in items:
+        test_args_value = []
+        for dimension in DIMENSIONS_MARKER_ARGS:
+            test_args_value.append(item.callspec.params.get(dimension))
+        allowed_values = []
+        for marker in item.iter_markers(name=marker_name):
+            _validate_marker(marker_name, DIMENSIONS_MARKER_ARGS, len(marker.args))
+            allowed_values.append(marker.args)
+            dimensions_match = _compare_dimension_lists(test_args_value, marker.args)
+            if dimensions_match:
+                continue
 
-    if allowed_values:
-        skip_message = (
-            "Skipping test {test_name} because dimensions {test_args_value} do not match any marker {marker} values: "
-            "{allowed_values}".format(
-                test_name=item.name, test_args_value=test_args_value, marker=marker_name, allowed_values=allowed_values
+        if allowed_values:
+            skip_message = (
+                "Skipping test {test_name} because dimensions {test_args_value} do not match any marker {marker}"
+                " values: {allowed_values}".format(
+                    test_name=item.name,
+                    test_args_value=test_args_value,
+                    marker=marker_name,
+                    allowed_values=allowed_values,
+                )
             )
-        )
-        logging.info(skip_message)
-        pytest.skip(skip_message)
+            logging.info(skip_message)
+            items.remove(item)
 
 
 def _validate_marker(marker_name, expected_args, args_count):


### PR DESCRIPTION
- This allow a better redistribution of tests across the workers
- Also the `--dry-run` option now shows the collected tests after filtering is applied, making it more useful to understand what tests would run with a given submission command


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
