### PR TITLE
Comment flake8-docstrings tox dependency

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -98,7 +98,7 @@ basepython = python3
 skip_install = true
 deps =
     flake8
-    flake8-docstrings
+    # flake8-docstrings # TODO revert comment when https://gitlab.com/pycqa/flake8-docstrings/issues/36 get fixed
     flake8-bugbear
     flake8-mypy
     # flake8-import-order # delegated to isort


### PR DESCRIPTION
Remove the comment once https://gitlab.com/pycqa/flake8-docstrings/issues/36 get fixed

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
