### PR TITLE
performance tests: fix issue with end_time

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -130,7 +130,7 @@ def pytest_collection_modifyitems(items):
 
 def pytest_exception_interact(node, call, report):
     """Called when an exception was raised which can potentially be interactively handled.."""
-    logging.error("Exception raised while executing {0}: {1}".format(node.name, call.excinfo))
+    logging.exception("Exception raised while executing {0}: {1}".format(node.name, call.excinfo))
 
 
 def _add_filename_markers(items):


### PR DESCRIPTION
timestamp is not getting updated if there is no variation in the number of nodes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
