### PR TITLE
Use full CFN stack id hash when generating unique Lambda function name

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1266,22 +1266,12 @@
           },
           "MainStackUniqueId": {
             "Fn::Select": [
-              "4",
+              "2",
               {
                 "Fn::Split": [
-                  "-",
+                  "/",
                   {
-                    "Fn::Select": [
-                      "2",
-                      {
-                        "Fn::Split": [
-                          "/",
-                          {
-                            "Ref": "AWS::StackId"
-                          }
-                        ]
-                      }
-                    ]
+                    "Ref": "AWS::StackId"
                   }
                 ]
               }
@@ -3989,22 +3979,12 @@
           },
           "MainStackUniqueId": {
             "Fn::Select": [
-              "4",
+              "2",
               {
                 "Fn::Split": [
-                  "-",
+                  "/",
                   {
-                    "Fn::Select": [
-                      "2",
-                      {
-                        "Fn::Split": [
-                          "/",
-                          {
-                            "Ref": "AWS::StackId"
-                          }
-                        ]
-                      }
-                    ]
+                    "Ref": "AWS::StackId"
                   }
                 ]
               }

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -79,7 +79,7 @@
       "Type": "String"
     },
     "MainStackUniqueId": {
-      "Description": "Final 12 digits of the main CloudFormation stack id",
+      "Description": "Final 36 digits of the main CloudFormation stack id",
       "Type": "String"
     }
   },
@@ -640,7 +640,7 @@
         "LogsConfig": {
           "CloudWatchLogs": {
             "GroupName": {
-              "Fn::Sub": "/aws/codebuild/${ClusterName}-CodeBuildDockerImageBuilderProject-${MainStackUniqueId}"
+              "Fn::Sub": "/aws/codebuild/${ClusterName}-CodeBuildDockerImageBuilderProject"
             },
             "Status": "ENABLED"
           }
@@ -752,7 +752,7 @@
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "FunctionName": {
-          "Fn::Sub": "parallelcluster-ManageDockerImages-${MainStackUniqueId}"
+          "Fn::Sub": "pcluster-ManageDockerImages-${MainStackUniqueId}"
         },
         "Code": {
           "S3Bucket": {
@@ -900,7 +900,7 @@
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "FunctionName": {
-          "Fn::Sub": "parallelcluster-SendBuildNotification-${MainStackUniqueId}"
+          "Fn::Sub": "pcluster-SendBuildNotificat-${MainStackUniqueId}"
         },
         "Code": {
           "S3Bucket": {

--- a/cloudformation/cw-logs-substack.cfn.json
+++ b/cloudformation/cw-logs-substack.cfn.json
@@ -49,7 +49,7 @@
       "Type": "String"
     },
     "MainStackUniqueId": {
-      "Description": "Final 12 digits of the main CloudFormation stack id",
+      "Description": "Final 36 digits of the main CloudFormation stack id",
       "Type": "String"
     },
     "CreateCleanupResourcesFunctionLogGroup": {
@@ -88,7 +88,7 @@
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
         "LogGroupName": {
-          "Fn::Sub": "/aws/lambda/parallelcluster-CleanupResources-${MainStackUniqueId}"
+          "Fn::Sub": "/aws/lambda/pcluster-CleanupResources-${MainStackUniqueId}"
         },
         "RetentionInDays": {
           "Fn::Select": [
@@ -110,7 +110,7 @@
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
         "LogGroupName": {
-          "Fn::Sub": "/aws/codebuild/${MainStackName}-CodeBuildDockerImageBuilderProject-${MainStackUniqueId}"
+          "Fn::Sub": "/aws/codebuild/${MainStackName}-CodeBuildDockerImageBuilderProject"
         },
         "RetentionInDays": {
           "Fn::Select": [
@@ -132,7 +132,7 @@
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
         "LogGroupName": {
-          "Fn::Sub": "/aws/lambda/parallelcluster-ManageDockerImages-${MainStackUniqueId}"
+          "Fn::Sub": "/aws/lambda/pcluster-ManageDockerImages-${MainStackUniqueId}"
         },
         "RetentionInDays": {
           "Fn::Select": [
@@ -154,7 +154,7 @@
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
         "LogGroupName": {
-          "Fn::Sub": "/aws/lambda/parallelcluster-SendBuildNotification-${MainStackUniqueId}"
+          "Fn::Sub": "/aws/lambda/pcluster-SendBuildNotificat-${MainStackUniqueId}"
         },
         "RetentionInDays": {
           "Fn::Select": [


### PR DESCRIPTION
Using only the last 12 digits might generate duplicate resource names.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
