### PR TITLE
Add possibility to add suffix to integration tests stack names

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -74,6 +74,7 @@ def pytest_addoption(parser):
     )
     parser.addoption("--benchmarks-target-capacity", help="set the target capacity for benchmarks tests", type=int)
     parser.addoption("--benchmarks-max-time", help="set the max waiting time in minutes for benchmarks tests", type=int)
+    parser.addoption("--stackname-suffix", help="set a suffix in the integration tests stack names")
 
 
 def pytest_generate_tests(metafunc):
@@ -189,7 +190,11 @@ def clusters_factory(request):
         cluster = Cluster(
             name=request.config.getoption("cluster")
             if request.config.getoption("cluster")
-            else "integ-tests-" + random_alphanumeric(),
+            else "integ-tests-{0}{1}{2}".format(
+                random_alphanumeric(),
+                "-" if request.config.getoption("stackname_suffix") else "",
+                request.config.getoption("stackname_suffix"),
+            ),
             config_file=cluster_config,
             ssh_key=request.config.getoption("key_path"),
         )
@@ -396,7 +401,15 @@ def _create_vpc_stack(request, template, region, cfn_stacks_factory):
         logging.info("Using stack {0} in region {1}".format(request.config.getoption("vpc_stack"), region))
         stack = CfnStack(name=request.config.getoption("vpc_stack"), region=region, template=template.to_json())
     else:
-        stack = CfnStack(name="integ-tests-vpc-" + random_alphanumeric(), region=region, template=template.to_json())
+        stack = CfnStack(
+            name="integ-tests-vpc-{0}{1}{2}".format(
+                random_alphanumeric(),
+                "-" if request.config.getoption("stackname_suffix") else "",
+                request.config.getoption("stackname_suffix"),
+            ),
+            region=region,
+            template=template.to_json(),
+        )
         cfn_stacks_factory.create_stack(stack)
     return stack
 

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -72,6 +72,7 @@ TEST_DEFAULTS = {
     "benchmarks": False,
     "benchmarks_target_capacity": 200,
     "benchmarks_max_time": 30,
+    "stackname_suffix": "",
 }
 
 
@@ -205,6 +206,11 @@ def _init_argparser():
         default=TEST_DEFAULTS.get("benchmarks_max_time"),
         type=int,
     )
+    parser.add_argument(
+        "--stackname-suffix",
+        help="set a suffix in the integration tests stack names",
+        default=TEST_DEFAULTS.get("stackname_suffix"),
+    )
 
     return parser
 
@@ -244,6 +250,7 @@ def _get_pytest_args(args, regions, log_file, out_dir):
     pytest_args.extend(["--output-dir", "{0}/{1}".format(args.output_dir, out_dir)])
     pytest_args.extend(["--key-name", args.key_name])
     pytest_args.extend(["--key-path", args.key_path])
+    pytest_args.extend(["--stackname-suffix", args.stackname_suffix])
 
     if args.credential:
         pytest_args.append("--credential")

--- a/tests/integration-tests/tests/networking/test_networking.py
+++ b/tests/integration-tests/tests/networking/test_networking.py
@@ -29,7 +29,11 @@ def networking_stack_factory(request):
     def _create_network(region, template_path, parameters):
         file_content = extract_template(template_path)
         stack = CfnStack(
-            name="integ-tests-networking-" + random_alphanumeric(),
+            name="integ-tests-networking-{0}{1}{2}".format(
+                random_alphanumeric(),
+                "-" if request.config.getoption("stackname_suffix") else "",
+                request.config.getoption("stackname_suffix"),
+            ),
             region=region,
             template=file_content,
             parameters=parameters,


### PR DESCRIPTION
Default is to use the username of the user launching the tests suite

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
