### PR TITLE
Fallback sanity_check to default if global section is not initialized

### DIFF
--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -222,7 +222,11 @@ class PclusterConfig(object):
     def fail_on_error(self):
         """Get fail_on_error property value. Will fall back to sanity_check parameter if not explicitly set."""
         if self._fail_on_error is None:
-            self._fail_on_error = self.get_section("global").get_param_value("sanity_check")
+            self._fail_on_error = (
+                self.get_section("global").get_param_value("sanity_check")
+                if self.get_section("global")
+                else GLOBAL.get("params").get("sanity_check").get("default")
+            )
         return self._fail_on_error
 
     @fail_on_error.setter


### PR DESCRIPTION
The AWS section is the first one parsed, before the GLOBAL one.

When using an "xxx" parameter in the AWS section, the error was:
`AttributeError: 'NoneType' object has no attribute 'get_param_value'`

The current output is:
`ERROR: The configuration parameter 'xxx' is not allowed in the [aws] section`
