### PR TITLE
Move all LogGroup definitions to CW substack

### DIFF
--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -79,11 +79,7 @@ def update_stack_template(stack_name, updated_template, cfn_parameters):
     except ClientError as client_err:
         if "no updates are to be performed" in client_err.response.get("Error").get("Message").lower():
             return  # If updated_template was the same as the stack's current one, consider the update a success
-        error(
-            "Unable to update stack template for stack {stack_name}: {emsg}".format(
-                stack_name=stack_name, emsg=client_err.response.get("Error").get("Message")
-            )
-        )
+        raise
 
 
 def get_region():

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1260,6 +1260,46 @@
                 }
               }
             ]
+          },
+          "MainStackName": {
+            "Ref": "AWS::StackName"
+          },
+          "MainStackUniqueId": {
+            "Fn::Select": [
+              "4",
+              {
+                "Fn::Split": [
+                  "-",
+                  {
+                    "Fn::Select": [
+                      "2",
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "AWS::StackId"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "CreateCleanupResourcesFunctionLogGroup": {
+            "Fn::If": [
+              "HasResourcesS3Bucket",
+              "true",
+              "false"
+            ]
+          },
+          "CreateAWSBatchLogGroups": {
+            "Fn::If": [
+              "CreateAWSBatchStack",
+              "true",
+              "false"
+            ]
           }
         },
         "TemplateURL": {
@@ -3758,7 +3798,8 @@
     "AWSBatchStack": {
       "Type": "AWS::CloudFormation::Stack",
       "DependsOn": [
-        "CleanupResourcesCustomResource"
+        "CleanupResourcesCustomResource",
+        "CloudWatchLogsSubstack"
       ],
       "Properties": {
         "Parameters": {
@@ -3945,6 +3986,29 @@
                 ]
               }
             ]
+          },
+          "MainStackUniqueId": {
+            "Fn::Select": [
+              "4",
+              {
+                "Fn::Split": [
+                  "-",
+                  {
+                    "Fn::Select": [
+                      "2",
+                      {
+                        "Fn::Split": [
+                          "/",
+                          {
+                            "Ref": "AWS::StackId"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           }
         },
         "TemplateURL": {
@@ -4078,13 +4142,43 @@
         }
       },
       "DependsOn": [
-        "CleanupResourcesFunctionLogGroup"
+        "CloudWatchLogsSubstack"
       ],
       "Condition": "HasResourcesS3Bucket"
     },
     "CleanupResourcesFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
+        "FunctionName": {
+          "Fn::Sub": [
+            "parallelcluster-CleanupResources-${StackId}",
+            {
+              "StackId": {
+                "Fn::Select": [
+                  "4",
+                  {
+                    "Fn::Split": [
+                      "-",
+                      {
+                        "Fn::Select": [
+                          "2",
+                          {
+                            "Fn::Split": [
+                              "/",
+                              {
+                                "Ref": "AWS::StackId"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
         "Code": {
           "S3Bucket": {
             "Ref": "ResourcesS3Bucket"
@@ -4101,16 +4195,6 @@
         },
         "Runtime": "python3.6",
         "Timeout": 60
-      },
-      "Condition": "HasResourcesS3Bucket"
-    },
-    "CleanupResourcesFunctionLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": {
-          "Fn::Sub": "/aws/lambda/${CleanupResourcesFunction}"
-        },
-        "RetentionInDays": 14
       },
       "Condition": "HasResourcesS3Bucket"
     },

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -77,6 +77,10 @@
     "S3Url": {
       "Description": "amazonaws.com or amazonaws.com.cn",
       "Type": "String"
+    },
+    "MainStackUniqueId": {
+      "Description": "Final 12 digits of the main CloudFormation stack id",
+      "Type": "String"
     }
   },
   "Conditions": {
@@ -632,16 +636,15 @@
             "Fn::Sub": "${ResourcesS3Bucket}/docker/artifacts.zip"
           },
           "Type": "S3"
-        }
-      }
-    },
-    "CodeBuildLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": {
-          "Fn::Sub": "/aws/codebuild/${CodeBuildDockerImageBuilderProject}"
         },
-        "RetentionInDays": 14
+        "LogsConfig": {
+          "CloudWatchLogs": {
+            "GroupName": {
+              "Fn::Sub": "/aws/codebuild/${ClusterName}-CodeBuildDockerImageBuilderProject-${MainStackUniqueId}"
+            },
+            "Status": "ENABLED"
+          }
+        }
       }
     },
     "CodeBuildPolicy": {
@@ -748,6 +751,9 @@
     "ManageDockerImagesFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
+        "FunctionName": {
+          "Fn::Sub": "parallelcluster-ManageDockerImages-${MainStackUniqueId}"
+        },
         "Code": {
           "S3Bucket": {
             "Ref": "ResourcesS3Bucket"
@@ -835,15 +841,6 @@
         ]
       }
     },
-    "ManageDockerImagesFunctionLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": {
-          "Fn::Sub": "/aws/lambda/${ManageDockerImagesFunction}"
-        },
-        "RetentionInDays": 14
-      }
-    },
     "DockerBuildWaitHandle": {
       "Type": "AWS::CloudFormation::WaitConditionHandle",
       "Properties": {}
@@ -902,6 +899,9 @@
     "SendBuildNotificationFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
+        "FunctionName": {
+          "Fn::Sub": "parallelcluster-SendBuildNotification-${MainStackUniqueId}"
+        },
         "Code": {
           "S3Bucket": {
             "Ref": "ResourcesS3Bucket"
@@ -920,15 +920,6 @@
         "Timeout": 60
       },
       "DependsOn": "DockerBuildWaitHandle"
-    },
-    "SendBuildNotificationFunctionLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": {
-          "Fn::Sub": "/aws/lambda/${SendBuildNotificationFunction}"
-        },
-        "RetentionInDays": 14
-      }
     },
     "SendBuildNotificationFunctionInvokePermission": {
       "Type": "AWS::Lambda::Permission",

--- a/cloudformation/cw-logs-substack.cfn.json
+++ b/cloudformation/cw-logs-substack.cfn.json
@@ -17,6 +17,22 @@
         },
         "true"
       ]
+    },
+    "CreateCleanupResourcesFunctionLogGroup": {
+      "Fn::Equals": [
+        {
+          "Ref": "CreateCleanupResourcesFunctionLogGroup"
+        },
+        "true"
+      ]
+    },
+    "CreateAWSBatchLogGroups": {
+      "Fn::Equals": [
+        {
+          "Ref": "CreateAWSBatchLogGroups"
+        },
+        "true"
+      ]
     }
   },
   "Parameters": {
@@ -26,6 +42,22 @@
     },
     "CWLogGroupName": {
       "Description": "Name of the CloudWatch Log Group to be created",
+      "Type": "String"
+    },
+    "MainStackName": {
+      "Description": "Name of the main CloudFormation stack",
+      "Type": "String"
+    },
+    "MainStackUniqueId": {
+      "Description": "Final 12 digits of the main CloudFormation stack id",
+      "Type": "String"
+    },
+    "CreateCleanupResourcesFunctionLogGroup": {
+      "Description": "Set to true in order to create the log group for CreateCleanupResourcesFunction",
+      "Type": "String"
+    },
+    "CreateAWSBatchLogGroups": {
+      "Description": "Set to true in order to create the log groups for AWS Batch scheduler",
       "Type": "String"
     }
   },
@@ -51,6 +83,94 @@
           ]
         }
       }
+    },
+    "CleanupResourcesFunctionLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": "/aws/lambda/parallelcluster-CleanupResources-${MainStackUniqueId}"
+        },
+        "RetentionInDays": {
+          "Fn::Select": [
+            "1",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "CWLogOptions"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "Condition": "CreateCleanupResourcesFunctionLogGroup"
+    },
+    "CodeBuildLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": "/aws/codebuild/${MainStackName}-CodeBuildDockerImageBuilderProject-${MainStackUniqueId}"
+        },
+        "RetentionInDays": {
+          "Fn::Select": [
+            "1",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "CWLogOptions"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "Condition": "CreateAWSBatchLogGroups"
+    },
+    "ManageDockerImagesFunctionLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": "/aws/lambda/parallelcluster-ManageDockerImages-${MainStackUniqueId}"
+        },
+        "RetentionInDays": {
+          "Fn::Select": [
+            "1",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "CWLogOptions"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "Condition": "CreateAWSBatchLogGroups"
+    },
+    "SendBuildNotificationFunctionLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": "/aws/lambda/parallelcluster-SendBuildNotification-${MainStackUniqueId}"
+        },
+        "RetentionInDays": {
+          "Fn::Select": [
+            "1",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "CWLogOptions"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "Condition": "CreateAWSBatchLogGroups"
     }
   },
   "Outputs": {


### PR DESCRIPTION
With this change all LogGroup definitions are moved to the `cw-logs-substack`. The main reason of this change is that it allows an easier and more resilient stack update when `--keep-logs` flag is used and log groups need to be retained. If log groups are spread across several stacks we need to update each of them and this increases the probability that one of those substacks are in a failed state.

Some important details to justify some of the choices:
- When defining a lambda function you cannot set the LogGroup to use but AWS Lambda by default uses a log group named `/aws/lambda/${function_name}`. To avoid introducing too many resources dependencies across stacks the name of the Lambda function is set by us in the resource definition and not randomly generated.
- The name of each Lambda function we define in CloudFormation is composed by using a `parallelcluster-` prefix + an arbitrary function name + the final 12 chars of the CloudFormation stack id that are meant to work as a hash that confers uniqueness to the resource name. The alternative could have been to use the stack name but unfortunately Lambda function names can only be 64 characters long.
- RetentionInDays for all log groups can be now configured through the CW config settings.

Also for some reason when we set the function name a new policy is required in the role for the user that creates the cluster: `lambda:GetFunction`. Need to update public docs before releasing this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
