### PR TITLE
integ tests: add skip_instances in scaling tests

### DIFF
--- a/tests/integration-tests/tests/test_scaling.py
+++ b/tests/integration-tests/tests/test_scaling.py
@@ -24,6 +24,7 @@ from time_utils import minutes, seconds
 
 
 @pytest.mark.skip_schedulers(["awsbatch"])
+@pytest.mark.skip_instances(["c5n.18xlarge", "p3dn.24xlarge", "i3en.24xlarge"])
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):
     scaledown_idletime = 4


### PR DESCRIPTION
Skip instances used for EFA tests in scaling tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
