### PR TITLE
Join pytest markers when preceding "not" is found

### DIFF
--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -248,6 +248,19 @@ def _is_file(value):
     return value
 
 
+def _join_with_not(args):
+    """
+    Join 'not' with next token, so they
+    can be used together as single pytest marker
+    """
+    it = iter(args)
+    while True:
+        current = next(it)
+        if current == "not":
+            current += " " + next(it)
+        yield current
+
+
 def _get_pytest_args(args, regions, log_file, out_dir):
     pytest_args = ["-s", "-vv", "-l"]
 
@@ -264,7 +277,7 @@ def _get_pytest_args(args, regions, log_file, out_dir):
     pytest_args.append("--durations=0")
     # Run only tests with the given markers
     pytest_args.append("-m")
-    pytest_args.append(" or ".join(args.features))
+    pytest_args.append(" or ".join(list(_join_with_not(args.features))))
     pytest_args.append("--regions")
     pytest_args.extend(regions)
     pytest_args.append("--instances")


### PR DESCRIPTION
Before patch
Every element of the incoming string is treated as pytest marker
```
features = ["slurm", "not", "createami", "scaling"]
pytest markers = "slurm or not or createami or scaling"
```

After patch
When "not" is found, it's joined with the next incoming string, in order to compose one single marker
```
features = ["slurm", "not", "createami", "scaling"]
pytest markers = "slurm or not createami or scaling"
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
