### PR TITLE
Restore know host file management for CentOS6

### DIFF
--- a/tests/integration-tests/tests/scaling/test_mpi.py
+++ b/tests/integration-tests/tests/scaling/test_mpi.py
@@ -91,7 +91,7 @@ def _test_mpi_ssh(remote_command_executor, scheduler, os, test_datadir):
 
     # mpirun_out_ip = ["Warning: Permanently added '192.168.60.89' (ECDSA) to the list of known hosts.",
     # '', 'ip-192-168-60-89']
-    assert_that(len(mpirun_out_ip)).is_equal_to(3)
+    assert_that(len(mpirun_out_ip)).is_equal_to(1 if os == "centos6" else 3)
     assert_that(mpirun_out_ip[-1]).is_equal_to(remote_host)
 
     mpirun_out = remote_command_executor.run_remote_script(
@@ -100,5 +100,5 @@ def _test_mpi_ssh(remote_command_executor, scheduler, os, test_datadir):
 
     # mpirun_out = ["Warning: Permanently added 'ip-192-168-60-89,192.168.60.89' (ECDSA) to the list of known hosts.",
     # '', 'ip-192-168-60-89']
-    assert_that(len(mpirun_out)).is_equal_to(3)
+    assert_that(len(mpirun_out)).is_equal_to(1 if os == "centos6" else 3)
     assert_that(mpirun_out[-1]).is_equal_to(remote_host)


### PR DESCRIPTION
The OpenSSH version in CentOS6 doesn't support the Match directive that allows to conditionally disable the StrictHostKeyChecking parameter

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
