### PR TITLE
Disable EBS tests in China

### DIFF
--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -20,7 +20,7 @@ from tests.storage.snapshots_factory import EBSSnapshotsFactory
 from tests.storage.storage_common import verify_directory_correctly_shared
 
 
-@pytest.mark.regions(["us-west-2", "cn-north-1", "us-gov-west-1"])
+@pytest.mark.regions(["us-west-2", "us-gov-west-1"])
 @pytest.mark.instances(["c4.xlarge", "c5.xlarge"])
 @pytest.mark.schedulers(["sge", "awsbatch"])
 @pytest.mark.usefixtures("region", "os", "instance")
@@ -87,7 +87,7 @@ def test_ebs_multiple(scheduler, pcluster_config_reader, clusters_factory):
         _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
 
-@pytest.mark.regions(["eu-west-2", "cn-northwest-1", "us-gov-west-1"])
+@pytest.mark.regions(["eu-west-2", "us-gov-west-1"])
 @pytest.mark.instances(["c4.xlarge", "c5.xlarge"])
 @pytest.mark.schedulers(["sge", "awsbatch"])
 @pytest.mark.usefixtures("region", "os", "instance")
@@ -102,7 +102,7 @@ def test_default_ebs(scheduler, pcluster_config_reader, clusters_factory):
     _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
 
-@pytest.mark.regions(["us-west-2", "cn-north-1", "us-gov-east-1"])
+@pytest.mark.regions(["us-west-2", "us-gov-east-1"])
 @pytest.mark.instances(["c4.xlarge", "c5.xlarge"])
 @pytest.mark.schedulers(["sge", "awsbatch"])
 @pytest.mark.usefixtures("region", "os", "instance")


### PR DESCRIPTION
The EBS tests in China timeout regularly when using AWS batch as the
scheduler. This has been remedied in develop by increasing the timeout,
but this change has not been applied to the release branch or (more
importantly) the most recent version of aws-parallelcluster 2.5 in PyPI.
Thus, this commit disables the EBS tests in China.

Signed-off-by: Tim Lane <tilne@amazon.com>