### PR TITLE
Add CHANGELOG entry for initial size validation added in v2.8.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ CHANGELOG
 * Install third-party cookbook dependencies via local source, rather than using the Chef supermarket.
 * Use https wherever possible in download URLs.
 * Install glibc-static, which is required to support certain options for the Intel MPI compiler.
+* Require an initial cluster size greater than zero when the option to maintain the initial cluster size is used.
 
 **BUG FIXES**
 


### PR DESCRIPTION
A validator was added as part of b9d1a5491 that requires the
`initial_queue_size` parameter to have a value greater than zero if the
`maintain_initial_queue_size` parameter was set to `true`. This change
from the previous version's behavior was not documented in the
changelog.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
