### PR TITLE
Change nodewatcher test to not rely on failing compute logs

### DIFF
--- a/tests/integration-tests/tests/scaling/test_scaling/test_nodewatcher_terminates_failing_node/pcluster.config.ini
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_nodewatcher_terminates_failing_node/pcluster.config.ini
@@ -12,6 +12,7 @@ scheduler = {{ scheduler }}
 master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 initial_queue_size = {{ initial_queue_size }}
+max_queue_size = {{ initial_queue_size }}
 maintain_initial_size = true
 
 [vpc parallelcluster-vpc]


### PR DESCRIPTION
* Pending change in nodewatcher logic will no longer push failed compute logs after cluster creation to /home/logs/compute/. See this commit: https://github.com/aws/aws-parallelcluster-node/pull/201/commits/b6f35b8176089332eaaf178119c2f4c6a7f43c5a
* Change nodewatcher test to not check and rely on logs in /home/logs/compute.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
