### PR TITLE
Fix fsx validator to not fail if there are no ENI associated to it

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -155,25 +155,33 @@ def fsx_id_validator(param_key, param_value, pcluster_config):
                 "Currently only support using FSx file system that is in the same VPC as the stack. "
                 "The file system provided is in {0}".format(file_system.get("VpcId"))
             )
+
         # If there is an existing mt in the az, need to check the inbound and outbound rules of the security groups
         network_interface_ids = file_system.get("NetworkInterfaceIds")
-        network_interface_responses = ec2.describe_network_interfaces(NetworkInterfaceIds=network_interface_ids).get(
-            "NetworkInterfaces"
-        )
-        fs_access = False
-        network_interfaces = [i for i in network_interface_responses if i.get("VpcId") == vpc_id]
-        for network_interface in network_interfaces:
-            # Get list of security group IDs
-            sg_ids = [i.get("GroupId") for i in network_interface.get("Groups")]
-            if _check_in_out_access(sg_ids, port=988):
-                fs_access = True
-                break
-        if not fs_access:
+        if not network_interface_ids:
             errors.append(
-                "The current security group settings on file system %s does not satisfy "
-                "mounting requirement. The file system must be associated to a security group that allows "
-                "inbound and outbound TCP traffic through port 988." % param_value
+                "Unable to validate FSx security groups. The given FSx file system '{0}' doesn't have "
+                "Elastic Network Interfaces attached to it.".format(param_value)
             )
+        else:
+            network_interface_responses = ec2.describe_network_interfaces(
+                NetworkInterfaceIds=network_interface_ids
+            ).get("NetworkInterfaces")
+
+            fs_access = False
+            network_interfaces = [ni for ni in network_interface_responses if ni.get("VpcId") == vpc_id]
+            for network_interface in network_interfaces:
+                # Get list of security group IDs
+                sg_ids = [sg.get("GroupId") for sg in network_interface.get("Groups")]
+                if _check_in_out_access(sg_ids, port=988):
+                    fs_access = True
+                    break
+            if not fs_access:
+                errors.append(
+                    "The current security group settings on file system '{0}' does not satisfy mounting requirement. "
+                    "The file system must be associated to a security group that allows inbound and outbound "
+                    "TCP traffic through port 988.".format(param_value)
+                )
     except ClientError as e:
         errors.append(e.response.get("Error").get("Message"))
 

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -450,6 +450,199 @@ def test_fsx_validator(mocker, section_dict, expected_message):
 
 
 @pytest.mark.parametrize(
+    "fsx_vpc, ip_permissions, network_interfaces, expected_message",
+    [
+        (  # working case, right vpc and sg, multiple network interfaces
+            "vpc-06e4ab6c6cEXAMPLE",
+            [{"IpProtocol": "-1", "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}]}],
+            ["eni-09b9460295ddd4e5f", "eni-001b3cef7c78b45c4"],
+            None,
+        ),
+        (  # working case, right vpc and sg, single network interface
+            "vpc-06e4ab6c6cEXAMPLE",
+            [{"IpProtocol": "-1", "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}]}],
+            ["eni-09b9460295ddd4e5f"],
+            None,
+        ),
+        (  # not working case --> no network interfaces
+            "vpc-06e4ab6c6cEXAMPLE",
+            [{"IpProtocol": "-1", "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}]}],
+            [],
+            "doesn't have Elastic Network Interfaces attached",
+        ),
+        (  # not working case --> wrong vpc
+            "vpc-06e4ab6c6ccWRONG",
+            [{"IpProtocol": "-1", "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}]}],
+            ["eni-09b9460295ddd4e5f"],
+            "only support using FSx file system that is in the same VPC as the stack",
+        ),
+        (  # not working case --> wrong ip permissions in security group
+            "vpc-06e4ab6c6cWRONG",
+            [
+                {
+                    "PrefixListIds": [],
+                    "FromPort": 22,
+                    "IpRanges": [{"CidrIp": "203.0.113.0/24"}],
+                    "ToPort": 22,
+                    "IpProtocol": "tcp",
+                    "UserIdGroupPairs": [],
+                }
+            ],
+            ["eni-09b9460295ddd4e5f"],
+            "does not satisfy mounting requirement",
+        ),
+    ],
+)
+def test_fsx_id_validator(mocker, boto3_stubber, fsx_vpc, ip_permissions, network_interfaces, expected_message):
+    describe_file_systems_response = {
+        "FileSystems": [
+            {
+                "VpcId": fsx_vpc,
+                "NetworkInterfaceIds": network_interfaces,
+                "SubnetIds": ["subnet-12345678"],
+                "FileSystemType": "LUSTRE",
+                "CreationTime": 1567636453.038,
+                "ResourceARN": "arn:aws:fsx:us-west-2:111122223333:file-system/fs-0ff8da96d57f3b4e3",
+                "StorageCapacity": 3600,
+                "LustreConfiguration": {"WeeklyMaintenanceStartTime": "4:07:00"},
+                "FileSystemId": "fs-0ff8da96d57f3b4e3",
+                "DNSName": "fs-0ff8da96d57f3b4e3.fsx.us-west-2.amazonaws.com",
+                "OwnerId": "059623208481",
+                "Lifecycle": "AVAILABLE",
+            }
+        ]
+    }
+    fsx_mocked_requests = [
+        MockedBoto3Request(
+            method="describe_file_systems",
+            response=describe_file_systems_response,
+            expected_params={"FileSystemIds": ["fs-0ff8da96d57f3b4e3"]},
+        )
+    ]
+    boto3_stubber("fsx", fsx_mocked_requests)
+
+    describe_subnets_response = {
+        "Subnets": [
+            {
+                "AvailabilityZone": "us-east-2c",
+                "AvailabilityZoneId": "use2-az3",
+                "AvailableIpAddressCount": 248,
+                "CidrBlock": "10.0.1.0/24",
+                "DefaultForAz": False,
+                "MapPublicIpOnLaunch": False,
+                "State": "available",
+                "SubnetId": "subnet-12345678",
+                "VpcId": "vpc-06e4ab6c6cEXAMPLE",
+                "OwnerId": "111122223333",
+                "AssignIpv6AddressOnCreation": False,
+                "Ipv6CidrBlockAssociationSet": [],
+                "Tags": [{"Key": "Name", "Value": "MySubnet"}],
+                "SubnetArn": "arn:aws:ec2:us-east-2:111122223333:subnet/subnet-12345678",
+            }
+        ]
+    }
+    ec2_mocked_requests = [
+        MockedBoto3Request(
+            method="describe_subnets",
+            response=describe_subnets_response,
+            expected_params={"SubnetIds": ["subnet-12345678"]},
+        ),
+    ] * 2
+
+    if network_interfaces:
+        network_interfaces_in_response = []
+        for network_interface in network_interfaces:
+            network_interfaces_in_response.append(
+                {
+                    "Association": {
+                        "AllocationId": "eipalloc-01564b674a1a88a47",
+                        "AssociationId": "eipassoc-02726ee370e175cea",
+                        "IpOwnerId": "111122223333",
+                        "PublicDnsName": "ec2-34-248-114-123.eu-west-1.compute.amazonaws.com",
+                        "PublicIp": "34.248.114.123",
+                    },
+                    "Attachment": {
+                        "AttachmentId": "ela-attach-0cf98331",
+                        "DeleteOnTermination": False,
+                        "DeviceIndex": 1,
+                        "InstanceOwnerId": "amazon-aws",
+                        "Status": "attached",
+                    },
+                    "AvailabilityZone": "eu-west-1a",
+                    "Description": "Interface for NAT Gateway nat-0a8b0e0d28266841f",
+                    "Groups": [{"GroupName": "default", "GroupId": "sg-12345678"}],
+                    "InterfaceType": "nat_gateway",
+                    "Ipv6Addresses": [],
+                    "MacAddress": "0a:e5:8a:82:fd:24",
+                    "NetworkInterfaceId": network_interface,
+                    "OwnerId": "111122223333",
+                    "PrivateDnsName": "ip-10-0-124-85.eu-west-1.compute.internal",
+                    "PrivateIpAddress": "10.0.124.85",
+                    "PrivateIpAddresses": [
+                        {
+                            "Association": {
+                                "AllocationId": "eipalloc-01564b674a1a88a47",
+                                "AssociationId": "eipassoc-02726ee370e175cea",
+                                "IpOwnerId": "111122223333",
+                                "PublicDnsName": "ec2-34-248-114-123.eu-west-1.compute.amazonaws.com",
+                                "PublicIp": "34.248.114.123",
+                            },
+                            "Primary": True,
+                            "PrivateDnsName": "ip-10-0-124-85.eu-west-1.compute.internal",
+                            "PrivateIpAddress": "10.0.124.85",
+                        }
+                    ],
+                    "RequesterId": "036872051663",
+                    "RequesterManaged": True,
+                    "SourceDestCheck": False,
+                    "Status": "in-use",
+                    "SubnetId": "subnet-12345678",
+                    "TagSet": [],
+                    "VpcId": fsx_vpc,
+                },
+            )
+        describe_network_interfaces_response = {"NetworkInterfaces": network_interfaces_in_response}
+        ec2_mocked_requests.append(
+            MockedBoto3Request(
+                method="describe_network_interfaces",
+                response=describe_network_interfaces_response,
+                expected_params={"NetworkInterfaceIds": network_interfaces},
+            )
+        )
+
+        if fsx_vpc == "vpc-06e4ab6c6cEXAMPLE":
+            # the describe security group is performed only if the VPC of the network interface is the same of the FSX
+            describe_security_groups_response = {
+                "SecurityGroups": [
+                    {
+                        "IpPermissionsEgress": ip_permissions,
+                        "Description": "My security group",
+                        "IpPermissions": ip_permissions,
+                        "GroupName": "MySecurityGroup",
+                        "OwnerId": "123456789012",
+                        "GroupId": "sg-12345678",
+                    }
+                ]
+            }
+            ec2_mocked_requests.append(
+                MockedBoto3Request(
+                    method="describe_security_groups",
+                    response=describe_security_groups_response,
+                    expected_params={"GroupIds": ["sg-12345678"]},
+                )
+            )
+
+    boto3_stubber("ec2", ec2_mocked_requests)
+
+    config_parser_dict = {
+        "cluster default": {"fsx_settings": "default", "vpc_settings": "default"},
+        "vpc default": {"master_subnet_id": "subnet-12345678"},
+        "fsx default": {"fsx_fs_id": "fs-0ff8da96d57f3b4e3"},
+    }
+    utils.assert_param_validator(mocker, config_parser_dict, expected_message)
+
+
+@pytest.mark.parametrize(
     "section_dict, expected_message",
     [
         ({"enable_intel_hpc_platform": "true", "base_os": "centos7"}, None),


### PR DESCRIPTION
If the FSx file system doesn't have network interfaces
the code must skip the security group validation phase.

I added a set of unit tests for the validator to test:
* working case with multiple network interfaces
* working case with single network interface
* not working case, no network interface
* not working case, wrong vpc
* not working case, wrong security group