### PR TITLE
Fix: Global sections like GLOBAL and AWS are not persisted

### DIFF
--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -159,10 +159,10 @@ class Param(object):
                 else:
                     LOGGER.debug("Configuration parameter '%s' is valid", self.key)
 
-    def to_file(self, config_parser):
+    def to_file(self, config_parser, write_defaults=False):
         """Set parameter in the config_parser in the right section."""
         section_name = _get_file_section_name(self.section_key, self.section_label)
-        if self.value is not None and self.value != self.get_default_value():
+        if self.value is not None and (write_defaults or self.value != self.get_default_value()):
             _ensure_section_existence(config_parser, section_name)
             config_parser.set(section_name, self.key, self.get_string_value())
         else:
@@ -448,7 +448,7 @@ class ExtraJsonParam(JsonParam):
             self.value = {"cfncluster": self.value.pop("cluster")}
         return self.get_string_value()
 
-    def to_file(self, config_parser):
+    def to_file(self, config_parser, write_defaults=False):
         """Set parameter in the config_parser in the right section.
 
         The extra_json configuration parameter can contain both "cfncluster" or "cluster" keys but
@@ -477,11 +477,11 @@ class SharedDirParam(Param):
         # else: there are ebs volumes, let the EBSSettings populate the SharedDir CFN parameter.
         return cfn_params
 
-    def to_file(self, config_parser):
+    def to_file(self, config_parser, write_defaults=False):
         """Set parameter in the config_parser only if the PclusterConfig object does not contains ebs sections."""
         # if not contains ebs_settings --> single SharedDir
         section_name = _get_file_section_name(self.section_key, self.section_label)
-        if not self.pcluster_config.get_section("ebs") and self.value != self.get_default_value():
+        if not self.pcluster_config.get_section("ebs") and (write_defaults or self.value != self.get_default_value()):
             _ensure_section_existence(config_parser, section_name)
             config_parser.set(section_name, self.key, self.value)
         # else: there are ebs volumes, let the EBSSettings parse the SharedDir CFN parameter.
@@ -662,7 +662,7 @@ class AdditionalIamPoliciesParam(CommaSeparatedParam):
         )
         self.aws_batch_iam_policy = "arn:{0}:iam::aws:policy/AWSBatchFullAccess".format(get_partition())
 
-    def to_file(self, config_parser):
+    def to_file(self, config_parser, write_defaults=False):
         """Set parameter in the config_parser in the right section."""
         # remove awsbatch policy, if there
         if self.aws_batch_iam_policy in self.value:
@@ -715,7 +715,7 @@ class AvailabilityZoneParam(Param):
 
         return self
 
-    def to_file(self, config_parser):
+    def to_file(self, config_parser, write_defaults=False):
         """Do nothing, because master_availability_zone it is an internal parameter, not exposed in the config file."""
         pass
 
@@ -844,7 +844,7 @@ class SettingsParam(Param):
                 )
                 self.pcluster_config.add_section(section)
 
-    def to_file(self, config_parser):
+    def to_file(self, config_parser, write_defaults=False):
         """Convert the param value into a section in the config_parser and initialize it."""
         section = self.pcluster_config.get_section(self.referred_section_key, self.value)
         if section:
@@ -855,8 +855,8 @@ class SettingsParam(Param):
                 param_value = section.get_param_value(param_key)
 
                 section_name = _get_file_section_name(self.section_key, self.section_label)
-                if not config_parser.has_option(section_name, self.key) and param_value != param_definition.get(
-                    "default", None
+                if not config_parser.has_option(section_name, self.key) and (
+                    write_defaults or (param_value != param_definition.get("default", None))
                 ):
                     _ensure_section_existence(config_parser, section_name)
                     config_parser.set(section_name, self.key, self.value)
@@ -942,7 +942,7 @@ class EBSSettingsParam(SettingsParam):
 
         return self
 
-    def to_file(self, config_parser):
+    def to_file(self, config_parser, write_defaults=False):
         """Convert the param value into a list of sections in the config_parser and initialize them."""
         sections = {}
         if self.value:
@@ -1130,7 +1130,7 @@ class Section(object):
                         fail_on_error
                     )
 
-    def to_file(self, config_parser):
+    def to_file(self, config_parser, write_defaults=False):
         """Create the section and add all the parameters in the config_parser."""
         section_name = _get_file_section_name(self.key, self.label)
 
@@ -1141,11 +1141,11 @@ class Section(object):
                 param_type = param_definition.get("type", Param)
                 param = param_type(self.key, self.label, param_key, param_definition, self.pcluster_config)
 
-            if param.value != param_definition.get("default", None):
+            if write_defaults or param.value != param_definition.get("default", None):
                 # add section in the config file only if at least one parameter value is different by the default
                 _ensure_section_existence(config_parser, section_name)
 
-            param.to_file(config_parser)
+            param.to_file(config_parser, write_defaults)
 
     def to_cfn(self):
         """

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -193,6 +193,16 @@ class PclusterConfig(object):
             # we rely on the AWS CLI configuration or already set env variable
             pass
 
+    @property
+    def region(self):
+        """Get the region. The value is stored inside the aws_region_name of the aws section."""
+        return self.get_section("aws").get_param_value("aws_region_name")
+
+    @region.setter
+    def region(self, region):
+        """Set the region. The value is stored inside the aws_region_name of the aws section."""
+        self.get_section("aws").get_param("aws_region_name").value = region
+
     def __init_region(self):
         """
         Evaluate region to use and set in the environment to be available for all the boto3 calls.
@@ -202,15 +212,13 @@ class PclusterConfig(object):
         if os.environ.get("AWS_DEFAULT_REGION"):
             self.region = os.environ.get("AWS_DEFAULT_REGION")
         else:
-            self.region = self.get_section("aws").get_param_value("aws_region_name")
             os.environ["AWS_DEFAULT_REGION"] = self.region
 
     def to_file(self):
-        """
-        Convert the internal representation of the cluster to the relative file sections.
+        """Convert the internal representation of the cluster to the relative file sections."""
+        for section_key in ["aws", "global", "aliases"]:
+            self.get_section(section_key).to_file(self.config_parser, write_defaults=True)
 
-        NOTE: aws, global, aliases sections will be excluded from this transformation.
-        """
         self.get_section("cluster").to_file(self.config_parser)
 
         # ensure that the directory for the config file exists


### PR DESCRIPTION
Fix: Global sections like GLOBAL and AWS are not persisted currently from pcluster configure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
