### PR TITLE
Enable "runtime bake" tests

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -17,7 +17,7 @@ from retrying import retry
 OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "alinux": {"name": "amzn-ami-hvm-*.*.*.*-*-gp2", "owners": ["amazon"]},
     "alinux2": {"name": "amzn2-ami-hvm-*.*.*.*-*-gp2", "owners": ["amazon"]},
-    "centos7": {"name": "CentOS Linux 7 * HVM EBS ENA *", "owners": ["410186602215"]},
+    "centos7": {"name": "CentOS 7.* *", "owners": ["125523088429"]},
     "ubuntu1404": {
         "name": "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-*-server-*",
         "owners": ["099720109477", "513442679011", "837727238323"],

--- a/tests/integration-tests/tests/runtime_bake/test_runtime_bake.py
+++ b/tests/integration-tests/tests/runtime_bake/test_runtime_bake.py
@@ -17,13 +17,10 @@ from tests.common.schedulers_common import get_scheduler_commands
 from tests.common.utils import retrieve_latest_ami
 
 
-@pytest.mark.skip(reason="Temporarily disable this test")
-@pytest.mark.dimensions("eu-west-2", "c5.xlarge", "alinux", "slurm")
-@pytest.mark.dimensions("eu-west-3", "c5.xlarge", "alinux2", "torque")
+@pytest.mark.dimensions("eu-west-3", "c5.xlarge", "alinux", "torque")
 @pytest.mark.dimensions("us-east-2", "c5.xlarge", "centos7", "sge")
-@pytest.mark.dimensions("us-east-1", "c5.xlarge", "ubuntu1604", "slurm")
-@pytest.mark.dimensions("eu-west-1", "c5.xlarge", "ubuntu1804", "sge")
-@pytest.mark.dimensions("us-gov-east-1", "c5.xlarge", "ubuntu1604", "slurm")
+@pytest.mark.dimensions("eu-west-2", "c5.xlarge", "ubuntu1604", "sge")
+@pytest.mark.dimensions("us-gov-east-1", "c5.xlarge", "alinux2", "slurm")
 @pytest.mark.dimensions("us-gov-west-1", "c5.xlarge", "ubuntu1804", "sge")
 @pytest.mark.dimensions("us-east-1", "m6g.xlarge", "ubuntu1804", "sge")
 @pytest.mark.dimensions("eu-west-1", "m6g.xlarge", "alinux2", "slurm")

--- a/tests/integration-tests/tests/runtime_bake/test_runtime_bake/test_runtime_bake/verify_chef_download.sh
+++ b/tests/integration-tests/tests/runtime_bake/test_runtime_bake/test_runtime_bake/verify_chef_download.sh
@@ -13,9 +13,24 @@ if [ $? -eq 0 ]; then
     exit 1
 fi
 
-# Verify chef client is installed from S3
-sudo grep -ir "aws-parallelcluster/archives/chef/chef-install.sh" /var/log/cloud-init-output.log
+# Verify no chef client is installed from S3
+sudo grep -iEr "aws-parallelcluster.*/archives/chef/chef-install.sh" /var/log/cloud-init-output.log
+if [ $? -eq 0 ]; then
+    echo "Chef installer downloaded from S3"
+    exit 1
+fi
+
+
+# Verify cinc.sh is not called to download cinc installer script or client
+sudo grep -ir "omnitruck.cinc.sh/install.sh" /var/log/cloud-init-output.log
+if [ $? -eq 0 ]; then
+    echo "Cinc installer downloaded from cinc.sh"
+    exit 1
+fi
+
+# Verify cinc client is installed from S3
+sudo grep -iEr "aws-parallelcluster.*/archives/cinc/cinc-install.sh" /var/log/cloud-init-output.log
 if [ $? -ne 0 ]; then
-    echo "Chef installer not downloaded from S3"
+    echo "Cinc installer NOT downloaded from S3"
     exit 1
 fi


### PR DESCRIPTION
Test is checking if, during runtime bake, the Cinc installer is downloaded from PCluster S3 buckets

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
