### PR TITLE
Implement test for PMIx install and configuration

### DIFF
--- a/tests/integration-tests/tests/common/data/mpi/mpi_submit_no_module_available.sh
+++ b/tests/integration-tests/tests/common/data/mpi/mpi_submit_no_module_available.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-rm -f /shared/mpi.out
-# -mca btl ^openib is needed to avoid to have the following warning in the stdout:
-# A high-performance Open MPI point-to-point messaging module was unable to find any relevant network interfaces:
-# Module: OpenFabrics (openib). Another transport will be used instead, although this may result in lower performance.
-mpirun --map-by ppr:1:node -mca btl ^openib --timeout 10 "ring" >> /shared/mpi.out

--- a/tests/integration-tests/tests/common/mpi_common.py
+++ b/tests/integration-tests/tests/common/mpi_common.py
@@ -14,6 +14,18 @@ OS_TO_ARCHITECTURE_TO_OPENMPI_MODULE = {
     "ubuntu1804": {"x86_64": "openmpi", "arm64": "openmpi"},
 }
 
+MPI_COMMON_DATADIR = pathlib.Path(__file__).parent / "data/mpi/"
+
+
+def compile_mpi_ring(mpi_module, remote_command_executor, binary_path="ring"):
+    """
+    Copy the source for an MPI ring program to a running cluster and compile the program.
+
+    By default the resulting binary is written to ${HOME}/ring. This can be changed via the binary_path arg.
+    """
+    command = f"module load {mpi_module} && mpicc -o {binary_path} ring.c"
+    remote_command_executor.run_remote_command(command, additional_files=[str(MPI_COMMON_DATADIR / "ring.c")])
+
 
 def _test_mpi(
     remote_command_executor,
@@ -27,16 +39,14 @@ def _test_mpi(
     verify_scaling=False,
 ):
     logging.info("Testing mpi job")
-    datadir = pathlib.Path(__file__).parent / "data/mpi/"
     mpi_module = OS_TO_ARCHITECTURE_TO_OPENMPI_MODULE[os][architecture]
     # Compile mpi script
-    command = "module load {0} && mpicc -o ring ring.c".format(mpi_module)
-    remote_command_executor.run_remote_command(command, additional_files=[str(datadir / "ring.c")])
+    compile_mpi_ring(mpi_module, remote_command_executor)
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
 
     # submit script using additional files
     result = scheduler_commands.submit_script(
-        str(datadir / "mpi_submit_{0}.sh".format(mpi_module)), slots=2 * slots_per_instance
+        str(MPI_COMMON_DATADIR / "mpi_submit_{0}.sh".format(mpi_module)), slots=2 * slots_per_instance
     )
     job_id = scheduler_commands.assert_job_submitted(result.stdout)
 

--- a/tests/integration-tests/tests/common/mpi_common.py
+++ b/tests/integration-tests/tests/common/mpi_common.py
@@ -30,9 +30,7 @@ def _test_mpi(
     datadir = pathlib.Path(__file__).parent / "data/mpi/"
     mpi_module = OS_TO_ARCHITECTURE_TO_OPENMPI_MODULE[os][architecture]
     # Compile mpi script
-    command = "mpicc -o ring ring.c"
-    if mpi_module != "no_module_available":
-        command = "module load {0} && {1}".format(mpi_module, command)
+    command = "module load {0} && mpicc -o ring ring.c".format(mpi_module)
     remote_command_executor.run_remote_command(command, additional_files=[str(datadir / "ring.c")])
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
 

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/mpi_ssh.sh
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/mpi_ssh.sh
@@ -4,7 +4,5 @@ set -e
 _openmpi_module=$1
 _remote_host=$2
 
-if [ "${_openmpi_module}" != "no_module_available" ]; then
-  module load ${_openmpi_module}
-fi
+module load ${_openmpi_module}
 $(which mpirun) --host ${_remote_host} hostname

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -19,6 +19,7 @@ from retrying import retry
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutionError, RemoteCommandExecutor
 from tests.common.assertions import assert_asg_desired_capacity, assert_no_errors_in_logs, assert_scaling_worked
+from tests.common.mpi_common import OS_TO_ARCHITECTURE_TO_OPENMPI_MODULE, compile_mpi_ring
 from tests.common.schedulers_common import SlurmCommands
 from tests.schedulers.common import assert_overscaling_when_job_submitted_during_scaledown
 from time_utils import minutes, seconds
@@ -88,6 +89,39 @@ def test_slurm_gpu(region, pcluster_config_reader, clusters_factory):
     _gpu_test_conflicting_options(remote_command_executor, 2)
 
     assert_no_errors_in_logs(remote_command_executor, ["/var/log/sqswatcher", "/var/log/jobwatcher"])
+
+
+@pytest.mark.regions(["eu-west-1"])
+@pytest.mark.instances(["c5.xlarge", "m6g.xlarge"])
+@pytest.mark.schedulers(["slurm"])
+@pytest.mark.usefixtures("os", "instance", "scheduler")
+def test_slurm_pmix(pcluster_config_reader, clusters_factory, os, architecture):
+    """Test interactive job submission using PMIx."""
+    num_computes = 2
+    cluster_config = pcluster_config_reader(queue_size=num_computes)
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    # Ensure the expected PMIx version is listed when running `srun --mpi=list`.
+    # Since we're installing PMIx v3.1.5, we expect to see pmix and pmix_v3 in the output.
+    # Sample output:
+    # [ec2-user@ip-172-31-33-187 ~]$ srun 2>&1 --mpi=list
+    # srun: MPI types are...
+    # srun: none
+    # srun: openmpi
+    # srun: pmi2
+    # srun: pmix
+    # srun: pmix_v3
+    mpi_list_output = remote_command_executor.run_remote_command("srun 2>&1 --mpi=list").stdout
+    assert_that(mpi_list_output).matches(r"\s+pmix\s($|\s+)")
+    assert_that(mpi_list_output).matches(r"\s+pmix_v3\s($|\s+)")
+
+    # Compile and run an MPI program interactively
+    mpi_module = OS_TO_ARCHITECTURE_TO_OPENMPI_MODULE[os][architecture]
+    binary_path = "/shared/ring"
+    compile_mpi_ring(mpi_module, remote_command_executor, binary_path=binary_path)
+    interactive_command = f"module load {mpi_module} && srun --mpi=pmix -N {num_computes} {binary_path}"
+    remote_command_executor.run_remote_command(interactive_command)
 
 
 def _test_mpi_job_termination(remote_command_executor, test_datadir):

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_pmix/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_pmix/pcluster.config.ini
@@ -1,0 +1,21 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = slurm
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+initial_queue_size = {{ queue_size }}
+maintain_initial_size = true
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false


### PR DESCRIPTION
Validate PMIx installation and configuration by running an OMPI app interactively via slurm's `srun` command, using the `--mpi=pmix` flag to ensure the PMIx API is used. More info [here](https://slurm.schedmd.com/mpi_guide.html#pmix).

I also removed the logic and artifacts for handling cases where a distro doesn't have an OMPI module, because all of the distros we support now have one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
