### PR TITLE
Adds validators for newly added FSx Lustre backup parameters

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -163,6 +163,22 @@ def fsx_validator(section_key, section_label, pcluster_config):
         if fsx_section.get_param_value("per_unit_storage_throughput"):
             errors.append("'per_unit_storage_throughput' can only be used when 'deployment_type = PERSISTENT_1'")
 
+    fsx_daily_automatic_backup_start_time = fsx_section.get_param_value("daily_automatic_backup_start_time")
+    fsx_automatic_backup_retention_days = fsx_section.get_param_value("automatic_backup_retention_days")
+    fsx_copy_tags_to_backups = fsx_section.get_param_value("copy_tags_to_backups")
+
+    if not fsx_automatic_backup_retention_days and (fsx_daily_automatic_backup_start_time or fsx_copy_tags_to_backups):
+        errors.append(
+            "'automatic_backup_retention_days' must be greater than 0 if \
+                'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided."
+        )
+
+    if fsx_section.get_param_value("deployment_type") != "PERSISTENT_1" and fsx_automatic_backup_retention_days:
+        errors.append("FSx automatic backup features can be used only with 'PERSISTENT_1' file systems")
+
+    if (fsx_imported_file_chunk_size or fsx_import_path or fsx_export_path) and fsx_automatic_backup_retention_days:
+        errors.append("Backups cannot be created on S3-linked file systems")
+
     return errors, warnings
 
 

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -679,6 +679,76 @@ def _kms_key_stubber(mocker, boto3_stubber, kms_key_id, expected_message, num_ca
             "'per_unit_storage_throughput' can only be used when 'deployment_type = PERSISTENT_1'",
             0,
         ),
+        (
+            {"storage_capacity": 1200, "deployment_type": "PERSISTENT_1", "automatic_backup_retention_days": 2},
+            None,
+            None,
+            1,
+        ),
+        (
+            {
+                "storage_capacity": 1200,
+                "deployment_type": "PERSISTENT_1",
+                "automatic_backup_retention_days": 2,
+                "daily_automatic_backup_start_time": "03:00",
+                "copy_tags_to_backups": True,
+            },
+            None,
+            None,
+            1,
+        ),
+        (
+            {"automatic_backup_retention_days": 2, "deployment_type": "SCRATCH_1"},
+            None,
+            "FSx automatic backup features can be used only with 'PERSISTENT_1' file systems",
+            1,
+        ),
+        (
+            {"daily_automatic_backup_start_time": "03:00"},
+            None,
+            "'automatic_backup_retention_days' must be greater than 0 if \
+                'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            1,
+        ),
+        (
+            {"copy_tags_to_backups": True},
+            None,
+            "'automatic_backup_retention_days' must be greater than 0 if \
+                'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            1,
+        ),
+        (
+            {"daily_automatic_backup_start_time": "03:00", "copy_tags_to_backups": True},
+            None,
+            "'automatic_backup_retention_days' must be greater than 0 if \
+                'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            1,
+        ),
+        (
+            {
+                "deployment_type": "PERSISTENT_1",
+                "automatic_backup_retention_days": 2,
+                "imported_file_chunk_size": 1024,
+                "export_path": "s3://test",
+                "import_path": "s3://test",
+                "storage_capacity": 1200,
+            },
+            {"Bucket": "test"},
+            "Backups cannot be created on S3-linked file systems",
+            0,
+        ),
+        (
+            {
+                "deployment_type": "PERSISTENT_1",
+                "automatic_backup_retention_days": 2,
+                "export_path": "s3://test",
+                "import_path": "s3://test",
+                "storage_capacity": 1200,
+            },
+            {"Bucket": "test"},
+            "Backups cannot be created on S3-linked file systems",
+            0,
+        ),
     ],
 )
 def test_fsx_validator(mocker, boto3_stubber, section_dict, bucket, expected_error, num_calls):


### PR DESCRIPTION
**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:
Following constraints are added:
* automatic_backup_retention_days can’t be 0 if copy_tags_to_backups or daily_automatic_backup_start_time is specified.
* Parameters related to automatic backup are only valid if deployment_type is PERSISTENT_1.
* S3-linked parameters cannot be specified along with backup parameters in Create File System request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
