### PR TITLE
Fix cloudwatch pagination issue

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/cloudwatch_logging_boto3_utils.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/cloudwatch_logging_boto3_utils.py
@@ -14,15 +14,21 @@ def _dumps_json(obj):
     return json.dumps(obj, indent=2)
 
 
-def get_log_groups():
+def get_cluster_log_groups_from_boto3(cluster_log_group_prefix):
     """
-    Get list of log groups.
+    Get log groups with cluster log group prefix from boto3.
 
     Raises ClientError.
     """
-    log_groups = boto3.client("logs").describe_log_groups().get("logGroups")
-    LOGGER.debug("Log groups: {0}\n".format(_dumps_json(log_groups)))
-    return log_groups
+    try:
+        log_groups = (
+            boto3.client("logs").describe_log_groups(logGroupNamePrefix=cluster_log_group_prefix).get("logGroups")
+        )
+        LOGGER.debug("Log groups: {0}\n".format(_dumps_json(log_groups)))
+        return log_groups
+    except ClientError as e:
+        LOGGER.debug("Unable to retrieve any log group with prefix {0}\nError: {1}".format(cluster_log_group_prefix, e))
+        raise ClientError
 
 
 def get_log_streams(log_group_name):

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -523,7 +523,7 @@ class CloudWatchLoggingTestRunner:
 
     def run_tests(self, logs_state, cluster_has_been_deleted=False):
         """Run all CloudWatch logging integration tests."""
-        log_groups = cw_logs_utils.get_log_groups()
+        log_groups = cw_logs_utils.get_cluster_log_groups_from_boto3(self.log_group_name)
         self.verify_log_group_exists(log_groups, cluster_has_been_deleted)
         self.verify_log_group_retention_days(log_groups, cluster_has_been_deleted)
 
@@ -629,7 +629,10 @@ def _check_log_groups_after_test(test_func):  # noqa: D202
         try:
             test_func(cluster, keep_logs, *args, **kwargs)
             if keep_logs and pre_test_log_groups:
-                post_test_log_groups = [lg.get("logGroupName") for lg in cw_logs_utils.get_log_groups()]
+                post_test_log_groups = [
+                    lg.get("logGroupName")
+                    for lg in cw_logs_utils.get_cluster_log_groups_from_boto3(pre_test_log_groups)
+                ]
                 LOGGER.info("Log groups after deleting the cluster:\n{0}".format("\n".join(post_test_log_groups)))
                 assert_that(post_test_log_groups).contains(*pre_test_log_groups)
         finally:


### PR DESCRIPTION
* `describe_log_groups` only returns 50 log groups by default, which could be a problem for test
* Using filter instead to look for log groups

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
