### PR TITLE
integ-tests backport: Decrease scaledown_idletime in slurm GPU test

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -75,7 +75,7 @@ def test_slurm_gpu(region, pcluster_config_reader, clusters_factory):
 
     Grouped all tests in a single function so that cluster can be reused for all of them.
     """
-    scaledown_idletime = 3
+    scaledown_idletime = 1
     max_queue_size = 4
     cluster_config = pcluster_config_reader(scaledown_idletime=scaledown_idletime, max_queue_size=max_queue_size)
     cluster = clusters_factory(cluster_config)


### PR DESCRIPTION
Backport of #1819 

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
