### PR TITLE
Make pcluster update's extra-parameters arg of type json.loads

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -189,7 +189,7 @@ Examples::
     pupdate.add_argument(
         "-t", "--cluster-template", help="Indicates which section of the configuration file to use for cluster update."
     )
-    pupdate.add_argument("-p", "--extra-parameters", help="Adds extra parameters to the stack update.")
+    pupdate.add_argument("-p", "--extra-parameters", type=json.loads, help="Adds extra parameters to the stack update.")
     pupdate.add_argument(
         "-rd",
         "--reset-desired",


### PR DESCRIPTION
Issue #118

Enable users to pass in configuration data via a JSON string when using pcluster update's extra-parameters option.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
