### PR TITLE
Added integration test for ebs /NONE bug

### DIFF
--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -102,6 +102,21 @@ def test_default_ebs(scheduler, pcluster_config_reader, clusters_factory):
     _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
 
+@pytest.mark.regions(["us-west-2", "cn-north-1", "us-gov-east-1"])
+@pytest.mark.instances(["c4.xlarge", "c5.xlarge"])
+@pytest.mark.schedulers(["sge", "awsbatch"])
+@pytest.mark.usefixtures("region", "os", "instance")
+def test_ebs_single_empty(scheduler, pcluster_config_reader, clusters_factory):
+    cluster_config = pcluster_config_reader()
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    mount_dir = "/shared"
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+    _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size=20)
+    _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
+
+
 def _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size):
     logging.info("Testing ebs {0} is correctly mounted".format(mount_dir))
     result = remote_command_executor.run_remote_command(

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.ini
@@ -1,0 +1,28 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+ebs_settings = empty
+{% if scheduler == "awsbatch" %}
+min_vcpus = 4
+desired_vcpus = 4
+{% else %}
+initial_queue_size = 1
+maintain_initial_size = true
+{% endif %}
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+
+[ebs empty]


### PR DESCRIPTION
* Added test to reproduce the setup of /NONE bug
* 1 ebs section, no content specified

Signed-off-by: Rex <shuningc@amazon.com>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
