### PR TITLE
release-2.6: Pin pytest because latest version 5.4 breaks pytest-rerunfailures

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -5,7 +5,10 @@ boto3
 fabric
 jinja2
 junitparser
-pytest
+# Pinning pytest because latest version 5.4 breaks pytest-rerunfailures
+# https://github.com/pytest-dev/pytest-rerunfailures/issues/103
+# https://github.com/pytest-dev/pytest-rerunfailures/issues/105
+pytest==5.3.5
 pytest-datadir
 pytest-html
 pytest-rerunfailures


### PR DESCRIPTION
See
https://github.com/pytest-dev/pytest-rerunfailures/issues/103
https://github.com/pytest-dev/pytest-rerunfailures/issues/105

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
