### PR TITLE
Fix and Test PclusterConfig behaviour at runtime

### DIFF
--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -1039,12 +1039,23 @@ class Section(object):
     def __init__(self, section_definition, pcluster_config, section_label=None):
         self.definition = section_definition
         self.key = section_definition.get("key")
-        self.label = section_label or self.definition.get("default_label", "")
+        self._label = section_label or self.definition.get("default_label", "")
         self.pcluster_config = pcluster_config
 
         # initialize section parameters with default values
         self.params = {}
         self._from_definition()
+
+    @property
+    def label(self):
+        """Get the section label."""
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        """Set the section label. Marks the PclusterConfig parent for refreshing if called."""
+        self._label = label
+        self.pcluster_config.refresh()
 
     def from_file(self, config_parser, fail_on_absence=False):
         """Initialize section configuration parameters by parsing config file."""

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -62,7 +62,7 @@ class PclusterConfig(object):
         """
         self.__stale = False
         self.fail_on_error = fail_on_error
-        self.sections = OrderedDict({})
+        self.__sections = OrderedDict({})
 
         # always parse the configuration file if there, to get AWS section
         self._init_config_parser(config_file, fail_on_file_absence)
@@ -137,7 +137,7 @@ class PclusterConfig(object):
         :return a dictionary containing the section
         """
         self.__refresh()
-        return self.sections.get(section_key, {})
+        return self.__sections.get(section_key, {})
 
     def get_section(self, section_key, section_label=None):
         """
@@ -170,11 +170,11 @@ class PclusterConfig(object):
 
         :param section, a Section object
         """
-        if section.key not in self.sections:
-            self.sections[section.key] = {}
+        if section.key not in self.__sections:
+            self.__sections[section.key] = {}
 
         section_label = section.label if section.label else section.definition.get("default_label", "default")
-        self.sections[section.key][section_label] = section
+        self.__sections[section.key][section_label] = section
 
     def remove_section(self, section_key, section_label):
         """
@@ -183,8 +183,8 @@ class PclusterConfig(object):
         :param section_key: the identifier of the section type
         :param section_label: the label of the section to delete.
         """
-        if section_key in self.sections:
-            self.sections[section_key].pop(section_label, None)
+        if section_key in self.__sections:
+            self.__sections[section_key].pop(section_label, None)
 
     def __init_aws_credentials(self):
         """Set credentials in the environment to be available for all the boto3 calls."""
@@ -313,12 +313,12 @@ class PclusterConfig(object):
         """When the object is marked as stale, reload the sections structure."""
         if self.__stale:
             new_sections = OrderedDict({})
-            for key, sections in self.sections.items():
+            for key, sections in self.__sections.items():
                 new_sections_map = {}
                 new_sections[key] = new_sections_map
                 for _, section in sections.items():
                     new_sections_map[section.label] = section
-            self.sections = new_sections
+            self.__sections = new_sections
 
     def refresh(self):
         """
@@ -362,7 +362,7 @@ class PclusterConfig(object):
 
     def validate(self):
         """Validate the configuration."""
-        for _, sections in self.sections.items():
+        for _, sections in self.__sections.items():
             for _, section in sections.items():
                 section.validate()
 

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -156,12 +156,9 @@ def pcluster_config_reader(test_datadir):
     The current renderer injects options for custom templates and packages in case these
     are passed to the cli and not present already in the cluster config.
     Also sanity_check is set to true by default unless explicitly set in config.
-
     :return: a _config_renderer(**kwargs) function which gets as input a dictionary of values to replace in the template
     """
-    config_file = "pcluster.config.ini"
-
-    def _config_renderer(**kwargs):
+    def _config_renderer(config_file = "pcluster.config.ini", **kwargs):
         config_file_path = os.path.join(str(test_datadir), config_file)
         # default_values = _get_default_template_values(vpc_stacks, region, request)
         file_loader = FileSystemLoader(str(test_datadir))

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -158,7 +158,8 @@ def pcluster_config_reader(test_datadir):
     Also sanity_check is set to true by default unless explicitly set in config.
     :return: a _config_renderer(**kwargs) function which gets as input a dictionary of values to replace in the template
     """
-    def _config_renderer(config_file = "pcluster.config.ini", **kwargs):
+
+    def _config_renderer(config_file="pcluster.config.ini", **kwargs):
         config_file_path = os.path.join(str(test_datadir), config_file)
         # default_values = _get_default_template_values(vpc_stacks, region, request)
         file_loader = FileSystemLoader(str(test_datadir))

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -103,7 +103,7 @@ DEFAULT_CLUSTER_DICT = {
     "spot_bid_percentage": 0,
     "proxy_server": None,
     "ec2_iam_role": None,
-    "additional_iam_policies": [],
+    "additional_iam_policies": ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"],
     "s3_read_resource": None,
     "s3_read_write_resource": None,
     "enable_efa": None,

--- a/cli/tests/pcluster/config/test_runtime.py
+++ b/cli/tests/pcluster/config/test_runtime.py
@@ -1,0 +1,27 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from pcluster.config.pcluster_config import PclusterConfig
+
+
+def test_update_section_label(pcluster_config_reader):
+    pcluster_config = PclusterConfig(
+        cluster_label="default", config_file=pcluster_config_reader(), fail_on_file_absence=True, fail_on_error=True,
+    )
+
+    ebs1 = pcluster_config.get_section("ebs", "ebs1")
+    assert ebs1
+    assert ebs1.get_param_value("shared_dir") == "ebs1"
+
+    ebs1.label = "ebs1_updated"
+    assert pcluster_config.get_section("ebs", "ebs1") is None
+    ebs1_updated = pcluster_config.get_section("ebs", "ebs1_updated")
+    assert ebs1_updated
+    assert ebs1_updated.get_param_value("shared_dir") == "ebs1"

--- a/cli/tests/pcluster/config/test_runtime/test_update_section_label/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_runtime/test_update_section_label/pcluster.config.ini
@@ -1,0 +1,27 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = false
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+ebs_settings = ebs1, ebs2
+
+[ebs ebs1]
+shared_dir = ebs1
+volume_type = io1
+volume_size = 40
+volume_iops = 200
+encrypted = true
+ebs_kms_key_id = kms_key
+ebs_volume_id = vol-12345678
+
+[ebs ebs2]
+shared_dir = ebs2
+volume_type = standard
+volume_size = 30
+volume_iops = 300
+encrypted = false
+

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -93,6 +93,7 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
                     "placement": "cluster",
                     "maintain_initial_size": True,
                     "enable_intel_hpc_platform": True,
+                    "additional_iam_policies": [],
                 },
             ),
         )
@@ -106,8 +107,14 @@ def test_cluster_section_from_250_cfn(mocker, cfn_params_dict, expected_section_
 @pytest.mark.parametrize(
     "cfn_params_dict, expected_section_dict",
     [
-        ({}, DefaultDict["cluster"].value),
-        (DefaultCfnParams["cluster"].value, DefaultDict["cluster"].value),
+        ({}, utils.merge_dicts(DefaultDict["cluster"].value, {"additional_iam_policies": []})),
+        (
+            DefaultCfnParams["cluster"].value,
+            utils.merge_dicts(
+                DefaultDict["cluster"].value,
+                {"additional_iam_policies": ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"]},
+            ),
+        ),
         # awsbatch defaults
         (
             utils.merge_dicts(DefaultCfnParams["cluster"].value, {"Scheduler": "awsbatch"}),
@@ -124,6 +131,7 @@ def test_cluster_section_from_250_cfn(mocker, cfn_params_dict, expected_section_
                     "max_queue_size": 10,
                     "maintain_initial_size": False,
                     "spot_price": 0,
+                    "additional_iam_policies": ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"],
                 },
             ),
         ),
@@ -269,6 +277,7 @@ def test_cluster_section_from_241_cfn(mocker, cfn_params_dict, expected_section_
                     "max_queue_size": 3,
                     "placement": "cluster",
                     "maintain_initial_size": True,
+                    "additional_iam_policies": [],
                 },
             ),
         )
@@ -355,6 +364,7 @@ def test_cluster_section_from_240_cfn(mocker, cfn_params_dict, expected_section_
                     "max_queue_size": 2,
                     "placement": "compute",
                     "base_os": "centos7",
+                    "additional_iam_policies": [],
                 },
             ),
         )
@@ -439,6 +449,7 @@ def test_cluster_section_from_231_cfn(mocker, cfn_params_dict, expected_section_
                     "max_queue_size": 3,
                     "placement": "cluster",
                     "base_os": "ubuntu1404",  # NOTE: We create the config with the old base_os (no longer supported)
+                    "additional_iam_policies": [],
                 },
             ),
         )
@@ -522,6 +533,7 @@ def test_cluster_section_from_210_cfn(mocker, cfn_params_dict, expected_section_
                     "initial_queue_size": 0,
                     "max_queue_size": 10,
                     "placement": "cluster",
+                    "additional_iam_policies": [],
                 },
             ),
         )
@@ -536,10 +548,10 @@ def test_cluster_section_from_200_cfn(mocker, cfn_params_dict, expected_section_
     "config_parser_dict, expected_dict_params, expected_message",
     [
         # default
-        ({"cluster default": {}}, {}, None),
+        ({"cluster default": {}}, {"additional_iam_policies": []}, None),
         # right value
-        ({"cluster default": {"key_name": "test"}}, {"key_name": "test"}, None),
-        ({"cluster default": {"base_os": "alinux"}}, {"base_os": "alinux"}, None),
+        ({"cluster default": {"key_name": "test"}}, {"key_name": "test", "additional_iam_policies": []}, None),
+        ({"cluster default": {"base_os": "alinux"}}, {"base_os": "alinux", "additional_iam_policies": []}, None),
         # invalid value
         ({"cluster default": {"base_os": "wrong_value"}}, None, "has an invalid value"),
         # invalid key
@@ -904,7 +916,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "SpotPrice": "5.5",
                     "ProxyServer": "proxy",
                     "EC2IAMRoleName": "role",
-                    "EC2IAMPolicies": "policy1,policy2,arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+                    "EC2IAMPolicies": "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy,policy1,policy2",
                     "S3ReadResource": "s3://url",
                     "S3ReadWriteResource": "s3://url",
                     "EFA": "compute",
@@ -942,8 +954,8 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "SpotPrice": "0",
                     "EC2IAMPolicies": ",".join(
                         [
-                            "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
                             "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+                            "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
                         ]
                     ),
                     "ComputeInstanceType": "optimal",
@@ -967,10 +979,10 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "SpotPrice": "25",
                     "EC2IAMPolicies": ",".join(
                         [
+                            "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+                            "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
                             "policy1",
                             "policy2",
-                            "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
-                            "arn:aws:iam::aws:policy/AWSBatchFullAccess",
                         ]
                     ),
                     "ComputeInstanceType": "optimal",
@@ -1033,8 +1045,8 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     "SpotPrice": "25",
                     "EC2IAMPolicies": ",".join(
                         [
-                            "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
                             "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+                            "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
                         ]
                     ),
                     "ComputeInstanceType": "optimal",

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -72,6 +72,18 @@ def assert_param_validator(mocker, config_parser_dict, expected_error=None, caps
     mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
     mocker.patch.object(PclusterConfig, "_PclusterConfig__check_account_capacity")
 
+    # Mock IAM policies validator to prevent boto3 calls in tests
+    accepted_policies = [
+        "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+        "arn:aws:iam::aws:policy/AWSBatchFullAccess",
+    ]
+
+    def mock_iam_policies_validate(self):
+        """Mock validation: just check that the policy is among the accepted ones."""
+        assert set(self.value).issubset(accepted_policies)
+
+    mocker.patch("pcluster.config.param_types.AdditionalIamPoliciesParam.validate", new=mock_iam_policies_validate)
+
     if expected_error:
         with pytest.raises(SystemExit, match=expected_error):
             _ = init_pcluster_config_from_configparser(config_parser)
@@ -122,7 +134,9 @@ def assert_section_from_file(mocker, section_definition, config_parser_dict, exp
     if default_dict_key == "global":
         default_dict_key += "_"
     default_dict = DefaultDict[default_dict_key].value
+
     expected_dict = default_dict.copy()
+
     if isinstance(expected_dict_params, dict):
         expected_dict.update(expected_dict_params)
 


### PR DESCRIPTION
Fix AdditionalIamPoliciesParam to store loaded policies at runtime
Fix get section by key and label when section label is updated
Accept optional config_file parameter in pcluster_config_reader

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
