### PR TITLE
Autoscaling metrics

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1716,7 +1716,8 @@
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:UpdateAutoScalingGroup",
                 "autoscaling:DescribeTags",
-                "autoscaling:SetInstanceHealth"
+                "autoscaling:SetInstanceHealth",
+		"autoscaling:EnableMetricsCollection"  
               ],
               "Effect": "Allow",
               "Resource": [
@@ -2792,7 +2793,16 @@
               "Ref": "AWS::NoValue"
             }
           ]
-        }
+        },
+	"MetricsCollection": [
+	    {
+		"Granularity" : "1Minute",
+		"Metrics" : [
+		    "GroupDesiredCapacity",
+		    "GroupTotalInstances"
+		]
+	    }
+	]
       },
       "DependsOn": "MasterServer",
       "CreationPolicy": {

--- a/util/uploadCLI.sh
+++ b/util/uploadCLI.sh
@@ -70,7 +70,7 @@ main() {
     aws ${_profile} s3api head-bucket --bucket "${_bucket}" --region "${_region}"
     if [ $? -ne 0 ]; then
         _info "Bucket ${_bucket} do not exist, trying to create it"
-        aws ${_profile} s3api create-bucket --bucket "${_bucket}" --region "${_region}" --create-bucket-configuration LocationConstraint="${_region}"
+        aws ${_profile} s3api create-bucket --bucket "${_bucket}" --region "${_region}"
         if [ $? -ne 0 ]; then
             _error_exit "Unable to create bucket ${_bucket}"
         fi

--- a/util/uploadCLI.sh
+++ b/util/uploadCLI.sh
@@ -70,7 +70,7 @@ main() {
     aws ${_profile} s3api head-bucket --bucket "${_bucket}" --region "${_region}"
     if [ $? -ne 0 ]; then
         _info "Bucket ${_bucket} do not exist, trying to create it"
-        aws ${_profile} s3api create-bucket --bucket "${_bucket}" --region "${_region}"
+        aws ${_profile} s3api create-bucket --bucket "${_bucket}" --region "${_region}" --create-bucket-configuration LocationConstraint="${_region}"
         if [ $? -ne 0 ]; then
             _error_exit "Unable to create bucket ${_bucket}"
         fi


### PR DESCRIPTION
The actual and desired size of the cluster are among the most fundamental metrics you want to capture when monitoring the cluster.

*Issue #, if available:*

*Description of changes:*
Added metrics collection to autoscaling group and appropriate IAM permissions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.