### PR TITLE
Don't check placement group capacity if NONE or DYNAMIC

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -386,7 +386,7 @@ class ParallelClusterConfig(object):
                 ImageId=test_ami_id,
                 SubnetId=subnet_id,
                 Placement={"GroupName": self.parameters.get("PlacementGroup")}
-                if self.parameters.get("PlacementGroup")
+                if self.parameters.get("PlacementGroup") not in [None, "NONE", "DYNAMIC"]
                 else {},
                 DryRun=True,
             )


### PR DESCRIPTION
See https://aws-parallelcluster.readthedocs.io/en/latest/configuration.html#placement-group

### Before

```bash

# config
placement_group = NONE

$ pcluster create test
Beginning cluster creation for cluster: test
ERROR: Unable to check AWS Account limits. Please double check your cluster configuration.
The placement group 'NONE' is unknown.
```

### After

```bash
$ pcluster create test
Beginning cluster creation for cluster: test
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
