### PR TITLE
Add possibility to not associate public IP for Packer instance

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -355,6 +355,13 @@ Variables substituted::
         dest="custom_ami_cookbook",
         help="Specifies the cookbook to use to build the AWS ParallelCluster AMI.",
     )
+    pami.add_argument(
+        "--no-public-ip",
+        dest="associate_public_ip",
+        action="store_false",
+        default=True,
+        help="Do not associate public IP to the Packer instance. Defaults to associate public ip",
+    )
     _addarg_config(pami)
     pami_group1 = pami.add_argument_group("Build AMI by using VPC settings from configuration file")
     pami_group1.add_argument(

--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -924,6 +924,7 @@ def create_ami(args):
             "AMI_NAME_PREFIX": args.custom_ami_name_prefix,
             "AWS_VPC_ID": vpc_id,
             "AWS_SUBNET_ID": subnet_id,
+            "ASSOCIATE_PUBLIC_IP": "true" if args.associate_public_ip else "false",
         }
 
         aws_section = pcluster_config.get_section("aws")


### PR DESCRIPTION
Default value is to associate public IP, to keep backward compatibility

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
