### PR TITLE
Release 2.5.1: back-port enhancements to integ-tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,8 @@ CHANGELOG
 
 **ENHANCEMENTS**
 
-* Add ``--show-url`` flag to ``pcluster dcv`` command in order to generate a one-time URL that can be used to start
-  a DCV session. This unblocks the usage of DCV when the browser cannot be launched automatically.
+* Add ``--show-url`` flag to ``pcluster dcv connect`` command in order to generate a one-time URL that can be used to
+  start a DCV session. This unblocks the usage of DCV when the browser cannot be launched automatically.
 
 **CHANGES**
 

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -42,6 +42,7 @@ from utils import (
     delete_s3_bucket,
     random_alphanumeric,
     set_credentials,
+    set_logger_formatter,
     to_snake_case,
     unset_credentials,
 )
@@ -109,7 +110,12 @@ def pytest_configure(config):
 def pytest_runtest_call(item):
     """Called to execute the test item."""
     _add_properties_to_report(item)
+    set_logger_formatter(logging.Formatter(fmt=f"%(asctime)s - %(levelname)s - {item.name} - %(module)s - %(message)s"))
     logging.info("Running test " + item.name)
+
+
+def pytest_runtest_logfinish(nodeid, location):
+    set_logger_formatter(logging.Formatter(fmt="%(asctime)s - %(levelname)s - %(module)s - %(message)s"))
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -51,7 +51,14 @@ class RemoteCommandExecutor:
             logging.warning("Exception raised when closing remote ssh client: {0}".format(e))
 
     def run_remote_command(
-        self, command, log_error=True, additional_files=None, raise_on_error=True, login_shell=True, hide=False
+        self,
+        command,
+        log_error=True,
+        additional_files=None,
+        raise_on_error=True,
+        login_shell=True,
+        hide=False,
+        log_output=False,
     ):
         """
         Execute remote command on the cluster master node.
@@ -62,6 +69,7 @@ class RemoteCommandExecutor:
         :param raise_on_error: if True raises a RemoteCommandExecutionError on failures
         :param login_shell: if True prepends /bin/bash --login -c to the given command
         :param hide: do not print command output to the local stdout
+        :param log_output: log the command output.
         :return: result of the execution.
         """
         if isinstance(command, list):
@@ -74,6 +82,8 @@ class RemoteCommandExecutor:
         result = self.__connection.run(command, warn=True, pty=True, hide=hide)
         result.stdout = "\n".join(result.stdout.splitlines())
         result.stderr = "\n".join(result.stderr.splitlines())
+        if log_output:
+            logging.info("Command output:\n%s", result.stdout)
         if result.failed and raise_on_error:
             if log_error:
                 logging.error(

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 import boto3
 
-from assertpy import assert_that
+from assertpy import assert_that, soft_assertions
 from tests.common.scaling_common import get_compute_nodes_allocation
 from time_utils import minutes
 
@@ -63,9 +63,21 @@ def assert_scaling_worked(
         + minutes(estimated_scaleup_time)
         + minutes(max_scaledown_time),
     )
-    if assert_asg:
-        assert_that(max(asg_capacity_time_series)).is_equal_to(expected_max)
-        assert_that(asg_capacity_time_series[-1]).is_equal_to(expected_final)
-    if assert_scheduler:
-        assert_that(max(compute_nodes_time_series)).is_equal_to(expected_max)
-        assert_that(compute_nodes_time_series[-1]).is_equal_to(expected_final)
+
+    with soft_assertions():
+        if assert_asg:
+            asg_capacity_time_series_str = f"asg_capacity_time_series={asg_capacity_time_series}"
+            assert_that(max(asg_capacity_time_series)).described_as(asg_capacity_time_series_str).is_equal_to(
+                expected_max
+            )
+            assert_that(asg_capacity_time_series[-1]).described_as(asg_capacity_time_series_str).is_equal_to(
+                expected_final
+            )
+        if assert_scheduler:
+            compute_nodes_time_series_str = f"compute_nodes_time_series={compute_nodes_time_series}"
+            assert_that(max(compute_nodes_time_series)).described_as(compute_nodes_time_series_str).is_equal_to(
+                expected_max
+            )
+            assert_that(compute_nodes_time_series[-1]).described_as(compute_nodes_time_series_str).is_equal_to(
+                expected_final
+            )

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -118,7 +118,7 @@ class AWSBatchCommands(SchedulerCommands):
         stop_max_delay=minutes(15),
     )
     def wait_job_completed(self, job_id):  # noqa: D102
-        result = self._remote_command_executor.run_remote_command("awsbstat -d {0}".format(job_id))
+        result = self._remote_command_executor.run_remote_command("awsbstat -d {0}".format(job_id), log_output=True)
         return re.findall(r"status\s+: (.+)", result.stdout)
 
     def get_job_exit_status(self, job_id):  # noqa: D102

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -14,7 +14,7 @@ import logging
 import pytest
 from retrying import retry
 
-from assertpy import assert_that
+from assertpy import assert_that, soft_assertions
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
 from tests.common.assertions import assert_instance_replaced_or_terminating, assert_no_errors_in_logs
 from tests.common.compute_logs_common import wait_compute_log
@@ -128,18 +128,19 @@ def _assert_scaling_works(
     actual_compute_nodes_min = min(
         compute_nodes_time_series[compute_nodes_time_series.index(actual_compute_nodes_max) :]  # noqa E203
     )
-    assert_that(actual_asg_capacity_min).described_as(
-        "actual asg min capacity does not match the expected one"
-    ).is_equal_to(expected_asg_capacity_min)
-    assert_that(actual_asg_capacity_max).described_as(
-        "actual asg max capacity does not match the expected one"
-    ).is_equal_to(expected_asg_capacity_max)
-    assert_that(actual_compute_nodes_min).described_as(
-        "actual number of min compute nodes does not match the expected one"
-    ).is_equal_to(expected_compute_nodes_min)
-    assert_that(actual_compute_nodes_max).described_as(
-        "actual number of max compute nodes does not match the expected one"
-    ).is_equal_to(expected_compute_nodes_max)
+    with soft_assertions():
+        assert_that(actual_asg_capacity_min).described_as(
+            "actual asg min capacity does not match the expected one"
+        ).is_equal_to(expected_asg_capacity_min)
+        assert_that(actual_asg_capacity_max).described_as(
+            "actual asg max capacity does not match the expected one"
+        ).is_equal_to(expected_asg_capacity_max)
+        assert_that(actual_compute_nodes_min).described_as(
+            "actual number of min compute nodes does not match the expected one"
+        ).is_equal_to(expected_compute_nodes_min)
+        assert_that(actual_compute_nodes_max).described_as(
+            "actual number of max compute nodes does not match the expected one"
+        ).is_equal_to(expected_compute_nodes_max)
 
 
 def _assert_test_jobs_completed(remote_command_executor, max_jobs_exec_time):

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -208,3 +208,8 @@ def unset_credentials():
         del os.environ["AWS_SECRET_ACCESS_KEY"]
     if "AWS_SESSION_TOKEN" in os.environ:
         del os.environ["AWS_SESSION_TOKEN"]
+
+
+def set_logger_formatter(formatter):
+    for handler in logging.getLogger().handlers:
+        handler.setFormatter(formatter)


### PR DESCRIPTION
Back-port a set of enhancements to integ-tests and changelog. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
