### PR TITLE
Refactoring for createami and runtime_bake tests

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -57,4 +57,23 @@ def test_createami(region, os, instance, request, pcluster_config_reader, vpc_st
         + networking_args
     )
 
+    assert_that(
+        any(
+            "downloading https://{0}-aws-parallelcluster.s3".format(region).lower() in s.lower()
+            for s in pcluster_createami_result.stdout.split("\n")
+        )
+    ).is_true()
+    assert_that(
+        any("chef.io/chef/install.sh".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
+    ).is_false()
+    assert_that(
+        any("packages.chef.io".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
+    ).is_false()
+    assert_that(
+        any("Thank you for installing Chef".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
+    ).is_true()
+    assert_that(
+        any("Starting Chef Client".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
+    ).is_true()
+
     assert_that(pcluster_createami_result.stdout).does_not_contain("No custom AMI created")

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -59,23 +59,14 @@ def test_createami(region, os, instance, request, pcluster_config_reader, vpc_st
         + networking_args
     )
 
+    pcluster_createami_result_stdout_list = [s.lower() for s in pcluster_createami_result.stdout.split("\n")]
+
     assert_that(
-        any(
-            "downloading https://{0}-aws-parallelcluster.s3".format(region).lower() in s.lower()
-            for s in pcluster_createami_result.stdout.split("\n")
-        )
+        any("downloading https://{0}-aws-parallelcluster.s3".format(region) in pcluster_createami_result_stdout_list)
     ).is_true()
-    assert_that(
-        any("chef.io/chef/install.sh".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
-    ).is_false()
-    assert_that(
-        any("packages.chef.io".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
-    ).is_false()
-    assert_that(
-        any("Thank you for installing Chef".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
-    ).is_true()
-    assert_that(
-        any("Starting Chef Client".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
-    ).is_true()
+    assert_that(any("chef.io/chef/install.sh" in pcluster_createami_result_stdout_list)).is_false()
+    assert_that(any("packages.chef.io" in pcluster_createami_result_stdout_list)).is_false()
+    assert_that(any("Thank you for installing Chef".lower() in pcluster_createami_result_stdout_list)).is_true()
+    assert_that(any("Starting Chef Client".lower() in pcluster_createami_result_stdout_list)).is_true()
 
     assert_that(pcluster_createami_result.stdout).does_not_contain("No custom AMI created")

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -30,7 +30,7 @@ def vpc_stack(vpc_stacks, region):
 @pytest.mark.dimensions("us-east-1", "c5.xlarge", "ubuntu1804", "*")
 @pytest.mark.dimensions("us-gov-east-1", "c5.xlarge", "ubuntu1604", "*")
 @pytest.mark.dimensions("us-gov-west-1", "c5.xlarge", "ubuntu1804", "*")
-@pytest.mark.dimensions("cn-northwest-1", "c5.xlarge", "alinux2", "*")
+@pytest.mark.dimensions("cn-northwest-1", "c4.xlarge", "alinux2", "*")
 def test_createami(region, os, instance, request, pcluster_config_reader, vpc_stack):
     """Test createami for given region and os"""
     cluster_config = pcluster_config_reader()

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -26,6 +26,8 @@ def vpc_stack(vpc_stacks, region):
 @pytest.mark.dimensions("eu-west-1", "c5.xlarge", "alinux", "*")
 @pytest.mark.dimensions("us-west-1", "c5.xlarge", "alinux2", "*")
 @pytest.mark.dimensions("us-west-2", "c5.xlarge", "centos7", "*")
+@pytest.mark.dimensions("eu-west-2", "c5.xlarge", "ubuntu1604", "*")
+@pytest.mark.dimensions("us-east-1", "c5.xlarge", "ubuntu1804", "*")
 @pytest.mark.dimensions("us-gov-east-1", "c5.xlarge", "ubuntu1604", "*")
 @pytest.mark.dimensions("us-gov-west-1", "c5.xlarge", "ubuntu1804", "*")
 @pytest.mark.dimensions("cn-northwest-1", "c5.xlarge", "alinux2", "*")

--- a/tests/integration-tests/tests/runtime_bake/test_runtime_bake.py
+++ b/tests/integration-tests/tests/runtime_bake/test_runtime_bake.py
@@ -23,13 +23,18 @@ from tests.common.utils import retrieve_latest_ami
 @pytest.mark.dimensions("us-gov-east-1", "c5.xlarge", "ubuntu1604", "slurm")
 @pytest.mark.dimensions("us-gov-west-1", "c5.xlarge", "ubuntu1804", "sge")
 @pytest.mark.usefixtures("instance", "scheduler")
-def test_runtime_bake(scheduler, os, region, pcluster_config_reader, clusters_factory):
+def test_runtime_bake(scheduler, os, region, pcluster_config_reader, clusters_factory, test_datadir):
     """Test cluster creation with runtime bake."""
     cluster_config = pcluster_config_reader(custom_ami=retrieve_latest_ami(region, os, ami_type="remarkable"))
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
+
+    # Verify no chef.io endpoint is called in cloud-init-output log to download chef installer or chef packages"""
+    # on master
+    remote_command_executor.run_remote_script(str(test_datadir / "verify_chef_download.sh"))
+    # on compute
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
-    result = scheduler_commands.submit_command("sleep 5")
+    result = scheduler_commands.submit_script(str(test_datadir / "verify_chef_download.sh"))
     job_id = scheduler_commands.assert_job_submitted(result.stdout)
     scheduler_commands.wait_job_completed(job_id)
     scheduler_commands.assert_job_succeeded(job_id)

--- a/tests/integration-tests/tests/runtime_bake/test_runtime_bake.py
+++ b/tests/integration-tests/tests/runtime_bake/test_runtime_bake.py
@@ -20,6 +20,8 @@ from tests.common.utils import retrieve_latest_ami
 @pytest.mark.dimensions("eu-west-2", "c5.xlarge", "alinux", "slurm")
 @pytest.mark.dimensions("us-west-3", "c5.xlarge", "alinux2", "torque")
 @pytest.mark.dimensions("us-east-2", "c5.xlarge", "centos7", "sge")
+@pytest.mark.dimensions("us-east-1", "c5.xlarge", "ubuntu1604", "slurm")
+@pytest.mark.dimensions("eu-west-1", "c5.xlarge", "ubuntu1804", "sge")
 @pytest.mark.dimensions("us-gov-east-1", "c5.xlarge", "ubuntu1604", "slurm")
 @pytest.mark.dimensions("us-gov-west-1", "c5.xlarge", "ubuntu1804", "sge")
 @pytest.mark.usefixtures("instance", "scheduler")

--- a/tests/integration-tests/tests/runtime_bake/test_runtime_bake/test_runtime_bake/verify_chef_download.sh
+++ b/tests/integration-tests/tests/runtime_bake/test_runtime_bake/test_runtime_bake/verify_chef_download.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -x
+
+# Verify chef.io is not called to download chef installer script or client
+sudo grep -ir "chef.io/chef/install.sh" /var/log/cloud-init-output.log
+if [ $? -eq 0 ]; then
+    echo "Chef installer downloaded from chef.io"
+    exit 1
+fi
+sudo grep -ir "packages.chef.io" /var/log/cloud-init-output.log
+if [ $? -eq 0 ]; then
+    echo "Chef package downloaded from chef.io"
+    exit 1
+fi
+
+# Verify chef client is installed from S3
+sudo grep -ir "aws-parallelcluster/archives/chef/chef-install.sh" /var/log/cloud-init-output.log
+if [ $? -ne 0 ]; then
+    echo "Chef installer not downloaded from S3"
+    exit 1
+fi


### PR DESCRIPTION
* Add assertions to verify that chef is downloaded from S3
* Add tests for Ubuntu (16 and 18) in commercial
* Enable createami test in china (running on c4.large)

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
