### PR TITLE
Don't set EC2 IAM Policy if None

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -549,7 +549,8 @@ class ParallelClusterConfig(object):
             if aws_batch_iam_policy not in iam_policies:
                 iam_policies.append(aws_batch_iam_policy)
         self.__validate_resource("EC2IAMPolicies", iam_policies)
-        self.parameters["EC2IAMPolicies"] = ",".join(iam_policies)
+        if iam_policies:
+            self.parameters["EC2IAMPolicies"] = ",".join(iam_policies)
 
     def __init_efa_parameters(self):
         try:


### PR DESCRIPTION
Tested with the following combinations:

Where `additional_iam_policies` is set as follows:
```
additional_iam_policies = arn:aws:iam::[Account Id]:policy/ParallelClusterInstancePolicy, arn:aws:iam::aws:policy/AdministratorAccess
```

1. IAM Policies, SGE
2. IAM Policies, AWS Batch
3. AWS Batch, no IAM Policies
4. SGE, no IAM Policies

Integration test in https://github.com/aws/aws-parallelcluster/pull/1313 tests 1, 3 & 4 are covered by existing tests.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
