### PR TITLE
Add alinux2 to script used to generate AMI list

### DIFF
--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -30,6 +30,7 @@ from botocore.exceptions import ClientError
 DISTROS = OrderedDict(
     [
         ("alinux", "amzn"),
+        ("alinux2", "amzn2"),
         ("centos6", "centos6"),
         ("centos7", "centos7"),
         ("ubuntu1604", "ubuntu-1604"),


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
