### PR TITLE
Enable validation of dockerfile entry point deps

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_awsbatch.py
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch.py
@@ -18,6 +18,7 @@ from remote_command_executor import RemoteCommandExecutor
 from tests.common.schedulers_common import AWSBatchCommands
 
 
+@pytest.mark.batch_dockerfile_deps
 @pytest.mark.skip_regions(["ap-northeast-3", "us-gov-east-1", "us-gov-west-1"])
 @pytest.mark.instances(["c5.xlarge", "t2.large"])
 @pytest.mark.dimensions("*", "*", "alinux", "awsbatch")

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
@@ -14,8 +14,14 @@ compute_instance_type = {{ instance }}
 min_vcpus = 2
 desired_vcpus = 2
 max_vcpus = 40
+# EFS is integrated in order to exercise the mount_efs.sh script called from the
+# entry point of the docker image generated when the scheduler is awsbatch.
+efs_settings = custom_efs
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+
+[efs custom_efs]
+shared_dir = efs


### PR DESCRIPTION
This PR enables more thorough validation of the dependencies (and
functionality) of the docker image generated when a cluster uses
awsbatch as its scheduler. It does this via two changes:
1. The `batch_dockerfile_deps` mark has been added to the awsbatch
scheduler test function, in order to allow for selecting only this test.
2. An EFS filesystem is configured in the awsbatch scheduler test
function's config file, in order to exercies the `mount_efs.sh` entry
point script in the generated docker image.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.