### PR TITLE
Add new parameter --credential to integration tests runner

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -193,6 +193,27 @@ tests_outputs
             └── ...
 ```
 
+## Cross Account Integration Tests
+If you want to distribute integration tests across multiple accounts you can make use of the `--credential` flag. 
+This is useful to overcome restrictions related to account limits and be compliant with a multi-region, multi-account 
+setup.
+
+When the `--credential` flag is specified and STS assume-role call is made in order to fetch temporary credentials to 
+be used to run tests in a specific region. 
+
+The `--credential` flag is in the form `<region>,<endpoint_url>,<ARN>,<external_id>` and needs to be specified for each 
+region you want to use with an STS assumed role (that usually means for every region you want to have in a separate 
+account).
+
+ * `region` is the region you want to test with an assumed STS role (which is in the target account where you want to 
+ launch the integration tests)
+ * `endpoint_url` is the STS endpoint url of the main account to be called in order to assume the delegation role
+ * `ARN` is the ARN of the delegation role in the optin region account to be assumed by the main account
+ * `external_id` is the external ID of the delegation role  
+
+By default, the delegation role lifetime last for one hour. Mind that if you are planning to launch tests that last 
+more than one hour.
+
 ## Write Integration Tests
 
 All integration tests are defined in the `integration-tests/tests` directory.

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -14,7 +14,7 @@ import boto3
 from botocore.exceptions import ClientError
 from retrying import retry
 
-from utils import retrieve_cfn_outputs
+from utils import retrieve_cfn_outputs, set_credentials, unset_credentials
 
 
 class CfnStack:
@@ -41,8 +41,9 @@ class CfnStack:
 class CfnStacksFactory:
     """Manage creation and deletion of CloudFormation stacks."""
 
-    def __init__(self):
+    def __init__(self, credentials):
         self.__created_stacks = {}
+        self.__credentials = credentials
 
     def create_stack(self, stack):
         """
@@ -52,23 +53,28 @@ class CfnStacksFactory:
         """
         name = stack.name
         region = stack.region
-        id = self.__get_stack_internal_id(name, region)
-        if id in self.__created_stacks:
-            raise ValueError("Stack {0} already exists in region {1}".format(name, region))
-
-        logging.info("Creating stack {0} in region {1}".format(name, region))
-        self.__created_stacks[id] = stack
         try:
-            cfn_client = boto3.client("cloudformation", region_name=region)
-            result = cfn_client.create_stack(StackName=name, TemplateBody=stack.template)
-            stack.cfn_stack_id = result["StackId"]
-            final_status = self.__wait_for_stack_creation(stack.cfn_stack_id, cfn_client)
-            self.__assert_stack_status(final_status, "CREATE_COMPLETE")
-        except Exception as e:
-            logging.error("Creation of stack {0} in region {1} failed with exception: {2}".format(name, region, e))
-            raise
+            set_credentials(region, self.__credentials)
 
-        logging.info("Stack {0} created successfully in region {1}".format(name, region))
+            id = self.__get_stack_internal_id(name, region)
+            if id in self.__created_stacks:
+                raise ValueError("Stack {0} already exists in region {1}".format(name, region))
+
+            logging.info("Creating stack {0} in region {1}".format(name, region))
+            self.__created_stacks[id] = stack
+            try:
+                cfn_client = boto3.client("cloudformation", region_name=region)
+                result = cfn_client.create_stack(StackName=name, TemplateBody=stack.template)
+                stack.cfn_stack_id = result["StackId"]
+                final_status = self.__wait_for_stack_creation(stack.cfn_stack_id, cfn_client)
+                self.__assert_stack_status(final_status, "CREATE_COMPLETE")
+            except Exception as e:
+                logging.error("Creation of stack {0} in region {1} failed with exception: {2}".format(name, region, e))
+                raise
+
+            logging.info("Stack {0} created successfully in region {1}".format(name, region))
+        finally:
+            unset_credentials()
 
     @retry(
         stop_max_attempt_number=10,
@@ -77,22 +83,29 @@ class CfnStacksFactory:
     )
     def delete_stack(self, name, region):
         """Destroy a created cfn stack."""
-        id = self.__get_stack_internal_id(name, region)
-        if id in self.__created_stacks:
-            logging.info("Destroying stack {0} in region {1}".format(name, region))
-            try:
-                stack = self.__created_stacks[id]
-                cfn_client = boto3.client("cloudformation", region_name=stack.region)
-                cfn_client.delete_stack(StackName=stack.name)
-                final_status = self.__wait_for_stack_deletion(stack.cfn_stack_id, cfn_client)
-                self.__assert_stack_status(final_status, "DELETE_COMPLETE")
-            except Exception as e:
-                logging.error("Deletion of stack {0} in region {1} failed with exception: {2}".format(name, region, e))
-                raise
-            del self.__created_stacks[id]
-            logging.info("Stack {0} deleted successfully in region {1}".format(name, region))
-        else:
-            logging.warning("Couldn't find stack with name {0} in region. Skipping deletion.".format(name, region))
+        try:
+            set_credentials(region, self.__credentials)
+
+            id = self.__get_stack_internal_id(name, region)
+            if id in self.__created_stacks:
+                logging.info("Destroying stack {0} in region {1}".format(name, region))
+                try:
+                    stack = self.__created_stacks[id]
+                    cfn_client = boto3.client("cloudformation", region_name=stack.region)
+                    cfn_client.delete_stack(StackName=stack.name)
+                    final_status = self.__wait_for_stack_deletion(stack.cfn_stack_id, cfn_client)
+                    self.__assert_stack_status(final_status, "DELETE_COMPLETE")
+                except Exception as e:
+                    logging.error(
+                        "Deletion of stack {0} in region {1} failed with exception: {2}".format(name, region, e)
+                    )
+                    raise
+                del self.__created_stacks[id]
+                logging.info("Stack {0} deleted successfully in region {1}".format(name, region))
+            else:
+                logging.warning("Couldn't find stack with name {0} in region. Skipping deletion.".format(name, region))
+        finally:
+            unset_credentials()
 
     def delete_all_stacks(self):
         """Destroy all created stacks."""

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -35,13 +35,23 @@ from conftest_markers import (
     check_marker_skip_list,
 )
 from jinja2 import Environment, FileSystemLoader
-from utils import create_s3_bucket, delete_s3_bucket, random_alphanumeric, to_snake_case
+from utils import (
+    create_s3_bucket,
+    delete_s3_bucket,
+    random_alphanumeric,
+    set_credentials,
+    to_snake_case,
+    unset_credentials,
+)
 from vpc_builder import Gateways, SubnetConfig, VPCConfig, VPCTemplateBuilder
 
 
 def pytest_addoption(parser):
     """Register argparse-style options and ini-style config values, called once at the beginning of a test run."""
     parser.addoption("--regions", help="aws region where tests are executed", default=["us-east-1"], nargs="+")
+    parser.addoption(
+        "--credential", help="STS credential endpoint, in the format <region>,<endpoint>,<ARN>,<externalId>.", nargs="+"
+    )
     parser.addoption("--instances", help="aws instances under test", default=["c5.xlarge"], nargs="+")
     parser.addoption("--oss", help="OSs under test", default=["alinux"], nargs="+")
     parser.addoption("--schedulers", help="schedulers under test", default=["slurm"], nargs="+")
@@ -159,6 +169,7 @@ def _add_properties_to_report(item):
 
 
 @pytest.fixture(scope="class")
+@pytest.mark.usefixtures("setup_sts_credentials")
 def clusters_factory(request):
     """
     Define a fixture to manage the creation and destruction of clusters.
@@ -296,7 +307,7 @@ def _get_default_template_values(vpc_stacks, region, request):
 @pytest.fixture(scope="session")
 def cfn_stacks_factory(request):
     """Define a fixture to manage the creation and destruction of CloudFormation stacks."""
-    factory = CfnStacksFactory()
+    factory = CfnStacksFactory(request.config.getoption("credential"))
     yield factory
     if not request.config.getoption("no_delete"):
         factory.delete_all_stacks()
@@ -321,6 +332,14 @@ _AVAILABILITY_ZONE_OVERRIDES = {
     # NAT Gateway not available in sa-east-1b
     "sa-east-1": ["sa-east-1a", "sa-east-1c"],
 }
+
+
+@pytest.fixture(scope="class", autouse=True)
+def setup_sts_credentials(region, request):
+    """Setup environment for the integ tests"""
+    set_credentials(region, request.config.getoption("credential"))
+    yield
+    unset_credentials()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -91,6 +91,13 @@ def _init_argparser():
         "-r", "--regions", help="AWS region where tests are executed.", default=TEST_DEFAULTS.get("regions"), nargs="+"
     )
     parser.add_argument(
+        "--credential",
+        action="append",
+        help="STS credential endpoint, in the format <region>,<endpoint>,<ARN>,<externalId>. "
+        "Could be specified multiple times.",
+        required=False,
+    )
+    parser.add_argument(
         "-i", "--instances", help="AWS instances under test.", default=TEST_DEFAULTS.get("instances"), nargs="+"
     )
     parser.add_argument("-o", "--oss", help="OSs under test.", default=TEST_DEFAULTS.get("oss"), nargs="+")
@@ -237,6 +244,10 @@ def _get_pytest_args(args, regions, log_file, out_dir):
     pytest_args.extend(["--output-dir", "{0}/{1}".format(args.output_dir, out_dir)])
     pytest_args.extend(["--key-name", args.key_name])
     pytest_args.extend(["--key-path", args.key_path])
+
+    if args.credential:
+        pytest_args.append("--credential")
+        pytest_args.extend(args.credential)
 
     if args.retry_on_failures:
         # Rerun tests on failures for one more time after 60 seconds delay


### PR DESCRIPTION
Integration tests can be now launched in new optin region, specifying the --credential parameter for each new region to test.
Credential parameter is a comma separated list in the format region,endpoint,ARN,externalId.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
