### PR TITLE
Implement --keep-logs flag for pcluster delete

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -231,6 +231,12 @@ Examples::
         'calling "pcluster status mycluster".',
     )
     pdelete.add_argument("cluster_name", help="Names the cluster to delete.")
+    pdelete.add_argument(
+        "--keep-logs",
+        action="store_true",
+        help="Keep cluster's CloudWatch log group data after deleting. The log group will persist until it's deleted "
+        "manually, but log events will still expire based on the previously configured retention time.",
+    )
     _addarg_config(pdelete)
     _addarg_region(pdelete)
     _addarg_nowait(pdelete)

--- a/cli/tests/pcluster/delete/test_pcluster_delete.py
+++ b/cli/tests/pcluster/delete/test_pcluster_delete.py
@@ -1,0 +1,102 @@
+"""This module provides unit tests for the functions in the pcluster.delete module."""
+
+from collections import namedtuple
+
+import pytest
+
+import pcluster.commands as commands
+from assertpy import assert_that
+
+FakePdeleteArgs = namedtuple("FakePdeleteArgs", "cluster_name config_file nowait keep_logs region")
+
+
+def get_fake_pdelete_args(cluster_name="cluster_name", config_file=None, nowait=False, keep_logs=False, region=None):
+    """Get a FakePdeleteArgs instance, with None used for any parameters not specified."""
+    return FakePdeleteArgs(
+        cluster_name=cluster_name, config_file=config_file, nowait=nowait, keep_logs=keep_logs, region=region
+    )
+
+
+@pytest.mark.parametrize(
+    "keep_logs,stack_exists,warn_call_count,persist_called,delete_called",
+    [
+        (True, False, 2, False, False),
+        (False, False, 1, False, False),
+        (False, True, 0, False, True),
+        (True, True, 0, True, True),
+    ],
+)
+def test_delete(mocker, keep_logs, stack_exists, warn_call_count, persist_called, delete_called):
+    """Verify that commands.delete behaves as expected."""
+    mocker.patch("pcluster.commands.utils.stack_exists").return_value = stack_exists
+    mocker.patch("pcluster.commands._persist_cloudwatch_log_group")
+    mocker.patch("pcluster.commands._delete_cluster")
+    mocker.patch("pcluster.commands.utils.warn")
+    mocker.patch("pcluster.commands.PclusterConfig")
+    args = get_fake_pdelete_args(keep_logs=keep_logs)
+
+    if not stack_exists:
+        with pytest.raises(SystemExit) as sysexit:
+            commands.delete(args)
+        assert_that(sysexit.value.code).is_equal_to(0)
+    else:
+        commands.delete(args)
+
+    assert_that(commands.utils.warn.call_count).is_equal_to(warn_call_count)
+    if warn_call_count > 0:
+        commands.utils.warn.assert_called_with("Cluster {0} has already been deleted.".format(args.cluster_name))
+
+    assert_that(commands._persist_cloudwatch_log_group.called).is_equal_to(persist_called)
+    if persist_called:
+        commands._persist_cloudwatch_log_group.assert_called_with(
+            args.cluster_name, commands.PclusterConfig(args.cluster_name)
+        )
+
+    assert_that(commands._delete_cluster.called).is_equal_to(delete_called)
+    if delete_called:
+        commands._delete_cluster.assert_called_with(args.cluster_name, args.nowait)
+
+
+@pytest.mark.parametrize(
+    "feature_enabled,substack,substack_template",
+    [
+        (False, None, None),
+        (True, {"StackName": "stack_name"}, {"Resources": {"CloudWatchLogGroup": {"DeletionPolicy": "Retain"}}}),
+        (
+            True,
+            {"StackName": "stack_name"},
+            {"Resources": {"CloudWatchLogGroup": {"DeletionPolicy": "NotRetain"}}, "Parameters": "FakeParameters"},
+        ),
+    ],
+)
+def test_persist_cloudwatch_log_group(mocker, feature_enabled, substack, substack_template):
+    """Verify that commands._persist_cloudwatch_log_group behaves as expected."""
+    cluster_name = "cluster_name"
+    pcluster_config = mocker.Mock()
+    pcluster_config.get_section.return_value.get_param_value.return_value = feature_enabled
+
+    mocker.patch("pcluster.commands.utils.warn")
+    mocker.patch("pcluster.commands.utils.get_cloudwatch_logs_substack").return_value = substack
+    mocker.patch("pcluster.commands.utils.get_stack_template").return_value = substack_template
+    mocker.patch("pcluster.commands.utils.update_stack_template")
+    if substack_template:
+        orig_retain = substack_template.get("Resources").get("CloudWatchLogGroup").get("DeletionPolicy") == "Retain"
+    else:
+        orig_retain = False
+
+    commands._persist_cloudwatch_log_group(cluster_name, pcluster_config)
+
+    if not feature_enabled:
+        commands.utils.warn.assert_called_with("CloudWatch logging is not enabled for cluster {0}".format(cluster_name))
+
+    if substack:
+        commands.utils.get_cloudwatch_logs_substack.assert_called_with(cluster_name)
+
+    if substack_template:
+        commands.utils.get_stack_template.assert_called_with(substack.get("StackName"))
+        if orig_retain:
+            assert_that(commands.utils.update_stack_template.called).is_false()
+        else:
+            commands.utils.update_stack_template.assert_called_with(
+                substack.get("StackName"), substack_template, substack.get("Parameters")
+            )

--- a/cli/tests/pcluster/utils/test_pcluster_utils.py
+++ b/cli/tests/pcluster/utils/test_pcluster_utils.py
@@ -1,0 +1,196 @@
+"""This module provides unit tests for the functions in the pcluster.utils module."""
+
+import json
+
+import pytest
+
+import pcluster.utils as utils
+from assertpy import assert_that
+from tests.common import MockedBoto3Request
+
+FAKE_CLUSTER_NAME = "cluster_name"
+FAKE_STACK_NAME = utils.get_stack_name(FAKE_CLUSTER_NAME)
+STACK_TYPE = "AWS::CloudFormation::Stack"
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    """Specify that boto3_mocker should stub calls to boto3 for the pcluster.utils module."""
+    return "pcluster.utils.boto3"
+
+
+def test_get_stack_name():
+    """Test utils.get_stack_name."""
+    expected_stack_name = "parallelcluster-{0}".format(FAKE_CLUSTER_NAME)
+    assert_that(utils.get_stack_name(FAKE_CLUSTER_NAME)).is_equal_to(expected_stack_name)
+
+
+@pytest.mark.parametrize(
+    "template_body,error_message",
+    [
+        ({"TemplateKey": "TemplateValue"}, None),
+        ({}, "Unable to get template for stack {0}.$".format(FAKE_STACK_NAME)),
+        (None, "Unable to get template for stack {0}\n.+".format(FAKE_STACK_NAME)),
+    ],
+)
+def test_get_stack_template(boto3_stubber, template_body, error_message):
+    """Verify that utils.get_stack_template behaves as expected."""
+    response = {"TemplateBody": json.dumps(template_body)} if template_body is not None else error_message
+    mocked_requests = [
+        MockedBoto3Request(method="get_template", response=response, expected_params={"StackName": FAKE_STACK_NAME})
+    ]
+    generate_errors = template_body is None
+    boto3_stubber("cloudformation", mocked_requests, generate_errors=generate_errors)
+    if error_message is not None:
+        with pytest.raises(SystemExit, match=error_message) as sysexit:
+            utils.get_stack_template(stack_name=FAKE_STACK_NAME)
+        assert_that(sysexit.value.code).is_not_equal_to(0)
+    else:
+        assert_that(utils.get_stack_template(stack_name=FAKE_STACK_NAME)).is_equal_to(response.get("TemplateBody"))
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        None,
+        "No UpDatES ARE TO BE PERformed",
+        "no updates are to be performed",
+        "NO UPDATES ARE TO BE PERFORMED",
+        "some longer message also containing no updates are to be performed and more words at the end"
+        "some other error message",
+    ],
+)
+def test_update_stack_template(boto3_stubber, error_message):
+    """Verify that utils.update_stack_template behaves as expected."""
+    template_body = {"TemplateKey": "TemplateValue"}
+    cfn_params = [{"ParameterKey": "Key", "ParameterValue": "Value"}]
+    expected_params = {
+        "StackName": FAKE_STACK_NAME,
+        "TemplateBody": json.dumps(template_body, indent=2),
+        "Parameters": cfn_params,
+    }
+    response = error_message if error_message is not None else {"StackId": "stack ID"}
+    mocked_requests = [MockedBoto3Request(method="update_stack", response=response, expected_params=expected_params)]
+    generate_errors = error_message is not None
+    boto3_stubber("cloudformation", mocked_requests, generate_errors=generate_errors)
+    if error_message is None or "no updates are to be performed" in error_message.lower():
+        utils.update_stack_template(FAKE_STACK_NAME, template_body, cfn_params)
+    else:
+        full_error_message = "Unable to update stack template for stack {stack_name}: {emsg}".format(
+            stack_name=FAKE_STACK_NAME, emsg=error_message
+        )
+        with pytest.raises(SystemExit, match=full_error_message) as sysexit:
+            utils.update_stack_template(FAKE_STACK_NAME, template_body, cfn_params)
+        assert_that(sysexit.value.code).is_not_equal_to(0)
+
+
+@pytest.mark.parametrize(
+    "resources",
+    [
+        [
+            {"ResourceType": "Not a stack", "ResourceName": "name_one"},
+            {"ResourceType": STACK_TYPE, "ResourceName": "name_two"},
+            {"ResourceType": "Also not a stack", "ResourceName": "name_three"},
+            {"ResourceType": STACK_TYPE, "ResourceName": "name_four"},
+        ],
+        [],
+    ],
+)
+def test_get_cluster_substacks(mocker, resources):
+    """Verify that utils.get_cluster_substacks behaves as expected."""
+    mocker.patch("pcluster.utils.get_stack_resources").return_value = resources
+    expected_substacks = [r for r in resources if r.get("ResourceType") == STACK_TYPE]
+    observed_substacks = utils.get_cluster_substacks(FAKE_CLUSTER_NAME)
+    utils.get_stack_resources.assert_called_with(FAKE_STACK_NAME)
+    assert_that(observed_substacks).is_equal_to(expected_substacks)
+
+
+@pytest.mark.parametrize(
+    "substacks_response,expected,error_message",
+    [
+        (
+            [
+                {"StackName": "substack_one"},
+                {"StackName": "substack_two"},
+                {"StackName": "not_a_substack"},
+                {"StackName": "{0}-CloudWatchLogsSubstack-skdfjaldks".format(utils.get_stack_name(FAKE_CLUSTER_NAME))},
+            ],
+            {"StackName": "{0}-CloudWatchLogsSubstack-skdfjaldks".format(utils.get_stack_name(FAKE_CLUSTER_NAME))},
+            None,
+        ),
+        (
+            [{"StackName": "substack_one"}, {"StackName": "substack_two"}, {"StackName": "not_a_substack"}],
+            None,
+            "Unable to get CloudWatch logs substack for cluster {0}".format(FAKE_CLUSTER_NAME),
+        ),
+    ],
+)
+def test_get_cloudwatch_logs_substack(mocker, substacks_response, expected, error_message):
+    """Verify that utils.get_cloudwatch_logs_substack behaves as expected."""
+    mocker.patch("pcluster.utils.get_cluster_substacks").return_value = substacks_response
+    if error_message is None:
+        assert_that(utils.get_cloudwatch_logs_substack(FAKE_CLUSTER_NAME)).is_equal_to(expected)
+    else:
+        with pytest.raises(SystemExit, match=error_message) as sysexit:
+            utils.get_cloudwatch_logs_substack(FAKE_CLUSTER_NAME)
+        assert_that(sysexit.value.code).is_not_equal_to(0)
+    utils.get_cluster_substacks.assert_called_with(FAKE_CLUSTER_NAME)
+
+
+@pytest.mark.parametrize(
+    "response,is_error",
+    [
+        ("Stack with id {0} does not exist".format(FAKE_STACK_NAME), True),
+        ({"Stacks": [{"StackName": FAKE_STACK_NAME, "CreationTime": 0, "StackStatus": "CREATED"}]}, False),
+    ],
+)
+def test_stack_exists(boto3_stubber, response, is_error):
+    """Verify that utils.stack_exists behaves as expected."""
+    mocked_requests = [
+        MockedBoto3Request(method="describe_stacks", response=response, expected_params={"StackName": FAKE_STACK_NAME},)
+    ]
+    boto3_stubber("cloudformation", mocked_requests, generate_errors=is_error)
+    should_exist = not is_error
+    assert_that(utils.stack_exists(FAKE_STACK_NAME)).is_equal_to(should_exist)
+
+
+@pytest.mark.parametrize(
+    "resources,error_message",
+    [
+        (
+            [
+                {
+                    "StackName": FAKE_STACK_NAME,
+                    "StackId": "stack_id",
+                    "LogicalResourceId": "logical_resource_id",
+                    "ResourceType": "resource_type",
+                    "Timestamp": 0,
+                    "ResourceStatus": "resource_status",
+                },
+            ],
+            None,
+        ),
+        (None, "Some error message"),
+    ],
+)
+def test_get_stack_resources(boto3_stubber, resources, error_message):
+    """Verify that utils.get_stack_resources behaves as expected."""
+    if error_message is None:
+        response = {"StackResources": resources}
+    else:
+        response = "Unable to get {stack_name}'s resources: {error_message}".format(
+            stack_name=FAKE_STACK_NAME, error_message=error_message
+        )
+    mocked_requests = [
+        MockedBoto3Request(
+            method="describe_stack_resources", response=response, expected_params={"StackName": FAKE_STACK_NAME}
+        )
+    ]
+    generate_errors = error_message is not None
+    boto3_stubber("cloudformation", mocked_requests, generate_errors=generate_errors)
+    if error_message is None:
+        assert_that(utils.get_stack_resources(FAKE_STACK_NAME)).is_equal_to(resources)
+    else:
+        with pytest.raises(SystemExit, match=response) as sysexit:
+            utils.get_stack_resources(FAKE_STACK_NAME)
+        assert_that(sysexit.value.code).is_not_equal_to(0)

--- a/tests/integration-tests/tests/cloudwatch_logging/cloudwatch_logging_boto3_utils.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/cloudwatch_logging_boto3_utils.py
@@ -1,0 +1,97 @@
+import json
+import logging
+
+import boto3
+from botocore.exceptions import ClientError
+
+import utils
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _dumps_json(obj):
+    """Dump obj to a JSON string."""
+    return json.dumps(obj, indent=2)
+
+
+def get_log_groups():
+    """
+    Get list of log groups.
+
+    Raises ClientError.
+    """
+    log_groups = boto3.client("logs").describe_log_groups().get("logGroups")
+    LOGGER.debug("Log groups: {0}\n".format(_dumps_json(log_groups)))
+    return log_groups
+
+
+def get_log_streams(log_group_name):
+    """
+    Get list of log streams.
+
+    Raises ClientError if the log group doesn't exist.
+    """
+    streams = boto3.client("logs").describe_log_streams(logGroupName=log_group_name).get("logStreams")
+    LOGGER.debug("Log streams for {group}:\n{streams}".format(group=log_group_name, streams=_dumps_json(streams)))
+    return streams
+
+
+def get_log_events(log_group_name, log_stream_name):
+    """
+    Get log events for the given log_stream_name.
+
+    Raises ClientError if the given log group or stream doesn't exist.
+    """
+    logs_client = boto3.client("logs")
+    events = logs_client.get_log_events(logGroupName=log_group_name, logStreamName=log_stream_name).get("events")
+    LOGGER.debug(
+        "Log events for {group}/{stream}:\n{events}".format(
+            group=log_group_name, stream=log_stream_name, events=_dumps_json(events)
+        )
+    )
+    return events
+
+
+def get_ec2_instances():
+    """Iterate through ec2's describe_instances."""
+    for instance_page in utils.paginate_boto3(boto3.client("ec2").describe_instances):
+        for instance in instance_page.get("Instances"):
+            yield instance
+
+
+def _get_log_group_for_stack(stack_name):
+    """Return a list of log groups belonging to the given stack."""
+    log_groups = []
+    for resource in utils.get_cfn_resources(stack_name):
+        if resource.get("ResourceType") == "AWS::Logs::LogGroup":
+            log_groups.append(resource.get("PhysicalResourceId"))
+    return log_groups
+
+
+def get_cluster_log_groups(stack_name):
+    """Return list of PhysicalResourceIds for log groups created by cluster with given stack name."""
+    log_groups = []
+    substack_phys_ids = utils.get_substacks(stack_name)
+    for substack_phys_id in substack_phys_ids:
+        log_groups.extend(_get_log_group_for_stack(substack_phys_id))
+    return log_groups
+
+
+def delete_log_group(log_group):
+    """Delete the given log group."""
+    try:
+        boto3.client("logs").delete_log_group(logGroupName=log_group)
+    except ClientError as client_err:
+        if client_err.response.get("Error").get("Code") == "ResourceNotFoundException":
+            return  # Log group didn't exist.
+        LOGGER.warning(
+            "Error when deleting log group {log_group}: {msg}".format(
+                log_group=log_group, msg=client_err.response.get("Error").get("Message")
+            )
+        )
+
+
+def delete_log_groups(log_groups):
+    """Delete the given log groups, if they exist."""
+    for log_group in log_groups:
+        delete_log_group(log_group)


### PR DESCRIPTION
This PR implements the `--keep-logs` flag for `pcluster delete`. When
set, a cluster's CloudWatch logs will not be deleted with the rest of
its resources.

This PR includes:
* Implementation of the new flag in the CLI
* Unit tests for the changes to the CLI
* Additional tests in the CloudWatch logs integration tests

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
