### PR TITLE
Update test mapping for test type, OS and region

### DIFF
--- a/tests/integration-tests/tests/chef/test_chef/test_chef_s3_centos6/pcluster.config.ini
+++ b/tests/integration-tests/tests/chef/test_chef/test_chef_s3_centos6/pcluster.config.ini
@@ -1,0 +1,23 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+initial_queue_size = 1
+maintain_initial_size = false
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+scheduler = {{ scheduler }}
+extra_json = { "cluster" : { "skip_install_recipes" : "no" } }
+custom_ami = {{ custom_ami }}
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/chef/test_chef/test_chef_s3_centos6/verify_chef_s3.sh
+++ b/tests/integration-tests/tests/chef/test_chef/test_chef_s3_centos6/verify_chef_s3.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -x
+
+# Verify chef.io is not called to download chef installer script or client
+sudo grep -ir "chef.io/chef/install.sh" /var/log/cloud-init-output.log
+if [ $? -eq 0 ]; then
+    echo "Chef installer downloaded from chef.io"
+    exit 1
+fi
+sudo grep -ir "packages.chef.io" /var/log/cloud-init-output.log
+if [ $? -eq 0 ]; then
+    echo "Chef package downloaded from chef.io"
+    exit 1
+fi

--- a/tests/integration-tests/tests/chef/test_chef/test_create_ami_centos6/pcluster.config.ini
+++ b/tests/integration-tests/tests/chef/test_chef/test_create_ami_centos6/pcluster.config.ini
@@ -1,0 +1,13 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -293,6 +293,7 @@ def get_username_for_os(os):
         "alinux2": "ec2-user",
         "centos6": "centos",
         "centos7": "centos",
+        "ubuntu1404": "ubuntu",
         "ubuntu1604": "ubuntu",
         "ubuntu1804": "ubuntu",
     }


### PR DESCRIPTION
* create_ami test is launched on all supported OSs, but for centos6 only in us-east-1
* no_chef_install test (cluster creation official AMI) is launched on ubuntu16
* chef_s3 test (cluster creation with baking at runtime) is launched on alinux

Added assertion on chef client execution during create_ami test

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
