### PR TITLE
Fix SSH test for new SSH client configuration

### DIFF
--- a/tests/integration-tests/tests/scaling/test_mpi.py
+++ b/tests/integration-tests/tests/scaling/test_mpi.py
@@ -90,14 +90,16 @@ def _test_mpi_ssh(remote_command_executor, scheduler, os, test_datadir):
         str(test_datadir / "mpi_ssh.sh"), args=[mpi_module, remote_host_ip]
     ).stdout.splitlines()
 
-    # mpirun_out_ip = "ip-10-0-127-71"
-    assert_that(len(mpirun_out_ip)).is_equal_to(1)
+    # mpirun_out_ip = ["Warning: Permanently added '192.168.60.89' (ECDSA) to the list of known hosts.",
+    # '', 'ip-192-168-60-89']
+    assert_that(len(mpirun_out_ip)).is_equal_to(3)
     assert_that(mpirun_out_ip[-1]).is_equal_to(remote_host)
 
     mpirun_out = remote_command_executor.run_remote_script(
         str(test_datadir / "mpi_ssh.sh"), args=[mpi_module, remote_host]
     ).stdout.splitlines()
 
-    # mpirun_out = "ip-10-0-127-71"
-    assert_that(len(mpirun_out)).is_equal_to(1)
+    # mpirun_out = ["Warning: Permanently added 'ip-192-168-60-89,192.168.60.89' (ECDSA) to the list of known hosts.",
+    # '', 'ip-192-168-60-89']
+    assert_that(len(mpirun_out)).is_equal_to(3)
     assert_that(mpirun_out[-1]).is_equal_to(remote_host)


### PR DESCRIPTION
StrictHostKeyChecking is now disabled when target host is inside VPC, and UserKnownHostsFile is set to /dev/null.
See https://github.com/aws/aws-parallelcluster-cookbook/pull/523

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
