### PR TITLE
Validate KMS Key

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -56,6 +56,7 @@ from pcluster.config.validators import (
     fsx_storage_capacity_validator,
     fsx_validator,
     intel_hpc_validator,
+    kms_key_validator,
     raid_volume_iops_validator,
     scheduler_validator,
     shared_dir_validator,
@@ -255,6 +256,7 @@ EBS = {
         },
         "ebs_kms_key_id": {
             "cfn_param_mapping": "EBSKMSKeyId",
+            "validators": [kms_key_validator],
         },
         "ebs_volume_id": {
             "cfn_param_mapping": "EBSVolumeId",
@@ -284,7 +286,9 @@ EFS = {
                 "default": "generalPurpose",
                 "allowed_values": ["generalPurpose", "maxIO"],
             }),
-            ("efs_kms_key_id", {}),
+            ("efs_kms_key_id", {
+                "validators": [kms_key_validator],
+            }),
             ("provisioned_throughput", {
                 "allowed_values": r"^([0-9]{1,3}|10[0-1][0-9]|102[0-4])(\.[0-9])?$",  # 0.0 to 1024.0
                 "type": FloatParam,
@@ -337,7 +341,9 @@ RAID = {
                 "type": BoolParam,
                 "default": False,
             }),
-            ("ebs_kms_key_id", {}),
+            ("ebs_kms_key_id", {
+                "validators": [kms_key_validator],
+            }),
         ]
     )
 }
@@ -363,7 +369,9 @@ FSX = {
                 "type": IntParam,
                 "validators": [fsx_storage_capacity_validator]
             }),
-            ("fsx_kms_key_id", {}),
+            ("fsx_kms_key_id", {
+                "validators": [kms_key_validator],
+            }),
             ("imported_file_chunk_size", {
                 "type": IntParam,
                 "validators": [fsx_imported_file_chunk_size_validator]

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -268,6 +268,18 @@ def fsx_imported_file_chunk_size_validator(param_key, param_value, pcluster_conf
     return errors, warnings
 
 
+def kms_key_validator(param_key, param_value, pcluster_config):
+    errors = []
+    warnings = []
+
+    try:
+        boto3.client("kms").describe_key(KeyId=param_value)
+    except ClientError as e:
+        errors.append(e.response.get("Error").get("Message"))
+
+    return errors, warnings
+
+
 def efa_validator(param_key, param_value, pcluster_config):
     errors = []
     warnings = []


### PR DESCRIPTION
This adds a validator to the KMS key provided for EBS, FSx, and EFS.

For example:
```
$ pcluster create fsx-kms -t fsx -nr
Beginning cluster creation for cluster: fsx-kms
ERROR: The configuration parameter 'fsx_kms_key_id' generated the following errors:
Key 'arn:aws:kms:us-east-1:822857487308:key/5254ce99-38dj-46a8-ace3-007dff0371bb' does not exist
```

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
