### PR TITLE
enum34 dependency not required for Python 3.4+

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -27,9 +27,11 @@ REQUIRES = [
     "future>=0.16.0,<=0.18.2",
     "tabulate>=0.8.2,<=0.8.3",
     "ipaddress>=1.0.22",
-    "enum34>=1.1.6",
     "PyYAML==5.2" if sys.version_info.major == 3 and sys.version_info.minor <= 4 else "PyYAML>=5.1.2",
 ]
+
+if sys.version_info < (3, 4):
+    REQUIRES.append("enum34>=1.1.6")
 
 if sys.version_info[0] == 2:
     REQUIRES.append("configparser>=3.5.0,<=3.8.1")


### PR DESCRIPTION
After building `aws-parallelcluster@2.5.1` for Python 3.7, I discovered the following error message:
```console
$ pcluster configure
Traceback (most recent call last):
  File "/Users/Adam/.spack/darwin/.spack-env/view/bin/pcluster", line 7, in <module>
    from pkg_resources import load_entry_point
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3250, in <module>
    @_call_aside
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3234, in _call_aside
    f(*args, **kwargs)
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3263, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/Users/Adam/.spack/darwin/.spack-env/view/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'enum34>=1.1.6' distribution was not found and is required by aws-parallelcluster
```
Unfortunately, it's not possible to build `enum34` for Python 3.6+. `enum34` is a backport of the `enum` library from Python 3.4. In Python 3.6, new features were added that are not compatible with `enum34`. See https://bitbucket.org/stoneleaf/enum34/issues/19/enum34-isnt-compatible-with-python-36 for more info:

> The basic issue is that enum34 is not meant to be installed in Python versions 3.4+. Project should only include it as a dependency for 3.3-; if that it is not an option then using aenum is a fairly painless way to work around the issue -- it's compatible with the stdlib enum, won't be used by nor conflict with the stdlib, plus has some extra cool features.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
