### PR TITLE
setuptools is needed at run-time

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -23,6 +23,7 @@ def readme():
 
 VERSION = "2.5.1"
 REQUIRES = [
+    "setuptools",
     "boto3>=1.10.15",
     "future>=0.16.0,<=0.18.2",
     "tabulate>=0.8.2,<=0.8.3",


### PR DESCRIPTION
By explicitly including `setuptools` in the list of required dependencies, it makes it clear that `setuptools` is needed at run-time, not just build-time. Aka, `pkg_resources` needs to be present in the `PYTHONPATH` when you run any of the installed executables.

Setuptools is kind of a nightmare in that you can't use `install_requires` without first importing `setuptools`, so there's no easy way of stating a dependence on `setuptools`. The new `pyproject.toml` logic seems to be the recommended way around this, but requires a fairly new version of `setuptools`. Most projects I see that require `setuptools` at run-time add it to `install_requires`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
