### PR TITLE
Restore chef run_list removed as part of 5f8a8f6

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2480,6 +2480,9 @@
                         "QueueName"
                       ]
                     }
+                  },
+                  "run_list": {
+                    "Fn::Sub": "recipe[aws-parallelcluster::${Scheduler}_config]"
                   }
                 }
               },
@@ -3291,6 +3294,9 @@
                         "User"
                       ]
                     }
+                  },
+                  "run_list": {
+                    "Fn::Sub": "recipe[aws-parallelcluster::${Scheduler}_config]"
                   }
                 }
               },
@@ -3958,6 +3964,9 @@
                         "User"
                       ]
                     }
+                  },
+                  "run_list": {
+                    "Fn::Sub": "recipe[aws-parallelcluster::${Scheduler}_config]"
                   }
                 }
               },


### PR DESCRIPTION
This was preventing chef from running the runtime recipes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
