### PR TITLE
Change prefix of the overscaling common function from test_ to assert_

### DIFF
--- a/tests/integration-tests/tests/schedulers/common.py
+++ b/tests/integration-tests/tests/schedulers/common.py
@@ -16,7 +16,7 @@ from tests.common.assertions import assert_scaling_worked
 from tests.common.schedulers_common import get_scheduler_commands
 
 
-def test_overscaling_when_job_submitted_during_scaledown(
+def assert_overscaling_when_job_submitted_during_scaledown(
     remote_command_executor, scheduler, region, stack_name, scaledown_idletime
 ):
     """Test that if a job gets submitted when a node is locked the cluster does not overscale"""

--- a/tests/integration-tests/tests/schedulers/test_sge.py
+++ b/tests/integration-tests/tests/schedulers/test_sge.py
@@ -19,7 +19,7 @@ from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 from tests.common.assertions import assert_no_errors_in_logs, assert_scaling_worked
 from tests.common.schedulers_common import SgeCommands
-from tests.schedulers.common import test_overscaling_when_job_submitted_during_scaledown
+from tests.schedulers.common import assert_overscaling_when_job_submitted_during_scaledown
 
 
 @pytest.mark.regions(["ap-southeast-1"])
@@ -43,7 +43,7 @@ def test_sge(region, pcluster_config_reader, clusters_factory):
     _test_non_runnable_jobs(remote_command_executor, max_queue_size, max_slots, region, cluster, scaledown_idletime)
     _test_job_dependencies(remote_command_executor, region, cluster.cfn_name, scaledown_idletime)
     _test_job_arrays_and_parallel_jobs(remote_command_executor, region, cluster.cfn_name, scaledown_idletime, max_slots)
-    test_overscaling_when_job_submitted_during_scaledown(
+    assert_overscaling_when_job_submitted_during_scaledown(
         remote_command_executor, "sge", region, cluster.cfn_name, scaledown_idletime
     )
     # TODO: _test_dynamic_max_cluster_size

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -19,7 +19,7 @@ from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
 from tests.common.assertions import assert_asg_desired_capacity, assert_no_errors_in_logs, assert_scaling_worked
 from tests.common.schedulers_common import SlurmCommands
-from tests.schedulers.common import test_overscaling_when_job_submitted_during_scaledown
+from tests.schedulers.common import assert_overscaling_when_job_submitted_during_scaledown
 
 
 @pytest.mark.regions(["us-west-1"])
@@ -43,7 +43,7 @@ def test_slurm(region, pcluster_config_reader, clusters_factory):
     _test_cluster_limits(remote_command_executor, max_queue_size, region, cluster.asg)
     _test_job_dependencies(remote_command_executor, region, cluster.cfn_name, scaledown_idletime, max_queue_size)
     _test_job_arrays_and_parallel_jobs(remote_command_executor, region, cluster.cfn_name, scaledown_idletime)
-    test_overscaling_when_job_submitted_during_scaledown(
+    assert_overscaling_when_job_submitted_during_scaledown(
         remote_command_executor, "slurm", region, cluster.cfn_name, scaledown_idletime
     )
     _test_dynamic_dummy_nodes(remote_command_executor, max_queue_size)

--- a/tests/integration-tests/tests/schedulers/test_torque.py
+++ b/tests/integration-tests/tests/schedulers/test_torque.py
@@ -20,7 +20,7 @@ from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
 from tests.common.assertions import assert_no_errors_in_logs, assert_scaling_worked
 from tests.common.schedulers_common import TorqueCommands
-from tests.schedulers.common import test_overscaling_when_job_submitted_during_scaledown
+from tests.schedulers.common import assert_overscaling_when_job_submitted_during_scaledown
 
 
 @pytest.mark.regions(["us-west-2"])
@@ -45,7 +45,7 @@ def test_torque(region, pcluster_config_reader, clusters_factory):
     _test_job_dependencies(remote_command_executor, region, cluster.cfn_name, scaledown_idletime)
     _test_job_arrays_and_parallel_jobs(remote_command_executor, region, cluster.cfn_name, scaledown_idletime, max_slots)
     _test_dynamic_cluster_limits(remote_command_executor, max_queue_size, max_slots, region, cluster.asg)
-    test_overscaling_when_job_submitted_during_scaledown(
+    assert_overscaling_when_job_submitted_during_scaledown(
         remote_command_executor, "torque", region, cluster.cfn_name, scaledown_idletime
     )
 


### PR DESCRIPTION
It is required to avoid that the common function is executed from the integration test framework.

Signed-off-by: Enrico Usai <usai@amazon.com>
