### PR TITLE
Add FSx backup params to update test

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -166,7 +166,7 @@ def _add_compute_nodes(slurm_commands, number_of_nodes=1):
 
 
 def _get_instance(region, stack_name, host, none_expected=False):
-    hostname = "{0}.{1}.compute.internal".format(host, region)
+    hostname = f"{host}.ec2.internal" if region == "us-east-1" else "{0}.{1}.compute.internal".format(host, region)
     ec2_resource = boto3.resource("ec2", region_name=region)
     instance = next(
         iter(

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.ini
@@ -58,8 +58,12 @@ shared_dir = raid
 
 [fsx custom]
 shared_dir = fsx
-storage_capacity = 3600
+storage_capacity = 2400
+deployment_type = PERSISTENT_1
+per_unit_storage_throughput = 200
+automatic_backup_retention_days = 1
 #weekly_maintenance_start_time = None #Initially not set
+#daily_automatic_backup_start_time = None #Initially not set
 
 [dcv custom]
 enable = master

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.ini
@@ -58,8 +58,12 @@ volume_iops = 110
 
 [fsx custom]
 shared_dir = fsx
-storage_capacity = 3600
+storage_capacity = 2400
+deployment_type = PERSISTENT_1
+per_unit_storage_throughput = 200
+automatic_backup_retention_days = 10
 weekly_maintenance_start_time = 3:02:30
+daily_automatic_backup_start_time = 23:09
 
 [dcv custom]
 enable = master


### PR DESCRIPTION
Include the updatable FSx backup parameters in the `pcluster update` integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
