### PR TITLE
Fix invalid spot_price default value

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -498,7 +498,7 @@ CLUSTER = {
             }),
             ("spot_price", {
                 "type": SpotPriceParam,
-                "default": 0.0,
+                "default": 0,
                 "cfn_param_mapping": "SpotPrice",
             }),
             ("spot_bid_percentage", {

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -495,14 +495,21 @@ class SpotPriceParam(FloatParam):
 
         return self
 
+    def get_cfn_value(self):
+        """
+        Convert parameter value into CFN value.
+
+        Insignificant trailing zeros removed to correctly match CloudFormation conditions using "0" as test value
+        """
+        return str("{0:g}".format(self.value) if self.value is not None else self.definition.get("default", "NONE"))
+
     def to_cfn(self):
         """Convert parameter to CFN representation."""
         cfn_params = {}
 
         cluster_config = self.pcluster_config.get_section(self.section_key)
         if cluster_config.get_param_value("scheduler") != "awsbatch":
-            cfn_value = cluster_config.get_param_value("spot_price")
-            cfn_params[self.definition.get("cfn_param_mapping")] = str(cfn_value)
+            cfn_params[self.definition.get("cfn_param_mapping")] = self.get_cfn_value()
 
         return cfn_params
 
@@ -533,8 +540,7 @@ class SpotBidPercentageParam(IntParam):
 
         cluster_config = self.pcluster_config.get_section(self.section_key)
         if cluster_config.get_param_value("scheduler") == "awsbatch":
-            cfn_value = cluster_config.get_param_value("spot_bid_percentage")
-            cfn_params[self.definition.get("cfn_param_mapping")] = str(cfn_value)
+            cfn_params[self.definition.get("cfn_param_mapping")] = self.get_cfn_value()
 
         return cfn_params
 

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -212,7 +212,7 @@ DEFAULT_CLUSTER_CFN_PARAMS = {
     "MaxSize": "10",
     "MinSize": "0",
     "ClusterType": "ondemand",
-    "SpotPrice": "0.0",
+    "SpotPrice": "0",
     "ProxyServer": "NONE",
     "EC2IAMRoleName": "NONE",
     "EC2IAMPolicies": "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",

--- a/cli/tests/pcluster/config/test_param_from_cfn.py
+++ b/cli/tests/pcluster/config/test_param_from_cfn.py
@@ -64,7 +64,8 @@ from tests.pcluster.config.utils import get_mocked_pcluster_config, get_param_de
         (CLUSTER, "spot_price", "10", 10),
         (CLUSTER, "spot_price", "3", 3),
         (CLUSTER, "spot_price", "0.0009", 0.0009),
-        (CLUSTER, "spot_price", "0.0", 0.0),
+        (CLUSTER, "spot_price", "0", 0.0),
+        (CLUSTER, "spot_price", "0.00", 0.0),
         # SpotBidPercentageParam --> IntParam
         (CLUSTER, "spot_bid_percentage", "", 0),
         (CLUSTER, "spot_bid_percentage", "NONE", 0),

--- a/cli/tests/pcluster/config/test_param_to_cfn.py
+++ b/cli/tests/pcluster/config/test_param_to_cfn.py
@@ -43,9 +43,9 @@ from tests.pcluster.config.utils import get_mocked_pcluster_config, get_param_de
             '{"cfncluster": {"cfn_scheduler_slots": "cores"}}',
         ),
         # SpotPriceParam --> FloatParam
-        (CLUSTER, "spot_price", None, "0.0"),
+        (CLUSTER, "spot_price", None, "0"),
         (CLUSTER, "spot_price", 0.0009, "0.0009"),
-        (CLUSTER, "spot_price", 0.0, "0.0"),
+        (CLUSTER, "spot_price", 0.0, "0"),
         (CLUSTER, "spot_price", 10, "10"),
         (CLUSTER, "spot_price", 3, "3"),
         # SharedDirParam

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -676,7 +676,7 @@ def test_cluster_section_from_file(mocker, config_parser_dict, expected_dict_par
         ("spot_price", "NONE", None, "must be a Float"),
         ("spot_price", "wrong_value", None, "must be a Float"),
         ("spot_price", "0.09", 0.09, None),
-        ("spot_price", "0.0", 0.0, None),
+        ("spot_price", "0", 0.0, None),
         ("spot_price", "0.1", 0.1, None),
         ("spot_price", "1", 1, None),
         ("spot_price", "100", 100, None),

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -39,7 +39,7 @@
     "SpotPrice": {
       "Description": "Spot bid price for the ComputeFleet AutoScaling Group when the ClusterType = \"spot\". When awsbatch is the scheduler, this is spot bid percentage.",
       "Type": "Number",
-      "Default": "0.0"
+      "Default": "0"
     },
     "ClusterType": {
       "Description": "Type of cluster to launch. Can either be \"ondemand\" or \"spot\". Choosing \"spot\" will cause the ComputeFleet AutoScaling group to launch EC2 Spot instances. Default value is \"ondemand\".",


### PR DESCRIPTION
This commit makes default value for SpotPriceParam to be "0" replacing
"0.0" which prevented the no-value condition to work properly and caused
the invalid 0.0 value to be passed to CloudFormation

Signed-off-by: ddeidda <ddeidda@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
