### PR TITLE
integ-tests: disable awsbatch tests in cn regions

### DIFF
--- a/tests/integration-tests/conftest_markers.py
+++ b/tests/integration-tests/conftest_markers.py
@@ -25,6 +25,10 @@ UNSUPPORTED_DIMENSIONS = [
     ("us-gov-west-1", "*", "*", "awsbatch"),
     ("us-gov-east-1", "*", "*", "awsbatch"),
     ("us-gov-east-1", "*", "c4.xlarge", "*"),
+    # Disabling awsbatch tests in China.
+    # Tests are encountering sporadic failures when building Docker images due to slow networking.
+    ("cn-north-1", "*", "*", "awsbatch"),
+    ("cn-northwest-1", "*", "*", "awsbatch"),
 ]
 
 


### PR DESCRIPTION
There are sporadic failures due to slow networking when building docker images.
Suppressing tests for now only for version 2.6.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
