### PR TITLE
S3 Bucket Validator fixes

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -546,11 +546,9 @@ CLUSTER = {
             }),
             ("s3_read_resource", {
                 "cfn_param_mapping": "S3ReadResource",
-                "validators": [s3_bucket_validator],
             }),
             ("s3_read_write_resource", {
                 "cfn_param_mapping": "S3ReadWriteResource",
-                "validators": [s3_bucket_validator],
             }),
             (
                 "disable_hyperthreading",

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -324,35 +324,27 @@ def test_url_validator(mocker, boto3_stubber):
     [
         (
             {
-                "cluster default": {
-                    "fsx_settings": "fsx",
-                    "s3_read_write_resource": "s3://test/test1/test2",
-                    "s3_read_resource": "s3://test/test1/test2",
-                },
+                "cluster default": {"fsx_settings": "fsx"},
                 "fsx fsx": {
                     "storage_capacity": 1200,
                     "import_path": "s3://test/test1/test2",
                     "export_path": "s3://test/test1/test2",
                 },
             },
-            4,
+            2,
             {"Bucket": "test"},
             None,
         ),
         (
             {
-                "cluster default": {
-                    "fsx_settings": "fsx",
-                    "s3_read_write_resource": "s3://test/test1/test2",
-                    "s3_read_resource": "s3://test/test1/test2",
-                },
+                "cluster default": {"fsx_settings": "fsx"},
                 "fsx fsx": {
                     "storage_capacity": 1200,
                     "import_path": "http://test/test.json",
                     "export_path": "s3://test/test1/test2",
                 },
             },
-            3,
+            1,
             {"Bucket": "test"},
             "The value 'http://test/test.json' used for the parameter 'import_path' is not a valid S3 URI.",
         ),

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -162,6 +162,10 @@ class ClustersFactory:
             error = "Cluster creation failed for {0} with output: {1}".format(name, result.stdout)
             logging.error(error)
             raise Exception(error)
+        elif "WARNING" in result.stdout:
+            error = "Cluster creation for {0} generated a warning: {1}".format(name, result.stdout)
+            logging.error(error)
+            raise Exception(error)
         logging.info("Cluster {0} created successfully".format(name))
         cluster.create_complete = True
 


### PR DESCRIPTION
* Removes the bucket validator from `s3_read_resource` and `s3_read_write_resource`
* Adds a check in the integration tests to fail if WARNINGS are created during cluster create

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
