### PR TITLE
Removes @timeout decorator and Wrapt package.

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -17,4 +17,3 @@ pytest-xdist
 retrying
 troposphere
 untangle
-wrapt_timeout_decorator

--- a/tests/integration-tests/tests/scaling/test_mpi.py
+++ b/tests/integration-tests/tests/scaling/test_mpi.py
@@ -18,7 +18,6 @@ from remote_command_executor import RemoteCommandExecutionError, RemoteCommandEx
 from tests.common.mpi_common import OS_TO_OPENMPI_MODULE_MAP, _test_mpi
 from tests.common.schedulers_common import get_scheduler_commands
 from tests.common.utils import fetch_instance_slots
-from wrapt_timeout_decorator import timeout
 
 
 @pytest.mark.regions(["us-east-1"])
@@ -69,7 +68,6 @@ def test_mpi_ssh(scheduler, os, pcluster_config_reader, clusters_factory, test_d
     _test_mpi_ssh(remote_command_executor, scheduler, os, test_datadir)
 
 
-@timeout(10, use_signals=False, timeout_exception=RemoteCommandExecutionError)
 def _test_mpi_ssh(remote_command_executor, scheduler, os, test_datadir):
     logging.info("Testing mpi SSH")
     mpi_module = OS_TO_OPENMPI_MODULE_MAP[os]


### PR DESCRIPTION
*Description of changes:*
The Wrapt package has requirements that temporarily install versions of python that are not compatible with a strict 3.6 or 3.7 Python install. This issue was noticed when attempting to create an AWS Lambda layer from ParallelCluster's testing framework. Many other timeout mechanisms exist and the existing package is only used in a single case.

The Wrapt requirements can be seen at https://github.com/bitranox/wrapt_timeout_decorator/blob/master/requirements.txt. 