### PR TITLE
Pass shared dir path to CloudWatch logs test class

### DIFF
--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -96,7 +96,9 @@ def test_dcv_configuration(
     _check_shared_dir(remote_command_executor, shared_dir)
 
     # Check that logs are stored in CloudWatch as expected
-    FeatureSpecificCloudWatchLoggingTestRunner.run_tests_for_feature(cluster, scheduler, os, "dcv_enabled", region)
+    FeatureSpecificCloudWatchLoggingTestRunner.run_tests_for_feature(
+        cluster, scheduler, os, "dcv_enabled", region, shared_dir
+    )
 
 
 def _check_auth_ko(remote_command_executor, dcv_authenticator_port, params, expected_message):


### PR DESCRIPTION
Enable passing the path to the shared directory configured for a cluster
to the feature-specific CloudWatch logging tests. This is required
because the CloudWatch logging tests get output from commands run on the
compute nodes by creating a temporary directory in the cluster's shared
directory and re-directing all output to files in that directory.

These changes were tested by running the affected integration tests locally.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
