### PR TITLE
Enable integration tests for Amazon Linux 2

### DIFF
--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -51,7 +51,7 @@ TEST_DEFAULTS = {
         "sa-east-1",
         "eu-west-3",
     ],
-    "oss": ["alinux", "centos6", "centos7", "ubuntu1804", "ubuntu1604"],
+    "oss": ["alinux", "alinux2", "centos6", "centos7", "ubuntu1804", "ubuntu1604"],
     "schedulers": ["sge", "slurm", "torque", "awsbatch"],
     "instances": ["c4.xlarge", "c5.xlarge"],
     "dry_run": False,

--- a/tests/integration-tests/tests/common/mpi_common.py
+++ b/tests/integration-tests/tests/common/mpi_common.py
@@ -7,6 +7,7 @@ from tests.common.schedulers_common import get_scheduler_commands
 
 OS_TO_OPENMPI_MODULE_MAP = {
     "alinux": "openmpi",
+    "alinux2": "openmpi",
     "centos7": "openmpi",
     "ubuntu1604": "openmpi",
     "centos6": "openmpi-x86_64",

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -28,7 +28,7 @@ DCV_CONNECT_SCRIPT = "/opt/parallelcluster/scripts/pcluster_dcv_connect.sh"
     "dcv_port, access_from, shared_dir", [(8443, "0.0.0.0/0", "/shared"), (5678, "192.168.1.1/32", "/myshared")]
 )
 @pytest.mark.regions(["eu-west-1", "cn-northwest-1"])  # DCV license bucket not present in us-gov
-@pytest.mark.oss(["centos7", "ubuntu1804"])
+@pytest.mark.oss(["centos7", "ubuntu1804", "alinux2"])
 @pytest.mark.instances(["c4.xlarge", "g3.8xlarge"])
 @pytest.mark.schedulers(["sge"])
 def test_dcv_configuration(

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -25,7 +25,7 @@ from utils import get_compute_nodes_instance_ids
 
 @pytest.mark.regions(["us-east-1", "us-gov-west-1"])
 @pytest.mark.instances(["c5n.18xlarge", "p3dn.24xlarge", "i3en.24xlarge"])
-@pytest.mark.oss(["alinux", "centos7", "ubuntu1604", "ubuntu1804"])
+@pytest.mark.skip_oss(["centos6"])
 @pytest.mark.schedulers(["sge", "slurm"])
 def test_efa(region, scheduler, instance, os, pcluster_config_reader, clusters_factory, test_datadir):
     """

--- a/tests/integration-tests/tests/scaling/test_mpi.py
+++ b/tests/integration-tests/tests/scaling/test_mpi.py
@@ -24,7 +24,6 @@ from wrapt_timeout_decorator import timeout
 @pytest.mark.regions(["us-west-2"])
 @pytest.mark.instances(["c5.xlarge", "c5n.18xlarge"])
 @pytest.mark.schedulers(["slurm", "sge"])
-@pytest.mark.oss(["alinux", "centos7", "centos6", "ubuntu1604", "ubuntu1804"])
 def test_mpi(scheduler, region, os, instance, pcluster_config_reader, clusters_factory):
     scaledown_idletime = 3
     max_queue_size = 3

--- a/tests/integration-tests/tests/schedulers/test_awsbatch.py
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch.py
@@ -22,6 +22,7 @@ from tests.common.schedulers_common import AWSBatchCommands
 @pytest.mark.skip_regions(["ap-northeast-3", "us-gov-east-1", "us-gov-west-1"])
 @pytest.mark.instances(["c5.xlarge", "t2.large"])
 @pytest.mark.dimensions("*", "*", "alinux", "awsbatch")
+@pytest.mark.dimensions("*", "*", "alinux2", "awsbatch")
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
 def test_awsbatch(pcluster_config_reader, clusters_factory, test_datadir):
     """

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -26,7 +26,7 @@ from utils import get_vpc_snakecase_value
 @pytest.mark.regions(["us-east-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["slurm", "awsbatch"])
-@pytest.mark.os(["alinux"])
+@pytest.mark.os(["alinux2"])
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_efs_compute_az(region, scheduler, pcluster_config_reader, clusters_factory, vpc_stacks):
     """
@@ -49,7 +49,7 @@ def test_efs_compute_az(region, scheduler, pcluster_config_reader, clusters_fact
 @pytest.mark.regions(["us-east-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["slurm", "awsbatch"])
-@pytest.mark.os(["alinux"])
+@pytest.mark.os(["alinux2"])
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_efs_same_az(region, scheduler, pcluster_config_reader, clusters_factory, vpc_stacks):
     """

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -21,9 +21,9 @@ from tests.common.schedulers_common import SgeCommands
 
 @pytest.mark.regions(["us-east-1"])
 @pytest.mark.instances(["c5.xlarge"])
-@pytest.mark.oss(["centos7", "alinux", "ubuntu1604", "ubuntu1804"])
+@pytest.mark.skip_oss(["centos6"])
 @pytest.mark.schedulers(["sge"])
-@pytest.mark.usefixtures("os", "instance", "scheduler")
+@pytest.mark.usefixtures("instance", "scheduler")
 def test_fsx_lustre(region, pcluster_config_reader, clusters_factory, s3_bucket_factory, test_datadir, os):
     """
     Test all FSx Lustre related features.

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -33,7 +33,7 @@ PClusterConfig = namedtuple(
 )
 
 
-@pytest.mark.dimensions("eu-west-1", "c5.xlarge", "alinux", "slurm")
+@pytest.mark.dimensions("eu-west-1", "c5.xlarge", "alinux2", "slurm")
 @pytest.mark.usefixtures("os", "scheduler")
 def test_update(instance, region, pcluster_config_reader, clusters_factory, test_datadir):
     """

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -260,6 +260,7 @@ def get_username_for_os(os):
     """Return username for a given os."""
     usernames = {
         "alinux": "ec2-user",
+        "alinux2": "ec2-user",
         "centos6": "centos",
         "centos7": "centos",
         "ubuntu1604": "ubuntu",


### PR DESCRIPTION
Enable existing integration tests to run on Amazon Linux 2 (alinux2).
Any test that runs for alinux should run for alinux2. Any test that only
ran on alinux should now run on alinux2 instead (e.g., the EFS tests).

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
