### PR TITLE
Fix awsbatch cluster creation when long cluster name is used

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,7 @@ CHANGELOG
 * Fix bug that was causing failures in sqswatcher when ADD and REMOVE event for the same host are fetched together.
 * Fix bug that was preventing nodes to mount partitioned EBS volumes.
 * Implement paginated calls in ``pcluster list``.
+* Fix bug when creating ``awsbatch`` cluster with name longer than 31 chars
 
 2.4.1
 =====

--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -49,7 +49,8 @@ LOGGER = logging.getLogger(__name__)
 
 def _create_bucket_with_batch_resources(stack_name, resources_dir, region):
     random_string = "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(16))
-    s3_bucket_name = "-".join([stack_name.lower(), random_string])
+    # bucket names must be at least 3 and no more than 63 characters long
+    s3_bucket_name = "-".join([stack_name.lower()[: 63 - len(random_string) - 1], random_string])
 
     try:
         utils.create_s3_bucket(bucket_name=s3_bucket_name, region=region)


### PR DESCRIPTION
The S3 resource bucket is created when scheduler awsbatch is selected.
Bucket names must be at least 3 and no more than 63 characters long.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
