### PR TITLE
Fix bucket creation utility function

### DIFF
--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -602,7 +602,7 @@ def _kms_key_stubber(mocker, boto3_stubber, kms_key_id, expected_message, num_ca
             0,
         ),
         ({"shared_dir": "NONE", "storage_capacity": 1200}, None, "NONE cannot be used as a shared directory", 0),
-        ({"shared_dir": "/NONE", "storage_capacity": 1200}, None, "/NONE cannot be used as a shared directory", 0,),
+        ({"shared_dir": "/NONE", "storage_capacity": 1200}, None, "/NONE cannot be used as a shared directory", 0),
         ({"shared_dir": "/fsx"}, None, "the 'storage_capacity' option must be specified", 0),
         ({"shared_dir": "/fsx", "storage_capacity": 1200}, None, None, 0),
         (

--- a/cli/tests/pcluster/test_commands.py
+++ b/cli/tests/pcluster/test_commands.py
@@ -1,0 +1,93 @@
+# Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module provides unit tests for the functions in the pcluster.commands module."""
+
+import pytest
+from botocore.exceptions import ClientError
+
+import pcluster.utils as utils
+from assertpy import assert_that
+from pcluster.commands import _create_bucket_with_batch_resources
+
+
+def test_create_bucket_with_batch_resources_success(mocker):
+    """Verify that create_bucket_with_batch_resources behaves as expected."""
+    region = "eu-west-1"
+    stack_name = "test"
+
+    mocker.patch("pcluster.utils.generate_random_bucket_name")
+    mocker.patch("pcluster.utils.create_s3_bucket")
+    mocker.patch("pcluster.utils.upload_resources_artifacts")
+    mocker.patch("pcluster.utils.delete_s3_bucket")
+
+    _create_bucket_with_batch_resources(stack_name, region)
+    utils.delete_s3_bucket.assert_not_called()
+
+
+def test_create_bucket_with_batch_resources_creation_failure(mocker, caplog):
+    """Verify that create_bucket_with_batch_resources behaves as expected in case of bucket creation failure."""
+    region = "eu-west-1"
+    stack_name = "test"
+    bucket_name = stack_name + "-123"
+    error = "BucketAlreadyExists"
+    client_error = ClientError({"Error": {"Code": error}}, "create_bucket")
+
+    mocker.patch("pcluster.utils.generate_random_bucket_name", return_value=bucket_name)
+    mocker.patch("pcluster.utils.create_s3_bucket", side_effect=client_error)
+    mocker.patch("pcluster.utils.upload_resources_artifacts")
+    mocker.patch("pcluster.utils.delete_s3_bucket")
+
+    with pytest.raises(ClientError, match=error):
+        _create_bucket_with_batch_resources(stack_name, region)
+    utils.delete_s3_bucket.assert_not_called()
+    assert_that(caplog.text).contains("Unable to create S3 bucket")
+
+
+def test_create_bucket_with_batch_resources_upload_failure(mocker, caplog):
+    """Verify that create_bucket_with_batch_resources behaves as expected in case of upload failure."""
+    region = "eu-west-1"
+    stack_name = "test"
+    bucket_name = stack_name + "-123"
+    error = "ExpiredToken"
+    client_error = ClientError({"Error": {"Code": error}}, "upload_fileobj")
+
+    mocker.patch("pcluster.utils.generate_random_bucket_name", return_value=bucket_name)
+    mocker.patch("pcluster.utils.create_s3_bucket")
+    mocker.patch("pcluster.utils.upload_resources_artifacts", side_effect=client_error)
+    mocker.patch("pcluster.utils.delete_s3_bucket")
+
+    with pytest.raises(ClientError, match=error):
+        _create_bucket_with_batch_resources(stack_name, region)
+    # if resource upload fails we delete the stack
+    utils.delete_s3_bucket.assert_called_with(bucket_name)
+    assert_that(caplog.text).contains("Unable to upload AWS Batch resources")
+
+
+def test_create_bucket_with_batch_resources_deletion_failure(mocker, caplog):
+    """Verify that create_bucket_with_batch_resources behaves as expected in case of deletion failure."""
+    region = "eu-west-1"
+    stack_name = "test"
+    bucket_name = stack_name + "-123"
+    error = "AccessDenied"
+    client_error = ClientError({"Error": {"Code": error}}, "delete")
+
+    mocker.patch("pcluster.utils.generate_random_bucket_name", return_value=bucket_name)
+    mocker.patch("pcluster.utils.create_s3_bucket")
+    # to check bucket deletion we need to trigger a failure in the upload
+    mocker.patch("pcluster.utils.upload_resources_artifacts", side_effect=client_error)
+    mocker.patch("pcluster.utils.delete_s3_bucket", side_effect=client_error)
+
+    # force upload failure to trigger a stack deletion and then check the behaviour when the deletion fails
+    with pytest.raises(ClientError, match=error):
+        _create_bucket_with_batch_resources(stack_name, region)
+    utils.delete_s3_bucket.assert_called_with(bucket_name)
+    assert_that(caplog.text).contains("Unable to upload AWS Batch resources")


### PR DESCRIPTION
From now the `generate_random_bucket_name` function will raise the `ClientError` exception in each case and it is up to the caller to manage the different cases.

The function is only used to create the internal s3 bucket used for the awsbatch scheduler.

Since the awsbatch bucket is removed a cluster deletion time I removed the condition to skip the `BucketAlreadyOwnedByYou` exception, because we need to be sure that the bucket belongs to a specific cluster and is not a bucket previously created, already owned by the user.

Then I split the `try` blocks for the cluster creation and the resource artifacts upload, because it can happen that the bucket creation fails and the code in the catch block was trying to delete a nonexistent bucket.

Changed the log level to `CRITICAL`.

Refactored batch bucket creation function to be more testable:
* Moved bucket name generation in a separate function: `generate_random_bucket_name`.
* Moved resources folder discovery into the `create_bucket_with_batch_resources` function.

Added unit test for: 
* `generate_random_bucket_name`,
* `create_s3_bucket` 
* `create_bucket_with_batch_resources`
