### PR TITLE
Fix: pcluster configure does not work with non existent conf file

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -86,6 +86,7 @@ def create(args):  # noqa: C901 FIXME!!!
         cluster_label=args.cluster_template,
         fail_on_file_absence=True,
     )
+    pcluster_config.validate()
     # get CFN parameters, template url and tags from config
     cluster_section = pcluster_config.get_section("cluster")
     cfn_params = pcluster_config.to_cfn()
@@ -245,6 +246,7 @@ def update(args):  # noqa: C901 FIXME!!!
         cluster_label=args.cluster_template,
         fail_on_file_absence=True,
     )
+    pcluster_config.validate()
     cfn_params = pcluster_config.to_cfn()
 
     cluster_section = pcluster_config.get_section("cluster")

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -71,7 +71,6 @@ class PclusterConfig(object):
             self.__init_sections_from_cfn(cluster_name)
         else:
             self.__init_sections_from_file(file_sections, cluster_label, self.config_parser, fail_on_file_absence)
-            self.__validate()
 
     def _init_config_parser(self, config_file, fail_on_config_file_absence=True):
         """
@@ -298,7 +297,8 @@ class PclusterConfig(object):
                 )
             )
 
-    def __validate(self):
+    def validate(self):
+        """Validate the configuration."""
         fail_on_error = (
             self.get_section("global").get_param_value("sanity_check")
             if self.get_section("global")

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -51,8 +51,6 @@ def test_mapping_consistency():
 
 def test_example_config_consistency(mocker):
     """Validate example file and try to convert to CFN."""
-    # mock validation to avoid boto3 calls required at validation stage
-    mocker.patch.object(PclusterConfig, "_PclusterConfig__validate")
     mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
     pcluster_config = PclusterConfig(
         config_file=utils.get_pcluster_config_example(),

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -108,7 +108,6 @@ def assert_section_from_cfn(mocker, section_definition, cfn_params_dict, expecte
 
 
 def get_mocked_pcluster_config(mocker):
-    mocker.patch.object(PclusterConfig, "_PclusterConfig__validate")
     return PclusterConfig(config_file="wrong-file", file_sections=[GLOBAL, ALIASES, CLUSTER])
 
 
@@ -192,7 +191,6 @@ def assert_section_to_cfn(mocker, section_definition, section_dict, expected_cfn
 
 
 def assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
-    mocker.patch.object(PclusterConfig, "_PclusterConfig__validate")
     if isinstance(expected_cfn_params, SystemExit):
         with pytest.raises(SystemExit):
             PclusterConfig(
@@ -218,7 +216,7 @@ def assert_section_params(mocker, pcluster_config_reader, settings_label, expect
             )
 
 
-def init_pcluster_config_from_configparser(config_parser):
+def init_pcluster_config_from_configparser(config_parser, validate=True):
     with tempfile.NamedTemporaryFile(delete=False) as config_file:
 
         with open(config_file.name, "w") as cf:
@@ -230,4 +228,6 @@ def init_pcluster_config_from_configparser(config_parser):
             file_sections=[GLOBAL, CLUSTER, ALIASES],
             fail_on_file_absence=True,
         )
+        if validate:
+            pcluster_config.validate()
     return pcluster_config

--- a/cli/tests/pcluster/configure/test_pcluster_configure.py
+++ b/cli/tests/pcluster/configure/test_pcluster_configure.py
@@ -5,7 +5,6 @@ import pytest
 from configparser import ConfigParser
 
 from assertpy import assert_that
-from pcluster.config.pcluster_config import PclusterConfig
 from pcluster.configure.easyconfig import configure
 from pcluster.configure.networking import NetworkConfiguration
 
@@ -110,7 +109,6 @@ def _mock_create_network_configuration(mocker, public_subnet_id, private_subnet_
 
 def _mock_parallel_cluster_config(mocker):
     mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
-    mocker.patch.object(PclusterConfig, "_PclusterConfig__validate")
 
 
 def _launch_config(mocker, path, remove_path=True):


### PR DESCRIPTION
Signed-off-by: ddeidda <ddeidda@amazon.com>

Fix: pcluster configure does not work with non existent conf file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
