### PR TITLE
Make Placement Group configuration optional when using EFA

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 CHANGELOG
 =========
 
+2.5.1
+=====
+
+**ENHANCEMENTS**
+
+**CHANGES**
+
+* Using a Placement Group is not required anymore when enabling EFA
+
+**BUG FIXES**
+
 2.5.0
 =====
 

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -134,7 +134,7 @@ class Param(object):
                     )
                 elif warnings:
                     self.pcluster_config.warn(
-                        "The configuration parameter '{0}' has a wrong value '{1}'\n{2}".format(
+                        "The configuration parameter '{0} = {1}' generated the following warnings:\n{2}".format(
                             self.key, self.value, "\n".join(warnings)
                         )
                     )

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -264,10 +264,7 @@ def efa_validator(param_key, param_value, pcluster_config):
         )
 
     if cluster_section.get_param_value("placement_group") is None:
-        errors.append(
-            "When using 'enable_efa = {0}' it is required to set the 'placement_group' parameter "
-            "to DYNAMIC or to an existing EC2 cluster placement group name".format(param_value)
-        )
+        warnings.append("You may see better performance using a cluster placement group.")
 
     _validate_efa_sg(pcluster_config, errors)
 

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -519,14 +519,19 @@ def test_fsx_imported_file_chunk_size_validator(mocker, section_dict, expected_m
 
 
 @pytest.mark.parametrize(
-    "section_dict, expected_message",
+    "section_dict, expected_error, expected_warning",
     [
-        ({"enable_efa": "NONE"}, "invalid value"),
-        ({"enable_efa": "compute"}, "is required to set the 'compute_instance_type'"),
-        ({"enable_efa": "compute", "compute_instance_type": "t2.large"}, "is required to set the 'placement_group'"),
+        ({"enable_efa": "NONE"}, "invalid value", None),
+        ({"enable_efa": "compute"}, "is required to set the 'compute_instance_type'", None),
+        (
+            {"enable_efa": "compute", "compute_instance_type": "t2.large"},
+            None,
+            "You may see better performance using a cluster placement group",
+        ),
         (
             {"enable_efa": "compute", "compute_instance_type": "t2.large", "base_os": "centos6"},
             "it is required to set the 'base_os'",
+            None,
         ),
         (
             {
@@ -536,6 +541,7 @@ def test_fsx_imported_file_chunk_size_validator(mocker, section_dict, expected_m
                 "scheduler": "awsbatch",
             },
             "it is required to set the 'scheduler'",
+            None,
         ),
         (
             {
@@ -546,14 +552,15 @@ def test_fsx_imported_file_chunk_size_validator(mocker, section_dict, expected_m
                 "placement_group": "DYNAMIC",
             },
             None,
+            None,
         ),
     ],
 )
-def test_efa_validator(mocker, section_dict, expected_message):
+def test_efa_validator(mocker, capsys, section_dict, expected_error, expected_warning):
     mocker.patch("pcluster.config.validators.get_supported_features", return_value={"instances": ["t2.large"]})
 
     config_parser_dict = {"cluster default": section_dict}
-    utils.assert_param_validator(mocker, config_parser_dict, expected_message)
+    utils.assert_param_validator(mocker, config_parser_dict, expected_error, capsys, expected_warning)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -65,18 +65,21 @@ def assert_param_from_file(mocker, section_definition, param_key, param_value, e
         assert_that(param.value, description="{0} assert fail".format(param.key)).is_equal_to(expected_value)
 
 
-def assert_param_validator(mocker, config_parser_dict, expected_message=None):
+def assert_param_validator(mocker, config_parser_dict, expected_error=None, capsys=None, expected_warning=None):
     config_parser = configparser.ConfigParser()
     config_parser.read_dict(config_parser_dict)
 
     mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
     mocker.patch.object(PclusterConfig, "_PclusterConfig__check_account_capacity")
 
-    if expected_message:
-        with pytest.raises(SystemExit, match=expected_message):
+    if expected_error:
+        with pytest.raises(SystemExit, match=expected_error):
             _ = init_pcluster_config_from_configparser(config_parser)
     else:
         _ = init_pcluster_config_from_configparser(config_parser)
+        if expected_warning:
+            assert_that(capsys).is_not_none()
+            assert_that(capsys.readouterr().out).matches(expected_warning)
 
 
 def assert_section_from_cfn(mocker, section_definition, cfn_params_dict, expected_section_dict):


### PR DESCRIPTION
EFA is not enforcing Placement Groups to be required, hence we should follow the same convention. Printing a warning and not failing when EFA is enabled and no placement group is specified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
