### PR TITLE
Fixes to logging and pcluster configure validation

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -23,7 +23,7 @@ from botocore.exceptions import NoCredentialsError
 from pcluster import pcluster
 from pcluster.configure import easyconfig
 
-LOGGER = logging.getLogger("pcluster.pcluster")
+LOGGER = logging.getLogger("pcluster." + __name__)
 
 
 def create(args):
@@ -76,7 +76,7 @@ def create_ami(args):
 
 
 def config_logger():
-    logger = logging.getLogger("pcluster.pcluster")
+    logger = logging.getLogger("pcluster")
     logger.setLevel(logging.DEBUG)
 
     ch = logging.StreamHandler(sys.stdout)
@@ -369,7 +369,7 @@ Variables substituted::
 def main():
     config_logger()
 
-    logger = logging.getLogger("pcluster.pcluster")
+    logger = logging.getLogger("pcluster." + __name__)
     logger.debug("pcluster CLI starting")
 
     parser = _get_parser()

--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -32,7 +32,7 @@ from pcluster.utils import get_supported_os, get_supported_schedulers
 standard_library.install_aliases()
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("pcluster." + __name__)
 DEFAULT_VALUES = {
     "aws_region_name": "us-east-1",
     "cluster_template": "default",

--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -205,6 +205,11 @@ def configure(args):
     args.cluster_template = cluster_template
     if _is_config_valid(args):
         print("The configuration is valid")
+        print("Configuration file written to {0}".format(config_file))
+        print(
+            "You can edit your configuration file or simply run 'pcluster create -c {0} cluster-name' "
+            "to create your cluster".format(config_file)
+        )
 
 
 def _check_destination_directory(config_file):

--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -136,6 +136,7 @@ def configure(args):
 
     # Use built in boto regions as an available option
     aws_region_name = prompt_iterable("AWS Region ID", get_regions())
+    os.environ["AWS_DEFAULT_REGION"] = aws_region_name
 
     scheduler = prompt_iterable(
         "Scheduler",

--- a/cli/pcluster/configure/networking.py
+++ b/cli/pcluster/configure/networking.py
@@ -25,7 +25,7 @@ from pcluster.subnet_computation import evaluate_cidr, get_subnet_cidr
 from pcluster.utils import get_stack_output_value, get_templates_bucket_path, verify_stack_creation
 
 DEFAULT_AWS_REGION_NAME = "us-east-1"
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("pcluster." + __name__)
 TIMESTAMP = "-{:%Y%m%d%H%M%S}".format(datetime.datetime.utcnow())
 MASTER_SUBNET_IPS = 250
 

--- a/cli/pcluster/configure/utils.py
+++ b/cli/pcluster/configure/utils.py
@@ -16,7 +16,7 @@ from builtins import input
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("pcluster." + __name__)
 unsupported_regions = ["ap-northeast-3"]
 
 

--- a/cli/pcluster/pcluster.py
+++ b/cli/pcluster/pcluster.py
@@ -45,7 +45,7 @@ if sys.version_info[0] >= 3:
 else:
     from urllib import urlretrieve  # pylint: disable=no-name-in-module
 
-LOGGER = logging.getLogger("pcluster.pcluster")
+LOGGER = logging.getLogger("pcluster." + __name__)
 
 
 def create_bucket_with_batch_resources(stack_name, aws_client_config, resources_dir):

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -27,7 +27,7 @@ import boto3
 import pkg_resources
 from botocore.exceptions import ClientError
 
-LOGGER = logging.getLogger("pcluster.pcluster")
+LOGGER = logging.getLogger("pcluster." + __name__)
 
 
 def boto3_client(service, aws_client_config):

--- a/cli/tests/pcluster/configure/test_pclusterconfigure.py
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure.py
@@ -139,10 +139,12 @@ def _are_configurations_equals(path_verify, path_verified):
     return True
 
 
-def _are_output_error_correct(capsys, output, error):
+def _are_output_error_correct(capsys, output, error, config_path):
     readouterr = capsys.readouterr()
     with open(output) as f:
-        assert_that(readouterr.out).is_equal_to(f.read())
+        expected_output = f.read()
+        expected_output = expected_output.replace("{{ CONFIG_FILE }}", config_path)
+        assert_that(readouterr.out).is_equal_to(expected_output)
     with open(error) as f:
         assert_that(readouterr.err).is_equal_to(f.read())
 
@@ -208,7 +210,7 @@ def get_file_path(test_datadir):
 def _verify_test(mocker, capsys, output, error, config, temp_path_for_config):
     _launch_config(mocker, temp_path_for_config)
     assert_that(_are_configurations_equals(temp_path_for_config, config)).is_true()
-    _are_output_error_correct(capsys, output, error)
+    _are_output_error_correct(capsys, output, error, temp_path_for_config)
     os.remove(temp_path_for_config)
 
 
@@ -311,7 +313,7 @@ def test_subnet_automation_no_awsbatch_no_errors_with_config_file(mocker, capsys
 
     _launch_config(mocker, old_config_file, remove_path=False)
     assert_that(_are_configurations_equals(old_config_file, config)).is_true()
-    _are_output_error_correct(capsys, output, error)
+    _are_output_error_correct(capsys, output, error, old_config_file)
     os.remove(old_config_file)
 
 

--- a/cli/tests/pcluster/configure/test_pclusterconfigure/test_no_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure/test_no_automation_no_awsbatch_no_errors/output.txt
@@ -45,3 +45,5 @@ Allowed values for Compute Subnet ID:
 1. subnet-11 | ParallelClusterPublicSubnet | Subnet size: 256
 2. subnet-12 | ParallelClusterPrivateSubnet | Subnet size: 4096
 The configuration is valid
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pclusterconfigure/test_no_automation_yes_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure/test_no_automation_yes_awsbatch_no_errors/output.txt
@@ -39,3 +39,5 @@ Allowed values for Compute Subnet ID:
 1. subnet-11 | ParallelClusterPublicSubnet | Subnet size: 256
 2. subnet-12 | ParallelClusterPrivateSubnet | Subnet size: 4096
 The configuration is valid
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pclusterconfigure/test_subnet_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure/test_subnet_automation_no_awsbatch_no_errors/output.txt
@@ -42,3 +42,5 @@ Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet
 2. Master and compute fleet in the same public subnet
 The configuration is valid
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pclusterconfigure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
@@ -42,3 +42,5 @@ Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet
 2. Master and compute fleet in the same public subnet
 The configuration is valid
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pclusterconfigure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
@@ -42,3 +42,5 @@ Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet
 2. Master and compute fleet in the same public subnet
 The configuration is valid
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pclusterconfigure/test_subnet_automation_yes_awsbatch_invalid_vpc/output.txt
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure/test_subnet_automation_yes_awsbatch_invalid_vpc/output.txt
@@ -33,3 +33,5 @@ Allowed values for VPC ID:
 3. vpc-3 | default | 3 subnets inside
 4. vpc-4 | ParallelClusterVPC-20190626095403 | 1 subnets inside
 The configuration is valid
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pclusterconfigure/test_vpc_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure/test_vpc_automation_no_awsbatch_no_errors/output.txt
@@ -38,3 +38,5 @@ Allowed values for Network Configuration:
 2. Master and compute fleet in the same public subnet
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 The configuration is valid
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pclusterconfigure/test_vpc_automation_no_vpc_in_region/output.txt
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure/test_vpc_automation_no_vpc_in_region/output.txt
@@ -39,3 +39,5 @@ Allowed values for Network Configuration:
 2. Master and compute fleet in the same public subnet
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 The configuration is valid
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pclusterconfigure/test_vpc_automation_no_vpc_in_region_public/output.txt
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure/test_vpc_automation_no_vpc_in_region_public/output.txt
@@ -39,3 +39,5 @@ Allowed values for Network Configuration:
 2. Master and compute fleet in the same public subnet
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 The configuration is valid
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pclusterconfigure/test_vpc_automation_yes_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pclusterconfigure/test_vpc_automation_yes_awsbatch_no_errors/output.txt
@@ -29,3 +29,5 @@ Allowed values for EC2 Key Pair Name:
 6. key6
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 The configuration is valid
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster


### PR DESCRIPTION
The Python logging module organizes loggers in a hierarchy. We were configuring the logger for "pcluster.pcluster" and then use logging.getLogger(__name__) in some of the modules. This was causing messages to use the default root logger, hence the output was not being displayed. I uniformed this behaviour by configuring the logger on "pcluster" and then using it with logging.getLogger("pcluster." + __name__). As an additional future enhancement it would be nice to configure the logger by using a configuration file so that an expert user can customize its behaviour if necessary.

When validating the cluster configuration as last step of pcluster configure we were not using the region selected by the user, hence the validation was failing if the default aws region set by the user (for example with the AWS_DEFAULT_REGION env var) was different. 

I also added some additional output at the end of pcluster configure workflow to explicitly report the path of the generated config file and to suggest what command to use to create a cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
