### PR TITLE
Validate OS according to the scheduler and fix get_supported_os utility

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -25,6 +25,7 @@ from pcluster.utils import (
     get_supported_compute_instance_types,
     get_supported_features,
     get_supported_instance_types,
+    get_supported_os,
 )
 
 
@@ -648,6 +649,10 @@ def scheduler_validator(param_key, param_value, pcluster_config):
     if param_value == "awsbatch":
         if pcluster_config.region in ["ap-northeast-3", "us-gov-east-1", "us-gov-west-1"]:
             errors.append("'awsbatch' scheduler is not supported in the '{0}' region".format(pcluster_config.region))
+
+    supported_os = get_supported_os(param_value)
+    if pcluster_config.get_section("cluster").get_param_value("base_os") not in supported_os:
+        errors.append("'{0}' scheduler supports the following Operating Systems: {1}".format(param_value, supported_os))
 
     return errors, warnings
 

--- a/cli/pcluster/examples/config
+++ b/cli/pcluster/examples/config
@@ -101,7 +101,7 @@ key_name = mykey
 # ComputeFleet root volume size in GB. (AMI must support growroot)
 # (defaults to 25)
 #compute_root_volume_size = 25
-# OS type used in the cluster
+# OS type used in the cluster. If the scheduler is awsbatch, only 'alinux' is supported.
 # (defaults to alinux)
 #base_os = alinux
 # Existing EC2 IAM role to be associated with the EC2 instances

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -275,12 +275,12 @@ def get_supported_compute_instance_types(scheduler):
 
 def get_supported_os(scheduler):
     """
-    Return a tuple of the os supported by parallelcluster for the specific scheduler.
+    Return an array containing the list of OSes supported by parallelcluster for the specific scheduler.
 
     :param scheduler: the scheduler for which we want to know the supported os
-    :return: a tuple of strings of the supported os
+    :return: an array of strings of the supported OSes
     """
-    return "alinux" if scheduler == "awsbatch" else "alinux", "centos6", "centos7", "ubuntu1604", "ubuntu1804"
+    return ["alinux"] if scheduler == "awsbatch" else ["alinux", "centos6", "centos7", "ubuntu1604", "ubuntu1804"]
 
 
 def get_supported_schedulers():

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -223,24 +223,54 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
 
 
 @pytest.mark.parametrize(
-    "region, expected_message",
+    "region, base_os, scheduler, expected_message",
     [
-        # validate awsbatch not supported regions
-        ("ap-northeast-3", "scheduler is not supported in the .* region"),
-        ("us-gov-east-1", "scheduler is not supported in the .* region"),
-        ("us-gov-west-1", "scheduler is not supported in the .* region"),
-        # test some awsbatch supported regions
-        ("eu-west-1", None),
-        ("us-east-1", None),
-        ("eu-north-1", None),
-        ("cn-north-1", None),
-        ("cn-northwest-1", None),
+        # verify awsbatch supported regions
+        ("ap-northeast-3", "alinux", "awsbatch", "scheduler is not supported in the .* region"),
+        ("us-gov-east-1", "alinux", "awsbatch", "scheduler is not supported in the .* region"),
+        ("us-gov-west-1", "alinux", "awsbatch", "scheduler is not supported in the .* region"),
+        ("eu-west-1", "alinux", "awsbatch", None),
+        ("us-east-1", "alinux", "awsbatch", None),
+        ("eu-north-1", "alinux", "awsbatch", None),
+        ("cn-north-1", "alinux", "awsbatch", None),
+        ("cn-northwest-1", "alinux", "awsbatch", None),
+        # verify traditional schedulers are supported in all the regions
+        ("cn-northwest-1", "alinux", "sge", None),
+        ("ap-northeast-3", "alinux", "sge", None),
+        ("cn-northwest-1", "alinux", "slurm", None),
+        ("ap-northeast-3", "alinux", "slurm", None),
+        ("cn-northwest-1", "alinux", "torque", None),
+        ("ap-northeast-3", "alinux", "torque", None),
+        # verify awsbatch supported OSes
+        ("eu-west-1", "centos6", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("eu-west-1", "centos7", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("eu-west-1", "ubuntu1604", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("eu-west-1", "ubuntu1804", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("eu-west-1", "alinux", "awsbatch", None),
+        # verify sge supports all the OSes
+        ("eu-west-1", "centos6", "sge", None),
+        ("eu-west-1", "centos7", "sge", None),
+        ("eu-west-1", "ubuntu1604", "sge", None),
+        ("eu-west-1", "ubuntu1804", "sge", None),
+        ("eu-west-1", "alinux", "sge", None),
+        # verify slurm supports all the OSes
+        ("eu-west-1", "centos6", "slurm", None),
+        ("eu-west-1", "centos7", "slurm", None),
+        ("eu-west-1", "ubuntu1604", "slurm", None),
+        ("eu-west-1", "ubuntu1804", "slurm", None),
+        ("eu-west-1", "alinux", "slurm", None),
+        # verify torque supports all the OSes
+        ("eu-west-1", "centos6", "torque", None),
+        ("eu-west-1", "centos7", "torque", None),
+        ("eu-west-1", "ubuntu1604", "torque", None),
+        ("eu-west-1", "ubuntu1804", "torque", None),
+        ("eu-west-1", "alinux", "torque", None),
     ],
 )
-def test_scheduler_validator(mocker, region, expected_message):
+def test_scheduler_validator(mocker, region, base_os, scheduler, expected_message):
     # we need to set the region in the environment because it takes precedence respect of the config file
     os.environ["AWS_DEFAULT_REGION"] = region
-    config_parser_dict = {"cluster default": {"scheduler": "awsbatch"}}
+    config_parser_dict = {"cluster default": {"base_os": base_os, "scheduler": scheduler}}
     utils.assert_param_validator(mocker, config_parser_dict, expected_message)
 
 
@@ -763,7 +793,7 @@ def test_fsx_imported_file_chunk_size_validator(mocker, section_dict, expected_m
             {
                 "enable_efa": "compute",
                 "compute_instance_type": "t2.large",
-                "base_os": "centos6",
+                "base_os": "alinux",
                 "scheduler": "awsbatch",
             },
             "it is required to set the 'scheduler'",


### PR DESCRIPTION
+ Added validation for the os, according to the scheduler, since currently awsbatch only supports alinux.
+ Fix `get_supported_os` utility method. It was always returning a tuple, because the if/else inline was wrongly applied only for the first item of the tuple.
+ Extend unit tests to cover all the "scheduler vs os" and "scheduler vs region" combinations.
+ I manually tested `pcluster configure` and `pcluster create`

Issue https://github.com/aws/aws-parallelcluster/issues/1585


