### PR TITLE
Fix iam_policies integration test

### DIFF
--- a/tests/integration-tests/tests/iam_policies/test_iam_policies.py
+++ b/tests/integration-tests/tests/iam_policies/test_iam_policies.py
@@ -21,6 +21,8 @@ from tests.common.assertions import assert_no_errors_in_logs
 @pytest.mark.regions(["us-east-1"])
 @pytest.mark.schedulers(["sge", "awsbatch"])
 @pytest.mark.skip_instances(["g3.8xlarge"])
+@pytest.mark.os(["alinux2"])
+@pytest.mark.usefixtures("os")
 def test_iam_policies(region, scheduler, pcluster_config_reader, clusters_factory):
     """Test IAM Policies"""
     cluster_config = pcluster_config_reader(


### PR DESCRIPTION
The test was failing in the configuration validation phase because no
base_os was specified and this parameter does no longer has a default
value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
