### PR TITLE
Use cores for cfn_scheduler_slots

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2222,7 +2222,7 @@
                         "DisableHyperthreading",
                         {
                           "Fn::Select": [
-                            "0",
+                            "1",
                             {
                               "Ref": "Cores"
                             }


### PR DESCRIPTION
* previously used the core count from instances.json, this sets it to use `cores`

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
