### PR TITLE
Fix syntax for add bootstrapped file command

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2545,7 +2545,7 @@
                 "cwd": "/etc/chef"
               },
               "bootstrap": {
-                "command": "[[ ! -f /opt/parallelcluster/.bootstrapped ]] && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped"
+                "command": "[ ! -f /opt/parallelcluster/.bootstrapped ] && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped || exit 0"
               }
             }
           }
@@ -3470,7 +3470,7 @@
                 "cwd": "/etc/chef"
               },
               "bootstrap": {
-                "command": "[[ ! -f /opt/parallelcluster/.bootstrapped ]] && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped"
+                "command": "[ ! -f /opt/parallelcluster/.bootstrapped ] && echo ${parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped || exit 0"
               }
             }
           }


### PR DESCRIPTION
* Fix syntax for add bootstrapped file command to use `sh` compatible single bracket and always return 0

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
