### PR TITLE
Add missing policy autoScaling:SetInstanceHealth

### DIFF
--- a/cli/pcluster/config_sanity.py
+++ b/cli/pcluster/config_sanity.py
@@ -335,6 +335,7 @@ class ResourceValidator(object):
                             "autoscaling:SetDesiredCapacity",
                             "autoscaling:DescribeTags",
                             "autoScaling:UpdateAutoScalingGroup",
+                            "autoScaling:SetInstanceHealth",
                         ],
                         "*",
                     ),


### PR DESCRIPTION
Policy used when reporting instance as unhealthy

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
