### PR TITLE
Load JSON config file only for HIT enabled clusters.

### DIFF
--- a/cli/tests/pcluster/config/test_pcluster_config.py
+++ b/cli/tests/pcluster/config/test_pcluster_config.py
@@ -8,6 +8,8 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import json
+
 import pytest
 from assertpy import assert_that
 
@@ -61,3 +63,55 @@ def test_get_latest_alinux_ami_id(mocker, boto3_stubber, path, boto3_response, e
     else:
         latest_linux_ami_id = pcluster_config._PclusterConfig__get_latest_alinux_ami_id()
         assert_that(latest_linux_ami_id).is_equal_to(boto3_response.get("Parameters")[0].get("Value"))
+
+
+@pytest.mark.parametrize(
+    "cfn_params_dict, valid_bucket, expected_json, expected_message",
+    [
+        (
+            # ResourceS3Bucket expected and not available
+            {"Scheduler": "slurm"},
+            False,
+            None,
+            "Unable to retrieve configuration: ResourceS3Bucket not available.",
+        ),
+        (
+            # Invalid ResourcesS3Bucket
+            {"Scheduler": "slurm", "ResourcesS3Bucket": "invalid_bucket"},
+            False,
+            None,
+            "Unable to load configuration from bucket 'invalid_bucket'.\nInvalid file url",
+        ),
+        (
+            # ResourceS3Bucket available
+            {"Scheduler": "slurm", "ResourcesS3Bucket": "valid_bucket"},
+            True,
+            {"test_key": "test_value"},
+            None,
+        ),
+        (
+            # ResourceS3Bucket not expected
+            {"Scheduler": "sge"},
+            False,
+            None,
+            None,
+        ),
+    ],
+)
+def test_load_json_config(mocker, valid_bucket, cfn_params_dict, expected_json, expected_message):
+    cfn_params = []
+    for cfn_key, cfn_value in cfn_params_dict.items():
+        cfn_params.append({"ParameterKey": cfn_key, "ParameterValue": cfn_value})
+    pcluster_config = get_mocked_pcluster_config(mocker)
+
+    patched_read_remote_file = mocker.patch("pcluster.config.pcluster_config.read_remote_file")
+    if valid_bucket:
+        patched_read_remote_file.return_value = json.dumps(expected_json)
+    else:
+        patched_read_remote_file.side_effect = Exception("Invalid file url")
+
+    if expected_message:
+        with pytest.raises(SystemExit, match=expected_message):
+            pcluster_config._PclusterConfig__load_json_config(cfn_params)
+    else:
+        assert_that(pcluster_config._PclusterConfig__load_json_config(cfn_params)).is_equal_to(expected_json)


### PR DESCRIPTION
The code was always trying to retrieve and parse the JSON configuration file, which would be missing with traditional schedulers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
