### PR TITLE
configure: fix config folder creation

### DIFF
--- a/cli/pcluster/easyconfig.py
+++ b/cli/pcluster/easyconfig.py
@@ -228,7 +228,8 @@ def configure(args):  # noqa: C901 FIXME!!!
     # ensure that the directory for the config file exists (because
     # ~/.parallelcluster is likely not to exist on first usage)
     try:
-        os.makedirs(os.path.dirname(config_file))
+        config_folder = os.path.dirname(config_file) or "."
+        os.makedirs(config_folder)
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise  # can safely ignore EEXISTS for this purpose...


### PR DESCRIPTION
The folder creation was failing when passing a filename to `-c` parameter

Tested with:
* `-c /test/config1`
* `-c test/config2`
* `-c config3`

Issue #1197 

