### PR TITLE
release 2.5 backport: Fix DCV test and suppress clck failure

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -798,7 +798,7 @@ def _run_packer(packer_command, packer_env):
         sys.stdout.flush()
         LOGGER.error("Failed to run %s\n", _command)
         sys.exit(1)
-    except (IOError, OSError):
+    except (IOError, OSError):  # noqa: B014
         sys.stdout.flush()
         LOGGER.error("Failed to run %s\nCommand not found", packer_command)
         sys.exit(1)

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -386,7 +386,7 @@ class JsonParam(Param):
                 string_value = str(string_value).strip()
                 if string_value != "NONE":
                     param_value = yaml.safe_load(string_value)
-        except (TypeError, ValueError, Exception) as e:
+        except Exception as e:
             self.pcluster_config.error("Error parsing JSON parameter '{0}'. {1}".format(self.key, e))
 
         return param_value

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -28,7 +28,7 @@ REQUIRES = [
     "tabulate>=0.8.2,<=0.8.3",
     "ipaddress>=1.0.22",
     "enum34>=1.1.6",
-    "PyYAML>=5.1.2",
+    "PyYAML==5.2" if sys.version_info.major == 3 and sys.version_info.minor <= 4 else "PyYAML>=5.1.2",
 ]
 
 if sys.version_info[0] == 2:

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1317,6 +1317,7 @@
     "DynamoDBTable": {
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Delete",
       "Properties": {
         "AttributeDefinitions": [
           {

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
@@ -75,5 +75,12 @@ def _test_intel_clck(remote_command_executor, scheduler_commands, slots_per_inst
     try:
         assert_that(result.stdout).contains("Overall Result: PASS")
     except AssertionError as e:
-        logging.error(remote_command_executor.run_remote_command("cat clck_results.log").stdout)
+        clck_log = remote_command_executor.run_remote_command("cat clck_results.log").stdout
+        if (
+            "Total number of issues contributing to FAIL: 1 (0 diagnoses, 1 observation)" in clck_log
+            and "missing-tool-core-intel-runtime-2018.0:python3" in clck_log
+        ):
+            logging.info("Suppressing failure since this is not a real issue.")
+            return
+        logging.error(clck_log)
         raise e

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
@@ -14,9 +14,6 @@ compute_instance_type = {{ instance }}
 min_vcpus = 2
 desired_vcpus = 2
 max_vcpus = 40
-# EFS is integrated in order to exercise the mount_efs.sh script called from the
-# entry point of the docker image generated when the scheduler is awsbatch.
-efs_settings = custom_efs
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -14,6 +14,7 @@ import os
 import random
 import re
 import shlex
+import socket
 import string
 import subprocess
 
@@ -213,3 +214,26 @@ def unset_credentials():
 def set_logger_formatter(formatter):
     for handler in logging.getLogger().handlers:
         handler.setFormatter(formatter)
+
+
+def get_username_for_os(os):
+    """Return username for a given os."""
+    usernames = {
+        "alinux": "ec2-user",
+        "centos6": "centos",
+        "centos7": "centos",
+        "ubuntu1604": "ubuntu",
+        "ubuntu1804": "ubuntu",
+    }
+    return usernames.get(os)
+
+
+def add_keys_to_known_hosts(hostname, host_keys_file):
+    """Add ssh key for a host to a known_hosts file."""
+    os.system("ssh-keyscan -t rsa {0} >> {1}".format(hostname, host_keys_file))
+
+
+def remove_keys_from_known_hosts(hostname, host_keys_file, env):
+    """Remove ssh key for a host from a known_hosts file."""
+    for host in hostname, "{0}.".format(hostname), socket.gethostbyname(hostname):
+        run_command("ssh-keygen -R {0} -f {1}".format(host, host_keys_file), env=env)


### PR DESCRIPTION
- Backport fixes to dcv tests
- Suppress failures when cluster checker fails due to missing Intel Python string in the latest version of intelpython3.
- Disable EFS in AWS Batch test. Known issue: https://github.com/aws/aws-parallelcluster/pull/1563

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
