### PR TITLE
Fix EBS snapshot test

### DIFF
--- a/tests/integration-tests/tests/storage/snapshots_factory.py
+++ b/tests/integration-tests/tests/storage/snapshots_factory.py
@@ -17,6 +17,7 @@ import boto3
 from retrying import retry
 
 from fabric import Connection
+from utils import random_alphanumeric
 
 SnapshotConfig = namedtuple("ClusterConfig", ["ssh_key", "key_name", "vpc_id", "master_subnet_id"])
 
@@ -153,22 +154,16 @@ class EBSSnapshotsFactory:
         return vol
 
     def _get_security_group_id(self):
-        response = self.boto_client.describe_security_groups(
-            Filters=[{"Name": "group-name", "Values": ["snapshot"]}, {"Name": "vpc-id", "Values": [self.config.vpc_id]}]
-        )
-        if len(response["SecurityGroups"]) == 0:
-            security_group_id = self.boto_client.create_security_group(
-                Description="security group for snapshot instance node", GroupName="snapshot", VpcId=self.config.vpc_id
-            )["GroupId"]
+        security_group_id = self.boto_client.create_security_group(
+            Description="security group for snapshot instance node",
+            GroupName="snapshot-" + random_alphanumeric(),
+            VpcId=self.config.vpc_id,
+        )["GroupId"]
 
-            self.boto_client.authorize_security_group_ingress(
-                GroupId=security_group_id,
-                IpPermissions=[
-                    {"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}
-                ],
-            )
-        else:
-            security_group_id = response["SecurityGroups"][0]["GroupId"]
+        self.boto_client.authorize_security_group_ingress(
+            GroupId=security_group_id,
+            IpPermissions=[{"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}],
+        )
 
         return security_group_id
 
@@ -184,7 +179,7 @@ class EBSSnapshotsFactory:
                     "SubnetId": subnet.id,
                     "DeviceIndex": 0,
                     "AssociatePublicIpAddress": True,
-                    "Groups": [self._get_security_group_id()],
+                    "Groups": [self.security_group_id],
                 }
             ],
             TagSpecifications=[


### PR DESCRIPTION
* Revised logic in snapshot factory to alway create new SG with unique name
* Old logic of using existing SG if possible will cause SG deletion failure when 2 tests are running in parallel in the same VPC

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
