### PR TITLE
Enable base_os of alinux2 in config file

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -447,7 +447,7 @@ CLUSTER = {
             ("base_os", {
                 "default": "alinux",
                 "cfn_param_mapping": "BaseOS",
-                "allowed_values": ["alinux", "ubuntu1604", "ubuntu1804", "centos6", "centos7"],
+                "allowed_values": ["alinux", "alinux2", "ubuntu1604", "ubuntu1804", "centos6", "centos7"],
             }),
             ("scheduler", {
                 "default": "sge",

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -293,7 +293,7 @@ def efa_validator(param_key, param_value, pcluster_config):
             "to one of the following values : {1}".format(param_value, allowed_instances)
         )
 
-    allowed_oses = ["alinux", "centos7", "ubuntu1604", "ubuntu1804"]
+    allowed_oses = ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]
     if cluster_section.get_param_value("base_os") not in allowed_oses:
         errors.append(
             "When using 'enable_efa = {0}' it is required to set the 'base_os' parameter "

--- a/cli/pcluster/dcv/utils.py
+++ b/cli/pcluster/dcv/utils.py
@@ -15,7 +15,7 @@ DCV_CONNECT_SCRIPT = "/opt/parallelcluster/scripts/pcluster_dcv_connect.sh"
 
 def get_supported_dcv_os():
     """Return a list of all the operating system supported by DCV."""
-    return ["centos7", "ubuntu1804"]
+    return ["centos7", "ubuntu1804", "alinux2"]
 
 
 def get_supported_dcv_partition():

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -279,7 +279,10 @@ def get_supported_os(scheduler):
     :param scheduler: the scheduler for which we want to know the supported os
     :return: an array of strings of the supported OSes
     """
-    return ["alinux"] if scheduler == "awsbatch" else ["alinux", "centos6", "centos7", "ubuntu1604", "ubuntu1804"]
+    oses = ["alinux", "alinux2"]
+    if scheduler != "awsbatch":
+        oses.extend(["centos6", "centos7", "ubuntu1604", "ubuntu1804"])
+    return list(oses)
 
 
 def get_supported_schedulers():

--- a/cli/tests/pcluster/config/test_param_to_file.py
+++ b/cli/tests/pcluster/config/test_param_to_file.py
@@ -24,6 +24,7 @@ from tests.pcluster.config.utils import get_mocked_pcluster_config, get_param_de
         (CLUSTER, "key_name", "test", "test"),
         (CLUSTER, "key_name", "NONE", "NONE"),
         (CLUSTER, "base_os", "alinux", None),  # alinux is the default so it will not be added to the file
+        (CLUSTER, "base_os", "alinux2", "alinux2"),
         (CLUSTER, "base_os", "ubuntu1804", "ubuntu1804"),
         (CLUSTER, "base_os", "ubuntu1404", "ubuntu1404"),  # no longer supported value
         # BoolParam

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -93,6 +93,7 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
                     "placement": "cluster",
                     "maintain_initial_size": True,
                     "enable_intel_hpc_platform": True,
+                    "base_os": "alinux",
                 },
             ),
         )
@@ -269,6 +270,7 @@ def test_cluster_section_from_241_cfn(mocker, cfn_params_dict, expected_section_
                     "max_queue_size": 3,
                     "placement": "cluster",
                     "maintain_initial_size": True,
+                    "base_os": "alinux",
                 },
             ),
         )
@@ -522,6 +524,7 @@ def test_cluster_section_from_210_cfn(mocker, cfn_params_dict, expected_section_
                     "initial_queue_size": 0,
                     "max_queue_size": 10,
                     "placement": "cluster",
+                    "base_os": "alinux",
                 },
             ),
         )

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -237,6 +237,7 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
         ("eu-north-1", "alinux", "awsbatch", None),
         ("cn-north-1", "alinux", "awsbatch", None),
         ("cn-northwest-1", "alinux", "awsbatch", None),
+        ("cn-northwest-1", "alinux2", "awsbatch", None),
         # verify traditional schedulers are supported in all the regions
         ("cn-northwest-1", "alinux", "sge", None),
         ("ap-northeast-3", "alinux", "sge", None),
@@ -250,24 +251,28 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
         ("eu-west-1", "ubuntu1604", "awsbatch", "scheduler supports the following Operating Systems"),
         ("eu-west-1", "ubuntu1804", "awsbatch", "scheduler supports the following Operating Systems"),
         ("eu-west-1", "alinux", "awsbatch", None),
+        ("eu-west-1", "alinux2", "awsbatch", None),
         # verify sge supports all the OSes
         ("eu-west-1", "centos6", "sge", None),
         ("eu-west-1", "centos7", "sge", None),
         ("eu-west-1", "ubuntu1604", "sge", None),
         ("eu-west-1", "ubuntu1804", "sge", None),
         ("eu-west-1", "alinux", "sge", None),
+        ("eu-west-1", "alinux2", "sge", None),
         # verify slurm supports all the OSes
         ("eu-west-1", "centos6", "slurm", None),
         ("eu-west-1", "centos7", "slurm", None),
         ("eu-west-1", "ubuntu1604", "slurm", None),
         ("eu-west-1", "ubuntu1804", "slurm", None),
         ("eu-west-1", "alinux", "slurm", None),
+        ("eu-west-1", "alinux2", "slurm", None),
         # verify torque supports all the OSes
         ("eu-west-1", "centos6", "torque", None),
         ("eu-west-1", "centos7", "torque", None),
         ("eu-west-1", "ubuntu1604", "torque", None),
         ("eu-west-1", "ubuntu1804", "torque", None),
         ("eu-west-1", "alinux", "torque", None),
+        ("eu-west-1", "alinux2", "torque", None),
     ],
 )
 def test_scheduler_validator(mocker, region, base_os, scheduler, expected_message):
@@ -956,6 +961,17 @@ def test_fsx_imported_file_chunk_size_validator(mocker, boto3_stubber, section_d
             None,
             None,
         ),
+        (
+            {
+                "enable_efa": "compute",
+                "compute_instance_type": "t2.large",
+                "base_os": "alinux2",
+                "scheduler": "slurm",
+                "placement_group": "DYNAMIC",
+            },
+            None,
+            None,
+        ),
     ],
 )
 def test_efa_validator(mocker, capsys, section_dict, expected_error, expected_warning):
@@ -1095,6 +1111,7 @@ def test_shared_dir_validator(mocker, section_dict, expected_message):
         ("ubuntu1804", None, None),
         ("ubuntu1804", "1.2.3.4/32", None),
         ("centos7", "0.0.0.0/0", None),
+        ("alinux2", None, None),
     ],
 )
 def test_dcv_enabled_validator(mocker, base_os, expected_message, access_from, caplog, capsys):

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/output.txt
@@ -38,10 +38,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 Allowed values for VPC ID:
 1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
 2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
@@ -33,10 +33,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 Allowed values for VPC ID:
 1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
 2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_available_no_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_available_no_input_no_automation_no_errors_with_config_file/output.txt
@@ -16,10 +16,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 Allowed values for VPC ID:
 1. vpc-abcdefgh | ParallelClusterVPC-20190625135738 | 2 subnets inside
 2. vpc-bcdefghi | ParallelClusterVPC-20190624105051 | 0 subnets inside

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/output.txt
@@ -33,10 +33,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 Allowed values for VPC ID:
 1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
 2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
@@ -33,10 +33,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 Allowed values for VPC ID:
 1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
 2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
@@ -33,10 +33,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 Allowed values for VPC ID:
 1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
 2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
@@ -33,10 +33,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 Allowed values for VPC ID:
 1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
 2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
@@ -33,10 +33,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet
 2. Master and compute fleet in the same public subnet

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
@@ -33,10 +33,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 There are no VPC for the given region. Starting automatic creation of VPC and subnets...
 Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
@@ -33,10 +33,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 There are no VPC for the given region. Starting automatic creation of VPC and subnets...
 Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/output.txt
@@ -33,10 +33,11 @@ Allowed values for Scheduler:
 4. awsbatch
 Allowed values for Operating System:
 1. alinux
-2. centos6
-3. centos7
-4. ubuntu1604
-5. ubuntu1804
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 Allowed values for VPC ID:
 1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
 2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -198,6 +198,7 @@
         "centos6",
         "centos7",
         "alinux",
+        "alinux2",
         "ubuntu1604",
         "ubuntu1804"
       ]
@@ -1122,6 +1123,10 @@
         "RootDevice": "/dev/sda1"
       },
       "alinux": {
+        "User": "ec2-user",
+        "RootDevice": "/dev/xvda"
+      },
+      "alinux2": {
         "User": "ec2-user",
         "RootDevice": "/dev/xvda"
       },


### PR DESCRIPTION
Enable users to specify a `base_os` value of `alinux2`. The changes
checked in here assume that alinux2 will support EFA and DCV.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
