### PR TITLE
release-2.6: Add timeout on cluster creation

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -157,7 +157,7 @@ class ClustersFactory:
         # create the cluster
         logging.info("Creating cluster {0} with config {1}".format(name, config))
         self.__created_clusters[name] = cluster
-        result = run_command(["pcluster", "create", "--norollback", "--config", config, name])
+        result = run_command(["pcluster", "create", "--norollback", "--config", config, name], timeout=7200)
         if "Status: {0} - CREATE_COMPLETE".format(cluster.cfn_name) not in result.stdout:
             error = "Cluster creation failed for {0} with output: {1}".format(name, result.stdout)
             logging.error(error)


### PR DESCRIPTION
Add 2 hours timeout on command executing cluster creation

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
