### PR TITLE
integ-tests: add options to preserve CW logs on failures

### DIFF
--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -74,6 +74,8 @@ TEST_DEFAULTS = {
     "benchmarks_target_capacity": 200,
     "benchmarks_max_time": 30,
     "stackname_suffix": "",
+    "keep_logs_on_cluster_failure": False,
+    "keep_logs_on_test_failure": False,
 }
 
 
@@ -218,6 +220,18 @@ def _init_argparser():
         help="set a suffix in the integration tests stack names",
         default=TEST_DEFAULTS.get("stackname_suffix"),
     )
+    parser.add_argument(
+        "--keep-logs-on-cluster-failure",
+        help="preserve CloudWatch logs when a cluster fails to be created",
+        action="store_true",
+        default=TEST_DEFAULTS.get("keep_logs_on_cluster_failure"),
+    )
+    parser.add_argument(
+        "--keep-logs-on-test-failure",
+        help="preserve CloudWatch logs when a test fails",
+        action="store_true",
+        default=TEST_DEFAULTS.get("keep_logs_on_test_failure"),
+    )
 
     return parser
 
@@ -258,6 +272,11 @@ def _get_pytest_args(args, regions, log_file, out_dir):
     pytest_args.extend(["--key-name", args.key_name])
     pytest_args.extend(["--key-path", args.key_path])
     pytest_args.extend(["--stackname-suffix", args.stackname_suffix])
+
+    if args.keep_logs_on_cluster_failure:
+        pytest_args.append("--keep-logs-on-cluster-failure")
+    if args.keep_logs_on_test_failure:
+        pytest_args.append("--keep-logs-on-test-failure")
 
     if args.credential:
         pytest_args.append("--credential")

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -617,9 +617,7 @@ def test_cloudwatch_logging(
         cw_logs_persist_after_delete,
     )
     cluster_logs_state = CloudWatchLoggingClusterState(scheduler, os, cluster).get_logs_state()
-    _test_cw_logs_before_after_delete(
-        cluster, cw_logs_persist_after_delete, cw_logging_enabled, cluster_logs_state, test_runner
-    )
+    _test_cw_logs_before_after_delete(cluster, cw_logs_persist_after_delete, cluster_logs_state, test_runner)
 
 
 def _check_log_groups_after_test(test_func):  # noqa: D202
@@ -640,15 +638,9 @@ def _check_log_groups_after_test(test_func):  # noqa: D202
     return wrapped_test
 
 
-def _delete_cluster(cluster, logging_enabled, keep_logs):
-    """Delete a cluster, passing it the appropriate logs."""
-    extra_delete_args = ["--keep-logs"] if keep_logs else []
-    cluster.delete(extra_args=extra_delete_args)
-
-
 @_check_log_groups_after_test
-def _test_cw_logs_before_after_delete(cluster, keep_logs, logging_enabled, cluster_logs_state, test_runner):
+def _test_cw_logs_before_after_delete(cluster, keep_logs, cluster_logs_state, test_runner):
     """Verify CloudWatch logs integration behaves as expected while a cluster is running and after it's deleted."""
     test_runner.run_tests(cluster_logs_state, cluster_has_been_deleted=False)
-    _delete_cluster(cluster, logging_enabled, keep_logs)
+    cluster.delete(keep_logs=keep_logs)
     test_runner.run_tests(cluster_logs_state, cluster_has_been_deleted=True)


### PR DESCRIPTION
```python
    parser.addoption(
        "--keep-logs-on-cluster-failure",
        help="preserve CloudWatch logs when a cluster fails to be created",
        action="store_true",
    )
    parser.addoption(
        "--keep-logs-on-test-failure", help="preserve CloudWatch logs when a test fails", action="store_true"
    )
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
