### PR TITLE
Skip g3 in non-GPU tests

### DIFF
--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -26,7 +26,8 @@ DCV_CONNECT_SCRIPT = "/opt/parallelcluster/scripts/pcluster_dcv_connect.sh"
 )
 @pytest.mark.regions(["eu-west-1", "cn-northwest-1"])  # DCV license bucket not present in us-gov
 @pytest.mark.oss(["centos7"])
-@pytest.mark.schedulers(["sge", "awsbatch"])
+@pytest.mark.instances(["c4.xlarge", "g3.8xlarge"])
+@pytest.mark.schedulers(["sge"])
 def test_dcv_configuration(
     dcv_port, access_from, shared_dir, region, instance, os, scheduler, pcluster_config_reader, clusters_factory
 ):

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -24,7 +24,7 @@ from time_utils import minutes, seconds
 
 
 @pytest.mark.skip_schedulers(["awsbatch"])
-@pytest.mark.skip_instances(["c5n.18xlarge", "p3dn.24xlarge", "i3en.24xlarge"])
+@pytest.mark.skip_instances(["c5n.18xlarge", "p3dn.24xlarge", "i3en.24xlarge", "g3.8xlarge"])
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):
     scaledown_idletime = 4


### PR DESCRIPTION
* Only need to run test_slurm_gpu and DCV tests with g3.8xlarge
* Adding skip g3.8xlarge to all other tests so that they are not run with GPU instance
* Adding markers to DCV tests to run on all schedulers

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
