### PR TITLE
Fixed parsing issue when using ec2_iam_role option

### DIFF
--- a/cli/pcluster/cfnconfig.py
+++ b/cli/pcluster/cfnconfig.py
@@ -515,7 +515,7 @@ class ParallelClusterConfig(object):
             master_root_volume_size=("MasterRootVolumeSize", None),
             compute_root_volume_size=("ComputeRootVolumeSize", None),
             base_os=("BaseOS", None),
-            ec2_iam_role=("EC2IAMRoleName", "EC2IAMRoleName"),
+            ec2_iam_role=("EC2IAMRoleName", None),
             extra_json=("ExtraJson", None),
             custom_chef_cookbook=("CustomChefCookbook", None),
             additional_cfn_template=("AdditionalCfnTemplate", None),


### PR DESCRIPTION
Fixed issue with parsing error when trying to use a custom IAM role with the ec2_iam_role option:

"Unexpected error of type ValueError: too many values to unpack (expected 2)"

The code is looking for two values for this option, but there should only be one (the name of the IAM role). This change has been tested in my environment, and has resolved my issue.

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
