### PR TITLE
Scheduled Events: Handle Multiple Instances in Single Notification

### DIFF
--- a/cloudformation/scheduled-events-substack.cfn.json
+++ b/cloudformation/scheduled-events-substack.cfn.json
@@ -94,7 +94,7 @@
             "Id": "sqswatcher_target",
             "InputTransformer": {
               "InputPathsMap": {
-                "Instances": "$.resources[0]"
+                "Instances": "$.resources"
               },
               "InputTemplate": "\"{\\\"Type\\\" : \\\"Notification\\\", \\\"Message\\\" : \\\"{\\\\\\\"StatusCode\\\\\\\":\\\\\\\"Scheduled_Events\\\\\\\",\\\\\\\"Description\\\\\\\":\\\\\\\"Detected scheduled events for instance <Instances>\\\\\\\",\\\\\\\"Event\\\\\\\":\\\\\\\"parallelcluster:EC2_SCHEDULED_EVENT\\\\\\\",\\\\\\\"EC2InstanceId\\\\\\\":\\\\\\\"<Instances>\\\\\\\"}\\\"}\""
             }

--- a/util/cfn-stacks-generators/generate-scheduled-events-substack.py
+++ b/util/cfn-stacks-generators/generate-scheduled-events-substack.py
@@ -31,7 +31,7 @@ def generate_scheduled_event_rule(output_path, make_real_rule=True, input_parame
         Id="sqswatcher_target",
         InputTransformer=events.InputTransformer(
             title="ScheduledEventInputeTransformer",
-            InputPathsMap={"Instances": "$.resources[0]"},
+            InputPathsMap={"Instances": "$.resources"},
             InputTemplate=(
                 '"{\\"Type\\" : \\"Notification\\", \\"Message\\" : '
                 '\\"{\\\\\\"StatusCode\\\\\\":\\\\\\"Scheduled_Events\\\\\\",\\\\\\"Description\\\\\\":'


### PR DESCRIPTION
* Modified scheduled events input transformer to append all resources in a notification to SQS message, instead of only parsing out the first resource/instance
* Modified scheduled events integration test to send out notifications containing multiple instances

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
