### PR TITLE
Enable feature-specific CW Logging Tests

### DIFF
--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -17,6 +17,7 @@ import pytest
 
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
+from tests.cloudwatch_logging.test_cloudwatch_logging import FeatureSpecificCloudWatchLoggingTestRunner
 from utils import run_command
 
 SERVER_URL = "https://localhost"
@@ -87,6 +88,9 @@ def test_dcv_configuration(
 
     # check shared dir configuration
     _check_shared_dir(remote_command_executor, shared_dir)
+
+    # Check that logs are stored in CloudWatch as expected
+    FeatureSpecificCloudWatchLoggingTestRunner.run_tests_for_feature(cluster, scheduler, os, "dcv_enabled", region)
 
 
 def _check_auth_ko(remote_command_executor, dcv_authenticator_port, params, expected_message):

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.ini
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.ini
@@ -12,7 +12,7 @@ scheduler = {{ scheduler }}
 master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 initial_queue_size = 1
-maintain_initial_size = false
+maintain_initial_size = true
 dcv_settings = test
 shared_dir = {{ shared_dir }}
 


### PR DESCRIPTION
This commit implements the FeatureSpecificCloudWatchLoggingTestRunner
class that other integration tests can use to test how CloudWatch (CW)
logging integration is behaving with respect to only a specific feature's logs
(as opposed to validating CW logs integration for all logs that should
be collected for a given cluster).

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
