### PR TITLE
Disable fabric agent forwarding

### DIFF
--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -38,7 +38,7 @@ class RemoteCommandExecutor:
         self.__connection = Connection(
             host=cluster.master_ip,
             user=self.USERNAMES[cluster.os],
-            forward_agent=True,
+            forward_agent=False,
             connect_kwargs={"key_filename": cluster.ssh_key},
         )
         self.__user_at_hostname = "{0}@{1}".format(self.USERNAMES[cluster.os], cluster.master_ip)


### PR DESCRIPTION
We are getting "paramiko.ssh_exception.AuthenticationException: Unable to connect to SSH agent" when we try to run an SSH command inside an SSH session,
e.g.
RemoteCommandExecutor.run_remote_command("ssh {0}".format(mpi_module, remote_host))

Possibly related to https://github.com/fabric/fabric/issues/562

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
