### PR TITLE
Fix config file resolution from env var.

### DIFF
--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -87,12 +87,10 @@ class PclusterConfig(object):
             self.config_file = os.environ["AWS_PCLUSTER_CONFIG_FILE"]
             default_config = False
         else:
-            config_file = os.path.expanduser(os.path.join("~", ".parallelcluster", "config"))
+            self.config_file = os.path.expanduser(os.path.join("~", ".parallelcluster", "config"))
             default_config = True
 
-        self.config_file = str(
-            config_file if config_file else os.path.expanduser(os.path.join("~", ".parallelcluster", "config"))
-        )
+        self.config_file = str(self.config_file)
 
         if not os.path.isfile(self.config_file):
             if fail_on_config_file_absence:


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-parallelcluster/issues/1579

*Description of changes:*

Fix config file resolution from `AWS_PCLUSTER_CONFIG_FILE` environment variable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
