### PR TITLE
Exit with status code 1 if "pcluster create" fails to create a stack

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -131,10 +131,12 @@ def create(args):  # noqa: C901 FIXME!!!
         LOGGER.debug("StackId: %s", stack.get("StackId"))
 
         if not args.nowait:
-            utils.verify_stack_creation(stack_name, cfn_client)
+            verified = utils.verify_stack_creation(stack_name, cfn_client)
             LOGGER.info("")
             result_stack = utils.get_stack(stack_name, cfn_client)
             _print_stack_outputs(result_stack)
+            if not verified:
+                sys.exit(1)
         else:
             stack_status = utils.get_stack(stack_name, cfn_client).get("StackStatus")
             LOGGER.info("Status: %s", stack_status)


### PR DESCRIPTION
Unless nowait is specified, this will make the "pcluster create"
command exit with code 1 instead of 0 if the CloudFormation stack
creation does not result in a CREATION_COMPLETE status.

This enables higher-level automation scripts and CI/CD tools to handle
stack creation failures through the usual shell script error handling
mechanisms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.