### PR TITLE
Fix: pcluster configure should not fail with bad config files

### DIFF
--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -16,7 +16,6 @@ standard_library.install_aliases()
 
 import logging
 import os
-import sys
 
 import boto3
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -357,7 +357,18 @@ def get_efs_mount_target_id(efs_fs_id, avail_zone):
 
 
 def get_avail_zone(subnet_id):
-    return boto3.client("ec2").describe_subnets(SubnetIds=[subnet_id]).get("Subnets")[0].get("AvailabilityZone")
+    avail_zone = None
+    try:
+        avail_zone = (
+            boto3.client("ec2").describe_subnets(SubnetIds=[subnet_id]).get("Subnets")[0].get("AvailabilityZone")
+        )
+    except ClientError as e:
+        LOGGER.debug(
+            "Unable to detect availability zone for subnet {0}.\n{1}".format(
+                subnet_id, e.response.get("Error").get("Message")
+            )
+        )
+    return avail_zone
 
 
 def get_latest_alinux_ami_id():

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/original_config_file
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/original_config_file
@@ -1,0 +1,36 @@
+#Invalid section - must be completely ignored
+[ignored section]
+ignored value=invalid_value
+
+[aws]
+aws_region_name = eu-west-1
+#Invalid param key
+invalid_key=invalid_value
+
+[cluster default]
+key_name = key1
+vpc_settings = default
+#Invalid param value
+scheduler = invalid_value
+base_os = centos6
+compute_instance_type = t2.micro
+master_instance_type = t2.nano
+#Invalid value type
+max_queue_size = True
+initial_queue_size = 13
+#Invalid value type
+maintain_initial_size = ABC
+
+[vpc default]
+vpc_id = vpc-12345678
+master_subnet_id = subnet-12345678
+compute_subnet_id = subnet-23456789
+use_public_ips = false
+
+[global]
+cluster_template = default
+update_check = true
+sanity_check = true
+
+[aliases]
+ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/output.txt
@@ -1,0 +1,54 @@
+ERROR: The configuration parameter 'invalid_key' is not allowed in the [aws] section
+ERROR: The configuration parameter 'scheduler' has an invalid value 'invalid_value'
+Allowed values are: ['awsbatch', 'sge', 'slurm', 'torque']
+ERROR: Configuration parameter 'max_queue_size' must be an Integer
+ERROR: Configuration parameter 'maintain_initial_size' must be a Boolean
+WARNING: Configuration file {{ CONFIG_FILE }} will be overwritten.
+Press CTRL-C to interrupt the procedure.
+
+
+Allowed values for AWS Region ID:
+1. eu-north-1
+2. ap-south-1
+3. eu-west-3
+4. eu-west-2
+5. eu-west-1
+6. ap-northeast-2
+7. ap-northeast-1
+8. sa-east-1
+9. ca-central-1
+10. ap-southeast-1
+11. ap-southeast-2
+12. eu-central-1
+13. us-east-1
+14. us-east-2
+15. us-west-1
+16. us-west-2
+Allowed values for Scheduler:
+1. sge
+2. torque
+3. slurm
+4. awsbatch
+Allowed values for Operating System:
+1. alinux
+2. centos6
+3. centos7
+4. ubuntu1604
+5. ubuntu1804
+Allowed values for EC2 Key Pair Name:
+1. key1
+2. key2
+3. key3
+4. key4
+5. key5
+6. key6
+Allowed values for VPC ID:
+1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
+2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
+3. vpc-34567891 | default | 3 subnets inside
+4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+Allowed values for Network Configuration:
+1. Master in a public subnet and compute fleet in a private subnet
+2. Master and compute fleet in the same public subnet
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/pcluster.config.ini
@@ -1,0 +1,36 @@
+#Invalid section - must be completely ignored
+[ignored section]
+ignored value=invalid_value
+
+[aws]
+aws_region_name = eu-west-1
+#Invalid param key
+invalid_key=invalid_value
+
+[cluster default]
+key_name = key1
+vpc_settings = default
+#Invalid param value
+scheduler = sge
+base_os = centos6
+compute_instance_type = t2.micro
+master_instance_type = t2.nano
+#Invalid value type
+max_queue_size = 14
+initial_queue_size = 13
+#Invalid value type
+maintain_initial_size = true
+
+[vpc default]
+vpc_id = vpc-12345678
+master_subnet_id = subnet-12345678
+compute_subnet_id = subnet-23456789
+use_public_ips = false
+
+[global]
+cluster_template = default
+update_check = true
+sanity_check = true
+
+[aliases]
+ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
@@ -1,3 +1,7 @@
+INFO: Configuration file {{ CONFIG_FILE }} will be written.
+Press CTRL-C to interrupt the procedure.
+
+
 Allowed values for AWS Region ID:
 1. eu-north-1
 2. ap-south-1

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/output.txt
@@ -1,3 +1,7 @@
+INFO: Configuration file {{ CONFIG_FILE }} will be written.
+Press CTRL-C to interrupt the procedure.
+
+
 Allowed values for AWS Region ID:
 1. eu-north-1
 2. ap-south-1

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
@@ -1,3 +1,7 @@
+INFO: Configuration file {{ CONFIG_FILE }} will be written.
+Press CTRL-C to interrupt the procedure.
+
+
 Allowed values for AWS Region ID:
 1. eu-north-1
 2. ap-south-1

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
@@ -1,3 +1,7 @@
+INFO: Configuration file {{ CONFIG_FILE }} will be written.
+Press CTRL-C to interrupt the procedure.
+
+
 Allowed values for AWS Region ID:
 1. eu-north-1
 2. ap-south-1

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
@@ -1,3 +1,7 @@
+WARNING: Configuration file {{ CONFIG_FILE }} will be overwritten.
+Press CTRL-C to interrupt the procedure.
+
+
 Allowed values for AWS Region ID:
 1. eu-north-1
 2. ap-south-1

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/output.txt
@@ -1,3 +1,7 @@
+INFO: Configuration file {{ CONFIG_FILE }} will be written.
+Press CTRL-C to interrupt the procedure.
+
+
 Allowed values for AWS Region ID:
 1. eu-north-1
 2. ap-south-1

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
@@ -1,3 +1,7 @@
+INFO: Configuration file {{ CONFIG_FILE }} will be written.
+Press CTRL-C to interrupt the procedure.
+
+
 Allowed values for AWS Region ID:
 1. eu-north-1
 2. ap-south-1

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
@@ -1,3 +1,7 @@
+INFO: Configuration file {{ CONFIG_FILE }} will be written.
+Press CTRL-C to interrupt the procedure.
+
+
 Allowed values for AWS Region ID:
 1. eu-north-1
 2. ap-south-1

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
@@ -1,3 +1,7 @@
+INFO: Configuration file {{ CONFIG_FILE }} will be written.
+Press CTRL-C to interrupt the procedure.
+
+
 Allowed values for AWS Region ID:
 1. eu-north-1
 2. ap-south-1

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/output.txt
@@ -1,3 +1,7 @@
+INFO: Configuration file {{ CONFIG_FILE }} will be written.
+Press CTRL-C to interrupt the procedure.
+
+
 Allowed values for AWS Region ID:
 1. eu-north-1
 2. ap-south-1


### PR DESCRIPTION
If pcluster configure was executed against an existing config file with
wrong parameter values it failed without letting the user enter new values.

Signed-off-by: ddeidda <ddeidda@amazon.com>