### PR TITLE
Change EFA device name in Tests

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -59,11 +59,17 @@ def _test_efa_installed(scheduler_commands, remote_command_executor):
 
     # Check EFA interface is present on compute node
     result = remote_command_executor.run_remote_command("cat /shared/lspci.out")
-    assert_that(result.stdout).contains("00:06.0 Ethernet controller: Amazon.com, Inc. Device efa0")
+    assert_that(
+        ("Ethernet controller: Amazon.com, Inc. Elastic Fabric Adapter (EFA)" in result.stdout)
+        or ("Ethernet controller: Amazon.com, Inc. Device efa0" in result.stdout)
+    ).is_true()
 
     # Check EFA interface not present on master
     result = remote_command_executor.run_remote_command("lspci")
-    assert_that(result.stdout).does_not_contain("00:06.0 Ethernet controller: Amazon.com, Inc. Device efa0")
+    assert_that(
+        ("Ethernet controller: Amazon.com, Inc. Elastic Fabric Adapter (EFA)" in result.stdout)
+        or ("Ethernet controller: Amazon.com, Inc. Device efa0" in result.stdout)
+    ).is_false()
 
 
 def _test_osu_benchmarks(mpi_version, remote_command_executor, scheduler_commands, test_datadir, slots_per_instance):


### PR DESCRIPTION
Device name for EFA was changed on Centos 7, now it's `Ethernet controller: Amazon.com, Inc. Elastic Fabric Adapter (EFA)`.

The list now looks like:
```
00:00.0 Host bridge: Intel Corporation 440FX - 82441FX PMC [Natoma]
00:01.0 ISA bridge: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II]
00:01.3 Non-VGA unclassified device: Intel Corporation 82371AB/EB/MB PIIX4 ACPI (rev 08)
00:03.0 VGA compatible controller: Amazon.com, Inc. Device 1111
00:04.0 Non-Volatile memory controller: Amazon.com, Inc. Device 8061
00:05.0 Ethernet controller: Amazon.com, Inc. Elastic Network Adapter (ENA)
00:06.0 Ethernet controller: Amazon.com, Inc. Elastic Fabric Adapter (EFA)
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
