### PR TITLE
integ tests: improve exception logging

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -19,6 +19,7 @@ import os
 import random
 import re
 from shutil import copyfile
+from traceback import format_tb
 
 import configparser
 import pytest
@@ -130,7 +131,9 @@ def pytest_collection_modifyitems(items):
 
 def pytest_exception_interact(node, call, report):
     """Called when an exception was raised which can potentially be interactively handled.."""
-    logging.exception("Exception raised while executing {0}: {1}".format(node.name, call.excinfo))
+    logging.error(
+        "Exception raised while executing %s: %s\n%s", node.name, call.excinfo, "".join(format_tb(call.excinfo.tb))
+    )
 
 
 def _add_filename_markers(items):


### PR DESCRIPTION
Example:
```
2019-07-09 16:33:48,149 - ERROR - <string> - Exception raised while executing test_scaling_performance[cn-north-1-c4.xlarge-alinux-sge]: /Users/fdm/workspace/cfncluster/cfncluster/tests/integration-tests/benchmarks/test_scaling_performance.py:82: AssertionError: Expected <False>, but was not.
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/_pytest/runner.py", line 226, in from_call
    result = func()
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/_pytest/runner.py", line 198, in <lambda>
    lambda: ihook(item=item, **kwds), when=when, reraise=reraise
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/hooks.py", line 284, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/manager.py", line 68, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/manager.py", line 62, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/_pytest/runner.py", line 123, in pytest_runtest_call
    item.runtest()
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/_pytest/python.py", line 1448, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/hooks.py", line 284, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/manager.py", line 68, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/manager.py", line 62, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
    testfunction(**testargs)
  File "/Users/fdm/workspace/cfncluster/cfncluster/tests/integration-tests/benchmarks/test_scaling_performance.py", line 82, in test_scaling_performance
    assert_that(True).is_false()
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/assertpy/assertpy.py", line 198, in is_false
    self._err('Expected <False>, but was not.')
  File "/Users/fdm/.pyenv/versions/integ-tests/lib/python3.7/site-packages/assertpy/assertpy.py", line 1103, in _err
    raise AssertionError(out)

```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
