### PR TITLE
Support inline comments on Config

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -156,7 +156,7 @@ class ParallelClusterConfig(object):
             else:
                 self.__fail("Config file %s not found" % config_file)
 
-        config = configparser.ConfigParser()
+        config = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
         config.read(config_file)
         return config
 


### PR DESCRIPTION
See https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour

**For example:**

```ini
[cluster test]
key_name = test ; here is a comment
```
### Before
```bash
pcluster create test
Beginning cluster creation for cluster: test
Config sanity error on resource EC2KeyPair: The key pair 'test ; here is a comment' does not exist
```
### After
```bash
pcluster create test
Beginning cluster creation for cluster: test
...
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
