### PR TITLE
Add pcluster dcv command

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -33,6 +33,7 @@ from pcluster.config.param_types import (
 from pcluster.config.validators import (
     cluster_validator,
     compute_instance_type_validator,
+    dcv_enabled_validator,
     disable_hyperthreading_validator,
     ec2_ami_validator,
     ec2_ebs_snapshot_validator,
@@ -361,6 +362,29 @@ FSX = {
     )
 }
 
+DCV = {
+    "type": Section,
+    "key": "dcv",
+    "default_label": "default",
+    "cfn_param_mapping": "DCVOptions",  # All the parameters in the section are converted into a single CFN parameter
+    "params": OrderedDict(  # Use OrderedDict because the parameters must respect the order in the CFN parameter
+        [
+            ("enable", {
+                "allowed_values": ["master"],
+                "validators": [dcv_enabled_validator],
+            }),
+            ("port", {
+                "type": IntParam,
+                "default": 8443,
+            }),
+            ("access_from", {
+                "default": "0.0.0.0/0",
+                "allowed_values": ALLOWED_VALUES["cidr"],
+            }),
+        ]
+    )
+}
+
 CLUSTER = {
     "type": ClusterSection,
     "key": "cluster",
@@ -587,6 +611,10 @@ CLUSTER = {
             ("fsx_settings", {
                 "type": SettingsParam,
                 "referred_section": FSX,
+            }),
+            ("dcv_settings", {
+                "type": SettingsParam,
+                "referred_section": DCV,
             }),
         ]
     )

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -19,6 +19,7 @@ from configparser import NoSectionError
 
 import yaml
 from pcluster.utils import (
+    PCLUSTER_ISSUES_LINK,
     error,
     get_avail_zone,
     get_cfn_param,
@@ -756,8 +757,7 @@ class DisableHyperThreadingParam(BoolParam):
                 self.pcluster_config.error(
                     "For disable_hyperthreading, unable to get number of vcpus for {0} instance. "
                     "Please open an issue {1}".format(
-                        master_instance_type if master_cores < 0 else compute_instance_type,
-                        "https://github.com/aws/aws-parallelcluster/issues",
+                        master_instance_type if master_cores < 0 else compute_instance_type, PCLUSTER_ISSUES_LINK
                     )
                 )
             cfn_params.update({self.definition.get("cfn_param_mapping"): "{0},{1}".format(master_cores, compute_cores)})

--- a/cli/pcluster/dcv/__init__.py
+++ b/cli/pcluster/dcv/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cli/pcluster/dcv/connect.py
+++ b/cli/pcluster/dcv/connect.py
@@ -1,0 +1,96 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import re
+import subprocess as sub
+import webbrowser
+
+from pcluster.config.pcluster_config import PclusterConfig
+from pcluster.dcv.utils import DCV_CONNECT_SCRIPT
+from pcluster.utils import (
+    PCLUSTER_ISSUES_LINK,
+    error,
+    get_cfn_param,
+    get_master_ip_and_username,
+    get_stack,
+    get_stack_name,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _check_command_output(cmd):
+    return sub.check_output(cmd, shell=True, universal_newlines=True, stderr=sub.STDOUT).strip()
+
+
+def dcv_connect(args):
+    """
+    Execute pcluster dcv connect command.
+
+    :param args: pcluster cli arguments.
+    """
+    # Parse configuration file to read the AWS section
+    PclusterConfig()  # FIXME it always searches for the default configuration file
+
+    # Prepare ssh command to execute in the master instance
+    stack = get_stack(get_stack_name(args.cluster_name))
+    shared_dir = get_cfn_param(stack.get("Parameters"), "SharedDir")
+    master_ip, username = get_master_ip_and_username(args.cluster_name)
+    cmd = 'ssh {CFN_USER}@{MASTER_IP} {KEY} "{REMOTE_COMMAND} {DCV_SHARED_DIR}"'.format(
+        CFN_USER=username,
+        MASTER_IP=master_ip,
+        KEY="-i {0}".format(args.key_path) if args.key_path else "",
+        REMOTE_COMMAND=DCV_CONNECT_SCRIPT,
+        DCV_SHARED_DIR=shared_dir,
+    )
+
+    # Connect by ssh to the master instance and prepare DCV session
+    try:
+        LOGGER.debug("SSH command: {0}".format(cmd))
+        output = _check_command_output(cmd)
+        # At first ssh connection, the ssh command alerts it is adding the host to the known hosts list
+        if re.search("Permanently added .* to the list of known hosts.", output):
+            output = _check_command_output(cmd)
+
+        dcv_parameters = re.search(
+            r"PclusterDcvServerPort=([\d]+) PclusterDcvSessionId=([\w]+) PclusterDcvSessionToken=([\w-]+)", output
+        )
+        if dcv_parameters:
+            dcv_server_port = dcv_parameters.group(1)
+            dcv_session_id = dcv_parameters.group(2)
+            dcv_session_token = dcv_parameters.group(3)
+        else:
+            error(
+                "Something went wrong during DCV connection. Please manually execute the command:\n{0}\n"
+                "If the problem persists, please check the logs in the /var/log/parallelcluster/ folder "
+                "of the master instance and submit an issue {1}.".format(cmd, PCLUSTER_ISSUES_LINK)
+            )
+
+    except sub.CalledProcessError as e:
+        if "{0}: No such file or directory".format(DCV_CONNECT_SCRIPT) in e.output:
+            error(
+                "The cluster {0} has been created with an old version of ParallelCluster "
+                "without the DCV support.".format(args.cluster_name)
+            )
+        else:
+            error("Something went wrong during DCV connection.\n{0}".format(e.output))
+
+    # Open web browser
+    url = "https://{IP}:{PORT}?authToken={TOKEN}#{SESSION_ID}".format(
+        IP=master_ip, PORT=dcv_server_port, TOKEN=dcv_session_token, SESSION_ID=dcv_session_id
+    )
+    try:
+        webbrowser.open_new(url)
+    except webbrowser.Error:
+        LOGGER.info(
+            "Unable to open the Web browser. "
+            "Please use the following URL in your browser within 30 seconds:\n{0}".format(url)
+        )

--- a/cli/pcluster/dcv/utils.py
+++ b/cli/pcluster/dcv/utils.py
@@ -1,0 +1,23 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DCV_CONNECT_SCRIPT = "/opt/parallelcluster/scripts/pcluster_dcv_connect.sh"
+
+
+def get_supported_dcv_os():
+    """Return a list of all the operating system supported by DCV."""
+    return ["centos7"]
+
+
+def get_supported_dcv_partition():
+    """Return a list of all the partition supported by DCV."""
+    return ["aws"]  # NICE DCV license bucket is not present in us-gov

--- a/cli/pcluster/examples/config
+++ b/cli/pcluster/examples/config
@@ -125,6 +125,8 @@ vpc_settings = public
 #efs_settings = customfs
 # Settings section relating to RAID drive
 #raid_settings = rs
+# Settings section relating to NICE DCV connection
+#dcv_settings = dcv-custom
 
 ## VPC Settings
 [vpc public]
@@ -240,3 +242,15 @@ master_subnet_id = subnet-12345678
 # Use encrypted volume
 # (defaults to false)
 #encrypted = false
+
+## DCV settings
+#[dcv dcv-custom]
+# Parameter required to explicitly enable DCV feature
+#enable = master
+# The port to use to connect to the NICE DCV server
+# (defaults to 8443)
+#port = 8443
+# DCV access from CIDR
+# This is used when AWS ParallelCluster creates the security group
+# (defaults to 0.0.0.0/0)
+#access_from = 0.0.0.0/0

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -77,6 +77,8 @@ DEFAULT_FSX_DICT = {
     "weekly_maintenance_start_time": None,
 }
 
+DEFAULT_DCV_DICT = {"enable": None, "port": 8443, "access_from": "0.0.0.0/0"}
+
 DEFAULT_CLUSTER_DICT = {
     "key_name": None,
     "template_url": None,
@@ -123,6 +125,7 @@ DEFAULT_CLUSTER_DICT = {
     "efs_settings": None,
     "raid_settings": None,
     "fsx_settings": None,
+    "dcv_settings": None,
 }
 
 DEFAULT_PCLUSTER_DICT = {"cluster": DEFAULT_CLUSTER_DICT}
@@ -141,13 +144,14 @@ class DefaultDict(Enum):
     efs = DEFAULT_EFS_DICT
     raid = DEFAULT_RAID_DICT
     fsx = DEFAULT_FSX_DICT
+    dcv = DEFAULT_DCV_DICT
     pcluster = DEFAULT_PCLUSTER_DICT
 
 
 # ------------------ Default CFN parameters ------------------ #
 
 # number of CFN parameters created by the PclusterConfig object.
-CFN_CONFIG_NUM_OF_PARAMS = 55
+CFN_CONFIG_NUM_OF_PARAMS = 56
 
 # CFN parameters created by the pcluster CLI
 CFN_CLI_RESERVED_PARAMS = ["ResourcesS3Bucket"]
@@ -183,6 +187,8 @@ DEFAULT_EFS_CFN_PARAMS = {"EFSOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE
 DEFAULT_RAID_CFN_PARAMS = {"RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
 DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
+
+DEFAULT_DCV_CFN_PARAMS = {"DCVOptions": "NONE,NONE,NONE"}
 
 DEFAULT_CLUSTER_CFN_PARAMS = {
     "KeyName": "NONE",
@@ -248,6 +254,8 @@ DEFAULT_CLUSTER_CFN_PARAMS = {
     "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # fsx
     "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+    # dcv
+    "DCVOptions": "NONE,NONE,NONE",
 }
 
 
@@ -260,4 +268,5 @@ class DefaultCfnParams(Enum):
     efs = DEFAULT_EFS_CFN_PARAMS
     raid = DEFAULT_RAID_CFN_PARAMS
     fsx = DEFAULT_FSX_CFN_PARAMS
+    dcv = DEFAULT_DCV_CFN_PARAMS
     cluster = DEFAULT_CLUSTER_CFN_PARAMS

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -1006,6 +1006,19 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
             ),
         ),
         (
+            "dcv",
+            utils.merge_dicts(
+                DefaultCfnParams["cluster"].value,
+                {
+                    "CLITemplate": "dcv",
+                    "AvailabilityZone": "mocked_avail_zone",
+                    "VPCId": "vpc-12345678",
+                    "MasterSubnetId": "subnet-12345678",
+                    "DCVOptions": "master,8555,10.0.0.0/0",
+                },
+            ),
+        ),
+        (
             "ebs",
             utils.merge_dicts(
                 DefaultCfnParams["cluster"].value,
@@ -1072,6 +1085,8 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "RAIDOptions": "raid,NONE,NONE,gp2,20,100,false,NONE",
                     # fsx
                     "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    # dcv
+                    "DCVOptions": "master,8555,10.0.0.0/0",
                 },
             ),
         ),
@@ -1133,6 +1148,8 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "RAIDOptions": "raid,NONE,NONE,gp2,20,100,false,NONE",
                     # fsx
                     "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    # dcv
+                    "DCVOptions": "master,8555,10.0.0.0/0",
                 },
             ),
         ),

--- a/cli/tests/pcluster/config/test_section_cluster/test_cluster_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_cluster/test_cluster_from_file_to_cfn/pcluster.config.ini
@@ -154,6 +154,16 @@ efs_settings = default
 [efs default]
 shared_dir = efs
 
+# Test: dcv settings
+[cluster dcv]
+vpc_settings = default
+dcv_settings = default
+
+[dcv default]
+enable = master
+access_from = 10.0.0.0/0
+port = 8555
+
 # Test: All the *_settings configured in cluster section
 [cluster all-settings]
 scaling_settings = scaling
@@ -162,6 +172,7 @@ ebs_settings = ebs1
 efs_settings = default
 raid_settings = default
 fsx_settings = default
+dcv_settings = default
 
 [scaling scaling]
 scaledown_idletime = 15
@@ -180,6 +191,7 @@ ebs_settings = ebs1
 efs_settings = default
 raid_settings = default
 fsx_settings = default
+dcv_settings = default
 key_name = key
 template_url = https://template
 base_os = ubuntu1804

--- a/cli/tests/pcluster/config/test_section_dcv.py
+++ b/cli/tests/pcluster/config/test_section_dcv.py
@@ -1,0 +1,126 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+import tests.pcluster.config.utils as utils
+from pcluster.config.mappings import DCV
+from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
+
+
+@pytest.mark.parametrize(
+    "cfn_params_dict, expected_section_dict",
+    [
+        (DefaultCfnParams["dcv"].value, DefaultDict["dcv"].value),
+        ({}, DefaultDict["dcv"].value),
+        ({"DCVOptions": "NONE, NONE, NONE"}, DefaultDict["dcv"].value),
+        ({"DCVOptions": "NONE,NONE,NONE"}, DefaultDict["dcv"].value),
+        (
+            {"DCVOptions": "master,8555,10.10.10.10/10"},
+            {"enable": "master", "port": 8555, "access_from": "10.10.10.10/10"},
+        ),
+        ({"DCVOptions": "master,NONE,NONE"}, {"enable": "master", "port": 8443, "access_from": "0.0.0.0/0"}),
+    ],
+)
+def test_dcv_section_from_cfn(mocker, cfn_params_dict, expected_section_dict):
+    utils.assert_section_from_cfn(mocker, DCV, cfn_params_dict, expected_section_dict)
+
+
+@pytest.mark.parametrize(
+    "config_parser_dict, expected_dict_params, expected_message",
+    [
+        # default
+        ({"dcv default": {}}, {}, None),
+        # right value
+        ({"dcv default": {"enable": "master"}}, {"enable": "master"}, None),
+        # invalid value
+        ({"dcv default": {"enable": "wrong_value"}}, None, "has an invalid value"),
+        ({"dcv default": {"port": "wrong_value"}}, None, "must be an Integer"),
+        ({"dcv default": {"access_from": "wrong_value"}}, None, "has an invalid value"),
+        # invalid key
+        ({"dcv default": {"invalid_key": "fake_value"}}, None, "'invalid_key' is not allowed in the .* section"),
+    ],
+)
+def test_dcv_section_from_file(mocker, config_parser_dict, expected_dict_params, expected_message):
+    utils.assert_section_from_file(mocker, DCV, config_parser_dict, expected_dict_params, expected_message)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_config_parser_dict, expected_message",
+    [
+        # default
+        ({}, {"dcv default": {}}, None),
+        # other values
+        ({"port": 10}, {"dcv default": {"port": "10"}}, None),
+        ({"access_from": "10.0.0.0/10"}, {"dcv default": {"access_from": "10.0.0.0/10"}}, None),
+    ],
+)
+def test_dcv_section_to_file(mocker, section_dict, expected_config_parser_dict, expected_message):
+    utils.assert_section_to_file(mocker, DCV, section_dict, expected_config_parser_dict, expected_message)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_cfn_params", [(DefaultDict["dcv"].value, DefaultCfnParams["dcv"].value)]
+)
+def test_dcv_section_to_cfn(mocker, section_dict, expected_cfn_params):
+    utils.assert_section_to_cfn(mocker, DCV, section_dict, expected_cfn_params)
+
+
+@pytest.mark.parametrize(
+    "param_key, param_value, expected_value, expected_message",
+    [
+        ("enable", None, None, None),
+        ("enable", "", None, None),
+        ("enable", "wrong_value", None, "has an invalid value"),
+        ("enable", "NONE", None, "has an invalid value"),
+        ("enable", "master", "master", None),
+        ("port", None, 8443, None),
+        ("port", "", 8443, None),
+        ("port", "NONE", None, "must be an Integer"),
+        ("port", "wrong_value", None, "must be an Integer"),
+        ("port", "1", 1, None),
+        ("port", "20", 20, None),
+        ("access_from", None, "0.0.0.0/0", None),
+        ("access_from", "", "0.0.0.0/0", None),
+        ("access_from", "wrong_value", None, "Allowed values are"),
+        ("access_from", "111.111.111.111", None, "Allowed values are"),
+        ("access_from", "111.111.111.111/222", None, "Allowed values are"),
+        ("access_from", "NONE", None, "Allowed values are"),
+        ("access_from", "1.1.1.1/0", "1.1.1.1/0", None),
+        ("access_from", "1.1.1.1/2", None, "Allowed values are"),
+        ("access_from", "1.1.1.1/15", None, "Allowed values are"),
+        ("access_from", "1.1.1.1/16", "1.1.1.1/16", None),
+        ("access_from", "1.1.1.1/32", "1.1.1.1/32", None),
+        ("access_from", "1.1.1.1/33", None, "Allowed values are"),
+        ("access_from", "11.11.11.11/32", "11.11.11.11/32", None),
+        ("access_from", "111.111.111.111/22", "111.111.111.111/22", None),
+    ],
+)
+def test_dcv_param_from_file(mocker, param_key, param_value, expected_value, expected_message):
+    utils.assert_param_from_file(mocker, DCV, param_key, param_value, expected_value, expected_message)
+
+
+@pytest.mark.parametrize(
+    "settings_label, expected_cfn_params",
+    [
+        ("test1", SystemExit()),
+        ("test2", utils.merge_dicts(DefaultCfnParams["cluster"].value, {"DCVOptions": "master,8443,0.0.0.0/0"})),
+        ("test3", utils.merge_dicts(DefaultCfnParams["cluster"].value, {"DCVOptions": "master,8555,10.0.0.0/0"})),
+        ("test1,test2", SystemExit()),
+        ("test4", SystemExit()),
+        ("test5", SystemExit()),
+        ("test6", SystemExit()),
+    ],
+)
+def test_dcv_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
+    """Unit tests for parsing EFS related options."""
+    mocker.patch("pcluster.config.param_types.get_efs_mount_target_id", return_value="mount_target_id")
+    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)

--- a/cli/tests/pcluster/config/test_section_dcv/test_dcv_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_dcv/test_dcv_from_file_to_cfn/pcluster.config.ini
@@ -1,0 +1,38 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = false
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+dcv_settings = {{ settings_label }}
+
+[dcv test1]
+enable = NONE
+port = NONE
+access_from = NONE
+
+[dcv test2]
+enable = master
+
+[dcv test3]
+enable = master
+port = 8555
+access_from = 10.0.0.0/0
+
+[dcv test4]
+enable = wrong_value
+port = 8555
+access_from = 10.0.0.0/0
+
+[dcv test5]
+enable = master
+port = wrong_value
+access_from = 10.0.0.0/0
+
+[dcv test6]
+enable = master
+port = 8555
+access_from = wrong_value

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -329,6 +329,11 @@
       "Description": "Enable EFA on the compute nodes, enable_efa = compute",
       "Type": "String",
       "Default": "NONE"
+    },
+    "DCVOptions": {
+      "Description": "Comma separated list of NICE DCV related options, 3 parameters in total, [enabled,port,access_from]",
+      "Type": "String",
+      "Default": "NONE,NONE,NONE"
     }
   },
   "Conditions": {
@@ -932,6 +937,24 @@
           ]
         }
       ]
+    },
+    "EnableDCV": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "0",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "DCVOptions"
+                }
+              ]
+            }
+          ]
+        },
+        "master"
+      ]
     }
   },
   "Mappings": {
@@ -1505,6 +1528,16 @@
               "Resource": [
                 {
                   "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster-*"
+                }
+              ]
+            },
+            {
+              "Sid": "DcvLicense",
+              "Effect": "Allow",
+              "Action": "s3:GetObject",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::dcv-license.${AWS::Region}/*"
                 }
               ]
             }
@@ -2275,6 +2308,26 @@
                       "Fn::GetAtt": [
                         "SQS",
                         "QueueName"
+                      ]
+                    },
+                    "dcv_enabled": {
+                      "Fn::If": [
+                        "EnableDCV",
+                        "master",
+                        "false"
+                      ]
+                    },
+                    "dcv_port": {
+                      "Fn::Select": [
+                        "1",
+                        {
+                          "Fn::Split": [
+                            ",",
+                            {
+                              "Ref": "DCVOptions"
+                            }
+                          ]
+                        }
                       ]
                     }
                   },
@@ -3344,6 +3397,56 @@
             "CidrIp": {
               "Ref": "AccessFrom"
             }
+          },
+          {
+            "Fn::If": [
+              "EnableDCV",
+              {
+                "IpProtocol": "tcp",
+                "FromPort": {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Fn::Split": [
+                        ",",
+                        {
+                          "Ref": "DCVOptions"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "ToPort": {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Fn::Split": [
+                        ",",
+                        {
+                          "Ref": "DCVOptions"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "CidrIp": {
+                  "Fn::Select": [
+                    "2",
+                    {
+                      "Fn::Split": [
+                        ",",
+                        {
+                          "Ref": "DCVOptions"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
           }
         ]
       },

--- a/tests/integration-tests/tests/dcv/__init__.py
+++ b/tests/integration-tests/tests/dcv/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -1,0 +1,109 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import re
+
+import boto3
+import pytest
+
+from assertpy import assert_that
+from pcluster.dcv.utils import DCV_CONNECT_SCRIPT, get_supported_dcv_os
+from remote_command_executor import RemoteCommandExecutor
+
+SERVER_URL = "https://localhost"
+
+
+@pytest.mark.parametrize(
+    "dcv_port, access_from, shared_dir", [(8443, "0.0.0.0/0", "/shared"), (5678, "192.168.1.1/32", "/myshared")]
+)
+@pytest.mark.regions(["eu-west-1", "cn-northwest-1"])  # DCV license bucket not present in us-gov
+@pytest.mark.oss(get_supported_dcv_os())
+@pytest.mark.schedulers(["sge", "awsbatch"])
+def test_dcv_configuration(
+    dcv_port, access_from, shared_dir, region, instance, os, scheduler, pcluster_config_reader, clusters_factory
+):
+    dcv_authenticator_port = dcv_port + 1
+    cluster_config = pcluster_config_reader(dcv_port=str(dcv_port), access_from=access_from, shared_dir=shared_dir)
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    # check configuration parameters
+    _check_security_group(region, cluster, dcv_port, expected_cidr=access_from)
+
+    # check error cases
+    _check_auth_ko(
+        remote_command_executor,
+        dcv_authenticator_port,
+        "-d action=requestToken -d authUser=centos -d sessionID=invalidSessionId",
+        "The given session does not exists",
+    )
+    _check_auth_ko(
+        remote_command_executor, dcv_authenticator_port, "-d action=test", "The action specified 'test' is not valid"
+    )
+    _check_auth_ko(
+        remote_command_executor, dcv_authenticator_port, "-d action=requestToken -d authUser=centos", "Wrong parameters"
+    )
+    _check_auth_ko(
+        remote_command_executor, dcv_authenticator_port, "-d action=sessionToken -d authUser=centos", "Wrong parameters"
+    )
+
+    # launch a session and verify the authenticator works
+    command_execution = remote_command_executor.run_remote_command(f"{DCV_CONNECT_SCRIPT} {shared_dir}")
+    dcv_parameters = re.search(
+        r"PclusterDcvServerPort=([\d]+) PclusterDcvSessionId=([\w]+) PclusterDcvSessionToken=([\w-]+)",
+        command_execution.stdout,
+    )
+    if dcv_parameters:
+        dcv_session_id = dcv_parameters.group(2)
+        dcv_session_token = dcv_parameters.group(3)
+        _check_auth_ok(remote_command_executor, dcv_authenticator_port, dcv_session_id, dcv_session_token)
+    else:
+        print(
+            "Command '{0} {1}' fails, output: {2}, error: {3}".format(
+                DCV_CONNECT_SCRIPT, shared_dir, command_execution.stdout, command_execution.stderr
+            )
+        )
+        raise AssertionError
+
+    # check shared dir configuration
+    _check_shared_dir(remote_command_executor, shared_dir)
+
+
+def _check_auth_ko(remote_command_executor, dcv_authenticator_port, params, expected_message):
+    assert_that(
+        remote_command_executor.run_remote_command(
+            f"curl -s -k -X GET -G {SERVER_URL}:{dcv_authenticator_port} {params}"
+        ).stdout
+    ).contains(expected_message)
+
+
+def _check_shared_dir(remote_command_executor, shared_dir):
+    assert_that(
+        int(remote_command_executor.run_remote_command(f"cat /var/log/dcv/server.log | grep -c {shared_dir}").stdout)
+    ).is_greater_than(0)
+
+
+def _check_auth_ok(remote_command_executor, external_authenticator_port, session_id, session_token):
+    assert_that(
+        remote_command_executor.run_remote_command(
+            f"curl -s -k {SERVER_URL}:{external_authenticator_port} "
+            f"-d sessionId={session_id} -d authenticationToken={session_token} -d clientAddr=someIp"
+        ).stdout
+    ).is_equal_to('<auth result="yes"><username>centos</username></auth>')
+
+
+def _check_security_group(region, cluster, port, expected_cidr):
+    security_group_id = cluster.cfn_resources.get("MasterSecurityGroup")
+    response = boto3.client("ec2", region_name=region).describe_security_groups(GroupIds=[security_group_id])
+
+    ips = response["SecurityGroups"][0]["IpPermissions"]
+    target = next(filter(lambda x: x.get("FromPort", -1) == port, ips), {})
+    assert_that(target["IpRanges"][0]["CidrIp"]).is_equal_to(expected_cidr)

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.ini
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.ini
@@ -1,0 +1,26 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+initial_queue_size = 1
+maintain_initial_size = false
+dcv_settings = test
+shared_dir = {{ shared_dir }}
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+
+[dcv test]
+enable = master
+port =  {{ dcv_port }}
+access_from = {{ access_from }}

--- a/util/cfn-stacks-generators/generate-ebs-substack.py
+++ b/util/cfn-stacks-generators/generate-ebs-substack.py
@@ -113,7 +113,7 @@ def main(args):
                 "Volume%s" % (i + 1),
                 AvailabilityZone=Ref(availability_zone),
                 VolumeType=If(use_vol_type, Select(str(i), Ref(volume_type)), "gp2"),
-                Size=If(use_ebs_snapshot, NoValue, If(use_vol_size, Select(str(i), Ref(volume_size)), "20")),
+                Size=If(use_vol_size, Select(str(i), Ref(volume_size)), "20"),
                 SnapshotId=If(use_ebs_snapshot, Select(str(i), Ref(ebs_snapshot_id)), NoValue),
                 Iops=If(use_ebs_iops, Select(str(i), Ref(volume_iops)), NoValue),
                 Encrypted=If(use_ebs_encryption, Select(str(i), Ref(ebs_encryption)), NoValue),


### PR DESCRIPTION
This patch adds a new command to the ParallelCluster CLI:  `pcluster dcv`.

This new command allows the user to open a web browser and automatically connect to a NICE DCV session in the master instance.

The master instance must have NICE DCV installed on it, the external authenticator and the tools required for the integration (see https://github.com/aws/aws-parallelcluster-cookbook/pull/386) .
______
This patch replaces the https://github.com/aws/aws-parallelcluster/pull/1205 :

- I rebased the code with the latest changes
- I reworded the commit messages and fixed up the gpu support commit that was actually included in the previous one.

I also added some minor improvements:
+ Format cfn file
+ Created a folder `dcv` for dcv modules
+ Moved `dcv_connect` module to `dcv/connect`
+ Defined a `dcv.utils` module
+ Defined a constant for pcluster_dcv_connect.sh script
+ moved get_supported_dcv_os to the dcv.utils module
+ renamed get_param_value to get_stack_param_value
+ Improved comments and error messages
