### PR TITLE
Fix JsonParam class to emit well formed Json

### DIFF
--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -11,6 +11,7 @@
 from future.moves.collections import OrderedDict
 
 import functools
+import json
 import logging
 import re
 
@@ -396,6 +397,14 @@ class JsonParam(Param):
     def get_default_value(self):
         """Get default value from the Param definition, if there, {} otherwise."""
         return self.definition.get("default", {})
+
+    def get_string_value(self):
+        """Convert internal representation into JSON."""
+        return json.dumps(self.value)
+
+    def get_cfn_value(self):
+        """Convert parameter value into CFN value."""
+        return self.get_string_value()
 
 
 # ---------------------- custom Parameters ---------------------- #

--- a/cli/tests/pcluster/config/test_param_to_file.py
+++ b/cli/tests/pcluster/config/test_param_to_file.py
@@ -41,7 +41,7 @@ from tests.pcluster.config.utils import get_mocked_pcluster_config, get_param_de
             CLUSTER,
             "extra_json",
             {"cluster": {"cfn_scheduler_slots": "cores"}},
-            "{'cluster': {'cfn_scheduler_slots': 'cores'}}",
+            '{"cluster": {"cfn_scheduler_slots": "cores"}}',
         ),
     ],
 )

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -690,9 +690,15 @@ def test_cluster_section_from_file(mocker, config_parser_dict, expected_dict_par
         ("extra_json", None, {}, None),
         ("extra_json", "", {}, None),
         ("extra_json", "{}", {}, None),
-        ("extra_json", "{'test': 'test'}", {"test": "test"}, None),
+        ("extra_json", '{"test": "test"}', {"test": "test"}, None),
+        (
+            "extra_json",
+            "{'test': 'test'}",
+            {"test": "test"},
+            None,
+        ),  # WARNING it is considered a valid value by yaml.safe_load
         ("extra_json", "{'test': 'test'", None, "Error parsing JSON parameter"),
-        ("extra_json", "fake_value", "fake_value", None),  # WARNING it is considered a valid value by yaml.safe_load
+        ("extra_json", "fake_value", "fake_value", None),
         # TODO add regex for additional_cfn_template
         ("additional_cfn_template", None, None, None),
         ("additional_cfn_template", "", None, None),
@@ -808,7 +814,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "PreInstallArgs": '"one two"',
                     "PostInstallScript": "postinstall",
                     "PostInstallArgs": '"one two"',
-                    "ExtraJson": "{'cluster': {'cfn_scheduler_slots': 'cores'}}",
+                    "ExtraJson": '{"cluster": {"cfn_scheduler_slots": "cores"}}',
                     "AdditionalCfnTemplate": "https://test",
                     "CustomChefCookbook": "https://test",
                     "CustomAWSBatchTemplateURL": "https://test",
@@ -1008,7 +1014,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "PreInstallArgs": '"one two"',
                     "PostInstallScript": "postinstall",
                     "PostInstallArgs": '"one two"',
-                    "ExtraJson": "{'cluster': {'cfn_scheduler_slots': 'cores'}}",
+                    "ExtraJson": '{"cluster": {"cfn_scheduler_slots": "cores"}}',
                     "AdditionalCfnTemplate": "https://test",
                     "CustomChefCookbook": "https://test",
                     "CustomAWSBatchTemplateURL": "https://test",


### PR DESCRIPTION
Override the to_cfn and to_file methods of parent class in order to output a well formed Json starting from a dict as input

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
