### PR TITLE
integ-tests: adjust networking tests to new vpc setup

### DIFF
--- a/cli/awsbatch/awsbhosts.py
+++ b/cli/awsbatch/awsbhosts.py
@@ -70,7 +70,7 @@ class Host(object):
         cpu_avail,
         mem_avail,
     ):
-        """Constructor."""
+        """Initialize the object."""
         self.container_instance_arn = container_instance_arn
         self.status = status
         self.ec2_instance = ec2_instance
@@ -92,7 +92,7 @@ class AWSBhostsCommand(object):
 
     def __init__(self, log, boto3_factory):
         """
-        Constructor.
+        Initialize the object.
 
         :param log: log
         :param boto3_factory: an initialized Boto3ClientFactory object

--- a/cli/awsbatch/awsbkill.py
+++ b/cli/awsbatch/awsbkill.py
@@ -54,7 +54,7 @@ class AWSBkillCommand(object):
 
     def __init__(self, log, boto3_factory):
         """
-        Constructor.
+        Initialize the object.
 
         :param log: log
         :param boto3_factory: an initialized Boto3ClientFactory object

--- a/cli/awsbatch/awsbout.py
+++ b/cli/awsbatch/awsbout.py
@@ -76,7 +76,7 @@ class AWSBoutCommand(object):
 
     def __init__(self, log, boto3_factory):
         """
-        Constructor.
+        Initialize the object.
 
         :param log: log
         :param boto3_factory: an initialized Boto3ClientFactory object

--- a/cli/awsbatch/awsbqueues.py
+++ b/cli/awsbatch/awsbqueues.py
@@ -54,7 +54,7 @@ class Queue(object):
     """Generic queue object."""
 
     def __init__(self, arn, name, priority, status, status_reason):
-        """Constructor."""
+        """Initialize the object."""
         self.arn = arn
         self.name = name
         self.priority = priority
@@ -67,7 +67,7 @@ class AWSBqueuesCommand(object):
 
     def __init__(self, log, boto3_factory):
         """
-        Constructor.
+        Initialize the object.
 
         :param log: log
         :param boto3_factory: an initialized Boto3ClientFactory object

--- a/cli/awsbatch/awsbstat.py
+++ b/cli/awsbatch/awsbstat.py
@@ -99,7 +99,7 @@ class Job(object):
         log_stream_url,
         s3_folder_url,
     ):
-        """Constructor."""
+        """Initialize the object."""
         self.id = job_id
         self.name = name
         self.creation_time = creation_time
@@ -254,7 +254,7 @@ class AWSBstatCommand(object):
 
     def __init__(self, log, boto3_factory):
         """
-        Constructor.
+        Initialize the object.
 
         :param log: log
         :param boto3_factory: an initialized Boto3ClientFactory object

--- a/cli/awsbatch/awsbsub.py
+++ b/cli/awsbatch/awsbsub.py
@@ -425,7 +425,7 @@ class AWSBsubCommand(object):
 
     def __init__(self, log, boto3_factory):
         """
-        Constructor.
+        Initialize the object.
 
         :param log: log
         :param boto3_factory: an initialized Boto3ClientFactory object

--- a/cli/awsbatch/common.py
+++ b/cli/awsbatch/common.py
@@ -103,7 +103,7 @@ class Boto3ClientFactory(object):
     """Boto3 configuration object."""
 
     def __init__(self, region, aws_access_key_id, aws_secret_access_key, proxy="NONE"):
-        """Constructor."""
+        """Initialize the object."""
         self.region = region
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
@@ -135,7 +135,7 @@ class AWSBatchCliConfig(object):
 
     def __init__(self, log, cluster):
         """
-        Constructor.
+        Initialize the object.
 
         Search for the [cluster cluster-name] section in the /etc/awsbatch-cli.cfg configuration file, if there
         or ask to the pcluster status.

--- a/cli/awsbatch/utils.py
+++ b/cli/awsbatch/utils.py
@@ -133,7 +133,7 @@ class S3Uploader(object):
     """S3 uploader."""
 
     def __init__(self, boto3_factory, s3_bucket, default_folder=""):
-        """Constructor.
+        """Initialize the object.
 
         :param boto3_factory: initialized Boto3ClientFactory object
         :param s3_bucket: S3 bucket to use

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -376,7 +376,7 @@ def vpc_stacks(cfn_stacks_factory, request):
         # defining subnets per region to allow AZs override
         public_subnet = SubnetConfig(
             name="Public",
-            cidr="192.168.0.0/18",  # 16382 IPs
+            cidr="192.168.32.0/19",  # 8190 IPs
             map_public_ip_on_launch=True,
             has_nat_gateway=True,
             default_gateway=Gateways.INTERNET_GATEWAY,


### PR DESCRIPTION
networking tests are using the same VPC generated by the testing framework and creating subnets in it. Since we changed the CIDR of the main VPC we also need to update the CIDR ranges of the subnets created by these tests.

This helps understanding how the network is partitioned:
http://www.davidc.net/sites/default/subnets/subnets.html?network=192.168.0.0&mask=17&division=23.f72310

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
