### PR TITLE
Adds validators for newly added fsx lustre backup parameters

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -474,7 +474,6 @@ FSX = {
             }),
             ("copy_tags_to_backups", {
                 "type": BoolParam,
-                "default": False,
                 "update_policy": UpdatePolicy.SUPPORTED
             }),
         ]

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -335,6 +335,9 @@ class BoolParam(Param):
 
     def get_string_value(self):
         """Convert internal representation into string."""
+        if self.value is None:
+            return "NONE"
+
         return "true" if self.value else "false"
 
     def get_cfn_value(self):
@@ -344,10 +347,6 @@ class BoolParam(Param):
         Used when the parameter must go into a comma separated CFN parameter.
         """
         return self.get_string_value()
-
-    def get_default_value(self):
-        """Get default value from the Param definition if there, False otherwise."""
-        return self.definition.get("default", False)
 
 
 class IntParam(Param):

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -163,6 +163,24 @@ def fsx_validator(section_key, section_label, pcluster_config):
         if fsx_section.get_param_value("per_unit_storage_throughput"):
             errors.append("'per_unit_storage_throughput' can only be used when 'deployment_type = PERSISTENT_1'")
 
+    fsx_daily_automatic_backup_start_time = fsx_section.get_param_value("daily_automatic_backup_start_time")
+    fsx_automatic_backup_retention_days = fsx_section.get_param_value("automatic_backup_retention_days")
+    fsx_copy_tags_to_backups = fsx_section.get_param_value("copy_tags_to_backups")
+
+    if not fsx_automatic_backup_retention_days and (
+        fsx_daily_automatic_backup_start_time or fsx_copy_tags_to_backups is not None
+    ):
+        errors.append(
+            "'automatic_backup_retention_days' must be greater than 0 if "
+            + "'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided."
+        )
+
+    if fsx_section.get_param_value("deployment_type") != "PERSISTENT_1" and fsx_automatic_backup_retention_days:
+        errors.append("FSx automatic backup features can be used only with 'PERSISTENT_1' file systems")
+
+    if (fsx_imported_file_chunk_size or fsx_import_path or fsx_export_path) and fsx_automatic_backup_retention_days:
+        errors.append("Backups cannot be created on S3-linked file systems")
+
     return errors, warnings
 
 

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -80,7 +80,7 @@ DEFAULT_FSX_DICT = {
     "per_unit_storage_throughput": None,
     "daily_automatic_backup_start_time": None,
     "automatic_backup_retention_days": None,
-    "copy_tags_to_backups": False,
+    "copy_tags_to_backups": None,
 }
 
 DEFAULT_DCV_DICT = {"enable": None, "port": 8443, "access_from": "0.0.0.0/0"}

--- a/cli/tests/pcluster/config/test_param_to_cfn.py
+++ b/cli/tests/pcluster/config/test_param_to_cfn.py
@@ -23,7 +23,7 @@ from tests.pcluster.config.utils import get_mocked_pcluster_config, get_param_de
         (CLUSTER, "key_name", "test", "test"),
         (CLUSTER, "key_name", "NONE", "NONE"),
         # BoolParam
-        (CLUSTER, "encrypted_ephemeral", None, "false"),
+        (CLUSTER, "encrypted_ephemeral", None, "NONE"),
         (CLUSTER, "encrypted_ephemeral", True, "true"),
         (CLUSTER, "encrypted_ephemeral", False, "false"),
         # IntParam
@@ -76,7 +76,7 @@ def test_param_to_cfn_value(mocker, section_definition, param_key, param_value, 
         (CLUSTER, "key_name", "NONE", {"KeyName": "NONE"}),
         (CLUSTER, "key_name", "test", {"KeyName": "test"}),
         # BoolParam
-        (CLUSTER, "encrypted_ephemeral", None, {"EncryptedEphemeral": "false"}),
+        (CLUSTER, "encrypted_ephemeral", None, {"EncryptedEphemeral": "NONE"}),
         (CLUSTER, "encrypted_ephemeral", True, {"EncryptedEphemeral": "true"}),
         (CLUSTER, "encrypted_ephemeral", False, {"EncryptedEphemeral": "false"}),
         # IntParam

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -742,7 +742,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     # raid
                     "RAIDOptions": "raid,NONE,NONE,gp2,20,100,false,NONE",
                     # fsx
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,false",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                 },
@@ -807,7 +807,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     # raid
                     "RAIDOptions": "raid,NONE,NONE,gp2,20,100,false,NONE",
                     # fsx
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,false",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                 },

--- a/cli/tests/pcluster/config/test_section_fsx.py
+++ b/cli/tests/pcluster/config/test_section_fsx.py
@@ -190,7 +190,7 @@ def test_fsx_section_to_cfn(mocker, section_dict, expected_cfn_params):
         ("automatic_backup_retention_days", "0", 0, None),
         ("automatic_backup_retention_days", "35", 35, None),
         ("automatic_backup_retention_days", "36", 36, "'automatic_backup_retention_days' has an invalid value '36'"),
-        ("copy_tags_to_backups", None, False, None),
+        ("copy_tags_to_backups", None, None, None),
         ("copy_tags_to_backups", "", None, "must be a Boolean"),
         ("copy_tags_to_backups", "NONE", None, "must be a Boolean"),
         ("copy_tags_to_backups", "true", True, None),
@@ -219,7 +219,7 @@ def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, exp
                 {
                     "MasterSubnetId": "subnet-12345678",
                     "AvailabilityZone": "mocked_avail_zone",
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,false",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                 },
             ),
         ),
@@ -245,7 +245,7 @@ def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, exp
                 {
                     "MasterSubnetId": "subnet-12345678",
                     "AvailabilityZone": "mocked_avail_zone",
-                    "FSXOptions": "/fsx,NONE,3600,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,false",
+                    "FSXOptions": "/fsx,NONE,3600,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                 },
             ),
         ),

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -36,13 +36,6 @@ def test_mapping_consistency():
 
         for param_key, param_definition in section_definition.get("params").items():
 
-            # Boolean params must have a default value
-            if param_definition.get("type") is BoolParam:
-                assert_that(
-                    param_definition.get("default"),
-                    description="BoolParam '{0}' must have a default value".format(param_key),
-                ).is_not_none()
-
             for param_definition_key, _ in param_definition.items():
                 assert_that(
                     param_definition_key,

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -679,6 +679,83 @@ def _kms_key_stubber(mocker, boto3_stubber, kms_key_id, expected_message, num_ca
             "'per_unit_storage_throughput' can only be used when 'deployment_type = PERSISTENT_1'",
             0,
         ),
+        (
+            {"storage_capacity": 1200, "deployment_type": "PERSISTENT_1", "automatic_backup_retention_days": 2},
+            None,
+            None,
+            0,
+        ),
+        (
+            {
+                "storage_capacity": 1200,
+                "deployment_type": "PERSISTENT_1",
+                "automatic_backup_retention_days": 2,
+                "daily_automatic_backup_start_time": "03:00",
+                "copy_tags_to_backups": True,
+            },
+            None,
+            None,
+            0,
+        ),
+        (
+            {"automatic_backup_retention_days": 2, "deployment_type": "SCRATCH_1"},
+            None,
+            "FSx automatic backup features can be used only with 'PERSISTENT_1' file systems",
+            0,
+        ),
+        (
+            {"daily_automatic_backup_start_time": "03:00"},
+            None,
+            "'automatic_backup_retention_days' must be greater than 0 if "
+            + "'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            0,
+        ),
+        (
+            {"storage_capacity": 1200, "deployment_type": "PERSISTENT_1", "copy_tags_to_backups": True},
+            None,
+            "'automatic_backup_retention_days' must be greater than 0 if "
+            + "'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            0,
+        ),
+        (
+            {"storage_capacity": 1200, "deployment_type": "PERSISTENT_1", "copy_tags_to_backups": False},
+            None,
+            "'automatic_backup_retention_days' must be greater than 0 if "
+            + "'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            0,
+        ),
+        (
+            {"daily_automatic_backup_start_time": "03:00", "copy_tags_to_backups": True},
+            None,
+            "'automatic_backup_retention_days' must be greater than 0 if "
+            + "'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            0,
+        ),
+        (
+            {
+                "deployment_type": "PERSISTENT_1",
+                "automatic_backup_retention_days": 2,
+                "imported_file_chunk_size": 1024,
+                "export_path": "s3://test",
+                "import_path": "s3://test",
+                "storage_capacity": 1200,
+            },
+            {"Bucket": "test"},
+            "Backups cannot be created on S3-linked file systems",
+            0,
+        ),
+        (
+            {
+                "deployment_type": "PERSISTENT_1",
+                "automatic_backup_retention_days": 2,
+                "export_path": "s3://test",
+                "import_path": "s3://test",
+                "storage_capacity": 1200,
+            },
+            {"Bucket": "test"},
+            "Backups cannot be created on S3-linked file systems",
+            0,
+        ),
     ],
 )
 def test_fsx_validator(mocker, boto3_stubber, section_dict, bucket, expected_error, num_calls):


### PR DESCRIPTION
This commit also adds a change to allow 'BoolParam' with 'None' value.

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
