### PR TITLE
integ-tests: log collected tests after all filtering is performed

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -143,7 +143,9 @@ def pytest_collection_modifyitems(config, items):
 
     _add_filename_markers(items)
 
-    _log_collected_tests(config, items)
+
+def pytest_collection_finish(session):
+    _log_collected_tests(session.config, session.items)
 
 
 def _log_collected_tests(config, items):


### PR DESCRIPTION
Moved the log of collected tests to a hook that is called at a later staged so that also mark expressions are processed (marker expressions are used when the --features flag is specified in test_runner)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
