### PR TITLE
Integ tests:  Enable test_nodewatcher_terminates_failing_node for torque

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -145,7 +145,7 @@ class SgeCommands(SchedulerCommands):
     def __init__(self, remote_command_executor):
         super().__init__(remote_command_executor)
 
-    @retry(retry_on_result=lambda result: result != 0, wait_fixed=seconds(7), stop_max_delay=minutes(5))
+    @retry(retry_on_result=lambda result: result != 0, wait_fixed=seconds(3), stop_max_delay=minutes(7))
     def wait_job_completed(self, job_id):  # noqa: D102
         result = self._remote_command_executor.run_remote_command("qacct -j {0}".format(job_id), raise_on_error=False)
         return result.return_code
@@ -214,8 +214,8 @@ class SlurmCommands(SchedulerCommands):
     @retry(
         retry_on_result=lambda result: "JobState" not in result
         or any(value in result for value in ["EndTime=Unknown", "JobState=RUNNING", "JobState=COMPLETING"]),
-        wait_fixed=seconds(7),
-        stop_max_delay=minutes(5),
+        wait_fixed=seconds(3),
+        stop_max_delay=minutes(7),
     )
     def wait_job_completed(self, job_id):  # noqa: D102
         result = self._remote_command_executor.run_remote_command(
@@ -282,7 +282,7 @@ class TorqueCommands(SchedulerCommands):
         super().__init__(remote_command_executor)
 
     @retry(
-        retry_on_result=lambda result: "job_state = C" not in result, wait_fixed=seconds(7), stop_max_delay=minutes(5)
+        retry_on_result=lambda result: "job_state = C" not in result, wait_fixed=seconds(3), stop_max_delay=minutes(7)
     )
     def wait_job_completed(self, job_id):  # noqa: D102
         result = self._remote_command_executor.run_remote_command("qstat -f {0}".format(job_id))

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -65,7 +65,7 @@ def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clu
 
 @pytest.mark.regions(["sa-east-1"])
 @pytest.mark.instances(["c5.xlarge"])
-@pytest.mark.schedulers(["slurm", "sge"])
+@pytest.mark.schedulers(["slurm", "sge", "torque"])
 @pytest.mark.usefixtures("region", "os", "instance")
 @pytest.mark.nodewatcher
 def test_nodewatcher_terminates_failing_node(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):

--- a/tests/integration-tests/tests/scaling/test_scaling/test_nodewatcher_terminates_failing_node/torque_kill_scheduler_job.sh
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_nodewatcher_terminates_failing_node/torque_kill_scheduler_job.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+sudo /etc/init.d/pbs_mom stop
+# keep job up and running
+sleep infinity


### PR DESCRIPTION
- Enable test_nodewatcher_terminates_failing_node for torque
- small change in sge test to generalize expected_max in parallel_jobs
- integ tests: increase check rate in wait_job_completed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
