### PR TITLE
Add warning to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,11 @@
     You can adapt this file completely to your liking, but it should at least
     contain the root `toctree` directive.
 
+.. important::
+
+   New Docs are available at https://docs.aws.amazon.com/parallelcluster
+
+   All new features, starting with 2.4.0, will be documented there.
 
 AWS ParallelCluster
 ###################


### PR DESCRIPTION
Redirect users to the new docs page.

![image](https://user-images.githubusercontent.com/5545980/59394138-807c7780-8d33-11e9-81dc-3af7808ffa1d.png)


Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
