### PR TITLE
Fix ebs_settings_validator to handle comma separated list with space

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -549,7 +549,7 @@ def ebs_settings_validator(param_key, param_value, pcluster_config):
 
     list_of_shared_dir = []
     for section_label in param_value.split(","):
-        section = pcluster_config.get_section("ebs", section_label)
+        section = pcluster_config.get_section("ebs", section_label.strip())
         list_of_shared_dir.append(section.get_param_value("shared_dir"))
 
     max_number_of_ebs_volumes = 5

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -546,7 +546,7 @@ def test_fsx_id_validator(mocker, boto3_stubber, fsx_vpc, ip_permissions, networ
             method="describe_subnets",
             response=describe_subnets_response,
             expected_params={"SubnetIds": ["subnet-12345678"]},
-        ),
+        )
     ] * 2
 
     if network_interfaces:
@@ -599,7 +599,7 @@ def test_fsx_id_validator(mocker, boto3_stubber, fsx_vpc, ip_permissions, networ
                     "SubnetId": "subnet-12345678",
                     "TagSet": [],
                     "VpcId": fsx_vpc,
-                },
+                }
             )
         describe_network_interfaces_response = {"NetworkInterfaces": network_interfaces_in_response}
         ec2_mocked_requests.append(
@@ -834,7 +834,7 @@ def test_efa_validator_with_vpc_security_group(
     "cluster_section_dict, ebs_section_dict, expected_message",
     [
         (
-            {"ebs_settings": "vol1,vol2,vol3,vol4,vol5,vol6"},
+            {"ebs_settings": "vol1, vol2, vol3, vol4, vol5, vol6"},
             {
                 "vol1": {"shared_dir": "/vol1"},
                 "vol2": {"shared_dir": "/vol2"},
@@ -846,7 +846,7 @@ def test_efa_validator_with_vpc_security_group(
             "Currently only supports upto 5 EBS volumes",
         ),
         (
-            {"ebs_settings": "vol1,vol2"},
+            {"ebs_settings": "vol1, vol2 "},
             {"vol1": {"shared_dir": "vol1"}, "vol2": {"volume_type": "io1"}},
             "When using more than 1 EBS volume, shared_dir is required under each EBS section",
         ),
@@ -856,7 +856,7 @@ def test_efa_validator_with_vpc_security_group(
             "/NONE cannot be used as a shared directory",
         ),
         (
-            {"ebs_settings": "vol1,vol2"},
+            {"ebs_settings": "vol1, vol2 "},
             {"vol1": {"shared_dir": "/vol1"}, "vol2": {"shared_dir": "NONE"}},
             "NONE cannot be used as a shared directory",
         ),


### PR DESCRIPTION
* Added .strip() when parsing ebs_settings to avoid section/parameter not found error
* Adjusted unit test to include ebs_settings with space
* This should fix some ebs_multi failures in integration test

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
