### PR TITLE
Export Master Private IP in dna.json and use it for NFS mount

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -3415,6 +3415,12 @@
                         "PrivateDnsName"
                       ]
                     },
+                    "cfn_master_privateip": {
+                      "Fn::GetAtt": [
+                        "MasterServer",
+                        "PrivateIp"
+                      ]
+                    },
                     "cfn_node_type": "ComputeFleet",
                     "cfn_cluster_user": {
                       "Fn::FindInMap": [


### PR DESCRIPTION
Compute node will mount NFS share from master using private IP instead of private DNS name

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
