### PR TITLE
Support awsbatch scheduler with COMPUTE_FLEET_STOP UpdatePolicy

### DIFF
--- a/cli/pcluster/config/update_policy.py
+++ b/cli/pcluster/config/update_policy.py
@@ -138,7 +138,7 @@ UpdatePolicy.COMPUTE_FLEET_STOP = UpdatePolicy(
     level=10,
     fail_reason="All compute nodes must be stopped",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
-    condition_checker=lambda change, patch: len(utils.get_asg_instances(patch.stack_name)) == 0,
+    condition_checker=lambda change, patch: utils.get_cluster_capacity(patch.stack_name) == 0,
 )
 
 # Update supported only with master node down

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -744,3 +744,13 @@ def get_base_additional_iam_policies():
         policy_name_to_arn("CloudWatchAgentServerPolicy"),
         policy_name_to_arn("AWSBatchFullAccess"),
     ]
+
+
+def get_cluster_capacity(stack_name):
+    stack = get_stack(stack_name)
+    scheduler = get_cfn_param(stack.get("Parameters", []), "Scheduler")
+    return (
+        get_batch_ce_capacity(stack_name)
+        if scheduler == "awsbatch"
+        else get_asg_settings(stack_name).get("DesiredCapacity")
+    )


### PR DESCRIPTION
The COMPUTE_FLEET_STOP update policy was referring to ASG also with
awsbatch scheduler. That could lead to errors during the creation of a PclusterPatch for a pcluster update command

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
