### PR TITLE
Fixed vpc-coherence to take into account auto assign public ip address.

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -363,8 +363,9 @@ class ParallelClusterConfig(object):
         # Check that cidr and public ips are not both set
         cidr_value = self.__config.get(vpc_section, "compute_subnet_cidr", fallback=None)
         public_ips = self.__config.getboolean(vpc_section, "use_public_ips", fallback=True)
+        master_subnet_id = self.__config.get(vpc_section, "master_subnet_id", fallback=None)
         if self.__sanity_check:
-            ResourceValidator.validate_vpc_coherence(cidr_value, public_ips)
+            ResourceValidator.validate_vpc_coherence(cidr_value, public_ips, master_subnet_id)
 
     def __check_account_capacity(self):
         """Try to launch the requested number of instances to verify Account limits."""

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -594,7 +594,8 @@ If false, the Master instance will have a Public IP (or not) according to the va
 of the "Auto-assign Public IP" subnet configuration parameter.
 
 .. note::
-    This parameter can't be set to false if :code:`compute_subnet_cidr` is specified.
+    This parameter can't be set to false if :code:`compute_subnet_cidr` is specified and the master subnet has the
+    property :code:`Auto-assign public IPv4 address` set to :code:`No`.
 
 See :ref:`networking configuration <networking>` for some examples.
 


### PR DESCRIPTION
The pull request #1057 didn't take into account the fact that auto assign public ip can be set to true, therefore making it possible to have compute_subnet_cidr and use_public_ip = false and still have pcluster working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
