### PR TITLE
Provision central logging option

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -518,6 +518,7 @@ class ParallelClusterConfig(object):
             custom_chef_runlist=("CustomChefRunList", None),
             additional_cfn_template=("AdditionalCfnTemplate", None),
             custom_awsbatch_template_url=("CustomAWSBatchTemplateURL", None),
+            centralised_logging=("CentralisedLogging", None),
         )
         for key in cluster_options:
             try:

--- a/cli/post_install.sh
+++ b/cli/post_install.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+########
+# NOTE #
+########
+#
+# THIS FILE IS PROVIDED AS AN EXAMPLE AND NOT INTENDED TO BE USED BESIDES TESTING
+# USE IT AS AN EXAMPLE BUT NOT AS IS FOR PRODUCTION
+#
+
+# Setup the SSH authentication
+ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+AZ=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+REGION=$(echo "${AZ}" | sed 's/[a-z]$//')
+
+export AWS_DEFAULT_REGION=${REGION}
+
+# install and setup cloudwatch to push in logs in the local region
+sudo yum install awslogs -y
+cat > /etc/awslogs/awscli.conf << EOF
+[plugins]
+cwlogs = cwlogs
+[default]
+region = ${REGION}
+EOF
+
+# check if this is the master instance
+MASTER=false
+if [[ $(aws ec2 describe-instances \
+            --instance-id ${ID} \
+            --query 'Reservations[].Instances[].Tags[?Key==`Name`].Value[]' \
+            --output text) = "Master" ]]; then
+    MASTER=true
+fi
+
+if ${MASTER}; then
+
+# Setup cloudwatch logs for master
+cat >>/etc/awslogs/awslogs.conf << EOF
+[/opt/sge/default/spool/qmaster/messages]
+datetime_format = %b %d %H:%M:%S
+file = /opt/sge/default/spool/qmaster/messages
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = pcluster-master-sge-qmaster-messages
+
+[/var/log/jobwatcher]
+datetime_format = %b %d %H:%M:%S
+file = /var/log/jobwatcher
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = pcluster-master-job-watcher
+
+[/var/log/sqswatcher]
+datetime_format = %b %d %H:%M:%S
+file = /var/log/sqswatcher
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = pcluster-master-sqs-watcher
+EOF
+
+
+else
+
+# Setup cloudwatch logs for compute
+cat >>/etc/awslogs/awslogs.conf << EOF
+
+[/var/log/nodewatcher]
+datetime_format = %b %d %H:%M:%S
+file = /var/log/nodewatcher
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = pcluster-compute-node-watcher
+EOF
+
+fi
+
+# start awslogs
+sudo service awslogs start
+sudo chkconfig awslogs on

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -77,7 +77,8 @@
             "Tenancy",
             "MasterRootVolumeSize",
             "ComputeRootVolumeSize",
-            "EC2IAMRoleName"
+            "EC2IAMRoleName",
+            "CentralisedLogging"
           ]
         },
         {
@@ -260,6 +261,9 @@
         },
         "CLITemplate": {
           "default": "CLI TEMPLATE"
+        },
+        "CentralisedLogging": {
+          "default": "centralised_logs"
         }
       }
     }
@@ -498,6 +502,12 @@
       "Description": "cluster_template section used in the config.",
       "Type": "String",
       "Default": "default"
+    },
+    "CentralisedLogging": {
+      "Description": "Option for enabling or disabling centralised logging options",
+      "Type": "String",
+      "Default": "NONE",
+      "AllowedPattern": "(NONE|YES|NO)"
     },
     "AdditionalSG": {
       "Description": "Additional VPC security group to be added to instances. Defaults to NONE",
@@ -1677,6 +1687,20 @@
               "Effect": "Allow",
               "Resource": [
                 "*"
+              ]
+            },
+            {
+              "Sid": "CloudWatchLogs",
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:logs:*:*:*",
+                "Ref": "CentralisedLogging"
               ]
             },
             {


### PR DESCRIPTION
*Issue #, if available:*

Fixes https://github.com/aws/aws-parallelcluster/issues/1085.

*Description of changes:*

For enabling different logs stored in sqswatcher, nodewatcher,
default/spool/qmaster/messages parameter centralised_logging in config
has been added. Enabling the parameter and adding the post_script will
enable the log types described in respective locations. 

One more implementation can be writing the post_install script in Python, I have added a draft implementation. A method would be present https://github.com/aws/aws-parallelcluster/blob/master/cli/pcluster/cfnconfig.py, as per `centralised_logging` parameter value the script given in post_script would be running. Seemed like an extra effort. Please let me know if you prefer no bash scripts. 

`CentralisedLogging` config paramter will have values defined as per the cloudformation. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
