### PR TITLE
awsbatch: add iproute package to alinux Dockerfile

### DIFF
--- a/cli/pcluster/resources/batch/docker/alinux/Dockerfile
+++ b/cli/pcluster/resources/batch/docker/alinux/Dockerfile
@@ -14,6 +14,7 @@ RUN yum update -y \
     binutils \
     gcc \
     gfortran \
+    iproute \
     nfs-utils \
     openssh-server \
     openssh-clients \


### PR DESCRIPTION
/sbin/ip command is required by the generate_hostfile.sh script and was
being installed as a transitive dependecy of the openmpi-devel package.
openmpi got updated from version 2 to version 4 and the new version does
not install iproute package and hence the ip command is missing.

Tested locally by running the following commands:
```
docker build -f pcluster/resources/batch/docker/alinux/Dockerfile -t pcluster-fdm-repo:alinux pcluster/resources/batch/docker
docker run -it --entrypoint "bash" pcluster-fdm-repo:alinux
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
