### PR TITLE
Change generate_json_report to parse root <testsuites> tag

### DIFF
--- a/tests/integration-tests/reports_generator.py
+++ b/tests/integration-tests/reports_generator.py
@@ -76,7 +76,7 @@ def generate_json_report(test_results_dir, save_to_file=True):
     result_to_label_mapping = {"skipped": "skipped", "failure": "failures", "error": "errors"}
     results = {"all": _empty_results_dict()}
     xml = untangle.parse(test_report_file)
-    for testcase in xml.testsuite.children:
+    for testcase in xml.testsuites.testsuite.children:
         label = "succeeded"
         for key, value in result_to_label_mapping.items():
             if hasattr(testcase, key):


### PR DESCRIPTION
On August 15th, `pytest` released version 5.1.0 https://pypi.org/project/pytest/#history

This version adds a new root `<testsuites>` tag. See https://github.com/pytest-dev/pytest/issues/5477

**Now**
```xml
<testsuites>
<testsuite errors="0" failures="18" hostname="3a266349df18" name="pytest" skipped="0" tests="30" time="13427.235" timestamp="2019-08-23T04:05:15.798369">
...
```

**Previously**
```xml
<testsuite errors="204" failures="9" name="pytest" skipped="0" tests="793" time="947565.5930000005">
...
```

This patch parses that tag properly.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
