### PR TITLE
Handle test metrics `feature` dimension in pytest

### DIFF
--- a/tests/integration-tests/reports_generator.py
+++ b/tests/integration-tests/reports_generator.py
@@ -12,7 +12,6 @@
 import datetime
 import json
 import os
-import re
 import time
 
 import boto3
@@ -97,10 +96,6 @@ def generate_json_report(test_results_dir, save_to_file=True):
             if hasattr(testcase, "properties"):
                 for property in testcase.properties.children:
                     _record_result(results, property["name"], property["value"], label)
-
-            if testcase.get_attribute("file"):
-                feature = re.sub(r"test_|_test|.py", "", os.path.splitext(os.path.basename(testcase["file"]))[0])
-                _record_result(results, "feature", feature, label)
 
     if save_to_file:
         with open("{0}/test_report.json".format(test_results_dir), "w") as out_f:


### PR DESCRIPTION
Prior to this commit, we added the `feature` dimension to the JSON
reports used to generate metrics for our integration tests as a
post-processing step. This led to situations where the `feature`
dimension was present in reports where none of the other dimensions
were.

To remedy this, add a `feature` user_property to test items via a pytest
hook, which then allows for metrics to be generated for this dimension
in the same way it is for the others (OS, region, scheduler, instance).

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
