### PR TITLE
Use is_hit_enabled_cluster and add test

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -57,7 +57,7 @@ def _create_bucket_with_resources(pcluster_config, json_params):
         for resources_dir in resources_dirs:
             resources = pkg_resources.resource_filename(__name__, resources_dir)
             utils.upload_resources_artifacts(s3_bucket_name, root=resources)
-        if scheduler == "slurm":
+        if utils.is_hit_enabled_cluster(scheduler):
             _upload_hit_resources(s3_bucket_name, pcluster_config, json_params)
     except Exception:
         LOGGER.error("Unable to upload cluster resources to the S3 bucket %s.", s3_bucket_name)

--- a/cli/tests/pcluster/config/test_hit_converter.py
+++ b/cli/tests/pcluster/config/test_hit_converter.py
@@ -14,6 +14,7 @@ from assertpy import assert_that
 
 from pcluster.cluster_model import ClusterModel
 from pcluster.config.hit_converter import HitConverter
+from pcluster.utils import is_hit_enabled_cluster
 from tests.common import MockedBoto3Request
 from tests.pcluster.config.utils import init_pcluster_config_from_configparser
 
@@ -109,7 +110,7 @@ def test_hit_converter(boto3_stubber, src_config_dict, dst_config_dict):
     scheduler = src_config_dict["cluster default"]["scheduler"]
     instance_type = src_config_dict["cluster default"]["compute_instance_type"]
 
-    if scheduler == "slurm":
+    if is_hit_enabled_cluster(scheduler):
         mocked_requests = [
             MockedBoto3Request(
                 method="describe_instance_types",

--- a/cli/tests/pcluster/utils/test_pcluster_utils.py
+++ b/cli/tests/pcluster/utils/test_pcluster_utils.py
@@ -597,6 +597,22 @@ def test_get_master_server_ips(mocker, master_instance, expected_ip, error):
 
 
 @pytest.mark.parametrize(
+    "scheduler, expected_is_hit_enabled",
+    [
+        ("sge", False),
+        ("slurm", True),
+        ("torque", False),
+        ("awsbatch", False),
+        # doesn't check scheduler's validity, only whether it's slurm or not
+        ("madeup-scheduler", False),
+    ],
+)
+def test_is_hit_enabled_cluster(scheduler, expected_is_hit_enabled):
+    """Verify that the expected schedulers are hit enabled."""
+    assert_that(utils.is_hit_enabled_cluster(scheduler)).is_equal_to(expected_is_hit_enabled)
+
+
+@pytest.mark.parametrize(
     "region, expected_url",
     [
         ("us-east-1", "https://us-east-1-aws-parallelcluster.s3.us-east-1.amazonaws.com"),


### PR DESCRIPTION
With this patch we are unifying the way to detect the cluster model of the cluster, to see it it is HIT or SIT.

Signed-off-by: Alexandre Gobeaux <gobeaa@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
