### PR TITLE
Skip PMIx integration test on CentOS 6

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -94,6 +94,7 @@ def test_slurm_gpu(region, pcluster_config_reader, clusters_factory):
 @pytest.mark.regions(["eu-west-1"])
 @pytest.mark.instances(["c5.xlarge", "m6g.xlarge"])
 @pytest.mark.schedulers(["slurm"])
+@pytest.mark.skip_oss(["centos6"])
 @pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_slurm_pmix(pcluster_config_reader, clusters_factory, os, architecture):
     """Test interactive job submission using PMIx."""


### PR DESCRIPTION
Don't run PMIx integration test on CentOS 6 because it's not installed

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
