### PR TITLE
Remove ec2 instance type validator

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -39,7 +39,6 @@ from pcluster.config.validators import (
     ec2_ebs_snapshot_validator,
     ec2_iam_policies_validator,
     ec2_iam_role_validator,
-    ec2_instance_type_validator,
     ec2_key_pair_validator,
     ec2_placement_group_validator,
     ec2_security_group_validator,
@@ -421,7 +420,6 @@ CLUSTER = {
             ("master_instance_type", {
                 "default": "t2.micro",
                 "cfn_param_mapping": "MasterInstanceType",
-                "validators": [ec2_instance_type_validator],
             }),
             ("master_root_volume_size", {
                 "type": IntParam,

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -416,24 +416,6 @@ def _get_pcluster_user_policy(partition, region, account_id):
     ]
 
 
-def ec2_instance_type_validator(param_key, param_value, pcluster_config):
-    errors = []
-    warnings = []
-
-    try:
-        if param_value not in list_ec2_instance_types():
-            errors.append(
-                "The instance type '{0}' used for the '{1}' parameter is not supported by EC2.".format(
-                    param_value, param_key
-                )
-            )
-
-    except ClientError as e:
-        errors.append(e.response.get("Error").get("Message"))
-
-    return errors, warnings
-
-
 def ec2_vpc_id_validator(param_key, param_value, pcluster_config):
     errors = []
     warnings = []
@@ -683,9 +665,6 @@ def compute_instance_type_validator(param_key, param_value, pcluster_config):
                         )
         except ClientError as e:
             errors.append(e.response.get("Error").get("Message"))
-
-    else:
-        errors, warnings = ec2_instance_type_validator(param_key, param_value, pcluster_config)
 
     return errors, warnings
 

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -59,21 +59,6 @@ def test_cluster_validator(mocker, section_dict, expected_message):
     utils.assert_param_validator(mocker, config_parser_dict, expected_message)
 
 
-@pytest.mark.parametrize(
-    "instance_type, expected_message",
-    [
-        ("wrong_instance_type", "has an invalid value"),
-        ("t2.micro", None),
-        ("c4.xlarge", None),
-        ("c5.xlarge", "has an invalid value"),  # to verify mock is working
-    ],
-)
-def test_instance_type_validator(mocker, instance_type, expected_message):
-    mocker.patch("pcluster.config.validators.list_ec2_instance_types", return_value=["t2.micro", "c4.xlarge"])
-    config_parser_dict = {"cluster default": {"compute_instance_type": instance_type}}
-    utils.assert_param_validator(mocker, config_parser_dict, expected_message)
-
-
 def test_ec2_key_pair_validator(mocker, boto3_stubber):
     describe_key_pairs_response = {
         "KeyPairs": [


### PR DESCRIPTION
We are removing it since it is based on botocore metadata.


