### PR TITLE
Restore default values for disable_hyperthreading and enable_efa in cluster section

### DIFF
--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -15,15 +15,7 @@ from collections import OrderedDict
 import yaml
 
 from pcluster.config.iam_policy_rules import AWSBatchFullAccessInclusionRule, CloudWatchAgentServerPolicyInclusionRule
-from pcluster.config.param_types import (
-    LOGGER,
-    Param,
-    Section,
-    SettingsParam,
-    StorageData,
-    _ensure_section_existence,
-    get_file_section_name,
-)
+from pcluster.config.param_types import LOGGER, Param, Section, SettingsParam, StorageData, _ensure_section_existence
 from pcluster.config.resource_map import ResourceMap
 from pcluster.constants import PCLUSTER_ISSUES_LINK
 from pcluster.utils import (
@@ -31,6 +23,7 @@ from pcluster.utils import (
     get_avail_zone,
     get_cfn_param,
     get_efs_mount_target_id,
+    get_file_section_name,
     get_instance_vcpus,
     get_supported_architectures_for_instance_type,
 )
@@ -660,12 +653,12 @@ class DisableHyperThreadingCfnParam(BoolCfnParam):
         cluster_config = self.pcluster_config.get_section(self.section_key)
         if self.value:
             master_instance_type = cluster_config.get_param_value("master_instance_type")
-            master_cores = get_instance_vcpus(self.pcluster_config.region, master_instance_type) // 2
+            master_cores = get_instance_vcpus(master_instance_type) // 2
 
             if self.pcluster_config.cluster_model.name == "SIT":
                 # compute_instance_type parameter is valid only in SIT clusters
                 compute_instance_type = cluster_config.get_param_value("compute_instance_type")
-                compute_cores = get_instance_vcpus(self.pcluster_config.region, compute_instance_type) // 2
+                compute_cores = get_instance_vcpus(compute_instance_type) // 2
             else:
                 compute_instance_type = None
                 compute_cores = 0

--- a/cli/pcluster/config/config_patch.py
+++ b/cli/pcluster/config/config_patch.py
@@ -16,8 +16,8 @@ from collections import namedtuple
 
 # Represents a single parameter change in a ConfigPatch instance
 from pcluster import utils
-from pcluster.config.param_types import get_file_section_name
 from pcluster.config.update_policy import UpdatePolicy
+from pcluster.utils import get_file_section_name
 
 Change = namedtuple("Change", ["section_key", "section_label", "param_key", "old_value", "new_value", "update_policy"])
 

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -19,6 +19,7 @@ from configparser import NoSectionError
 
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import settings_validator
+from pcluster.utils import get_file_section_name
 
 LOGGER = logging.getLogger(__name__)
 
@@ -589,10 +590,6 @@ class Section(ABC):
 
 
 # ---------------------- Common functions ---------------------- #
-def get_file_section_name(section_key, section_label=None):
-    return section_key + (" {0}".format(section_label) if section_label else "")
-
-
 def _ensure_section_existence(config_parser, section_name):
     """Add a section to the config_parser if not present."""
     if not config_parser.has_section(section_name):

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -263,7 +263,6 @@ def get_instance_vcpus(instance_type):
     """
     Get number of vcpus for the given instance type.
 
-    :param region: AWS Region
     :param instance_type: the instance type to search for.
     :return: the number of vcpus or -1 if the instance type cannot be found
     """
@@ -868,3 +867,8 @@ def get_bucket_url(region):
     return ("https://{region}-aws-parallelcluster.s3.{region}.amazonaws.com{suffix}").format(
         region=region, suffix=s3_suffix
     )
+
+
+def get_file_section_name(section_key, section_label=None):
+    """Build a section name as in the config file, given section key and label."""
+    return section_key + (" {0}".format(section_label) if section_label else "")

--- a/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
@@ -4,7 +4,8 @@ cluster_template = default
 [cluster default]
 queue_settings = {{queue_settings}}
 enable_efa = compute
-disable_hyperthreading = false
+# disable_hyperthreading not defined, fallback to False expected
+# disable_hyperthreading = false
 
 [queue queue1]
 compute_resource_settings = q1-i1,q1-i2,q1-i3
@@ -49,7 +50,7 @@ spot_price = 0.6
 compute_resource_settings = q3-i1
 compute_type = spot
 # enable_efa should be inherited from cluster section
-# enable_efa = false
+# enable_efa = true
 # disable_hyperthreading should be inherited from cluster section
 # disable_hyperthreading = false
 placement_group = DYNAMIC

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -1525,19 +1525,7 @@ def test_queue_settings_validator(mocker, cluster_section_dict, expected_message
             {"compute_resource_settings": "cr2,cr4", "enable_efa": True, "disable_hyperthreading": True},
             None,
         ),
-        (
-            {"queue_settings": "default"},
-            {"compute_resource_settings": "cr1"},
-            [
-                "Parameter 'enable_efa' must be specified in 'cluster' or in 'queue' section",
-                "Parameter 'disable_hyperthreading' must be specified in 'cluster' or in 'queue' section",
-            ],
-        ),
-        (
-            {"queue_settings": "default", "enable_efa": "compute", "disable_hyperthreading": True},
-            {"compute_resource_settings": "cr1"},
-            None,
-        ),
+        ({"queue_settings": "default"}, {"compute_resource_settings": "cr1"}, None,),
         (
             {"queue_settings": "default", "enable_efa": "compute", "disable_hyperthreading": True},
             {"compute_resource_settings": "cr1", "enable_efa": True, "disable_hyperthreading": True},
@@ -1546,9 +1534,17 @@ def test_queue_settings_validator(mocker, cluster_section_dict, expected_message
                 "Parameter 'disable_hyperthreading' can be used only in 'cluster' or in 'queue' section",
             ],
         ),
+        (
+            {"queue_settings": "default", "enable_efa": "compute", "disable_hyperthreading": True},
+            {"compute_resource_settings": "cr1", "enable_efa": False, "disable_hyperthreading": False},
+            [
+                "Parameter 'enable_efa' can be used only in 'cluster' or in 'queue' section",
+                "Parameter 'disable_hyperthreading' can be used only in 'cluster' or in 'queue' section",
+            ],
+        ),
     ],
 )
-def test_queue_validator(mocker, cluster_dict, queue_dict, expected_messages):
+def test_queue_validator(cluster_dict, queue_dict, expected_messages):
     config_parser_dict = {
         "cluster default": cluster_dict,
         "queue default": queue_dict,


### PR DESCRIPTION
This commit fixes a regression introduced in https://github.com/aws/aws-parallelcluster/pull/1928, which made these parameters mandatory either in the cluster or in queue sections.

The new behavior allows configuration files to omit these parameter, with the meaning of setting them to false.
The validation checks that the parameters are specified only in cluster or in queue section, or that at least their valuea are the same in both sections.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
