### PR TITLE
Backport workaround for Intel HPC platform version

### DIFF
--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.ini
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.ini
@@ -17,6 +17,8 @@ master_root_volume_size = 80
 compute_root_volume_size = 80
 ebs_settings = large
 enable_intel_hpc_platform = true
+# workaround for intel HPC version
+extra_json = {"cfncluster": {"intelhpc":{"version": "2018.0-*.el7"}}}
 
 [ebs large]
 shared_dir = /shared


### PR DESCRIPTION
* Intel HPC platform version number is changed, as shown in this commit https://github.com/aws/aws-parallelcluster-cookbook/commit/afce2a687fada887e57784c497b8eecf12d564f6
* Workaround is required in order to use Intel HPC in all versions <=2.7.0

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
