### PR TITLE
Add missing ec2:CreateTags policy to ParallelClusterHITPolicies

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1573,7 +1573,7 @@
                 "ec2:DescribeLaunchTemplates",
                 "ec2:RunInstances",
                 "ec2:DescribeInstanceStatus",
-                "ec2:RunInstances"
+                "ec2:CreateTags"
               ],
               "Resource": "*"
             },


### PR DESCRIPTION
This is require to invoke the run_instances call from the resume script.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
