### PR TITLE
Add skip_install_recipes=no to integration test config

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -319,6 +319,9 @@ def _add_custom_packages_configs(cluster_config, request):
             cluster = extra_json.get("cluster", {})
             if extra_json_custom_option not in cluster:
                 cluster[extra_json_custom_option] = request.config.getoption(extra_json_custom_option)
+                if extra_json_custom_option == "custom_node_package":
+                    # Do not skip install recipes so that custom node package can take effect
+                    cluster["skip_install_recipes"] = "no"
                 extra_json["cluster"] = cluster
     if extra_json:
         config[cluster_template]["extra_json"] = json.dumps(extra_json)


### PR DESCRIPTION
* Add skip_install_recipes=no to integration test config when using extra json, so that integration test specification like custom node packages can take effect

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
