### PR TITLE
Increase timeout for DockerBuildWaitHandle to 30 mins and retention for logs

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -4058,7 +4058,7 @@
         "LogGroupName": {
           "Fn::Sub": "/aws/lambda/${CleanupResourcesFunction}"
         },
-        "RetentionInDays": 1
+        "RetentionInDays": 14
       },
       "Condition": "HasResourcesS3Bucket"
     },

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -855,7 +855,7 @@
         "Handle": {
           "Ref": "DockerBuildWaitHandle"
         },
-        "Timeout": "1200"
+        "Timeout": "1800"
       }
     },
     "SendBuildNotificationFunctionExecutionRole": {

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -641,7 +641,7 @@
         "LogGroupName": {
           "Fn::Sub": "/aws/codebuild/${CodeBuildDockerImageBuilderProject}"
         },
-        "RetentionInDays": 1
+        "RetentionInDays": 14
       }
     },
     "CodeBuildPolicy": {
@@ -841,7 +841,7 @@
         "LogGroupName": {
           "Fn::Sub": "/aws/lambda/${ManageDockerImagesFunction}"
         },
-        "RetentionInDays": 1
+        "RetentionInDays": 14
       }
     },
     "DockerBuildWaitHandle": {
@@ -927,7 +927,7 @@
         "LogGroupName": {
           "Fn::Sub": "/aws/lambda/${SendBuildNotificationFunction}"
         },
-        "RetentionInDays": 1
+        "RetentionInDays": 14
       }
     },
     "SendBuildNotificationFunctionInvokePermission": {


### PR DESCRIPTION
I increased the time allowed for a Docker container to be built in order to cope with slow networking in China.

Also Increased the retention for cw logs from 1 day to 14 days. This is to give some additional time to retrieve these logs in case of failures. Long term this should be aligned with the new CloudWatch feature support

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
