### PR TITLE
Take into account multiple testsuites

### DIFF
--- a/tests/integration-tests/reports_generator.py
+++ b/tests/integration-tests/reports_generator.py
@@ -76,21 +76,22 @@ def generate_json_report(test_results_dir, save_to_file=True):
     result_to_label_mapping = {"skipped": "skipped", "failure": "failures", "error": "errors"}
     results = {"all": _empty_results_dict()}
     xml = untangle.parse(test_report_file)
-    for testcase in xml.testsuites.testsuite.children:
-        label = "succeeded"
-        for key, value in result_to_label_mapping.items():
-            if hasattr(testcase, key):
-                label = value
-                break
-        results["all"][label] += 1
-        results["all"]["total"] += 1
+    for testsuite in xml.testsuites.children:
+        for testcase in testsuite.children:
+            label = "succeeded"
+            for key, value in result_to_label_mapping.items():
+                if hasattr(testcase, key):
+                    label = value
+                    break
+            results["all"][label] += 1
+            results["all"]["total"] += 1
 
-        if hasattr(testcase, "properties"):
-            for property in testcase.properties.children:
-                _record_result(results, property["name"], property["value"], label)
+            if hasattr(testcase, "properties"):
+                for property in testcase.properties.children:
+                    _record_result(results, property["name"], property["value"], label)
 
-        feature = re.sub(r"test_|_test|.py", "", os.path.splitext(os.path.basename(testcase["file"]))[0])
-        _record_result(results, "feature", feature, label)
+            feature = re.sub(r"test_|_test|.py", "", os.path.splitext(os.path.basename(testcase["file"]))[0])
+            _record_result(results, "feature", feature, label)
 
     if save_to_file:
         with open("{0}/test_report.json".format(test_results_dir), "w") as out_f:


### PR DESCRIPTION

### Old Version
```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuite errors="204" failures="9" name="pytest" skipped="0" tests="793" time="947565.5930000005">
...
```

### New Version
```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
	<testsuite errors="12" failures="0" hostname="3a266349df18" name="pytest" skipped="0" tests="42" time="6494.691" timestamp="2019-08-25T21:03:17.716772">
...
	</testsuite>
	<testsuite errors="12" failures="0" hostname="3a266349df18" name="pytest" skipped="0" tests="48" time="8003.670" timestamp="2019-08-25T21:03:17.730325">
...
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
