### PR TITLE
Fix easy config not preserving initial_queue_size and max_queue_size

### DIFF
--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -52,8 +52,7 @@ class Param(object):
         """Return internal representation starting from CFN/user-input value."""
         param_value = self.get_default_value()
 
-        if isinstance(string_value, str):
-            string_value = string_value.strip()
+        string_value = str(string_value).strip()
 
         if string_value and string_value != "NONE":
             param_value = string_value
@@ -263,8 +262,8 @@ class FloatParam(Param):
         param_value = self.get_default_value()
 
         try:
-            if string_value is not None and isinstance(string_value, str):
-                string_value = string_value.strip()
+            if string_value is not None:
+                string_value = str(string_value).strip()
                 if string_value != "NONE":
                     param_value = float(string_value)
         except ValueError:
@@ -299,8 +298,8 @@ class BoolParam(Param):
         """Return internal representation starting from CFN/user-input value."""
         param_value = self.get_default_value()
 
-        if string_value is not None and isinstance(string_value, str):
-            string_value = string_value.strip()
+        if string_value is not None:
+            string_value = str(string_value).strip()
             if string_value != "NONE":
                 param_value = string_value == "true"
 
@@ -346,8 +345,8 @@ class IntParam(Param):
         """Return internal representation starting from CFN/user-input value."""
         param_value = self.get_default_value()
         try:
-            if string_value is not None and isinstance(string_value, str):
-                string_value = string_value.strip()
+            if string_value is not None:
+                string_value = str(string_value).strip()
                 if string_value != "NONE":
                     param_value = int(string_value)
         except ValueError:
@@ -382,8 +381,8 @@ class JsonParam(Param):
         try:
             # Do not convert empty string and use format and yaml.load in place of json.loads
             # for Python 2.7 compatibility because it returns unicode chars
-            if string_value and isinstance("{0}".format(string_value), str):
-                string_value = string_value.strip()
+            if string_value:
+                string_value = str(string_value).strip()
                 if string_value != "NONE":
                     param_value = yaml.safe_load(string_value)
         except (TypeError, ValueError, Exception) as e:

--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -160,12 +160,12 @@ def configure(args):
     cluster_section.label = cluster_label
     for param_key, param_value in cluster_parameters.items():
         param = cluster_section.get_param(param_key)
-        param.value = param.get_value_from_string(param_value)
+        param.value = param.get_value_from_string(str(param_value))
 
     vpc_section.label = vpc_label
     for param_key, param_value in vpc_parameters.items():
         param = vpc_section.get_param(param_key)
-        param.value = param.get_value_from_string(param_value)
+        param.value = param.get_value_from_string(str(param_value))
 
     # Update config file by overriding changed settings
     pcluster_config.to_file()

--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -119,12 +119,18 @@ def configure(args):
     vpc_label = vpc_section.label
 
     # Use built in boto regions as an available option
-    aws_region_name = prompt_iterable("AWS Region ID", get_regions())
+    aws_region_name = prompt_iterable(
+        "AWS Region ID",
+        get_regions(),
+        default_value=pcluster_config.get_section("aws").get_param_value("aws_region_name"),
+    )
     # Set provided region into os environment for suggestions and validations from here on
     os.environ["AWS_DEFAULT_REGION"] = aws_region_name
 
     # Get the key name from the current region, if any
-    key_name = prompt_iterable("EC2 Key Pair Name", _get_keys())
+    key_name = prompt_iterable(
+        "EC2 Key Pair Name", _get_keys(), default_value=cluster_section.get_param_value("key_name")
+    )
 
     scheduler = prompt_iterable(
         "Scheduler", get_supported_schedulers(), default_value=cluster_section.get_param_value("scheduler")
@@ -160,12 +166,12 @@ def configure(args):
     cluster_section.label = cluster_label
     for param_key, param_value in cluster_parameters.items():
         param = cluster_section.get_param(param_key)
-        param.value = param.get_value_from_string(str(param_value))
+        param.value = param.get_value_from_string(param_value)
 
     vpc_section.label = vpc_label
     for param_key, param_value in vpc_parameters.items():
         param = vpc_section.get_param(param_key)
-        param.value = param.get_value_from_string(str(param_value))
+        param.value = param.get_value_from_string(param_value)
 
     # Update config file by overriding changed settings
     pcluster_config.to_file()
@@ -208,13 +214,20 @@ def _create_vpc_parameters(vpc_section, scheduler, min_subnet_size, automate_vpc
                     automate_subnet_creation(vpc_id, _choose_network_configuration(scheduler), min_subnet_size)
                 )
             else:
-                vpc_parameters.update(_ask_for_subnets(subnet_list))
+                vpc_parameters.update(_ask_for_subnets(subnet_list, vpc_section))
     return vpc_parameters
 
 
-def _ask_for_subnets(subnet_list):
-    master_subnet_id = prompt_iterable("Master Subnet ID", subnet_list)
-    compute_subnet_id = prompt_iterable("Compute Subnet ID", subnet_list, default_value=master_subnet_id)
+def _ask_for_subnets(subnet_list, vpc_section):
+    master_subnet_id = prompt_iterable(
+        "Master Subnet ID", subnet_list, default_value=vpc_section.get_param_value("master_subnet_id")
+    )
+
+    compute_subnet_id = prompt_iterable(
+        "Compute Subnet ID",
+        subnet_list,
+        default_value=vpc_section.get_param_value("compute_subnet_id") or master_subnet_id,
+    )
     vpc_parameters = {"master_subnet_id": master_subnet_id}
 
     if master_subnet_id != compute_subnet_id:
@@ -277,7 +290,7 @@ class SchedulerHandler:
             self.compute_instance_type = prompt(
                 "Compute instance type",
                 lambda x: x in list_ec2_instance_types(),
-                default_value=self.compute_instance_type,
+                default_value=self.cluster_section.get_param_value("compute_instance_type"),
             )
 
     def prompt_cluster_size(self):

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -546,7 +546,7 @@ def test_fsx_id_validator(mocker, boto3_stubber, fsx_vpc, ip_permissions, networ
             method="describe_subnets",
             response=describe_subnets_response,
             expected_params={"SubnetIds": ["subnet-12345678"]},
-        ),
+        )
     ] * 2
 
     if network_interfaces:
@@ -599,7 +599,7 @@ def test_fsx_id_validator(mocker, boto3_stubber, fsx_vpc, ip_permissions, networ
                     "SubnetId": "subnet-12345678",
                     "TagSet": [],
                     "VpcId": fsx_vpc,
-                },
+                }
             )
         describe_network_interfaces_response = {"NetworkInterfaces": network_interfaces_in_response}
         ec2_mocked_requests.append(

--- a/cli/tests/pcluster/configure/test_pcluster_configure.py
+++ b/cli/tests/pcluster/configure/test_pcluster_configure.py
@@ -254,7 +254,6 @@ def test_no_automation_no_awsbatch_no_errors(mocker, capsys, test_datadir):
 
 
 def _run_input_test_with_config(mocker, config, old_config_file, error, output, capsys, with_input=False):
-    """Helper function to run input tests."""
     if with_input:
         input_composer = ComposeInput(aws_region_name="us-east-1", key="key2", scheduler="slurm")
         input_composer.add_first_flow(

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/pcluster.config.ini
@@ -11,9 +11,11 @@ invalid_key=invalid_value
 key_name = key1
 vpc_settings = default
 #Invalid param value
-scheduler = sge
+# Implied value
+# scheduler = sge
 base_os = centos6
-compute_instance_type = t2.micro
+# Implied value
+# compute_instance_type = t2.micro
 master_instance_type = t2.nano
 #Invalid value type
 max_queue_size = 14

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/original_config_file
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/original_config_file
@@ -2,17 +2,14 @@
 aws_region_name = eu-west-1
 
 [cluster default]
-key_name = key1
-# Implied value
-# base_os = alinux
+key_name = key3
 vpc_settings = default
-scheduler = awsbatch
-# Implied value
-# compute_instance_type = optimal
+scheduler = torque
 master_instance_type = t2.nano
-max_vcpus = 14
-min_vcpus = 13
-desired_vcpus = 13
+compute_instance_type = t2.nano
+max_queue_size = 14
+initial_queue_size = 13
+maintain_initial_size = true
 
 [vpc default]
 vpc_id = vpc-12345678
@@ -26,4 +23,3 @@ sanity_check = true
 
 [aliases]
 ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
-

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/output.txt
@@ -1,0 +1,52 @@
+WARNING: Configuration file {{ CONFIG_FILE }} will be overwritten.
+Press CTRL-C to interrupt the procedure.
+
+
+Allowed values for AWS Region ID:
+1. eu-north-1
+2. ap-south-1
+3. eu-west-3
+4. eu-west-2
+5. eu-west-1
+6. ap-northeast-2
+7. ap-northeast-1
+8. sa-east-1
+9. ca-central-1
+10. ap-southeast-1
+11. ap-southeast-2
+12. eu-central-1
+13. us-east-1
+14. us-east-2
+15. us-west-1
+16. us-west-2
+Allowed values for EC2 Key Pair Name:
+1. key1
+2. key2
+3. key3
+4. key4
+5. key5
+6. key6
+Allowed values for Scheduler:
+1. sge
+2. torque
+3. slurm
+4. awsbatch
+Allowed values for Operating System:
+1. alinux
+2. centos6
+3. centos7
+4. ubuntu1604
+5. ubuntu1804
+Allowed values for VPC ID:
+1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
+2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
+3. vpc-34567891 | default | 3 subnets inside
+4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+Allowed values for Master Subnet ID:
+1. subnet-12345678 | ParallelClusterPublicSubnet | Subnet size: 256
+2. subnet-23456789 | ParallelClusterPrivateSubnet | Subnet size: 4096
+Allowed values for Compute Subnet ID:
+1. subnet-12345678 | ParallelClusterPublicSubnet | Subnet size: 256
+2. subnet-23456789 | ParallelClusterPrivateSubnet | Subnet size: 4096
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/pcluster.config.ini
@@ -2,17 +2,14 @@
 aws_region_name = eu-west-1
 
 [cluster default]
-key_name = key1
-# Implied value
-# base_os = alinux
+key_name = key3
 vpc_settings = default
-scheduler = awsbatch
-# Implied value
-# compute_instance_type = optimal
+scheduler = torque
 master_instance_type = t2.nano
-max_vcpus = 14
-min_vcpus = 13
-desired_vcpus = 13
+compute_instance_type = t2.nano
+max_queue_size = 14
+initial_queue_size = 13
+maintain_initial_size = true
 
 [vpc default]
 vpc_id = vpc-12345678
@@ -26,4 +23,3 @@ sanity_check = true
 
 [aliases]
 ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
-

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.ini
@@ -4,9 +4,11 @@ aws_region_name = eu-west-1
 [cluster default]
 key_name = key1
 vpc_settings = default
-scheduler = sge
+# Implied value
+# scheduler = sge
 base_os = centos6
-compute_instance_type = t2.micro
+# Implied value
+# compute_instance_type = t2.micro
 master_instance_type = t2.nano
 max_queue_size = 14
 initial_queue_size = 13

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.ini
@@ -4,9 +4,11 @@ aws_region_name = eu-west-1
 [cluster default]
 key_name = key1
 vpc_settings = default
-scheduler = sge
+# Implied value
+# scheduler = sge
 base_os = centos6
-compute_instance_type = t2.micro
+# Implied value
+# compute_instance_type = t2.micro
 master_instance_type = t2.nano
 max_queue_size = 14
 initial_queue_size = 13

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/pcluster.config.ini
@@ -4,9 +4,11 @@ aws_region_name = eu-west-1
 [cluster default]
 key_name = key1
 vpc_settings = default
-scheduler = sge
+# Implied value
+# scheduler = sge
 base_os = centos6
-compute_instance_type = t2.micro
+# Implied value
+# compute_instance_type = t2.micro
 master_instance_type = t2.nano
 max_queue_size = 14
 initial_queue_size = 13

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.ini
@@ -5,8 +5,9 @@ aws_region_name = eu-west-1
 key_name = key1
 vpc_settings = default
 scheduler = awsbatch
-base_os = alinux
-compute_instance_type = optimal
+# Implied value
+# base_os = alinux
+# compute_instance_type = optimal
 master_instance_type = t2.nano
 max_vcpus = 14
 min_vcpus = 13

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.ini
@@ -4,9 +4,11 @@ aws_region_name = eu-west-1
 [cluster default]
 key_name = key1
 vpc_settings = default
-scheduler = sge
+# Implied value
+# scheduler = sge
 base_os = centos6
-compute_instance_type = t2.micro
+# Implied value
+# compute_instance_type = t2.micro
 master_instance_type = t2.nano
 max_queue_size = 14
 initial_queue_size = 13

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.ini
@@ -7,7 +7,8 @@ vpc_settings = default
 scheduler = slurm
 master_instance_type = t2.nano
 base_os = centos6
-compute_instance_type = t2.micro
+# Implied value
+# compute_instance_type = t2.micro
 max_queue_size = 14
 initial_queue_size = 13
 maintain_initial_size = true

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.ini
@@ -7,7 +7,8 @@ vpc_settings = default
 scheduler = slurm
 master_instance_type = t2.nano
 base_os = centos6
-compute_instance_type = t2.micro
+# Implied value
+# compute_instance_type = t2.micro
 max_queue_size = 14
 initial_queue_size = 13
 maintain_initial_size = true
@@ -15,7 +16,8 @@ maintain_initial_size = true
 [vpc default]
 vpc_id = vpc-12345678
 master_subnet_id = subnet-12345678
-use_public_ips = true
+# Implied value
+# use_public_ips = true
 
 [global]
 cluster_template = default

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.ini
@@ -5,8 +5,9 @@ aws_region_name = eu-west-1
 key_name = key1
 vpc_settings = default
 scheduler = awsbatch
-base_os = alinux
-compute_instance_type = optimal
+# Implied value
+# base_os = alinux
+# compute_instance_type = optimal
 master_instance_type = t2.nano
 max_vcpus = 14
 min_vcpus = 13

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/original_config_file
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/original_config_file
@@ -3,16 +3,14 @@ aws_region_name = eu-west-1
 
 [cluster default]
 key_name = key1
-# Implied value
-# base_os = alinux
+base_os = ubuntu1604
 vpc_settings = default
-scheduler = awsbatch
-# Implied value
-# compute_instance_type = optimal
+scheduler = torque
 master_instance_type = t2.nano
-max_vcpus = 14
-min_vcpus = 13
-desired_vcpus = 13
+compute_instance_type = t2.micro
+max_queue_size = 14
+initial_queue_size = 13
+maintain_initial_size = true
 
 [vpc default]
 vpc_id = vpc-12345678
@@ -26,4 +24,3 @@ sanity_check = true
 
 [aliases]
 ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
-

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/output.txt
@@ -1,0 +1,54 @@
+WARNING: Configuration file {{ CONFIG_FILE }} will be overwritten.
+Press CTRL-C to interrupt the procedure.
+
+
+Allowed values for AWS Region ID:
+1. eu-north-1
+2. ap-south-1
+3. eu-west-3
+4. eu-west-2
+5. eu-west-1
+6. ap-northeast-2
+7. ap-northeast-1
+8. sa-east-1
+9. ca-central-1
+10. ap-southeast-1
+11. ap-southeast-2
+12. eu-central-1
+13. us-east-1
+14. us-east-2
+15. us-west-1
+16. us-west-2
+Allowed values for EC2 Key Pair Name:
+1. key1
+2. key2
+3. key3
+4. key4
+5. key5
+6. key6
+Allowed values for Scheduler:
+1. sge
+2. torque
+3. slurm
+4. awsbatch
+Allowed values for Operating System:
+1. alinux
+2. centos6
+3. centos7
+4. ubuntu1604
+5. ubuntu1804
+Allowed values for VPC ID:
+1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
+2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
+3. vpc-34567891 | default | 3 subnets inside
+4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+Allowed values for Master Subnet ID:
+1. subnet-34567891 | Subnet size: 4096
+2. subnet-45678912 | Subnet size: 4096
+3. subnet-56789123 | Subnet size: 4096
+Allowed values for Compute Subnet ID:
+1. subnet-34567891 | Subnet size: 4096
+2. subnet-45678912 | Subnet size: 4096
+3. subnet-56789123 | Subnet size: 4096
+Configuration file written to {{ CONFIG_FILE }}
+You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/pcluster.config.ini
@@ -1,0 +1,26 @@
+[aws]
+aws_region_name = us-east-1
+
+[cluster default]
+key_name = key2
+base_os = ubuntu1604
+vpc_settings = default
+scheduler = slurm
+master_instance_type = c5.xlarge
+compute_instance_type = g3.8xlarge
+max_queue_size = 18
+initial_queue_size = 7
+maintain_initial_size = true
+
+[vpc default]
+vpc_id = vpc-34567891
+master_subnet_id = subnet-34567891
+compute_subnet_id = subnet-45678912
+
+[global]
+cluster_template = default
+update_check = true
+sanity_check = true
+
+[aliases]
+ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}


### PR DESCRIPTION
* Added string casting to get_value_from_string calls to avoid error
* Added error message in get_value_from_string to make user aware that the parameter is not set when the input is not a string
* Changed logic in test_pcluster_configure to test that the expected config is a subset of resulting config after running pcluster configure. Before this change we were testing the other way around and we would never know what the resulting config actually is.
* Added test_no_input_no_automation_no_error_with_config_file and test_with_input_no_automation_no_error_with_config_file to test that resulting config is as expected
* Changed majority of the test config files to adapt to above mentioned changes. Basically commenting out fields with default values, because these field will not be written into the config after we run pcluster configure.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
