### PR TITLE
createami: add possibility to specify vpc settings

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -156,9 +156,11 @@ Examples::
     pcreate.add_argument(
         "-u",
         "--template-url",
-        help="Specifies the URL for a custom CloudFormation template, " "if it was used at creation time.",
+        help="Specifies the URL for a custom CloudFormation template, if it was used at creation time.",
     )
-    pcreate.add_argument("-t", "--cluster-template", help="Indicates which section of the cluster template to use.")
+    pcreate.add_argument(
+        "-t", "--cluster-template", help="Indicates the cluster section of the configuration file to use."
+    )
     pcreate.add_argument("-p", "--extra-parameters", type=json.loads, help="Adds extra parameters to the stack create.")
     pcreate.add_argument("-g", "--tags", type=json.loads, help="Specifies additional tags to be added to the stack.")
     pcreate.set_defaults(func=create)
@@ -182,7 +184,9 @@ Examples::
         default=False,
         help="Disable CloudFormation stack rollback on error.",
     )
-    pupdate.add_argument("-t", "--cluster-template", help="Indicates which section of the cluster template to use.")
+    pupdate.add_argument(
+        "-t", "--cluster-template", help="Indicates the cluster section of the configuration file to use."
+    )
     pupdate.add_argument("-p", "--extra-parameters", help="Adds extra parameters to the stack update.")
     pupdate.add_argument(
         "-rd",
@@ -338,7 +342,7 @@ Variables substituted::
     pami.add_argument(
         "-t",
         "--cluster-template",
-        help="Specifies the cluster section of the ParallelCluster configuration file to retrieve VPC settings."
+        help="Specifies the cluster section of the configuration file to retrieve VPC settings.",
     )
     _addarg_region(pami)
     pami.set_defaults(template_url=None)

--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -159,7 +159,9 @@ Examples::
         help="Specifies the URL for a custom CloudFormation template, if it was used at creation time.",
     )
     pcreate.add_argument(
-        "-t", "--cluster-template", help="Indicates the cluster section of the configuration file to use."
+        "-t",
+        "--cluster-template",
+        help="Indicates which section of the configuration file to use for cluster creation.",
     )
     pcreate.add_argument("-p", "--extra-parameters", type=json.loads, help="Adds extra parameters to the stack create.")
     pcreate.add_argument("-g", "--tags", type=json.loads, help="Specifies additional tags to be added to the stack.")
@@ -185,7 +187,7 @@ Examples::
         help="Disable CloudFormation stack rollback on error.",
     )
     pupdate.add_argument(
-        "-t", "--cluster-template", help="Indicates the cluster section of the configuration file to use."
+        "-t", "--cluster-template", help="Indicates which section of the configuration file to use for cluster update."
     )
     pupdate.add_argument("-p", "--extra-parameters", help="Adds extra parameters to the stack update.")
     pupdate.add_argument(
@@ -339,11 +341,15 @@ Variables substituted::
         help="Specifies the cookbook to use to build the AWS ParallelCluster AMI.",
     )
     _addarg_config(pami)
-    pami.add_argument(
+    pami_group1 = pami.add_argument_group("Build AMI by using VPC settings from configuration file")
+    pami_group1.add_argument(
         "-t",
         "--cluster-template",
         help="Specifies the cluster section of the configuration file to retrieve VPC settings.",
     )
+    pami_group2 = pami.add_argument_group("Build AMI in a custom VPC and Subnet")
+    pami_group2.add_argument("--vpc-id", help="Specifies the VPC to use to build the AWS ParallelCluster AMI.")
+    pami_group2.add_argument("--subnet-id", help="Specifies the Subnet to use to build the AWS ParallelCluster AMI.")
     _addarg_region(pami)
     pami.set_defaults(template_url=None)
     pami.set_defaults(func=create_ami)

--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -335,6 +335,11 @@ Variables substituted::
         help="Specifies the cookbook to use to build the AWS ParallelCluster AMI.",
     )
     _addarg_config(pami)
+    pami.add_argument(
+        "-t",
+        "--cluster-template",
+        help="Specifies the cluster section of the ParallelCluster configuration file to retrieve VPC settings."
+    )
     _addarg_region(pami)
     pami.set_defaults(template_url=None)
     pami.set_defaults(func=create_ami)

--- a/cli/pcluster/pcluster.py
+++ b/cli/pcluster/pcluster.py
@@ -994,15 +994,15 @@ def create_ami(args):
     try:
         config = cfnconfig.ParallelClusterConfig(args)
 
-        vpc_id = config.parameters.get("VPCId")
-        master_subnet_id = config.parameters.get("MasterSubnetId")
+        vpc_id = args.vpc_id if args.vpc_id else config.parameters.get("VPCId")
+        subnet_id = args.subnet_id if args.subnet_id else config.parameters.get("MasterSubnetId")
 
         packer_env = {
             "CUSTOM_AMI_ID": args.base_ami_id,
             "AWS_FLAVOR_ID": instance_type,
             "AMI_NAME_PREFIX": args.custom_ami_name_prefix,
             "AWS_VPC_ID": vpc_id,
-            "AWS_SUBNET_ID": master_subnet_id,
+            "AWS_SUBNET_ID": subnet_id,
         }
 
         if config.aws_access_key_id:
@@ -1015,7 +1015,7 @@ def create_ami(args):
         LOGGER.info("Instance Type: %s", instance_type)
         LOGGER.info("Region: %s", config.region)
         LOGGER.info("VPC ID: %s", vpc_id)
-        LOGGER.info("Subnet ID: %s", master_subnet_id)
+        LOGGER.info("Subnet ID: %s", subnet_id)
 
         tmp_dir = mkdtemp()
         cookbook_dir = get_cookbook_dir(config, tmp_dir)


### PR DESCRIPTION
+ add --cluster-template option
+ Improve description of --cluster-template parameter
+ add --vpc-id and --subnet-id parameters --> they will override the values from the cluster template

```
$ pcluster createami --help
...
Build AMI by using VPC settings from configuration file:
  -t CLUSTER_TEMPLATE, --cluster-template CLUSTER_TEMPLATE
                        Specifies the cluster section of the configuration
                        file to retrieve VPC settings.

Build AMI in a custom VPC and Subnet:
  -vi VPC_ID, --vpc-id VPC_ID
                        Specifies the VPC to use to build the AWS
                        ParallelCluster AMI.
  -si SUBNET_ID, --subnet-id SUBNET_ID
                        Specifies the Subnet to use to build the AWS
                        ParallelCluster AMI.

$ pcluster createami .. -t default
VPC ID: vpc-xxx
Subnet ID: subnet-xxx

$ pcluster createami .. -t default -vi test
VPC ID: test
Subnet ID: subnet-xxx

$ pcluster createami .. -t default -vi test -si test2
VPC ID: test
Subnet ID: test2
```
