### PR TITLE
Add bootstrapped file at the end of the last chef run

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2162,7 +2162,7 @@
                   "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${cookbook_url}.date\n",
                   "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.md5 ${cookbook_url}.md5\n",
                   "  vendor_cookbook\n",
-                  "  mkdir /opt/parallelcluster && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped\n",
+                  "  mkdir /opt/parallelcluster\n",
                   "}\n",
                   "[ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh\n",
                   "custom_cookbook=",
@@ -2543,6 +2543,9 @@
               "chef": {
                 "command": "chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::finalize",
                 "cwd": "/etc/chef"
+              },
+              "bootstrap": {
+                "command": "[[ ! -f /opt/parallelcluster/.bootstrapped ]] && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped"
               }
             }
           }
@@ -3108,7 +3111,7 @@
                   "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${cookbook_url}.date\n",
                   "  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.md5 ${cookbook_url}.md5\n",
                   "  vendor_cookbook\n",
-                  "  mkdir /opt/parallelcluster && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped\n",
+                  "  mkdir /opt/parallelcluster\n",
                   "}\n",
                   "[ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh\n",
                   "custom_cookbook=",
@@ -3465,6 +3468,9 @@
               "chef": {
                 "command": "chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::finalize",
                 "cwd": "/etc/chef"
+              },
+              "bootstrap": {
+                "command": "[[ ! -f /opt/parallelcluster/.bootstrapped ]] && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped"
               }
             }
           }


### PR DESCRIPTION
This fixes regression introduced by https://github.com/aws/aws-parallelcluster-cookbook/commit/b569176603c909c7c38d4f9f7402fe901e0fbf96
where installation recipes were skipped because of the presence of the boostrapped file.

The bootstrapped file is now created (if missing) at the end of the last chef run.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
