### PR TITLE
Fix Intel Cluster Checker test

### DIFF
--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/clck.xml
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/clck.xml
@@ -64,7 +64,7 @@
     <!-- This tag can be used to set the network interface used for
          accumulating data collected on-demand.
     -->
-    <network_interface>ens5</network_interface>
+    <network_interface>eth0</network_interface>
 
     <!-- This tag can be used to override the default location for
          data provider helper files.


### PR DESCRIPTION
* Network interface is now eth0 after using new CentOS7 base AMI
* Update cluster checker specification file to use eth0 as network interface instead of ens5

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
