### PR TITLE
Integ tests minor improvements

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -42,6 +42,7 @@ from utils import (
     delete_s3_bucket,
     random_alphanumeric,
     set_credentials,
+    set_logger_formatter,
     to_snake_case,
     unset_credentials,
 )
@@ -109,7 +110,12 @@ def pytest_configure(config):
 def pytest_runtest_call(item):
     """Called to execute the test item."""
     _add_properties_to_report(item)
+    set_logger_formatter(logging.Formatter(fmt=f"%(asctime)s - %(levelname)s - {item.name} - %(module)s - %(message)s"))
     logging.info("Running test " + item.name)
+
+
+def pytest_runtest_logfinish(nodeid, location):
+    set_logger_formatter(logging.Formatter(fmt="%(asctime)s - %(levelname)s - %(module)s - %(message)s"))
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 import boto3
 
-from assertpy import assert_that
+from assertpy import assert_that, soft_assertions
 from tests.common.scaling_common import get_compute_nodes_allocation
 from time_utils import minutes
 
@@ -63,9 +63,21 @@ def assert_scaling_worked(
         + minutes(estimated_scaleup_time)
         + minutes(max_scaledown_time),
     )
-    if assert_asg:
-        assert_that(max(asg_capacity_time_series)).is_equal_to(expected_max)
-        assert_that(asg_capacity_time_series[-1]).is_equal_to(expected_final)
-    if assert_scheduler:
-        assert_that(max(compute_nodes_time_series)).is_equal_to(expected_max)
-        assert_that(compute_nodes_time_series[-1]).is_equal_to(expected_final)
+
+    with soft_assertions():
+        if assert_asg:
+            asg_capacity_time_series_str = f"asg_capacity_time_series={asg_capacity_time_series}"
+            assert_that(max(asg_capacity_time_series)).described_as(asg_capacity_time_series_str).is_equal_to(
+                expected_max
+            )
+            assert_that(asg_capacity_time_series[-1]).described_as(asg_capacity_time_series_str).is_equal_to(
+                expected_final
+            )
+        if assert_scheduler:
+            compute_nodes_time_series_str = f"compute_nodes_time_series={compute_nodes_time_series}"
+            assert_that(max(compute_nodes_time_series)).described_as(compute_nodes_time_series_str).is_equal_to(
+                expected_max
+            )
+            assert_that(compute_nodes_time_series[-1]).described_as(compute_nodes_time_series_str).is_equal_to(
+                expected_final
+            )

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -14,7 +14,7 @@ import logging
 import pytest
 from retrying import retry
 
-from assertpy import assert_that
+from assertpy import assert_that, soft_assertions
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
 from tests.common.assertions import assert_instance_replaced_or_terminating, assert_no_errors_in_logs
 from tests.common.compute_logs_common import wait_compute_log
@@ -128,18 +128,19 @@ def _assert_scaling_works(
     actual_compute_nodes_min = min(
         compute_nodes_time_series[compute_nodes_time_series.index(actual_compute_nodes_max) :]  # noqa E203
     )
-    assert_that(actual_asg_capacity_min).described_as(
-        "actual asg min capacity does not match the expected one"
-    ).is_equal_to(expected_asg_capacity_min)
-    assert_that(actual_asg_capacity_max).described_as(
-        "actual asg max capacity does not match the expected one"
-    ).is_equal_to(expected_asg_capacity_max)
-    assert_that(actual_compute_nodes_min).described_as(
-        "actual number of min compute nodes does not match the expected one"
-    ).is_equal_to(expected_compute_nodes_min)
-    assert_that(actual_compute_nodes_max).described_as(
-        "actual number of max compute nodes does not match the expected one"
-    ).is_equal_to(expected_compute_nodes_max)
+    with soft_assertions():
+        assert_that(actual_asg_capacity_min).described_as(
+            "actual asg min capacity does not match the expected one"
+        ).is_equal_to(expected_asg_capacity_min)
+        assert_that(actual_asg_capacity_max).described_as(
+            "actual asg max capacity does not match the expected one"
+        ).is_equal_to(expected_asg_capacity_max)
+        assert_that(actual_compute_nodes_min).described_as(
+            "actual number of min compute nodes does not match the expected one"
+        ).is_equal_to(expected_compute_nodes_min)
+        assert_that(actual_compute_nodes_max).described_as(
+            "actual number of max compute nodes does not match the expected one"
+        ).is_equal_to(expected_compute_nodes_max)
 
 
 def _assert_test_jobs_completed(remote_command_executor, max_jobs_exec_time):

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -208,3 +208,8 @@ def unset_credentials():
         del os.environ["AWS_SECRET_ACCESS_KEY"]
     if "AWS_SESSION_TOKEN" in os.environ:
         del os.environ["AWS_SESSION_TOKEN"]
+
+
+def set_logger_formatter(formatter):
+    for handler in logging.getLogger().handlers:
+        handler.setFormatter(formatter)


### PR DESCRIPTION
- On cluster teardown do not fail on delete if cluster does not exist (e.g. if create already failed before cluster got created)
- Add the name of the test function to the logging messages so that it's easier to retrieve all logs related to a specific failure
- improve assertions and messaging in scaling tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
