### PR TITLE
Exit with error on get_keys failure

### DIFF
--- a/cli/pcluster/configure/utils.py
+++ b/cli/pcluster/configure/utils.py
@@ -74,11 +74,10 @@ def prompt_iterable(message, options, default_value=None):
     :param default_value: the default value
     :return: the validated value
     """
-    is_tuple = isinstance(options[0], (list, tuple))
-
     if not options:
         LOGGER.error("ERROR: No options found for {0}".format(message))
         sys.exit(1)
+    is_tuple = isinstance(options[0], (list, tuple))
 
     if not default_value:
         default_value = options[0][0] if is_tuple else options[0]


### PR DESCRIPTION
Exit gracefully when no key pair is found in the provided region. Previously an error like "no index found for item..." was written after the information for no key pair found.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
