### PR TITLE
Pin isort version to 4.3.21

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -59,7 +59,7 @@ commands =
 basepython = python3
 skip_install = true
 deps =
-    isort
+    isort==4.3.21
     seed-isort-config
 commands =
     isort -rc -w 120 \


### PR DESCRIPTION
* isort version 5.0.0 introduced a number of breaking changes. It will now sort import differently and seems not compatible with python 2.x, namely the __future__ library gets sorted incorrectly
* Pinning to most recent 4.x.x version as workaround for now

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
