### PR TITLE
Merge cloudwatch-logging feature branch

### DIFF
--- a/cli/pcluster/config/iam_policy_rules.py
+++ b/cli/pcluster/config/iam_policy_rules.py
@@ -1,0 +1,84 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import sys
+
+from pcluster.utils import get_partition
+
+if sys.version_info >= (3, 4):
+    ABC = abc.ABC
+else:
+    ABC = abc.ABCMeta("ABC", (), {})
+
+
+class EC2IAMPolicyInclusionRule(ABC):
+    """
+    Encapsulate logic for conditional inclusion of policies in the EC2IAMPolicies cfn parameter.
+
+    Certain IAM policies must be included in the EC2IAMPolicies CloudFormation parameter based on
+    a requested cluster configuration. This class provides an interface for deciding wheter a
+    a specific configuration requires a specific policy.
+    """
+
+    @classmethod
+    @abc.abstractmethod
+    def policy_is_required(cls, pcluster_config):
+        """Describe whether the policy represented by this class must be included."""
+        return cls("Conditional policy inclusion rule not implemented.")
+
+    @classmethod
+    @abc.abstractmethod
+    def get_policy(cls):
+        """Return the ARN for the polciy that must be included."""
+        return cls("Policy getter not implemented.")
+
+    @staticmethod
+    def policy_name_to_arn(policy_name):
+        """Return an ARN for the given IAM policy."""
+        return "arn:{0}:iam::aws:policy/{1}".format(get_partition(), policy_name)
+
+
+class CloudWatchAgentServerPolicyInclusionRule(EC2IAMPolicyInclusionRule):
+    """Include the CloudWatchServerAgentPolicy when CloudWatch logging is enabled."""
+
+    @classmethod
+    def policy_is_required(cls, pcluster_config):
+        """Describe whether the policy represented by this class must be included."""
+        cw_log_settings = pcluster_config.get_section("cluster").get_param("cw_log_settings")
+        if cw_log_settings.value is not None:
+            # A cw_log section was referenced from the config file's cluster section.
+            # Use that section's "enable" parameter's value
+            cw_log_section = pcluster_config.get_section("cw_log", cw_log_settings.value)
+            should_include_policy = cw_log_section.get_param_value("enable")
+        else:
+            # A cw_log section was referenced from the config file's cluster section
+            should_include_policy = cw_log_settings.referred_section_definition["params"]["enable"]["default"]
+        return should_include_policy
+
+    @classmethod
+    def get_policy(cls):
+        """Return the ARN for the polciy that must be included."""
+        return cls.policy_name_to_arn("CloudWatchAgentServerPolicy")
+
+
+class AWSBatchFullAccessInclusionRule(EC2IAMPolicyInclusionRule):
+    """Include the AWSBatchFullAccess when the scheduler is awsbatch."""
+
+    @classmethod
+    def policy_is_required(cls, pcluster_config):
+        """Describe whether the policy represented by this class must be included."""
+        return pcluster_config.get_section("cluster").get_param_value("scheduler") == "awsbatch"
+
+    @classmethod
+    def get_policy(cls):
+        """Return the ARN for the polciy that must be included."""
+        return cls.policy_name_to_arn("AWSBatchFullAccess")

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -384,6 +384,26 @@ DCV = {
         ]
     )
 }
+CW_LOG = {
+    "type": Section,
+    "key": "cw_log",
+    "default_label": "default",
+    "cfn_param_mapping": "CWLogOptions",  # Stringify params into single CFN parameter
+    "params": OrderedDict([
+        ("enable", {
+            "type": BoolParam,
+            "default": True,
+        }),
+        ("retention_days", {
+            "type": IntParam,
+            "default": 14,
+            "cfn_param_mapping": "CWLogEventRententionDays",
+            "allowed_values": [
+                1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653
+            ]
+        }),
+    ])
+}
 
 CLUSTER = {
     "type": ClusterSection,
@@ -494,11 +514,6 @@ CLUSTER = {
             ("ec2_iam_role", {
                 "cfn_param_mapping": "EC2IAMRoleName",
                 "validators": [ec2_iam_role_validator],  # TODO add regex
-            }),
-            ("additional_iam_policies", {
-                "type": AdditionalIamPoliciesParam,
-                "cfn_param_mapping": "EC2IAMPolicies",
-                "validators": [ec2_iam_policies_validator],
             }),
             ("s3_read_resource", {
                 "cfn_param_mapping": "S3ReadResource",  # TODO add validator
@@ -620,6 +635,17 @@ CLUSTER = {
             ("dcv_settings", {
                 "type": SettingsParam,
                 "referred_section": DCV,
+            }),
+            ("cw_log_settings", {
+                "type": SettingsParam,
+                "referred_section": CW_LOG,
+            }),
+            # Moved from the "Access and Networking" section because its configuration is
+            # dependent on multiple other parameters from within this section.
+            ("additional_iam_policies", {
+                "type": AdditionalIamPoliciesParam,
+                "cfn_param_mapping": "EC2IAMPolicies",
+                "validators": [ec2_iam_policies_validator],
             }),
         ]
     )

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -17,13 +17,13 @@ import re
 from configparser import NoSectionError
 
 import yaml
+from pcluster.config.iam_policy_rules import AWSBatchFullAccessInclusionRule, CloudWatchAgentServerPolicyInclusionRule
 from pcluster.utils import (
     PCLUSTER_ISSUES_LINK,
     get_avail_zone,
     get_cfn_param,
     get_efs_mount_target_id,
     get_instance_vcpus,
-    get_partition,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -626,21 +626,23 @@ class AdditionalIamPoliciesParam(CommaSeparatedParam):
     """
     Class to manage the additional_iam_policies configuration parameters.
 
-    We need this class because in the awsbatch case we need to add/remove the AWSBatchFullAccess policy
-    during CFN conversion.
+    We need this class for 2 reasons:
+    * When the scheduler is awsbatch, we need to add/remove the AWSBatchFullAccess policy
+      during CFN conversion.
+    * When CloudWatch logging is enabled, we need to add/remove the CloudWatchAgentServerPolicy
+      during CFN conversion.
     """
 
     def __init__(self, section_key, section_label, param_key, param_definition, pcluster_config):
         super(AdditionalIamPoliciesParam, self).__init__(
             section_key, section_label, param_key, param_definition, pcluster_config
         )
-        self.aws_batch_iam_policy = "arn:{0}:iam::aws:policy/AWSBatchFullAccess".format(get_partition())
+        self.policy_inclusion_rules = [CloudWatchAgentServerPolicyInclusionRule, AWSBatchFullAccessInclusionRule]
 
     def to_file(self, config_parser, write_defaults=False):
         """Set parameter in the config_parser in the right section."""
-        # remove awsbatch policy, if there
-        if self.aws_batch_iam_policy in self.value:
-            self.value.remove(self.aws_batch_iam_policy)
+        # remove conditional policies, if there
+        self._remove_conditional_policies()
         super(AdditionalIamPoliciesParam, self).to_file(config_parser)
 
     def from_cfn_params(self, cfn_params):
@@ -650,24 +652,26 @@ class AdditionalIamPoliciesParam(CommaSeparatedParam):
         :param cfn_params: list of all the CFN parameters, used if "cfn_param_mapping" is specified in the definition
         """
         super(AdditionalIamPoliciesParam, self).from_cfn_params(cfn_params)
-
-        # remove awsbatch policy, if there
-        if self.aws_batch_iam_policy in self.value:
-            self.value.remove(self.aws_batch_iam_policy)
-
+        # remove conditional policies, if there
+        self._remove_conditional_policies()
         return self
 
     def to_cfn(self):
         """Convert param to CFN representation, if "cfn_param_mapping" attribute is present in the Param definition."""
-        # add awsbatch policy if scheduler is awsbatch
-        cluster_config = self.pcluster_config.get_section(self.section_key)
-        if cluster_config.get_param_value("scheduler") == "awsbatch":
-            if self.aws_batch_iam_policy not in self.value:
-                self.value.append(self.aws_batch_iam_policy)
+        # Add conditional policies if appropriate
+        for rule in self.policy_inclusion_rules:
+            if rule.policy_is_required(self.pcluster_config) and rule.get_policy() not in self.value:
+                self.value.append(rule.get_policy())
 
         cfn_params = super(AdditionalIamPoliciesParam, self).to_cfn()
 
         return cfn_params
+
+    def _remove_conditional_policies(self):
+        """Remove any of the policy ARNs in self.conditional_policies from self.value."""
+        for rule in self.policy_inclusion_rules:
+            if rule.get_policy() in self.value:
+                self.value.remove(rule.get_policy())
 
 
 class AvailabilityZoneParam(Param):

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -127,7 +127,10 @@ DEFAULT_CLUSTER_DICT = {
     "raid_settings": None,
     "fsx_settings": None,
     "dcv_settings": None,
+    "cw_log_settings": None,
 }
+
+DEFAULT_CW_LOG_DICT = {"enable": True, "retention_days": 14}
 
 DEFAULT_PCLUSTER_DICT = {"cluster": DEFAULT_CLUSTER_DICT}
 
@@ -146,13 +149,14 @@ class DefaultDict(Enum):
     raid = DEFAULT_RAID_DICT
     fsx = DEFAULT_FSX_DICT
     dcv = DEFAULT_DCV_DICT
+    cw_log = DEFAULT_CW_LOG_DICT
     pcluster = DEFAULT_PCLUSTER_DICT
 
 
 # ------------------ Default CFN parameters ------------------ #
 
 # number of CFN parameters created by the PclusterConfig object.
-CFN_CONFIG_NUM_OF_PARAMS = 57
+CFN_CONFIG_NUM_OF_PARAMS = 58
 
 # CFN parameters created by the pcluster CLI
 CFN_CLI_RESERVED_PARAMS = ["ResourcesS3Bucket"]
@@ -190,6 +194,7 @@ DEFAULT_RAID_CFN_PARAMS = {"RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NO
 DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
 DEFAULT_DCV_CFN_PARAMS = {"DCVOptions": "NONE,NONE,NONE"}
+DEFAULT_CW_LOG_CFN_PARAMS = {"CWLogOptions": "true,14"}
 
 DEFAULT_CLUSTER_CFN_PARAMS = {
     "KeyName": "NONE",
@@ -210,7 +215,7 @@ DEFAULT_CLUSTER_CFN_PARAMS = {
     "SpotPrice": "0.0",
     "ProxyServer": "NONE",
     "EC2IAMRoleName": "NONE",
-    "EC2IAMPolicies": "NONE",
+    "EC2IAMPolicies": "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
     "S3ReadResource": "NONE",
     "S3ReadWriteResource": "NONE",
     "EFA": "NONE",
@@ -258,6 +263,8 @@ DEFAULT_CLUSTER_CFN_PARAMS = {
     "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # dcv
     "DCVOptions": "NONE,NONE,NONE",
+    # cw_log_settings
+    "CWLogOptions": "true,14",
 }
 
 
@@ -271,4 +278,5 @@ class DefaultCfnParams(Enum):
     raid = DEFAULT_RAID_CFN_PARAMS
     fsx = DEFAULT_FSX_CFN_PARAMS
     dcv = DEFAULT_DCV_CFN_PARAMS
+    cw_log = DEFAULT_CW_LOG_CFN_PARAMS
     cluster = DEFAULT_CLUSTER_CFN_PARAMS

--- a/cli/tests/pcluster/config/test_section_cluster/test_cluster_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_cluster/test_cluster_from_file_to_cfn/pcluster.config.ini
@@ -93,6 +93,25 @@ spot_bid_percentage = 25
 vpc_settings = default
 additional_iam_policies = policy1,policy2
 
+
+# Test: awsbatch scheduler with cloudwatch logging disabled
+[cluster batch-no-cw-logging]
+scheduler = awsbatch
+cluster_type = spot
+initial_queue_size = 1
+max_queue_size = 2
+maintain_initial_size = true
+min_vcpus = 2
+desired_vcpus = 3
+max_vcpus = 4
+spot_price = 5.5
+spot_bid_percentage = 25
+vpc_settings = default
+cw_log_settings = batch-no-cw-logging
+
+[cw_log batch-no-cw-logging]
+enable = false
+
 # Test: mixed awsbatch and traditional scheduler params with slurm scheduler
 [cluster wrong_mix_traditional]
 scheduler = slurm
@@ -228,3 +247,11 @@ custom_chef_cookbook = https://test
 custom_awsbatch_template_url = https://test
 disable_hyperthreading = false
 enable_intel_hpc_platform = false
+
+# test: cw_log settings
+[cluster cw_log]
+cw_log_settings = cw_log
+
+[cw_log cw_log]
+enable = true
+retention_days = 1

--- a/cli/tests/pcluster/config/test_section_cw_log.py
+++ b/cli/tests/pcluster/config/test_section_cw_log.py
@@ -1,0 +1,129 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+import tests.pcluster.config.utils as utils
+from pcluster.config.mappings import CW_LOG
+from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
+
+
+@pytest.mark.parametrize(
+    "config_parser_dict, expected_dict_params, expected_message",
+    [
+        # default
+        ({"cw_log default": {}}, {}, None),
+        # right value
+        ({"cw_log default": {"enable": "True"}}, {}, None),
+        ({"cw_log default": {"enable": "False"}}, {"enable": False}, None),
+        ({"cw_log default": {"retention_days": "1"}}, {"retention_days": 1}, None),
+        ({"cw_log default": {"retention_days": "14"}}, {"retention_days": 14}, None),
+        ({"cw_log default": {"retention_days": "3653"}}, {"retention_days": 3653}, None),
+        # invalid value
+        ({"cw_log default": {"enable": "not_a_bool"}}, None, "must be a Boolean"),
+        ({"cw_log default": {"retention_days": "3652"}}, None, "has an invalid value"),
+        ({"cw_log default": {"retention_days": "not_an_int"}}, None, "must be an Integer"),
+        # invalid key
+        ({"cw_log default": {"invalid_key": "fake_value"}}, None, "'invalid_key' is not allowed in the .* section"),
+        (
+            {"cw_log default": {"invalid_key": "fake_value", "invalid_key2": "fake_value"}},
+            None,
+            "'invalid_key.*,invalid_key.*' are not allowed in the .* section",
+        ),
+    ],
+)
+def test_cw_log_section_from_file(mocker, config_parser_dict, expected_dict_params, expected_message):
+    """Verify that cw_log behaves as expected when parsed in a config file."""
+    utils.assert_section_from_file(mocker, CW_LOG, config_parser_dict, expected_dict_params, expected_message)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_config_parser_dict, expected_message",
+    [
+        # default values are not written back to config files
+        ({}, {"cw_log default": {}}, "No section.*"),
+        ({"enable": True, "retention_days": 14}, {"cw_log default": {"enable": True}}, "No section: 'cw_log default'"),
+        ({"enable": True, "retention_days": 1}, {"cw_log default": {"enable": True}}, "No option 'enable'"),
+        (
+            {"enable": False, "retention_days": 14},
+            {"cw_log default": {"retention_days": 14}},
+            "No option 'retention_days'",
+        ),
+        # Non-default values are written back to config files
+        ({"enable": False, "retention_days": 14}, {"cw_log default": {"enable": "false"}}, None),
+        ({"enable": True, "retention_days": 1}, {"cw_log default": {"retention_days": "1"}}, None),
+    ],
+)
+def test_cw_log_settings_section_to_file(mocker, section_dict, expected_config_parser_dict, expected_message):
+    """Verify that the cw_log_settings section is as expected when writing back to a file."""
+    utils.assert_section_to_file(mocker, CW_LOG, section_dict, expected_config_parser_dict, expected_message)
+
+
+@pytest.mark.parametrize(
+    "param_key, param_value, expected_value, expected_message",
+    [
+        # Enable parameter
+        ("enable", None, True, None),
+        ("enable", "true", True, None),
+        ("enable", "false", False, None),
+        ("enable", "not_a_bool", None, "'enable' must be a Boolean"),
+        ("enable", "", True, None),  # Empty string gets default value
+        # retention_days parameter
+        ("retention_days", "1", 1, None),
+        ("retention_days", "14", 14, None),
+        ("retention_days", "3653", 3653, None),
+        ("retention_days", "2", None, "'retention_days' has an invalid value"),
+        ("retention_days", "", 14, None),  # Empty string gets default value
+    ],
+)
+def test_cw_log_settings_param_from_file(mocker, param_key, param_value, expected_value, expected_message):
+    """Verify that the cw_log_settings config file section results in the correct CFN parameters."""
+    utils.assert_param_from_file(mocker, CW_LOG, param_key, param_value, expected_value, expected_message)
+
+
+@pytest.mark.parametrize(
+    "cfn_params_dict, expected_section_dict",
+    [
+        # Defaults in various forms
+        (DefaultCfnParams["cw_log"].value, DefaultDict["cw_log"].value),
+        ({}, DefaultDict["cw_log"].value),
+        ({"CWLogOptions": "   true  ,   14     "}, DefaultDict["cw_log"].value),
+        ({"CWLogOptions": "true,14"}, DefaultDict["cw_log"].value),
+        # Non-default values
+        ({"CWLogOptions": "false,14"}, {"enable": False, "retention_days": 14}),
+        ({"CWLogOptions": "true,3"}, {"enable": True, "retention_days": 3}),
+    ],
+)
+def test_cw_log_settings_section_from_cfn(mocker, cfn_params_dict, expected_section_dict):
+    """Verify expected cw_log_settings config file section results from given CFN params."""
+    utils.assert_section_from_cfn(mocker, CW_LOG, cfn_params_dict, expected_section_dict)
+
+
+@pytest.mark.parametrize(
+    "settings_label, expected_cfn_params",
+    [
+        ("defaults", DefaultCfnParams["cluster"].value),
+        (
+            "disabled",
+            utils.merge_dicts(
+                DefaultCfnParams["cluster"].value, {"EC2IAMPolicies": "NONE", "CWLogOptions": "false,14"}
+            ),
+        ),
+        ("one_day_retention", utils.merge_dicts(DefaultCfnParams["cluster"].value, {"CWLogOptions": "true,1"})),
+        ("bad_retention_val", SystemExit()),
+        ("bad_enable_val", SystemExit()),
+        ("empty_enable_val", SystemExit()),
+        ("empty_retention_days", SystemExit()),
+        ("nonexistent", SystemExit()),
+    ],
+)
+def test_cw_log_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
+    """Verify various cw_log sections results in expected CFN parameters."""
+    utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)

--- a/cli/tests/pcluster/config/test_section_cw_log/test_cw_log_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_cw_log/test_cw_log_from_file_to_cfn/pcluster.config.ini
@@ -1,0 +1,32 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = true
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+cw_log_settings = {{ settings_label }}
+
+[cw_log defaults]
+enable = true
+retention_days = 14
+
+[cw_log disabled]
+enable = false
+
+[cw_log one_day_retention]
+retention_days = 1
+
+[cw_log bad_retention_val]
+retention_days = 2
+
+[cw_log bad_enable_val]
+enable = notabool
+
+[cw_log empty_enable_val]
+enable =
+
+[cw_log empty_retention_days]
+retention_days = 

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -74,13 +74,18 @@ def test_defaults_consistency():
     total_number_of_params = CFN_CONFIG_NUM_OF_PARAMS + len(CFN_CLI_RESERVED_PARAMS)
     assert_that(total_number_of_params).is_equal_to(template_num_of_params)
 
+    # The EC2IAMPoicies parameter is expected to differ by default from the default value in the
+    # CFN template. This is because CloudWatch logging is enabled by default, and the appropriate
+    # policy is added to this parameter in a transparent fashion.
+    ignored_params = CFN_CLI_RESERVED_PARAMS + ["EC2IAMPolicies"]
+
     cfn_params = [section_cfn_params.value for section_cfn_params in DefaultCfnParams]
     default_cfn_values = utils.merge_dicts(*cfn_params)
 
     # verify default parameter values used for tests with default values in CFN template
     pcluster_cfn_json = _get_pcluster_cfn_json()
     for param_key, param in pcluster_cfn_json["Parameters"].items():
-        if param_key not in CFN_CLI_RESERVED_PARAMS:
+        if param_key not in ignored_params:
             default_value = param.get("Default", None)
             if default_value:
                 assert_that(default_value, description=param_key).is_equal_to(default_cfn_values.get(param_key, None))

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -342,6 +342,11 @@
         "true",
         "false"
       ]
+    },
+    "CWLogOptions": {
+      "Description": "Comma separated list of CloudWatch logging, 2 parameters in total, [enabled, retention_days]",
+      "Type": "String",
+      "Default": "true,14"
     }
   },
   "Conditions": {
@@ -1200,6 +1205,59 @@
       },
       "Condition": "CreateEFSSubstack"
     },
+    "CloudWatchLogsSubstack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "Parameters": {
+          "CWLogOptions": {
+            "Ref": "CWLogOptions"
+          },
+          "CWLogGroupName": {
+            "Fn::Sub": [
+              "/aws/parallelcluster/${cluster_name}",
+              {
+                "cluster_name": {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Fn::Split": [
+                        "parallelcluster-",
+                        {
+                          "Ref": "AWS::StackName"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "TemplateURL": {
+          "Fn::Sub": [
+            "https://${s3_domain}/${AWS::Region}-aws-parallelcluster/templates/cw-logs-substack-${version}.cfn.json",
+            {
+              "s3_domain": {
+                "Fn::If": [
+                  "GovCloudRegion",
+                  {
+                    "Fn::Sub": "s3-${AWS::Region}.amazonaws.com"
+                  },
+                  "s3.amazonaws.com"
+                ]
+              },
+              "version": {
+                "Fn::FindInMap": [
+                  "PackagesVersions",
+                  "default",
+                  "parallelcluster"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
     "SQS": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
@@ -1648,6 +1706,9 @@
     },
     "MasterServer": {
       "Type": "AWS::EC2::Instance",
+      "DependsOn": [
+        "CloudWatchLogsSubstack"
+      ],
       "Properties": {
         "LaunchTemplate": {
           "LaunchTemplateId": {
@@ -2361,6 +2422,12 @@
                     },
                     "enable_intel_hpc_platform": {
                       "Ref": "IntelHPCPlatform"
+                    },
+                    "cfn_cluster_cw_logging_enabled": {
+                      "Fn::GetAtt": [
+                        "CloudWatchLogsSubstack",
+                        "Outputs.Enabled"
+                      ]
                     }
                   },
                   "run_list": {
@@ -2457,6 +2524,9 @@
     },
     "ComputeFleet": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "DependsOn": [
+        "CloudWatchLogsSubstack"
+      ],
       "Properties": {
         "MaxSize": {
           "Ref": "MaxSize"
@@ -3268,6 +3338,19 @@
                     },
                     "enable_intel_hpc_platform": {
                       "Ref": "IntelHPCPlatform"
+                    },
+                    "cfn_cluster_cw_logging_enabled": {
+                      "Fn::Select": [
+                        "0",
+                        {
+                          "Fn::Split": [
+                            ",",
+                            {
+                              "Ref": "CWLogOptions"
+                            }
+                          ]
+                        }
+                      ]
                     }
                   },
                   "run_list": {

--- a/cloudformation/cw-logs-substack.cfn.json
+++ b/cloudformation/cw-logs-substack.cfn.json
@@ -1,0 +1,74 @@
+{
+  "Conditions": {
+    "CreateCloudWatchLogGroup": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "0",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "CWLogOptions"
+                }
+              ]
+            }
+          ]
+        },
+        "true"
+      ]
+    }
+  },
+  "Parameters": {
+    "CWLogOptions": {
+      "Description": "Comma separated list of CloudWatch logging, 2 parameters in total, [enabled, retention_days]",
+      "Type": "String"
+    },
+    "CWLogGroupName": {
+      "Description": "Name of the CloudWatch Log Group to be created",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "CloudWatchLogGroup": {
+      "Condition": "CreateCloudWatchLogGroup",
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Ref": "CWLogGroupName"
+        },
+        "RetentionInDays": {
+          "Fn::Select": [
+            "1",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "CWLogOptions"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "Enabled": {
+      "Description": "'true' if CloudWatch logging is enabled for this cluster, 'false' otherwise",
+      "Value": {
+        "Fn::Select": [
+          "0",
+          {
+            "Fn::Split": [
+              ",",
+              {
+                "Ref": "CWLogOptions"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/integration-tests/tests/cloudwatch_logging/__init__.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -1,0 +1,469 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import json
+import logging
+import random
+import re
+import string
+from os import environ
+from pathlib import Path
+
+import boto3
+import pytest
+
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+from tests.common.schedulers_common import get_scheduler_commands
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CloudWatchLoggingClusterState:
+    """
+    Encapsulate the state of a running cluster as it pertains to the CloudWatch logging feature.
+
+    The state is stored in the self._cluster_log_state dict. Here is an example of what that
+    structure might look like for a cluster with one compute node, each containing one log:
+    {
+        "MasterServer": {
+            "node_role": "MasterServer",
+            "hostname": "ip-10-0-127-157.us-west-1.compute.internal",
+            "instance_id": "i-01be4c67943df785d",
+            "logs": {
+                "/var/log/cfn-init-cmd.log": {
+                    "file_path": "/var/log/cfn-init-cmd.log",
+                    "log_stream_name": "cfn-init-cmd",
+                    "exists": true,
+                    "is_empty": false,
+                    "tail": "2019-11-01 21:58:07,407 P1974 [INFO] Completed successfully."
+                }
+            },
+            "agent_status": "running"
+        },
+        "ComputeFleet": {
+            "ip-10-0-155-82.us-west-1.compute.internal": {
+                "node_role": "ComputeFleet",
+                "hostname": "ip-10-0-155-82.us-west-1.compute.internal",
+                "instance_id": "i-0d80db39340ce94d8",
+                "logs": {
+                    "/var/spool/torque/client_logs/*": {
+                        "file_path": "/var/spool/torque/client_logs/*",
+                        "log_stream_name": "torque-client",
+                        "exists": true,
+                        "is_empty": false,
+                        "tail": "2019-11-01 22:00:14.7647 TORQUE authd daemon started"
+                    }
+                },
+                "agent_status": "running"
+            }
+        }
+    }
+    """
+
+    def __init__(self, scheduler, os, cluster, data_retriever):
+        """Get the state of the cluster as it pertains to the CloudWatch logging feature."""
+        self.scheduler = scheduler
+        self.platform = self._base_os_to_platform(os)
+        self.cluster = cluster
+        self.remote_command_executor = RemoteCommandExecutor(self.cluster)
+        self.scheduler_commands = get_scheduler_commands(self.scheduler, self.remote_command_executor)
+        self.data_retriever = data_retriever
+        self._relevant_logs = {"MasterServer": [], "ComputeFleet": []}
+        self._cluster_log_state = {"MasterServer": {}, "ComputeFleet": {}}
+        self._set_cluster_log_state()
+
+    def get_logs_state(self):
+        """Get the state of the log files applicable to each of the cluster's EC2 instances."""
+        desired_keys = ["hostname", "instance_id", "node_role", "agent_status", "logs"]
+        states = [{key: self._cluster_log_state.get("MasterServer").get(key) for key in desired_keys}]
+        states.extend(
+            [
+                {key: host_dict[key] for key in desired_keys}
+                for hostname, host_dict in self._cluster_log_state.get("ComputeFleet").items()
+            ]
+        )
+        assert_that(states).is_length(self.scheduler_commands.compute_nodes_count() + 1)  # computes + master
+        return states
+
+    def _dump_cluster_log_state(self):
+        """Dump the JSON-ified string of self._cluster_log_state for debugging purposes."""
+        return json.dumps(self._cluster_log_state, indent=4)
+
+    @staticmethod
+    def _base_os_to_platform(base_os):
+        """Turn the name of a base OS into the platform."""
+        # Special case: alinux is how the config file refers to amazon linux, but in the chef cookbook
+        # (and the cloudwatch log config produced by it) the platform is "amazon".
+        translations = {"alinux": "amazon"}
+        no_digits = base_os.rstrip(string.digits)
+        return translations.get(no_digits, no_digits)
+
+    def _set_master_instance(self, instance):
+        """Set the master instance field in self.cluster_log_state."""
+        self._cluster_log_state.get("MasterServer").update(
+            {
+                "node_role": "MasterServer",
+                "hostname": instance.get("PrivateDnsName"),
+                "instance_id": instance.get("InstanceId"),
+            }
+        )
+
+    def _add_compute_instance(self, instance):
+        """Update the cluster's log state by adding a compute node."""
+        self._cluster_log_state["ComputeFleet"][instance.get("PrivateDnsName")] = {
+            "node_role": "ComputeFleet",
+            "hostname": instance.get("PrivateDnsName"),
+            "instance_id": instance.get("InstanceId"),
+        }
+
+    def _get_initial_cluster_log_state(self):
+        """Get EC2 instances belonging to this cluster. Figure out their roles in the cluster."""
+        for instance in self.data_retriever.get_ec2_instances():
+            tags = {tag.get("Key"): tag.get("Value") for tag in instance.get("Tags", [])}
+            if tags.get("ClusterName", "") != self.cluster.name:
+                continue
+            elif tags.get("Name", "") == "Master":
+                self._set_master_instance(instance)
+            else:
+                self._add_compute_instance(instance)
+        LOGGER.debug("After getting initial cluster state:\n{}".format(self._dump_cluster_log_state()))
+
+    def _read_log_configs_from_master(self):
+        """Read the log configs file at /usr/local/etc/cloudwatch_log_files.json."""
+        read_cmd = "cat /usr/local/etc/cloudwatch_log_files.json"
+        config = json.loads(self._run_command_on_master(read_cmd))
+        return config.get("log_configs")
+
+    @staticmethod
+    def _clean_log_config(log):
+        """Remove unnecessary fields from the given log dict."""
+        desired_keys = ["file_path", "log_stream_name"]
+        return {key: log[key] for key in desired_keys}
+
+    def _get_relevant_logs(self):
+        """Get subset of all log configs that apply to this cluster's scheduler/os combo."""
+        # Figure out which logs are relevant to the master and computes for this cluster
+        logs = self._read_log_configs_from_master()
+        for log in logs:
+            if self.scheduler not in log.get("schedulers") or self.platform not in log.get("platforms"):
+                continue
+            for node_role in log.get("node_roles"):
+                self._relevant_logs[node_role].append(self._clean_log_config(log))
+        # Give each nodes representative dict in self._cluster_log_state a copy
+        self._cluster_log_state["MasterServer"]["logs"] = {
+            log.get("file_path"): log for log in self._relevant_logs.get("MasterServer")
+        }
+        for _hostname, compute_instance_dict in self._cluster_log_state.get("ComputeFleet").items():
+            compute_instance_dict["logs"] = {
+                log.get("file_path"): log.copy() for log in self._relevant_logs.get("ComputeFleet")
+            }
+        LOGGER.debug("After populating relevant logs:\n{}".format(self._dump_cluster_log_state()))
+
+    def _run_command_on_master(self, cmd):
+        """Run cmd on cluster's MasterServer."""
+        return self.remote_command_executor.run_remote_command(cmd).stdout.strip()
+
+    def _run_command_on_computes(self, cmd, assert_success=True):
+        """Run cmd on all computes in the cluster."""
+        # Create directory in /shared to direct outputs to
+        out_dir = Path(self._run_command_on_master("mktemp -d -p /shared"))
+        redirect = " > {out_dir}/$(hostname -f) ".format(out_dir=out_dir)
+        remote_cmd = cmd.format(redirect=redirect)
+
+        # Run the command, wait for it to complete
+        submit_out = self.scheduler_commands.submit_command(
+            remote_cmd, nodes=self.scheduler_commands.compute_nodes_count()
+        )
+        job_id = self.scheduler_commands.assert_job_submitted(submit_out.stdout)
+        self.scheduler_commands.wait_job_completed(job_id)
+        if assert_success:
+            self.scheduler_commands.assert_job_succeeded(job_id)
+
+        # Read the output and map it to the hostname
+        outputs = {}
+        result_files = self._run_command_on_master("ls {}".format(out_dir))
+        for hostname in result_files.split():
+            outputs[hostname] = self._run_command_on_master("sudo cat {}".format(out_dir / hostname))
+        self._run_command_on_master("rm -rf {}".format(out_dir))
+        return outputs
+
+    def _populate_master_log_existence(self):
+        """Figure out which of the relevant logs for the MasterServer don't exist."""
+        for log_path, log_dict in self._cluster_log_state.get("MasterServer").get("logs").items():
+            cmd = "[[ -n `ls {path}` ]] && echo exists || echo does not exist".format(path=log_path)
+            output = self._run_command_on_master(cmd)
+            log_dict["exists"] = output == "exists"
+
+    def _populate_compute_log_existence(self):
+        """Figure out which of the relevant logs for the ComputeFleet nodes don't exist."""
+        for log_dict in self._relevant_logs.get("ComputeFleet"):
+            cmd = "[[ -n `ls {path}` ]] && echo {{redirect}} exists || " "echo {{redirect}} does not exist".format(
+                path=log_dict.get("file_path")
+            )
+            hostname_to_output = self._run_command_on_computes(cmd)
+            for hostname, output in hostname_to_output.items():
+                node_log_dict = (
+                    self._cluster_log_state.get("ComputeFleet").get(hostname).get("logs").get(log_dict.get("file_path"))
+                )
+                node_log_dict["exists"] = output == "exists"
+
+    def _populate_log_existence(self):
+        """Figure out which of the relevant logs for each node type don't exist."""
+        self._populate_master_log_existence()
+        self._populate_compute_log_existence()
+        LOGGER.debug("After populating log existence:\n{}".format(self._dump_cluster_log_state()))
+
+    def _populate_master_log_emptiness_and_tail(self):
+        """Figure out which of the relevant logs for the MasterServer are empty."""
+        for log_path, log_dict in self._cluster_log_state.get("MasterServer").get("logs").items():
+            if not log_dict.get("exists"):
+                continue
+            output = self._run_command_on_master("sudo tail -n 1 {path}".format(path=log_path))
+            log_dict["is_empty"] = output == ""
+            log_dict["tail"] = output
+
+    def _populate_compute_log_emptiness_and_tail(self):
+        """Figure out which of the relevant logs for the ComputeFleet nodes are empty."""
+        for log_dict in self._relevant_logs.get("ComputeFleet"):
+            # If this file doesn't exist on any of the computes, don't assert success
+            assert_success = True
+            for _, compute_dict in self._cluster_log_state.get("ComputeFleet").items():
+                if not compute_dict.get("logs").get(log_dict.get("file_path")).get("exists"):
+                    assert_success = False
+                    break
+            cmd = "sudo tail {{redirect}} -n 1 {path}".format(path=log_dict.get("file_path"))
+            hostname_to_output = self._run_command_on_computes(cmd, assert_success=assert_success)
+            for hostname, output in hostname_to_output.items():
+                host_log_dict = (
+                    self._cluster_log_state.get("ComputeFleet").get(hostname).get("logs").get(log_dict.get("file_path"))
+                )
+                host_log_dict["is_empty"] = output == ""
+                host_log_dict["tail"] = output
+
+    def _populate_log_emptiness_and_tail(self):
+        """Figure out which of the relevant logs for each node type are empty."""
+        self._populate_master_log_emptiness_and_tail()
+        self._populate_compute_log_emptiness_and_tail()
+        LOGGER.debug("After populating log emptiness and tails:\n{}".format(self._dump_cluster_log_state()))
+
+    def _populate_master_agent_status(self):
+        """Get the cloudwatch agent's status for the MasterServer."""
+        status_cmd = "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status"
+        status = json.loads(self._run_command_on_master(status_cmd))
+        self._cluster_log_state["MasterServer"]["agent_status"] = status.get("status")
+
+    def _populate_compute_agent_status(self):
+        """Get the cloudwatch agent's status for all the compute nodes in the cluster."""
+        status_cmd = "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl {redirect} -a status"
+        compute_statuses = self._run_command_on_computes(status_cmd)
+        hostname_to_status_dict = {hostname: json.loads(status) for hostname, status in compute_statuses.items()}
+        for hostname, status_dict in hostname_to_status_dict.items():
+            self._cluster_log_state["ComputeFleet"][hostname]["agent_status"] = status_dict.get("status")
+
+    def _populate_agent_status(self):
+        """Get the cloudwatch agent's status for all the nodes in the cluster."""
+        self._populate_master_agent_status()
+        self._populate_compute_agent_status()
+        LOGGER.debug("After populating agent statuses:\n{}".format(self._dump_cluster_log_state()))
+
+    def _set_cluster_log_state(self):
+        """
+        Get the state of the cluster as it pertains to the CloudWatch logging feature.
+
+        In particular:
+        * Identify which EC2 instances belong to this cluster
+        * Identify which logs are relevant to the MasterServer and ComputeFleet nodes
+        * Identify whether each of a node's relevant logs contain data or not. If they do contain
+          data, save the last line of the file.
+        * Get the CloudWatch agent's status for each node
+        """
+        self._get_initial_cluster_log_state()
+        self._get_relevant_logs()
+        self._populate_log_existence()
+        self._populate_log_emptiness_and_tail()
+        self._populate_agent_status()
+
+
+class Boto3DataRetriever:
+    """Class used to get data from CloudWatch logs."""
+
+    def __init__(self, region):
+        """Save references to the variables the class will need to get log data."""
+        self.region = region
+
+    def get_log_groups(self):
+        """Get list of log groups."""
+        logs_client = boto3.client("logs", region_name=self.region)
+        log_groups = logs_client.describe_log_groups().get("logGroups")
+        LOGGER.debug("Log groups: {}\n".format(json.dumps(log_groups, indent=4)))
+        return log_groups
+
+    def get_log_streams(self, log_group_name):
+        """Get list of log streams."""
+        logs_client = boto3.client("logs", region_name=self.region)
+        streams = logs_client.describe_log_streams(logGroupName=log_group_name).get("logStreams")
+        LOGGER.debug(
+            "Log streams for {group}:\n{streams}".format(group=log_group_name, streams=json.dumps(streams, indent=4))
+        )
+        return streams
+
+    def get_log_events(self, log_group_name, log_stream_name):
+        """Get log events for the given log_stream_name."""
+        logs_client = boto3.client("logs", region_name=self.region)
+        events = logs_client.get_log_events(logGroupName=log_group_name, logStreamName=log_stream_name).get("events")
+        LOGGER.debug(
+            "Log events for {group}/{stream}:\n{events}".format(
+                group=log_group_name, stream=log_stream_name, events=json.dumps(events, indent=4)
+            )
+        )
+        return events
+
+    def get_ec2_instances(self):
+        """Iterate through ec2's describe_instances."""
+        ec2_client = boto3.client("ec2", region_name=self.region)
+        paginator = ec2_client.get_paginator("describe_instances")
+        for page in paginator.paginate():
+            for reservation in page.get("Reservations"):
+                for instance in reservation.get("Instances"):
+                    yield instance
+
+
+class CloudWatchLoggingTestRunner:
+    """Tests and utilities for verifying that CloudWatch logging integration works as expected."""
+
+    def __init__(self, data_retriever, log_group_name, enabled, retention_days):
+        """Initialize class for CloudWatch logging testing."""
+        self.data_retriever = data_retriever
+        self.log_group_name = log_group_name
+        self.enabled = enabled
+        self.retention_days = retention_days
+        self.failures = []
+
+    @staticmethod
+    def _fqdn_to_local_hostname(fqdn):
+        """Turn a fullly qualified domain name into a local hostname of the form ip-X-X-X-X."""
+        local_hostname = fqdn.split(".")[0]
+        assert_that(re.match(r"ip-\d{1,3}-\d{1,3}-\d{1,3}-\d{1,3}$", local_hostname)).is_not_none()
+        return local_hostname
+
+    @staticmethod
+    def _get_expected_log_stream_name(hostname, instance_id, log_pseudonym):
+        """Return expected log stream name for log with given pseudonym on specified host."""
+        return ".".join([CloudWatchLoggingTestRunner._fqdn_to_local_hostname(hostname), instance_id, log_pseudonym])
+
+    def _get_expected_log_stream_index(self, logs_state):
+        """Get map from expected log stream names to dict representing logs from which their events come."""
+        expected_stream_index = {}
+        for instance in logs_state:
+            for _log_path, log_dict in instance.get("logs").items():
+                if log_dict.get("is_empty"):
+                    continue  # Log streams aren't created until events are logged to the file
+                expected_stream_name = self._get_expected_log_stream_name(
+                    instance.get("hostname"), instance.get("instance_id"), log_dict.get("log_stream_name")
+                )
+                expected_stream_index[expected_stream_name] = log_dict
+        LOGGER.info("Expected log streams:\n{}".format("\n".join(expected_stream_index.keys())))
+        return expected_stream_index
+
+    def verify_log_streams_exist(self, logs_state, expected_stream_index, observed_streams):
+        """Verify that log streams representing the given logs exist."""
+        observed_stream_names = [stream.get("logStreamName") for stream in observed_streams]
+        assert_that(observed_stream_names).contains_only(*expected_stream_index)
+
+    def verify_log_streams_data(self, logs_state, expected_stream_index, observed_streams):
+        """Verify each observed log stream has >= 1 event and that its timestamp format is working."""
+        for stream in observed_streams:
+            events = self.data_retriever.get_log_events(self.log_group_name, stream.get("logStreamName"))
+            assert_that(events).is_not_empty()
+            expected_tail = expected_stream_index.get(stream.get("logStreamName")).get("tail")
+            event_generator = (event for event in events if event.get("message") == expected_tail)
+            assert_that(next(event_generator, None)).is_not_none()
+
+    def verify_log_group_created(self, log_groups):
+        """Verify whether or not the cluster's log group was created depending on whether it was enabled."""
+        assert_that_log_group_names = assert_that(log_groups).extracting("logGroupName")
+        if self.enabled:
+            assert_that_log_group_names.contains(self.log_group_name)
+        else:
+            assert_that_log_group_names.does_not_contain(self.log_group_name)
+
+    def verify_log_group_retention_days(self, log_groups):
+        """Verify whether or not the cluster's log group was created depending on whether it was enabled."""
+        if not self.enabled:
+            return  # Log group should not be created if not enabled.
+        log_group = next((group for group in log_groups if group.get("logGroupName") == self.log_group_name), None)
+        assert_that(log_group).is_not_none().is_equal_to(
+            {"retentionInDays": self.retention_days}, include="retentionInDays"
+        )
+
+    def verify_agent_status(self, logs_state):
+        """Verify CloudWatch agent is running on the MasterServer (or not if not enabled)."""
+        expected_status = "running" if self.enabled else "stopped"
+        assert_that(logs_state).extracting("agent_status").contains_only(expected_status)
+
+    @staticmethod
+    def verify_logs_exist(logs_state):
+        """Verify that the log files expected to exist on the nodes of this cluster do."""
+        for host_dict in logs_state:
+            for _log_path, log_dict in host_dict.get("logs").items():
+                assert_that(log_dict).is_equal_to({"exists": True}, include="exists")
+
+    def run_tests(self, logs_state):
+        """Run all CloudWatch logging integration tests."""
+        log_groups = self.data_retriever.get_log_groups()
+        self.verify_log_group_created(log_groups)
+        self.verify_log_group_retention_days(log_groups)
+
+        LOGGER.info("state of logs for cluster:\n{}".format(json.dumps(logs_state, indent=4)))
+        self.verify_agent_status(logs_state)
+        self.verify_logs_exist(logs_state)
+
+        if self.enabled:  # Log streams are only relevant when the feature is enabled
+            observed_streams = self.data_retriever.get_log_streams(self.log_group_name)
+            expected_stream_index = self._get_expected_log_stream_index(logs_state)
+            self.verify_log_streams_exist(logs_state, expected_stream_index, observed_streams)
+            self.verify_log_streams_data(logs_state, expected_stream_index, observed_streams)
+
+        if self.failures:
+            pytest.fail("Failures: {}".format(", ".join(self.failures)), pytrace=False)
+
+
+@pytest.mark.parametrize("cw_logging_enabled", [True, False])
+@pytest.mark.regions(["us-east-1", "cn-north-1", "us-gov-west-1"])
+@pytest.mark.instances(["t2.micro", "c5.xlarge"])
+def test_cloudwatch_logging(
+    region, scheduler, instance, os, pcluster_config_reader, clusters_factory, cw_logging_enabled
+):
+    """
+    Test all CloudWatch logging features.
+
+    All tests are grouped in a single function so that the cluster can be reused for all of them.
+    """
+    # Allow certain params to be set via environment variable in case manually re-testing on an existing cluster
+    retention_days = int(
+        environ.get(
+            "CW_LOGGING_RETENTION_DAYS",
+            random.choice([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]),
+        )
+    )
+    queue_size = int(environ.get("CW_LOGGING_QUEUE_SIZE", 1))
+    param_kwargs = {
+        "enable": str(cw_logging_enabled).lower(),
+        "retention_days": retention_days,
+        "queue_size": queue_size,
+    }
+    cluster_config = pcluster_config_reader(**param_kwargs)
+    cluster = clusters_factory(cluster_config)
+    log_group_name = "/aws/parallelcluster/{}".format(cluster.name)
+    data_retriever = Boto3DataRetriever(region)
+    test_runner = CloudWatchLoggingTestRunner(data_retriever, log_group_name, cw_logging_enabled, retention_days)
+    test_runner.run_tests(CloudWatchLoggingClusterState(scheduler, os, cluster, data_retriever).get_logs_state())

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.ini
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.ini
@@ -1,0 +1,25 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+initial_queue_size = {{ queue_size }}
+maintain_initial_size = true
+cw_log_settings = default
+
+[cw_log default]
+enable = {{ enable }}
+retention_days = {{ retention_days }}
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}

--- a/util/logging/retrieve-cluster-logs.py
+++ b/util/logging/retrieve-cluster-logs.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+#
+# Future enhancements:
+#   * Catch KeyboardInterrupt exceptions while waiting for export tasks to start or finish and clean up accordingly.
+
+import gzip
+import json
+import logging
+import os
+import sys
+import tarfile
+import tempfile
+import time
+from datetime import datetime
+
+import argparse
+import boto3
+
+logging.basicConfig(level=logging.INFO)
+LOGGER = logging.getLogger(__file__)
+
+
+def err_and_exit(message):
+    """Log the given error message and exit nonzero."""
+    LOGGER.error(message)
+    sys.exit(1)
+
+
+def get_default_bucket_prefix(cluster_name):
+    """Get default keypath to store logs under in an s3 bucket for the given cluster."""
+    return "{cluster_name}-logs-{timestamp}".format(cluster_name=cluster_name, timestamp=datetime.now().timestamp())
+
+
+def get_log_group(args):
+    """Get log group for args.cluster."""
+    log_group_name = "/aws/parallelcluster/{}".format(args.cluster)
+    logs = boto3.client("logs", region_name=args.region)
+    paginator = logs.get_paginator("describe_log_groups")
+    for result in paginator.paginate(logGroupNamePrefix=log_group_name):
+        for group in result.get("logGroups"):
+            if group.get("logGroupName") == log_group_name:
+                return group
+    err_and_exit(
+        "Unable to find log group for cluster {cluster}. Expected to find one named {log_group_name}".format(
+            cluster=args.cluster, log_group_name=log_group_name
+        )
+    )
+
+
+def verify_bucket_exists_in_region(args):
+    """Verify that bucket exists."""
+    bucket = boto3.resource("s3", region_name=args.region).Bucket(args.bucket)
+    if bucket.creation_date is None:
+        err_and_exit("s3 bucket {} does not exist.".format(args.bucket))
+    bucket_region = bucket.meta.client.get_bucket_location(Bucket=bucket.name).get("LocationConstraint")
+    expected_region = args.region if args.region != "us-east-1" else None
+    if bucket_region != expected_region:
+        err_and_exit(
+            "CloudWatch requires buckets to use for exporting logs to be in the same region as the log group. "
+            "The given cluster's log group is in {region}, but the given bucket's region is {bucket_region} ".format(
+                region=expected_region, bucket_region=bucket_region
+            )
+        )
+
+
+def verify_times(args):
+    """Verify that the start and end times represent a window containing at least one log event."""
+    if args.from_time >= args.to_time:
+        err_and_exit("Start time must be earlier than end time.")
+    logs_client = boto3.client("logs", region_name=args.region)
+    event_in_window = logs_client.filter_log_events(
+        logGroupName=args.log_group.get("logGroupName"),
+        startTime=int(1000 * args.from_time.timestamp()),
+        endTime=int(1000 * args.to_time.timestamp()),
+        limit=1,
+    ).get("events")
+    if not event_in_window:
+        err_and_exit(
+            "No log events in the log group {log_group} in interval starting at {start} and ending at {end}".format(
+                log_group=args.log_group.get("logGroupName"), start=args.from_time, end=args.to_time
+            )
+        )
+
+
+def parse_args():
+    """Parse command line args."""  # noqa: D202
+
+    def timestamp_from_arg(arg):
+        """Convert arg into a UNIX timestamp."""
+        return datetime.fromtimestamp(int(arg))
+
+    parser = argparse.ArgumentParser(description="Create an archive for a ParallelCluster's CloudWatch logs.")
+    parser.add_argument("--bucket", required=True, help="s3 bucket to export CloudWatch logs data to.")
+    parser.add_argument("--cluster", required=True, help="Name of cluster whose logs to get.")
+    parser.add_argument(
+        "--bucket-prefix", help="Keypath under which exported CloudWatch logs data will be stored in s3 bucket."
+    )
+    parser.add_argument(
+        "--from-time",
+        type=timestamp_from_arg,
+        help="Start time of interval of interest for log events, as number of seconds since the epoch. Deafults to "
+        "cluster's start time.",
+    )
+    parser.add_argument("--region", required=True, help="Region in which the CloudWatch log group exists.")
+    parser.add_argument(
+        "--to-time",
+        type=timestamp_from_arg,
+        help="End time of interval of interest for log events, as number of seconds since the epoch. Defaults to the "
+        "current time.",
+    )
+    args = parser.parse_args()
+
+    # Set defaults that require other args
+    if not args.bucket_prefix:
+        args.bucket_prefix = get_default_bucket_prefix(args.cluster)
+    args.log_group = get_log_group(args)
+    if args.from_time is None:
+        args.from_time = datetime.fromtimestamp(args.log_group.get("creationTime") / 1000)
+    if args.to_time is None:
+        args.to_time = datetime.now()
+
+    # Verify args
+    verify_bucket_exists_in_region(args)
+    verify_times(args)
+
+    return args
+
+
+def start_export_task(logs_client, args):
+    """Start the task that will export the cluster's logs to an s3 bucket, and return the task ID."""
+    LOGGER.info(
+        "Starting export of logs from log group {log_group} to s3 bucket {bucket}".format(
+            log_group=args.log_group.get("logGroupName"), bucket=args.bucket
+        )
+    )
+    try:
+        response = logs_client.create_export_task(
+            logGroupName=args.log_group.get("logGroupName"),
+            fromTime=int(1000 * args.from_time.timestamp()),
+            to=int(1000 * args.to_time.timestamp()),
+            destination=args.bucket,
+            destinationPrefix=args.bucket_prefix,
+        )
+    except Exception as err:
+        if "Please check if CloudWatch Logs has been granted permission to perform this operation." in str(err):
+            err_and_exit(
+                "CloudWatch Logs needs GetBucketAcl and PutObject permisson for the s3 bucket {bucket}. See {url} for "
+                "more details.".format(
+                    bucket=args.bucket,
+                    url="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3ExportTasks.html#S3Permissions",
+                )
+            )
+        else:
+            err_and_exit("Unexpected error when starting export task: {}".format(err))
+    return response.get("taskId")
+
+
+def get_status_for_export_task(logs_client, task_id):
+    """Get the status for the CloudWatch export task with the given task_id."""
+    tasks = logs_client.describe_export_tasks(taskId=task_id).get("exportTasks")
+    if not tasks:
+        err_and_exit("Unable to get status for CloudWatch logs export task with ID={}".format(task_id))
+    elif len(tasks) > 2:
+        err_and_exit(
+            "More than one CloudWatch logs export task with ID={task_id}:\n{tasks}".format(
+                task_id=task_id, tasks=json.dumps(tasks, indent=2)
+            )
+        )
+    return tasks[0].get("status").get("code")
+
+
+def wait_for_task_completion(logs_client, task_id):
+    """Wait for the CloudWatch logs export task given by task_id to finish."""
+    LOGGER.info("Waiting for export task with task ID {} to finish.".format(task_id))
+    status = "PENDING"
+    still_running_statuses = ("PENDING", "PENDING_CANCEL", "RUNNING")
+    while status in still_running_statuses:
+        time.sleep(1)
+        status = get_status_for_export_task(logs_client, task_id)
+    return status
+
+
+def export_logs_to_s3(args):
+    """Export the contents of a cluster's CloudWatch log group to an s3 bucket."""
+    logs_client = boto3.client("logs", region_name=args.region)
+    task_id = start_export_task(logs_client, args)
+    result_status = wait_for_task_completion(logs_client, task_id)
+    if result_status != "COMPLETED":
+        err_and_exit(
+            "CloudWatch logs export task {task_id} failed with status: {result_status}".format(
+                task_id=task_id, result_status=result_status
+            )
+        )
+        sys.exit(1)
+    return task_id
+
+
+def download_all_objects_with_prefix(bucket, prefix, destdir):
+    """Download all object in bucket with given prefix into destdir."""
+    LOGGER.info(
+        "Downloading exported logs from s3 bucket {bucket} (under key prefix {prefix}) to {destdir}".format(
+            bucket=bucket.name, prefix=prefix, destdir=destdir
+        )
+    )
+    for log_archive_object in bucket.objects.filter(Prefix=prefix):
+        decompressed_path = os.path.dirname(os.path.join(destdir, log_archive_object.key))
+        decompressed_path = decompressed_path.replace(
+            r"{unwanted_path_segment}{sep}".format(unwanted_path_segment=prefix, sep=os.path.sep), ""
+        )
+        compressed_path = "{}.gz".format(decompressed_path)
+        LOGGER.debug(
+            "Downloading object with key={key} to {compressed}".format(
+                key=log_archive_object.key, compressed=compressed_path
+            )
+        )
+        os.makedirs(os.path.dirname(compressed_path), exist_ok=True)
+        bucket.download_file(log_archive_object.key, compressed_path)
+
+        # Create a decompressed copy of the downloaded archive and remove the original
+        LOGGER.debug(
+            "Extracting object at {compressed_path} to {decompressed_path}".format(
+                compressed_path=compressed_path, decompressed_path=decompressed_path
+            )
+        )
+        with gzip.open(compressed_path) as gfile, open(decompressed_path, "wb") as outfile:
+            outfile.write(gfile.read())
+        os.remove(compressed_path)
+
+
+def archive_dir(src, dest):
+    """Create a gzipped tarball archive for the directory at src and save it to dest."""
+    LOGGER.info("Creating archive of logs at {src} and saving it {dest}".format(src=src, dest=dest))
+    with tarfile.open(dest, "w:gz") as tar:
+        tar.add(src, arcname=os.path.basename(src))
+
+
+def download_and_archive_logs_from_s3(args, task_id):
+    """Download logs from s3 bucket."""
+    bucket = boto3.resource("s3", region_name=args.region).Bucket(args.bucket)
+    prefix = "{explicit_prefix}/{task_id}".format(explicit_prefix=args.bucket_prefix, task_id=task_id)
+    archive_path = "{}.tar.gz".format(args.bucket_prefix)
+    with tempfile.TemporaryDirectory() as parent_tempdir:
+        tempdir = os.path.join(parent_tempdir, args.bucket_prefix)
+        download_all_objects_with_prefix(bucket, prefix, tempdir)
+        archive_dir(tempdir, archive_path)
+    return archive_path
+
+
+def main():
+    """Run the script."""
+    args = parse_args()
+    task_id = export_logs_to_s3(args)
+    archive_path = download_and_archive_logs_from_s3(args, task_id)
+    LOGGER.info(
+        "Archive of CloudWatch logs from cluster {cluster} saved to {archive_path}".format(
+            cluster=args.cluster, archive_path=archive_path
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Implement CloudWatch logging configuration.
* Manage a cluster's log group via the CloudFormation templates
* Enable configuration of the feature.

## Implement CloudWatch logging integration tests.
These tests verify:
* whether or not the log files that are expected to exist on the master
and compute instances actually do exist
* whether or not a log group was created depending on whether the
feature was enabled
* whether or not the log streams for non-empty logs on all of the
instances were created as expected
* whether or not these same log streams contain data
* whether or not these same log streams contain the last line read from
the logs that they represent

There are known issues with these tests:
* The tests do not verify that the log groups are deleted when the
cluster is deleted
* The tests do not verify that the correctness of the timestamp formats
used to set the event times for log events.

## Add script to get archive of cluster's log group

This is the initial check-in for a script that enables a user to extract
all of the logs in a given cluster's CloudWatch log group and create a
tarball of the extracted data. This allows for ease in attaching logs to
tickets.

Potentially useful enhancements include:
* Allow for optionally deleting data from the s3 bucket that serves as
the intermediary between CloudWatch and the local filesystem.
* Enable a user to specify that the data only be exported to s3 and not
downloaded to the local filesystem.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
