### PR TITLE
release-2.5: Fix missing region parameter in test_spot_default

### DIFF
--- a/tests/integration-tests/tests/spot/test_spot.py
+++ b/tests/integration-tests/tests/spot/test_spot.py
@@ -19,7 +19,7 @@ from tests.common.schedulers_common import get_scheduler_commands
 @pytest.mark.regions(["us-east-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["sge"])
-@pytest.mark.usefixtures("os", "instance", "scheduler")
+@pytest.mark.usefixtures("region", "os", "instance", "scheduler")
 def test_spot_default(scheduler, pcluster_config_reader, clusters_factory):
     """Test that a cluster with spot instances can be created with default spot_price_value."""
     cluster_config = pcluster_config_reader()


### PR DESCRIPTION
After the new pytest release (5.4.0) the test was failing due to the
missing declaration of the "region" parameter.
From the changelog:

5712: Now all arguments to @pytest.mark.parametrize need to be
explicitly declared in the function signature or via indirect.
Previously it was possible to omit an argument if a fixture with
the same name existed, which was just an accident of implementation
and was not meant to be a part of the API.

https://docs.pytest.org/en/latest/changelog.html

Signed-off-by: ddeidda ddeidda@amazon.com

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
