### PR TITLE
FSx Section Validation Enhancements

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -59,6 +59,7 @@ from pcluster.config.validators import (
     efs_validator,
     fsx_architecture_os_validator,
     fsx_id_validator,
+    fsx_ignored_parameters_validator,
     fsx_imported_file_chunk_size_validator,
     fsx_lustre_backup_validator,
     fsx_storage_capacity_validator,
@@ -422,7 +423,7 @@ FSX = {
     "type": Section,
     "key": "fsx",
     "default_label": "default",
-    "validators": [fsx_validator, fsx_storage_capacity_validator],
+    "validators": [fsx_validator, fsx_storage_capacity_validator, fsx_ignored_parameters_validator],
     "cfn_param_mapping": "FSXOptions",  # All the parameters in the section are converted into a single CFN parameter
     "params": OrderedDict(  # Use OrderedDict because the parameters must respect the order in the CFN parameter
         [

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -1093,6 +1093,7 @@ def fsx_lustre_backup_validator(param_key, param_value, pcluster_config):
         "import_path",
         "export_path",
         "imported_file_chunk_size",
+        "fsx_kms_key_id",
     ]
 
     for config_param_name in unsupported_config_param_names:

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -1100,3 +1100,24 @@ def fsx_lustre_backup_validator(param_key, param_value, pcluster_config):
             errors.append(FSX_MESSAGES["errors"]["unsupported_backup_param"].format(name=config_param_name))
 
     return errors, warnings
+
+
+def fsx_ignored_parameters_validator(section_key, section_label, pcluster_config):
+    """Return errors for parameters in the FSx config section that would be ignored."""
+    errors = []
+    warnings = []
+
+    fsx_section = pcluster_config.get_section(section_key, section_label)
+
+    # If fsx_fs_id is specified, all parameters besides shared_dir are ignored.
+    relevant_when_using_existing_fsx = ["fsx_fs_id", "shared_dir"]
+    if fsx_section.get_param_value("fsx_fs_id") is not None:
+        for fsx_param in fsx_section.params:
+            if fsx_param not in relevant_when_using_existing_fsx and fsx_section.get_param_value(fsx_param) is not None:
+                errors.append(
+                    "{fsx_param} is ignored when specifying an existing Lustre file system via fsx_fs_id.".format(
+                        fsx_param=fsx_param
+                    )
+                )
+
+    return errors, warnings


### PR DESCRIPTION
* Don't allow use of KMS key parameter in FSx section when restoring from backup
* Add validator that causes FSx validation to fail when parameters that would be ignored are used when using an existing Lustre file system (via the fsx_fs_id parameter)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
