### PR TITLE
Use describe_instance_types to get efa enabled instance types

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,4 +1,4 @@
-boto3>=1.10.15
+boto3>=1.14.3
 future>=0.18.2
 tabulate>=0.8.2
 ipaddress>=1.0.22

--- a/cli/requirements34.txt
+++ b/cli/requirements34.txt
@@ -1,4 +1,4 @@
-boto3>=1.10.15
+boto3>=1.14.3
 future>=0.18.2
 tabulate>=0.8.2
 ipaddress>=1.0.22

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -24,7 +24,7 @@ def readme():
 VERSION = "2.7.0"
 REQUIRES = [
     "setuptools",
-    "boto3>=1.10.15",
+    "boto3>=1.14.3",
     "future>=0.16.0,<=0.18.2",
     "tabulate>=0.8.2,<=0.8.3",
     "ipaddress>=1.0.22",

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -825,10 +825,7 @@ def test_cluster_from_file_to_cfn(mocker, pcluster_config_reader, settings_label
         "pcluster.config.param_types.get_avail_zone",
         side_effect=lambda subnet: "mocked_avail_zone" if subnet == "subnet-12345678" else "some_other_az",
     )
-    mocker.patch(
-        "pcluster.config.validators.get_supported_features",
-        return_value={"instances": ["t2.large"], "baseos": ["ubuntu1804"], "schedulers": ["slurm"]},
-    )
+
     mocker.patch("pcluster.config.param_types.get_instance_vcpus", return_value=2)
     utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)
 


### PR DESCRIPTION
This commit replaces the usage of the features json file with a call to describe_instanceTypes
to get the list of efa enabled instance types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
