### PR TITLE
Move property to enable Intel HPC in the right level of the dna.json

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2337,10 +2337,10 @@
                           ]
                         }
                       ]
+                    },
+                    "enable_intel_hpc_platform": {
+                      "Ref": "IntelHPCPlatform"
                     }
-                  },
-                  "enable_intel_hpc_platform": {
-                    "Ref": "IntelHPCPlatform"
                   },
                   "run_list": {
                     "Fn::Sub": "recipe[aws-parallelcluster::${Scheduler}_config]"


### PR DESCRIPTION
In the cookbook recipes https://github.com/aws/aws-parallelcluster-cookbook/pull/430 we are searching for the `enable_intel_hpc_platform` key in the `cfncluster` dictionary of the `dna.json` file.

It was:
```
{
  "cfncluster": {
    "stack_name": "parallelcluster-intel-hpc",
    ...
  },
  "run_list": "recipe[aws-parallelcluster::sge_config]",
  "enable_intel_hpc_platform": "true"
}
```

now it is:
```
{
  "cfncluster": {
    "stack_name": "parallelcluster-intel-hpc",
    ...
    "enable_intel_hpc_platform": "true"
  },
  "run_list": "recipe[aws-parallelcluster::sge_config]"
}
```