### PR TITLE
Add test for multi CIDR VPC

### DIFF
--- a/tests/integration-tests/tests/networking/test_multi_cidr.py
+++ b/tests/integration-tests/tests/networking/test_multi_cidr.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+@pytest.mark.regions(["us-east-2"])
+@pytest.mark.instances(["c5.xlarge"])
+@pytest.mark.schedulers(["slurm", "awsbatch"])
+@pytest.mark.usefixtures("os", "instance", "scheduler", "region")
+def test_multi_cidr(pcluster_config_reader, clusters_factory):
+    """
+    Test cluster creation when there is multiple CIDR in a VPC.
+
+    Specifically test that cluster is created when compute subnet is in the second CIDR block of the VPC.
+    """
+    cluster_config = pcluster_config_reader()
+    clusters_factory(cluster_config)

--- a/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.ini
+++ b/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.ini
@@ -1,0 +1,21 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+initial_queue_size = 1
+max_queue_size = 1
+maintain_initial_size = true
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_additional_cidr_subnet_id }}


### PR DESCRIPTION
* Added test to test that a cluster is created when using VPC with 2 CIDR and compute subnet in the 2nd CIDR block of VPC.
* Testing changes made in https://github.com/aws/aws-parallelcluster-cookbook/pull/449. Cluster creation will fail without this change

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
