### PR TITLE
Add slurm scaling test cases for manual actions

### DIFF
--- a/tests/integration-tests/tests/cfn-init/test_cfn_init.py
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init.py
@@ -40,7 +40,7 @@ def test_replace_compute_on_failure(region, pcluster_config_reader, clusters_fac
     # submit a job to spin up a compute node that will fail due to post_install script
     sge_commands = SlurmCommands(remote_command_executor)
     sge_commands.submit_command("sleep 1")
-    instance_id = wait_compute_log(remote_command_executor)
+    instance_id = wait_compute_log(remote_command_executor)[0]
 
     # extract logs and check one of them
     _assert_compute_logs(remote_command_executor, instance_id)

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -105,6 +105,16 @@ class SchedulerCommands(metaclass=ABCMeta):
         """Get number of slots per instance."""
         pass
 
+    @abstractmethod
+    def set_nodes_state(self, compute_nodes, state):
+        """Set nodes to down state in scheduler"""
+        pass
+
+    @abstractmethod
+    def get_nodes_status(self):
+        """Retrieve node state/status from scheduler"""
+        pass
+
 
 class AWSBatchCommands(SchedulerCommands):
     """Implement commands for awsbatch scheduler."""
@@ -152,6 +162,14 @@ class AWSBatchCommands(SchedulerCommands):
         raise NotImplementedError
 
     def get_node_cores(self):  # noqa: D102
+        raise NotImplementedError
+
+    def set_nodes_state(self, compute_nodes, state):
+        """Not implemented."""
+        raise NotImplementedError
+
+    def get_nodes_status(self):
+        """Not implemented."""
         raise NotImplementedError
 
 
@@ -236,6 +254,14 @@ class SgeCommands(SchedulerCommands):
         """Return number of slots from the scheduler."""
         result = self._remote_command_executor.run_remote_command("qhost -F | grep hl:m_core")
         return re.search(r"hl:m_core=(\d+).000000", result.stdout).group(1)
+
+    def set_nodes_state(self, compute_nodes, state):
+        """Not implemented."""
+        raise NotImplementedError
+
+    def get_nodes_status(self):
+        """Not implemented."""
+        raise NotImplementedError
 
 
 class SlurmCommands(SchedulerCommands):
@@ -332,6 +358,24 @@ class SlurmCommands(SchedulerCommands):
         """Cancel a job"""
         return self._remote_command_executor.run_remote_command("scancel {}".format(job_id))
 
+    def set_nodes_state(self, compute_nodes, state):
+        """Put nodes into down state."""
+        self._remote_command_executor.run_remote_command(
+            "sudo /opt/slurm/bin/scontrol update NodeName={} state={} reason=testing".format(
+                ",".join(compute_nodes), state
+            )
+        )
+
+    def get_nodes_status(self, nodes):
+        """Retrieve node state/status from scheduler"""
+        result = self._remote_command_executor.run_remote_command(
+            "/opt/slurm/bin/sinfo -O nodehost,statelong | tail -n +2"
+        ).stdout.splitlines()
+        current_node_states = {}
+        for entry in result:
+            current_node_states[entry.split()[0]] = entry.split()[1]
+        return {node: current_node_states.get(node, "Unable to retrieve state") for node in nodes}
+
 
 class TorqueCommands(SchedulerCommands):
     """Implement commands for torque scheduler."""
@@ -406,6 +450,14 @@ class TorqueCommands(SchedulerCommands):
         """Return number of slots from the scheduler."""
         result = self._remote_command_executor.run_remote_command("pbsnodes | tail -n +10")
         return re.search(r"np = (\d+)", result.stdout).group(1)
+
+    def set_nodes_state(self, compute_nodes, state):
+        """Not implemented."""
+        raise NotImplementedError
+
+    def get_nodes_status(self):
+        """Not implemented."""
+        raise NotImplementedError
 
 
 def get_scheduler_commands(scheduler, remote_command_executor):

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -72,6 +72,7 @@ def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clu
 @pytest.mark.usefixtures("region", "os", "instance")
 @pytest.mark.nodewatcher
 def test_nodewatcher_terminates_failing_node(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):
+    # slurm test use more nodes because of internal request to test in multi-node settings
     initial_queue_size = 5 if scheduler == "slurm" else 1
     cluster_config = pcluster_config_reader(initial_queue_size=initial_queue_size)
     cluster = clusters_factory(cluster_config)
@@ -117,11 +118,11 @@ def test_nodewatcher_terminates_failing_node(scheduler, region, pcluster_config_
 @pytest.mark.scaling_with_manual_actions
 def test_scaling_with_manual_actions(scheduler, region, pcluster_config_reader, clusters_factory):
     """Test that slurm-specific scaling logic is resistent to manual actions and failures."""
-    cluster_config = pcluster_config_reader()
+    num_compute_nodes = 5
+    cluster_config = pcluster_config_reader(initial_queue_size=num_compute_nodes)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
-    num_compute_nodes = 5
 
     instance_ids = get_compute_nodes_instance_ids(cluster.cfn_name, region)
 

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -10,7 +10,9 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
+import time
 
+import boto3
 import pytest
 from retrying import retry
 
@@ -21,6 +23,7 @@ from tests.common.compute_logs_common import wait_compute_log
 from tests.common.scaling_common import get_compute_nodes_allocation, get_desired_asg_capacity
 from tests.common.schedulers_common import get_scheduler_commands
 from time_utils import minutes, seconds
+from utils import get_compute_nodes_instance_ids, get_instance_ids_to_compute_hostnames_dict
 
 
 @pytest.mark.skip_schedulers(["awsbatch"])
@@ -69,29 +72,207 @@ def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clu
 @pytest.mark.usefixtures("region", "os", "instance")
 @pytest.mark.nodewatcher
 def test_nodewatcher_terminates_failing_node(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):
-    cluster_config = pcluster_config_reader()
+    initial_queue_size = 5 if scheduler == "slurm" else 1
+    cluster_config = pcluster_config_reader(initial_queue_size=initial_queue_size)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
 
     compute_nodes = scheduler_commands.get_compute_nodes()
+    instance_ids = get_compute_nodes_instance_ids(cluster.cfn_name, region)
+    instance_ids_to_hostname = get_instance_ids_to_compute_hostnames_dict(instance_ids)
 
-    # submit a job that kills the slurm daemon so that the node enters a failing state
-    scheduler_commands.submit_script(str(test_datadir / "{0}_kill_scheduler_job.sh".format(scheduler)))
-    instance_id = wait_compute_log(remote_command_executor)
+    logging.info("Testing that nodewatcher will terminate a node in failing state")
+    # submit a job to run on all nodes
+    scheduler_commands.submit_command("sleep infinity", nodes=initial_queue_size)
+    expected_num_nodes_killed = 4 if scheduler == "slurm" else 1
+    # simulate unexpected hardware failure by killing first x nodes
+    nodes_to_remove = compute_nodes[:expected_num_nodes_killed]
+    for node in nodes_to_remove:
+        remote_command_executor.run_remote_script(
+            str(test_datadir / "{0}_kill_scheduler_job.sh".format(scheduler)), args=[node]
+        )
+    failed_instances = wait_compute_log(remote_command_executor, expected_num_nodes_killed)
 
-    _assert_compute_logs(remote_command_executor, instance_id)
-    assert_instance_replaced_or_terminating(instance_id, region)
-    # verify that desired capacity is still 1
-    assert_that(get_desired_asg_capacity(region, cluster.cfn_name)).is_equal_to(1)
-    _assert_nodes_removed_from_scheduler(scheduler_commands, compute_nodes)
+    for instance_id in failed_instances:
+        assert_that(nodes_to_remove).contains(instance_ids_to_hostname.get(instance_id))
+        _assert_compute_logs(remote_command_executor, instance_id)
+        assert_instance_replaced_or_terminating(instance_id, region)
+
+    nodes_to_retain = [compute for compute in compute_nodes if compute not in nodes_to_remove]
+    # verify that desired capacity is still the initial_queue_size
+    assert_that(get_desired_asg_capacity(region, cluster.cfn_name)).is_equal_to(initial_queue_size)
+    _assert_nodes_removed_and_replaced_in_scheduler(
+        scheduler_commands, nodes_to_remove, nodes_to_retain, desired_capacity=initial_queue_size
+    )
 
     assert_no_errors_in_logs(remote_command_executor, ["/var/log/sqswatcher", "/var/log/jobwatcher"])
 
 
-@retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))
+@pytest.mark.regions(["us-west-1"])
+@pytest.mark.instances(["c5.xlarge"])
+@pytest.mark.schedulers(["slurm"])
+@pytest.mark.os(["ubuntu1804"])
+@pytest.mark.usefixtures("region", "os", "instance")
+@pytest.mark.scaling_with_manual_actions
+def test_scaling_with_manual_actions(scheduler, region, pcluster_config_reader, clusters_factory):
+    """Test that slurm-specific scaling logic is resistent to manual actions and failures."""
+    cluster_config = pcluster_config_reader()
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+    num_compute_nodes = 5
+
+    instance_ids = get_compute_nodes_instance_ids(cluster.cfn_name, region)
+
+    _test_replace_terminated_nodes(scheduler_commands, num_compute_nodes, instance_ids)
+    _test_replace_down_nodes(scheduler_commands, num_compute_nodes)
+    _test_keep_or_replace_suspended_nodes(scheduler_commands, num_compute_nodes)
+
+
+def _assert_initial_conditions(scheduler_commands, num_compute_nodes):
+    """Assert cluster is in expected state before test starts; return list of compute nodes."""
+    compute_nodes = scheduler_commands.get_compute_nodes()
+    logging.info(
+        "Assert initial condition, expect cluster to have {num_nodes} idle nodes".format(num_nodes=num_compute_nodes)
+    )
+    _assert_num_nodes_in_scheduler(scheduler_commands, num_compute_nodes)
+    _assert_compute_node_states(scheduler_commands, compute_nodes, expected_states=["idle"])
+
+    return compute_nodes
+
+
+def _test_replace_terminated_nodes(scheduler_commands, num_compute_nodes, instance_ids):
+    """Test that slurm nodes are replaced if instances are terminated manually."""
+    logging.info("Testing that nodes are replaced when terminated manually")
+    compute_nodes = _assert_initial_conditions(scheduler_commands, num_compute_nodes)
+    instance_ids_to_hostname = get_instance_ids_to_compute_hostnames_dict(instance_ids)
+    # Run job on all nodes
+    _submit_sleep_job(scheduler_commands, num_compute_nodes)
+    nodes_to_retain = [instance_ids_to_hostname[instance_ids[0]]]
+    compute_nodes.remove(instance_ids_to_hostname[instance_ids[0]])
+    # terminate n-1 nodes manually
+    _terminate_nodes_manually(instance_ids[1:])
+    # ASG does EC2 health check and replace node 1 at a time, each node takes about 2 mins to replace
+    # This process does not scale well if large number of nodes are terminated manually
+    _assert_nodes_removed_and_replaced_in_scheduler(
+        scheduler_commands, compute_nodes, nodes_to_retain, desired_capacity=num_compute_nodes
+    )
+
+
+def _test_replace_down_nodes(scheduler_commands, num_compute_nodes):
+    """Test that slurm nodes are replaced if nodes are marked DOWN."""
+    logging.info("Testing that nodes replaced when set to down state")
+    compute_nodes = _assert_initial_conditions(scheduler_commands, num_compute_nodes)
+    # Run job on all nodes
+    _submit_sleep_job(scheduler_commands, num_compute_nodes)
+    # Set n-1 nodes to down
+    nodes_to_remove = compute_nodes[:-1]
+    nodes_to_retain = compute_nodes[-1:]
+    _set_nodes_to_down_manually(scheduler_commands, nodes_to_remove)
+    _assert_nodes_removed_and_replaced_in_scheduler(
+        scheduler_commands, nodes_to_remove, nodes_to_retain, desired_capacity=num_compute_nodes
+    )
+
+
+def _test_keep_or_replace_suspended_nodes(scheduler_commands, num_compute_nodes):
+    """Test keep DRAIN nodes if there is job running, or terminate if no job is running."""
+    logging.info(
+        "Testing that nodes are NOT terminated when set to suspend state and there is job running on the nodes"
+    )
+    compute_nodes = _assert_initial_conditions(scheduler_commands, num_compute_nodes)
+    # Run job on all nodes
+    job_id = _submit_sleep_job(scheduler_commands, num_compute_nodes)
+    # Set n-1 nodes to drain
+    nodes_to_remove = compute_nodes[:-1]
+    nodes_to_retain = compute_nodes[-1:]
+    _set_nodes_to_suspend_state_manually(scheduler_commands, nodes_to_remove)
+    # assert all nodes are retained correctly
+    _assert_nodes_not_terminated_by_nodewatcher(scheduler_commands, compute_nodes)
+    # wait until the job is completed and check that the drain nodes are then terminated
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)
+    _assert_nodes_removed_and_replaced_in_scheduler(
+        scheduler_commands, nodes_to_remove, nodes_to_retain, desired_capacity=num_compute_nodes
+    )
+
+
+def _submit_sleep_job(scheduler_commands, num_compute_nodes):
+    # submit job with --no-requeue so that we do not have to wait for job to finish
+    # if job is automatically requeued by slurm after node replacement
+    result = scheduler_commands.submit_command(
+        command="sleep 500", nodes=num_compute_nodes, other_options="--no-requeue"
+    )
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    # sleep for 10 seconds to avoid case of node is put into a state before job is assigned to the node
+    time.sleep(10)
+    return job_id
+
+
+def _assert_nodes_not_terminated_by_nodewatcher(scheduler_commands, nodes, nodewatcher_timeout=7):
+    logging.info("Waiting for nodewatcher action")
+    start_time = time.time()
+    while time.time() < start_time + 60 * (nodewatcher_timeout):
+        assert_that(set(nodes) <= set(scheduler_commands.get_compute_nodes())).is_true()
+        time.sleep(10)
+
+
+def _assert_nodes_removed_and_replaced_in_scheduler(
+    scheduler_commands, nodes_to_remove, nodes_to_retain, desired_capacity
+):
+    """
+    Assert that nodes are removed from scheduler and replaced so that number of nodes in scheduler equals to desired.
+    Returns list of new nodenames in scheduler.
+    """
+    _assert_nodes_removed_from_scheduler(scheduler_commands, nodes_to_remove)
+    _assert_num_nodes_in_scheduler(scheduler_commands, desired_capacity)
+    new_compute_nodes = scheduler_commands.get_compute_nodes()
+    if nodes_to_retain:
+        assert_that(set(nodes_to_retain) <= set(new_compute_nodes)).is_true()
+    logging.info(
+        "\nNodes removed from scheduler: {}"
+        "\nNodes retained in scheduler {}"
+        "\nNodes currently in scheduler after replacements: {}".format(
+            nodes_to_remove, nodes_to_retain, new_compute_nodes
+        )
+    )
+
+
+def _set_nodes_to_suspend_state_manually(scheduler_commands, compute_nodes):
+    scheduler_commands.set_nodes_state(compute_nodes, state="drain")
+    # draining means that there is job currently running on the node
+    # drained would mean we placed node in drain when there is no job running on the node
+    _assert_compute_node_states(scheduler_commands, compute_nodes, expected_states=["draining"])
+
+
+def _set_nodes_to_down_manually(scheduler_commands, compute_nodes):
+    scheduler_commands.set_nodes_state(compute_nodes, state="down")
+    _assert_compute_node_states(scheduler_commands, compute_nodes, expected_states=["down"])
+
+
+def _assert_compute_node_states(scheduler_commands, compute_nodes, expected_states):
+    node_states = scheduler_commands.get_nodes_status(compute_nodes)
+    for node in compute_nodes:
+        assert_that(expected_states).contains(node_states.get(node))
+
+
+def _terminate_nodes_manually(instance_ids):
+    ec2_client = boto3.client("ec2")
+    for instance_id in instance_ids:
+        instance_states = ec2_client.terminate_instances(InstanceIds=[instance_id]).get("TerminatingInstances")[0]
+        assert_that(instance_states.get("InstanceId")).is_equal_to(instance_id)
+        assert_that(instance_states.get("CurrentState").get("Name")).is_in("shutting-down", "terminated")
+    logging.info("Terminated nodes: {}".format(instance_ids))
+
+
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(10))
 def _assert_nodes_removed_from_scheduler(scheduler_commands, nodes):
     assert_that(scheduler_commands.get_compute_nodes()).does_not_contain(*nodes)
+
+
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(10))
+def _assert_num_nodes_in_scheduler(scheduler_commands, desired):
+    assert_that(len(scheduler_commands.get_compute_nodes())).is_equal_to(desired)
 
 
 def _assert_compute_logs(remote_command_executor, instance_id):

--- a/tests/integration-tests/tests/scaling/test_scaling/test_nodewatcher_terminates_failing_node/sge_kill_scheduler_job.sh
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_nodewatcher_terminates_failing_node/sge_kill_scheduler_job.sh
@@ -10,6 +10,4 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-sudo /etc/init.d/sgeexecd.p6444 stop
-# keep job up and running
-sleep infinity
+ssh $1 sudo /etc/init.d/sgeexecd.p6444 stop

--- a/tests/integration-tests/tests/scaling/test_scaling/test_nodewatcher_terminates_failing_node/slurm_kill_scheduler_job.sh
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_nodewatcher_terminates_failing_node/slurm_kill_scheduler_job.sh
@@ -10,6 +10,4 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-sudo kill $(ps aux | grep '[s]lurm' | awk '{print $2}')
-# keep job up and running
-sleep infinity
+ssh $1 sudo pkill -f slurmd

--- a/tests/integration-tests/tests/scaling/test_scaling/test_nodewatcher_terminates_failing_node/torque_kill_scheduler_job.sh
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_nodewatcher_terminates_failing_node/torque_kill_scheduler_job.sh
@@ -10,6 +10,4 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-sudo /etc/init.d/pbs_mom stop
-# keep job up and running
-sleep infinity
+ssh $1 sudo /etc/init.d/pbs_mom stop

--- a/tests/integration-tests/tests/scaling/test_scaling/test_scaling_with_manual_actions/pcluster.config.ini
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_scaling_with_manual_actions/pcluster.config.ini
@@ -11,7 +11,7 @@ vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
 master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
-initial_queue_size = {{ initial_queue_size }}
+initial_queue_size = 5
 maintain_initial_size = true
 
 [vpc parallelcluster-vpc]

--- a/tests/integration-tests/tests/scaling/test_scaling/test_scaling_with_manual_actions/pcluster.config.ini
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_scaling_with_manual_actions/pcluster.config.ini
@@ -11,7 +11,7 @@ vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
 master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
-initial_queue_size = 5
+initial_queue_size = {{ initial_queue_size }}
 maintain_initial_size = true
 
 [vpc parallelcluster-vpc]

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -125,6 +125,21 @@ def get_compute_nodes_instance_ids(stack_name, region):
         raise
 
 
+def get_instance_ids_to_compute_hostnames_dict(instance_ids):
+    """Return dict of instanceIDs to hostnames."""
+    try:
+        instance_id_to_hostname = {}
+        ec2_client = boto3.client("ec2")
+        response = ec2_client.describe_instances(InstanceIds=instance_ids).get("Reservations")
+        for reservation in response:
+            for instance in reservation.get("Instances"):
+                instance_id_to_hostname[instance.get("InstanceId")] = instance.get("PrivateDnsName").split(".")[0]
+
+        return instance_id_to_hostname
+    except Exception as e:
+        logging.error("Failed retrieving hostnames for instances {} with exception: {}".format(instance_ids, e))
+
+
 def to_snake_case(input):
     """Convert a string into its snake case representation."""
     s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", input)


### PR DESCRIPTION
* Test that node is replaced if node is terminated manually
* Test that node is replaced if node is placed in down state
* Test that node is NOT replaced if node is placed in drain and there is job running on the node
* Add assertion to make sure nodewatcher will replace compute node when slurmd is terminated

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
