### PR TITLE
Fix and Test PclusterConfig behaviour at runtime

### DIFF
--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -659,8 +659,10 @@ class AdditionalIamPoliciesParam(CommaSeparatedParam):
         Conditional policies are automatically added if appropriate.
         """
         super(AdditionalIamPoliciesParam, self).from_file(config_parser)
+        # Cluster section name in config file
+        section_name = _get_file_section_name(self.section_key, self.section_label)
         for rule in self.policy_inclusion_rules:
-            if rule.policy_is_required(self.pcluster_config) and rule.get_policy() not in self.value:
+            if rule.policy_is_required(config_parser, section_name) and rule.get_policy() not in self.value:
                 self.value.append(rule.get_policy())
         self.value = sorted(set(self.value))
         return self

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -785,7 +785,7 @@ class SettingsParam(Param):
                     self.pcluster_config.remove_section(
                         self.referred_section_key, self.referred_section_definition.get("default_label")
                     )
-                    self.pcluster_config.add_section(section)
+                    self.pcluster_config.add_section(section, override=True)
 
         return self
 
@@ -796,7 +796,7 @@ class SettingsParam(Param):
             section = self.referred_section_type(
                 self.referred_section_definition, self.pcluster_config, section_label=self.value
             ).from_cfn_params(cfn_params)
-            self.pcluster_config.add_section(section)
+            self.pcluster_config.add_section(section, override=True)
 
         return self
 
@@ -817,7 +817,7 @@ class SettingsParam(Param):
                 section = self.referred_section_type(
                     self.referred_section_definition, self.pcluster_config, section_label=self.value
                 )
-                self.pcluster_config.add_section(section)
+                self.pcluster_config.add_section(section, override=True)
 
     def to_file(self, config_parser, write_defaults=False):
         """Convert the param value into a section in the config_parser and initialize it."""
@@ -875,7 +875,7 @@ class EBSSettingsParam(SettingsParam):
                     section = self.referred_section_type(
                         self.referred_section_definition, self.pcluster_config, section_label=section_label.strip()
                     ).from_file(config_parser=config_parser, fail_on_absence=True)
-                    self.pcluster_config.add_section(section)
+                    self.pcluster_config.add_section(section, override=True)
 
         return self
 
@@ -910,7 +910,7 @@ class EBSSettingsParam(SettingsParam):
                             ).from_cfn_value(cfn_value)
                             referred_section.add_param(param)
 
-                    self.pcluster_config.add_section(referred_section)
+                    self.pcluster_config.add_section(referred_section, override=True)
 
         self.value = ",".join(labels) if labels else None
 

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -146,7 +146,12 @@ class PclusterConfig(object):
         :param section_label: the label of the section, returns the first section if empty.
         """
         if section_label:
-            section = self.get_sections(section_key).get(section_label, None)
+            # TODO: use list instead of dict for sections with same key
+            # section = self.get_sections(section_key).get(section_label, None)
+            section = next(
+                (section for _, section in self.get_sections(section_key).items() if section.label == section_label),
+                None,
+            )
         else:
             sections = self.get_sections(section_key)
             section = next(iter(sections.values()), None) if sections else None

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -149,12 +149,9 @@ def pcluster_config_reader(test_datadir):
     The current renderer injects options for custom templates and packages in case these
     are passed to the cli and not present already in the cluster config.
     Also sanity_check is set to true by default unless explicitly set in config.
-
     :return: a _config_renderer(**kwargs) function which gets as input a dictionary of values to replace in the template
     """
-    config_file = "pcluster.config.ini"
-
-    def _config_renderer(**kwargs):
+    def _config_renderer(config_file = "pcluster.config.ini", **kwargs):
         config_file_path = os.path.join(str(test_datadir), config_file)
         # default_values = _get_default_template_values(vpc_stacks, region, request)
         file_loader = FileSystemLoader(str(test_datadir))

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -151,7 +151,8 @@ def pcluster_config_reader(test_datadir):
     Also sanity_check is set to true by default unless explicitly set in config.
     :return: a _config_renderer(**kwargs) function which gets as input a dictionary of values to replace in the template
     """
-    def _config_renderer(config_file = "pcluster.config.ini", **kwargs):
+
+    def _config_renderer(config_file="pcluster.config.ini", **kwargs):
         config_file_path = os.path.join(str(test_datadir), config_file)
         # default_values = _get_default_template_values(vpc_stacks, region, request)
         file_loader = FileSystemLoader(str(test_datadir))

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -102,7 +102,7 @@ DEFAULT_CLUSTER_DICT = {
     "spot_bid_percentage": 0,
     "proxy_server": None,
     "ec2_iam_role": None,
-    "additional_iam_policies": [],
+    "additional_iam_policies": ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"],
     "s3_read_resource": None,
     "s3_read_write_resource": None,
     "enable_efa": None,

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -198,7 +198,7 @@ def assert_section_to_cfn(mocker, section_definition, section_dict, expected_cfn
         param = param_type(section_definition.get("key"), "default", param_key, param_definition, pcluster_config)
         param.value = param_value
         section.add_param(param)
-    pcluster_config.add_section(section)
+    pcluster_config.add_section(section, override=True)
 
     cfn_params = section.to_cfn()
     assert_that(cfn_params).is_equal_to(expected_cfn_params)

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -72,6 +72,18 @@ def assert_param_validator(mocker, config_parser_dict, expected_error=None, caps
     mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
     mocker.patch.object(PclusterConfig, "_PclusterConfig__check_account_capacity")
 
+    # Mock IAM policies validator to prevent boto3 calls in tests
+    accepted_policies = [
+        "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+        "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+    ]
+
+    def mock_iam_policies_validate(self):
+        """Mock validation: just check that the policy is among the accepted ones."""
+        assert set(self.value).issubset(accepted_policies)
+
+    mocker.patch("pcluster.config.param_types.AdditionalIamPoliciesParam.validate", new=mock_iam_policies_validate)
+
     if expected_error:
         with pytest.raises(SystemExit, match=expected_error):
             _ = init_pcluster_config_from_configparser(config_parser)


### PR DESCRIPTION
- Fix AdditionalIamPoliciesParam to store loaded policies at runtime
- Fix get section by key and label when section label is updated
- Accept optional config_file parameter in pcluster_config_reader

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
