### PR TITLE
Add test to verify there are no crash files

### DIFF
--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/verify_no_core_files.sh
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/verify_no_core_files.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -x
+
+CRASHDIR=/var/crash
+
+# There are no crash files if the directory doesn't exist
+[ -d ${CRASHDIR} ] || exit 0
+
+# Exit nonzero if there are any files
+crash_files="$(ls -A ${CRASHDIR})"
+if [ -n "${crash_files}" ]; then
+  echo "Found crash files in ${CRASHDIR}: ${crash_files}"
+  exit 1
+fi


### PR DESCRIPTION
This commit adds an integration test to ensure that there are no core
dumps in /var/crash of the tested cluster's master node.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
