### PR TITLE
Allow re-use of Cluster in Tests

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -142,6 +142,33 @@ The configuration for the custom templates and packages are automatically inject
 all cluster configs when these are rendered. In case any of these parameters is already set
 in the cluster config then the value in the config is used.
 
+### Re-use clusters and vpc clusters
+
+When developing integration tests, it can be helpful to re-use a cluster between tests. 
+This is easily accomplished with the use of the `--vpc-stack` and `--cluster` flags. 
+
+If you're starting from scratch, run the test with the `--no-delete` flag. 
+This preserves any stacks created for the test:
+
+```bash
+python -m test_runner \
+  ...
+  --no-delete
+```
+
+Then when you have a vpc stack and cluster, reference them when starting a test:
+
+```bash
+python -m test_runner \
+  ...
+  --vpc-stack "integ-tests-vpc-ncw7zrccsau8uh6k"
+  --cluster "efa-demo"
+  --no-delete
+```
+
+Keep in mind, the cluster you pass can have different `scheduler`, `os` or other features 
+than what is specified in the test. This can break the tests in unexpected ways. Be mindful.
+
 ## Write Integration Tests
 
 All integration tests are defined in the `integration-tests/tests` directory.

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -20,7 +20,7 @@ from utils import retrieve_cfn_outputs
 class CfnStack:
     """Identify a CloudFormation stack."""
 
-    def __init__(self, name, region, template):
+    def __init__(self, name, region, template=None):
         self.name = name
         self.region = region
         self.template = template

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -21,7 +21,7 @@ from utils import retrieve_cfn_outputs, retrieve_cfn_resources, retry_if_subproc
 class Cluster:
     """Contain all static and dynamic data related to a cluster instance."""
 
-    def __init__(self, name, config_file, ssh_key):
+    def __init__(self, name, ssh_key, config_file=None):
         self.name = name
         self.config_file = config_file
         self.ssh_key = ssh_key
@@ -121,7 +121,7 @@ class ClustersFactory:
         # create the cluster
         logging.info("Creating cluster {0} with config {1}".format(name, config))
         self.__created_clusters[name] = cluster
-        result = run_command(["pcluster", "create", "--config", config, name])
+        result = run_command(["pcluster", "create", "--no-rollback", "--config", config, name])
         if "Status: {0} - CREATE_COMPLETE".format(cluster.cfn_name) not in result.stdout:
             error = "Cluster creation failed for {0} with output: {1}".format(name, result.stdout)
             logging.error(error)

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -63,6 +63,9 @@ TEST_DEFAULTS = {
     "custom_awsbatch_template_url": None,
     "custom_awsbatchcli_url": None,
     "custom_ami": None,
+    "vpc_stack": None,
+    "cluster": None,
+    "no_delete": False,
 }
 
 
@@ -152,6 +155,16 @@ def _init_argparser():
     parser.add_argument(
         "--custom-ami", help="custom AMI to use for all tests.", default=TEST_DEFAULTS.get("custom_ami")
     )
+    parser.add_argument("--vpc-stack", help="Name of an existing vpc stack.", default=TEST_DEFAULTS.get("vpc_stack"))
+    parser.add_argument(
+        "--cluster", help="Use an existing cluster instead of creating one.", default=TEST_DEFAULTS.get("cluster")
+    )
+    parser.add_argument(
+        "--no-delete",
+        action="store_true",
+        help="Don't delete stacks after tests are complete.",
+        default=TEST_DEFAULTS.get("no_delete"),
+    )
 
     return parser
 
@@ -199,6 +212,7 @@ def _get_pytest_args(args, regions, log_file, out_dir):
         pytest_args.append("--html={0}/{1}/results.html".format(args.output_dir, out_dir))
 
     _set_custom_packages_args(args, pytest_args)
+    _set_custom_stack_args(args, pytest_args)
 
     return pytest_args
 
@@ -221,6 +235,17 @@ def _set_custom_packages_args(args, pytest_args):
 
     if args.custom_ami:
         pytest_args.extend(["--custom-ami", args.custom_ami])
+
+
+def _set_custom_stack_args(args, pytest_args):
+    if args.vpc_stack:
+        pytest_args.extend(["--vpc-stack", args.vpc_stack])
+
+    if args.cluster:
+        pytest_args.extend(["--cluster", args.cluster])
+
+    if args.no_delete:
+        pytest_args.append("--no-delete")
 
 
 def _get_pytest_regionalized_args(region, args):


### PR DESCRIPTION
* `--vpc-cluster` allows re-use of the vpc cluster between tests
* `--cluster` allows re-use of the cluster between tests
* `--no-delete` makes it easy to not delete created cluster, and re-use them

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
