### PR TITLE
Add ec2:DescribeNetworkInterfaceAttribute to User policy

### DIFF
--- a/docs/iam.rst
+++ b/docs/iam.rst
@@ -241,6 +241,7 @@ To: ::
                   "ec2:DescribeAddresses",
                   "ec2:CreateTags",
                   "ec2:DescribeNetworkInterfaces",
+                  "ec2:DescribeNetworkInterfaceAttribute",
                   "ec2:DescribeAvailabilityZones"
               ],
               "Effect": "Allow",


### PR DESCRIPTION
Fixes #1139 

Cluster creation will fail during sanity checks (specifically the DescribeMountTargetSecurityGroups call) if an EFS volume is specified in config. This additional permission should allow that endpoint to be called without error. See https://docs.aws.amazon.com/efs/latest/ug/API_DescribeMountTargetSecurityGroups.html and #1139 for more details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
