### PR TITLE
integ tests: fix mpi tests

### DIFF
--- a/tests/integration-tests/tests/common/data/mpi/mpi_submit_openmpi-x86_64.sh
+++ b/tests/integration-tests/tests/common/data/mpi/mpi_submit_openmpi-x86_64.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 set -e
 
+rm -f /shared/mpi.out
 module load openmpi-x86_64
+# -mca btl ^openib is needed to avoid to have the following warning in the stdout:
+# A high-performance Open MPI point-to-point messaging module was unable to find any relevant network interfaces:
+# Module: OpenFabrics (openib). Another transport will be used instead, although this may result in lower performance.
 mpirun --map-by ppr:1:node -mca btl ^openib "mpi_hello_world" >> /shared/mpi.out

--- a/tests/integration-tests/tests/common/data/mpi/mpi_submit_openmpi.sh
+++ b/tests/integration-tests/tests/common/data/mpi/mpi_submit_openmpi.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
 
+rm -f /shared/mpi.out
 module load openmpi
 mpirun --map-by ppr:1:node "mpi_hello_world" >> /shared/mpi.out

--- a/tests/integration-tests/tests/scaling/test_mpi.py
+++ b/tests/integration-tests/tests/scaling/test_mpi.py
@@ -28,18 +28,6 @@ def test_mpi(scheduler, region, os, instance, pcluster_config_reader, clusters_f
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
-    # This verifies that scaling worked
-    _test_mpi(
-        remote_command_executor,
-        slots_per_instance,
-        scheduler,
-        os,
-        region,
-        cluster.cfn_name,
-        scaledown_idletime,
-        verify_scaling=True,
-    )
-
     # This verifies that the job completes correctly
     _test_mpi(
         remote_command_executor,
@@ -50,4 +38,16 @@ def test_mpi(scheduler, region, os, instance, pcluster_config_reader, clusters_f
         cluster.cfn_name,
         scaledown_idletime,
         verify_scaling=False,
+    )
+
+    # This verifies that scaling worked
+    _test_mpi(
+        remote_command_executor,
+        slots_per_instance,
+        scheduler,
+        os,
+        region,
+        cluster.cfn_name,
+        scaledown_idletime,
+        verify_scaling=True,
     )


### PR DESCRIPTION
- mpi.out file was not being deleted and when running two mpi tests in a row it was failing the assertions.
- also inverted the scaling check and completion check to have a faster test and work around the fact that  when the queue is 0 sge gives a submission error although the job is correctly submitted 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
