### PR TITLE
Add backup_id parameter to support fsx create file system from backup

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -476,6 +476,10 @@ FSX = {
                 "type": BoolParam,
                 "update_policy": UpdatePolicy.SUPPORTED
             }),
+            ("backup_id", {
+                "allowed_values": "^(backup-[0-9a-f]{8,})$",
+                "update_policy": UpdatePolicy.UNSUPPORTED
+            }),
         ]
     )
 }

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -167,12 +167,14 @@ def fsx_validator(section_key, section_label, pcluster_config):
     fsx_automatic_backup_retention_days = fsx_section.get_param_value("automatic_backup_retention_days")
     fsx_copy_tags_to_backups = fsx_section.get_param_value("copy_tags_to_backups")
 
-    if not fsx_automatic_backup_retention_days and (
-        fsx_daily_automatic_backup_start_time or fsx_copy_tags_to_backups is not None
-    ):
+    if not fsx_automatic_backup_retention_days and fsx_daily_automatic_backup_start_time:
         errors.append(
-            "'automatic_backup_retention_days' must be greater than 0 if "
-            + "'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided."
+            "When specifying 'daily_automatic_backup_start_time', the 'automatic_backup_retention_days' option must be specified"
+        )
+
+    if not fsx_automatic_backup_retention_days and fsx_copy_tags_to_backups is not None:
+        errors.append(
+            "When specifying 'copy_tags_to_backups', the 'automatic_backup_retention_days' option must be specified"
         )
 
     if fsx_section.get_param_value("deployment_type") != "PERSISTENT_1" and fsx_automatic_backup_retention_days:

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -81,6 +81,7 @@ DEFAULT_FSX_DICT = {
     "daily_automatic_backup_start_time": None,
     "automatic_backup_retention_days": None,
     "copy_tags_to_backups": None,
+    "backup_id": None,
 }
 
 DEFAULT_DCV_DICT = {"enable": None, "port": 8443, "access_from": "0.0.0.0/0"}
@@ -198,7 +199,7 @@ DEFAULT_EFS_CFN_PARAMS = {"EFSOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE
 
 DEFAULT_RAID_CFN_PARAMS = {"RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
-DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
+DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
 DEFAULT_DCV_CFN_PARAMS = {"DCVOptions": "NONE,NONE,NONE"}
 DEFAULT_CW_LOG_CFN_PARAMS = {"CWLogOptions": "true,14"}
@@ -266,7 +267,7 @@ DEFAULT_CLUSTER_CFN_PARAMS = {
     # raid
     "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # fsx
-    "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+    "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # dcv
     "DCVOptions": "NONE,NONE,NONE",
     # cw_log_settings

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -742,7 +742,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     # raid
                     "RAIDOptions": "raid,NONE,NONE,gp2,20,100,false,NONE",
                     # fsx
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                 },
@@ -807,7 +807,7 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                     # raid
                     "RAIDOptions": "raid,NONE,NONE,gp2,20,100,false,NONE",
                     # fsx
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                 },

--- a/cli/tests/pcluster/config/test_section_fsx.py
+++ b/cli/tests/pcluster/config/test_section_fsx.py
@@ -21,16 +21,21 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
         (DefaultCfnParams["fsx"].value, DefaultDict["fsx"].value),
         ({}, DefaultDict["fsx"].value),
         (
-            {"FSXOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE"},
+            {"FSXOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE"},
             DefaultDict["fsx"].value,
         ),
-        ({"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}, DefaultDict["fsx"].value),
         (
-            {"FSXOptions": "test,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"},
+            {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE, NONE"},
+            DefaultDict["fsx"].value,
+        ),
+        (
+            {"FSXOptions": "test,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"},
             utils.merge_dicts(DefaultDict["fsx"].value, {"shared_dir": "test"}),
         ),
         (
-            {"FSXOptions": "test,test1,10,test2,20,test3,test4,test5,SCRATCH_1,50,01:00,5,false"},
+            {
+                "FSXOptions": "test,test1,10,test2,20,test3,test4,test5,SCRATCH_1,50,01:00,5,false,backup-0a1b2c3d4e5f6a7b8"
+            },
             {
                 "shared_dir": "test",
                 "fsx_fs_id": "test1",
@@ -45,6 +50,7 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
                 "daily_automatic_backup_start_time": "01:00",
                 "automatic_backup_retention_days": 5,
                 "copy_tags_to_backups": False,
+                "backup_id": "backup-0a1b2c3d4e5f6a7b8",
             },
         ),
     ],
@@ -195,6 +201,11 @@ def test_fsx_section_to_cfn(mocker, section_dict, expected_cfn_params):
         ("copy_tags_to_backups", "NONE", None, "must be a Boolean"),
         ("copy_tags_to_backups", "true", True, None),
         ("copy_tags_to_backups", "false", False, None),
+        ("backup_id", None, None, None),
+        ("backup_id", "", None, "'backup_id' has an invalid value ''"),
+        ("backup_id", "back-0a1b2c3d4e5f6a7b8", None, "'backup_id' has an invalid value 'back-0a1b2c3d4e5f6a7b8'"),
+        ("backup_id", "backup-0A1B2C3d4e5f6a7b8", None, "'backup_id' has an invalid value 'backup-0A1B2C3d4e5f6a7b8'"),
+        ("backup_id", "backup-0a1b2c3d4e5f6a7b8", "backup-0a1b2c3d4e5f6a7b8", None),
     ],
 )
 def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, expected_message):
@@ -219,7 +230,7 @@ def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, exp
                 {
                     "MasterSubnetId": "subnet-12345678",
                     "AvailabilityZone": "mocked_avail_zone",
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                 },
             ),
         ),
@@ -231,7 +242,7 @@ def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, exp
                     "MasterSubnetId": "subnet-12345678",
                     "AvailabilityZone": "mocked_avail_zone",
                     "FSXOptions": "fsx,fs-12345678901234567,10,key1,1020,s3://test-export,"
-                    "s3://test-import,1:10:17,SCRATCH_1,50,01:00,5,false",
+                    "s3://test-import,1:10:17,SCRATCH_1,50,01:00,5,false,NONE",
                 },
             ),
         ),
@@ -245,7 +256,7 @@ def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, exp
                 {
                     "MasterSubnetId": "subnet-12345678",
                     "AvailabilityZone": "mocked_avail_zone",
-                    "FSXOptions": "/fsx,NONE,3600,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    "FSXOptions": "/fsx,NONE,3600,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                 },
             ),
         ),

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -706,29 +706,25 @@ def _kms_key_stubber(mocker, boto3_stubber, kms_key_id, expected_message, num_ca
         (
             {"daily_automatic_backup_start_time": "03:00"},
             None,
-            "'automatic_backup_retention_days' must be greater than 0 if "
-            + "'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            "When specifying 'daily_automatic_backup_start_time', the 'automatic_backup_retention_days' option must be specified",
             0,
         ),
         (
             {"storage_capacity": 1200, "deployment_type": "PERSISTENT_1", "copy_tags_to_backups": True},
             None,
-            "'automatic_backup_retention_days' must be greater than 0 if "
-            + "'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            "When specifying 'copy_tags_to_backups', the 'automatic_backup_retention_days' option must be specified",
             0,
         ),
         (
             {"storage_capacity": 1200, "deployment_type": "PERSISTENT_1", "copy_tags_to_backups": False},
             None,
-            "'automatic_backup_retention_days' must be greater than 0 if "
-            + "'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            "When specifying 'copy_tags_to_backups', the 'automatic_backup_retention_days' option must be specified",
             0,
         ),
         (
             {"daily_automatic_backup_start_time": "03:00", "copy_tags_to_backups": True},
             None,
-            "'automatic_backup_retention_days' must be greater than 0 if "
-            + "'daily_automatic_backup_start_time' or 'copy_tags_to_backups' parameters are provided.",
+            "When specifying 'daily_automatic_backup_start_time', the 'automatic_backup_retention_days' option must be specified",
             0,
         ),
         (

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -312,9 +312,9 @@
       "Default": "1"
     },
     "FSXOptions": {
-      "Description": "Comma separated list of FSx related options, 10 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups]",
+      "Description": "Comma separated list of FSx related options, 14 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,backup_id]",
       "Type": "String",
-      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
+      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },
     "EFSOptions": {
       "Description": "Comma separated list of efs related options, 9 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,exists_valid_master_mt,exists_valid_compute_mt]",

--- a/cloudformation/fsx-substack.cfn.json
+++ b/cloudformation/fsx-substack.cfn.json
@@ -220,6 +220,23 @@
           ]
         }
       ]
+    },
+    "UseBackupId": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "13",
+                {
+                  "Ref": "FSXOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
     }
   },
   "Outputs": {
@@ -436,6 +453,22 @@
               }
             ]
           }
+        },
+        "BackupId": {
+          "Fn::If": [
+            "UseBackupId",
+            {
+              "Fn::Select": [
+                "13",
+                {
+                  "Ref": "FSXOptions"
+                }
+              ]
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
         },
         "SecurityGroupIds": [
           {


### PR DESCRIPTION
Customers can specify backup_id as an input parameter to fsx section. This parameter when specified creates an fsx file system and restores the given backup to the newly created file system.

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
