### PR TITLE
EFS - Add logic to create additional mount target in compute subnet

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -12,9 +12,9 @@ from future.moves.collections import OrderedDict
 
 from pcluster.config.param_types import (
     AdditionalIamPoliciesParam,
-    AvailabilityZoneParam,
     BoolParam,
     ClusterSection,
+    ComputeAvailabilityZoneParam,
     DisableHyperThreadingParam,
     EBSSettingsParam,
     EFSSection,
@@ -23,6 +23,7 @@ from pcluster.config.param_types import (
     IntParam,
     JsonParam,
     MaintainInitialSizeParam,
+    MasterAvailabilityZoneParam,
     QueueSizeParam,
     Section,
     SettingsParam,
@@ -205,8 +206,12 @@ VPC = {
         },
         "master_availability_zone": {
             # NOTE: this is not exposed as a configuration parameter
-            "type": AvailabilityZoneParam,
+            "type": MasterAvailabilityZoneParam,
             "cfn_param_mapping": "AvailabilityZone",
+        },
+        "compute_availability_zone": {
+            # NOTE: this is not exposed as a configuration parameter
+            "type": ComputeAvailabilityZoneParam,
         }
     },
 }

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -689,6 +689,26 @@ class AdditionalIamPoliciesParam(CommaSeparatedParam):
 
 class AvailabilityZoneParam(Param):
     """
+    Base class to manage availability_zone internal attribute.
+
+    This parameter is not exposed as configuration parameter in the file but it exists as CFN parameter
+    and it is used for master_availability_zone and compute_availability_zone.
+    """
+
+    def _init_az(self, config_parser, subnet_parameter):
+        section_name = _get_file_section_name(self.section_key, self.section_label)
+        if config_parser.has_option(section_name, subnet_parameter):
+            subnet_id = config_parser.get(section_name, subnet_parameter)
+            self.value = get_avail_zone(subnet_id)
+            self._check_allowed_values()
+
+    def to_file(self, config_parser, write_defaults=False):
+        """Do nothing, because master_availability_zone it is an internal parameter, not exposed in the config file."""
+        pass
+
+
+class MasterAvailabilityZoneParam(AvailabilityZoneParam):
+    """
     Class to manage master_availability_zone internal attribute.
 
     This parameter is not exposed as configuration parameter in the file but it exists as CFN parameter
@@ -697,17 +717,24 @@ class AvailabilityZoneParam(Param):
 
     def from_file(self, config_parser):
         """Initialize the Availability zone of the cluster by checking the Master Subnet."""
-        section_name = _get_file_section_name(self.section_key, self.section_label)
-        if config_parser.has_option(section_name, "master_subnet_id"):
-            master_subnet_id = config_parser.get(section_name, "master_subnet_id")
-            self.value = get_avail_zone(master_subnet_id)
-            self._check_allowed_values()
+        self._init_az(config_parser, "master_subnet_id")
 
         return self
 
-    def to_file(self, config_parser, write_defaults=False):
-        """Do nothing, because master_availability_zone it is an internal parameter, not exposed in the config file."""
-        pass
+
+class ComputeAvailabilityZoneParam(AvailabilityZoneParam):
+    """
+    Class to manage compute_availability_zone internal attribute.
+
+    This parameter is not exposed as configuration parameter in the file but it exists as CFN parameter
+    and it is used during EFS conversion and validation.
+    """
+
+    def from_file(self, config_parser):
+        """Initialize the Availability zone of the cluster by checking the Compute Subnet."""
+        self._init_az(config_parser, "compute_subnet_id")
+
+        return self
 
 
 class DisableHyperThreadingParam(BoolParam):
@@ -1238,18 +1265,28 @@ class EFSSection(Section):
                 cfn_items.append(param.get_cfn_value())
 
         if cfn_items[0] == "NONE":
-            efs_section_valid = False
+            master_mt_valid = False
+            compute_mt_valid = False
+            master_avail_zone = "fake_az1"
+            compute_avail_zone = "fake_az2"
             # empty dict or first item is NONE --> set all values to NONE
             cfn_items = ["NONE"] * len(self.definition.get("params"))
         else:
             # add another CFN param that will identify if create or not a Mount Target for the given EFS FS Id
             master_avail_zone = self.pcluster_config.get_master_availability_zone()
-            mount_target_id = get_efs_mount_target_id(
+            master_mount_target_id = get_efs_mount_target_id(
                 efs_fs_id=self.get_param_value("efs_fs_id"), avail_zone=master_avail_zone
             )
-            efs_section_valid = bool(mount_target_id)
+            compute_avail_zone = self.pcluster_config.get_compute_availability_zone()
+            compute_mount_target_id = get_efs_mount_target_id(
+                efs_fs_id=self.get_param_value("efs_fs_id"), avail_zone=compute_avail_zone
+            )
+            master_mt_valid = bool(master_mount_target_id)
+            compute_mt_valid = bool(compute_mount_target_id)
 
-        cfn_items.append("Valid" if efs_section_valid else "NONE")
+        cfn_items.append("Valid" if master_mt_valid else "NONE")
+        # Do not create additional compute mount target if compute and master subnet in the same AZ
+        cfn_items.append("Valid" if compute_mt_valid or (master_avail_zone == compute_avail_zone) else "NONE")
         cfn_params[cfn_converter] = ",".join(cfn_items)
 
         return cfn_params

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -332,6 +332,10 @@ class PclusterConfig(object):
         """Get the Availability zone of the Master Subnet."""
         return self.get_section("vpc").get_param_value("master_availability_zone")
 
+    def get_compute_availability_zone(self):
+        """Get the Availability zone of the Compute Subnet."""
+        return self.get_section("vpc").get_param_value("compute_availability_zone")
+
     def __check_account_capacity(self):  # noqa: C901
         """Try to launch the requested number of instances to verify Account limits."""
         cluster_section = self.get_section("cluster")

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -32,6 +32,7 @@ DEFAULT_VPC_DICT = {
     "use_public_ips": True,
     "vpc_security_group_id": None,
     "master_availability_zone": None,
+    "compute_availability_zone": None,
 }
 
 DEFAULT_EBS_DICT = {
@@ -187,7 +188,7 @@ DEFAULT_EBS_CFN_PARAMS = {
     "EBSVolumeId": "NONE,NONE,NONE,NONE,NONE",
 }
 
-DEFAULT_EFS_CFN_PARAMS = {"EFSOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
+DEFAULT_EFS_CFN_PARAMS = {"EFSOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
 DEFAULT_RAID_CFN_PARAMS = {"RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
@@ -256,7 +257,7 @@ DEFAULT_CLUSTER_CFN_PARAMS = {
     "EBSKMSKeyId": "NONE,NONE,NONE,NONE,NONE",
     "EBSVolumeId": "NONE,NONE,NONE,NONE,NONE",
     # efs
-    "EFSOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+    "EFSOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # raid
     "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # fsx

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -42,7 +42,7 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
                 "EBSSnapshotId": "NONE, NONE, NONE, NONE, NONE",
                 "EBSVolumeId": "NONE, NONE, NONE, NONE, NONE",
                 "EC2IAMRoleName": "NONE",
-                "EFSOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE",
+                "EFSOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE",
                 "EncryptedEphemeral": "false",
                 "EphemeralDir": "/scratch",
                 "ExtraJson": "{}",
@@ -222,7 +222,7 @@ def test_cluster_section_from_241_cfn(mocker, cfn_params_dict, expected_section_
                 "EBSSnapshotId": "NONE, NONE, NONE, NONE, NONE",
                 "EBSVolumeId": "NONE, NONE, NONE, NONE, NONE",
                 "EC2IAMRoleName": "NONE",
-                "EFSOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE",
+                "EFSOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE",
                 "EncryptedEphemeral": "false",
                 "EphemeralDir": "/scratch",
                 "ExtraJson": "{}",
@@ -307,7 +307,7 @@ def test_cluster_section_from_240_cfn(mocker, cfn_params_dict, expected_section_
                 "EBSSnapshotId": "NONE,NONE,NONE,NONE,NONE",
                 "EBSVolumeId": "NONE,NONE,NONE,NONE,NONE",
                 "EC2IAMRoleName": "NONE",
-                "EFSOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE",
+                "EFSOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE",
                 "EncryptedEphemeral": "false",
                 "EphemeralDir": "/scratch",
                 "ExtraJson": "{}",
@@ -392,7 +392,7 @@ def test_cluster_section_from_231_cfn(mocker, cfn_params_dict, expected_section_
                 "EBSSnapshotId": "NONE, NONE, NONE, NONE, NONE",
                 "EBSVolumeId": "NONE, NONE, NONE, NONE, NONE",
                 "EC2IAMRoleName": "NONE",
-                "EFSOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE",
+                "EFSOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE",
                 "EncryptedEphemeral": "false",
                 "EphemeralDir": "/scratch",
                 "ExtraJson": "{}",
@@ -1050,7 +1050,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "AvailabilityZone": "mocked_avail_zone",
                     "VPCId": "vpc-12345678",
                     "MasterSubnetId": "subnet-12345678",
-                    "EFSOptions": "efs,NONE,generalPurpose,NONE,NONE,false,bursting,Valid",
+                    "EFSOptions": "efs,NONE,generalPurpose,NONE,NONE,false,bursting,Valid,NONE",
                 },
             ),
         ),
@@ -1193,7 +1193,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "EBSKMSKeyId": "kms_key,NONE,NONE,NONE,NONE",
                     "EBSVolumeId": "vol-12345678,NONE,NONE,NONE,NONE",
                     # efs
-                    "EFSOptions": "efs,NONE,generalPurpose,NONE,NONE,false,bursting,Valid",
+                    "EFSOptions": "efs,NONE,generalPurpose,NONE,NONE,false,bursting,Valid,NONE",
                     # raid
                     "RAIDOptions": "raid,NONE,NONE,gp2,20,100,false,NONE",
                     # fsx
@@ -1246,7 +1246,9 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "ScaleDownIdleTime": "15",
                     # vpc
                     "VPCId": "vpc-12345678",
+                    #
                     "MasterSubnetId": "subnet-12345678",
+                    "ComputeSubnetId": "subnet-23456789",
                     # ebs
                     "NumberOfEBSVol": "1",
                     "SharedDir": "ebs1,NONE,NONE,NONE,NONE",
@@ -1257,7 +1259,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "EBSKMSKeyId": "kms_key,NONE,NONE,NONE,NONE",
                     "EBSVolumeId": "vol-12345678,NONE,NONE,NONE,NONE",
                     # efs
-                    "EFSOptions": "efs,NONE,generalPurpose,NONE,NONE,false,bursting,Valid",
+                    "EFSOptions": "efs,NONE,generalPurpose,NONE,NONE,false,bursting,Valid,NONE",
                     # raid
                     "RAIDOptions": "raid,NONE,NONE,gp2,20,100,false,NONE",
                     # fsx
@@ -1271,8 +1273,14 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
 )
 def test_cluster_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
     """Unit tests for parsing Cluster related options."""
-    mocker.patch("pcluster.config.param_types.get_efs_mount_target_id", return_value="mount_target_id")
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch(
+        "pcluster.config.param_types.get_efs_mount_target_id",
+        side_effect=lambda efs_fs_id, avail_zone: "master_mt" if avail_zone == "mocked_avail_zone" else None,
+    )
+    mocker.patch(
+        "pcluster.config.param_types.get_avail_zone",
+        side_effect=lambda subnet: "mocked_avail_zone" if subnet == "subnet-12345678" else "some_other_az",
+    )
     mocker.patch(
         "pcluster.config.validators.get_supported_features",
         return_value={"instances": ["t2.large"], "baseos": ["ubuntu1804"], "schedulers": ["slurm"]},

--- a/cli/tests/pcluster/config/test_section_cluster/test_cluster_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_cluster/test_cluster_from_file_to_cfn/pcluster.config.ini
@@ -59,6 +59,11 @@ enable_intel_hpc_platform = true
 vpc_id = vpc-12345678
 master_subnet_id = subnet-12345678
 
+[vpc withcompute]
+vpc_id = vpc-12345678
+master_subnet_id = subnet-12345678
+compute_subnet_id = subnet-23456789
+
 # Test: vpc settings
 [cluster vpc]
 vpc_settings = vpc
@@ -233,7 +238,7 @@ shared_dir = fsx
 # Test: custom values with a random order and *_settings on top
 [cluster random-order]
 scaling_settings = scaling
-vpc_settings = default
+vpc_settings = withcompute
 ebs_settings = ebs1
 efs_settings = default
 raid_settings = default

--- a/cli/tests/pcluster/config/test_section_efs/test_efs_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_efs/test_efs_from_file_to_cfn/pcluster.config.ini
@@ -13,6 +13,7 @@ vpc_settings = default
 [vpc default]
 # EFS conversion requires master subnet id to check mount-target avail zone
 master_subnet_id = subnet-12345678
+compute_subnet_id = subnet-23456789
 
 [efs test1]
 shared_dir = NONE

--- a/cli/tests/pcluster/delete/test_pcluster_delete.py
+++ b/cli/tests/pcluster/delete/test_pcluster_delete.py
@@ -64,13 +64,13 @@ def test_delete(mocker, keep_logs, stack_exists, warn_call_count, persist_called
 @pytest.mark.parametrize(
     "stacks,template",
     [
-        ([], {},),
+        ([], {}),
         (
             [{"StackName": FAKE_STACK_NAME}, {"StackName": "substack_one"}],
             {"Resources": {"key": {"DeletionPolicy": "Retain"}}},
         ),
-        ([{"StackName": FAKE_STACK_NAME}], {"Resources": {"key": {"DeletionPolicy": "Don't Retain"}}},),
-        ([{"StackName": FAKE_STACK_NAME}], {"Resources": {"key": {"DeletionPolicy": "Delete"}}},),
+        ([{"StackName": FAKE_STACK_NAME}], {"Resources": {"key": {"DeletionPolicy": "Don't Retain"}}}),
+        ([{"StackName": FAKE_STACK_NAME}], {"Resources": {"key": {"DeletionPolicy": "Delete"}}}),
     ],
 )
 def test_persist_cloudwatch_log_groups(mocker, stacks, template):

--- a/cli/tests/pcluster/utils/test_pcluster_utils.py
+++ b/cli/tests/pcluster/utils/test_pcluster_utils.py
@@ -153,7 +153,7 @@ def test_get_cluster_substacks(mocker, resources):  # noqa: D202
 def test_stack_exists(boto3_stubber, response, is_error):
     """Verify that utils.stack_exists behaves as expected."""
     mocked_requests = [
-        MockedBoto3Request(method="describe_stacks", response=response, expected_params={"StackName": FAKE_STACK_NAME},)
+        MockedBoto3Request(method="describe_stacks", response=response, expected_params={"StackName": FAKE_STACK_NAME})
     ]
     boto3_stubber("cloudformation", mocked_requests, generate_errors=is_error)
     should_exist = not is_error
@@ -172,7 +172,7 @@ def test_stack_exists(boto3_stubber, response, is_error):
                     "ResourceType": "resource_type",
                     "Timestamp": 0,
                     "ResourceStatus": "resource_status",
-                },
+                }
             ],
             None,
         ),

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -316,9 +316,9 @@
       "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },
     "EFSOptions": {
-      "Description": "Comma separated list of efs related options, 8 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,valid_existing_MTorNot]",
+      "Description": "Comma separated list of efs related options, 9 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,exists_valid_master_mt,exists_valid_compute_mt]",
       "Type": "String",
-      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
+      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },
     "Cores": {
       "Description": "Comma seperated string of [master cores], [compute cores]. If set to -1,-1 no CpuOptions are set.",
@@ -1175,8 +1175,11 @@
               }
             ]
           },
-          "SubnetId": {
+          "MasterSubnetId": {
             "Ref": "MasterSubnetId"
+          },
+          "ComputeSubnetId": {
+            "Ref": "ComputeSubnetId"
           }
         },
         "TemplateURL": {

--- a/cloudformation/efs-substack.cfn.json
+++ b/cloudformation/efs-substack.cfn.json
@@ -1,5 +1,15 @@
 {
   "Conditions": {
+    "CreateComputeMT": {
+      "Fn::And": [
+        {
+          "Condition": "UseUserProvidedComputeSubnet"
+        },
+        {
+          "Condition": "NoMTInComputeAZ"
+        }
+      ]
+    },
     "CreateEFS": {
       "Fn::And": [
         {
@@ -34,7 +44,7 @@
         }
       ]
     },
-    "CreateMT": {
+    "CreateMasterMT": {
       "Fn::And": [
         {
           "Fn::Not": [
@@ -66,6 +76,19 @@
             "NONE"
           ]
         }
+      ]
+    },
+    "NoMTInComputeAZ": {
+      "Fn::Equals": [
+        {
+          "Fn::Select": [
+            "8",
+            {
+              "Ref": "EFSOptions"
+            }
+          ]
+        },
+        "NONE"
       ]
     },
     "UseEFSEncryption": {
@@ -175,6 +198,18 @@
           ]
         }
       ]
+    },
+    "UseUserProvidedComputeSubnet": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "ComputeSubnetId"
+            },
+            "NONE"
+          ]
+        }
+      ]
     }
   },
   "Outputs": {
@@ -200,19 +235,53 @@
   },
   "Parameters": {
     "ComputeSecurityGroup": {
-      "Description": "SecurityGroup for Mount Target",
-      "Type": "AWS::EC2::SecurityGroup::Id"
+      "Description": "Security Group for Mount Target",
+      "Type": "String"
+    },
+    "ComputeSubnetId": {
+      "Description": "User provided compute subnet id. Will be use to create compute mount target if needed.",
+      "Type": "String"
     },
     "EFSOptions": {
-      "Description": "Comma separated list of efs related options, 8 parameters in total",
+      "Description": "Comma separated list of efs related options, 9 parameters in total",
       "Type": "CommaDelimitedList"
     },
-    "SubnetId": {
-      "Description": "SubnetId for Mount Target",
+    "MasterSubnetId": {
+      "Description": "Master subnet id for master mount target",
       "Type": "String"
     }
   },
   "Resources": {
+    "ComputeSubnetEFSMT": {
+      "Condition": "CreateComputeMT",
+      "Properties": {
+        "FileSystemId": {
+          "Fn::If": [
+            "CreateEFS",
+            {
+              "Ref": "EFSFS"
+            },
+            {
+              "Fn::Select": [
+                "1",
+                {
+                  "Ref": "EFSOptions"
+                }
+              ]
+            }
+          ]
+        },
+        "SecurityGroups": [
+          {
+            "Ref": "ComputeSecurityGroup"
+          }
+        ],
+        "SubnetId": {
+          "Ref": "ComputeSubnetId"
+        }
+      },
+      "Type": "AWS::EFS::MountTarget"
+    },
     "EFSFS": {
       "Condition": "CreateEFS",
       "Properties": {
@@ -299,8 +368,8 @@
       },
       "Type": "AWS::EFS::FileSystem"
     },
-    "EFSMT": {
-      "Condition": "CreateMT",
+    "MasterSubnetEFSMT": {
+      "Condition": "CreateMasterMT",
       "Properties": {
         "FileSystemId": {
           "Fn::If": [
@@ -324,7 +393,7 @@
           }
         ],
         "SubnetId": {
-          "Ref": "SubnetId"
+          "Ref": "MasterSubnetId"
         }
       },
       "Type": "AWS::EFS::MountTarget"

--- a/tests/integration-tests/network_template_builder.py
+++ b/tests/integration-tests/network_template_builder.py
@@ -44,6 +44,7 @@ class SubnetConfig(NamedTuple):
     cidr: object = None
     map_public_ip_on_launch: bool = True
     has_nat_gateway: bool = True
+    availability_zone: str = None
     default_gateway: Gateways = Gateways.INTERNET_GATEWAY
 
     def tags(self):
@@ -199,7 +200,7 @@ class NetworkTemplateBuilder:
             VpcId=Ref(vpc),
             MapPublicIpOnLaunch=subnet_config.map_public_ip_on_launch,
             Tags=subnet_config.tags(),
-            AvailabilityZone=self.__availability_zone,
+            AvailabilityZone=subnet_config.availability_zone or self.__availability_zone,
             DependsOn=additional_vpc_cidr_blocks,
         )
         self.__template.add_resource(subnet)

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -432,11 +432,7 @@ def get_config_param_vals(cw_logging_enabled):
         )
     )
     queue_size = int(environ.get("CW_LOGGING_QUEUE_SIZE", 1))
-    return {
-        "enable": str(cw_logging_enabled).lower(),
-        "retention_days": retention_days,
-        "queue_size": queue_size,
-    }
+    return {"enable": str(cw_logging_enabled).lower(), "retention_days": retention_days, "queue_size": queue_size}
 
 
 @pytest.mark.parametrize("cw_logging_enabled", [True, False])

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -1,0 +1,84 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+
+import pytest
+
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+from tests.common.schedulers_common import get_scheduler_commands
+from tests.storage.storage_common import verify_directory_correctly_shared
+
+
+# For EFS tests, only use regions defined in AVAILABILITY_ZONE_OVERRIDES in conftest
+# Otherwise we cannot control the AZs of the subnets to properly test EFS.
+@pytest.mark.regions(["us-east-1"])
+@pytest.mark.instances(["c5.xlarge"])
+@pytest.mark.schedulers(["slurm", "awsbatch"])
+@pytest.mark.os(["alinux"])
+@pytest.mark.usefixtures("region", "os", "instance")
+def test_efs_compute_az(scheduler, pcluster_config_reader, clusters_factory):
+    """
+    Test when compute subnet is in a different AZ from master subnet.
+
+    A compute mount target should be created and the efs correctly mounted on compute.
+    """
+    mount_dir = "efs_mount_dir"
+    cluster_config = pcluster_config_reader(mount_dir=mount_dir)
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    mount_dir = "/" + mount_dir
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+    _test_efs_correctly_mounted(remote_command_executor, mount_dir)
+    _test_efs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
+
+
+@pytest.mark.regions(["us-east-1"])
+@pytest.mark.instances(["c5.xlarge"])
+@pytest.mark.schedulers(["slurm", "awsbatch"])
+@pytest.mark.os(["alinux"])
+@pytest.mark.usefixtures("region", "os", "instance")
+def test_efs_same_az(scheduler, pcluster_config_reader, clusters_factory):
+    """
+    Test when compute subnet is in the same AZ as master subnet.
+
+    No compute mount point needed and the efs correctly mounted on compute.
+    """
+    mount_dir = "efs_mount_dir"
+    cluster_config = pcluster_config_reader(mount_dir=mount_dir)
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    mount_dir = "/" + mount_dir
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+    _test_efs_correctly_mounted(remote_command_executor, mount_dir)
+    _test_efs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
+
+
+def _test_efs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands):
+    logging.info("Testing efs correctly mounted on compute nodes")
+    verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
+
+
+def _test_efs_correctly_mounted(remote_command_executor, mount_dir):
+    logging.info("Testing ebs {0} is correctly mounted".format(mount_dir))
+    result = remote_command_executor.run_remote_command("df | grep '{0}'".format(mount_dir))
+    assert_that(result.stdout).contains(mount_dir)
+
+    result = remote_command_executor.run_remote_command("cat /etc/fstab")
+    assert_that(result.stdout).matches(
+        (
+            r".* {mount_dir} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,"
+            r"timeo=30,retrans=2,noresvport,_netdev 0 0"
+        ).format(mount_dir=mount_dir)
+    )

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.ini
@@ -1,0 +1,31 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+{% if scheduler == "awsbatch" %}
+min_vcpus = 4
+desired_vcpus = 4
+{% else %}
+initial_queue_size = 1
+maintain_initial_size = true
+{% endif %}
+efs_settings = efs
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+# This compute subnet would be in a different AZ than master for regions defined in AVAILABILITY_ZONE_OVERRIDES
+# See conftest for details
+compute_subnet_id = {{ private_additional_cidr_subnet_id }}
+
+[efs efs]
+shared_dir = {{ mount_dir }}

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.ini
@@ -1,24 +1,29 @@
 [global]
-cluster_template = awsbatch
+cluster_template = default
 
 [aws]
 aws_region_name = {{ region }}
 
-[cluster awsbatch]
+[cluster default]
 base_os = {{ os }}
 key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
-scheduler = awsbatch
+scheduler = {{ scheduler }}
 master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
-min_vcpus = 2
-desired_vcpus = 2
-max_vcpus = 40
+{% if scheduler == "awsbatch" %}
+min_vcpus = 4
+desired_vcpus = 4
+{% else %}
+initial_queue_size = 1
+maintain_initial_size = true
+{% endif %}
+efs_settings = efs
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
 
-[efs custom_efs]
-shared_dir = efs
+[efs efs]
+shared_dir = {{ mount_dir }}


### PR DESCRIPTION
* EFS can only be mounted if there is a mount target in the AZ of the instance's subnet.
* Previously we only create mount target in the master's subnet. In some cases the compute subnet could be in a different AZ than the master subnet, which means EFS cannot be mounted to the compute in this case.
* Added logic to create mount target in the AZ of the compute subnet, if needed.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
