### PR TITLE
Remove changes required for old OMPI versions

### DIFF
--- a/tests/integration-tests/tests/common/data/mpi/mpi_submit_openmpi.sh
+++ b/tests/integration-tests/tests/common/data/mpi/mpi_submit_openmpi.sh
@@ -3,5 +3,4 @@ set -e
 
 rm -f /shared/mpi.out
 module load openmpi
-export MPIEXEC_TIMEOUT=10  # 10 second timeout
-mpirun --mca btl_base_warn_component_unused 0 --map-by ppr:1:node "ring" >> /shared/mpi.out
+mpirun --map-by ppr:1:node --timeout 10 "ring" >> /shared/mpi.out


### PR DESCRIPTION
Only 2.X versions of OMPI were available for Amazon Linux 2 and Ubuntu
18.04 via their respective package managers on the ARM AMIs. Now that
the EFA intaller provides a much more up-to-date version, remove the
changes that were made to accommodate the older version as part of
2a86d68c.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
