### PR TITLE
Do not validate awsbatch managed policy in sanity_check

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -544,11 +544,11 @@ class ParallelClusterConfig(object):
         except configparser.NoOptionError:
             pass
 
+        self.__validate_resource("EC2IAMPolicies", iam_policies)
         if self.parameters.get("Scheduler") == "awsbatch":
             aws_batch_iam_policy = "arn:{0}:iam::aws:policy/AWSBatchFullAccess".format(get_partition(self.region))
             if aws_batch_iam_policy not in iam_policies:
                 iam_policies.append(aws_batch_iam_policy)
-        self.__validate_resource("EC2IAMPolicies", iam_policies)
         if iam_policies:
             self.parameters["EC2IAMPolicies"] = ",".join(iam_policies)
 


### PR DESCRIPTION
This is done not to ask for additional IAM permissions to validate ParallelCluster internal policies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
