### PR TITLE
Enable cloudwatch logging config

### DIFF
--- a/cli/pcluster/config/iam_policy_rules.py
+++ b/cli/pcluster/config/iam_policy_rules.py
@@ -1,0 +1,84 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import sys
+
+from pcluster.utils import get_partition
+
+if sys.version_info >= (3, 4):
+    ABC = abc.ABC
+else:
+    ABC = abc.ABCMeta("ABC", (), {})
+
+
+class EC2IAMPolicyInclusionRule(ABC):
+    """
+    Encapsulate logic for conditional inclusion of policies in the EC2IAMPolicies cfn parameter.
+
+    Certain IAM policies must be included in the EC2IAMPolicies CloudFormation parameter based on
+    a requested cluster configuration. This class provides an interface for deciding wheter a
+    a specific configuration requires a specific policy.
+    """
+
+    @classmethod
+    @abc.abstractmethod
+    def policy_is_required(cls, pcluster_config):
+        """Describe whether the policy represented by this class must be included."""
+        return cls("Conditional policy inclusion rule not implemented.")
+
+    @classmethod
+    @abc.abstractmethod
+    def get_policy(cls):
+        """Return the ARN for the polciy that must be included."""
+        return cls("Policy getter not implemented.")
+
+    @staticmethod
+    def policy_name_to_arn(policy_name):
+        """Return an ARN for the given IAM policy."""
+        return "arn:{0}:iam::aws:policy/{1}".format(get_partition(), policy_name)
+
+
+class CloudWatchAgentServerPolicyInclusionRule(EC2IAMPolicyInclusionRule):
+    """Include the CloudWatchServerAgentPolicy when CloudWatch logging is enabled."""
+
+    @classmethod
+    def policy_is_required(cls, pcluster_config):
+        """Describe whether the policy represented by this class must be included."""
+        cw_log_settings = pcluster_config.get_section("cluster").get_param("cw_log_settings")
+        if cw_log_settings.value is not None:
+            # A cw_log section was referenced from the config file's cluster section.
+            # Use that section's "enable" parameter's value
+            cw_log_section = pcluster_config.get_section("cw_log", cw_log_settings.value)
+            should_include_policy = cw_log_section.get_param_value("enable")
+        else:
+            # A cw_log section was referenced from the config file's cluster section
+            should_include_policy = cw_log_settings.referred_section_definition["params"]["enable"]["default"]
+        return should_include_policy
+
+    @classmethod
+    def get_policy(cls):
+        """Return the ARN for the polciy that must be included."""
+        return cls.policy_name_to_arn("CloudWatchAgentServerPolicy")
+
+
+class AWSBatchFullAccessInclusionRule(EC2IAMPolicyInclusionRule):
+    """Include the AWSBatchFullAccess when the scheduler is awsbatch."""
+
+    @classmethod
+    def policy_is_required(cls, pcluster_config):
+        """Describe whether the policy represented by this class must be included."""
+        return pcluster_config.get_section("cluster").get_param_value("scheduler") == "awsbatch"
+
+    @classmethod
+    def get_policy(cls):
+        """Return the ARN for the polciy that must be included."""
+        return cls.policy_name_to_arn("AWSBatchFullAccess")

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -361,6 +361,27 @@ FSX = {
     )
 }
 
+CW_LOG = {
+    "type": Section,
+    "key": "cw_log",
+    "default_label": "default",
+    "cfn_param_mapping": "CWLogOptions",  # Stringify params into single CFN parameter
+    "params": OrderedDict([
+        ("enable", {
+            "type": BoolParam,
+            "default": True,
+        }),
+        ("retention_days", {
+            "type": IntParam,
+            "default": 14,
+            "cfn_param_mapping": "CWLogEventRententionDays",
+            "allowed_values": [
+                1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653
+            ]
+        }),
+    ])
+}
+
 CLUSTER = {
     "type": ClusterSection,
     "key": "cluster",
@@ -472,11 +493,6 @@ CLUSTER = {
                 "cfn_param_mapping": "EC2IAMRoleName",
                 "validators": [ec2_iam_role_validator],  # TODO add regex
             }),
-            ("additional_iam_policies", {
-                "type": AdditionalIamPoliciesParam,
-                "cfn_param_mapping": "EC2IAMPolicies",
-                "validators": [ec2_iam_policies_validator],
-            }),
             ("s3_read_resource", {
                 "cfn_param_mapping": "S3ReadResource",  # TODO add validator
             }),
@@ -587,6 +603,17 @@ CLUSTER = {
             ("fsx_settings", {
                 "type": SettingsParam,
                 "referred_section": FSX,
+            }),
+            ("cw_log_settings", {
+                "type": SettingsParam,
+                "referred_section": CW_LOG,
+            }),
+            # Moved from the "Access and Networking" section because its configuration is
+            # dependent on multiple other parameters from within this section.
+            ("additional_iam_policies", {
+                "type": AdditionalIamPoliciesParam,
+                "cfn_param_mapping": "EC2IAMPolicies",
+                "validators": [ec2_iam_policies_validator],
             }),
         ]
     )

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -18,15 +18,8 @@ import re
 from configparser import NoSectionError
 
 import yaml
-from pcluster.utils import (
-    error,
-    get_avail_zone,
-    get_cfn_param,
-    get_efs_mount_target_id,
-    get_instance_vcpus,
-    get_partition,
-    warn,
-)
+from pcluster.config.iam_policy_rules import AWSBatchFullAccessInclusionRule, CloudWatchAgentServerPolicyInclusionRule
+from pcluster.utils import error, get_avail_zone, get_cfn_param, get_efs_mount_target_id, get_instance_vcpus, warn
 
 LOGGER = logging.getLogger(__name__)
 
@@ -652,21 +645,23 @@ class AdditionalIamPoliciesParam(CommaSeparatedParam):
     """
     Class to manage the additional_iam_policies configuration parameters.
 
-    We need this class because in the awsbatch case we need to add/remove the AWSBatchFullAccess policy
-    during CFN conversion.
+    We need this class for 2 reasons:
+    * When the scheduler is awsbatch, we need to add/remove the AWSBatchFullAccess policy
+      during CFN conversion.
+    * When CloudWatch logging is enabled, we need to add/remove the CloudWatchAgentServerPolicy
+      during CFN conversion.
     """
 
     def __init__(self, section_key, section_label, param_key, param_definition, pcluster_config):
         super(CommaSeparatedParam, self).__init__(
             section_key, section_label, param_key, param_definition, pcluster_config
         )
-        self.aws_batch_iam_policy = "arn:{0}:iam::aws:policy/AWSBatchFullAccess".format(get_partition())
+        self.policy_inclusion_rules = [CloudWatchAgentServerPolicyInclusionRule, AWSBatchFullAccessInclusionRule]
 
     def to_file(self, config_parser):
         """Set parameter in the config_parser in the right section."""
-        # remove awsbatch policy, if there
-        if self.aws_batch_iam_policy in self.value:
-            self.value.remove(self.aws_batch_iam_policy)
+        # remove conditional policies, if there
+        self._remove_conditional_policies()
         super(CommaSeparatedParam, self).to_file(config_parser)
 
     def from_cfn_params(self, cfn_params):
@@ -676,24 +671,26 @@ class AdditionalIamPoliciesParam(CommaSeparatedParam):
         :param cfn_params: list of all the CFN parameters, used if "cfn_param_mapping" is specified in the definition
         """
         super(CommaSeparatedParam, self).from_cfn_params(cfn_params)
-
-        # remove awsbatch policy, if there
-        if self.aws_batch_iam_policy in self.value:
-            self.value.remove(self.aws_batch_iam_policy)
-
+        # remove conditional policies, if there
+        self._remove_conditional_policies()
         return self
 
     def to_cfn(self):
         """Convert param to CFN representation, if "cfn_param_mapping" attribute is present in the Param definition."""
-        # add awsbatch policy if scheduler is awsbatch
-        cluster_config = self.pcluster_config.get_section(self.section_key)
-        if cluster_config.get_param_value("scheduler") == "awsbatch":
-            if self.aws_batch_iam_policy not in self.value:
-                self.value.append(self.aws_batch_iam_policy)
+        # Add conditional policies if appropriate
+        for rule in self.policy_inclusion_rules:
+            if rule.policy_is_required(self.pcluster_config) and rule.get_policy() not in self.value:
+                self.value.append(rule.get_policy())
 
         cfn_params = super(CommaSeparatedParam, self).to_cfn()
 
         return cfn_params
+
+    def _remove_conditional_policies(self):
+        """Remove any of the policy ARNs in self.conditional_policies from self.value."""
+        for rule in self.policy_inclusion_rules:
+            if rule.get_policy() in self.value:
+                self.value.remove(rule.get_policy())
 
 
 class AvailabilityZoneParam(Param):

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -123,7 +123,10 @@ DEFAULT_CLUSTER_DICT = {
     "efs_settings": None,
     "raid_settings": None,
     "fsx_settings": None,
+    "cw_log_settings": None,
 }
+
+DEFAULT_CW_LOG_DICT = {"enable": True, "retention_days": 14}
 
 DEFAULT_PCLUSTER_DICT = {"cluster": DEFAULT_CLUSTER_DICT}
 
@@ -141,13 +144,14 @@ class DefaultDict(Enum):
     efs = DEFAULT_EFS_DICT
     raid = DEFAULT_RAID_DICT
     fsx = DEFAULT_FSX_DICT
+    cw_log = DEFAULT_CW_LOG_DICT
     pcluster = DEFAULT_PCLUSTER_DICT
 
 
 # ------------------ Default CFN parameters ------------------ #
 
 # number of CFN parameters created by the PclusterConfig object.
-CFN_CONFIG_NUM_OF_PARAMS = 55
+CFN_CONFIG_NUM_OF_PARAMS = 56
 
 # CFN parameters created by the pcluster CLI
 CFN_CLI_RESERVED_PARAMS = ["ResourcesS3Bucket"]
@@ -184,6 +188,8 @@ DEFAULT_RAID_CFN_PARAMS = {"RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NO
 
 DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
+DEFAULT_CW_LOG_CFN_PARAMS = {"CWLogOptions": "true,14"}
+
 DEFAULT_CLUSTER_CFN_PARAMS = {
     "KeyName": "NONE",
     "BaseOS": "alinux",
@@ -203,7 +209,7 @@ DEFAULT_CLUSTER_CFN_PARAMS = {
     "SpotPrice": "0.0",
     "ProxyServer": "NONE",
     "EC2IAMRoleName": "NONE",
-    "EC2IAMPolicies": "NONE",
+    "EC2IAMPolicies": "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
     "S3ReadResource": "NONE",
     "S3ReadWriteResource": "NONE",
     "EFA": "NONE",
@@ -248,6 +254,8 @@ DEFAULT_CLUSTER_CFN_PARAMS = {
     "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # fsx
     "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+    # cw_log_settings
+    "CWLogOptions": "true,14",
 }
 
 
@@ -260,4 +268,5 @@ class DefaultCfnParams(Enum):
     efs = DEFAULT_EFS_CFN_PARAMS
     raid = DEFAULT_RAID_CFN_PARAMS
     fsx = DEFAULT_FSX_CFN_PARAMS
+    cw_log = DEFAULT_CW_LOG_CFN_PARAMS
     cluster = DEFAULT_CLUSTER_CFN_PARAMS

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -856,7 +856,8 @@ def test_cluster_section_to_file(
 
 
 @pytest.mark.parametrize(
-    "section_dict, expected_cfn_params", [(DefaultDict["cluster"].value, DefaultCfnParams["cluster"].value)]
+    "section_dict, expected_cfn_params",
+    [(DefaultDict["cluster"].value, utils.merge_dicts(DefaultCfnParams["cluster"].value))],
 )
 def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
     mocker.patch("pcluster.config.param_types.get_efs_mount_target_id", return_value="valid_mount_target_id")
@@ -867,7 +868,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
 @pytest.mark.parametrize(
     "settings_label, expected_cfn_params",
     [
-        ("default", DefaultCfnParams["cluster"].value),
+        ("default", utils.merge_dicts(DefaultCfnParams["cluster"].value)),
         (
             "custom1",
             utils.merge_dicts(
@@ -894,7 +895,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "SpotPrice": "5.5",
                     "ProxyServer": "proxy",
                     "EC2IAMRoleName": "role",
-                    "EC2IAMPolicies": "policy1,policy2",
+                    "EC2IAMPolicies": "policy1,policy2,arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
                     "S3ReadResource": "s3://url",
                     "S3ReadWriteResource": "s3://url",
                     "EFA": "compute",
@@ -929,7 +930,12 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "MaxSize": "10",
                     "MinSize": "0",
                     "SpotPrice": "0",
-                    "EC2IAMPolicies": "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+                    "EC2IAMPolicies": ",".join(
+                        [
+                            "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+                            "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+                        ]
+                    ),
                     "ComputeInstanceType": "optimal",
                 },
             ),
@@ -949,8 +955,36 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "MinSize": "2",
                     "ClusterType": "spot",
                     "SpotPrice": "25",
-                    "EC2IAMPolicies": "policy1,policy2,arn:aws:iam::aws:policy/AWSBatchFullAccess",
+                    "EC2IAMPolicies": ",".join(
+                        [
+                            "policy1",
+                            "policy2",
+                            "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+                            "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+                        ]
+                    ),
                     "ComputeInstanceType": "optimal",
+                },
+            ),
+        ),
+        (
+            "batch-no-cw-logging",
+            utils.merge_dicts(
+                DefaultCfnParams["cluster"].value,
+                {
+                    "CLITemplate": "batch-no-cw-logging",
+                    "AvailabilityZone": "mocked_avail_zone",
+                    "VPCId": "vpc-12345678",
+                    "MasterSubnetId": "subnet-12345678",
+                    "Scheduler": "awsbatch",
+                    "DesiredSize": "3",
+                    "MaxSize": "4",
+                    "MinSize": "2",
+                    "ClusterType": "spot",
+                    "SpotPrice": "25",
+                    "EC2IAMPolicies": "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+                    "ComputeInstanceType": "optimal",
+                    "CWLogOptions": "false,14",
                 },
             ),
         ),
@@ -987,7 +1021,12 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "MinSize": "2",
                     "ClusterType": "spot",
                     "SpotPrice": "25",
-                    "EC2IAMPolicies": "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+                    "EC2IAMPolicies": ",".join(
+                        [
+                            "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+                            "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+                        ]
+                    ),
                     "ComputeInstanceType": "optimal",
                 },
             ),
@@ -1044,6 +1083,10 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "EBSVolumeId": "vol-12345678,NONE,NONE,NONE,NONE",
                 },
             ),
+        ),
+        (
+            "cw_log",
+            utils.merge_dicts(DefaultCfnParams["cluster"].value, {"CLITemplate": "cw_log", "CWLogOptions": "true,1"}),
         ),
         (
             "all-settings",

--- a/cli/tests/pcluster/config/test_section_cluster/test_cluster_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_cluster/test_cluster_from_file_to_cfn/pcluster.config.ini
@@ -92,6 +92,25 @@ spot_bid_percentage = 25
 vpc_settings = default
 additional_iam_policies = policy1,policy2
 
+
+# Test: awsbatch scheduler with cloudwatch logging disabled
+[cluster batch-no-cw-logging]
+scheduler = awsbatch
+cluster_type = spot
+initial_queue_size = 1
+max_queue_size = 2
+maintain_initial_size = true
+min_vcpus = 2
+desired_vcpus = 3
+max_vcpus = 4
+spot_price = 5.5
+spot_bid_percentage = 25
+vpc_settings = default
+cw_log_settings = batch-no-cw-logging
+
+[cw_log batch-no-cw-logging]
+enable = false
+
 # Test: mixed awsbatch and traditional scheduler params with slurm scheduler
 [cluster wrong_mix_traditional]
 scheduler = slurm
@@ -214,3 +233,11 @@ tags = {"test": "test"}
 custom_chef_cookbook = https://test
 custom_awsbatch_template_url = https://test
 disable_hyperthreading = false
+
+# test: cw_log settings
+[cluster cw_log]
+cw_log_settings = cw_log
+
+[cw_log cw_log]
+enable = true
+retention_days = 1

--- a/cli/tests/pcluster/config/test_section_cw_log.py
+++ b/cli/tests/pcluster/config/test_section_cw_log.py
@@ -1,0 +1,129 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+import tests.pcluster.config.utils as utils
+from pcluster.config.mappings import CW_LOG
+from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
+
+
+@pytest.mark.parametrize(
+    "config_parser_dict, expected_dict_params, expected_message",
+    [
+        # default
+        ({"cw_log default": {}}, {}, None),
+        # right value
+        ({"cw_log default": {"enable": "True"}}, {}, None),
+        ({"cw_log default": {"enable": "False"}}, {"enable": False}, None),
+        ({"cw_log default": {"retention_days": "1"}}, {"retention_days": 1}, None),
+        ({"cw_log default": {"retention_days": "14"}}, {"retention_days": 14}, None),
+        ({"cw_log default": {"retention_days": "3653"}}, {"retention_days": 3653}, None),
+        # invalid value
+        ({"cw_log default": {"enable": "not_a_bool"}}, None, "must be a Boolean"),
+        ({"cw_log default": {"retention_days": "3652"}}, None, "has an invalid value"),
+        ({"cw_log default": {"retention_days": "not_an_int"}}, None, "must be an Integer"),
+        # invalid key
+        ({"cw_log default": {"invalid_key": "fake_value"}}, None, "'invalid_key' is not allowed in the .* section"),
+        (
+            {"cw_log default": {"invalid_key": "fake_value", "invalid_key2": "fake_value"}},
+            None,
+            "'invalid_key.*,invalid_key.*' are not allowed in the .* section",
+        ),
+    ],
+)
+def test_cw_log_section_from_file(mocker, config_parser_dict, expected_dict_params, expected_message):
+    """Verify that cw_log behaves as expected when parsed in a config file."""
+    utils.assert_section_from_file(mocker, CW_LOG, config_parser_dict, expected_dict_params, expected_message)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_config_parser_dict, expected_message",
+    [
+        # default values are not written back to config files
+        ({}, {"cw_log default": {}}, "No section.*"),
+        ({"enable": True, "retention_days": 14}, {"cw_log default": {"enable": True}}, "No section: 'cw_log default'"),
+        ({"enable": True, "retention_days": 1}, {"cw_log default": {"enable": True}}, "No option 'enable'"),
+        (
+            {"enable": False, "retention_days": 14},
+            {"cw_log default": {"retention_days": 14}},
+            "No option 'retention_days'",
+        ),
+        # Non-default values are written back to config files
+        ({"enable": False, "retention_days": 14}, {"cw_log default": {"enable": "false"}}, None),
+        ({"enable": True, "retention_days": 1}, {"cw_log default": {"retention_days": "1"}}, None),
+    ],
+)
+def test_cw_log_settings_section_to_file(mocker, section_dict, expected_config_parser_dict, expected_message):
+    """Verify that the cw_log_settings section is as expected when writing back to a file."""
+    utils.assert_section_to_file(mocker, CW_LOG, section_dict, expected_config_parser_dict, expected_message)
+
+
+@pytest.mark.parametrize(
+    "param_key, param_value, expected_value, expected_message",
+    [
+        # Enable parameter
+        ("enable", None, True, None),
+        ("enable", "true", True, None),
+        ("enable", "false", False, None),
+        ("enable", "not_a_bool", None, "'enable' must be a Boolean"),
+        ("enable", "", True, None),  # Empty string gets default value
+        # retention_days parameter
+        ("retention_days", "1", 1, None),
+        ("retention_days", "14", 14, None),
+        ("retention_days", "3653", 3653, None),
+        ("retention_days", "2", None, "'retention_days' has an invalid value"),
+        ("retention_days", "", 14, None),  # Empty string gets default value
+    ],
+)
+def test_cw_log_settings_param_from_file(mocker, param_key, param_value, expected_value, expected_message):
+    """Verify that the cw_log_settings config file section results in the correct CFN parameters."""
+    utils.assert_param_from_file(mocker, CW_LOG, param_key, param_value, expected_value, expected_message)
+
+
+@pytest.mark.parametrize(
+    "cfn_params_dict, expected_section_dict",
+    [
+        # Defaults in various forms
+        (DefaultCfnParams["cw_log"].value, DefaultDict["cw_log"].value),
+        ({}, DefaultDict["cw_log"].value),
+        ({"CWLogOptions": "   true  ,   14     "}, DefaultDict["cw_log"].value),
+        ({"CWLogOptions": "true,14"}, DefaultDict["cw_log"].value),
+        # Non-default values
+        ({"CWLogOptions": "false,14"}, {"enable": False, "retention_days": 14}),
+        ({"CWLogOptions": "true,3"}, {"enable": True, "retention_days": 3}),
+    ],
+)
+def test_cw_log_settings_section_from_cfn(mocker, cfn_params_dict, expected_section_dict):
+    """Verify expected cw_log_settings config file section results from given CFN params."""
+    utils.assert_section_from_cfn(mocker, CW_LOG, cfn_params_dict, expected_section_dict)
+
+
+@pytest.mark.parametrize(
+    "settings_label, expected_cfn_params",
+    [
+        ("defaults", DefaultCfnParams["cluster"].value),
+        (
+            "disabled",
+            utils.merge_dicts(
+                DefaultCfnParams["cluster"].value, {"EC2IAMPolicies": "NONE", "CWLogOptions": "false,14"}
+            ),
+        ),
+        ("one_day_retention", utils.merge_dicts(DefaultCfnParams["cluster"].value, {"CWLogOptions": "true,1"})),
+        ("bad_retention_val", SystemExit()),
+        ("bad_enable_val", SystemExit()),
+        ("empty_enable_val", SystemExit()),
+        ("empty_retention_days", SystemExit()),
+        ("nonexistent", SystemExit()),
+    ],
+)
+def test_cw_log_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
+    """Verify various cw_log sections results in expected CFN parameters."""
+    utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)

--- a/cli/tests/pcluster/config/test_section_cw_log/test_cw_log_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_cw_log/test_cw_log_from_file_to_cfn/pcluster.config.ini
@@ -1,0 +1,32 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = true
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+cw_log_settings = {{ settings_label }}
+
+[cw_log defaults]
+enable = true
+retention_days = 14
+
+[cw_log disabled]
+enable = false
+
+[cw_log one_day_retention]
+retention_days = 1
+
+[cw_log bad_retention_val]
+retention_days = 2
+
+[cw_log bad_enable_val]
+enable = notabool
+
+[cw_log empty_enable_val]
+enable =
+
+[cw_log empty_retention_days]
+retention_days = 

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -80,13 +80,18 @@ def test_defaults_consistency():
     total_number_of_params = CFN_CONFIG_NUM_OF_PARAMS + len(CFN_CLI_RESERVED_PARAMS)
     assert_that(total_number_of_params).is_equal_to(template_num_of_params)
 
+    # The EC2IAMPoicies parameter is expected to differ by default from the default value in the
+    # CFN template. This is because CloudWatch logging is enabled by default, and the appropriate
+    # policy is added to this parameter in a transparent fashion.
+    ignored_params = CFN_CLI_RESERVED_PARAMS + ["EC2IAMPolicies"]
+
     cfn_params = [section_cfn_params.value for section_cfn_params in DefaultCfnParams]
     default_cfn_values = utils.merge_dicts(*cfn_params)
 
     # verify default parameter values used for tests with default values in CFN template
     pcluster_cfn_json = _get_pcluster_cfn_json()
     for param_key, param in pcluster_cfn_json["Parameters"].items():
-        if param_key not in CFN_CLI_RESERVED_PARAMS:
+        if param_key not in ignored_params:
             default_value = param.get("Default", None)
             if default_value:
                 assert_that(default_value, description=param_key).is_equal_to(default_cfn_values.get(param_key, None))

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -213,6 +213,7 @@ deps = cfn-lint
 commands =
     cfn-lint -iE2504 -iW2507 -iE2523 aws-parallelcluster.cfn.json
     cfn-lint -iE3008 batch-substack.cfn.json
+    cfn-lint cw-logs-substack.cfn.json
     cfn-lint ebs-substack.cfn.json
     cfn-lint efs-substack.cfn.json
     cfn-lint raid-substack.cfn.json

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -329,6 +329,11 @@
       "Description": "Enable EFA on the compute nodes, enable_efa = compute",
       "Type": "String",
       "Default": "NONE"
+    },
+    "CWLogOptions": {
+      "Description": "Comma separated list of CloudWatch logging, 2 parameters in total, [enabled, retention_days]",
+      "Type": "String",
+      "Default": "true,14"
     }
   },
   "Conditions": {
@@ -1148,30 +1153,57 @@
       },
       "Condition": "CreateEFSSubstack"
     },
-    "CloudWatchLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
+    "CloudWatchLogsSubstack": {
+      "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "LogGroupName": {
+        "Parameters": {
+          "CWLogOptions": {
+            "Ref": "CWLogOptions"
+          },
+          "CWLogGroupName": {
+            "Fn::Sub": [
+              "/aws/parallelcluster/${cluster_name}",
+              {
+                "cluster_name": {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Fn::Split": [
+                        "parallelcluster-",
+                        {
+                          "Ref": "AWS::StackName"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "TemplateURL": {
           "Fn::Sub": [
-            "/aws/parallelcluster/${cluster_name}",
+            "https://${s3_domain}/${AWS::Region}-aws-parallelcluster/templates/cw-logs-substack-${version}.cfn.json",
             {
-              "cluster_name": {
-                "Fn::Select": [
-                  "1",
+              "s3_domain": {
+                "Fn::If": [
+                  "GovCloudRegion",
                   {
-                    "Fn::Split": [
-                      "parallelcluster-",
-                      {
-                        "Ref": "AWS::StackName"
-                      }
-                    ]
-                  }
+                    "Fn::Sub": "s3-${AWS::Region}.amazonaws.com"
+                  },
+                  "s3.amazonaws.com"
+                ]
+              },
+              "version": {
+                "Fn::FindInMap": [
+                  "PackagesVersions",
+                  "default",
+                  "parallelcluster"
                 ]
               }
             }
           ]
-        },
-        "RetentionInDays": 14
+        }
       }
     },
     "SQS": {
@@ -1667,7 +1699,7 @@
     "MasterServer": {
       "Type": "AWS::EC2::Instance",
       "DependsOn": [
-        "CloudWatchLogGroup"
+        "CloudWatchLogsSubstack"
       ],
       "Properties": {
         "LaunchTemplate": {
@@ -2359,6 +2391,12 @@
                         "SQS",
                         "QueueName"
                       ]
+                    },
+                    "cfn_cluster_cw_logging_enabled": {
+                      "Fn::GetAtt": [
+                        "CloudWatchLogsSubstack",
+                        "Outputs.Enabled"
+                      ]
                     }
                   },
                   "run_list": {
@@ -2443,9 +2481,6 @@
     },
     "MasterServerWaitCondition": {
       "Type": "AWS::CloudFormation::WaitCondition",
-      "DependsOn": [
-        "MasterServer"
-      ],
       "CreationPolicy": {
         "ResourceSignal": {
           "Count": "1",
@@ -2456,7 +2491,7 @@
     "ComputeFleet": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "DependsOn": [
-        "CloudWatchLogGroup"
+        "CloudWatchLogsSubstack"
       ],
       "Properties": {
         "MaxSize": {
@@ -3265,6 +3300,19 @@
                           "Ref": "BaseOS"
                         },
                         "User"
+                      ]
+                    },
+                    "cfn_cluster_cw_logging_enabled": {
+                      "Fn::Select": [
+                        "0",
+                        {
+                          "Fn::Split": [
+                            ",",
+                            {
+                              "Ref": "CWLogOptions"
+                            }
+                          ]
+                        }
                       ]
                     }
                   },

--- a/cloudformation/cw-logs-substack.cfn.json
+++ b/cloudformation/cw-logs-substack.cfn.json
@@ -1,0 +1,74 @@
+{
+  "Conditions": {
+    "CreateCloudWatchLogGroup": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "0",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "CWLogOptions"
+                }
+              ]
+            }
+          ]
+        },
+        "true"
+      ]
+    }
+  },
+  "Parameters": {
+    "CWLogOptions": {
+      "Description": "Comma separated list of CloudWatch logging, 2 parameters in total, [enabled, retention_days]",
+      "Type": "String"
+    },
+    "CWLogGroupName": {
+      "Description": "Name of the CloudWatch Log Group to be created",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "CloudWatchLogGroup": {
+      "Condition": "CreateCloudWatchLogGroup",
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Ref": "CWLogGroupName"
+        },
+        "RetentionInDays": {
+          "Fn::Select": [
+            "1",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "CWLogOptions"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "Enabled": {
+      "Description": "'true' if CloudWatch logging is enabled for this cluster, 'false' otherwise",
+      "Value": {
+        "Fn::Select": [
+          "0",
+          {
+            "Fn::Split": [
+              ",",
+              {
+                "Ref": "CWLogOptions"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Add CWLog cfn parameter
* Use CWLog cfn parameter to conditionally create the log group with the
correct retention time for log events
* Implement new cw_log section in the config file
* Create new tests for the cw_log_section
* Add tests to the existing cluster section
* Fix tests broken by the addition of CloudWatchAgentServerPolicy to
default EC2IAMPolicies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
