### PR TITLE
Fix EFS test in China

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -404,6 +404,8 @@ AVAILABILITY_ZONE_OVERRIDES = {
     "sa-east-1": ["sa-east-1a", "sa-east-1c"],
     # m6g.xlarge instances not available in eu-west-1c
     "eu-west-1": ["eu-west-1a", "eu-west-1b"],
+    # provide AZs to enforce networking setup used for EFS test
+    "cn-north-1": ["cn-north-1a", "cn-north-1b"],
 }
 
 


### PR DESCRIPTION
* EFS test would fail in China because AZs are not explicitly provided so subnets would be set up in random AZs, and EFS test is not able to assert the networking assumptions

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
