### PR TITLE
Change AWS account limit checker to be a configuration tester and support shared VPC

### DIFF
--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -1118,6 +1118,7 @@ class Section(object):
         """Call the validator function of the section and of all the parameters."""
         if self.params:
             section_name = _get_file_section_name(self.key, self.label)
+            LOGGER.debug("Validating section '[%s]'...", section_name)
 
             # validate section
             for validation_func in self.definition.get("validators", []):
@@ -1134,6 +1135,7 @@ class Section(object):
                     LOGGER.debug("Section '[%s]' is valid", section_name)
 
             # validate items
+            LOGGER.debug("Validating parameters of section '[%s]'...", section_name)
             for param_key, param_definition in self.definition.get("params").items():
                 param_type = param_definition.get("type", Param)
 
@@ -1143,6 +1145,7 @@ class Section(object):
                 else:
                     # define a default param and validate it
                     param_type(self.key, self.label, param_key, param_definition, self.pcluster_config).validate()
+            LOGGER.debug("Parameters validation of section '[%s]' completed correctly.", section_name)
 
     def to_file(self, config_parser, write_defaults=False):
         """Create the section and add all the parameters in the config_parser."""

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -334,7 +334,8 @@ class PclusterConfig(object):
         Try to launch the requested instances (in dry-run mode) to verify configuration parameters.
 
         NOTE: The number of max instances is set to 1 because run_instances in dry-mode doesn't try to allocate the
-        requested instances. The goal of the test is verify the provided configuration."""
+        requested instances. The goal of the test is verify the provided configuration.
+        """
         LOGGER.debug("Testing configuration parameters...")
         cluster_section = self.get_section("cluster")
         vpc_section = self.get_section("vpc")
@@ -440,6 +441,13 @@ class PclusterConfig(object):
                 if "does not support specifying CpuOptions" in message:
                     self.error(message.replace("CpuOptions", "disable_hyperthreading"))
                 self.error(message)
+            elif code == "InstanceLimitExceeded":
+                self.error(
+                    "You've reached the limit on the number of instances you can run concurrently "
+                    "for the configured instance type.\n{0}".format(message)
+                )
+            elif code == "InsufficientInstanceCapacity":
+                self.error("There is not enough capacity to fulfill your request.\n{0}".format(message))
             elif code == "InsufficientFreeAddressesInSubnet":
                 self.error(
                     "The specified subnet does not contain enough free private IP addresses "

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -106,7 +106,7 @@ def mock_pcluster_config(mocker, scheduler=None):
         ),
     )
     mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
-    mocker.patch.object(PclusterConfig, "_PclusterConfig__check_account_capacity")
+    mocker.patch.object(PclusterConfig, "_PclusterConfig__test_configuration")
 
 
 def assert_param_validator(mocker, config_parser_dict, expected_error=None, capsys=None, expected_warning=None):


### PR DESCRIPTION
## 1. Shared VPC support
From now the code is using `vpc_security_group_id` when executing `run_instance` command, if specified.

I also improved error message to be clear it is coming from the account capacity check and added more debug message to highlight the validation steps.

## 2. From AWS account limit checker to configuration tester
When executing dry-run the run_instance function is not allocating the required number of nodes so the test by using max size was useless.
From now the code is no longer able to check AWS account limits for the instance types but only verify the provided configuration is valid.


## Tests
* cluster creation -> no changes
* cluster creation in a shared VPC by specifying a vpc_security_group_id -> works
* cluster creation in a shared VPC without specifying a vpc_security_group_id -> shows the message: `ERROR: Unable to validate configuration parameters. Please double check your cluster configuration. You do not have access to a default security group in VPC vpc-xxx. Specify a security group, and try again.`
(before it was: `ERROR: You do not have access to a default security group in VPC vpc-xxx. Specify a security group, and try again.`)

---

The debug messages are now:
```
2020-05-13 12:19:44,485 - DEBUG - pcluster_config - Parsing configuration file ~\.parallelcluster\config
...
2020-05-13 12:19:46,300 - DEBUG - param_types - Validating section '[cluster test]'...
2020-05-13 12:19:46,300 - DEBUG - param_types - Section '[cluster test]' is valid
2020-05-13 12:19:46,300 - DEBUG - param_types - Validating parameters of section '[cluster test]'...
2020-05-13 12:19:46,609 - DEBUG - param_types - Configuration parameter 'key_name' is valid
...
2020-05-13 12:19:47,467 - DEBUG - param_types - Parameters validation of section '[cluster test]' completed correctly.
2020-05-13 19:25:48,061 - DEBUG - pcluster_config - Testing configuration parameters...
2020-05-13 19:25:50,643 - DEBUG - pcluster_config - Configuration parameters tested correctly.
...
2020-05-13 12:19:50,521 - INFO - commands - Creating stack named: parallelcluster-test
...
```
