### PR TITLE
 Add support for HIT configuration settings.

### DIFF
--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -1,0 +1,1099 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from collections import OrderedDict
+
+import yaml
+from pcluster.config.iam_policy_rules import AWSBatchFullAccessInclusionRule, CloudWatchAgentServerPolicyInclusionRule
+from pcluster.config.param_types import (
+    LOGGER,
+    Param,
+    Section,
+    SettingsParam,
+    StorageData,
+    _ensure_section_existence,
+    get_file_section_name,
+)
+from pcluster.config.resource_map import ResourceMap
+from pcluster.constants import PCLUSTER_ISSUES_LINK
+from pcluster.utils import get_avail_zone, get_cfn_param, get_efs_mount_target_id, get_instance_vcpus
+
+
+# ---------------------- Params ---------------------- #
+class CfnParam(Param):
+    """Base class for configuration parameters using CloudFormation parameters as storage mechanism."""
+
+    def from_storage(self, storage_params):
+        """Load the param from the related storage data structure."""
+        return self.from_cfn_params(storage_params.cfn_params)
+
+    def to_storage(self, storage_params):
+        """Write the param into the related storage data structure."""
+        cfn_params = storage_params.cfn_params
+        cfn_params.update(self.to_cfn())
+
+    def from_cfn_params(self, cfn_params):
+        """
+        Initialize parameter value by parsing CFN input parameters.
+
+        :param cfn_params: list of all the CFN parameters, used if "cfn_param_mapping" is specified in the definition
+        """
+        cfn_converter = self.definition.get("cfn_param_mapping", None)
+        if cfn_params:
+            cfn_value = get_cfn_param(cfn_params, cfn_converter) if cfn_converter else "NONE"
+            self.value = self.get_value_from_string(cfn_value)
+
+        return self
+
+    def from_cfn_value(self, cfn_value):
+        """
+        Initialize parameter value by parsing from a given value coming from CFN.
+
+        :param cfn_value: a value coming from a comma separated CFN param
+        """
+        self.value = self.get_value_from_string(cfn_value)
+
+        return self
+
+    def to_cfn(self):
+        """Convert param to CFN representation, if "cfn_param_mapping" attribute is present in the Param definition."""
+        cfn_params = {}
+        cfn_converter = self.definition.get("cfn_param_mapping", None)
+
+        if cfn_converter:
+            cfn_value = self.get_cfn_value()
+            cfn_params[cfn_converter] = str(cfn_value)
+
+        return cfn_params
+
+    def get_cfn_value(self):
+        """
+        Convert parameter value into CFN value.
+
+        Used when the parameter must go into a comma separated CFN parameter.
+        """
+        return str(self.value if self.value is not None else self.definition.get("default", "NONE"))
+
+
+class CommaSeparatedCfnParam(CfnParam):
+    """Class to manage comma separated parameters. E.g. additional_iam_policies."""
+
+    def from_file(self, config_parser):
+        """
+        Initialize parameter value from config_parser.
+
+        :param config_parser: the configparser object from which get the parameter
+        """
+        section_name = get_file_section_name(self.section_key, self.section_label)
+        if config_parser.has_option(section_name, self.key):
+            config_value = config_parser.get(section_name, self.key)
+            self.value = list(map(lambda x: x.strip(), config_value.split(",")))
+            self._check_allowed_values()
+
+        return self
+
+    def get_string_value(self):
+        """Convert internal representation into string."""
+        return str(",".join(self.value))
+
+    def get_value_from_string(self, string_value):
+        """Return internal representation starting from string/CFN value."""
+        param_value = self.get_default_value()
+
+        if string_value and string_value != "NONE":
+            param_value = list(map(lambda x: x.strip(), string_value.split(",")))
+
+        return param_value
+
+    def get_cfn_value(self):
+        """
+        Convert parameter value into CFN value.
+
+        Used when the parameter must go into a comma separated CFN parameter.
+        """
+        return str(",".join(self.value) if self.value else self.definition.get("default", "NONE"))
+
+    def get_default_value(self):
+        """Get default value from the Param definition if there, empty list otherwise."""
+        return self.definition.get("default", [])
+
+
+class FloatCfnParam(CfnParam):
+    """Class to manage float configuration parameters."""
+
+    def from_file(self, config_parser):
+        """
+        Initialize parameter value from config_parser.
+
+        :param config_parser: the configparser object from which get the parameter
+        """
+        section_name = get_file_section_name(self.section_key, self.section_label)
+        if config_parser.has_option(section_name, self.key):
+            try:
+                self.value = config_parser.getfloat(section_name, self.key)
+                self._check_allowed_values()
+            except ValueError:
+                self.pcluster_config.error("Configuration parameter '{0}' must be a Float".format(self.key))
+
+        return self
+
+    def get_value_from_string(self, string_value):
+        """Return internal representation starting from CFN/user-input value."""
+        param_value = self.get_default_value()
+
+        try:
+            if string_value is not None:
+                string_value = str(string_value).strip()
+                if string_value != "NONE":
+                    param_value = float(string_value)
+        except ValueError:
+            self.pcluster_config.warn(
+                "Unable to convert the value '{0}' to a Float. "
+                "Using default value for parameter '{1}'".format(string_value, self.key)
+            )
+
+        return param_value
+
+
+class BoolCfnParam(CfnParam):
+    """Class to manage boolean configuration parameters."""
+
+    def from_file(self, config_parser):
+        """
+        Initialize parameter value from config_parser.
+
+        :param config_parser: the configparser object from which get the parameter
+        """
+        section_name = get_file_section_name(self.section_key, self.section_label)
+        if config_parser.has_option(section_name, self.key):
+            try:
+                self.value = config_parser.getboolean(section_name, self.key)
+                self._check_allowed_values()
+            except ValueError:
+                self.pcluster_config.error("Configuration parameter '{0}' must be a Boolean".format(self.key))
+
+        return self
+
+    def get_value_from_string(self, string_value):
+        """Return internal representation starting from CFN/user-input value."""
+        param_value = self.get_default_value()
+
+        if string_value is not None:
+            string_value = str(string_value).strip()
+            if string_value != "NONE":
+                param_value = string_value == "true"
+
+        return param_value
+
+    def get_string_value(self):
+        """Convert internal representation into string."""
+        return "true" if self.value else "false"
+
+    def get_cfn_value(self):
+        """
+        Convert parameter value into CFN value.
+
+        Used when the parameter must go into a comma separated CFN parameter.
+        """
+        return self.get_string_value()
+
+    def get_default_value(self):
+        """Get default value from the Param definition if there, False otherwise."""
+        return self.definition.get("default", False)
+
+
+class IntCfnParam(CfnParam):
+    """Class to manage integer configuration parameters."""
+
+    def from_file(self, config_parser):
+        """
+        Initialize param_value from config_parser.
+
+        :param config_parser: the configparser object from which get the parameter
+        """
+        section_name = get_file_section_name(self.section_key, self.section_label)
+        if config_parser.has_option(section_name, self.key):
+            try:
+                self.value = config_parser.getint(section_name, self.key)
+                self._check_allowed_values()
+            except ValueError:
+                self.pcluster_config.error("Configuration parameter '{0}' must be an Integer".format(self.key))
+
+        return self
+
+    def get_value_from_string(self, string_value):
+        """Return internal representation starting from CFN/user-input value."""
+        param_value = self.get_default_value()
+        try:
+            if string_value is not None:
+                string_value = str(string_value).strip()
+                if string_value != "NONE":
+                    param_value = int(string_value)
+        except ValueError:
+            self.pcluster_config.warn(
+                "Unable to convert the value '{0}' to an Integer. "
+                "Using default value for parameter '{1}'".format(string_value, self.key)
+            )
+
+        return param_value
+
+
+class JsonCfnParam(CfnParam):
+    """Class to manage json configuration parameters."""
+
+    def from_file(self, config_parser):
+        """
+        Initialize parameter value from config_parser.
+
+        :param config_parser: the configparser object from which get the parameter
+        """
+        section_name = get_file_section_name(self.section_key, self.section_label)
+        if config_parser.has_option(section_name, self.key):
+            config_value = config_parser.get(section_name, self.key)
+            self.value = self.get_value_from_string(config_value)
+            self._check_allowed_values()
+
+        return self
+
+    def get_value_from_string(self, string_value):
+        """Return internal representation starting from CFN/user-input value."""
+        param_value = self.get_default_value()
+        try:
+            # Do not convert empty string and use format and yaml.load in place of json.loads
+            # for Python 2.7 compatibility because it returns unicode chars
+            if string_value:
+                string_value = str(string_value).strip()
+                if string_value != "NONE":
+                    param_value = yaml.safe_load(string_value)
+        except Exception as e:
+            self.pcluster_config.error("Error parsing JSON parameter '{0}'. {1}".format(self.key, e))
+
+        return param_value
+
+    def get_default_value(self):
+        """Get default value from the Param definition, if there, {} otherwise."""
+        return self.definition.get("default", {})
+
+    def get_string_value(self):
+        """
+        Convert the internal representation into JSON.
+
+        The keys in the Json are sorted alphabetically to produce a predictable and easy to test output.
+        """
+        return json.dumps(self.value, sort_keys=True)
+
+    def get_cfn_value(self):
+        """Convert parameter value into CFN value."""
+        return self.get_string_value()
+
+
+class ExtraJsonCfnParam(JsonCfnParam):
+    """Class to manage extra_json configuration parameters."""
+
+    def get_cfn_value(self):
+        """
+        Convert parameter value into CFN value.
+
+        The extra_json configuration parameter can contain both "cfncluster" or "cluster" keys but cookbook
+        recipes require "cfncluster" as key.
+        """
+        if self.value and "cluster" in self.value:
+            self.value["cfncluster"] = self.value.pop("cluster")
+        return self.get_string_value()
+
+    def to_file(self, config_parser, write_defaults=False):
+        """Set parameter in the config_parser in the right section.
+
+        The extra_json configuration parameter can contain both "cfncluster" or "cluster" keys but
+        we are writing "cluster" in the file to suggest the users the recommended syntax.
+        """
+        if self.value and "cfncluster" in self.value:
+            self.value["cluster"] = self.value.pop("cfncluster")
+        super(ExtraJsonCfnParam, self).to_file(config_parser)
+
+
+class SharedDirCfnParam(CfnParam):
+    """
+    Class to manage the shared_dir configuration parameter.
+
+    We need this class since the same CFN input parameter "SharedDir" is populated
+    from the "shared" parameter of the cluster section (e.g. SharedDir = /shared)
+    and the "shared" parameter of the ebs sections (e.g. SharedDir = /shared1,/shared2,NONE,NONE,NONE).
+    """
+
+    def to_cfn(self):
+        """Convert parameter to CFN representation."""
+        cfn_params = {}
+        # if not using ebs_settings or
+        # if only using 1 volume without specifying shared_dir in EBS section
+        # use the shared_dir parameter in cluster section
+        ebs_labels = self.pcluster_config.get_section("cluster").get_param_value("ebs_settings")
+        if not ebs_labels or (
+            len(ebs_labels.split(",")) == 1
+            and not self.pcluster_config.get_section("ebs", ebs_labels).get_param_value("shared_dir")
+        ):
+            cfn_params[self.definition.get("cfn_param_mapping")] = self.get_cfn_value()
+        # else: there are shared_dir specified in EBS sections
+        # let the EBSSettings populate the SharedDir CFN parameter.
+        return cfn_params
+
+    def to_file(self, config_parser, write_defaults=False):
+        """Set parameter in the config_parser only if the PclusterConfig object does not contains ebs sections."""
+        # if not contains ebs_settings --> single SharedDir
+        section_name = get_file_section_name(self.section_key, self.section_label)
+        if not self.pcluster_config.get_section("ebs") and (write_defaults or self.value != self.get_default_value()):
+            _ensure_section_existence(config_parser, section_name)
+            config_parser.set(section_name, self.key, self.value)
+        # else: there are ebs volumes, let the EBSSettings parse the SharedDir CFN parameter.
+
+    def from_cfn_params(self, cfn_params):
+        """
+        Initialize param value by parsing CFN input only if the scheduler is a traditional one.
+
+        When the SharedDir doesn't contain commas, it has been created from a single EBS volume
+        specified through the shared_dir configuration parameter,
+        if it contains commas, we need to create at least one ebs section.
+        """
+        if cfn_params:
+            num_of_ebs = int(get_cfn_param(cfn_params, "NumberOfEBSVol"))
+            if num_of_ebs == 1 and "," not in get_cfn_param(cfn_params, "SharedDir"):
+                super(SharedDirCfnParam, self).from_cfn_params(cfn_params)
+
+        return self
+
+
+class SpotPriceCfnParam(FloatCfnParam):
+    """
+    Class to manage the spot_price configuration parameter.
+
+    We need this class since the same CFN input parameter "SpotPrice" is populated
+    from the "spot_bid_percentage" parameter when the scheduler is awsbatch and
+    from "spot_price" when the scheduler is a traditional one.
+    """
+
+    def from_cfn_params(self, cfn_params):
+        """Initialize param value by parsing CFN input only if the scheduler is a traditional one."""
+        cfn_converter = self.definition.get("cfn_param_mapping", None)
+        if cfn_converter and cfn_params:
+            if get_cfn_param(cfn_params, "Scheduler") != "awsbatch":
+                self.value = float(get_cfn_param(cfn_params, cfn_converter))
+
+        return self
+
+    def get_cfn_value(self):
+        """
+        Convert parameter value into CFN value.
+
+        Insignificant trailing zeros removed to correctly match CloudFormation conditions using "0" as test value
+        """
+        return str("{0:g}".format(self.value) if self.value is not None else self.definition.get("default", "NONE"))
+
+    def to_cfn(self):
+        """Convert parameter to CFN representation."""
+        cfn_params = {}
+
+        cluster_config = self.pcluster_config.get_section(self.section_key)
+        if cluster_config.get_param_value("scheduler") != "awsbatch":
+            cfn_params[self.definition.get("cfn_param_mapping")] = self.get_cfn_value()
+
+        return cfn_params
+
+
+class SpotBidPercentageCfnParam(IntCfnParam):
+    """
+    Class to manage the spot_bid_percentage configuration parameter.
+
+    We need this class since the same CFN input parameter "SpotPrice" is populated
+    from the "spot_bid_percentage" parameter when the scheduler is awsbatch and
+    from "spot_price" when the scheduler is a traditional one.
+    """
+
+    def from_cfn_params(self, cfn_params):
+        """Initialize param value by parsing CFN input only if the scheduler is awsbatch."""
+        cfn_converter = self.definition.get("cfn_param_mapping", None)
+        if cfn_converter and cfn_params:
+            if get_cfn_param(cfn_params, "Scheduler") == "awsbatch":
+                # we have the same CFN input parameters for both spot_price and spot_bid_percentage
+                # so the CFN input could be a float
+                self.value = int(float(get_cfn_param(cfn_params, cfn_converter)))
+
+        return self
+
+    def to_cfn(self):
+        """Convert parameter to CFN representation."""
+        cfn_params = {}
+
+        cluster_config = self.pcluster_config.get_section(self.section_key)
+        if cluster_config.get_param_value("scheduler") == "awsbatch":
+            cfn_params[self.definition.get("cfn_param_mapping")] = self.get_cfn_value()
+
+        return cfn_params
+
+
+class QueueSizeCfnParam(IntCfnParam):
+    """
+    Class to manage both the *_queue_size and *_vcpus configuration parameters.
+
+    We need this class since the same CFN input parameter "*Size" is populated
+    from the "*_vcpus" parameter when the scheduler is awsbatch and
+    from "*_queue_size" when the scheduler is a traditional one.
+    """
+
+    def from_cfn_params(self, cfn_params):
+        """Initialize param value by parsing the right CFN input according to the scheduler."""
+        cfn_converter = self.definition.get("cfn_param_mapping", None)
+        if cfn_converter and cfn_params:
+            cfn_value = get_cfn_param(cfn_params, cfn_converter) if cfn_converter else "NONE"
+
+            is_traditional_scheduler_param = get_cfn_param(cfn_params, "Scheduler") != "awsbatch" and (
+                self.key == "initial_queue_size" or self.key == "max_queue_size"
+            )
+            is_awsbatch_param = get_cfn_param(cfn_params, "Scheduler") == "awsbatch" and (
+                self.key == "desired_vcpus" or self.key == "max_vcpus" or self.key == "min_vcpus"
+            )
+
+            # initialize the value from cfn according to the scheduler
+            if is_traditional_scheduler_param or is_awsbatch_param:
+                self.value = self.get_value_from_string(cfn_value)
+
+        return self
+
+    def to_cfn(self):
+        """Convert parameter to CFN representation."""
+        cfn_params = {}
+
+        cluster_config = self.pcluster_config.get_section(self.section_key)
+        if (
+            # traditional scheduler parameters
+            cluster_config.get_param_value("scheduler") != "awsbatch"
+            and (self.key == "initial_queue_size" or self.key == "max_queue_size")
+        ) or (
+            # awsbatch scheduler parameters
+            cluster_config.get_param_value("scheduler") == "awsbatch"
+            and (self.key == "desired_vcpus" or self.key == "max_vcpus" or self.key == "min_vcpus")
+        ):
+            cfn_value = cluster_config.get_param_value(self.key)
+            cfn_params[self.definition.get("cfn_param_mapping")] = str(cfn_value)
+
+        return cfn_params
+
+
+class MaintainInitialSizeCfnParam(BoolCfnParam):
+    """
+    Class to manage the maintain_initial_size configuration parameters.
+
+    We need this class since the same CFN input parameter "MinSize" is populated
+    from the "min_vcpus" parameter when the scheduler is awsbatch and
+    merging info from "initial_queue_size" and "maintain_initial_size" when the scheduler is a traditional one.
+    """
+
+    def from_cfn_params(self, cfn_params):
+        """Initialize param value by parsing the right CFN input."""
+        cfn_converter = self.definition.get("cfn_param_mapping", None)
+        if cfn_converter and cfn_params:
+            # initialize the value from cfn only if the scheduler is a traditional one
+            if get_cfn_param(cfn_params, "Scheduler") != "awsbatch":
+                # MinSize param > 0 means that maintain_initial_size was set to true at cluster creation
+                min_size_cfn_value = get_cfn_param(cfn_params, cfn_converter) if cfn_converter else "0"
+                min_size_value = int(min_size_cfn_value) if min_size_cfn_value != "NONE" else 0
+                self.value = min_size_value > 0
+
+        return self
+
+    def to_cfn(self):
+        """Convert parameter to CFN representation."""
+        cfn_params = {}
+
+        cluster_config = self.pcluster_config.get_section(self.section_key)
+        if cluster_config.get_param_value("scheduler") != "awsbatch":
+            cfn_value = cluster_config.get_param_value("maintain_initial_size")
+            min_size_value = cluster_config.get_param_value("initial_queue_size") if cfn_value else "0"
+            cfn_params.update({self.definition.get("cfn_param_mapping"): str(min_size_value)})
+
+        return cfn_params
+
+
+class AdditionalIamPoliciesCfnParam(CommaSeparatedCfnParam):
+    """
+    Class to manage the additional_iam_policies configuration parameters.
+
+    We need this class for 2 reasons:
+    * When the scheduler is awsbatch, we need to add/remove the AWSBatchFullAccess policy
+      during CFN conversion.
+    * When CloudWatch logging is enabled, we need to add/remove the CloudWatchAgentServerPolicy
+      during CFN conversion.
+    """
+
+    policy_inclusion_rules = [CloudWatchAgentServerPolicyInclusionRule, AWSBatchFullAccessInclusionRule]
+
+    def __init__(self, section_key, section_label, param_key, param_definition, pcluster_config, owner_section=None):
+        super(AdditionalIamPoliciesCfnParam, self).__init__(
+            section_key, section_label, param_key, param_definition, pcluster_config, owner_section
+        )
+
+    def get_string_value(self):
+        """Convert internal representation into string. Conditionally enabled policies are not written."""
+        non_conditional_iam_policies = self._non_conditional_iam_policies()
+        return str(",".join(non_conditional_iam_policies)) if non_conditional_iam_policies else None
+
+    def refresh(self):
+        """Refresh the additional IAM policies by adding conditional policies, if needed."""
+        additional_policies = set(self.value)
+        for rule in AdditionalIamPoliciesCfnParam.policy_inclusion_rules:
+            if rule.policy_is_required(self.pcluster_config) and rule.get_policy() not in additional_policies:
+                additional_policies.add(rule.get_policy())
+        self.value = sorted(additional_policies)
+
+    def _non_conditional_iam_policies(self):
+        """Given a list of IAM policies return a new list containing only the non conditional ones."""
+        policies = set(self.value)  # List is cloned to avoid modifying self value
+        for rule in self.policy_inclusion_rules:
+            if rule.policy_is_required(self.pcluster_config):
+                policies.discard(rule.get_policy())
+        return sorted(policies)
+
+
+class AvailabilityZoneCfnParam(CfnParam):
+    """
+    Base class to manage availability_zone internal attribute.
+
+    This parameter is not exposed as configuration parameter in the file but it exists as CFN parameter
+    and it is used for master_availability_zone and compute_availability_zone.
+    """
+
+    def _init_az(self, config_parser, subnet_parameter):
+        section_name = get_file_section_name(self.section_key, self.section_label)
+        if config_parser.has_option(section_name, subnet_parameter):
+            subnet_id = config_parser.get(section_name, subnet_parameter)
+            self.value = get_avail_zone(subnet_id)
+            self._check_allowed_values()
+
+    def to_file(self, config_parser, write_defaults=False):
+        """Do nothing, because master_availability_zone it is an internal parameter, not exposed in the config file."""
+        pass
+
+
+class MasterAvailabilityZoneCfnParam(AvailabilityZoneCfnParam):
+    """
+    Class to manage master_availability_zone internal attribute.
+
+    This parameter is not exposed as configuration parameter in the file but it exists as CFN parameter
+    and it is used during EFS conversion and validation.
+    """
+
+    def from_file(self, config_parser):
+        """Initialize the Availability zone of the cluster by checking the Master Subnet."""
+        self._init_az(config_parser, "master_subnet_id")
+
+        return self
+
+    def from_cfn_params(self, cfn_params):
+        """Initialize the Availability zone by checking the Compute Subnet from cfn."""
+        master_subnet_id = get_cfn_param(cfn_params, "MasterSubnetId")
+        self.value = get_avail_zone(master_subnet_id)
+        return self
+
+
+class ComputeAvailabilityZoneCfnParam(AvailabilityZoneCfnParam):
+    """
+    Class to manage compute_availability_zone internal attribute.
+
+    This parameter is not exposed as configuration parameter in the file but it exists as CFN parameter
+    and it is used during EFS conversion and validation.
+    """
+
+    def from_file(self, config_parser):
+        """Initialize the Availability zone of the cluster by checking the Compute Subnet."""
+        self._init_az(config_parser, "compute_subnet_id")
+
+        return self
+
+    def from_cfn_params(self, cfn_params):
+        """Initialize the Availability zone by checking the Compute Subnet from cfn."""
+        compute_subnet_id = get_cfn_param(cfn_params, "ComputeSubnetId")
+        self.value = get_avail_zone(compute_subnet_id)
+        return self
+
+
+class DisableHyperThreadingCfnParam(BoolCfnParam):
+    """
+    Class to manage the disable_hyperthreading configuration parameter.
+
+    We need this class in order to convert the boolean disable_hyperthreading = [true/false] into Cores.
+    """
+
+    def from_cfn_params(self, cfn_params):
+        """Initialize param value by parsing the right CFN input."""
+        try:
+            cfn_converter = self.definition.get("cfn_param_mapping", None)
+            if cfn_converter and cfn_params:
+                cores = get_cfn_param(cfn_params, cfn_converter)
+                if cores and cores != "NONE":
+                    cores = int(cores.split(",")[0])
+                    self.value = cores > 0
+        except (ValueError, IndexError):
+            self.pcluster_config.warn("Unable to parse Cfn Parameter Cores = {0}".format(cfn_params))
+
+        return self
+
+    def to_cfn(self):
+        """
+        Define the Cores CFN parameter as a tuple (cores_master,cores_compute) if disable_hyperthreading = true.
+
+        :return: string (cores_master,cores_compute)
+        """
+        cfn_params = {self.definition.get("cfn_param_mapping"): "-1,-1"}
+
+        cluster_config = self.pcluster_config.get_section(self.section_key)
+        if cluster_config.get_param_value("disable_hyperthreading"):
+            master_instance_type = cluster_config.get_param_value("master_instance_type")
+            compute_instance_type = cluster_config.get_param_value("compute_instance_type")
+
+            master_cores = get_instance_vcpus(self.pcluster_config.region, master_instance_type) // 2
+            compute_cores = get_instance_vcpus(self.pcluster_config.region, compute_instance_type) // 2
+
+            if master_cores < 0 or compute_cores < 0:
+                self.pcluster_config.error(
+                    "For disable_hyperthreading, unable to get number of vcpus for {0} instance. "
+                    "Please open an issue {1}".format(
+                        master_instance_type if master_cores < 0 else compute_instance_type, PCLUSTER_ISSUES_LINK
+                    )
+                )
+            cfn_params.update({self.definition.get("cfn_param_mapping"): "{0},{1}".format(master_cores, compute_cores)})
+
+        return cfn_params
+
+
+class ClusterConfigMetadataCfnParam(JsonCfnParam):
+    """
+    Class to manage configuration metadata.
+
+    Uses an internal ResourceMap to manage section labels in order to ensure proper correspondence between the section
+    labels and their corresponding CloudFormation resources.
+    """
+
+    def _from_definition(self):
+        self.value = self.get_default_value()
+        self.__section_resources = ResourceMap(self.value.get("sections"))
+
+    def from_cfn_params(self, cfn_params):
+        """Initialize parameter by parsing CFN parameters."""
+        super(JsonCfnParam, self).from_cfn_params(cfn_params)
+        self.__section_resources = ResourceMap(self.value.get("sections"))
+        return self
+
+    def __store_section_labels(self, section_key):
+        """Store all the section labels corresponding to the provided section key into the internal ResourceMap."""
+        section = self.pcluster_config.get_section(section_key)
+        if section and section.has_metadata():
+            labels = [section.label for section in self.pcluster_config.get_sections(section.key).values()]
+
+            if not self.__section_resources.resources(section.key):
+                # Allocating more resources than allowed is fine here. Integrity check is performed by validation.
+                self.__section_resources.alloc(section.key, max(section.max_resources, len(labels)))
+
+            self.__section_resources.store(section.key, labels)
+
+    def get_cfn_value(self):
+        """Get value to store in CloudFormation."""
+        return self.get_string_value()
+
+    def get_default_value(self):
+        """Get default value from the Param definition."""
+        return self.definition.get("default", {"sections": {}})
+
+    def refresh(self):
+        """
+        Refresh the configuration metadata.
+
+        The operation is done by storing all section labels of the parent PClusterConfig instance into the internal
+        ResourceMap and then setting them back into the "sections" key of the parameter's Json value.
+        This allows the original order of the labels to be maintained when the configuration has been loaded from cfn.
+        """
+        for section_key in self.pcluster_config.get_section_keys():
+            self.__store_section_labels(section_key)
+        self.value["sections"] = self.__section_resources.resources()
+
+    def get_section_resources(self, section_key):
+        """Get the resources linked to a specific section key in the configuration metadata."""
+        return self.__section_resources.resources(section_key)
+
+    def create_section_resources(self, section_key, num_labels, max_resources):
+        """
+        Create automatic section resource labels for the provided section key.
+
+        :param section_key The section key
+        :param num_labels The number of labels to create
+        :param max_resources The max number of resources to allocate for this section key
+        """
+        self.__section_resources.alloc(section_key, max_resources)
+        section_labels = ["{0}{1}".format(section_key, str(index + 1)) for index in range(num_labels)]
+        self.__section_resources.store(section_key, section_labels)
+        LOGGER.debug("Automatic labels generated: {0}".format(str(section_labels)))
+        # Refresh param value
+        self.refresh()
+        return self.__section_resources.resources(section_key)
+
+
+# ---------------------- SettingsParams ---------------------- #
+class SettingsCfnParam(SettingsParam):
+    """Class to manage *_settings parameter on which the value is a single value (e.g. vpc_settings = default)."""
+
+    def from_storage(self, storage_params):
+        """Initialize section configuration parameters referred by the settings value by parsing CFN parameters."""
+        self.value = self.definition.get("default", None)
+        section_labels = self.get_metadata_labels()
+        label = section_labels[0] if section_labels else None
+
+        # Section if rebuilt only if section label is found in cluster metadata
+        if label:
+            if storage_params:
+                section = self.referred_section_type(
+                    self.referred_section_definition, self.pcluster_config, section_label=label
+                ).from_storage(storage_params)
+                self._replace_default_section(section)
+
+        return self
+
+    def to_storage(self, storage_params):
+        """Convert the referred section to CFN representation."""
+        section_labels = self.get_metadata_labels()
+
+        if self.referred_section_definition.get("max_resources", 1) > 1:
+            # Multiple section
+            for section_label in [section_label for section_label in section_labels if section_label is not None]:
+                section = self.pcluster_config.get_section(self.referred_section_key, section_label.strip())
+                section.to_storage(storage_params)
+        else:
+            # Single section
+            section = self.pcluster_config.get_section(self.referred_section_key, self.value)
+            if not section:
+                # Create a default section to populate with default values (e.g. NONE)
+                section = self.referred_section_type(self.referred_section_definition, self.pcluster_config)
+
+            section.to_storage(storage_params)
+
+    def get_metadata_labels(self, expected_num_labels=0, include_none_values=True):
+        """
+        Return the sections labels of this Settings param respecting their order in the cluster config metadata.
+
+        If the config metadata has been restored from CloudFormation, for instance in the context of a pcluster update
+        operation, this method ensures that the labels already stored in metadata will maintain their positions, so that
+        their correspondence with the existing CloudFormation resources is respected.
+        Important: calling this method is safe from all stages of configuration loading / writing  because the
+        CloudFormationMetadata parameter is the first to be loaded.
+
+        :param expected_num_labels: number of expected labels
+        :param include_none_values: Include None values in the result
+        :returns: The labels list as stored in config metadata
+        """
+        metadata = self.pcluster_config.get_section("cluster").get_param("cluster_config_metadata")
+        section_labels = metadata.get_section_resources(self.referred_section_key)
+        if not section_labels:
+            section_labels = self.value.split(",") if self.value else None
+
+        # Automatic section labels creation if no metadata information is found.
+        # This condition is expected in two cases:
+        #   1) when loading sections from cfn which where not present in the original config file (these sections will
+        #      contain all default parameter values)
+        #   2) in unit tests that build the configuration on the fly
+        if not section_labels:
+            max_resources = int(self.referred_section_definition.get("max_resources", "1"))
+            section_labels = metadata.create_section_resources(
+                self.referred_section_key, expected_num_labels, max_resources
+            )
+
+        if not include_none_values:
+            section_labels = [label for label in section_labels if label is not None]
+
+        return section_labels
+
+
+class EBSSettingsCfnParam(SettingsCfnParam):
+    """
+    Class to manage ebs_settings parameter.
+
+    We require a specific class for EBS settings because multiple parameters from multiple sections
+    are merged together to create CFN parameters.
+    Furthermore, as opposed to SettingsParam, the value can be a comma separated value (e.g. ebs_settings = ebs1,ebs2).
+    """
+
+    def from_storage(self, storage_params):
+        """Init ebs section only if there are more than one ebs (the default one)."""
+        labels = []
+        if storage_params.cfn_params:
+            cfn_params = storage_params.cfn_params
+            # FIXME: remove NumberOfEBSVol Parameter and use EBS section params to manage EBS Volumes in cfn template
+            # fix ebs substack - this code can be reused for back compatibility
+            num_of_ebs = int(get_cfn_param(cfn_params, "NumberOfEBSVol"))
+            if num_of_ebs >= 1 and "," in get_cfn_param(cfn_params, "SharedDir"):
+                # When the SharedDir doesn't contain commas, it has been created from a single EBS volume
+                # specified through the shared_dir configuration parameter only
+                # If SharedDir contains comma, we need to create at least one ebs section
+                labels = self.get_metadata_labels(expected_num_labels=num_of_ebs, include_none_values=False)
+                for index in range(len(labels)):
+                    # create empty section
+                    referred_section_type = self.referred_section_definition.get("type", CfnSection)
+                    referred_section = referred_section_type(
+                        self.referred_section_definition, self.pcluster_config, labels[index]
+                    )
+
+                    for param_key, param_definition in self.referred_section_definition.get("params").items():
+                        cfn_converter = param_definition.get("cfn_param_mapping", None)
+                        if cfn_converter:
+
+                            param_type = param_definition.get("type", CfnParam)
+                            cfn_value = get_cfn_param(cfn_params, cfn_converter).split(",")[index]
+                            param = param_type(
+                                self.section_key, self.section_label, param_key, param_definition, self.pcluster_config
+                            ).from_cfn_value(cfn_value)
+                            referred_section.add_param(param)
+
+                    self.pcluster_config.add_section(referred_section)
+
+        self.value = ",".join(labels) if labels else None
+
+        return self
+
+    def to_file(self, config_parser, write_defaults=False):
+        """Convert the param value into a list of sections in the config_parser and initialize them."""
+        sections = {}
+        if self.value:
+            for section_label in self.value.split(","):
+                sections.update(self.pcluster_config.get_section(self.referred_section_key, section_label.strip()))
+
+        if sections:
+            section_name = get_file_section_name(self.section_key, self.section_label)
+            # add "*_settings = *" to the parent section
+            _ensure_section_existence(config_parser, section_name)
+            config_parser.add_section(section_name)
+
+            # create sections
+            for _, section in sections:
+                section.to_file(config_parser)
+
+    def to_storage(self, storage_params):
+        """Convert a list of sections to multiple CFN params."""
+        sections = OrderedDict({})
+
+        # Section labels are retrieved from configuration metadata rather than directly from the ebs_settings param
+        # to respect the original order of Cfn resources
+        section_labels = self.get_metadata_labels()
+
+        for section_label in [section_label for section_label in section_labels if section_label is not None]:
+            section = self.pcluster_config.get_section(self.referred_section_key, section_label.strip())
+            sections[section_label] = section
+
+        cfn_params = storage_params.cfn_params
+        number_of_ebs_sections = len(sections)
+        for param_key, param_definition in self.referred_section_definition.get("params").items():
+            if param_key == "shared_dir":
+                # The same CFN parameter is used for both single and multiple EBS cases
+                # if there are no EBS volumes, or if user does not specify shared_dir when using 1 EBS volume
+                # let the SharedDirParam populate the "SharedDir" CFN parameter.
+                if number_of_ebs_sections == 0 or (
+                    number_of_ebs_sections == 1 and not next(iter(sections.values())).get_param_value("shared_dir")
+                ):
+                    continue
+
+            cfn_converter = param_definition.get("cfn_param_mapping", None)
+            if cfn_converter:
+
+                cfn_value_list = []
+                for section_label in section_labels:
+                    if section_label:
+                        section = sections[section_label]
+                        param = section.get_param(param_key)
+                    else:
+                        # Create a default param
+                        param_type = param_definition.get("type", CfnParam)
+                        param = param_type(
+                            self.referred_section_key, "default", param_key, param_definition, self.pcluster_config
+                        )
+                    cfn_value_list.append(param.to_cfn().get(cfn_converter))
+
+                cfn_value = ",".join(cfn_value_list)
+                cfn_params[cfn_converter] = cfn_value
+
+        # We always have at least one EBS volume
+        # FIXME: remove NumberOfEBSVol Parameter and use EBS section params to manage EBS Volumes in cfn template
+        cfn_params["NumberOfEBSVol"] = str(max(number_of_ebs_sections, 1))
+
+
+# ---------------------- Sections ---------------------- #
+class CfnSection(Section):
+    """Class to manage configuration sections with storage persistence in CloudFormation."""
+
+    def from_storage(self, storage_params):
+        """Initialize section configuration parameters by parsing CFN parameters."""
+        cfn_converter = self.definition.get("cfn_param_mapping", None)
+        if cfn_converter:
+            # It is a section converted to a single CFN parameter
+            cfn_values = get_cfn_param(storage_params.cfn_params, cfn_converter).split(",")
+
+            cfn_param_index = 0
+            for param_key, param_definition in self.definition.get("params").items():
+                try:
+                    cfn_value = cfn_values[cfn_param_index]
+                except IndexError:
+                    # This happen if the expected comma separated CFN param doesn't exist in the Stack,
+                    # so it is set to a single NONE value
+                    cfn_value = "NONE"
+
+                param_type = param_definition.get("type", CfnParam)
+                param = param_type(
+                    self.key, self.label, param_key, param_definition, self.pcluster_config, owner_section=self
+                ).from_cfn_value(cfn_value)
+
+                self.add_param(param)
+                cfn_param_index += 1
+        else:
+            for param_key, param_definition in self.definition.get("params").items():
+                param_type = param_definition.get("type", CfnParam)
+                param = param_type(
+                    self.key, self.label, param_key, param_definition, self.pcluster_config, owner_section=self
+                ).from_storage(storage_params)
+                self.add_param(param)
+
+        return self
+
+    def to_storage(self, storage_params=None):
+        """
+        Convert section to CFN representation.
+
+        The section is converted to a single CFN parameter if "cfn_param_mapping" is present in the Section definition,
+        otherwise each parameter of the section will be converted to the respective CFN parameter.
+        """
+        if not storage_params:
+            storage_params = StorageData({}, {})
+
+        cfn_converter = self.definition.get("cfn_param_mapping", None)
+        if cfn_converter:
+            # it is a section converted to a single CFN parameter
+            cfn_items = []
+            for param_key, param_definition in self.definition.get("params").items():
+                param = self.get_param(param_key)
+                if param:
+                    cfn_items.append(param.get_cfn_value())
+                else:
+                    param_type = param_definition.get("type", CfnParam)
+                    param = param_type(self.key, self.label, param_key, param_definition, self.pcluster_config)
+                    cfn_items.append(param.get_cfn_value())
+
+            if cfn_items[0] == "NONE":
+                # empty dict or first item is NONE --> set all values to NONE
+                cfn_items = ["NONE"] * len(self.definition.get("params"))
+
+            storage_params.cfn_params[cfn_converter] = ",".join(cfn_items)
+        else:
+            # get value from config object
+            for param_key, param_definition in self.definition.get("params").items():
+                param = self.get_param(param_key)
+                if param:
+                    param.to_storage(storage_params)
+                else:
+                    # set CFN value from a default param
+                    param_type = param_definition.get("type", Param)
+                    param = param_type(self.key, self.label, param_key, param_definition, self.pcluster_config)
+                    param.to_storage(storage_params)
+
+        return storage_params
+
+    def get_default_param_type(self):
+        """Get the default Param type managed by the Section type."""
+        return CfnParam
+
+
+class EFSCfnSection(CfnSection):
+    """
+    Class to manage [efs ...] section.
+
+    We need to define this class because during the CFN conversion it is required to perform custom actions.
+    """
+
+    def to_storage(self, storage_params=None):
+        """
+        Convert section to CFN representation.
+
+        In addition to the conversion of the parameter contained in the section definition,
+        it also add a final value in the CFN param that identifies if exists or not
+        a valid Mount Target for the given EFS FS Id.
+        """
+        if not storage_params:
+            storage_params = StorageData({}, {})
+        cfn_params = storage_params.cfn_params
+        cfn_converter = self.definition.get("cfn_param_mapping", None)
+
+        cfn_items = []
+        for param_key, param_definition in self.definition.get("params").items():
+            param = self.get_param(param_key)
+            if param:
+                cfn_items.append(param.get_cfn_value())
+            else:
+                param_type = param_definition.get("type", CfnParam)
+                param = param_type(self.key, self.label, param_key, param_definition, self.pcluster_config)
+                cfn_items.append(param.get_cfn_value())
+
+        if cfn_items[0] == "NONE":
+            master_mt_valid = False
+            compute_mt_valid = False
+            master_avail_zone = "fake_az1"
+            compute_avail_zone = "fake_az2"
+            # empty dict or first item is NONE --> set all values to NONE
+            cfn_items = ["NONE"] * len(self.definition.get("params"))
+        else:
+            # add another CFN param that will identify if create or not a Mount Target for the given EFS FS Id
+            master_avail_zone = self.pcluster_config.get_master_availability_zone()
+            master_mount_target_id = get_efs_mount_target_id(
+                efs_fs_id=self.get_param_value("efs_fs_id"), avail_zone=master_avail_zone
+            )
+            compute_avail_zone = self.pcluster_config.get_compute_availability_zone()
+            compute_mount_target_id = get_efs_mount_target_id(
+                efs_fs_id=self.get_param_value("efs_fs_id"), avail_zone=compute_avail_zone
+            )
+            master_mt_valid = bool(master_mount_target_id)
+            compute_mt_valid = bool(compute_mount_target_id)
+
+        cfn_items.append("Valid" if master_mt_valid else "NONE")
+        # Do not create additional compute mount target if compute and master subnet in the same AZ
+        cfn_items.append("Valid" if compute_mt_valid or (master_avail_zone == compute_avail_zone) else "NONE")
+        cfn_params[cfn_converter] = ",".join(cfn_items)
+
+        return storage_params
+
+
+class ClusterCfnSection(CfnSection):
+    """
+    Class to manage [cluster ...] section.
+
+    We need to define this class because during the CFN conversion it is required to manage another CFN param
+    that identifies the label in the template.
+    """
+
+    def from_storage(self, storage_params):
+        """Initialize section configuration parameters by parsing CFN parameters."""
+        if storage_params:
+            super(ClusterCfnSection, self).from_storage(storage_params)
+
+        # Update section label from metadata
+        section_metadata = self.get_param_value("cluster_config_metadata").get("sections").get("cluster")
+        self.label = section_metadata[0] if section_metadata else "default"
+
+        return self
+
+    def to_storage(self, storage_params=None):
+        """Convert section to CFN representation."""
+        if not storage_params:
+            storage_params = StorageData({}, {})
+
+        super(ClusterCfnSection, self).to_storage(storage_params)
+        return storage_params

--- a/cli/pcluster/config/config_patch.py
+++ b/cli/pcluster/config/config_patch.py
@@ -68,8 +68,8 @@ class ConfigPatch(object):
         self.target_config = copy.deepcopy(target_config)
 
         # Disable autorefresh to avoid breakages due to changes made to the configurations when creating the patch
-        self.base_config.set_auto_refresh(False)
-        self.target_config.set_auto_refresh(False)
+        self.base_config.auto_refresh = False
+        self.target_config.auto_refresh = False
 
         self.changes = []
         self._compare()

--- a/cli/pcluster/config/hit_converter.py
+++ b/cli/pcluster/config/hit_converter.py
@@ -1,0 +1,83 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from pcluster.config import mappings
+from pcluster.config.json_param_types import JsonSection
+
+
+class HitConverter:
+    """Utility class which takes care of ensuring backward compatibility with the pre-HIT configuration model."""
+
+    def __init__(self, pcluster_config):
+        self.pcluster_config = pcluster_config
+
+    def convert(self):
+        """
+        Convert the pcluster_config instance from pre-HIT to HIT configuration model.
+
+        Currently, the conversion is performed only if the configured scheduler is Slurm.
+        """
+        cluster_section = self.pcluster_config.get_section("cluster")
+        scheduler = cluster_section.get_param_value("scheduler")
+        queue_settings = cluster_section.get_param_value("queue_settings")
+
+        if scheduler == "slurm" and not queue_settings:
+            auto_refresh = self.pcluster_config.auto_refresh
+            self.pcluster_config.auto_refresh = False
+
+            # Default single queue
+            queue_section = JsonSection(
+                mappings.QUEUE, self.pcluster_config, section_label="default", parent_section=cluster_section
+            )
+            self.pcluster_config.add_section(queue_section)
+
+            self._move_param_value(cluster_section.get_param("cluster_type"), queue_section.get_param("compute_type"))
+            self._move_param_value(
+                cluster_section.get_param("enable_efa"),
+                queue_section.get_param("enable_efa"),
+                "compute" == cluster_section.get_param("enable_efa").value,
+            )
+            self._move_param_value(
+                queue_section.get_param("disable_hyperthreading"), queue_section.get_param("disable_hyperthreading")
+            )
+            self._move_param_value(
+                queue_section.get_param("placement_group"), queue_section.get_param("placement_group")
+            )
+
+            # Default single compute resource
+            compute_resource_section = JsonSection(
+                mappings.COMPUTE_RESOURCE, self.pcluster_config, section_label="default", parent_section=queue_section
+            )
+            self.pcluster_config.add_section(compute_resource_section)
+
+            self._move_param_value(
+                cluster_section.get_param("compute_instance_type"), compute_resource_section.get_param("instance_type")
+            )
+
+            self._move_param_value(
+                cluster_section.get_param("max_queue_size"), compute_resource_section.get_param("max_count")
+            )
+
+            self._move_param_value(
+                cluster_section.get_param("spot_price"), compute_resource_section.get_param("spot_price")
+            )
+
+            if cluster_section.get_param_value("maintain_initial_size"):
+                self._move_param_value(
+                    cluster_section.get_param("initial_queue_size"), compute_resource_section.get_param("min_count")
+                )
+
+            self.pcluster_config.refresh()
+            self.pcluster_config.auto_refresh = auto_refresh
+
+    def _move_param_value(self, old_param, new_param, new_value=None):
+        """Copy the value from the old param to the new one and reset old param to its default value."""
+        new_param.value = new_value if new_value is not None else old_param.value
+        old_param.reset_value()

--- a/cli/pcluster/config/json_param_types.py
+++ b/cli/pcluster/config/json_param_types.py
@@ -1,0 +1,286 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import OrderedDict
+
+from pcluster import utils
+from pcluster.config.param_types import Param, Section, SettingsParam, get_file_section_name
+
+
+# ---------------------- Params ---------------------- #
+class JsonParam(Param):
+    """Base class to manage configuration parameters stored in Json format."""
+
+    def get_value_type(self):
+        """Return the type of the value managed by the Param."""
+        return str
+
+    def from_file(self, config_parser):
+        """Load the param value from configuration file."""
+        section_name = get_file_section_name(self.section_key, self.section_label)
+        if config_parser.has_option(section_name, self.key):
+            try:
+                self.value = self._parse_value(config_parser, section_name)
+                self._check_allowed_values()
+            except ValueError:
+                self.pcluster_config.error(
+                    "Configuration parameter '{0}' must be of '{1}' type".format(
+                        self.key, self.get_value_type().__name__
+                    )
+                )
+
+        return self
+
+    def from_storage(self, storage_params):
+        """Load the param from the provided Json storage params dict."""
+        storage_value = _get_storage_subdict(self, storage_params.json_params).get(
+            self.get_storage_key(), self.get_default_value()
+        )
+        self.value = storage_value
+        return self
+
+    def to_storage(self, storage_params):
+        """Store the param into the provided Json storage params dict."""
+        _get_storage_subdict(self, storage_params.json_params)[self.get_storage_key()] = self.value
+
+    def _parse_value(self, config_parser, section_name):
+        """Parse the value from config file, converting to the needed type for the specific param."""
+        # No conversion is applied at base level
+        return config_parser.get(section_name, self.key)
+
+
+class IntJsonParam(JsonParam):
+    """Base JsonParam to manage int parameters."""
+
+    def get_value_type(self):
+        """Return the type of the value managed by the Param."""
+        return int
+
+    def _parse_value(self, config_parser, section_name):
+        """Parse the value from config file, converting to the needed type for the specific param."""
+        # Convert value to Int
+        return config_parser.getint(section_name, self.key)
+
+
+class BooleanJsonParam(JsonParam):
+    """Base JsonParam to manage boolean parameters."""
+
+    def get_value_type(self):
+        """Return the type of the value managed by the Param."""
+        return bool
+
+    def _parse_value(self, config_parser, section_name):
+        """Parse the value from config file, converting to the needed type for the specific param."""
+        # Convert value to boolean
+        return config_parser.getboolean(section_name, self.key)
+
+
+class FloatJsonParam(JsonParam):
+    """Base JsonParam to manage float parameters."""
+
+    def get_value_type(self):
+        """Return the type of the value managed by the Param."""
+        return float
+
+    def _parse_value(self, config_parser, section_name):
+        """Parse the value from config file, converting to the needed type for the specific param."""
+        # Convert value to Float
+        return config_parser.getfloat(section_name, self.key)
+
+
+class ComputeInstanceTypeJsonParam(JsonParam):
+    """JsonParam to manage compute instance type in compute_resource sections."""
+
+    def refresh(self):
+        """
+        Populate additional settings needed for the linked compute resource like vcpus, gpus etc.
+
+        These parameters are set according to queue settings and instance type capabilities.
+        """
+        if self.value:
+            instance_type = utils.get_instance_type(self.value)
+
+            # Set vcpus according to queue's disable_hyperthreading and instance features
+            queue_section = self.owner_section.parent_section
+            ht_disabled = queue_section.get_param_value("disable_hyperthreading") if queue_section else None
+            vcpus_info = instance_type.get("VCpuInfo")
+            default_cores = vcpus_info.get("DefaultCores")
+            vcpus = default_cores if ht_disabled and default_cores else vcpus_info.get("DefaultVCpus")
+            self.owner_section.get_param("vcpus").value = vcpus
+
+            # Set gpus according to instance features
+            gpu_info = instance_type.get("GpuInfo", None)
+            if gpu_info:
+                # Currently adding up all gpus. To be reviewed if the case of heterogeneous GPUs arises.
+                self.owner_section.get_param("gpus").value = sum([gpus.get("Count") for gpus in gpu_info.get("Gpus")])
+
+            # Set enable_efa according to queues' enable_efa and instance features
+            enable_efa = queue_section.get_param_value("enable_efa") if queue_section else None
+            self.owner_section.get_param("enable_efa").value = enable_efa and instance_type.get("NetworkInfo").get(
+                "EfaSupported"
+            )
+
+            # print warnings if any configuration fallback has occurred
+            if ht_disabled and not default_cores:
+                self.pcluster_config.warn(
+                    "Hyperthreading was disabled on queue '{0}', but disabling hyperthreading on instance type '{1}' "
+                    "is not currently supported by ParallelCluster.".format(queue_section.label, self.value)
+                )
+
+            if enable_efa and not self.owner_section.get_param("enable_efa").value:
+                self.pcluster_config.warn(
+                    "EFA was enabled on queue '{0}', but instance type '{1}' "
+                    "does not support EFA.".format(queue_section.label, self.value)
+                )
+
+
+class ScaleDownIdleTimeJsonParam(JsonParam):
+    """JsonParam to manage scaledown_idletime for Json configuration."""
+
+    def refresh(self):
+        """Take the value from the scaledown_idletime cfn parameter."""
+        self.value = self.owner_section.get_param("scaledown_idletime").value
+
+    def get_storage_key(self):
+        """Return the key by which the current param must be stored in the JSON."""
+        return "scaledown_idletime"
+
+
+class DefaultComputeQueueJsonParam(JsonParam):
+    """JsonParam to manage default_queue parameter in cluster section."""
+
+    def refresh(self):
+        """Take the label of the first queue as value."""
+        queue_settings_param = self.pcluster_config.get_section("cluster").get_param("queue_settings")
+        # First queue is the default one
+        if queue_settings_param:
+            queue_settings_param_value = queue_settings_param.value
+
+            if queue_settings_param_value:
+                self.value = queue_settings_param_value.split(",")[0].strip()
+
+
+# ---------------------- SettingsParams ---------------------- #
+class SettingsJsonParam(SettingsParam):
+    """Settings params with storage in Json."""
+
+    def to_storage(self, storage_params):
+        """
+        Convert the referred sections into the json storage representation.
+
+        For each label, a subdictionary is created is generated under the param key, with the section label as key and
+        the related section as value.
+        Example of storage conversion:
+        config file:
+            queue_settings = queue1, queue2
+
+        json config:
+            "cluster": {
+                ...
+                "queue_settings": {
+                    "queue1": {...},
+                    "queue2": {...}
+                }
+            }
+        """
+        if self.value:
+            labels = self.value.split(",")
+
+            for label in labels:
+                section = self.pcluster_config.get_section(self.referred_section_key, label.strip())
+                section.to_storage(storage_params)
+
+    def from_storage(self, storage_params):
+        """
+        Load the referred sections from storage representation.
+
+        This method rebuilds the settings labels by iterating through all subsections of the related section;
+        then each subsection is loaded from storage as well.
+        """
+        json_params = storage_params.json_params
+        json_subdict = _get_storage_subdict(self, json_params).get(self.key)
+        if json_subdict:
+            labels = [label for label in json_subdict.keys()]
+
+            self.value = ",".join(labels)
+            for label in labels:
+                section = self.referred_section_type(
+                    self.referred_section_definition,
+                    self.pcluster_config,
+                    section_label=label,
+                    parent_section=self.owner_section,
+                ).from_storage(storage_params)
+                self.pcluster_config.add_section(section)
+
+        return self
+
+
+# ---------------------- Sections ---------------------- #
+class JsonSection(Section):
+    """Class representing configuration sections which are persisted in Json."""
+
+    def from_storage(self, storage_params):
+        """Load the section from storage params."""
+        for param_key, param_definition in self.definition.get("params").items():
+            param_type = param_definition.get("type", Param)
+            param = param_type(
+                self.key, self.label, param_key, param_definition, self.pcluster_config, owner_section=self
+            ).from_storage(storage_params)
+            self.add_param(param)
+        return self
+
+    def to_storage(self, storage_params):
+        """Write the section into storage params."""
+        for param_key, _ in self.definition.get("params").items():
+            param = self.get_param(param_key)
+            if param:
+                param.to_storage(storage_params)
+
+    def has_metadata(self):
+        """No metadata must be stored in CloudFormation for Json Sections."""
+        return False
+
+    def get_default_param_type(self):
+        """Get the default Param type managed by the Section type."""
+        return JsonParam
+
+
+# ---------------------- Common functions ---------------------- #
+def _get_storage_subdict(param, json_storage_params):
+    """Get the JSON configuration subdictionary where the current parameter must be stored."""
+    parent_section = param.owner_section
+    sections_path = []
+    while parent_section:
+        sections_path.insert(0, parent_section)
+        parent_section = parent_section.parent_section
+
+    current_dict = json_storage_params
+
+    for section in sections_path:
+        dict_key = section.key + "_settings" if section.max_resources > 1 else section.key
+        section_key_dict = current_dict.get(dict_key, None)
+        if not section_key_dict:
+            section_key_dict = OrderedDict({})
+            # Single sections have label as attribute and no subsections
+            if section.max_resources == 1:
+                section_key_dict["label"] = section.label
+            current_dict[dict_key] = section_key_dict
+        current_dict = section_key_dict
+
+        if section.max_resources > 1:
+            # Multiple sections have one subsection per label
+            section_label_dict = current_dict.get(section.label, None)
+            if not section_label_dict:
+                section_label_dict = OrderedDict({})
+                current_dict[section.label] = section_label_dict
+
+            current_dict = section_label_dict
+
+    return current_dict

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,4 +1,4 @@
-boto3>=1.10.15
+boto3>=1.14.3
 future>=0.18.2
 tabulate>=0.8.2
 ipaddress>=1.0.22

--- a/cli/requirements34.txt
+++ b/cli/requirements34.txt
@@ -1,4 +1,4 @@
-boto3>=1.10.15
+boto3>=1.14.3
 future>=0.18.2
 tabulate>=0.8.2
 ipaddress>=1.0.22

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -24,7 +24,7 @@ def readme():
 VERSION = "2.7.0"
 REQUIRES = [
     "setuptools",
-    "boto3>=1.10.15",
+    "boto3>=1.14.3",
     "future>=0.16.0,<=0.18.2",
     "tabulate>=0.8.2,<=0.8.3",
     "ipaddress>=1.0.22",

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -132,6 +132,8 @@ DEFAULT_CLUSTER_DICT = {
     "fsx_settings": None,
     "dcv_settings": None,
     "cw_log_settings": None,
+    "queue_settings": None,
+    "default_queue": None,
     "cluster_config_metadata": {"sections": {}},
 }
 

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -37,7 +37,7 @@ def _check_patch(src_conf, dst_conf, expected_changes, expected_patch_policy):
 
 
 def test_config_patch(mocker):
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
     src_conf = PclusterConfig()
     dst_conf = PclusterConfig()
     # Two new configs must always be equal
@@ -66,7 +66,7 @@ def test_single_param_change(
     dst_param_value,
     change_update_policy,
 ):
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
     dst_config_file = "pcluster.config.dst.ini"
     duplicate_config_file(dst_config_file, test_datadir)
 
@@ -90,7 +90,7 @@ def test_single_param_change(
 
 
 def test_multiple_param_changes(mocker, pcluster_config_reader, test_datadir):
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
     dst_config_file = "pcluster.config.dst.ini"
     duplicate_config_file(dst_config_file, test_datadir)
 
@@ -256,7 +256,7 @@ def _test_different_labels(base_conf, target_conf):
     ],
 )
 def test_adaptation(mocker, test_datadir, pcluster_config_reader, test):
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
     base_config_file_name = "pcluster.config.base.ini"
     duplicate_config_file(base_config_file_name, test_datadir)
     target_config_file_name = "pcluster.config.dst.ini"

--- a/cli/tests/pcluster/config/test_hit_converter.py
+++ b/cli/tests/pcluster/config/test_hit_converter.py
@@ -1,0 +1,133 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import configparser
+import pytest
+
+from assertpy import assert_that
+from pcluster.config.hit_converter import HitConverter
+from tests.common import MockedBoto3Request
+from tests.pcluster.config.utils import init_pcluster_config_from_configparser
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    return "pcluster.utils.boto3"
+
+
+@pytest.mark.parametrize(
+    "src_config_dict, dst_config_dict",
+    [
+        (
+            # Scheduler is slurm, conversion expected
+            {
+                "cluster default": {
+                    "scheduler": "slurm",
+                    "cluster_type": "ondemand",
+                    "enable_efa": "compute",
+                    "disable_hyperthreading": True,
+                    "placement_group": "DYNAMIC",
+                    "compute_instance_type": "t2.micro",
+                    "max_queue_size": 10,
+                    "spot_price": 0.4,
+                    "maintain_initial_size": True,
+                    "initial_queue_size": 2,
+                }
+            },
+            {
+                "cluster default": {"scheduler": "slurm"},
+                "queue default": {
+                    "compute_type": "ondemand",
+                    "enable_efa": True,
+                    "disable_hyperthreading": True,
+                    "placement_group": "DYNAMIC",
+                    "compute_resource_settings": "default",
+                },
+                "compute_resource default": {
+                    "instance_type": "t2.micro",
+                    "min_count": 2,
+                    "max_count": 10,
+                    "spot_price": 0.4,
+                    "vcpus": 96,
+                    "gpus": 0,
+                    "enable_efa": True,
+                },
+            },
+        ),
+        (
+            # If scheduler != slurm no conversion must be done
+            {
+                "cluster default": {
+                    "scheduler": "sge",
+                    "cluster_type": "ondemand",
+                    "enable_efa": "compute",
+                    "disable_hyperthreading": True,
+                    "placement_group": "DYNAMIC",
+                    "compute_instance_type": "t2.micro",
+                    "max_queue_size": 10,
+                    "spot_price": 0.4,
+                    "maintain_initial_size": True,
+                    "initial_queue_size": 2,
+                }
+            },
+            {
+                "cluster default": {
+                    "scheduler": "sge",
+                    "cluster_type": "ondemand",
+                    "enable_efa": "compute",
+                    "disable_hyperthreading": True,
+                    "placement_group": "DYNAMIC",
+                    "compute_instance_type": "t2.micro",
+                    "max_queue_size": 10,
+                    "spot_price": 0.4,
+                    "maintain_initial_size": True,
+                    "initial_queue_size": 2,
+                }
+            },
+        ),
+    ],
+)
+def test_hit_converter(boto3_stubber, src_config_dict, dst_config_dict):
+    scheduler = src_config_dict["cluster default"]["scheduler"]
+    instance_type = src_config_dict["cluster default"]["compute_instance_type"]
+
+    if scheduler == "slurm":
+        mocked_requests = [
+            MockedBoto3Request(
+                method="describe_instance_types",
+                response={
+                    "InstanceTypes": [
+                        {
+                            "InstanceType": instance_type,
+                            "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48},
+                            "NetworkInfo": {"EfaSupported": True},
+                        }
+                    ]
+                },
+                expected_params={"InstanceTypes": [instance_type]},
+            )
+        ]
+        boto3_stubber("ec2", mocked_requests)
+
+    config_parser = configparser.ConfigParser()
+
+    config_parser.read_dict(src_config_dict)
+    src_pcluster_config = init_pcluster_config_from_configparser(config_parser, validate=False)
+
+    HitConverter(src_pcluster_config).convert()
+
+    for section_key_label, section in dst_config_dict.items():
+        section_key, section_label = section_key_label.split(" ")
+
+        src_section = src_pcluster_config.get_section(section_key, section_label)
+        assert_that(src_section).is_not_none()
+
+        for param_key, param_value in section.items():
+            assert_that(src_section.get_param_value(param_key) == param_value)

--- a/cli/tests/pcluster/config/test_json_param_types.py
+++ b/cli/tests/pcluster/config/test_json_param_types.py
@@ -1,0 +1,212 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import os
+from collections import OrderedDict
+
+import pytest
+
+from assertpy import assert_that
+from pcluster.config.cfn_param_types import CfnSection
+from pcluster.config.mappings import CLUSTER
+from pcluster.config.param_types import SettingsParam, StorageData
+from pcluster.config.pcluster_config import PclusterConfig
+from tests.common import MockedBoto3Request
+from tests.pcluster.config.utils import duplicate_config_file, get_mocked_pcluster_config
+
+# Mocked responses for describe_instance_types boto3 calls
+DESCRIBE_INSTANCE_TYPES_RESPONSES = {
+    # Disable hyperthreading: supported
+    # EFA: not supported
+    "c4.xlarge": {
+        "InstanceTypes": [
+            {
+                "InstanceType": "c4.xlarge",
+                "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2},
+                "NetworkInfo": {"EfaSupported": False},
+            }
+        ]
+    },
+    # Disable hyperthreading: not supported
+    # EFA: supported
+    "g4dn.metal": {
+        "InstanceTypes": [
+            {
+                "InstanceType": "g4dn.metal",
+                "VCpuInfo": {"DefaultVCpus": 96},
+                "GpuInfo": {"Gpus": [{"Name": "T4", "Manufacturer": "NVIDIA", "Count": 8}]},
+                "NetworkInfo": {"EfaSupported": True},
+            }
+        ]
+    },
+    # Disable hyperthreading: supported
+    # EFA: supported
+    "i3en.24xlarge": {
+        "InstanceTypes": [
+            {
+                "InstanceType": "i3en.24xlarge",
+                "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48},
+                "NetworkInfo": {"EfaSupported": True},
+            }
+        ]
+    },
+}
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    return "pcluster.utils.boto3"
+
+
+@pytest.mark.parametrize(
+    "queues, expected_warnings",
+    [
+        (
+            ["queue1"],
+            "WARNING: EFA was enabled on queue 'queue1', but instance type 'c4.xlarge' does not support EFA.\n"
+            "WARNING: Hyperthreading was disabled on queue 'queue1', but disabling hyperthreading on instance type "
+            "'g4dn.metal' is not currently supported by ParallelCluster.\n",
+        ),
+        (["queue2"], ""),
+        (
+            ["queue1", "queue2"],
+            "WARNING: EFA was enabled on queue 'queue1', but instance type 'c4.xlarge' does not support EFA.\n"
+            "WARNING: Hyperthreading was disabled on queue 'queue1', but disabling hyperthreading on instance type "
+            "'g4dn.metal' is not currently supported by ParallelCluster.\n",
+        ),
+        ([], ""),
+    ],
+)
+def test_config_to_json(capsys, boto3_stubber, test_datadir, pcluster_config_reader, queues, expected_warnings):
+    queue_settings = ",".join(queues)
+
+    # Create a new configuration file from the initial one
+    dst_config_file = "pcluster.config.{0}.ini".format("_".join(queues))
+    duplicate_config_file(dst_config_file, test_datadir)
+
+    # Created expected json params based on active queues
+    expected_json_params = _prepare_json_config(queues, test_datadir)
+
+    # Mock expected boto3 calls
+    _mock_boto3(boto3_stubber, expected_json_params)
+
+    # Load config from created config file
+    dst_config_file = pcluster_config_reader(dst_config_file, queue_settings=queue_settings)
+    pcluster_config = PclusterConfig(config_file=dst_config_file, fail_on_file_absence=True)
+
+    # Create json storage data from config
+    storage_data = pcluster_config.to_storage()
+
+    # Check that created json params match the expected ones
+    assert_that(json.dumps(storage_data.json_params, indent=2, sort_keys=True)).is_equal_to(
+        json.dumps(expected_json_params, indent=2, sort_keys=True)
+    )
+
+    readouterr = capsys.readouterr()
+    assert_that(readouterr.out).is_equal_to(expected_warnings)
+    assert_that(readouterr.err).is_equal_to("")
+
+    pass
+
+
+@pytest.mark.parametrize(
+    "queues", [(["queue1"]), (["queue2"]), (["queue1", "queue2"]), ([])],
+)
+def test_config_from_json(mocker, boto3_stubber, test_datadir, pcluster_config_reader, queues):
+    def mock_get_avail_zone(subnet_id):
+        # Mock az detection by returning a mock az if subnet has a value
+        return "my-avail-zone" if subnet_id and subnet_id != "NONE" else None
+
+    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", mock_get_avail_zone)
+
+    # Created expected json params based on active queues
+    expected_json_params = _prepare_json_config(queues, test_datadir)
+
+    # Mock expected boto3 calls
+    _mock_boto3(boto3_stubber, expected_json_params)
+
+    pcluster_config = get_mocked_pcluster_config(mocker)
+    cluster_section = CfnSection(CLUSTER, pcluster_config, section_label="default")
+    cluster_section.from_storage(StorageData(cfn_params=[], json_params=expected_json_params))
+    pcluster_config.add_section(cluster_section)
+    pcluster_config.refresh()
+
+    for queue in queues:
+        assert_that(pcluster_config.get_section("queue", queue)).is_not_none()
+        _check_queue_section_from_json(
+            expected_json_params, pcluster_config, pcluster_config.get_section("queue", queue)
+        )
+    pass
+
+
+def _check_queue_section_from_json(json_config, pcluster_config, queue_section):
+    """Check that the provided queue section has been loaded from Json config as expected."""
+    queue_dict = json_config["cluster"]["queue_settings"][queue_section.label]
+    _check_section(queue_section, queue_dict)
+
+    instance_settings = queue_section.get_param("compute_resource_settings").value
+    for label in instance_settings.split(","):
+        instance_section = pcluster_config.get_section("compute_resource", label)
+        instance_dict = queue_dict["compute_resource_settings"].get(label)
+        _check_section(instance_section, instance_dict)
+
+
+def _check_section(config_section, json_config_dict):
+    """Compare a pcluster_config section with a json config section."""
+    assert_that(config_section).is_not_none()
+    assert_that(json_config_dict).is_not_none()
+    for param_key, param_value in json_config_dict.items():
+        param = config_section.get_param(param_key)
+        if not isinstance(param, SettingsParam):
+            assert_that(param_value).is_equal_to(config_section.get_param(param_key).value)
+        else:
+            check_settings(param.key, config_section, json_config_dict)
+
+
+def check_settings(settings_param_key, config_section, json_config_dict):
+    """Check that the order of labels in the provided settings param is maintained in the Json representation."""
+    json_settings = ",".join([label for label, _ in json_config_dict[settings_param_key].items()])
+    assert_that(json_settings).is_equal_to(config_section.get_param(settings_param_key).value)
+
+
+def _prepare_json_config(queues, test_datadir):
+    """Prepare the json configuration based on the selected queues."""
+    json_config_path = os.path.join(str(test_datadir.parent), "s3_config.json")
+    with open(json_config_path) as json_config_file:
+        expected_json_params = json.load(json_config_file, object_pairs_hook=OrderedDict)
+
+    expected_cluster_json_params = expected_json_params.get("cluster")
+    queues_dict = expected_cluster_json_params.get("queue_settings")
+    expected_cluster_json_params.pop("queue_settings")
+    expected_json_queue_settings = {
+        queue_label: queues_dict[queue_label] for queue_label in queues_dict.keys() if queue_label in queues
+    }
+    expected_cluster_json_params["default_queue"] = queues[0] if queues else None
+    if expected_json_queue_settings:
+        expected_cluster_json_params["queue_settings"] = expected_json_queue_settings
+    return expected_json_params
+
+
+def _mock_boto3(boto3_stubber, expected_json_params):
+    """Mock the boto3 client based on the expected json configuration."""
+    expected_json_queue_settings = expected_json_params["cluster"].get("queue_settings", {})
+    mocked_requests = []
+    for _, queue in expected_json_queue_settings.items():
+        for _, compute_resource in queue.get("compute_resource_settings", {}).items():
+            instance_type = compute_resource["instance_type"]
+            mocked_requests.append(
+                MockedBoto3Request(
+                    method="describe_instance_types",
+                    response=DESCRIBE_INSTANCE_TYPES_RESPONSES[instance_type],
+                    expected_params={"InstanceTypes": [instance_type]},
+                )
+            )
+    boto3_stubber("ec2", mocked_requests)

--- a/cli/tests/pcluster/config/test_json_param_types/s3_config.json
+++ b/cli/tests/pcluster/config/test_json_param_types/s3_config.json
@@ -1,0 +1,82 @@
+{
+  "cluster": {
+    "label": "default",
+    "default_queue": "None",
+    "queue_settings": {
+      "queue1": {
+        "compute_type": "ondemand",
+        "enable_efa": true,
+        "disable_hyperthreading": true,
+        "placement_group": null,
+        "compute_resource_settings": {
+          "q1-i1": {
+            "instance_type": "c4.xlarge",
+            "min_count": 0,
+            "max_count": 10,
+            "spot_price": 0,
+            "vcpus": 2,
+            "gpus": 0,
+            "enable_efa": false
+          },
+          "q1-i2": {
+            "instance_type": "g4dn.metal",
+            "min_count": 0,
+            "max_count": 10,
+            "spot_price": 0,
+            "vcpus": 96,
+            "gpus": 8,
+            "enable_efa": true
+          },
+          "q1-i3": {
+            "instance_type": "i3en.24xlarge",
+            "min_count": 0,
+            "max_count": 10,
+            "spot_price": 0,
+            "vcpus": 48,
+            "gpus": 0,
+            "enable_efa": true
+          }
+        }
+      },
+      "queue2": {
+        "compute_type": "spot",
+        "enable_efa": false,
+        "disable_hyperthreading": false,
+        "placement_group": "DYNAMIC",
+        "compute_resource_settings": {
+          "q2-i1": {
+            "instance_type": "c4.xlarge",
+            "min_count": 0,
+            "max_count": 10,
+            "spot_price": 0.4,
+            "vcpus": 4,
+            "gpus": 0,
+            "enable_efa": false
+          },
+          "q2-i2": {
+            "instance_type": "g4dn.metal",
+            "min_count": 0,
+            "max_count": 10,
+            "spot_price": 0.5,
+            "vcpus": 96,
+            "gpus": 8,
+            "enable_efa": false
+          },
+          "q2-i3": {
+            "instance_type": "i3en.24xlarge",
+            "min_count": 0,
+            "max_count": 10,
+            "spot_price": 0.6,
+            "vcpus": 96,
+            "gpus": 0,
+            "enable_efa": false
+          }
+        }
+      }
+    }
+  },
+  "scaling": {
+    "label": "default",
+    "scaledown_idletime": 10
+  }
+}

--- a/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
@@ -1,0 +1,39 @@
+[global]
+cluster_template = default
+
+[cluster default]
+queue_settings = {{queue_settings}}
+
+[queue queue1]
+compute_resource_settings = q1-i1,q1-i2,q1-i3
+compute_type = ondemand
+enable_efa = true
+disable_hyperthreading = true
+
+[compute_resource q1-i1]
+instance_type = c4.xlarge
+
+[compute_resource q1-i2]
+instance_type = g4dn.metal
+
+[compute_resource q1-i3]
+instance_type = i3en.24xlarge
+
+[queue queue2]
+compute_resource_settings = q2-i1,q2-i2,q2-i3
+compute_type = spot
+enable_efa = false
+disable_hyperthreading = false
+placement_group = DYNAMIC
+
+[compute_resource q2-i1]
+instance_type = c4.xlarge
+spot_price = 0.4
+
+[compute_resource q2-i2]
+instance_type = g4dn.metal
+spot_price = 0.5
+
+[compute_resource q2-i3]
+instance_type = i3en.24xlarge
+spot_price = 0.6

--- a/cli/tests/pcluster/config/test_param_from_cfn.py
+++ b/cli/tests/pcluster/config/test_param_from_cfn.py
@@ -12,7 +12,7 @@ import pytest
 
 from assertpy import assert_that
 from pcluster.config.mappings import CLUSTER, SCALING
-from tests.pcluster.config.utils import get_mocked_pcluster_config, get_param_definition
+from tests.pcluster.config.utils import get_cfnparam_definition, get_mocked_pcluster_config
 
 
 @pytest.mark.parametrize(
@@ -84,7 +84,7 @@ from tests.pcluster.config.utils import get_mocked_pcluster_config, get_param_de
 )
 def test_param_from_cfn_value(mocker, section_definition, param_key, cfn_value, expected_value):
     """Test conversion from cfn value of simple parameters, that don't depends from multiple CFN parameters."""
-    param_definition, param_type = get_param_definition(section_definition, param_key)
+    param_definition, param_type = get_cfnparam_definition(section_definition, param_key)
 
     pcluster_config = get_mocked_pcluster_config(mocker)
 
@@ -140,15 +140,14 @@ def test_param_from_cfn_value(mocker, section_definition, param_key, cfn_value, 
 )
 def test_param_from_cfn(mocker, section_definition, param_key, cfn_params_dict, expected_value):
     """Test conversion of simple parameters, that don't depends from multiple CFN parameters."""
-    param_definition, param_type = get_param_definition(section_definition, param_key)
+    param_definition, param_type = get_cfnparam_definition(section_definition, param_key)
     cfn_params = []
     for cfn_key, cfn_value in cfn_params_dict.items():
         cfn_params.append({"ParameterKey": cfn_key, "ParameterValue": cfn_value})
 
     pcluster_config = get_mocked_pcluster_config(mocker)
 
-    param = param_type(
-        section_definition.get("key"), "default", param_key, param_definition, pcluster_config
-    ).from_cfn_params(cfn_params)
+    param_type = param_type(section_definition.get("key"), "default", param_key, param_definition, pcluster_config)
+    param = param_type.from_cfn_params(cfn_params)
 
     assert_that(param.value, description="param key {0}".format(param_key)).is_equal_to(expected_value)

--- a/cli/tests/pcluster/config/test_param_to_cfn.py
+++ b/cli/tests/pcluster/config/test_param_to_cfn.py
@@ -12,7 +12,7 @@ import pytest
 
 from assertpy import assert_that
 from pcluster.config.mappings import CLUSTER, SCALING
-from tests.pcluster.config.utils import get_mocked_pcluster_config, get_param_definition
+from tests.pcluster.config.utils import get_cfnparam_definition, get_mocked_pcluster_config
 
 
 @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ from tests.pcluster.config.utils import get_mocked_pcluster_config, get_param_de
 def test_param_to_cfn_value(mocker, section_definition, param_key, param_value, expected_value):
     pcluster_config = get_mocked_pcluster_config(mocker)
 
-    param_definition, param_type = get_param_definition(section_definition, param_key)
+    param_definition, param_type = get_cfnparam_definition(section_definition, param_key)
     param = param_type(section_definition.get("key"), "default", param_key, param_definition, pcluster_config)
     param.value = param_value
     cfn_value = param.get_cfn_value()
@@ -92,7 +92,7 @@ def test_param_to_cfn_value(mocker, section_definition, param_key, param_value, 
 def test_param_to_cfn(mocker, section_definition, param_key, param_value, expected_cfn_params):
     pcluster_config = get_mocked_pcluster_config(mocker)
 
-    param_definition, param_type = get_param_definition(section_definition, param_key)
+    param_definition, param_type = get_cfnparam_definition(section_definition, param_key)
     param = param_type(section_definition.get("key"), "default", param_key, param_definition, pcluster_config)
     param.value = param_value
     cfn_params = param.to_cfn()

--- a/cli/tests/pcluster/config/test_param_to_file.py
+++ b/cli/tests/pcluster/config/test_param_to_file.py
@@ -13,7 +13,7 @@ import pytest
 
 from assertpy import assert_that
 from pcluster.config.mappings import CLUSTER, SCALING
-from tests.pcluster.config.utils import get_mocked_pcluster_config, get_param_definition
+from tests.pcluster.config.utils import get_cfnparam_definition, get_mocked_pcluster_config
 
 
 @pytest.mark.parametrize(
@@ -59,7 +59,7 @@ def test_param_to_file(mocker, section_definition, param_key, param_value, expec
 
     pcluster_config = get_mocked_pcluster_config(mocker)
 
-    param_definition, param_type = get_param_definition(section_definition, param_key)
+    param_definition, param_type = get_cfnparam_definition(section_definition, param_key)
     param = param_type(section_definition.get("key"), section_label, param_key, param_definition, pcluster_config)
     param.value = param_value or param_definition.get("default")
     param.to_file(config_parser)

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -378,19 +378,13 @@ def test_cluster_section_from_file(mocker, config_parser_dict, expected_dict_par
         ("custom_awsbatch_template_url", "NONE", "NONE", None),
         # Settings
         ("scaling_settings", "test1", None, "Section .* not found in the config file"),
-        ("scaling_settings", "test1,test2", None, "is invalid. It can only contains a single .* section label"),
         ("vpc_settings", "test1", None, "Section .* not found in the config file"),
-        ("vpc_settings", "test1,test2", None, "is invalid. It can only contains a single .* section label"),
-        ("vpc_settings", "test1, test2", None, "is invalid. It can only contains a single .* section label"),
         ("ebs_settings", "test1", None, "Section .* not found in the config file"),
         ("ebs_settings", "test1,test2", None, "Section .* not found in the config file"),
         ("ebs_settings", "test1, test2", None, "Section .* not found in the config file"),
         ("efs_settings", "test1", None, "Section .* not found in the config file"),
-        ("efs_settings", "test1,test2", None, "is invalid. It can only contains a single .* section label"),
         ("raid_settings", "test1", None, "Section .* not found in the config file"),
-        ("raid_settings", "test1,test2", None, "is invalid. It can only contains a single .* section label"),
         ("fsx_settings", "test1", None, "Section .* not found in the config file"),
-        ("fsx_settings", "test1,test2", None, "is invalid. It can only contains a single .* section label"),
     ],
 )
 def test_cluster_param_from_file(mocker, param_key, param_value, expected_value, expected_message):
@@ -432,7 +426,7 @@ def test_cluster_section_to_file(mocker, section_dict, expected_config_parser_di
 def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
     utils.set_default_values_for_required_cluster_section_params(section_dict)
     utils.mock_pcluster_config(mocker)
-    mocker.patch("pcluster.config.param_types.get_efs_mount_target_id", return_value="valid_mount_target_id")
+    mocker.patch("pcluster.config.cfn_param_types.get_efs_mount_target_id", return_value="valid_mount_target_id")
     utils.assert_section_to_cfn(mocker, CLUSTER, section_dict, expected_cfn_params)
 
 
@@ -818,18 +812,18 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
 def test_cluster_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
     """Unit tests for parsing Cluster related options."""
     mocker.patch(
-        "pcluster.config.param_types.get_efs_mount_target_id",
+        "pcluster.config.cfn_param_types.get_efs_mount_target_id",
         side_effect=lambda efs_fs_id, avail_zone: "master_mt" if avail_zone == "mocked_avail_zone" else None,
     )
     mocker.patch(
-        "pcluster.config.param_types.get_avail_zone",
+        "pcluster.config.cfn_param_types.get_avail_zone",
         side_effect=lambda subnet: "mocked_avail_zone" if subnet == "subnet-12345678" else "some_other_az",
     )
     mocker.patch(
         "pcluster.config.validators.get_supported_features",
         return_value={"instances": ["t2.large"], "baseos": ["ubuntu1804"], "schedulers": ["slurm"]},
     )
-    mocker.patch("pcluster.config.param_types.get_instance_vcpus", return_value=2)
+    mocker.patch("pcluster.config.cfn_param_types.get_instance_vcpus", return_value=2)
     utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)
 
 
@@ -852,5 +846,5 @@ def test_cluster_from_file_to_cfn(mocker, pcluster_config_reader, settings_label
 )
 def test_cluster_config_metadata_to_cfn(mocker, section_dict, expected_cfn_params):
     utils.mock_pcluster_config(mocker)
-    mocker.patch("pcluster.config.param_types.get_efs_mount_target_id", return_value="valid_mount_target_id")
+    mocker.patch("pcluster.config.cfn_param_types.get_efs_mount_target_id", return_value="valid_mount_target_id")
     utils.assert_section_to_cfn(mocker, CLUSTER, section_dict, expected_cfn_params, ignore_metadata=False)

--- a/cli/tests/pcluster/config/test_section_compute_resource.py
+++ b/cli/tests/pcluster/config/test_section_compute_resource.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+import tests.pcluster.config.utils as utils
+from pcluster.config.mappings import COMPUTE_RESOURCE
+
+
+@pytest.mark.parametrize(
+    "param_key, param_value, expected_value, expected_message",
+    [
+        ("instance_type", None, None, None),
+        ("instance_type", "t2.micro", "t2.micro", None),
+        ("enable_efa", "invalid", None, "must be of 'bool' type"),
+        ("enable_efa", "true", True, None),
+        ("gpus", "invalid", None, "must be of 'int' type"),
+        ("gpus", "2", 2, None),
+        ("spot_price", "invalid", None, "must be of 'float' type"),
+        ("spot_price", "0.5", 0.5, None),
+    ],
+)
+def test_compute_resource_param_from_file(mocker, param_key, param_value, expected_value, expected_message):
+    utils.assert_param_from_file(mocker, COMPUTE_RESOURCE, param_key, param_value, expected_value, expected_message)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_config_parser_dict, expected_message",
+    [
+        # default
+        ({}, {"compute_resource default": {}}, None),
+        # default values
+        ({"instance_type": "t2.micro"}, {"compute_resource default": {"instance_type": "t2.micro"}}, None),
+        # other values
+        # Private params must not be written in file
+        ({"gpus": "8"}, {"compute_resource default": {"gpus": "8"}}, "No section.*"),
+        ({"enable_efa": True}, {"compute_resource default": {"enable_efa": True}}, "No section.*"),
+    ],
+)
+def test_compute_resource_section_to_file(mocker, section_dict, expected_config_parser_dict, expected_message):
+    utils.assert_section_to_file(mocker, COMPUTE_RESOURCE, section_dict, expected_config_parser_dict, expected_message)

--- a/cli/tests/pcluster/config/test_section_dcv.py
+++ b/cli/tests/pcluster/config/test_section_dcv.py
@@ -123,6 +123,6 @@ def test_dcv_param_from_file(mocker, param_key, param_value, expected_value, exp
 )
 def test_dcv_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
     """Unit tests for parsing EFS related options."""
-    mocker.patch("pcluster.config.param_types.get_efs_mount_target_id", return_value="mount_target_id")
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_efs_mount_target_id", return_value="mount_target_id")
+    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
     utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)

--- a/cli/tests/pcluster/config/test_section_efs.py
+++ b/cli/tests/pcluster/config/test_section_efs.py
@@ -158,7 +158,7 @@ def test_efs_param_from_file(mocker, param_key, param_value, expected_value, exp
     ],
 )
 def test_efs_section_to_cfn(mocker, section_dict, expected_cfn_params):
-    mocker.patch("pcluster.config.param_types.get_efs_mount_target_id", return_value="valid_mount_target_id")
+    mocker.patch("pcluster.config.cfn_param_types.get_efs_mount_target_id", return_value="valid_mount_target_id")
     mocker.patch(
         "pcluster.config.pcluster_config.PclusterConfig.get_master_availability_zone", return_value="mocked_avail_zone"
     )
@@ -222,8 +222,8 @@ def test_efs_section_to_cfn(mocker, section_dict, expected_cfn_params):
 def test_efs_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
     """Unit tests for parsing EFS related options."""
     mocker.patch(
-        "pcluster.config.param_types.get_efs_mount_target_id",
+        "pcluster.config.cfn_param_types.get_efs_mount_target_id",
         side_effect=lambda efs_fs_id, avail_zone: "master_mt" if avail_zone == "mocked_avail_zone" else None,
     )
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
     utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)

--- a/cli/tests/pcluster/config/test_section_fsx.py
+++ b/cli/tests/pcluster/config/test_section_fsx.py
@@ -231,6 +231,6 @@ def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, exp
 )
 def test_fsx_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
     """Unit tests for parsing EFS related options."""
-    mocker.patch("pcluster.config.param_types.get_efs_mount_target_id", return_value="mount_target_id")
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_efs_mount_target_id", return_value="mount_target_id")
+    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
     utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)

--- a/cli/tests/pcluster/config/test_section_queue.py
+++ b/cli/tests/pcluster/config/test_section_queue.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+import tests.pcluster.config.utils as utils
+from pcluster.config.mappings import QUEUE
+
+
+@pytest.mark.parametrize(
+    "param_key, param_value, expected_value, expected_message",
+    [
+        ("compute_type", "ondemand", "ondemand", None),
+        ("compute_type", "spot", "spot", None),
+        ("compute_type", "invalid", None, "has an invalid value"),
+        ("enable_efa", "invalid", None, "must be of 'bool' type"),
+        ("enable_efa", "True", True, None),
+        ("enable_efa", "False", False, None),
+        ("disable_hyperthreading", "invalid", None, "must be of 'bool' type"),
+        ("disable_hyperthreading", "True", True, None),
+        ("disable_hyperthreading", "False", False, None),
+        ("placement_group", "DYNAMIC", "DYNAMIC", None),
+    ],
+)
+def test_queue_param_from_file(mocker, param_key, param_value, expected_value, expected_message):
+    utils.assert_param_from_file(mocker, QUEUE, param_key, param_value, expected_value, expected_message)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_config_parser_dict, expected_message",
+    [
+        # default
+        ({}, {"queue default": {}}, None),
+        # default values
+        ({"compute_type": "ondemand"}, {"queue default": {"compute_type": "ondemand"}}, "No section"),
+        # other values
+        ({"compute_type": "spot"}, {"queue default": {"compute_type": "spot"}}, None),
+    ],
+)
+def test_queue_section_to_file(mocker, section_dict, expected_config_parser_dict, expected_message):
+    utils.assert_section_to_file(mocker, QUEUE, section_dict, expected_config_parser_dict, expected_message)

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -14,8 +14,8 @@ import os
 
 import tests.pcluster.config.utils as utils
 from assertpy import assert_that
+from pcluster.config.cfn_param_types import BoolCfnParam
 from pcluster.config.mappings import ALIASES, AWS, CLUSTER, CW_LOG, DCV, EBS, EFS, FSX, GLOBAL, RAID, SCALING, VPC
-from pcluster.config.param_types import BoolParam
 from pcluster.config.pcluster_config import PclusterConfig
 from tests.pcluster.config.defaults import CFN_CLI_RESERVED_PARAMS, CFN_CONFIG_NUM_OF_PARAMS, DefaultCfnParams
 
@@ -37,7 +37,7 @@ def test_mapping_consistency():
         for param_key, param_definition in section_definition.get("params").items():
 
             # Boolean params must have a default value
-            if param_definition.get("type") is BoolParam:
+            if param_definition.get("type") is BoolCfnParam:
                 assert_that(
                     param_definition.get("default"),
                     description="BoolParam '{0}' must have a default value".format(param_key),
@@ -56,6 +56,7 @@ def test_mapping_consistency():
                     "referred_section",
                     "update_policy",
                     "required",
+                    "visibility",
                 )
                 # Update policy must be always specified
                 assert_that(
@@ -66,7 +67,7 @@ def test_mapping_consistency():
 
 def test_example_config_consistency(mocker):
     """Validate example file and try to convert to CFN."""
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
     pcluster_config = PclusterConfig(config_file=utils.get_pcluster_config_example(), fail_on_file_absence=True)
 
     cfn_params = pcluster_config.to_cfn()

--- a/cli/tests/pcluster/configure/test_pcluster_configure.py
+++ b/cli/tests/pcluster/configure/test_pcluster_configure.py
@@ -143,7 +143,7 @@ def _mock_parallel_cluster_config(mocker):
     mocker.patch(
         "pcluster.configure.easyconfig.get_supported_compute_instance_types", return_value=supported_instance_types
     )
-    mocker.patch("pcluster.config.param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
 
 
 def _launch_config(mocker, path, remove_path=True):

--- a/cli/tests/pcluster/utils/test_pcluster_utils.py
+++ b/cli/tests/pcluster/utils/test_pcluster_utils.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError
 
 import pcluster.utils as utils
 from assertpy import assert_that
+from pcluster.utils import get_bucket_url
 from tests.common import MockedBoto3Request
 
 FAKE_CLUSTER_NAME = "cluster_name"
@@ -470,3 +471,14 @@ def test_get_master_server_ips(mocker, master_instance, expected_ip, error):
     else:
         assert_that(utils._get_master_server_ip("stack-name")).is_equal_to(expected_ip)
         describe_cluster_instances_mock.assert_called_with("stack-name", node_type=utils.NodeType.master)
+
+
+@pytest.mark.parametrize(
+    "region, expected_url",
+    [
+        ("us-east-1", "https://us-east-1-aws-parallelcluster.s3.us-east-1.amazonaws.com"),
+        ("cn-north-1", "https://cn-north-1-aws-parallelcluster.s3.cn-north-1.amazonaws.com.cn"),
+    ],
+)
+def test_get_bucket_url(region, expected_url):
+    assert_that(get_bucket_url(region)).is_equal_to(expected_url)

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -59,7 +59,7 @@ commands =
 basepython = python3
 skip_install = true
 deps =
-    isort
+    isort==4.3.21
     seed-isort-config
 commands =
     isort -rc -w 120 \

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -104,7 +104,7 @@ Resources:
             AssociatePublicIpAddress: !Ref 'AssociatePublicIpAddress'
             SubnetId: !Ref 'ComputeSubnetId'
         Placement:
-          GroupName: {% if queue_config.placement_group == "AUTO" %}!Ref 'PlacementGroup{{ queue | sha1 | truncate(16, True, "") | capitalize }}'{% elif queue_config.placement_group %}{{ queue_config.placement_group }}{% else %}!Ref 'AWS::NoValue'{% endif %}
+          GroupName: {% if queue_config.placement_group == "DYNAMIC" %}!Ref 'PlacementGroup{{ queue | sha1 | truncate(16, True, "") | capitalize }}'{% elif queue_config.placement_group %}{{ queue_config.placement_group }}{% else %}!Ref 'AWS::NoValue'{% endif %}
         KeyName: !Ref 'KeyName'
         IamInstanceProfile:
           Name: !Ref 'IamInstanceProfile'
@@ -387,7 +387,7 @@ Resources:
   {%- endfor %}
 {%- endfor %}
 {%- for queue, queue_config in queues.items() %}
-  {%- if queue_config.placement_group == "AUTO" %}
+  {%- if queue_config.placement_group == "DYNAMIC" %}
   PlacementGroup{{ queue | sha1 | truncate(16, True, "") | capitalize }}:
     Type: AWS::EC2::PlacementGroup
     Properties:

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -58,7 +58,7 @@ def test_hit_substack_rendering(tmp_path):
                     "compute_type": "ondemand",
                     "enable_efa": True,
                     "disable_hyperthreading": True,
-                    "placement_group": "AUTO",
+                    "placement_group": "DYNAMIC",
                 },
                 "gpu": {
                     "compute_resource_settings": {


### PR DESCRIPTION
This commit adds new parameters mappings (sections and parameters) to support the new configuration model
for heterogeneous instance types and for multiple queues management.
The new parameters are stored into the cluster's S3 bucket instead of the CloudFormation parameters like
the existing ones. A new parameters hierarchy has been introduced to support this new kind of params.
Additionally, an automatic conversion mechanism has been introduced to convert pre-hit configuration files (with slurm scheduler) to HIT ones.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
