### PR TITLE
Add new docs warning to all pages

### DIFF
--- a/docs/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
+++ b/docs/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
@@ -80,6 +80,11 @@
           {%- block sidebar1 %}{{ sidebar() }}{% endblock %}
           {%- block document %}
             <div class="body">
+              <div class="admonition important">
+                <p class="admonition-title">Important</p>
+                <p>New Docs are available at <a class="reference external" href="https://docs.aws.amazon.com/parallelcluster">https://docs.aws.amazon.com/parallelcluster</a></p>
+                <p>All new features, starting with 2.4.0, will be documented there.</p>
+              </div>
               {% block body %} {% endblock %}
             </div>
           {%- endblock %}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,11 +4,6 @@
     You can adapt this file completely to your liking, but it should at least
     contain the root `toctree` directive.
 
-.. important::
-
-   New Docs are available at https://docs.aws.amazon.com/parallelcluster
-
-   All new features, starting with 2.4.0, will be documented there.
 
 AWS ParallelCluster
 ###################


### PR DESCRIPTION
Adds warning to all pages:

```
New Docs are available at https://docs.aws.amazon.com/parallelcluster	

All new features, starting with 2.4.0, will be documented there.
```

![image](https://user-images.githubusercontent.com/5545980/59523803-18d74100-8e87-11e9-95c2-152da997cb95.png)

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
