### PR TITLE
integ-tests: test vpc with additional cidr block

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -370,19 +370,30 @@ def vpc_stacks(cfn_stacks_factory, request):
         # defining subnets per region to allow AZs override
         public_subnet = SubnetConfig(
             name="Public",
-            cidr="10.0.124.0/22",  # 1,022 IPs
+            cidr="192.168.0.0/18",  # 16382 IPs
             map_public_ip_on_launch=True,
             has_nat_gateway=True,
             default_gateway=Gateways.INTERNET_GATEWAY,
         )
         private_subnet = SubnetConfig(
             name="Private",
-            cidr="10.0.128.0/17",  # 32766 IPs
+            cidr="192.168.64.0/18",  # 16382 IPs
             map_public_ip_on_launch=False,
             has_nat_gateway=False,
             default_gateway=Gateways.NAT_GATEWAY,
         )
-        vpc_config = VPCConfig(subnets=[public_subnet, private_subnet])
+        private_subnet_different_cidr = SubnetConfig(
+            name="PrivateAdditionalCidr",
+            cidr="192.168.128.0/17",  # 32766 IPs
+            map_public_ip_on_launch=False,
+            has_nat_gateway=False,
+            default_gateway=Gateways.NAT_GATEWAY,
+        )
+        vpc_config = VPCConfig(
+            cidr="192.168.0.0/17",
+            additional_cidr_blocks=["192.168.128.0/17"],
+            subnets=[public_subnet, private_subnet, private_subnet_different_cidr],
+        )
         template = NetworkTemplateBuilder(vpc_configuration=vpc_config, availability_zone=availability_zone).build()
         vpc_stacks[region] = _create_vpc_stack(request, template, region, cfn_stacks_factory)
 


### PR DESCRIPTION
Add the possibility to test additional VPC cidr blocks.
With this change a new subnet is created in the additional vpc cidr block.

The new subnet can be used in cluster configs in the following way:
```
[vpc parallelcluster-vpc]
vpc_id = {{ vpc_id }}
master_subnet_id = {{ public_subnet_id }}
compute_subnet_id = {{ private_additional_cidr_subnet_id }}
```

See [this](http://www.davidc.net/sites/default/subnets/subnets.html?network=192.168.0.0&mask=16&division=13.ba20) for a better overview of how the CIDRs are allocated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
