### PR TITLE
Fix to_file bug for BoolParam with default=True.

### DIFF
--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -162,7 +162,7 @@ class Param(object):
     def to_file(self, config_parser):
         """Set parameter in the config_parser in the right section."""
         section_name = _get_file_section_name(self.section_key, self.section_label)
-        if self.value and self.value != self.get_default_value():
+        if self.value is not None and self.value != self.get_default_value():
             _ensure_section_existence(config_parser, section_name)
             config_parser.set(section_name, self.key, self.get_string_value())
         else:

--- a/cli/tests/pcluster/config/test_section_vpc.py
+++ b/cli/tests/pcluster/config/test_section_vpc.py
@@ -98,6 +98,7 @@ def test_vpc_section_from_file(mocker, config_parser_dict, expected_dict_params,
         # other values
         (VPC, {"ssh_from": "1.1.1.1/32"}, {"vpc default": {"ssh_from": "1.1.1.1/32"}}, None),
         (VPC, {"additional_sg": "sg-12345678"}, {"vpc default": {"additional_sg": "sg-12345678"}}, None),
+        (VPC, {"use_public_ips": False}, {"vpc default": {"use_public_ips": "false"}}, None),
     ],
 )
 def test_vpc_section_to_file(mocker, section_definition, section_dict, expected_config_parser_dict, expected_message):


### PR DESCRIPTION
In Param.to_file, there is a conditional that is meant to:
1. check whether the parameter has a value, and
2. check whether the parameter is equal to its default.

When boolean parameters that default to True have a value of False, they
should be written back to the file, but the current logic does not allow
for that.

To fix that: explicitly compare the parameter's value to None when
checking if it has a value. Add a unit test to verify the fix.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
