### PR TITLE
Allow Arbitrary Args in pcluster dcv connect

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -41,8 +41,8 @@ def ssh(args, extra_args):
     pcluster.ssh(args, extra_args)
 
 
-def dcv(args):
-    dcv_connect(args)
+def dcv(args, extra_args):
+    dcv_connect(args, extra_args)
 
 
 def status(args):
@@ -430,7 +430,7 @@ def main():
         if "region" in args and args.region:
             os.environ["AWS_DEFAULT_REGION"] = args.region
 
-        if args.func.__name__ == "ssh":
+        if args.func.__name__ in ["ssh", "dcv"]:
             args.func(args, extra_args)
         else:
             if extra_args:

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -44,7 +44,9 @@ def test_dcv_configuration(
     # dcv connect show url
     env = operating_system.environ.copy()
     env["AWS_DEFAULT_REGION"] = region
-    result = run_command(["pcluster", "dcv", "connect", cluster.name, "--show-url"], env=env)
+    result = run_command(
+        ["pcluster", "dcv", "connect", cluster.name, "--show-url", "-o StrictHostKeyChecking=no"], env=env
+    )
     assert_that(result.stdout).matches(
         r"Please use the following one-time URL in your browser within 30 seconds:\n"
         r"https:\/\/(\b(?:\d{1,3}\.){3}\d{1,3}\b):" + str(dcv_authenticator_port) + r"\?authToken=(.*)"


### PR DESCRIPTION
This patch allows arbitrary ssh arguments to get passed into dcv connect.

```bash
pcluster dcv connect mycluster -o StrictHostKeyChecking=no
```

Which becomes:

```bash
ssh centos@54.89.10.53 -o StrictHostKeyChecking=no  "/opt/parallelcluster/scripts/pcluster_dcv_connect.sh /shared"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
