### PR TITLE
Add a mechanism to compare two PclusterConfig instances

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -25,6 +25,7 @@ import pcluster.commands as pcluster
 import pcluster.configure.easyconfig as easyconfig
 import pcluster.utils as utils
 from pcluster.dcv.connect import dcv_connect
+from pcluster.update import update_command
 
 LOGGER = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ def instances(args):
 
 
 def update(args):
-    pcluster.update(args)
+    update_command.execute(args)
 
 
 def version(args):

--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -37,6 +37,8 @@ from botocore.exceptions import ClientError
 from tabulate import tabulate
 
 import pcluster.utils as utils
+from pcluster.config.config_patch import ConfigPatch
+from pcluster.config.param_types import Updatability
 from pcluster.config.pcluster_config import PclusterConfig
 
 if sys.version_info[0] >= 3:
@@ -237,69 +239,6 @@ def _is_ganglia_enabled(parameters):
     return is_ganglia_enabled
 
 
-def update(args):  # noqa: C901 FIXME!!!
-    LOGGER.info("Updating: %s", args.cluster_name)
-    stack_name = utils.get_stack_name(args.cluster_name)
-    pcluster_config = PclusterConfig(
-        config_file=args.config_file, cluster_label=args.cluster_template, fail_on_file_absence=True
-    )
-    pcluster_config.validate()
-    cfn_params = pcluster_config.to_cfn()
-
-    cluster_section = pcluster_config.get_section("cluster")
-    cfn = boto3.client("cloudformation")
-    if cluster_section.get_param_value("scheduler") != "awsbatch":
-        if not args.reset_desired:
-            asg_name = _get_asg_name(stack_name)
-            desired_capacity = (
-                boto3.client("autoscaling")
-                .describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
-                .get("AutoScalingGroups")[0]
-                .get("DesiredCapacity")
-            )
-            cfn_params["DesiredSize"] = str(desired_capacity)
-    else:
-        if args.reset_desired:
-            LOGGER.info("reset_desired flag does not work with awsbatch scheduler")
-        params = utils.get_stack(stack_name, cfn).get("Parameters")
-
-        for parameter in params:
-            if parameter.get("ParameterKey") == "ResourcesS3Bucket":
-                cfn_params["ResourcesS3Bucket"] = parameter.get("ParameterValue")
-
-    try:
-        LOGGER.debug(cfn_params)
-        if args.extra_parameters:
-            LOGGER.debug("Adding extra parameters to the CFN parameters")
-            cfn_params.update(dict(args.extra_parameters))
-
-        cfn_params = [{"ParameterKey": key, "ParameterValue": value} for key, value in cfn_params.items()]
-        LOGGER.info("Calling update_stack")
-        cfn.update_stack(
-            StackName=stack_name, UsePreviousTemplate=True, Parameters=cfn_params, Capabilities=["CAPABILITY_IAM"]
-        )
-        stack_status = utils.get_stack(stack_name, cfn).get("StackStatus")
-        if not args.nowait:
-            while stack_status == "UPDATE_IN_PROGRESS":
-                stack_status = utils.get_stack(stack_name, cfn).get("StackStatus")
-                events = cfn.describe_stack_events(StackName=stack_name).get("StackEvents")[0]
-                resource_status = (
-                    "Status: %s - %s" % (events.get("LogicalResourceId"), events.get("ResourceStatus"))
-                ).ljust(80)
-                sys.stdout.write("\r%s" % resource_status)
-                sys.stdout.flush()
-                time.sleep(5)
-        else:
-            stack_status = utils.get_stack(stack_name, cfn).get("StackStatus")
-            LOGGER.info("Status: %s", stack_status)
-    except ClientError as e:
-        LOGGER.critical(e.response.get("Error").get("Message"))
-        sys.exit(1)
-    except KeyboardInterrupt:
-        LOGGER.info("\nExiting...")
-        sys.exit(0)
-
-
 def start(args):
     """Restore ASG limits or awsbatch CE to min/max/desired."""
     stack_name = utils.get_stack_name(args.cluster_name)
@@ -321,8 +260,8 @@ def start(args):
             if cluster_section.get_param_value("maintain_initial_size")
             else 0
         )
-        asg_name = _get_asg_name(stack_name)
-        _set_asg_limits(asg_name=asg_name, min=min_desired_size, max=max_queue_size, desired=min_desired_size)
+        asg_name = utils.get_asg_name(stack_name)
+        utils.set_asg_limits(asg_name=asg_name, min=min_desired_size, max=max_queue_size, desired=min_desired_size)
 
 
 def stop(args):
@@ -337,8 +276,8 @@ def stop(args):
         _stop_batch_ce(ce_name=ce_name)
     else:
         LOGGER.info("Stopping compute fleet : %s", args.cluster_name)
-        asg_name = _get_asg_name(stack_name)
-        _set_asg_limits(asg_name=asg_name, min=0, max=0, desired=0)
+        asg_name = utils.get_asg_name(stack_name)
+        utils.set_asg_limits(asg_name=asg_name, min=0, max=0, desired=0)
 
 
 def _get_batch_ce(stack_name):
@@ -463,43 +402,6 @@ def _get_ec2_instances(stack):
     return stack_instances
 
 
-def _get_asg_name(stack_name):
-    try:
-        resources = boto3.client("cloudformation").describe_stack_resources(StackName=stack_name).get("StackResources")
-        return [r for r in resources if r.get("LogicalResourceId") == "ComputeFleet"][0].get("PhysicalResourceId")
-    except ClientError as e:
-        LOGGER.critical(e.response.get("Error").get("Message"))
-        sys.stdout.flush()
-        sys.exit(1)
-    except IndexError:
-        LOGGER.critical("Stack %s does not have a ComputeFleet", stack_name)
-        sys.exit(1)
-
-
-def _set_asg_limits(asg_name, min, max, desired):
-    asg = boto3.client("autoscaling")
-    asg.update_auto_scaling_group(
-        AutoScalingGroupName=asg_name, MinSize=int(min), MaxSize=int(max), DesiredCapacity=int(desired)
-    )
-
-
-def _get_asg_instances(stack):
-    asg = boto3.client("autoscaling")
-    asg_name = _get_asg_name(stack)
-    auto_scaling_groups = asg.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name]).get("AutoScalingGroups")
-    if not auto_scaling_groups:
-        LOGGER.error("Unable to retrieve ASG info. Please check cluster status.")
-        sys.exit(1)
-    asg = auto_scaling_groups[0]
-    name = [tag.get("Value") for tag in asg.get("Tags") if tag.get("Key") == "aws:cloudformation:logical-id"][0]
-
-    temp_instances = []
-    for instance in asg.get("Instances"):
-        temp_instances.append([name, instance.get("InstanceId")])
-
-    return temp_instances
-
-
 def _start_batch_ce(ce_name, min_vcpus, desired_vcpus, max_vcpus):
     try:
         boto3.client("batch").update_compute_environment(
@@ -529,7 +431,7 @@ def instances(args):
     instances.extend(_get_ec2_instances(stack_name))
 
     if cluster_section.get_param_value("scheduler") != "awsbatch":
-        instances.extend(_get_asg_instances(stack_name))
+        instances.extend(utils.get_asg_instances(stack_name))
 
     for instance in instances:
         LOGGER.info("%s         %s", instance[0], instance[1])
@@ -841,7 +743,7 @@ def _run_packer(packer_command, packer_env):
         sys.stdout.flush()
         LOGGER.error("Failed to run %s\n", _command)
         sys.exit(1)
-    except (IOError, OSError):  # noqa: B014
+    except (IOError, OSError):
         sys.stdout.flush()
         LOGGER.error("Failed to run %s\nCommand not found", packer_command)
         sys.exit(1)

--- a/cli/pcluster/config/config_patch.py
+++ b/cli/pcluster/config/config_patch.py
@@ -1,0 +1,137 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import namedtuple
+
+from pcluster.config.param_types import Updatability as Upd
+
+# Represents a single parameter change in a ConfigPatch instance
+Change = namedtuple("Change", ["section_key", "section_label", "param_key", "old_value", "new_value", "updatability"])
+
+
+class ConfigPatch(object):
+    """
+    Represents the Diff Patch between two PclusterConfig instances.
+
+    To be successfully created, it is mandatory that the base PclusterConfig instance can be "adapted" to the target
+    one, which means that all its sections can be matched to the base PClusterConfig instance's sections.
+    """
+
+    IGNORED_SECTIONS = ["global", "aliases"]  # Sections ignored for patch creation
+
+    def __init__(self, base_config, target_config):
+        """
+        Create a ConfigPatch.
+
+        Tries creating a ConfigPatch instance to describe the changes needed to update a pre-existing base_config
+        to the new settings contained in target_config.
+        :param base_config: The base configuration, f.i. as reconstructed from CloudFormation
+        :param target_config: The target configuration, f.i. as loaded from configuration file
+        """
+        self.base_config = base_config
+        self.target_config = target_config
+        self.changes = []
+        self._adapt()
+        self._compare()
+
+    def _adapt(self):
+        """
+        Adapt the base config to the target one.
+
+        The adaptation process involves restoring sections labels in the base config to make them match the ones in the
+        target config. If this process cannot be done, for instance because one or more sections cannot be found and/or
+        relabeled in the target config, an exception will be thrown.
+        """
+        for section_key in self.base_config.get_section_keys():
+            if section_key not in ConfigPatch.IGNORED_SECTIONS:
+                for _, base_section in self.base_config.get_sections(section_key).items():
+                    target_section = self._get_target_section(base_section)
+                    if not target_section:
+                        raise Exception(
+                            "Could not match base conf section {0} with target conf".format(base_section.key)
+                        )
+                    else:
+                        base_section.label = target_section.label
+
+        for section_key in self.target_config.get_section_keys():
+            if section_key not in ConfigPatch.IGNORED_SECTIONS:
+                for _, target_section in self.target_config.get_sections(section_key).items():
+                    base_section = self.base_config.get_section(target_section.key, target_section.label)
+                    if not base_section:
+                        raise Exception(
+                            "Could not match target conf section {0} with base conf".format(target_section.key)
+                        )
+
+    def _compare(self):
+        """Compare the target config to the source."""
+        for section_key in self.target_config.get_section_keys():
+            if section_key not in ConfigPatch.IGNORED_SECTIONS:
+                for _, section in self.target_config.get_sections(section_key).items():
+                    for _, param in section.params.items():
+                        base_section = self.base_config.get_section(section.key, section.label)
+                        base_value = base_section.get_param(param.key).value if base_section else None
+                        target_value = param.value
+
+                        if base_value != target_value:
+                            self.changes.append(
+                                Change(
+                                    section.key,
+                                    section.label,
+                                    param.key,
+                                    base_value,
+                                    param.value,
+                                    param.get_updatability(),
+                                )
+                            )
+
+    @property
+    def updatability(self):
+        """Get the updatability of the ConfigPatch."""
+        return max(change.updatability for change in self.changes) if len(self.changes) else Upd.ALLOWED
+
+    def _create_default_target_session(self, base_section):
+        # create a default target session of same type of base_section
+        section_definition = base_section.definition
+        section_type = section_definition.get("type")
+        section = section_type(
+            section_definition=section_definition, pcluster_config=self.target_config, section_label=base_section.label
+        )
+        self.target_config.add_section(section)
+        return section
+
+    def _get_target_section_by_param(self, section_key, param_key, param_value):
+        section = None
+        sections = self.target_config.get_sections(section_key)
+        for _, s in sections.items():
+            param = s.get_param(param_key)
+            if param and param.value == param_value:
+                section = s
+                break
+        return section
+
+    def _get_target_section(self, base_section):
+        section = None
+        key_param = base_section.key_param
+        if key_param:
+            # EBS sections are looked by shared dir
+            key_param_value = base_section.get_param_value(key_param)
+            section = self._get_target_section_by_param(base_section.key, key_param, key_param_value)
+        else:
+            # All other sections are matched only if exactly one is found
+            sections = self.target_config.get_sections(base_section.key)
+            if len(sections) == 1:
+                section = next(iter(sections.values()))
+
+        # If section is not present in target config we can build a default section to allow comparison
+        # but only if it is a section without key_param
+        if not section and not key_param:
+            section = self._create_default_target_session(base_section)
+
+        return section

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -57,6 +57,7 @@ from pcluster.config.validators import (
     fsx_storage_capacity_validator,
     fsx_validator,
     intel_hpc_validator,
+    maintain_initial_size_validator,
     raid_volume_iops_validator,
     scheduler_validator,
     shared_dir_validator,
@@ -500,6 +501,7 @@ CLUSTER = {
                 "type": MaintainInitialSizeParam,
                 "default": False,
                 "cfn_param_mapping": "MinSize",
+                "validators": [maintain_initial_size_validator]
             }),
             ("min_vcpus", {
                 "type": QueueSizeParam,

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -31,6 +31,7 @@ from pcluster.config.param_types import (
     SpotBidPercentageParam,
     SpotPriceParam,
 )
+from pcluster.config.param_types import Updatability as Upd
 from pcluster.config.validators import (
     cluster_validator,
     compute_instance_type_validator,
@@ -111,10 +112,15 @@ AWS = {
     "type": Section,
     "key": "aws",
     "params": {
-        "aws_access_key_id": {},
-        "aws_secret_access_key": {},
+        "aws_access_key_id": {
+            "updatability": Upd.DENIED
+        },
+        "aws_secret_access_key": {
+            "updatability": Upd.DENIED
+        },
         "aws_region_name": {
             "default": "us-east-1",  # TODO add regex
+            "updatability": Upd.DENIED
         },
     }
 }
@@ -134,6 +140,7 @@ GLOBAL = {
         "sanity_check": {
             "type": BoolParam,
             "default": True,
+            "updatability": Upd.ALLOWED
         },
     }
 }
@@ -170,11 +177,13 @@ VPC = {
             "cfn_param_mapping": "VPCId",
             "allowed_values": ALLOWED_VALUES["vpc_id"],
             "validators": [ec2_vpc_id_validator],
+            "updatability": Upd.DENIED
         },
         "master_subnet_id": {
             "cfn_param_mapping": "MasterSubnetId",
             "allowed_values": ALLOWED_VALUES["subnet_id"],
             "validators": [ec2_subnet_id_validator],
+            "updatability": Upd.DENIED
         },
         "ssh_from": {
             "default": "0.0.0.0/0",
@@ -185,11 +194,13 @@ VPC = {
             "cfn_param_mapping": "AdditionalSG",
             "allowed_values": ALLOWED_VALUES["security_group_id"],
             "validators": [ec2_security_group_validator],
+            "updatability": Upd.ALLOWED
         },
         "compute_subnet_id": {
             "cfn_param_mapping": "ComputeSubnetId",
             "allowed_values": ALLOWED_VALUES["subnet_id"],
             "validators": [ec2_subnet_id_validator],
+            "updatability": Upd.DENIED
         },
         "compute_subnet_cidr": {
             "cfn_param_mapping": "ComputeSubnetCidr",
@@ -221,6 +232,7 @@ EBS = {
     "type": Section,
     "key": "ebs",
     "default_label": "default",
+    "key_param": "shared_dir",
     "params": {
         "shared_dir": {
             "allowed_values": ALLOWED_VALUES["file_path"],
@@ -547,6 +559,8 @@ CLUSTER = {
             ("template_url", {
                 # TODO add regex
                 "validators": [url_validator],
+                # Ignored during update since we force using previous template
+                "updatability": Upd.IGNORED
             }),
             ("shared_dir", {
                 "type": SharedDirParam,

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -156,7 +156,11 @@ class Param(object):
     def to_file(self, config_parser, write_defaults=False):
         """Set parameter in the config_parser in the right section."""
         section_name = _get_file_section_name(self.section_key, self.section_label)
-        if self.value is not None and (write_defaults or self.value != self.get_default_value()):
+        if (
+            self.value is not None
+            and (write_defaults or self.value != self.get_default_value())
+            and self.get_string_value()
+        ):
             _ensure_section_existence(config_parser, section_name)
             config_parser.set(section_name, self.key, self.get_string_value())
         else:
@@ -669,7 +673,8 @@ class AdditionalIamPoliciesParam(CommaSeparatedParam):
 
     def get_string_value(self):
         """Convert internal representation into string. Conditionally enabled policies are not written."""
-        return str(",".join(self.pcluster_config.non_conditional_iam_policies(self.value)))
+        non_conditional_iam_policies = self.pcluster_config.non_conditional_iam_policies(self.value)
+        return str(",".join(non_conditional_iam_policies)) if len(non_conditional_iam_policies) else None
 
 
 class AvailabilityZoneParam(Param):

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -120,6 +120,10 @@ class PclusterConfig(object):
         except configparser.ParsingError as e:
             LOGGER.debug("Error parsing configuration file {0}.\n{1}".format(self.config_file, str(e)))
 
+    def get_section_keys(self):
+        """Return the section keys."""
+        return self.__sections.keys()
+
     def get_sections(self, section_key):
         """
         Get the Section(s) identified by the given key.

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -743,3 +743,11 @@ def intel_hpc_validator(param_key, param_value, pcluster_config):
         )
 
     return errors, warnings
+
+
+def maintain_initial_size_validator(param_key, param_value, pcluster_config):
+    errors = []
+    initial_queue_size = pcluster_config.get_section("cluster").get_param("initial_queue_size").value
+    if param_value and initial_queue_size == 0:
+        errors.append("maintain_initial_size cannot be set to true if initial_queue_size is 0")
+    return errors, []

--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -339,7 +339,7 @@ class SchedulerHandler:
         }
         if self.is_aws_batch:
             scheduler_parameters["desired_vcpus"] = self.min_cluster_size
-        else:
+        elif int(self.min_cluster_size) > 0:
             scheduler_parameters["maintain_initial_size"] = "true"
         return scheduler_parameters
 

--- a/cli/pcluster/update/__init__.py
+++ b/cli/pcluster/update/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/cli/pcluster/update/update_command.py
+++ b/cli/pcluster/update/update_command.py
@@ -1,0 +1,126 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+import time
+
+import boto3
+from botocore.exceptions import ClientError
+
+import pcluster.utils as utils
+from pcluster.config.config_patch import ConfigPatch
+from pcluster.config.param_types import Updatability
+from pcluster.config.pcluster_config import PclusterConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+def execute(args):
+    LOGGER.info("Updating: %s", args.cluster_name)
+    stack_name = utils.get_stack_name(args.cluster_name)
+    target_config = PclusterConfig(
+        config_file=args.config_file, cluster_label=args.cluster_template, fail_on_file_absence=True
+    )
+    target_config.validate()
+    cfn_params = target_config.to_cfn()
+
+    cluster_section = target_config.get_section("cluster")
+    cfn = boto3.client("cloudformation")
+    if cluster_section.get_param_value("scheduler") != "awsbatch":
+        if not args.reset_desired:
+            asg_name = utils.get_asg_name(stack_name)
+            desired_capacity = (
+                boto3.client("autoscaling")
+                .describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
+                .get("AutoScalingGroups")[0]
+                .get("DesiredCapacity")
+            )
+            cfn_params["DesiredSize"] = str(desired_capacity)
+    else:
+        if args.reset_desired:
+            LOGGER.info("reset_desired flag does not work with awsbatch scheduler")
+        params = utils.get_stack(stack_name, cfn).get("Parameters")
+
+        for parameter in params:
+            if parameter.get("ParameterKey") == "ResourcesS3Bucket":
+                cfn_params["ResourcesS3Bucket"] = parameter.get("ParameterValue")
+
+    # Retrieving base config from cfn
+    can_proceed = True
+    base_config = PclusterConfig(config_file=args.config_file, cluster_name=args.cluster_name)
+    try:
+        patch = ConfigPatch(base_config, target_config)
+        updatability = patch.updatability
+
+        LOGGER.info("Found Changes:")
+        if len(patch.changes):
+            for change in patch.changes:
+                LOGGER.info("{0}".format(change))
+        else:
+            LOGGER.info("No changes found in your cluster configuration. Update is not needed.")
+            sys.exit(0)
+
+        if updatability < Updatability.UNKNOWN:
+            LOGGER.info("Congratulations! The new configuration can be safely applied to your cluster.")
+            if updatability > Updatability.ALLOWED:
+                LOGGER.warning("The following additional operations will be needed:")
+                if updatability >= Updatability.COMPUTE_FLEET_RESTART:
+                    LOGGER.warning("- Restart compute fleet.")
+                if updatability == Updatability.MASTER_RESTART:
+                    LOGGER.warning("- Restart master node.")
+        else:
+            LOGGER.error("The new configuration cannot be safely applied to your cluster.")
+            LOGGER.error("Please check the report above for details.")
+            can_proceed = False
+    except Exception as e:
+        LOGGER.error(e)
+        can_proceed = False
+
+    if can_proceed:
+        user_input = input("Do you want to proceed? - Y/N").strip().lower()
+        if user_input != "y":
+            can_proceed = False
+
+    if not can_proceed:
+        sys.exit(1)
+
+    try:
+        LOGGER.debug(cfn_params)
+        if args.extra_parameters:
+            LOGGER.debug("Adding extra parameters to the CFN parameters")
+            cfn_params.update(dict(args.extra_parameters))
+
+        cfn_params = [{"ParameterKey": key, "ParameterValue": value} for key, value in cfn_params.items()]
+        LOGGER.info("Calling update_stack")
+        cfn.update_stack(
+            StackName=stack_name, UsePreviousTemplate=True, Parameters=cfn_params, Capabilities=["CAPABILITY_IAM"]
+        )
+        stack_status = utils.get_stack(stack_name, cfn).get("StackStatus")
+        if not args.nowait:
+            while stack_status == "UPDATE_IN_PROGRESS":
+                stack_status = utils.get_stack(stack_name, cfn).get("StackStatus")
+                events = cfn.describe_stack_events(StackName=stack_name).get("StackEvents")[0]
+                resource_status = (
+                    "Status: %s - %s" % (events.get("LogicalResourceId"), events.get("ResourceStatus"))
+                ).ljust(80)
+                sys.stdout.write("\r%s" % resource_status)
+                sys.stdout.flush()
+                time.sleep(5)
+        else:
+            stack_status = utils.get_stack(stack_name, cfn).get("StackStatus")
+            LOGGER.info("Status: %s", stack_status)
+    except ClientError as e:
+        LOGGER.critical(e.response.get("Error").get("Message"))
+        sys.exit(1)
+    except KeyboardInterrupt:
+        LOGGER.info("\nExiting...")
+        sys.exit(0)

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -1,0 +1,219 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import shutil
+
+import pytest
+
+from pcluster.config.config_patch import Change, ConfigPatch
+from pcluster.config.param_types import Updatability as Upd
+from pcluster.config.pcluster_config import PclusterConfig
+
+defaults = {
+    "master_subnet_id": "subnet-12345678",
+    "compute_subnet_id": "subnet-12345678",
+    "additional_sg": "sg-12345678",
+}
+
+
+def check_patch(src_conf, dst_conf, expected_changes, expected_patch_updatability):
+    patch = ConfigPatch(base_config=src_conf, target_config=dst_conf)
+    assert set(patch.changes) == set(expected_changes)
+    assert patch.updatability == expected_patch_updatability
+
+
+def test_config_patch(mocker):
+    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    src_conf = PclusterConfig()
+    dst_conf = PclusterConfig()
+    # Two new configs must always be equal
+    check_patch(src_conf, dst_conf, [], Upd.ALLOWED)
+
+
+def duplicate_config_file(dst_config_file, test_datadir):
+    # Make a copy of the src template to the target file.
+    # The two resulting PClusterConfig instances will be identical
+    src_config_file_path = os.path.join(str(test_datadir), "pcluster.config.ini")
+    dst_config_file_path = os.path.join(str(test_datadir), dst_config_file)
+    shutil.copy(src_config_file_path, dst_config_file_path)
+
+
+@pytest.mark.parametrize(
+    "section_key, section_label, param_key, src_param_value, dst_param_value, change_applicability, "
+    "patch_applicability",
+    [
+        ("vpc", "default", "master_subnet_id", "subnet-12345678", "subnet-1234567a", Upd.DENIED, Upd.DENIED),
+        ("vpc", "default", "additional_sg", "sg-12345678", "sg-1234567a", Upd.ALLOWED, Upd.ALLOWED),
+        ("vpc", "default", "additional_sg", "sg-12345678", "sg-1234567a", Upd.ALLOWED, Upd.ALLOWED),
+    ],
+)
+def test_single_param_change(
+    test_datadir,
+    pcluster_config_reader,
+    mocker,
+    section_key,
+    section_label,
+    param_key,
+    src_param_value,
+    dst_param_value,
+    change_applicability,
+    patch_applicability,
+):
+    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    dst_config_file = "pcluster.config.dst.ini"
+    duplicate_config_file(dst_config_file, test_datadir)
+
+    src_dict = {}
+    src_dict.update(defaults)
+    src_dict[param_key] = src_param_value
+
+    rendered_config_file = pcluster_config_reader(**src_dict)
+    src_conf = PclusterConfig(config_file=rendered_config_file, fail_on_file_absence=True)
+
+    dst_dict = {}
+    dst_dict.update(defaults)
+    dst_dict[param_key] = dst_param_value
+    rendered_config_file = pcluster_config_reader(dst_config_file, **dst_dict)
+    dst_conf = PclusterConfig(config_file=rendered_config_file,)
+
+    change = Change(section_key, section_label, param_key, src_param_value, dst_param_value, change_applicability)
+    check_patch(src_conf, dst_conf, [change], patch_applicability)
+
+
+def test_multiple_param_changes(mocker, pcluster_config_reader, test_datadir):
+    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    dst_config_file = "pcluster.config.dst.ini"
+    duplicate_config_file(dst_config_file, test_datadir)
+
+    src_dict = {}
+    src_dict.update(defaults)
+    src_dict["master_subnet_id"] = "subnet-12345678"
+    src_dict["compute_subnet_id"] = "subnet-12345678"
+    src_dict["additional_sg"] = "sg-12345678"
+
+    rendered_config_file = pcluster_config_reader(**src_dict)
+    src_conf = PclusterConfig(config_file=rendered_config_file, fail_on_file_absence=True)
+
+    dst_dict = {}
+    dst_dict.update(defaults)
+    dst_dict["master_subnet_id"] = "subnet-1234567a"
+    dst_dict["compute_subnet_id"] = "subnet-1234567a"
+    dst_dict["additional_sg"] = "sg-1234567a"
+
+    rendered_config_file = pcluster_config_reader(dst_config_file, **dst_dict)
+    dst_conf = PclusterConfig(config_file=rendered_config_file,)
+
+    check_patch(
+        src_conf,
+        dst_conf,
+        [
+            Change("vpc", "default", "master_subnet_id", "subnet-12345678", "subnet-1234567a", Upd.DENIED),
+            Change("vpc", "default", "compute_subnet_id", "subnet-12345678", "subnet-1234567a", Upd.DENIED),
+            Change("vpc", "default", "additional_sg", "sg-12345678", "sg-1234567a", Upd.ALLOWED),
+        ],
+        Upd.DENIED,
+    )
+
+
+def _test_equal_configs(base_conf, target_conf):
+    # Without doing any changes the two configs must be equal
+    check_patch(base_conf, target_conf, [], Upd.ALLOWED)
+
+
+def _test_less_target_sections(base_conf, target_conf):
+    # Remove an ebs section in the target conf
+    assert target_conf.get_section("ebs", "ebs-1") is not None
+    target_conf.remove_section("ebs", "ebs-1")
+    assert target_conf.get_section("ebs", "ebs-1") is None
+
+    patch = None
+    # A patch cannot be created because of the different number of sections
+    with pytest.raises(Exception):
+        patch = ConfigPatch(base_config=base_conf, target_config=target_conf)
+    assert not patch
+
+
+def _test_more_target_sections(base_conf, target_conf):
+    # Remove an ebs section into the base conf
+    assert base_conf.get_section("ebs", "ebs-1") is not None
+    base_conf.remove_section("ebs", "ebs-1")
+    assert base_conf.get_section("ebs", "ebs-1") is None
+
+    patch = None
+    # A patch cannot be created because of the different number of sections
+    with pytest.raises(Exception):
+        patch = ConfigPatch(base_config=base_conf, target_config=target_conf)
+    assert not patch
+
+
+def _test_incompatible_ebs_sections(base_conf, target_conf):
+    # Change shared_dir param value in target conf
+    target_conf.get_section("ebs", "ebs-1").get_param("shared_dir").value = "new_value"
+    # A patch cannot be created because of the different number of sections
+    with pytest.raises(Exception):
+        ConfigPatch(base_config=base_conf, target_config=target_conf)
+
+
+def _test_different_labels_only(base_conf, target_conf):
+    # First make sure sections are present with original labels
+
+    base_ebs_1_section = base_conf.get_section("ebs", "ebs-1")
+    base_ebs_2_section = base_conf.get_section("ebs", "ebs-2")
+
+    assert base_conf.get_section("ebs", "ebs-1")
+    assert base_conf.get_section("ebs", "ebs-2")
+
+    # Now update section labels and make sure they're not more present with original labels
+    base_ebs_1_section.label = "ebs-1_updated"
+    base_ebs_2_section.label = "ebs-2_updated"
+
+    assert base_conf.get_section("ebs", "ebs-1_updated")
+    assert base_conf.get_section("ebs", "ebs-2_updated")
+    assert not base_conf.get_section("ebs", "ebs-1")
+    assert not base_conf.get_section("ebs", "ebs-2")
+
+    # Now create the patch
+    patch = ConfigPatch(base_conf, target_conf)
+
+    # The patch should not contain any difference
+    assert patch.changes == []
+
+    # The section labels in the target config must have been restored
+    assert not base_conf.get_section("ebs", "ebs-1_updated")
+    assert not base_conf.get_section("ebs", "ebs-2_updated")
+    assert base_conf.get_section("ebs", "ebs-1")
+    assert base_conf.get_section("ebs", "ebs-2")
+
+
+@pytest.mark.parametrize(
+    "test",
+    [
+        _test_less_target_sections,
+        _test_more_target_sections,
+        _test_incompatible_ebs_sections,
+        _test_equal_configs,
+        _test_different_labels_only,
+    ],
+)
+def test_adaptation(mocker, test_datadir, pcluster_config_reader, test):
+    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    base_config_file = "pcluster.config.base.ini"
+    duplicate_config_file(base_config_file, test_datadir)
+    target_config_file = "pcluster.config.dst.ini"
+    duplicate_config_file(target_config_file, test_datadir)
+
+    rendered_base_config_file = pcluster_config_reader(base_config_file, **defaults)
+    rendered_target_config_file = pcluster_config_reader(target_config_file, **defaults)
+
+    base_conf = PclusterConfig(config_file=rendered_base_config_file, fail_on_file_absence=True)
+    target_conf = PclusterConfig(config_file=rendered_target_config_file, fail_on_file_absence=True)
+
+    test(base_conf, target_conf)

--- a/cli/tests/pcluster/config/test_config_patch/test_adaptation/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_config_patch/test_adaptation/pcluster.config.ini
@@ -1,0 +1,23 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = false
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+vpc_settings = default
+ebs_settings = ebs-1, ebs-2
+
+[vpc default]
+# FSX conversion requires master subnet id to check mount-target
+master_subnet_id = {{master_subnet_id}}
+compute_subnet_id = {{compute_subnet_id}}
+additional_sg = {{additional_sg}}
+
+[ebs ebs-1]
+shared_dir = vol1
+
+[ebs ebs-2]
+shared_dir = vol2

--- a/cli/tests/pcluster/config/test_config_patch/test_multiple_param_changes/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_config_patch/test_multiple_param_changes/pcluster.config.ini
@@ -1,0 +1,19 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = false
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+vpc_settings = default
+
+[vpc default]
+# FSX conversion requires master subnet id to check mount-target
+master_subnet_id = {{master_subnet_id}}
+compute_subnet_id = {{compute_subnet_id}}
+additional_sg = {{additional_sg}}
+
+[ebs ebs-1]
+shared_dir={{shared_dir}}

--- a/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.ini
@@ -1,0 +1,19 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = false
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+vpc_settings = default
+
+[vpc default]
+# FSX conversion requires master subnet id to check mount-target
+master_subnet_id = {{master_subnet_id}}
+compute_subnet_id = {{compute_subnet_id}}
+additional_sg = {{additional_sg}}
+
+[ebs ebs-1]
+shared_dir={{shared_dir}}

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -31,7 +31,7 @@ def test_mapping_consistency():
                 description="{0} is not allowed in {1} section definition".format(
                     section_key, section_definition.get("key")
                 ),
-            ).is_in("type", "key", "default_label", "cfn_param_mapping", "params", "validators")
+            ).is_in("type", "key", "default_label", "cfn_param_mapping", "params", "key_param", "validators")
 
         for param_key, param_definition in section_definition.get("params").items():
 
@@ -46,7 +46,15 @@ def test_mapping_consistency():
                 assert_that(
                     param_definition_key,
                     description="{0} is not allowed in {1} param definition".format(param_definition_key, param_key),
-                ).is_in("type", "cfn_param_mapping", "allowed_values", "validators", "default", "referred_section")
+                ).is_in(
+                    "type",
+                    "cfn_param_mapping",
+                    "allowed_values",
+                    "validators",
+                    "default",
+                    "referred_section",
+                    "updatability",
+                )
 
 
 def test_example_config_consistency(mocker):


### PR DESCRIPTION
This commit introduces the ConfigPatch class, a new class to check the
differences between two pcluster configurations (represented by
PclusterConfig instances) together with their updatability index.
The ConfigPatch itself, if successfully created, will have its own
updatability index which will tell if the patch is safely applicable or
not, based on the updatability index of its single changes.