### PR TITLE
Add StackName to instance Name tags

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2021,7 +2021,9 @@
                 },
                 {
                   "Key": "Name",
-                  "Value": "Master"
+                  "Value": {
+                    "Fn::Sub": "${AWS::StackName} Master"
+                  }
                 },
                 {
                   "Key": "aws-parallelcluster-attributes",
@@ -2648,7 +2650,9 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "Compute",
+            "Value": {
+              "Fn::Sub": "${AWS::StackName} Compute"
+            },
             "PropagateAtLaunch": true
           },
           {


### PR DESCRIPTION
Make it easier to find instance belonging to a particular parallel cluster.

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
