### PR TITLE
Set Instance Type on CLI in createami command

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -314,6 +314,13 @@ Variables substituted::
         "Valid options are: alinux, ubuntu1404, ubuntu1604, centos6, centos7.",
     )
     pami.add_argument(
+        "-i",
+        "--instance-type",
+        dest="instance_type",
+        default="t2.xlarge",
+        help="Sets instance type to build the ami on. Defaults to t2.xlarge.",
+    )
+    pami.add_argument(
         "-ap",
         "--ami-name-prefix",
         dest="custom_ami_name_prefix",

--- a/cli/pcluster/pcluster.py
+++ b/cli/pcluster/pcluster.py
@@ -1033,7 +1033,7 @@ def create_ami(args):
     LOGGER.debug("Building AMI based on args %s", str(args))
     results = {}
 
-    instance_type = "t2.large"
+    instance_type = args.instance_type
     try:
         config = cfnconfig.ParallelClusterConfig(args)
 


### PR DESCRIPTION
* Allows setting the instance type, which is very useful for creating AMI's with hardware specific compilation requirements. For example:
  * nvidia installers require gpu instances to be installed
  * arm packages should be compiled on an arm machine
  * high performance codes that require AVX-512
 
Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
