### PR TITLE
Signal MasterServerWaitCondition when Master fails during cfn-init

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1948,7 +1948,7 @@
                   {
                     "Ref": "AWS::StackName"
                   },
-                  " --resource=MasterServer --region=",
+                  " --resource=MasterServerWaitCondition --region=",
                   {
                     "Ref": "AWS::Region"
                   },


### PR DESCRIPTION
When cfn-init fails with errors, the resource MasterServer is already in
CREATE_COMPLETE and cannot be signaled. The right resource to signal is the MasterServerWaitCondition

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
