### PR TITLE
Stricter filter for AMI to avoid mixing alinux with alinux2

### DIFF
--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -91,7 +91,7 @@ def populate_amis_json(amis_json, images, region_name):
         amis = {}
         for image in images.get("Images"):
             for key, value in DISTROS.items():
-                if value in image.get("Name"):
+                if "-{0}-".format(value) in image.get("Name"):
                     amis[key] = image.get("ImageId")
         if len(amis) == 0:
             print("Warning: there are no AMIs in the selected region (%s)" % region_name)


### PR DESCRIPTION
* Use a stricter filter, `-{os}-`, for filtering AMI name in `populate_amis_json` so that alinux and alinux2 AMIs are not mixed up.
* Previously we only look for `{os}` in AMI name, if we look for `amzn` and `amzn2` in AMI name, alinux AMI will likely be overwritten by alinux2 AMI

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
