### PR TITLE
Added a CLI arg for additional_cfn_template.

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -69,6 +69,9 @@ class ParallelClusterConfig(object):
         # Initialize template url public attribute
         self.__init_template_url()
 
+        # Initialize additional_cfn_template url attribute.
+        self.__init_additional_cfn_template_url()
+
         # Validate VPC configuration settings and initialize corresponding parameters
         self.__init_vpc_parameters()
 
@@ -319,6 +322,31 @@ class ParallelClusterConfig(object):
         except AttributeError:
             pass
 
+    def __init_additional_cfn_template_url(self):
+        """
+        Determine the CloudFormation URL of the additional_cfn_template to be used and initializes the attribute.
+
+        Order is 1) CLI arg 2) Config file
+        """
+        try:
+            if self.args.additional_cfn_template_url is not None:
+                self.parameters["AdditionalCfnTemplate"] = self.args.additional_cfn_template_url
+            else:
+                try:
+                    self.parameters["AdditionalCfnTemplate"] = self.__config.get(
+                        self.__cluster_section, "additional_cfn_template"
+                    )
+                    if not self.parameters["AdditionalCfnTemplate"]:
+                        self.__fail(
+                            "additional_cfn_template set in [%s] section but not defined." % self.__cluster_section
+                        )
+                    self.__validate_resource("URL", self.parameters["AdditionalCfnTemplate"])
+                except configparser.NoOptionError:
+                    pass
+
+        except AttributeError:
+            pass
+
     def __init_vpc_parameters(self):
         """Initialize VPC Parameters."""
         # Determine which vpc settings section will be used
@@ -514,7 +542,6 @@ class ParallelClusterConfig(object):
             ec2_iam_role=("EC2IAMRoleName", "EC2IAMRoleName"),
             extra_json=("ExtraJson", None),
             custom_chef_cookbook=("CustomChefCookbook", None),
-            additional_cfn_template=("AdditionalCfnTemplate", None),
             custom_awsbatch_template_url=("CustomAWSBatchTemplateURL", None),
         )
         for key in cluster_options:

--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -159,6 +159,9 @@ Examples::
         help="Specifies the URL for a custom CloudFormation template, if it was used at creation time.",
     )
     pcreate.add_argument(
+        "-a", "--additional-cfn-template-url", help="Specifies the URL for a custom additional CloudFormation template."
+    )
+    pcreate.add_argument(
         "-t",
         "--cluster-template",
         help="Indicates which section of the configuration file to use for cluster creation.",


### PR DESCRIPTION
Related issue #1299

*Description of changes:*

I simply add a new command-line argumement `-a`, to set the AdditionalCfnTemplate attribute. This would allow the use of a dynamically generated pre-signed URL for both the TemplateURL and AdditionalCfnTemplate attributes without the need to manually edit the config file.

My next step would be to document this in the wiki. Since I can't edit the wiki, I was planning on proceeding like this [gist](https://gist.github.com/larrybotha/10650410) suggests.

I ran `tox -e autoformat` and `tox` on my machine and every test passed (for the python2.7 and python3.7, I don't have other versions of python installed).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
