### PR TITLE
integ tests: add mpirun communications test

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -14,3 +14,4 @@ pytest-xdist
 retrying
 troposphere
 untangle
+wrapt_timeout_decorator

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpirun_comms/pcluster.config.ini
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpirun_comms/pcluster.config.ini
@@ -1,0 +1,19 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+initial_queue_size = 1
+maintain_initial_size = true
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}


### PR DESCRIPTION
This test verify if it possible to run mpirun on a remote host.
Requirement for the test to pass is that passwordless SSH is configured and remote host is present in the known host file

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
