### PR TITLE
Create cloudwatch log group via cfn template.

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1126,6 +1126,32 @@
       },
       "Condition": "CreateEFSSubstack"
     },
+    "CloudWatchLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": [
+            "/aws/parallelcluster/${cluster_name}",
+            {
+              "cluster_name": {
+                "Fn::Select": [
+                  "1",
+                  {
+                    "Fn::Split": [
+                      "parallelcluster-",
+                      {
+                        "Ref": "AWS::StackName"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "RetentionInDays": 14
+      }
+    },
     "SQS": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
@@ -1618,6 +1644,9 @@
     },
     "MasterServer": {
       "Type": "AWS::EC2::Instance",
+      "DependsOn": [
+        "CloudWatchLogGroup"
+      ],
       "Properties": {
         "LaunchTemplate": {
           "LaunchTemplateId": {
@@ -2357,6 +2386,9 @@
     },
     "ComputeFleet": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "DependsOn": [
+        "CloudWatchLogGroup"
+      ],
       "Properties": {
         "MaxSize": {
           "Ref": "MaxSize"


### PR DESCRIPTION
Add cloudwatch log group to the cfn template.

Note that in addition to adding the new resource, I also marked it as a dependency for the MasterServer and ComputeFleet resources. The motivation for this is to ensure that those resources are deleted before the log group is deleted. If the log group is deleted first, what happens is that the EC2 instances that outlive it continue to send log events for a short while. These log events cause a log group to be created with an infinite retention time. In this scenario a user has to delete this log group manually, otherwise the next time a log group of the same name is attempted to be created as part of the creation of a cluster it will fail.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
