### PR TITLE
Assume STS credentials before VPC stack creation

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -415,6 +415,31 @@ def setup_sts_credentials(region, request):
     unset_credentials()
 
 
+def get_availability_zones(region, credential):
+    """
+    Return a list of availability zones for the given region.
+
+    Note that this function is called by the vpc_stacks fixture. Because vcp_stacks is session-scoped,
+    it cannot utilize setup_sts_credentials, which is required in opt-in regions in order to call
+    describe_availability_zones.
+    """
+    set_credentials(region, credential)
+    az_list = []
+    try:
+        client = boto3.client("ec2", region_name=region)
+        response_az = client.describe_availability_zones(
+            Filters=[
+                {"Name": "region-name", "Values": [str(region)]},
+                {"Name": "zone-type", "Values": ["availability-zone"]},
+            ]
+        )
+        for az in response_az.get("AvailabilityZones"):
+            az_list.append(az.get("ZoneName"))
+    finally:
+        unset_credentials()
+    return az_list
+
+
 @pytest.fixture(scope="session", autouse=True)
 def vpc_stacks(cfn_stacks_factory, request):
     """Create VPC used by integ tests in all configured regions."""
@@ -430,17 +455,7 @@ def vpc_stacks(cfn_stacks_factory, request):
             availability_zones = random.sample(AVAILABILITY_ZONE_OVERRIDES.get(region), k=2)
         # else if region is not in AVAILABILITY_ZONE_OVERRIDES keys, find available zones mapping to the region
         else:
-            # get ec2 client
-            client = boto3.client("ec2", region_name=region)
-            response_az = client.describe_availability_zones(
-                Filters=[
-                    {"Name": "region-name", "Values": [str(region)]},
-                    {"Name": "zone-type", "Values": ["availability-zone"]},
-                ]
-            )
-            az_list = []
-            for az in response_az.get("AvailabilityZones"):
-                az_list.append(az.get("ZoneName"))
+            az_list = get_availability_zones(region, request.config.getoption("credential"))
             # if number of available zones is smaller than 2, available zones should be [None, None]
             if len(az_list) < 2:
                 availability_zones = [None, None]


### PR DESCRIPTION
The change made in #1911 added a call to `describe_availability_zones`. In opt-in regions, this call requires assuming credentials first.

Note that the fixture to assume STS credentials is not used because that fixture must be class-scoped (due to the time limit on the credentials).

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
