### PR TITLE
Add timestamp literal arg to CW report function

### DIFF
--- a/tests/integration-tests/reports_generator.py
+++ b/tests/integration-tests/reports_generator.py
@@ -21,24 +21,27 @@ from junitparser import JUnitXml
 import untangle
 
 
-def generate_cw_report(test_results_dir, namespace, aws_region, timestamp_day_start=False):
+def generate_cw_report(test_results_dir, namespace, aws_region, timestamp_day_start=False, start_timestamp=None):
     """
     Publish tests results to CloudWatch
     :param test_results_dir: dir containing the tests outputs.
     :param namespace: namespace for the CW metric.
     :param aws_region: region where to push the metric.
     :param timestamp_day_start: timestamp of the CW metric equal to the start of the current day (midnight).
+    :param start_timestamp: timestamp value to use instead of generating one
     """
     test_report_file = os.path.join(test_results_dir, "test_report.xml")
     if not os.path.isfile(test_report_file):
         generate_junitxml_merged_report(test_results_dir)
     report = generate_json_report(test_results_dir=test_results_dir, save_to_file=False)
     cw_client = boto3.client("cloudwatch", region_name=aws_region)
-    timestamp = (
-        datetime.datetime.combine(datetime.datetime.utcnow(), datetime.time())
-        if timestamp_day_start
-        else datetime.datetime.utcnow()
-    )
+
+    if start_timestamp is not None:
+        timestamp = datetime.datetime.fromtimestamp(start_timestamp)
+    elif timestamp_day_start:
+        timestamp = datetime.datetime.combine(datetime.datetime.utcnow(), datetime.time())
+    else:
+        timestamp = datetime.datetime.utcnow()
 
     for key, value in report.items():
         if key == "all":


### PR DESCRIPTION
Enable a timestamp literal to be passed in to the function used to
upload test metrics to CloudWatch.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
