### PR TITLE
Improve dcv connect command by retrying in case of errors

### DIFF
--- a/cli/pcluster/dcv/connect.py
+++ b/cli/pcluster/dcv/connect.py
@@ -87,15 +87,14 @@ def dcv_connect(args):
     url = "https://{IP}:{PORT}?authToken={TOKEN}#{SESSION_ID}".format(
         IP=master_ip, PORT=dcv_server_port, TOKEN=dcv_session_token, SESSION_ID=dcv_session_id
     )
+    url_message = "Please use the following one-time URL in your browser within 30 seconds:\n{0}".format(url)
 
     if args.show_url:
-        LOGGER.info("Please use the following one-time URL in your browser within 30 seconds:\n{0}".format(url))
+        LOGGER.info(url_message)
         return
 
     try:
-        webbrowser.open_new(url)
-    except webbrowser.Error:
-        LOGGER.info(
-            "Unable to open the Web browser. "
-            "Please use the following URL in your browser within 30 seconds:\n{0}".format(url)
-        )
+        if not webbrowser.open_new(url):
+            raise webbrowser.Error("Unable to open the Web browser.")
+    except webbrowser.Error as e:
+        LOGGER.info("{0}\n{1}".format(e, url_message))

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -463,3 +463,25 @@ def get_master_ip_and_username(cluster_name):
 
 def get_cli_log_file():
     return os.path.expanduser(os.path.join("~", ".parallelcluster", "pcluster-cli.log"))
+
+
+def retry(func, func_args, attempts=1, wait=0):
+    """
+    Call function and re-execute it if it raises an Exception.
+
+    :param func: the function to execute.
+    :param func_args: the positional arguments of the function.
+    :param attempts: the maximum number of attempts. Default: 1.
+    :param wait: delay between attempts. Default: 0.
+    :returns: the result of the function.
+    """
+    while attempts:
+        try:
+            return func(*func_args)
+        except Exception as e:
+            attempts -= 1
+            if not attempts:
+                raise e
+
+            LOGGER.debug("{0}, retrying in {1} seconds..".format(e, wait))
+            time.sleep(wait)

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -422,7 +422,7 @@ def _get_master_server_ip(stack_name):
         ip_address = instance.get("PrivateIpAddress")
     state = instance.get("State").get("Name")
     if state != "running" or ip_address is None:
-        error("MasterServer: %s\nCannot get ip address.", state.upper())
+        error("MasterServer: {0}\nCannot get ip address.".format(state.upper()))
     return ip_address
 
 


### PR DESCRIPTION
* Fix error message when unable to get ip address
* Add retry to the `retrieve_dcv_session_url` function. It could happen that the dcv session hasn't started yet so we have to retry.
* Show url message when `webbrowser.open_new` returns `False`

## Unable to connect to the session
### Previous behaviour:
```
$ pcluster dcv connect testenv --key-path key
ERROR: Something went wrong during DCV connection.
ERROR: Unable to obtain the Request Token from the NICE DCV external authenticator.. Wrong JSON.
```

### Current behaviour
It tries 4 times before failing, then: 
```
$ pcluster dcv connect testenv --key-path key
ERROR: Something went wrong during DCV connection.
ERROR: Unable to obtain the Request Token from the NICE DCV external authenticator.. Wrong JSON.

Please check the logs in the /var/log/parallelcluster/ folder of the master instance and submit an issue https://github.com/aws/aws-parallelcluster/issues.
```

## Unable to open a browser (e.g. cloud9 ide)
### Previous behaviour:
No answer from the cli:
```
$ pcluster dcv connect testenv --key-path key 
```

### Current behaviour:
```
$ pcluster dcv connect testenv --key-path key 
Unable to open the Web browser.
Please use the following one-time URL in your browser within 30 seconds:
https://url
```