### PR TITLE
Add aws-parallelcluster-node-type to HIT compute fleet

### DIFF
--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -141,6 +141,8 @@ Resources:
                 Value: !Ref 'NetworkingTagValue'
               - Key: aws-parallelcluster-filesystem
                 Value: !Ref 'FilesystemTagValue'
+              - Key: aws-parallelcluster-node-type
+                Value: Compute
         BlockDeviceMappings:
           - DeviceName: /dev/xvdba
             VirtualName: ephemeral0


### PR DESCRIPTION
This in order not to rely on the Name tag that can be easily changed by the user

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
