### PR TITLE
Fix pcluster delete exits with error when cluster is deleted

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -651,7 +651,7 @@ def delete(args):
         if not args.nowait:
             while stack_status == "DELETE_IN_PROGRESS":
                 time.sleep(5)
-                stack_status = utils.get_stack(stack_name, cfn).get("StackStatus")
+                stack_status = cfn.describe_stacks(StackName=stack_name).get("Stacks")[0].get("StackStatus")
                 events = cfn.describe_stack_events(StackName=stack_name).get("StackEvents")[0]
                 resource_status = (
                     "Status: %s - %s" % (events.get("LogicalResourceId"), events.get("ResourceStatus"))


### PR DESCRIPTION
pcluster delete should exit with success when the stack is deleted and not fail because stack is not found

The utility function `utils.get_stack` exists with error on stack not found.

Test:
```
pcluster delete batch-test
Deleting: batch-test
Status: MasterSecurityGroup - DELETE_COMPLETE
Cluster deleted successfully.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
