### PR TITLE
Enable Intel HPC

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -53,6 +53,7 @@ from pcluster.config.validators import (
     fsx_imported_file_chunk_size_validator,
     fsx_storage_capacity_validator,
     fsx_validator,
+    intel_hpc_validator,
     raid_volume_iops_validator,
     scheduler_validator,
     url_validator,
@@ -584,6 +585,12 @@ CLUSTER = {
                 "cfn_param_mapping": "CustomAWSBatchTemplateURL",
                 # TODO add regex
                 "validators": [url_validator],
+            }),
+            ("enable_intel_hpc_platform", {
+                "default": False,
+                "type": BoolParam,
+                "cfn_param_mapping": "IntelHPCPlatform",
+                "validators": [intel_hpc_validator],
             }),
             # Settings
             ("scaling_settings", {

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -688,3 +688,19 @@ def compute_instance_type_validator(param_key, param_value, pcluster_config):
         errors, warnings = ec2_instance_type_validator(param_key, param_value, pcluster_config)
 
     return errors, warnings
+
+
+def intel_hpc_validator(param_key, param_value, pcluster_config):
+    errors = []
+    warnings = []
+
+    allowed_oses = ["centos7"]
+
+    cluster_section = pcluster_config.get_section("cluster")
+    if param_value and cluster_section.get_param_value("base_os") not in allowed_oses:
+        errors.append(
+            "When using 'enable_intel_hpc_platform = {0}' it is required to set the 'base_os' parameter "
+            "to one of the following values : {1}".format(param_value, allowed_oses)
+        )
+
+    return errors, warnings

--- a/cli/pcluster/examples/config
+++ b/cli/pcluster/examples/config
@@ -110,6 +110,12 @@ key_name = mykey
 # Existing EC2 IAM policies to be associated with the EC2 instances
 # (defaults to NONE)
 #additional_iam_policies = NONE
+# Disable Hyperthreading on all instances
+# (defaults to False)
+#disable_hyperthreading = false
+# Install Intel Parallel Studio at /opt/intel
+# (defaults to False)
+#enable_intel_hpc_platform = False
 # Extra Json to be merged with the dna.json used by Chef
 # (defaults to {})
 #extra_json = {}

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -119,6 +119,7 @@ DEFAULT_CLUSTER_DICT = {
     "custom_chef_cookbook": None,
     "custom_awsbatch_template_url": None,
     "disable_hyperthreading": False,
+    "enable_intel_hpc_platform": False,
     "scaling_settings": "default",
     "vpc_settings": "default",
     "ebs_settings": None,
@@ -151,7 +152,7 @@ class DefaultDict(Enum):
 # ------------------ Default CFN parameters ------------------ #
 
 # number of CFN parameters created by the PclusterConfig object.
-CFN_CONFIG_NUM_OF_PARAMS = 56
+CFN_CONFIG_NUM_OF_PARAMS = 57
 
 # CFN parameters created by the pcluster CLI
 CFN_CLI_RESERVED_PARAMS = ["ResourcesS3Bucket"]
@@ -226,6 +227,7 @@ DEFAULT_CLUSTER_CFN_PARAMS = {
     "CustomAWSBatchTemplateURL": "NONE",
     "NumberOfEBSVol": "1",
     "Cores": "-1,-1",
+    "IntelHPCPlatform": "false",
     # "ResourcesS3Bucket": "NONE",  # parameter added by the CLI
     # scaling
     "ScaleDownIdleTime": "10",

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -77,6 +77,7 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
                 "VolumeType": "gp2, gp2, gp2, gp2, gp2",
                 "Cores": "-1,-1",
                 "EC2IAMPolicies": "NONE",
+                "IntelHPCPlatform": "true",
             },
             utils.merge_dicts(
                 DefaultDict["cluster"].value,
@@ -91,6 +92,7 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
                     "max_queue_size": 3,
                     "placement": "cluster",
                     "maintain_initial_size": True,
+                    "enable_intel_hpc_platform": True,
                 },
             ),
         )
@@ -804,6 +806,11 @@ def test_cluster_section_from_file(mocker, config_parser_dict, expected_dict_par
         ("disable_hyperthreading", "NONE", None, "must be a Boolean"),
         ("disable_hyperthreading", "true", True, None),
         ("disable_hyperthreading", "false", False, None),
+        ("enable_intel_hpc_platform", None, False, None),
+        ("enable_intel_hpc_platform", "", False, None),
+        ("enable_intel_hpc_platform", "NONE", None, "must be a Boolean"),
+        ("enable_intel_hpc_platform", "true", True, None),
+        ("enable_intel_hpc_platform", "false", False, None),
         # TODO add regex for custom_chef_cookbook
         ("custom_chef_cookbook", None, None, None),
         ("custom_chef_cookbook", "", None, None),
@@ -912,6 +919,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "CustomChefCookbook": "https://test",
                     "CustomAWSBatchTemplateURL": "https://test",
                     "Cores": "1,1",
+                    "IntelHPCPlatform": "true",
                     # template_url = template
                     # tags = {"test": "test"}
                 },
@@ -1130,6 +1138,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "AdditionalCfnTemplate": "https://test",
                     "CustomChefCookbook": "https://test",
                     "CustomAWSBatchTemplateURL": "https://test",
+                    "IntelHPCPlatform": "false",
                     # scaling
                     "ScaleDownIdleTime": "15",
                     # vpc

--- a/cli/tests/pcluster/config/test_section_cluster/test_cluster_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_cluster/test_cluster_from_file_to_cfn/pcluster.config.ini
@@ -53,6 +53,7 @@ custom_chef_cookbook = https://test
 custom_awsbatch_template_url = https://test
 vpc_settings = default
 disable_hyperthreading = true
+enable_intel_hpc_platform = true
 
 [vpc default]
 vpc_id = vpc-12345678
@@ -226,3 +227,4 @@ tags = {"test": "test"}
 custom_chef_cookbook = https://test
 custom_awsbatch_template_url = https://test
 disable_hyperthreading = false
+enable_intel_hpc_platform = false

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -456,6 +456,19 @@ def test_fsx_validator(mocker, section_dict, expected_message):
 @pytest.mark.parametrize(
     "section_dict, expected_message",
     [
+        ({"enable_intel_hpc_platform": "true", "base_os": "centos7"}, None),
+        ({"enable_intel_hpc_platform": "true", "base_os": "alinux"}, "it is required to set the 'base_os'"),
+        ({"enable_intel_hpc_platform": "false", "base_os": "alinux"}, None),
+    ],
+)
+def test_intel_hpc_validator(mocker, section_dict, expected_message):
+    config_parser_dict = {"cluster default": section_dict}
+    utils.assert_param_validator(mocker, config_parser_dict, expected_message)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_message",
+    [
         ({"storage_capacity": 1}, "Capacity for FSx lustre filesystem, 1,200 GB, 2,400 GB or increments of 3,600 GB"),
         ({"storage_capacity": 1200}, None),
         ({"storage_capacity": 2400}, None),

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -334,6 +334,14 @@
       "Description": "Comma separated list of NICE DCV related options, 3 parameters in total, [enabled,port,access_from]",
       "Type": "String",
       "Default": "NONE,NONE,NONE"
+    },
+    "IntelHPCPlatform": {
+      "Description": "Enable Intel HPC Platform packages.",
+      "Type": "String",
+      "AllowedValues": [
+        "true",
+        "false"
+      ]
     }
   },
   "Conditions": {
@@ -2330,6 +2338,9 @@
                         }
                       ]
                     }
+                  },
+                  "enable_intel_hpc_platform": {
+                    "Ref": "IntelHPCPlatform"
                   },
                   "run_list": {
                     "Fn::Sub": "recipe[aws-parallelcluster::${Scheduler}_config]"

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.ini
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.ini
@@ -16,6 +16,7 @@ maintain_initial_size = true
 master_root_volume_size = 80
 compute_root_volume_size = 80
 ebs_settings = large
+enable_intel_hpc_platform = true
 
 [ebs large]
 shared_dir = /shared


### PR DESCRIPTION
Adds a new parameter to the config:

```ini
[cluster intel]
enable_intel_hpc_platform = true
```
This parameter installs Intel Parallel Studio on a shared directory `/opt/intel` on the master.

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
