### PR TITLE
Enable tests on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 matrix:
   include:

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 toxworkdir=../.tox
 envlist =
-    py{27,34,35,36,37}
+    py{27,34,35,36,37,38}
     code-linters
     cfn-{tests,lint,format-check}
 
@@ -15,7 +15,7 @@ commands =
     # Running with discover and not unittest discover for Python 2.6 compatibility
     python -m discover -s tests/pcluster -p "*_test.py"
     # awsbatch-cli is not currently compatible with Python2.6
-    py{27,34,35,36,37}: py.test -l -v --basetemp={envtmpdir} --html=report.html --cov={envsitepackagesdir}/awsbatch tests/ --cov={envsitepackagesdir}/pcluster
+    py{27,34,35,36,37,38}: py.test -l -v --basetemp={envtmpdir} --html=report.html --cov={envsitepackagesdir}/awsbatch tests/ --cov={envsitepackagesdir}/pcluster
 
 # Section used to define common variables used by multiple testenvs.
 [vars]


### PR DESCRIPTION
Enable unit tests for python 3.8

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
