### PR TITLE
Fixing condition in cloud-init userdata that was causing the script to exit with error

### DIFF
--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -371,7 +371,9 @@ Resources:
                 popd
               } || error_exit 'Failed to run bootstrap recipes. If --norollback was specified, check /var/log/cfn-init.log and /var/log/cloud-init-output.log.'
 
-              [ ! -f /opt/parallelcluster/.bootstrapped ] && echo ${!parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped
+              if [ ! -f /opt/parallelcluster/.bootstrapped ]; then
+                echo ${!parallelcluster_version} | tee /opt/parallelcluster/.bootstrapped
+              fi
               # End of file
               --==BOUNDARY==
             - YumProxy: !If


### PR DESCRIPTION
The `set -x` flag was causing the script to exit with error when the following was evaluated: `[ ! -f /opt/parallelcluster/.bootstrapped ]`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
