### PR TITLE
Fixed a bug for which specifying the same subnet for both master and compute will result in failure

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -854,21 +854,35 @@
       ]
     },
     "UseMasterSubnetForCompute": {
-      "Fn::And": [
+      "Fn::Or": [
         {
-          "Fn::Equals": [
+          "Fn::And": [
             {
-              "Ref": "ComputeSubnetId"
+              "Fn::Equals": [
+                {
+                  "Ref": "ComputeSubnetId"
+                },
+                "NONE"
+              ]
             },
-            "NONE"
+            {
+              "Fn::Equals": [
+                {
+                  "Ref": "ComputeSubnetCidr"
+                },
+                "NONE"
+              ]
+            }
           ]
         },
         {
           "Fn::Equals": [
             {
-              "Ref": "ComputeSubnetCidr"
+              "Ref": "ComputeSubnetId"
             },
-            "NONE"
+            {
+              "Ref": "MasterSubnetId"
+            }
           ]
         }
       ]


### PR DESCRIPTION
Fixed a bug for which specifying the same subnet for both master and compute will result in failure.

The property UseMasterSubnetForCompute need to also take into consideration the fact that the user can write the same subnet in `compute_subnet_id` and `master_subnet_id`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
