### PR TITLE
Add enable_intel_hpc_platform flag to compute

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -3244,6 +3244,9 @@
                         },
                         "User"
                       ]
+                    },
+                    "enable_intel_hpc_platform": {
+                      "Ref": "IntelHPCPlatform"
                     }
                   },
                   "run_list": {


### PR DESCRIPTION
Confirmed flag is in right place on the compute node:

```json
{
  "cfncluster": {
    "stack_name": "parallelcluster-intel-2",
    "cfn_raid_parameters": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
    "cfn_sqs_queue": "https://sqs.us-east-1.amazonaws.com/822857487308/parallelcluster-intel-2-SQS-BKG3HIBS4RQO",
    "cfn_postinstall": "NONE",
    "enable_intel_hpc_platform": "true",
    "cfn_node_type": "ComputeFleet",
    }
}
```
Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
