### PR TITLE
Revert "Display Public IP's for SSH"

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -4854,7 +4854,8 @@
           "MasterServer",
           "PublicIp"
         ]
-      }
+      },
+      "Condition": "MasterPublicIp"
     },
     "GangliaPrivateURL": {
       "Description": "Private URL to access Ganglia (disabled by default)",
@@ -4890,7 +4891,8 @@
             "/ganglia/"
           ]
         ]
-      }
+      },
+      "Condition": "MasterPublicIp"
     },
     "ResourcesS3Bucket": {
       "Description": "S3 user bucket where AWS ParallelCluster resources are stored",


### PR DESCRIPTION
In order for cluster's with no public ip's to work (clusters with a VPC or direct connect that allows them to resolve private ip's), the public ip needs to be conditionally output.

Previously I committed this change to enable `pcluster ssh` into instances that have no EIP. With this patch, customer's who set `use_public_ips = false` will not be able to use `pcluster ssh` to access their instances if they can't resolve the instance's private ip locally.

There will be a followup patch to allow ssh access by changing the ssh function to look at the master's public ip instead of just looking at the stack outputs.

This fixes https://github.com/aws/aws-parallelcluster/issues/1129

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
