### PR TITLE
integ-tests: reduce number of EIPs required by tests

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.ini
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.ini
@@ -23,3 +23,4 @@ retention_days = {{ retention_days }}
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_disable_hyperthreading/pcluster.config.ini
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_disable_hyperthreading/pcluster.config.ini
@@ -19,3 +19,4 @@ maintain_initial_size = true
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.ini
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.ini
@@ -21,3 +21,4 @@ placement_group = DYNAMIC
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/iam_policies/test_iam_policies/test_iam_policies/pcluster.config.ini
+++ b/tests/integration-tests/tests/iam_policies/test_iam_policies/test_iam_policies/pcluster.config.ini
@@ -14,3 +14,4 @@ additional_iam_policies = {{ iam_policies }}
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.ini
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.ini
@@ -26,3 +26,4 @@ volume_size = 200
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
@@ -22,6 +22,7 @@ efs_settings = custom_efs
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
 
 [efs custom_efs]
 shared_dir = efs

--- a/tests/integration-tests/tests/storage/test_ebs/test_default_ebs/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_default_ebs/pcluster.config.ini
@@ -23,3 +23,4 @@ maintain_initial_size = true
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.ini
@@ -24,6 +24,7 @@ ebs_settings = ebs1, ebs2, ebs3, ebs4, ebs5
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
 
 [ebs ebs1]
 shared_dir = {{ mount_dirs[0] }}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.ini
@@ -24,6 +24,7 @@ ebs_settings = ebs
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
 
 [ebs ebs]
 shared_dir = {{ mount_dir }}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.ini
@@ -24,5 +24,6 @@ maintain_initial_size = true
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
 
 [ebs empty]

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.ini
@@ -24,6 +24,7 @@ ebs_settings = ebs
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
 
 [ebs ebs]
 ebs_snapshot_id = {{ snapshot_id }}

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.ini
@@ -24,6 +24,7 @@ efs_settings = efs
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
 
 [efs efs]
 shared_dir = {{ mount_dir }}

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
@@ -25,6 +25,7 @@ s3_read_resource = arn:aws:s3:::{{ bucket_name }}/*
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
 
 [fsx fsx]
 shared_dir = {{ mount_dir }}

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.ini
@@ -24,6 +24,7 @@ raid_settings = raid_type1
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
 
 [raid raid_type1]
 shared_dir = raid_dir

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.ini
@@ -24,6 +24,7 @@ raid_settings = raid_type0
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
 
 [raid raid_type0]
 shared_dir = /raid_dir


### PR DESCRIPTION
As long as the compute nodes are in a private subnet with NAT and the master subnet has auto-assign public ip set to true then we can set use_public_ips to false. The master still gets a public ip from the subnet setting (auto-assign public ip) while the compute nodes only need a private IPs.
This reduces the number of Elastic IPs required to run integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
