### PR TITLE
Fix issues in script that generates AMI mappings

### DIFF
--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -270,8 +270,7 @@ def update_cfn_template(cfn_template_file, amis_to_update):
     # Read in existing CFN template
     cfn_data = read_cfn_template(cfn_template_file)
     # update id for new amis without removing regions that are not in the amis_to_update dict
-    current_amis = get_initialized_mappings_dicts()
-    for mapping_name in current_amis:
+    for mapping_name in ARCHITECTURES_TO_MAPPING_NAME.values():
         current_amis_for_mapping = cfn_data.get("Mappings").get(mapping_name, {})
         for region, amis_to_update_region_mapping in amis_to_update.get(mapping_name, {}).items():
             if not amis_to_update_region_mapping:
@@ -287,14 +286,10 @@ def update_cfn_template(cfn_template_file, amis_to_update):
         # enforce alphabetical regions order
         current_amis_for_mapping = OrderedDict(sorted(current_amis_for_mapping.items()))
         cfn_data.get("Mappings")[mapping_name] = current_amis_for_mapping
-        current_amis[mapping_name] = current_amis_for_mapping
     # Ensure mappings are sorted
     cfn_data["Mappings"] = OrderedDict(sorted(cfn_data["Mappings"].items()))
     # Write back modified CFN template
     write_cfn_template(cfn_template_file, cfn_data)
-
-    # returns the updated amis dict
-    return current_amis
 
 
 def update_amis_txt(amis_txt_file, cfn_template_file):

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -20,12 +20,13 @@
 
 import json
 import re
-import sys
 from collections import OrderedDict
 
 import argparse
 import boto3
 from botocore.exceptions import ClientError
+
+from common import PARTITION_TO_MAIN_REGION, PARTITIONS
 
 DISTROS = OrderedDict(
     [
@@ -341,7 +342,9 @@ def parse_args():
         "--json-regions", type=str, help="path to input json file containing the regions", required=False
     )
     parser.add_argument("--txt-file", type=str, help="txt output file path", required=False, default="amis.txt")
-    parser.add_argument("--partition", type=str, help="commercial | china | govcloud", required=True)
+    parser.add_argument(
+        "--partition", type=str, help="commercial | china | govcloud", required=True, choices=PARTITIONS
+    )
     parser.add_argument("--account-id", type=str, help="AWS account id owning the AMIs", required=True)
     parser.add_argument(
         "--cloudformation-template",
@@ -356,16 +359,7 @@ def parse_args():
 def main():
     """Run the script."""
     args = parse_args()
-
-    if args.partition == "commercial":
-        region = "us-east-1"
-    elif args.partition == "govcloud":
-        region = "us-gov-west-1"
-    elif args.partition == "china":
-        region = "cn-north-1"
-    else:
-        print("Unsupported partition %s" % args.partition)
-        sys.exit(1)
+    region = PARTITION_TO_MAIN_REGION.get(args.partition)
 
     credentials = []
     if args.credential:

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -349,6 +349,10 @@ def main():
         ]
 
     if args.cookbook_git_ref and args.node_git_ref:
+        # This path is used by the build_and_test and retrive_ami_list pipelines.
+        # Requiring all of the AMIs in the resulting mappings (for the applicable regions)
+        # to be created from the same cookbook and node repo git refs on the same date
+        # ensures that the AMIs were all produced by the same run of the build pipeline.
         amis_dict = get_ami_list_by_git_refs(
             main_region=region,
             regions=get_all_aws_regions_from_ec2(region),
@@ -359,6 +363,10 @@ def main():
             credentials=credentials,
         )
     else:
+        # This path is used by the pre_release_flow pipleine, which uses the
+        # retrive_ami_list pipeline to generate CFN templates with updated mappings
+        # for each partition and then aggregates the mappings from each those files
+        # into a single CFN template.
         regions = get_aws_regions_from_file(args.json_regions)
         amis_dict = get_ami_list_from_file(regions, args.json_template)
 

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -315,7 +315,8 @@ def update_amis_txt(amis_txt_file, amis):
         f.write("%s" % amis_txt)
 
 
-if __name__ == "__main__":
+def main():
+    """Run the script."""
     # parse inputs
     parser = argparse.ArgumentParser(description="Get AWS ParallelCluster instances and generate a json and txt file")
     group1 = parser.add_argument_group("Retrieve instances from EC2 searching by version and date")
@@ -389,3 +390,7 @@ if __name__ == "__main__":
 
     cfn_amis = update_cfn_template(cfn_template_file=args.cloudformation_template, amis_to_update=amis_dict)
     update_amis_txt(amis_txt_file=args.txt_file, amis=cfn_amis)
+
+
+if __name__ == "__main__":
+    main()

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -315,9 +315,8 @@ def update_amis_txt(amis_txt_file, amis):
         f.write("%s" % amis_txt)
 
 
-def main():
-    """Run the script."""
-    # parse inputs
+def parse_args():
+    """Parse command line args."""
     parser = argparse.ArgumentParser(description="Get AWS ParallelCluster instances and generate a json and txt file")
     group1 = parser.add_argument_group("Retrieve instances from EC2 searching by version and date")
     group1.add_argument("--version", type=str, help="release version", required=False)
@@ -351,7 +350,12 @@ def main():
         required=False,
         default="cloudformation/aws-parallelcluster.cfn.json",
     )
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def main():
+    """Run the script."""
+    args = parse_args()
 
     if args.partition == "commercial":
         region = "us-east-1"

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -297,9 +297,10 @@ def update_cfn_template(cfn_template_file, amis_to_update):
     return current_amis
 
 
-def update_amis_txt(amis_txt_file, amis):
-    """Write samis_txt_file using the information contained in amis."""
-    amis_txt = convert_json_to_txt(amis_json=amis)
+def update_amis_txt(amis_txt_file, cfn_template_file):
+    """Write amis_txt_file using the updated information contained in cfn_template_file."""
+    cfn_data = read_cfn_template(cfn_template_file)
+    amis_txt = convert_json_to_txt(cfn_data.get("Mappings"))
     with open(amis_txt_file, "w") as f:
         f.write("%s" % amis_txt)
 
@@ -380,8 +381,8 @@ def main():
         regions = get_aws_regions_from_file(args.json_regions)
         amis_dict = get_ami_list_from_file(regions, args.json_template)
 
-    cfn_amis = update_cfn_template(cfn_template_file=args.cloudformation_template, amis_to_update=amis_dict)
-    update_amis_txt(amis_txt_file=args.txt_file, amis=cfn_amis)
+    update_cfn_template(cfn_template_file=args.cloudformation_template, amis_to_update=amis_dict)
+    update_amis_txt(amis_txt_file=args.txt_file, cfn_template_file=args.cloudformation_template)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before this change, the script would avoid updating a mapping if a new AMI was not found when querying EC2. This change ensures that all entries in mappings specific to the regions specified via the command line arg are re-written entirely. If a an AMI cannot be found for the given region-OS-architecture combination, an "UNSUPPORTED" placeholder value is used.

This PR also fixes an issue where AMI mapping data was being errantly written to other mappings in the CFN template.

There was also some minor refactoring.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
