### PR TITLE
Decrease scaledown_idletime in slurm GPU test

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -75,7 +75,7 @@ def test_slurm_gpu(region, pcluster_config_reader, clusters_factory):
 
     Grouped all tests in a single function so that cluster can be reused for all of them.
     """
-    scaledown_idletime = 3
+    scaledown_idletime = 1
     max_queue_size = 4
     cluster_config = pcluster_config_reader(scaledown_idletime=scaledown_idletime, max_queue_size=max_queue_size)
     cluster = clusters_factory(cluster_config)


### PR DESCRIPTION
Test was failing sporadically because the time interval between the
first job submitted by the test exiting and the last compute node
scaling down would be greater than the value of MinJobAge in the default
slurm.conf. This means that when the test went to verify that the jobs
it submitted in order to get the cluster to scale up submitted
successfully, slurm had (sometimes) already purged the job's history.

Decreasing scaledown_idletime improves the chances of the job statuses
being queried before the history is purged.

Using a greater value for MinJobAge in slurm.conf would be a more robust
way of handling this issue, but this approach is being tried first
because the parameter is directly configurable in the test whereas
changing MinJobAge would require modifying the config file in place and
restarting slurmctld.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
