### PR TITLE
Fix linter errors related to exception catching

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -841,7 +841,7 @@ def _run_packer(packer_command, packer_env):
         sys.stdout.flush()
         LOGGER.error("Failed to run %s\n", _command)
         sys.exit(1)
-    except (IOError, OSError):
+    except (IOError, OSError):  # noqa: B014
         sys.stdout.flush()
         LOGGER.error("Failed to run %s\nCommand not found", packer_command)
         sys.exit(1)

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -386,7 +386,7 @@ class JsonParam(Param):
                 string_value = str(string_value).strip()
                 if string_value != "NONE":
                     param_value = yaml.safe_load(string_value)
-        except (TypeError, ValueError, Exception) as e:
+        except Exception as e:
             self.pcluster_config.error("Error parsing JSON parameter '{0}'. {1}".format(self.key, e))
 
         return param_value

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -4,4 +4,4 @@ tabulate>=0.8.2
 ipaddress>=1.0.22
 enum34>=1.1.6
 configparser>=3.5.0
-PyYAML>=5.1.2
+PyYAML==5.2

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -28,7 +28,7 @@ REQUIRES = [
     "tabulate>=0.8.2,<=0.8.3",
     "ipaddress>=1.0.22",
     "enum34>=1.1.6",
-    "PyYAML>=5.1.2",
+    "PyYAML==5.2",
 ]
 
 if sys.version_info[0] == 2:


### PR DESCRIPTION
* Fix linter failures related to style used for catching exceptions
* Also pin to a version of PYYaml that is compatible with python 3.4

Tested by running the linters locally.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
