### PR TITLE
Need to add LocationConstraint to create bucket outside of IAD

### DIFF
--- a/util/uploadCLI.sh
+++ b/util/uploadCLI.sh
@@ -70,7 +70,8 @@ main() {
     aws ${_profile} s3api head-bucket --bucket "${_bucket}" --region "${_region}"
     if [ $? -ne 0 ]; then
         _info "Bucket ${_bucket} do not exist, trying to create it"
-        aws ${_profile} s3api create-bucket --bucket "${_bucket}" --region "${_region}"
+        aws ${_profile} s3api create-bucket --bucket "${_bucket}" --region "${_region}" \
+	    --create-bucket-configuration LocationConstraint="${_region}"
         if [ $? -ne 0 ]; then
             _error_exit "Unable to create bucket ${_bucket}"
         fi


### PR DESCRIPTION
Below is the error message when this is omitted

stesachs@:~/git/aws-parallelcluster/util$ aws s3api create-bucket --bucket "stesachs-test" --region eu-west-1

An error occurred (IllegalLocationConstraintException) when calling the CreateBucket operation: The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.
stesachs@:~/git/aws-parallelcluster/util$ aws s3api create-bucket --bucket "stesachs-test" --region eu-west-1 --create-bucket-configuration LocationConstraint=eu-west-1

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
