### PR TITLE
CLI warning messages for v2.7.0

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -32,6 +32,7 @@ from pcluster.config.param_types import (
     SpotPriceParam,
 )
 from pcluster.config.validators import (
+    base_os_validator,
     cluster_validator,
     compute_instance_type_validator,
     dcv_enabled_validator,
@@ -457,6 +458,7 @@ CLUSTER = {
             ("base_os", {
                 "cfn_param_mapping": "BaseOS",
                 "allowed_values": ["alinux", "alinux2", "ubuntu1604", "ubuntu1804", "centos6", "centos7"],
+                "validators": [base_os_validator],
                 "required": True,
             }),
             ("scheduler", {

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -846,3 +846,16 @@ def intel_hpc_validator(param_key, param_value, pcluster_config):
         )
 
     return errors, warnings
+
+
+def base_os_validator(param_key, param_value, pcluster_config):
+    warnings = []
+
+    eol_2020 = ["centos6", "alinux"]
+    if param_value in eol_2020:
+        warnings.append(
+            "The operating system you are using ({0}) will reach end-of-life in late 2020. It will be deprecated in "
+            "future releases of ParallelCluster".format(param_value)
+        )
+
+    return [], warnings

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -746,10 +746,11 @@ def scheduler_validator(param_key, param_value, pcluster_config):
         errors.append("'{0}' scheduler supports the following Operating Systems: {1}".format(param_value, supported_os))
 
     will_be_deprecated = ["sge", "torque"]
+    wiki_url = "https://github.com/aws/aws-parallelcluster/wiki/Deprecation-of-SGE-and-Torque-in-ParallelCluster"
     if param_value in will_be_deprecated:
         warnings.append(
             "The job scheduler you are using ({0}) is scheduled to be deprecated in future releases of "
-            "ParallelCluster".format(param_value)
+            "ParallelCluster. More information is available here: {1}".format(param_value, wiki_url)
         )
 
     return errors, warnings

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -227,59 +227,64 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
 
 
 @pytest.mark.parametrize(
-    "region, base_os, scheduler, expected_message, expected_warning",
+    "region, base_os, scheduler, expected_message",
     [
         # verify awsbatch supported regions
-        ("ap-northeast-3", "alinux", "awsbatch", "scheduler is not supported in the .* region", None),
-        ("us-gov-east-1", "alinux", "awsbatch", "scheduler is not supported in the .* region", None),
-        ("us-gov-west-1", "alinux", "awsbatch", "scheduler is not supported in the .* region", None),
-        ("eu-west-1", "alinux", "awsbatch", None, None),
-        ("us-east-1", "alinux", "awsbatch", None, None),
-        ("eu-north-1", "alinux", "awsbatch", None, None),
-        ("cn-north-1", "alinux", "awsbatch", None, None),
-        ("cn-northwest-1", "alinux", "awsbatch", None, None),
-        ("cn-northwest-1", "alinux2", "awsbatch", None, None),
+        ("ap-northeast-3", "alinux", "awsbatch", "scheduler is not supported in the .* region"),
+        ("us-gov-east-1", "alinux", "awsbatch", "scheduler is not supported in the .* region"),
+        ("us-gov-west-1", "alinux", "awsbatch", "scheduler is not supported in the .* region"),
+        ("eu-west-1", "alinux", "awsbatch", None),
+        ("us-east-1", "alinux", "awsbatch", None),
+        ("eu-north-1", "alinux", "awsbatch", None),
+        ("cn-north-1", "alinux", "awsbatch", None),
+        ("cn-northwest-1", "alinux", "awsbatch", None),
+        ("cn-northwest-1", "alinux2", "awsbatch", None),
         # verify traditional schedulers are supported in all the regions
-        ("cn-northwest-1", "alinux", "sge", None, ".sge. is scheduled to be deprecated"),
-        ("ap-northeast-3", "alinux", "sge", None, ".sge. is scheduled to be deprecated"),
-        ("cn-northwest-1", "alinux", "slurm", None, None),
-        ("ap-northeast-3", "alinux", "slurm", None, None),
-        ("cn-northwest-1", "alinux", "torque", None, ".torque. is scheduled to be deprecated"),
-        ("ap-northeast-3", "alinux", "torque", None, ".torque. is scheduled to be deprecated"),
+        ("cn-northwest-1", "alinux", "sge", None),
+        ("ap-northeast-3", "alinux", "sge", None),
+        ("cn-northwest-1", "alinux", "slurm", None),
+        ("ap-northeast-3", "alinux", "slurm", None),
+        ("cn-northwest-1", "alinux", "torque", None),
+        ("ap-northeast-3", "alinux", "torque", None),
         # verify awsbatch supported OSes
-        ("eu-west-1", "centos6", "awsbatch", "scheduler supports the following Operating Systems", None),
-        ("eu-west-1", "centos7", "awsbatch", "scheduler supports the following Operating Systems", None),
-        ("eu-west-1", "ubuntu1604", "awsbatch", "scheduler supports the following Operating Systems", None),
-        ("eu-west-1", "ubuntu1804", "awsbatch", "scheduler supports the following Operating Systems", None),
-        ("eu-west-1", "alinux", "awsbatch", None, None),
-        ("eu-west-1", "alinux2", "awsbatch", None, None),
+        ("eu-west-1", "centos6", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("eu-west-1", "centos7", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("eu-west-1", "ubuntu1604", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("eu-west-1", "ubuntu1804", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("eu-west-1", "alinux", "awsbatch", None),
+        ("eu-west-1", "alinux2", "awsbatch", None),
         # verify sge supports all the OSes
-        ("eu-west-1", "centos6", "sge", None, ".sge. is scheduled to be deprecated"),
-        ("eu-west-1", "centos7", "sge", None, ".sge. is scheduled to be deprecated"),
-        ("eu-west-1", "ubuntu1604", "sge", None, ".sge. is scheduled to be deprecated"),
-        ("eu-west-1", "ubuntu1804", "sge", None, ".sge. is scheduled to be deprecated"),
-        ("eu-west-1", "alinux", "sge", None, ".sge. is scheduled to be deprecated"),
-        ("eu-west-1", "alinux2", "sge", None, ".sge. is scheduled to be deprecated"),
+        ("eu-west-1", "centos6", "sge", None),
+        ("eu-west-1", "centos7", "sge", None),
+        ("eu-west-1", "ubuntu1604", "sge", None),
+        ("eu-west-1", "ubuntu1804", "sge", None),
+        ("eu-west-1", "alinux", "sge", None),
+        ("eu-west-1", "alinux2", "sge", None),
         # verify slurm supports all the OSes
-        ("eu-west-1", "centos6", "slurm", None, None),
-        ("eu-west-1", "centos7", "slurm", None, None),
-        ("eu-west-1", "ubuntu1604", "slurm", None, None),
-        ("eu-west-1", "ubuntu1804", "slurm", None, None),
-        ("eu-west-1", "alinux", "slurm", None, None),
-        ("eu-west-1", "alinux2", "slurm", None, None),
+        ("eu-west-1", "centos6", "slurm", None),
+        ("eu-west-1", "centos7", "slurm", None),
+        ("eu-west-1", "ubuntu1604", "slurm", None),
+        ("eu-west-1", "ubuntu1804", "slurm", None),
+        ("eu-west-1", "alinux", "slurm", None),
+        ("eu-west-1", "alinux2", "slurm", None),
         # verify torque supports all the OSes
-        ("eu-west-1", "centos6", "torque", None, ".torque. is scheduled to be deprecated"),
-        ("eu-west-1", "centos7", "torque", None, ".torque. is scheduled to be deprecated"),
-        ("eu-west-1", "ubuntu1604", "torque", None, ".torque. is scheduled to be deprecated"),
-        ("eu-west-1", "ubuntu1804", "torque", None, ".torque. is scheduled to be deprecated"),
-        ("eu-west-1", "alinux", "torque", None, ".torque. is scheduled to be deprecated"),
-        ("eu-west-1", "alinux2", "torque", None, ".torque. is scheduled to be deprecated"),
+        ("eu-west-1", "centos6", "torque", None),
+        ("eu-west-1", "centos7", "torque", None),
+        ("eu-west-1", "ubuntu1604", "torque", None),
+        ("eu-west-1", "ubuntu1804", "torque", None),
+        ("eu-west-1", "alinux", "torque", None),
+        ("eu-west-1", "alinux2", "torque", None),
     ],
 )
-def test_scheduler_validator(mocker, capsys, region, base_os, scheduler, expected_message, expected_warning):
+def test_scheduler_validator(mocker, capsys, region, base_os, scheduler, expected_message):
     # we need to set the region in the environment because it takes precedence respect of the config file
     os.environ["AWS_DEFAULT_REGION"] = region
     config_parser_dict = {"cluster default": {"base_os": base_os, "scheduler": scheduler}}
+    # Deprecation warning should be printed for sge and torque
+    expected_warning = None
+    wiki_url = "https://github.com/aws/aws-parallelcluster/wiki/Deprecation-of-SGE-and-Torque-in-ParallelCluster"
+    if scheduler in ["sge", "torque"]:
+        expected_warning = ".{0}. is scheduled to be deprecated.*{1}".format(scheduler, wiki_url)
     utils.assert_param_validator(mocker, config_parser_dict, expected_message, capsys, expected_warning)
 
 

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -1195,3 +1195,19 @@ def test_fsx_os_support(mocker, base_os, expected_message):
     }
 
     utils.assert_param_validator(mocker, config_parser_dict, re.escape(expected_message) if expected_message else None)
+
+
+@pytest.mark.parametrize(
+    "base_os, expected_warning",
+    [
+        ("alinux2", None),
+        ("centos7", None),
+        ("ubuntu1604", None),
+        ("ubuntu1804", None),
+        ("centos6", "centos6.*will reach end-of-life in late 2020"),
+        ("alinux", "alinux.*will reach end-of-life in late 2020"),
+    ],
+)
+def test_base_os_validator(mocker, capsys, base_os, expected_warning):
+    config_parser_dict = {"cluster default": {"base_os": base_os}}
+    utils.assert_param_validator(mocker, config_parser_dict, capsys=capsys, expected_warning=expected_warning)


### PR DESCRIPTION
* When a scheduler to be deprecated in the near future is used, include the URL for the corresponding wiki page in the warning message.
* Print a warning message when using an OS that will reach EOL in 2020 (AL1 and CentOS 6).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
