### PR TITLE
Improve EC2 instance types validator to get the list from pricing file

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -41,6 +41,7 @@ from pcluster.config.validators import (
     ec2_ebs_snapshot_validator,
     ec2_iam_policies_validator,
     ec2_iam_role_validator,
+    ec2_instance_type_validator,
     ec2_key_pair_validator,
     ec2_placement_group_validator,
     ec2_security_group_validator,
@@ -451,6 +452,7 @@ CLUSTER = {
             ("master_instance_type", {
                 "default": "t2.micro",
                 "cfn_param_mapping": "MasterInstanceType",
+                "validators": [ec2_instance_type_validator],
             }),
             ("master_root_volume_size", {
                 "type": IntParam,

--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -27,7 +27,14 @@ from pcluster.configure.networking import (
     automate_vpc_with_subnet_creation,
 )
 from pcluster.configure.utils import get_regions, get_resource_tag, handle_client_exception, prompt, prompt_iterable
-from pcluster.utils import error, get_region, get_supported_os, get_supported_schedulers, list_ec2_instance_types
+from pcluster.utils import (
+    error,
+    get_region,
+    get_supported_compute_instance_types,
+    get_supported_instance_types,
+    get_supported_os,
+    get_supported_schedulers,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -146,7 +153,7 @@ def configure(args):
 
     master_instance_type = prompt(
         "Master instance type",
-        lambda x: x in list_ec2_instance_types(),
+        lambda x: x in get_supported_instance_types(),
         default_value=cluster_section.get_param_value("master_instance_type"),
     )
 
@@ -304,7 +311,7 @@ class SchedulerHandler:
         if not self.is_aws_batch:
             self.compute_instance_type = prompt(
                 "Compute instance type",
-                lambda x: x in list_ec2_instance_types(),
+                lambda x: x in get_supported_compute_instance_types(self.scheduler),
                 default_value=self.cluster_section.get_param_value("compute_instance_type"),
             )
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -245,6 +245,34 @@ def get_instance_vcpus(region, instance_type):
     return vcpus
 
 
+def get_supported_instance_types():
+    """
+    Get supported instance types.
+
+    :return: the list of supported instance types
+    """
+    try:
+        instances = _get_json_from_s3(get_region(), "instances/instances.json")
+        return instances.keys()
+    except (ValueError, ClientError):
+        error("Unable to retrieve the list of supported instance types.")
+
+
+def get_supported_compute_instance_types(scheduler):
+    """
+    Get supported instance types (and families in awsbatch case).
+
+    :param scheduler: the scheduler for which we want to know the supported compute instance types or families
+    :return: the list of supported instance types and families
+    """
+    instances = (
+        get_supported_features(get_region(), "batch").get("instances")
+        if scheduler == "awsbatch"
+        else get_supported_instance_types()
+    )
+    return instances
+
+
 def get_supported_os(scheduler):
     """
     Return a tuple of the os supported by parallelcluster for the specific scheduler.
@@ -458,11 +486,6 @@ def get_latest_alinux_ami_id():
         error("Unable to retrieve Amazon Linux AMI id.\n{0}".format(e.response.get("Error").get("Message")))
 
     return alinux_ami_id
-
-
-def list_ec2_instance_types():
-    """Return a list of all the instance types available on EC2, independent by the region."""
-    return boto3.client("ec2").meta.service_model.shape_for("InstanceType").enum
 
 
 def get_master_server_id(stack_name):

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -867,8 +867,8 @@ def test_cluster_section_to_file(mocker, section_dict, expected_config_parser_di
     [(DefaultDict["cluster"].value, utils.merge_dicts(DefaultCfnParams["cluster"].value))],
 )
 def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
+    utils.mock_pcluster_config(mocker)
     mocker.patch("pcluster.config.param_types.get_efs_mount_target_id", return_value="valid_mount_target_id")
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
     utils.assert_section_to_cfn(mocker, CLUSTER, section_dict, expected_cfn_params)
 
 

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -847,20 +847,18 @@ def test_cluster_param_from_file(mocker, param_key, param_value, expected_value,
 
 
 @pytest.mark.parametrize(
-    "section_definition, section_dict, expected_config_parser_dict, expected_message",
+    "section_dict, expected_config_parser_dict, expected_message",
     [
         # default
-        (CLUSTER, {}, {"cluster default": {}}, None),
+        ({}, {"cluster default": {}}, None),
         # default values
-        (CLUSTER, {"base_os": "alinux"}, {"cluster default": {"base_os": "alinux"}}, "No option .* in section: .*"),
+        ({"base_os": "alinux"}, {"cluster default": {"base_os": "alinux"}}, "No option .* in section: .*"),
         # other values
-        (CLUSTER, {"key_name": "test"}, {"cluster default": {"key_name": "test"}}, None),
-        (CLUSTER, {"base_os": "centos7"}, {"cluster default": {"base_os": "centos7"}}, None),
+        ({"key_name": "test"}, {"cluster default": {"key_name": "test"}}, None),
+        ({"base_os": "centos7"}, {"cluster default": {"base_os": "centos7"}}, None),
     ],
 )
-def test_cluster_section_to_file(
-    mocker, section_definition, section_dict, expected_config_parser_dict, expected_message
-):
+def test_cluster_section_to_file(mocker, section_dict, expected_config_parser_dict, expected_message):
     utils.assert_section_to_file(mocker, CLUSTER, section_dict, expected_config_parser_dict, expected_message)
 
 

--- a/cli/tests/pcluster/configure/test_pcluster_configure.py
+++ b/cli/tests/pcluster/configure/test_pcluster_configure.py
@@ -138,6 +138,11 @@ def _mock_create_network_configuration(mocker, public_subnet_id, private_subnet_
 
 
 def _mock_parallel_cluster_config(mocker):
+    supported_instance_types = ["t2.nano", "t2.micro", "t2.large", "c5.xlarge", "g3.8xlarge"]
+    mocker.patch("pcluster.configure.easyconfig.get_supported_instance_types", return_value=supported_instance_types)
+    mocker.patch(
+        "pcluster.configure.easyconfig.get_supported_compute_instance_types", return_value=supported_instance_types
+    )
     mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
 
 


### PR DESCRIPTION
The boto3 metadata are not updated, it is required to upgrade botocore library to see the newest instances. The pricing file is a list specific for the product.

From now the `compute_instance_type_validator` automatically calls `ec2_instance_type_validator` if the scheduler is not awsbatch.

I'm using two different methods to retrieve compute and master instance types because compute instance type list must contain also families and "optimal" keyword in case of awsbatch scheduler.

+ Remove useless parameter from `cluster_section_to_file` test

### Tests
#### awsbatch, compute_instance_type
- t2.micro --> compute_instance_type 't2.micro' is not supported by awsbatch in region 'eu-west-1'
- t2 --> compute_instance_type 't2' is not supported by awsbatch in region 'eu-west-1'
- test --> compute_instance_type 'test' is not supported by awsbatch in region 'eu-west-1'
- c4 --> ok
- c4.large --> ok
#### awsbatch, master_instance_type
- c4 --> The instance type 'c4' used for the 'master_instance_type' parameter is not supported by AWS ParallelCluster.
- t2.micro --> ok
- c4.large --> ok
#### sge, *_instance_type
- c4 --> The instance type 'c4' used for the 'master_instance_type' parameter is not supported by AWS ParallelCluster.
- c4 --> The instance type 'c4' used for the 'compute_instance_type' parameter is not supported by AWS ParallelCluster.
- test --> The instance type 'test' used for the 'master_instance_type' parameter is not supported by AWS ParallelCluster.
- test --> The instance type 'test' used for the 'compute_instance_type' parameter is not supported by AWS ParallelCluster.
- t2.micro --> ok
- c4.large --> ok



