### PR TITLE
Add support for all *.metal instances

### DIFF
--- a/util/upload-instance-slot-map.py
+++ b/util/upload-instance-slot-map.py
@@ -31,7 +31,7 @@ def dump_instances(instance_details):
         data = json.load(data_file)
     instances = {}
     for sku, product in data.get("products").iteritems():
-        if product.get("productFamily") == "Compute Instance":
+        if "Compute Instance" in product.get("productFamily"):
             instance = product.get("attributes")
             instances[instance.get("instanceType")] = {"vcpus": instance.get("vcpu")}
     print(json.dumps(instances))


### PR DESCRIPTION
For some *.metal instances the productFamily is _"Compute Instance (bare metal)"_ instead of _"Compute Instance"_.

The missing instance types were:
- z1d.metal
- r5d.metal
- i3.metal
- r5.metal
- i3en.metal

The following instances were already supported:
- m5.metal
- c5n.metal
- c5.metal
- m5d.metal
- c5d.metal

Fixes https://github.com/aws/aws-parallelcluster/issues/1283

