### PR TITLE
Add new param to specify custom cookbook for the createami command

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -139,6 +139,7 @@ To use custom templates or packages URLs or to run tests against a given custom 
 use the following options:
 * `--custom-node-url`: URL to a custom node package.
 * `--custom-cookbook-url`: URL to a custom cookbook package.
+* `--createami-custom-cookbook-url`: URL to a custom cookbook package for the createami command.
 * `--custom-template-url`: URL to a custom cfn template.
 * `--custom-awsbatch-template-url`: URL to a custom awsbatch cfn template.
 * `--custom-awsbatchcli-url`: URL to a custom awsbatch cli package.

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -63,6 +63,9 @@ def pytest_addoption(parser):
     parser.addoption("--key-name", help="key to use for EC2 instances", type=str)
     parser.addoption("--key-path", help="key path to use for SSH connections", type=str)
     parser.addoption("--custom-chef-cookbook", help="url to a custom cookbook package")
+    parser.addoption(
+        "--createami-custom-chef-cookbook", help="url to a custom cookbook package for the createami command"
+    )
     parser.addoption("--custom-awsbatch-template-url", help="url to a custom awsbatch template")
     parser.addoption("--template-url", help="url to a custom cfn template")
     parser.addoption("--custom-awsbatchcli-package", help="url to a custom awsbatch cli package")

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -63,6 +63,7 @@ TEST_DEFAULTS = {
     "output_dir": "tests_outputs",
     "custom_node_url": None,
     "custom_cookbook_url": None,
+    "createami_custom_cookbook_url": None,
     "custom_template_url": None,
     "custom_awsbatch_template_url": None,
     "custom_awsbatchcli_url": None,
@@ -170,6 +171,11 @@ def _init_argparser():
         "--custom-cookbook-url",
         help="URL to a custom cookbook package.",
         default=TEST_DEFAULTS.get("custom_cookbook_url"),
+    )
+    parser.add_argument(
+        "--createami-custom-cookbook-url",
+        help="URL to a custom cookbook package for the createami command.",
+        default=TEST_DEFAULTS.get("createami_custom_cookbook_url"),
     )
     parser.add_argument(
         "--custom-template-url", help="URL to a custom cfn template.", default=TEST_DEFAULTS.get("custom_template_url")
@@ -310,6 +316,9 @@ def _set_custom_packages_args(args, pytest_args):
 
     if args.custom_cookbook_url:
         pytest_args.extend(["--custom-chef-cookbook", args.custom_cookbook_url])
+
+    if args.createami_custom_cookbook_url:
+        pytest_args.extend(["--createami-custom-chef-cookbook", args.createami_custom_cookbook_url])
 
     if args.custom_template_url:
         pytest_args.extend(["--template-url", args.custom_template_url])

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -44,7 +44,7 @@ def test_createami(region, os, instance, request, pcluster_config_reader, vpc_st
     # networking_args = ["--vpc-id", vpc_id, "--subnet-id", vpc_stack.cfn_outputs["PublicSubnetId"]]
 
     # Custom Cookbook
-    custom_cookbook = request.config.getoption("custom_chef_cookbook")
+    custom_cookbook = request.config.getoption("createami_custom_chef_cookbook")
     custom_cookbook_args = [] if not custom_cookbook else ["-cc", custom_cookbook]
 
     # Instance type


### PR DESCRIPTION
In this way it's possible to specify a custom cookbook just for the createami command that will not be put in the cluster configuration and will not affect the cluster creation for other type of tests.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
