### PR TITLE
Ssh from public ips

### DIFF
--- a/cli/pcluster/pcluster.py
+++ b/cli/pcluster/pcluster.py
@@ -717,11 +717,7 @@ def command(args, extra_args):  # noqa: C901 FIXME!!!
         elif status in valid_status:
             outputs = stack_result.get("Outputs")
             username = _get_output_value(outputs, "ClusterUser")
-            ip = (
-                _get_output_value(outputs, "MasterPublicIP")
-                if _get_output_value(outputs, "MasterPublicIP")
-                else _get_output_value(outputs, "MasterPrivateIP")
-            )
+            ip = _get_output_value(outputs, "MasterPublicIP") or _get_master_server_ip(stack, config)
 
             if not username:
                 LOGGER.info("Failed to get cluster %s username.", args.cluster_name)


### PR DESCRIPTION
SSH without an elastic ip

Enables ssh to the master instance even when `use_public_ips = false`

This commit goes with https://github.com/aws/aws-parallelcluster/pull/1130

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
