### PR TITLE
PClusterConfig fixes to fail_on_error and loading logic

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -82,7 +82,6 @@ def create(args):  # noqa: C901 FIXME!!!
     # Build the config based on args
     pcluster_config = PclusterConfig(
         config_file=args.config_file,
-        file_sections=[GLOBAL, CLUSTER],
         cluster_label=args.cluster_template,
         fail_on_file_absence=True,
     )
@@ -243,7 +242,6 @@ def update(args):  # noqa: C901 FIXME!!!
     stack_name = utils.get_stack_name(args.cluster_name)
     pcluster_config = PclusterConfig(
         config_file=args.config_file,
-        file_sections=[GLOBAL, CLUSTER],
         cluster_label=args.cluster_template,
         fail_on_file_absence=True,
     )
@@ -545,7 +543,7 @@ def ssh(args, extra_args):  # noqa: C901 FIXME!!!
     :param args: pcluster CLI args
     :param extra_args: pcluster CLI extra_args
     """
-    pcluster_config = PclusterConfig(file_sections=[ALIASES])  # FIXME it always search for the default config file
+    pcluster_config = PclusterConfig(fail_on_error=False)  # FIXME it always search for the default config file
     if args.command in pcluster_config.get_section("aliases").params:
         ssh_command = pcluster_config.get_section("aliases").get_param_value(args.command)
     else:
@@ -835,7 +833,7 @@ def create_ami(args):
     try:
         # FIXME it doesn't work if there is no a default section
         pcluster_config = PclusterConfig(
-            config_file=args.config_file, file_sections=[GLOBAL, CLUSTER], fail_on_file_absence=True
+            config_file=args.config_file, fail_on_file_absence=True
         )
 
         vpc_section = pcluster_config.get_section("vpc")

--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -80,9 +80,7 @@ def create(args):  # noqa: C901 FIXME!!!
 
     # Build the config based on args
     pcluster_config = PclusterConfig(
-        config_file=args.config_file,
-        cluster_label=args.cluster_template,
-        fail_on_file_absence=True,
+        config_file=args.config_file, cluster_label=args.cluster_template, fail_on_file_absence=True
     )
     pcluster_config.validate()
     # get CFN parameters, template url and tags from config
@@ -240,9 +238,7 @@ def update(args):  # noqa: C901 FIXME!!!
     LOGGER.info("Updating: %s", args.cluster_name)
     stack_name = utils.get_stack_name(args.cluster_name)
     pcluster_config = PclusterConfig(
-        config_file=args.config_file,
-        cluster_label=args.cluster_template,
-        fail_on_file_absence=True,
+        config_file=args.config_file, cluster_label=args.cluster_template, fail_on_file_absence=True
     )
     pcluster_config.validate()
     cfn_params = pcluster_config.to_cfn()
@@ -388,7 +384,7 @@ def _colorize(stack_status, args):
 
 def list_stacks(args):
     # Parse configuration file to read the AWS section
-    PclusterConfig.init_AWS(config_file=args.config_file)
+    PclusterConfig.init_aws(config_file=args.config_file)
 
     try:
         result = []
@@ -577,7 +573,7 @@ def status(args):  # noqa: C901 FIXME!!!
     stack_name = utils.get_stack_name(args.cluster_name)
 
     # Parse configuration file to read the AWS section
-    PclusterConfig.init_AWS(config_file=args.config_file)
+    PclusterConfig.init_aws(config_file=args.config_file)
 
     cfn = boto3.client("cloudformation")
     try:
@@ -638,7 +634,7 @@ def delete(args):
     stack_name = utils.get_stack_name(args.cluster_name)
 
     # Parse configuration file to read the AWS section
-    PclusterConfig.init_AWS(config_file=args.config_file)
+    PclusterConfig.init_aws(config_file=args.config_file)
 
     cfn = boto3.client("cloudformation")
     try:
@@ -831,9 +827,7 @@ def create_ami(args):
     instance_type = args.instance_type
     try:
         # FIXME it doesn't work if there is no a default section
-        pcluster_config = PclusterConfig(
-            config_file=args.config_file, fail_on_file_absence=True
-        )
+        pcluster_config = PclusterConfig(config_file=args.config_file, fail_on_file_absence=True)
 
         vpc_section = pcluster_config.get_section("vpc")
         vpc_id = args.vpc_id if args.vpc_id else vpc_section.get_param_value("vpc_id")

--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -37,7 +37,6 @@ from botocore.exceptions import ClientError
 from tabulate import tabulate
 
 import pcluster.utils as utils
-from pcluster.config.mappings import ALIASES, CLUSTER, GLOBAL
 from pcluster.config.pcluster_config import PclusterConfig
 
 if sys.version_info[0] >= 3:
@@ -389,7 +388,7 @@ def _colorize(stack_status, args):
 
 def list_stacks(args):
     # Parse configuration file to read the AWS section
-    PclusterConfig(config_file=args.config_file)
+    PclusterConfig.init_AWS(config_file=args.config_file)
 
     try:
         result = []
@@ -578,7 +577,7 @@ def status(args):  # noqa: C901 FIXME!!!
     stack_name = utils.get_stack_name(args.cluster_name)
 
     # Parse configuration file to read the AWS section
-    PclusterConfig(config_file=args.config_file)
+    PclusterConfig.init_AWS(config_file=args.config_file)
 
     cfn = boto3.client("cloudformation")
     try:
@@ -639,7 +638,7 @@ def delete(args):
     stack_name = utils.get_stack_name(args.cluster_name)
 
     # Parse configuration file to read the AWS section
-    PclusterConfig(config_file=args.config_file)
+    PclusterConfig.init_AWS(config_file=args.config_file)
 
     cfn = boto3.client("cloudformation")
     try:

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -1092,7 +1092,7 @@ class Section(object):
             param = param_type(self.key, self.label, param_key, param_definition, self.pcluster_config)
             self.add_param(param)
 
-    def validate(self, fail_on_error=True):
+    def validate(self):
         """Call the validator function of the section and of all the parameters."""
         if self.params:
             section_name = _get_file_section_name(self.key, self.label)

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -276,9 +276,7 @@ class PclusterConfig(object):
         # get cluster by cluster_label
         if not cluster_label:
             cluster_label = (
-                self.get_section("global").get_param_value("cluster_template")
-                if self.get_section("global")
-                else None
+                self.get_section("global").get_param_value("cluster_template") if self.get_section("global") else None
             )
         self.__init_section_from_file(
             CLUSTER, config_parser, section_label=cluster_label, fail_on_absence=fail_on_absence

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -276,7 +276,9 @@ class PclusterConfig(object):
         # get cluster by cluster_label
         if not cluster_label:
             cluster_label = (
-                self.get_section("global").get_param_value("cluster_template") if self.get_section("global") else None
+                self.get_section("global").get_param_value("cluster_template")
+                if self.get_section("global")
+                else None
             )
         self.__init_section_from_file(
             CLUSTER, config_parser, section_label=cluster_label, fail_on_absence=fail_on_absence
@@ -456,7 +458,6 @@ class PclusterConfig(object):
 
         Useful when the only thing needed is to set AWS env variables, without really loading and checking the
         configuration settings.
-        :param config_file:
-        :return:
+        :param config_file: pcluster config file - None to use default
         """
         PclusterConfig(config_file=config_file, fail_on_error=False, fail_on_file_absence=False)

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -37,7 +37,6 @@ class PclusterConfig(object):
     def __init__(
         self,
         config_file=None,
-        file_sections=None,
         cluster_label=None,  # args.cluster_template
         fail_on_file_absence=False,
         fail_on_error=None,
@@ -50,8 +49,6 @@ class PclusterConfig(object):
 
         # "From file" initialization parameters:
         :param config_file: if specified the initialization of the sections will start from the file
-        :param file_sections: the sections of the configuration file to parse and initialize,
-        by default the init reads the configuration file to get AWS credentials.
         :param cluster_label: the label associated to a [cluster ...] section in the file
         :param fail_on_file_absence: initialization will fail if the specified file or a default one doesn't exist
         :param fail_on_error: tells if initialization must fail in presence of errors. If not set, the behaviour will
@@ -74,7 +71,7 @@ class PclusterConfig(object):
         if cluster_name:
             self.__init_sections_from_cfn(cluster_name)
         else:
-            self.__init_sections_from_file(file_sections, cluster_label, self.config_parser, fail_on_file_absence)
+            self.__init_sections_from_file(cluster_label, self.config_parser, fail_on_file_absence)
 
     def _init_config_parser(self, config_file, fail_on_config_file_absence=True):
         """
@@ -223,12 +220,14 @@ class PclusterConfig(object):
 
     @property
     def fail_on_error(self):
+        """Get fail_on_error property value. Will fall back to sanity_check parameter if not explicitly set."""
         if self._fail_on_error is None:
             self._fail_on_error = self.get_section("global").get_param_value("sanity_check")
         return self._fail_on_error
 
     @fail_on_error.setter
     def fail_on_error(self, fail_on_error):
+        """Set fail_on_error property value."""
         self._fail_on_error = fail_on_error
 
     def to_file(self):
@@ -263,33 +262,25 @@ class PclusterConfig(object):
         """
         return self.get_section("cluster").to_cfn()
 
-    def __init_sections_from_file(self, file_sections, cluster_label=None, config_parser=None, fail_on_absence=False):
+    def __init_sections_from_file(self, cluster_label=None, config_parser=None, fail_on_absence=False):
         """
         Initialize all the Sections object and add them to the internal structure by parsing configuration file.
 
-        :param file_sections: list of sections definition to initialize
         :param cluster_label: the label of the section (if there)
         :param config_parser: the config parser object to parse
         :param fail_on_absence: if true, the initialization will fail if one section doesn't exist in the file
         """
-        if not file_sections:
-            file_sections = []
-
         for section_definition in [ALIASES, GLOBAL]:
-            if section_definition in file_sections:
-                self.__init_section_from_file(section_definition, config_parser)
+            self.__init_section_from_file(section_definition, config_parser)
 
         # get cluster by cluster_label
-        if CLUSTER in file_sections:
-            if not cluster_label:
-                cluster_label = (
-                    self.get_section("global").get_param_value("cluster_template")
-                    if self.get_section("global")
-                    else None
-                )
-            self.__init_section_from_file(
-                CLUSTER, config_parser, section_label=cluster_label, fail_on_absence=fail_on_absence
+        if not cluster_label:
+            cluster_label = (
+                self.get_section("global").get_param_value("cluster_template") if self.get_section("global") else None
             )
+        self.__init_section_from_file(
+            CLUSTER, config_parser, section_label=cluster_label, fail_on_absence=fail_on_absence
+        )
 
     def __init_section_from_file(self, section_definition, config_parser, section_label=None, fail_on_absence=False):
         """
@@ -457,3 +448,15 @@ class PclusterConfig(object):
     def warn(self, message):
         """Print a warning message."""
         print("WARNING: {0}".format(message))
+
+    @staticmethod
+    def init_aws(config_file=None):
+        """
+        Initialize AWS env settings from pcluster config file.
+
+        Useful when the only thing needed is to set AWS env variables, without really loading and checking the
+        configuration settings.
+        :param config_file:
+        :return:
+        """
+        PclusterConfig(config_file=config_file, fail_on_error=False, fail_on_file_absence=False)

--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -103,7 +103,7 @@ def configure(args):
         error("Invalid configuration file path: {0}".format(args.config_file))
 
     pcluster_config = PclusterConfig(
-        config_file=args.config_file, file_sections=[GLOBAL, CLUSTER, ALIASES], fail_on_error=False
+        config_file=args.config_file, fail_on_error=False
     )
 
     if os.path.exists(pcluster_config.config_file):

--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -19,7 +19,6 @@ import os
 
 import boto3
 
-from pcluster.config.mappings import ALIASES, CLUSTER, GLOBAL
 from pcluster.config.pcluster_config import PclusterConfig
 from pcluster.configure.networking import (
     NetworkConfiguration,
@@ -102,9 +101,7 @@ def configure(args):
     if args.config_file and os.path.exists(args.config_file) and not os.path.isfile(args.config_file):
         error("Invalid configuration file path: {0}".format(args.config_file))
 
-    pcluster_config = PclusterConfig(
-        config_file=args.config_file, fail_on_error=False
-    )
+    pcluster_config = PclusterConfig(config_file=args.config_file, fail_on_error=False)
 
     if os.path.exists(pcluster_config.config_file):
         msg = "WARNING: Configuration file {0} will be overwritten."

--- a/cli/pcluster/dcv/connect.py
+++ b/cli/pcluster/dcv/connect.py
@@ -38,7 +38,7 @@ def dcv_connect(args):
     :param args: pcluster cli arguments.
     """
     # Parse configuration file to read the AWS section
-    PclusterConfig.init_AWS()  # FIXME it always searches for the default configuration file
+    PclusterConfig.init_aws()  # FIXME it always searches for the default configuration file
 
     # Prepare ssh command to execute in the master instance
     stack = get_stack(get_stack_name(args.cluster_name))

--- a/cli/pcluster/dcv/connect.py
+++ b/cli/pcluster/dcv/connect.py
@@ -38,7 +38,7 @@ def dcv_connect(args):
     :param args: pcluster cli arguments.
     """
     # Parse configuration file to read the AWS section
-    PclusterConfig()  # FIXME it always searches for the default configuration file
+    PclusterConfig.init_AWS()  # FIXME it always searches for the default configuration file
 
     # Prepare ssh command to execute in the master instance
     stack = get_stack(get_stack_name(args.cluster_name))

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -54,7 +54,6 @@ def test_example_config_consistency(mocker):
     mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
     pcluster_config = PclusterConfig(
         config_file=utils.get_pcluster_config_example(),
-        file_sections=[GLOBAL, CLUSTER, ALIASES],
         fail_on_file_absence=True,
     )
 

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -52,10 +52,7 @@ def test_mapping_consistency():
 def test_example_config_consistency(mocker):
     """Validate example file and try to convert to CFN."""
     mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
-    pcluster_config = PclusterConfig(
-        config_file=utils.get_pcluster_config_example(),
-        fail_on_file_absence=True,
-    )
+    pcluster_config = PclusterConfig(config_file=utils.get_pcluster_config_example(), fail_on_file_absence=True)
 
     cfn_params = pcluster_config.to_cfn()
 

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -108,7 +108,7 @@ def assert_section_from_cfn(mocker, section_definition, cfn_params_dict, expecte
 
 
 def get_mocked_pcluster_config(mocker):
-    return PclusterConfig(config_file="wrong-file", file_sections=[GLOBAL, ALIASES, CLUSTER])
+    return PclusterConfig(config_file="wrong-file")
 
 
 def assert_section_from_file(mocker, section_definition, config_parser_dict, expected_dict_params, expected_message):
@@ -196,14 +196,12 @@ def assert_section_params(mocker, pcluster_config_reader, settings_label, expect
             PclusterConfig(
                 cluster_label="default",
                 config_file=pcluster_config_reader(settings_label=settings_label),
-                file_sections=[GLOBAL, CLUSTER],
                 fail_on_file_absence=True,
                 fail_on_error=True,
             )
     else:
         pcluster_config = PclusterConfig(
             config_file=pcluster_config_reader(settings_label=settings_label),
-            file_sections=[GLOBAL, CLUSTER],
             fail_on_file_absence=True,
         )
 
@@ -226,7 +224,6 @@ def init_pcluster_config_from_configparser(config_parser, validate=True):
         pcluster_config = PclusterConfig(
             config_file=config_file.name,
             cluster_label="default",
-            file_sections=[GLOBAL, CLUSTER, ALIASES],
             fail_on_file_absence=True,
         )
         if validate:

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -17,7 +17,6 @@ import pytest
 from configparser import NoOptionError, NoSectionError
 
 from assertpy import assert_that
-from pcluster.config.mappings import ALIASES, CLUSTER, GLOBAL
 from pcluster.config.param_types import Param
 from pcluster.config.pcluster_config import PclusterConfig
 from tests.pcluster.config.defaults import CFN_CONFIG_NUM_OF_PARAMS, DefaultDict
@@ -201,8 +200,7 @@ def assert_section_params(mocker, pcluster_config_reader, settings_label, expect
             )
     else:
         pcluster_config = PclusterConfig(
-            config_file=pcluster_config_reader(settings_label=settings_label),
-            fail_on_file_absence=True,
+            config_file=pcluster_config_reader(settings_label=settings_label), fail_on_file_absence=True
         )
 
         cfn_params = pcluster_config.to_cfn()
@@ -222,9 +220,7 @@ def init_pcluster_config_from_configparser(config_parser, validate=True):
             config_parser.write(cf)
 
         pcluster_config = PclusterConfig(
-            config_file=config_file.name,
-            cluster_label="default",
-            fail_on_file_absence=True,
+            config_file=config_file.name, cluster_label="default", fail_on_file_absence=True
         )
         if validate:
             pcluster_config.validate()

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -198,6 +198,7 @@ def assert_section_params(mocker, pcluster_config_reader, settings_label, expect
                 config_file=pcluster_config_reader(settings_label=settings_label),
                 file_sections=[GLOBAL, CLUSTER],
                 fail_on_file_absence=True,
+                fail_on_error=True,
             )
     else:
         pcluster_config = PclusterConfig(


### PR DESCRIPTION
PClusterConfig refactorings:

- fail_on_error logic now falling back to sanity_check if None value is set
- the "file_sections" constructor parameters and related logic has been removed to guarantee configuration consistency no matter how the configuration was loaded
- a better way to initialize AWS environment for commands that needed it without having to initialize explicitly a PclusterConfig object