### PR TITLE
Fix ubuntu file existence tests

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -215,7 +215,7 @@ class CloudWatchLoggingClusterState:
     def _populate_master_log_existence(self):
         """Figure out which of the relevant logs for the MasterServer don't exist."""
         for log_path, log_dict in self._cluster_log_state.get("MasterServer").get("logs").items():
-            cmd = "[[ -n `ls {path}` ]] && echo exists || echo does not exist".format(path=log_path)
+            cmd = "[ -f {path} ] && echo exists || echo does not exist".format(path=log_path)
             output = self._run_command_on_master(cmd)
             log_dict["exists"] = output == "exists"
 
@@ -224,7 +224,7 @@ class CloudWatchLoggingClusterState:
         if self.compute_nodes_count == 0:
             return
         for log_dict in self._relevant_logs.get("ComputeFleet"):
-            cmd = "[[ -n `ls {path}` ]] && echo {{redirect}} exists || " "echo {{redirect}} does not exist".format(
+            cmd = "[ -f {path} ] && echo {{redirect}} exists || " "echo {{redirect}} does not exist".format(
                 path=log_dict.get("file_path")
             )
             hostname_to_output = self._run_command_on_computes(cmd)


### PR DESCRIPTION
The `[[` conditional doesn't work when used to test whether a file
exists via a traditional scheulder's batch submission CLI on ubuntu1604 and
ubuntu1804. This PR changes these tests to use the `[` operator instead.
It also uses the `-f` test instead of testing output from `ls`.

```
ubuntu@ip-172-31-9-241:~$ sbatch --wrap='[[ -n `ls /var/log/syslog` ]] && echo  > /shared/tmp.SqjNyyJdCl/$(hostname -f)  exists || echo  > /shared/tmp.SqjNyyJdCl/$(hostname -f) does not exist'  -N 1
Submitted batch job 24
ubuntu@ip-172-31-9-241:~$ cat /shared/tmp.SqjNyyJdCl/ip-172-31-7-203.us-west-1.compute.internal
does not exist
ubuntu@ip-172-31-9-241:~$ sbatch --wrap='[ -f /var/log/syslog ] && echo  > /shared/tmp.SqjNyyJdCl/$(hostname -f)  exists || echo  > /shared/tmp.SqjNyyJdCl/$(hostname -f) does not exist'  -N 1
Submitted batch job 25
ubuntu@ip-172-31-9-241:~$ cat /shared/tmp.SqjNyyJdCl/ip-172-31-7-203.us-west-1.compute.internal
exists
```

The reason `[[` doesn't work on ubuntu is because the `sh` command on
these OSes does not result in a bash shell, as it does on the amazon
linux and centos versions we support:

```
ubuntu@ip-172-31-9-241:~$ which sh
/bin/sh
ubuntu@ip-172-31-9-241:~$ ll `!!`
ll `which sh`
lrwxrwxrwx 1 root root 4 Nov 13 04:35 /bin/sh -> dash*
```

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
