### PR TITLE
Only pin specific PyYAML for python 3.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+X.X.X
+====
+
+**CHANGES**
+
+* Use version 5.2 of PyYAML for python 3 versions of 3.4 or earlier.
+
 2.5.1
 =====
 

--- a/cli/requirements34.txt
+++ b/cli/requirements34.txt
@@ -4,4 +4,4 @@ tabulate>=0.8.2
 ipaddress>=1.0.22
 enum34>=1.1.6
 configparser>=3.5.0
-PyYAML>=5.1.2
+PyYAML==5.2

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -28,7 +28,7 @@ REQUIRES = [
     "tabulate>=0.8.2,<=0.8.3",
     "ipaddress>=1.0.22",
     "enum34>=1.1.6",
-    "PyYAML==5.2",
+    "PyYAML==5.2" if sys.version_info.major == 3 and sys.version_info.minor <= 4 else "PyYAML>=5.1.2",
 ]
 
 if sys.version_info[0] == 2:


### PR DESCRIPTION
This commit conditionally specifies the PyYAML version installed as a
ParallelCluster dependency based on the version of python used.

PyYAML 5.3 is not compatible with python 3.4, so for this version of
python, pin to 5.2. Otherwise, use the latest compatible version.

Note that the corresponding `requirements.txt` still pins to 5.2.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
