### PR TITLE
Add warning message in cli logs when dcv port is open to 0.0.0.0/0

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -83,6 +83,7 @@ def create_ami(args):
 
 def config_logger():
     logger = logging.getLogger("pcluster")
+    file_only_logger = logging.getLogger("cli_log_file")
     logger.setLevel(logging.DEBUG)
 
     log_stream_handler = logging.StreamHandler(sys.stdout)
@@ -99,8 +100,9 @@ def config_logger():
 
     log_file_handler = RotatingFileHandler(logfile, maxBytes=5 * 1024 * 1024, backupCount=1)
     log_file_handler.setLevel(logging.DEBUG)
-    log_file_handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(name)s - %(message)s"))
+    log_file_handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(module)s - %(message)s"))
     logger.addHandler(log_file_handler)
+    file_only_logger.addHandler(log_file_handler)
 
 
 def _addarg_config(subparser):

--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -38,6 +38,7 @@ from tabulate import tabulate
 
 import pcluster.utils as utils
 from pcluster.config.pcluster_config import PclusterConfig
+from pcluster.constants import PCLUSTER_STACK_PREFIX
 
 if sys.version_info[0] >= 3:
     from urllib.request import urlretrieve
@@ -392,11 +393,11 @@ def list_stacks(args):
     try:
         result = []
         for stack in utils.paginate_boto3(boto3.client("cloudformation").describe_stacks):
-            if stack.get("ParentId") is None and stack.get("StackName").startswith(utils.PCLUSTER_STACK_PREFIX):
+            if stack.get("ParentId") is None and stack.get("StackName").startswith(PCLUSTER_STACK_PREFIX):
                 pcluster_version = _get_pcluster_version_from_stack(stack)
                 result.append(
                     [
-                        stack.get("StackName")[len(utils.PCLUSTER_STACK_PREFIX) :],  # noqa: E203
+                        stack.get("StackName")[len(PCLUSTER_STACK_PREFIX) :],  # noqa: E203
                         _colorize(stack.get("StackStatus"), args),
                         pcluster_version,
                     ]

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -61,6 +61,7 @@ from pcluster.config.validators import (
     shared_dir_validator,
     url_validator,
 )
+from pcluster.constants import CIDR_ALL_IPS
 
 # This file contains a definition of all the sections and the parameters configurable by the user
 # in the configuration file.
@@ -177,7 +178,7 @@ VPC = {
             "validators": [ec2_subnet_id_validator],
         },
         "ssh_from": {
-            "default": "0.0.0.0/0",
+            "default": CIDR_ALL_IPS,
             "allowed_values": ALLOWED_VALUES["cidr"],
             "cfn_param_mapping": "AccessFrom",
         },
@@ -390,7 +391,7 @@ DCV = {
                 "default": 8443,
             }),
             ("access_from", {
-                "default": "0.0.0.0/0",
+                "default": CIDR_ALL_IPS,
                 "allowed_values": ALLOWED_VALUES["cidr"],
             }),
         ]

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -18,13 +18,8 @@ from configparser import NoSectionError
 
 import yaml
 from pcluster.config.iam_policy_rules import AWSBatchFullAccessInclusionRule, CloudWatchAgentServerPolicyInclusionRule
-from pcluster.utils import (
-    PCLUSTER_ISSUES_LINK,
-    get_avail_zone,
-    get_cfn_param,
-    get_efs_mount_target_id,
-    get_instance_vcpus,
-)
+from pcluster.constants import PCLUSTER_ISSUES_LINK
+from pcluster.utils import get_avail_zone, get_cfn_param, get_efs_mount_target_id, get_instance_vcpus
 
 LOGGER = logging.getLogger(__name__)
 

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -8,6 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import re
 import urllib.error
 import urllib.request
@@ -27,6 +28,15 @@ from pcluster.utils import (
     get_supported_instance_types,
     get_supported_os,
 )
+
+LOGFILE_LOGGER = logging.getLogger("cli_log_file")
+
+DCV_MESSAGES = {
+    "warnings": {
+        "access_from_world": "With this configuration you are opening dcv port ({port}) to the world (0.0.0.0/0). "
+        "It is recommended to use dcv access_from config option to restrict access."
+    }
+}
 
 
 def _get_sts_endpoint():
@@ -236,6 +246,13 @@ def dcv_enabled_validator(param_key, param_value, pcluster_config):
 
         if get_partition() not in get_supported_dcv_partition():
             errors.append("NICE DCV is not supported in the selected region '{0}'".format(get_region()))
+
+        if pcluster_config.get_section("dcv").get_param_value("access_from") == "0.0.0.0/0":
+            LOGFILE_LOGGER.warning(
+                DCV_MESSAGES["warnings"]["access_from_world"].format(
+                    port=pcluster_config.get_section("dcv").get_param_value("port")
+                )
+            )
 
     return errors, warnings
 

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 import boto3
 from botocore.exceptions import ClientError
 
+from pcluster.constants import CIDR_ALL_IPS
 from pcluster.dcv.utils import get_supported_dcv_os, get_supported_dcv_partition
 from pcluster.utils import (
     get_efs_mount_target_id,
@@ -247,7 +248,7 @@ def dcv_enabled_validator(param_key, param_value, pcluster_config):
         if get_partition() not in get_supported_dcv_partition():
             errors.append("NICE DCV is not supported in the selected region '{0}'".format(get_region()))
 
-        if pcluster_config.get_section("dcv").get_param_value("access_from") == "0.0.0.0/0":
+        if pcluster_config.get_section("dcv").get_param_value("access_from") == CIDR_ALL_IPS:
             LOGFILE_LOGGER.warning(
                 DCV_MESSAGES["warnings"]["access_from_world"].format(
                     port=pcluster_config.get_section("dcv").get_param_value("port")

--- a/cli/pcluster/constants.py
+++ b/cli/pcluster/constants.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+PCLUSTER_STACK_PREFIX = "parallelcluster-"
+PCLUSTER_ISSUES_LINK = "https://github.com/aws/aws-parallelcluster/issues"

--- a/cli/pcluster/constants.py
+++ b/cli/pcluster/constants.py
@@ -11,3 +11,4 @@
 
 PCLUSTER_STACK_PREFIX = "parallelcluster-"
 PCLUSTER_ISSUES_LINK = "https://github.com/aws/aws-parallelcluster/issues"
+CIDR_ALL_IPS = "0.0.0.0/0"

--- a/cli/pcluster/dcv/connect.py
+++ b/cli/pcluster/dcv/connect.py
@@ -14,16 +14,9 @@ import subprocess as sub
 import webbrowser
 
 from pcluster.config.pcluster_config import PclusterConfig
+from pcluster.constants import PCLUSTER_ISSUES_LINK
 from pcluster.dcv.utils import DCV_CONNECT_SCRIPT
-from pcluster.utils import (
-    PCLUSTER_ISSUES_LINK,
-    error,
-    get_cfn_param,
-    get_master_ip_and_username,
-    get_stack,
-    get_stack_name,
-    retry,
-)
+from pcluster.utils import error, get_cfn_param, get_master_ip_and_username, get_stack, get_stack_name, retry
 
 LOGGER = logging.getLogger(__name__)
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -27,11 +27,10 @@ import boto3
 import pkg_resources
 from botocore.exceptions import ClientError
 
+from pcluster.constants import PCLUSTER_ISSUES_LINK, PCLUSTER_STACK_PREFIX
+
 LOGGER = logging.getLogger(__name__)
 
-PCLUSTER_STACK_PREFIX = "parallelcluster-"
-CW_LOGS_SUBSTACK_PREFIX = "CloudWatchLogsSubstack-"
-PCLUSTER_ISSUES_LINK = "https://github.com/aws/aws-parallelcluster/issues"
 STACK_TYPE = "AWS::CloudFormation::Stack"
 
 

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -5,4 +5,4 @@ pytest-datadir
 pytest-html
 pytest-mock
 assertpy
-discover # Needed for Python 2.6 compatibility
+codecov

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -7,15 +7,14 @@ envlist =
 
 # Default testenv. Used to run tests on all python versions.
 [testenv]
+passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT
 whitelist_externals =
     bash
 deps = -rtests/requirements.txt
 commands =
     bash ./tests/pcluster/test.sh
-    # Running with discover and not unittest discover for Python 2.6 compatibility
-    python -m discover -s tests/pcluster -p "*_test.py"
-    # awsbatch-cli is not currently compatible with Python2.6
-    py{27,34,35,36,37,38}: py.test -l -v --basetemp={envtmpdir} --html=report.html --cov={envsitepackagesdir}/awsbatch tests/ --cov={envsitepackagesdir}/pcluster
+    py{27,34,35,36,37,38}: py.test -l -v --basetemp={envtmpdir} --html=report.html --cov=awsbatch  --cov=pcluster tests/
+    codecov -e TOXENV
 
 # Section used to define common variables used by multiple testenvs.
 [vars]


### PR DESCRIPTION
Add warning message in cli logs when dcv port is open to 0.0.0.0/0

Codecov: https://codecov.io/gh/aws/aws-parallelcluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
