### PR TITLE
Improve validation messages

### DIFF
--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -128,13 +128,14 @@ class Param(object):
                 errors, warnings = validation_func(self.key, self.value, self.pcluster_config)
                 if errors:
                     self.pcluster_config.error(
-                        "The configuration parameter '{0}' has an invalid value '{1}'\n"
-                        "{2}".format(self.key, self.value, "\n".join(errors))
+                        "The configuration parameter '{0}' generated the following errors:\n{1}".format(
+                            self.key, "\n".join(errors)
+                        )
                     )
                 elif warnings:
                     self.pcluster_config.warn(
-                        "The configuration parameter '{0} = {1}' generated the following warnings:\n{2}".format(
-                            self.key, self.value, "\n".join(warnings)
+                        "The configuration parameter '{0}' generated the following warnings:\n{1}".format(
+                            self.key, "\n".join(warnings)
                         )
                     )
                 else:


### PR DESCRIPTION
We were showing the param.value in the error message, but it is different from the configuration value.

E.g. param.value is a Boolean (True|False), but the configuration value is true|false


Previous behaviour:
```
$ pcluster create testcluster -t testcluster
Beginning cluster creation for cluster: testcluster
ERROR: The configuration parameter 'disable_hyperthreading' has an invalid value 'True'
cfn_scheduler_slots cannot be set in addition to disable_hyperthreading = true
```

Current behaviour:
```
$ pcluster create testcluster -t testcluster
Beginning cluster creation for cluster: testcluster
ERROR: The configuration parameter 'disable_hyperthreading' generated the following errors:
cfn_scheduler_slots cannot be set in addition to disable_hyperthreading = true
```

See: https://github.com/aws/aws-parallelcluster/issues/1540