### PR TITLE
Rename AWS_PARALLELCLUSTER_CONFIG_FILE env var to AWS_PCLUSTER_CONFIG_FILE

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -135,8 +135,8 @@ class ParallelClusterConfig(object):
         if hasattr(self.args, "config_file") and self.args.config_file is not None:
             config_file = self.args.config_file
             default_config = False
-        elif "AWS_PARALLELCLUSTER_CONFIG_FILE" in os.environ:
-            config_file = os.environ["AWS_PARALLELCLUSTER_CONFIG_FILE"]
+        elif "AWS_PCLUSTER_CONFIG_FILE" in os.environ:
+            config_file = os.environ["AWS_PCLUSTER_CONFIG_FILE"]
             default_config = False
         else:
             config_file = os.path.expanduser(os.path.join("~", ".parallelcluster", "config"))

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,7 +4,7 @@ Configuration
 
 ParallelCluster uses the file ``~/.parallelcluster/config`` by default for all configuration parameters.
 You can change the location of the config file via the ``--config`` command option or by setting the
-AWS_PARALLELCLUSTER_CONFIG_FILE environment variable.
+``AWS_PCLUSTER_CONFIG_FILE`` environment variable.
 
 An example configuration file can be found at ``site-packages/aws-parallelcluster/examples/config``.
 


### PR DESCRIPTION
@asford: we are renaming the variable added as part of your PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
