### PR TITLE
Add default for the flag to push cloudwatch metrics with timestamp

### DIFF
--- a/tests/integration-tests/reports_generator.py
+++ b/tests/integration-tests/reports_generator.py
@@ -21,12 +21,13 @@ from junitparser import JUnitXml
 import untangle
 
 
-def generate_cw_report(test_results_dir, namespace, aws_region, timestamp_day_start):
+def generate_cw_report(test_results_dir, namespace, aws_region, timestamp_day_start=False):
     """
     Publish tests results to CloudWatch
     :param test_results_dir: dir containing the tests outputs.
     :param namespace: namespace for the CW metric.
     :param aws_region: region where to push the metric.
+    :param timestamp_day_start: timestamp of the CW metric equal to the start of the current day (midnight).
     """
     test_report_file = os.path.join(test_results_dir, "test_report.xml")
     if not os.path.isfile(test_report_file):


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
