### PR TITLE
ParallelCluster DCV support

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -21,8 +21,8 @@ import argparse
 from botocore.exceptions import NoCredentialsError
 
 import pcluster.commands as pcluster
-from pcluster.dcv_connect import dcv_connect
 from pcluster.configure import easyconfig
+from pcluster.dcv_connect import dcv_connect
 
 LOGGER = logging.getLogger("pcluster.pcluster")
 

--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -20,7 +20,8 @@ import textwrap
 import argparse
 from botocore.exceptions import NoCredentialsError
 
-from pcluster import pcluster
+import pcluster.commands as pcluster
+from pcluster.dcv_connect import dcv_connect
 from pcluster.configure import easyconfig
 
 LOGGER = logging.getLogger("pcluster.pcluster")
@@ -36,6 +37,10 @@ def configure(args):
 
 def command(args, extra_args):
     pcluster.command(args, extra_args)
+
+
+def dcv(args):
+    dcv_connect(args)
 
 
 def status(args):
@@ -362,6 +367,13 @@ Variables substituted::
     # version command subparser
     pversion = subparsers.add_parser("version", help="Displays the version of AWS ParallelCluster.")
     pversion.set_defaults(func=version)
+
+    pdcv = subparsers.add_parser(
+        "dcv", help="Creates an interactive session to the ParallelCluster master node, through NICE DCV"
+    )
+    pdcv.add_argument("cluster_name", help="Name of the cluster to connect to")
+    pdcv.add_argument("--key-path", "-k", dest="key_path", help="Key path of the SSH key to use for the connection")
+    pdcv.set_defaults(func=dcv)
 
     return parser
 

--- a/cli/pcluster/dcv_connect.py
+++ b/cli/pcluster/dcv_connect.py
@@ -1,0 +1,93 @@
+# Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import re
+import sys
+import webbrowser
+
+import boto3
+from botocore.exceptions import ClientError
+
+from pcluster import cfnconfig
+from pcluster.commands import command
+from pcluster.utils import get_param_value, get_stack_output_value
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _get_stack(args):
+    stack = "parallelcluster-" + args.cluster_name
+    config = cfnconfig.ParallelClusterConfig(args)
+    cfn = boto3.client(
+        "cloudformation",
+        region_name=config.region,
+        aws_access_key_id=config.aws_access_key_id,  # I would remove this backward compatibility
+        aws_secret_access_key=config.aws_secret_access_key,  # I would remove this backward compatibility
+    )
+    try:
+        stack_result = cfn.describe_stacks(StackName=stack).get("Stacks")[0]
+        status = stack_result.get("StackStatus")
+        valid_status = "CREATE_COMPLETE"
+
+        if status != valid_status:
+            LOGGER.error("Stack status: {0}. Can't connect until the status become {1}".format(status, valid_status))
+            sys.exit(1)
+        else:
+            return stack_result
+    except ClientError as e:
+        LOGGER.critical(e.response.get("Error").get("Message"))
+        sys.stdout.flush()
+        sys.exit(1)
+
+
+def _generate_ssh_command(commands):
+    return " ".join(commands).split(" ")
+
+
+def dcv_connect(args):
+    args.command = None
+    args.dryrun = None
+    commands = []
+    if args.key_path:
+        commands.append("-i {0}".format(args.key_path))
+
+    stack_result = _get_stack(args)
+    shared_dir = get_param_value(stack_result["Parameters"], "SharedDir")
+    command_to_execute = "/opt/parallelcluster/scripts/pcluster_dcv_connect.sh {0}".format(shared_dir)
+
+    commands.append(command_to_execute)
+    ssh_command = _generate_ssh_command(commands)
+
+    master_ip = get_stack_output_value(stack_result["Outputs"], "MasterPublicIP")
+    try:
+        output = command(args, ssh_command, return_output=True).decode("utf-8").strip().split(" ")
+        # if it is the first time we connect to the machine,
+        # ssh command will say that he added the host to the known hosts list.
+        if re.search("Permanently added .* to the list of known hosts.", " ".join(output)):
+            output = command(args, ssh_command, return_output=True).decode("utf-8").strip().split(" ")
+        session_id, port, token = output
+    except ValueError:
+        LOGGER.error(
+            "Something went wrong during DCV connection. Please try again. "
+            "If the problem persists, check the logs on the master."
+        )
+        sys.exit(1)
+
+    url = "https://{IP}:{PORT}?authToken={TOKEN}#{SESSION_ID}".format(
+        IP=master_ip, PORT=port, TOKEN=token, SESSION_ID=session_id
+    )
+    try:
+        webbrowser.open_new(url)
+    except webbrowser.Error:
+        LOGGER.info(
+            "Unable to open browser automatically. Please open the following URL in your browser within 30 seconds:"
+        )
+        LOGGER.info(url)

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -27,7 +27,7 @@ import boto3
 import pkg_resources
 from botocore.exceptions import ClientError
 
-LOGGER = logging.getLogger("pcluster.pcluster")
+LOGGER = logging.getLogger(__name__)
 
 
 def boto3_client(service, aws_client_config):
@@ -283,3 +283,19 @@ def check_if_latest_version():
             print("Info: There is a newer version %s of AWS ParallelCluster available." % latest)
     except Exception:
         pass
+
+
+def get_param_value(params, key_name):
+    """
+    Get parameter value from Cloudformation Stack Parameters.
+
+    :param params: Cloudformation Stack Parameters
+    :param key_name: Parameter Key
+    :return: ParameterValue if that parameter exists, otherwise None
+    """
+    return next((i.get("ParameterValue") for i in params if i.get("ParameterKey") == key_name), None)
+
+
+def get_supported_dcv_os():
+    """Return a list of all the operating system supported by DCV."""
+    return ["centos7"]

--- a/cli/tests/pcluster/pcluster-unittest.py
+++ b/cli/tests/pcluster/pcluster-unittest.py
@@ -22,7 +22,7 @@ import boto3
 import configparser
 
 from moto import mock_autoscaling, mock_cloudformation, mock_ec2, mock_s3
-from pcluster import pcluster
+from pcluster import commands
 
 try:
     from StringIO import StringIO
@@ -104,7 +104,7 @@ class TestPCluster(unittest.TestCase):
 
     def test_cfn_cluster_version(self):
         args = BaseArgs()
-        pcluster.version(args)
+        commands.version(args)
         log = test_log_stream.getvalue()
         version_returned = re.match(r"^INFO:\w+\.\w+:(\d+\.\d+\.\d+.*)$", log).group(1)
         self.assertEqual(version_returned, version_on_file)
@@ -115,7 +115,7 @@ class TestPCluster(unittest.TestCase):
     def test_cfn_cluster_create_nowait(self):
         template_url = setup_configurations()
         args = CreateClusterArgs(template_url, True)
-        pcluster.create(args)
+        commands.create(args)
         log = test_log_stream.getvalue()
         success_message = "INFO:parallelcluster.parallelcluster:Status: CREATE_COMPLETE"
         error_prefix = "CRITICAL:"
@@ -128,7 +128,7 @@ class TestPCluster(unittest.TestCase):
     def test_cfn_cluster_create_wait(self):
         template_url = setup_configurations()
         args = CreateClusterArgs(template_url, False)
-        pcluster.create(args)
+        commands.create(args)
         log = test_log_stream.getvalue()
         success_message = "INFO:parallelcluster.parallelcluster:MasterPublicIP:"
         error_prefix = "CRITICAL:"
@@ -142,7 +142,7 @@ class TestPCluster(unittest.TestCase):
         setup_configurations()
         args = CreateClusterArgs("", True)
         with self.assertRaises(SystemExit) as sys_ex:
-            pcluster.create(args)
+            commands.create(args)
 
         self.assertEqual(sys_ex.exception.code, 1)
         log = test_log_stream.getvalue()
@@ -154,7 +154,7 @@ class TestPCluster(unittest.TestCase):
     @mock_s3
     def test_cfn_cluster_list_empty(self):
         args = BaseArgs()
-        pcluster.list(args)
+        commands.list(args)
         self.assertEqual(test_log_stream.tell(), 0)
 
     @mock_ec2
@@ -163,10 +163,10 @@ class TestPCluster(unittest.TestCase):
     def test_cfn_cluster_list_nonempty(self):
         template_url = setup_configurations()
         args = CreateClusterArgs(template_url, False)
-        pcluster.create(args)
+        commands.create(args)
         # reset the logger
         self.tearDown()
-        pcluster.list(args)
+        commands.list(args)
         log = test_log_stream.getvalue()
         cluster_name = re.match(r"INFO:parallelcluster.parallelcluster:(\w+)", log).group(1)
         self.assertEqual(cluster_name, args.cluster_name)
@@ -178,8 +178,8 @@ class TestPCluster(unittest.TestCase):
     def test_cfn_cluster_update_no_reset(self):
         template_url = setup_configurations()
         args = UpdateClusterArgs(template_url, True, False)
-        pcluster.create(args)
-        pcluster.update(args)
+        commands.create(args)
+        commands.update(args)
         success_message = "INFO:parallelcluster.parallelcluster:Status: UPDATE_COMPLETE"
         log = test_log_stream.getvalue()
         self.assertTrue(success_message in log)
@@ -193,8 +193,8 @@ class TestPCluster(unittest.TestCase):
     def test_cfn_cluster_update_with_reset(self):
         template_url = setup_configurations()
         args = UpdateClusterArgs(template_url, True, True)
-        pcluster.create(args)
-        pcluster.update(args)
+        commands.create(args)
+        commands.update(args)
         success_message = "INFO:parallelcluster.parallelcluster:Status: UPDATE_COMPLETE"
         log = test_log_stream.getvalue()
         self.assertTrue(success_message in log)
@@ -209,7 +209,7 @@ class TestPCluster(unittest.TestCase):
         template_url = setup_configurations()
         args = UpdateClusterArgs(template_url, True, False)
         with self.assertRaises(SystemExit) as sys_ex:
-            pcluster.update(args)
+            commands.update(args)
         self.assertEqual(sys_ex.exception.code, 1)
         log = test_log_stream.getvalue()
         error_prefix = "CRITICAL:"
@@ -222,9 +222,9 @@ class TestPCluster(unittest.TestCase):
     def test_cfn_cluster_delete(self):
         template_url = setup_configurations()
         args = CreateClusterArgs(template_url, True)
-        pcluster.create(args)
+        commands.create(args)
         with self.assertRaises(SystemExit) as sys_ex:
-            pcluster.delete(args)
+            commands.delete(args)
             self.assertEqual(sys_ex.exception.code, 0)
         success_message = "Cluster deleted successfully"
         log = test_log_stream.getvalue()
@@ -238,7 +238,7 @@ class TestPCluster(unittest.TestCase):
         template_url = setup_configurations()
         args = CreateClusterArgs(template_url, True)
         with self.assertRaises(SystemExit) as sys_ex:
-            pcluster.delete(args)
+            commands.delete(args)
             self.assertEqual(sys_ex.exception.code, 1)
         log = test_log_stream.getvalue()
         error_prefix = "CRITICAL:"
@@ -251,8 +251,8 @@ class TestPCluster(unittest.TestCase):
     def test_cfn_cluster_start(self):
         template_url = setup_configurations()
         args = CreateClusterArgs(template_url, True)
-        pcluster.create(args)
-        pcluster.start(args)
+        commands.create(args)
+        commands.start(args)
         log = test_log_stream.getvalue()
         error_prefix = "CRITICAL:"
         success_message = "Starting compute fleet"
@@ -267,7 +267,7 @@ class TestPCluster(unittest.TestCase):
         template_url = setup_configurations()
         args = CreateClusterArgs(template_url, True)
         with self.assertRaises(SystemExit) as sys_ex:
-            pcluster.start(args)
+            commands.start(args)
         self.assertEqual(sys_ex.exception.code, 1)
         log = test_log_stream.getvalue()
         error_prefix = "CRITICAL:"
@@ -280,9 +280,9 @@ class TestPCluster(unittest.TestCase):
     def test_cfn_cluster_stop(self):
         template_url = setup_configurations()
         args = CreateClusterArgs(template_url, True)
-        pcluster.create(args)
-        pcluster.start(args)
-        pcluster.stop(args)
+        commands.create(args)
+        commands.start(args)
+        commands.stop(args)
         log = test_log_stream.getvalue()
         error_prefix = "CRITICAL:"
         success_message = "Stopping compute fleet"
@@ -297,7 +297,7 @@ class TestPCluster(unittest.TestCase):
         template_url = setup_configurations()
         args = CreateClusterArgs(template_url, True)
         with self.assertRaises(SystemExit):
-            pcluster.stop(args)
+            commands.stop(args)
         log = test_log_stream.getvalue()
         error_prefix = "CRITICAL:"
         self.assertTrue(error_prefix in log)

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -572,6 +572,11 @@
       "Description": "Enable EFA on the compute nodes, enable_efa = compute",
       "Type": "String",
       "Default": "NONE"
+    },
+    "DCVOptions": {
+      "Description": "Comma separated list of NICE DCV related options, 3 parameters in total, [enable, port, access_from]",
+      "Type": "String",
+      "Default": "NONE, NONE, NONE"
     }
   },
   "Conditions": {
@@ -1126,6 +1131,24 @@
             "NONE"
           ]
         }
+      ]
+    },
+    "DCVEnabled": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "0",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "DCVOptions"
+                }
+              ]
+            }
+          ]
+        },
+        "master"
       ]
     }
   },
@@ -1777,6 +1800,14 @@
                   "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster-*"
                 }
               ]
+            },
+            {
+              "Sid": "DcvLicense",
+              "Effect": "Allow",
+              "Action": "s3:GetObject",
+              "Resource": {
+                "Fn::Join": ["", ["arn:aws:s3:::dcv-license.", {"Ref": "AWS::Region"}, "/*"]]
+              }
             }
           ]
         },
@@ -2482,6 +2513,26 @@
                       "Fn::GetAtt": [
                         "SQS",
                         "QueueName"
+                      ]
+                    },
+                    "dcv_enabled": {
+                      "Fn::If": [
+                        "DCVEnabled",
+                        "master",
+                        "false"
+                      ]
+                    },
+                    "dcv_port": {
+                      "Fn::Select": [
+                        "1",
+                        {
+                          "Fn::Split": [
+                            ",",
+                            {
+                              "Ref": "DCVOptions"
+                            }
+                          ]
+                        }
                       ]
                     }
                   },
@@ -3487,6 +3538,54 @@
             "CidrIp": {
               "Ref": "AccessFrom"
             }
+          },
+          {
+            "Fn::If" : [
+              "DCVEnabled",
+              {
+                "IpProtocol": "tcp",
+                "FromPort": {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Fn::Split": [
+                        ",",
+                        {
+                          "Ref": "DCVOptions"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "ToPort": {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Fn::Split": [
+                        ",",
+                        {
+                          "Ref": "DCVOptions"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "CidrIp": {
+                  "Fn::Select": [
+                    "2",
+                    {
+                      "Fn::Split": [
+                        ",",
+                        {
+                          "Ref": "DCVOptions"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {"Ref" : "AWS::NoValue"}
+            ]
           }
         ]
       },

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -9,11 +9,62 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-
+import boto3
 import pytest
-from assertpy import assert_that
 
+from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
+
+
+def _check_ext_auth_blocking_invalid_sessions(remote_command_executor):
+    assert_that(
+        remote_command_executor.run_remote_command(
+            "curl -s -X GET -G http://localhost:8444  "
+            "-d action=requestToken -d authUser=centos -d sessionID=invalidSessionId"
+        ).stdout
+    ).is_equal_to("The given session for the user does not exists")
+
+
+def _check_working_dcv_setup(external_authenticator_port, remote_command_executor):
+    session_id, port, session_token = remote_command_executor.run_remote_command(
+        "/opt/parallelcluster/scripts/pcluster_dcv_connect.sh /shared"
+    ).stdout.split()
+
+    _check_auth_ok(external_authenticator_port, remote_command_executor, session_id, session_token)
+
+
+def _check_shared_dir(external_authenticator_port, remote_command_executor, shared_dir):
+    session_id, port, session_token = remote_command_executor.run_remote_command(
+        f"/opt/parallelcluster/scripts/pcluster_dcv_connect.sh {shared_dir}"
+    ).stdout.split()
+
+    assert_that(
+        int(
+            remote_command_executor.run_remote_command(
+                "cat /var/log/dcv/server.log | grep -c {0}".format(shared_dir)
+            ).stdout
+        )
+    ).is_greater_than(0)
+
+    _check_auth_ok(external_authenticator_port, remote_command_executor, session_id, session_token)
+
+
+def _check_auth_ok(external_authenticator_port, remote_command_executor, session_id, session_token):
+    assert_that(
+        remote_command_executor.run_remote_command(
+            f"curl -s -k http://localhost:{external_authenticator_port} "
+            f"-d sessionId={session_id} -d authenticationToken={session_token} -d clientAddr=someIp"
+        ).stdout
+    ).is_equal_to('<auth result="yes"><username>centos</username></auth>')
+
+
+def _check_security_group(region, cluster, port, expected):
+    security_group_id = cluster.cfn_resources.get("MasterSecurityGroup")
+    client = boto3.client("ec2", region_name=region)
+    response = client.describe_security_groups(GroupIds=[security_group_id])
+    ips = response["SecurityGroups"][0]["IpPermissions"]
+    target = next(filter(lambda x: x.get("FromPort", -1) == port, ips), {})
+    assert_that(target["IpRanges"][0]["CidrIp"]).is_equal_to(expected)
 
 
 @pytest.mark.regions(["eu-west-1"])
@@ -23,8 +74,25 @@ def test_dcv_connection(region, instance, os, scheduler, pcluster_config_reader,
     cluster_config = pcluster_config_reader()
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
-    output = remote_command_executor.run_remote_command("/opt/parallelcluster/scripts/pcluster_dcv_connect.sh /shared")
-    session_id, port, session_token = output.split()
-    assert_that(
-        remote_command_executor.run_remote_command(f"curl -k http://localhost:{port} -d sessionId={session_id} -d authenticationToken={session_token}")
-    ).is_equal_to('<auth result="yes"><username>centos</username></auth>')
+
+    _check_ext_auth_blocking_invalid_sessions(remote_command_executor)
+    _check_working_dcv_setup(8444, remote_command_executor)
+
+
+@pytest.mark.regions(["eu-west-1"])
+@pytest.mark.oss(["centos7"])
+@pytest.mark.schedulers(["sge"])
+def test_custom_dcv_configuration(
+    region, instance, os, scheduler, pcluster_config_reader, clusters_factory, test_datadir
+):
+    dcv_port = 5678
+    external_authenticator_port = dcv_port + 1
+    security_group_cidr = "192.168.1.1/32"
+    shared_dir = "/myshared"
+
+    cluster_config = pcluster_config_reader(port=str(dcv_port), access_from=security_group_cidr, shared=shared_dir)
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    _check_security_group(region, cluster, dcv_port, expected=security_group_cidr)
+    _check_shared_dir(external_authenticator_port, remote_command_executor, shared_dir)

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -1,0 +1,30 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+import pytest
+from assertpy import assert_that
+
+from remote_command_executor import RemoteCommandExecutor
+
+
+@pytest.mark.regions(["eu-west-1"])
+@pytest.mark.oss(["centos7"])
+@pytest.mark.schedulers(["sge"])
+def test_dcv_connection(region, instance, os, scheduler, pcluster_config_reader, clusters_factory, test_datadir):
+    cluster_config = pcluster_config_reader()
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    output = remote_command_executor.run_remote_command("/opt/parallelcluster/scripts/pcluster_dcv_connect.sh /shared")
+    session_id, port, session_token = output.split()
+    assert_that(
+        remote_command_executor.run_remote_command(f"curl -k http://localhost:{port} -d sessionId={session_id} -d authenticationToken={session_token}")
+    ).is_equal_to('<auth result="yes"><username>centos</username></auth>')

--- a/tests/integration-tests/tests/dcv/test_dcv/test_custom_dcv_configuration/pcluster.config.ini
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_custom_dcv_configuration/pcluster.config.ini
@@ -14,6 +14,7 @@ compute_instance_type = {{ instance }}
 initial_queue_size = 1
 maintain_initial_size = false
 dcv_settings = test
+shared_dir = {{ shared }}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
@@ -21,3 +22,5 @@ master_subnet_id = {{ public_subnet_id }}
 
 [dcv test]
 enable = master
+port =  {{ port }}
+access_from = {{ access_from }}

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_connection/pcluster.config.ini
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_connection/pcluster.config.ini
@@ -1,0 +1,25 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+initial_queue_size = 1
+maintain_initial_size = false
+dcv_settings = test
+template_url = https://fiore-mybucket-dcv-custom.s3-eu-west-1.amazonaws.com/aws-parallelcluster.cfn.json
+custom_chef_cookbook = https://s3.eu-west-1.amazonaws.com/fiore-mybucket-dcv-custom/cookbooks/aws-parallelcluster-cookbook-2.4.0.tgz
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+
+[dcv test]
+enable = master


### PR DESCRIPTION
This patch adds support for pallelcluster creating a new command, pcluster dcv, that allows to connect to pcluster instances which have dcv installed ([pull request 349 of the cookbook](https://github.com/aws/aws-parallelcluster-cookbook/pull/349))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
