### PR TITLE
integ-tests: fix collection of features metrics

### DIFF
--- a/tests/integration-tests/reports_generator.py
+++ b/tests/integration-tests/reports_generator.py
@@ -98,7 +98,7 @@ def generate_json_report(test_results_dir, save_to_file=True):
                 for property in testcase.properties.children:
                     _record_result(results, property["name"], property["value"], label)
 
-            if "file" in testcase:
+            if testcase.get_attribute("file"):
                 feature = re.sub(r"test_|_test|.py", "", os.path.splitext(os.path.basename(testcase["file"]))[0])
                 _record_result(results, "feature", feature, label)
 


### PR DESCRIPTION
Issue introduced in https://github.com/aws/aws-parallelcluster/pull/1697

[untangle library](https://github.com/stchris/untangle/blob/master/untangle.py#L40) overrides the `[]` operator in the Element object (`__getitem__`)  but does not override the `in` (`__contains__`) and that is why the if was not working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
