### PR TITLE
FSx Lustre Deployment Types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,14 @@ CHANGELOG
 =========
 
 2.6.0
-====
+=====
+
+**ENHANCEMENTS**
+* Support two new Lustre Features, Scratch 2 and Persistent filesystems
+  * This adds two parameters ``deployment_type`` and ``per_unit_storage_throughput`` to the ``fsx`` section.
+  * New storage sizes ``storage_capacity``, 1,200 GiB, 2,400 GiB and multiples of 2,400 are supported with ``SCRATCH_2``
+  * In transit encryption is available via ``kms_key_id`` parameter when ``deployment_type = PERSISTENT_1``.
+  * A new parameter, ``per_unit_storage_throughput`` is available when ``deployment_type = PERSISTENT_1``.
 
 **CHANGES**
 

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -108,6 +108,8 @@ ALLOWED_VALUES = {
     "volume_id": r"^vol-[0-9a-z]{8}$|^vol-[0-9a-z]{17}$",
     "volume_types": ["standard", "io1", "gp2", "st1", "sc1"],
     "vpc_id": r"^vpc-[0-9a-z]{8}$|^vpc-[0-9a-z]{17}$",
+    "deployment_type": ["SCRATCH_1", "SCRATCH_2", "PERSISTENT_1"],
+    "per_unit_storage_throughput": [50, 100, 200],
 }
 
 AWS = {
@@ -354,7 +356,7 @@ FSX = {
     "type": Section,
     "key": "fsx",
     "default_label": "default",
-    "validators": [fsx_validator],
+    "validators": [fsx_validator, fsx_storage_capacity_validator],
     "cfn_param_mapping": "FSXOptions",  # All the parameters in the section are converted into a single CFN parameter
     "params": OrderedDict(  # Use OrderedDict because the parameters must respect the order in the CFN parameter
         [
@@ -368,7 +370,6 @@ FSX = {
             }),
             ("storage_capacity", {
                 "type": IntParam,
-                "validators": [fsx_storage_capacity_validator]
             }),
             ("fsx_kms_key_id", {
                 "validators": [kms_key_validator],
@@ -385,6 +386,13 @@ FSX = {
             }),
             ("weekly_maintenance_start_time", {
                 "allowed_values": r"NONE|^[1-7]:([01]\d|2[0-3]):?([0-5]\d)$",
+            }),
+            ("deployment_type", {
+                "allowed_values": ALLOWED_VALUES["deployment_type"],
+            }),
+            ("per_unit_storage_throughput", {
+                "type": IntParam,
+                "allowed_values": ALLOWED_VALUES["per_unit_storage_throughput"],
             }),
         ]
     )
@@ -412,6 +420,7 @@ DCV = {
         ]
     )
 }
+
 CW_LOG = {
     "type": Section,
     "key": "cw_log",

--- a/cli/pcluster/examples/config
+++ b/cli/pcluster/examples/config
@@ -260,3 +260,21 @@ master_subnet_id = subnet-12345678
 # This is used when AWS ParallelCluster creates the security group
 # (defaults to 0.0.0.0/0)
 #access_from = 0.0.0.0/0
+
+## FSx settings
+#[fsx fsx-custom]
+# Mount Point for Shared Dir
+#shared_dir = /fsx
+# Storage Capacity in GiB
+#storage_capacity = 1200
+# Deployment type allows you to launch filesystems with different characteristics
+# Valid options are SCRATCH_1, PERSISTENT_1, SCRATCH_2
+#deployment_type = PERSISTENT_1
+# When using SCRATCH_2 or PERSISTENT_1 you can set storage throughput to 50,100,200
+#per_unit_storage_throughput = 50
+# S3 Bucket to hydrate the fs from
+#import_path = s3://import-path
+# S3 Location to backup too
+#export_path = s3://import-path/export-dir
+# For SCRATCH_2 and PERSISTENT_1 you can provide a KMS Key for in transit encryption
+#fsx_kms_key_id = XXXX-XXXXX-XXX-XXXXX

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -76,6 +76,8 @@ DEFAULT_FSX_DICT = {
     "export_path": None,
     "import_path": None,
     "weekly_maintenance_start_time": None,
+    "deployment_type": None,
+    "per_unit_storage_throughput": None,
 }
 
 DEFAULT_DCV_DICT = {"enable": None, "port": 8443, "access_from": "0.0.0.0/0"}
@@ -192,7 +194,7 @@ DEFAULT_EFS_CFN_PARAMS = {"EFSOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE
 
 DEFAULT_RAID_CFN_PARAMS = {"RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
-DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
+DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
 DEFAULT_DCV_CFN_PARAMS = {"DCVOptions": "NONE,NONE,NONE"}
 DEFAULT_CW_LOG_CFN_PARAMS = {"CWLogOptions": "true,14"}
@@ -261,7 +263,7 @@ DEFAULT_CLUSTER_CFN_PARAMS = {
     # raid
     "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # fsx
-    "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+    "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # dcv
     "DCVOptions": "NONE,NONE,NONE",
     # cw_log_settings

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -1198,7 +1198,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     # raid
                     "RAIDOptions": "raid,NONE,NONE,gp2,20,100,false,NONE",
                     # fsx
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                 },
@@ -1264,7 +1264,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     # raid
                     "RAIDOptions": "raid,NONE,NONE,gp2,20,100,false,NONE",
                     # fsx
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                 },

--- a/cli/tests/pcluster/config/test_section_fsx/test_fsx_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_fsx/test_fsx_from_file_to_cfn/pcluster.config.ini
@@ -31,6 +31,8 @@ imported_file_chunk_size = 1020
 export_path = s3://test-export
 import_path = s3://test-import
 weekly_maintenance_start_time = 10
+deployment_type = SCRATCH_1
+per_unit_storage_throughput = 50
 
 [fsx test4]
 shared_dir = /fsx

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -312,9 +312,9 @@
       "Default": "1"
     },
     "FSXOptions": {
-      "Description": "Comma separated list of FSx related options, 8 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time]",
+      "Description": "Comma separated list of FSx related options, 10 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput]",
       "Type": "String",
-      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
+      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },
     "EFSOptions": {
       "Description": "Comma separated list of efs related options, 9 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,exists_valid_master_mt,exists_valid_compute_mt]",
@@ -1609,6 +1609,16 @@
               "Sid": "SQSList",
               "Action": [
                 "sqs:ListQueues"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "*"
+              ]
+            },
+            {
+              "Sid": "FSx",
+              "Action": [
+                "fsx:DescribeFileSystems"
               ],
               "Effect": "Allow",
               "Resource": [

--- a/cloudformation/fsx-substack.cfn.json
+++ b/cloudformation/fsx-substack.cfn.json
@@ -135,6 +135,40 @@
           ]
         }
       ]
+    },
+    "UseDeploymentType": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "8",
+                {
+                  "Ref": "FSXOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
+    "UsePerUnitStorageThroughput": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "9",
+                {
+                  "Ref": "FSXOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
     }
   },
   "Outputs": {
@@ -168,7 +202,7 @@
       "Type": "String"
     },
     "FSXOptions": {
-      "Description": "Comma separated list of fsx related options, 8 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time]",
+      "Description": "Comma separated list of fsx related options, 10 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput]",
       "Type": "CommaDelimitedList"
     },
     "SubnetId": {
@@ -252,6 +286,38 @@
               {
                 "Fn::Select": [
                   "7",
+                  {
+                    "Ref": "FSXOptions"
+                  }
+                ]
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          },
+          "DeploymentType": {
+            "Fn::If": [
+              "UseDeploymentType",
+              {
+                "Fn::Select": [
+                  "8",
+                  {
+                    "Ref": "FSXOptions"
+                  }
+                ]
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          },
+          "PerUnitStorageThroughput": {
+            "Fn::If": [
+              "UsePerUnitStorageThroughput",
+              {
+                "Fn::Select": [
+                  "9",
                   {
                     "Ref": "FSXOptions"
                   }

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
@@ -33,3 +33,7 @@ imported_file_chunk_size = 1024
 import_path = s3://{{ bucket_name }}
 export_path = s3://{{ bucket_name }}/export_dir
 weekly_maintenance_start_time = 1:00:00
+deployment_type = {{ deployment_type }}
+{% if per_unit_storage_throughput %}
+per_unit_storage_throughput = {{ per_unit_storage_throughput }}
+{% endif %}


### PR DESCRIPTION
We've added support for two new FSx Lustre deployment types
  * `PERSISTENT_1` - The latest generation of scratch file systems that supports up to six times the baseline throughput for spiky workloads, and supports in-transit encryption of data for supported instance types. With this deployment type, the storage_capacity settings has possible values of 1200 and any multiple of 2400.
  * `SCRATCH_2` - Designed for longer-term storage. The file servers are highly available and the data is replicated within the file systems AWS Availability Zone (AZ), and supports in-transit encryption of data for supported instance types. With this deployment type, the storage_capacity settings has possible values of 1200 and any multiple of 2400.

* Add `deployment_type` parameter
* Add `per_unit_storage_throughput` parameter

* `fsx:DescribeFileSystems` This is needed to retreive the FSx MountName from the DescribeFileSystems API

* Validate `kms_key_id` and `per_unit_storage_throughput` are only set when `PERSISTENT_1`
* Add FSx Deployment Type Options to the integration tests
* Get FSx MountName from Boto3
  * For the new FSx FileSystem Types, the mountname changes from always /fsx to a value returned from the API. This is backwards compatible, so the API returns /fsx for `SCRATCH_1` (current default) filesystems.

Validate Storage Capacity

* If deployment_type == 'PERSISTENT_1' or 'SCRATCH_2' then

  storage_capacity can be 1200 GiB, 2400 GiB, or multiples of 2400

* If deployment_type == 'SCRATCH_1' then

  storage_capacity can be 1200 GiB, 2400 GiB, or multiples of 3600

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
