### PR TITLE
Increase timeout for DockerBuildWaitHandle to 60 mins

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,12 +2,14 @@
 CHANGELOG
 =========
 
-X.X.X
+2.6.0
 ====
 
 **CHANGES**
 
 * Use version 5.2 of PyYAML for python 3 versions of 3.4 or earlier.
+* Increase the total time allowed to build Docker images from 30 minutes to 60 minutes. This is done to better deal
+  with slow networking in China regions.
 
 2.5.1
 =====

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -855,7 +855,7 @@
         "Handle": {
           "Ref": "DockerBuildWaitHandle"
         },
-        "Timeout": "1800"
+        "Timeout": "3600"
       }
     },
     "SendBuildNotificationFunctionExecutionRole": {


### PR DESCRIPTION
Due to slow networking in China building a docker image can take some extra time

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
