### PR TITLE
release-2.5: Fix test for Intel HPC platform spec

### DIFF
--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.ini
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.ini
@@ -17,6 +17,7 @@ master_root_volume_size = 80
 compute_root_volume_size = 80
 ebs_settings = large
 enable_intel_hpc_platform = true
+pre_install = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.6.0/aws-parallelcluster-cookbook.intel.psxe.patch.sh
 
 [ebs large]
 shared_dir = /shared


### PR DESCRIPTION
Intel HPC platform specification version 2019.5 requires to be installed using yum version 4.
Fix test using preinstall script that patch Intel HPC platform spec recipe to use yum version 4.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
