### PR TITLE
Add CloudWatch dashboard (Head Node EC2 Metrics and Head Node Logs)

### DIFF
--- a/cli/pcluster/cli_commands/update.py
+++ b/cli/pcluster/cli_commands/update.py
@@ -22,7 +22,7 @@ from tabulate import tabulate
 
 import pcluster.utils as utils
 from pcluster.cluster_model import ClusterModel
-from pcluster.commands import _evaluate_pcluster_template_url, _upload_hit_resources
+from pcluster.commands import _evaluate_pcluster_template_url, _upload_dashboard_resource, _upload_hit_resources
 from pcluster.config.config_patch import ConfigPatch
 from pcluster.config.pcluster_config import PclusterConfig
 from pcluster.config.update_policy import UpdatePolicy
@@ -54,18 +54,18 @@ def execute(args):
         cfn_client = boto3.client("cloudformation")
         _restore_cfn_only_params(cfn_client, args, cfn_params, stack_name, target_config)
 
+        s3_bucket_name = cfn_params["ResourcesS3Bucket"]
+
         is_hit = utils.is_hit_enabled_cluster(base_config.cfn_stack)
         template_url = None
         if is_hit:
             try:
-                _upload_hit_resources(
-                    cfn_params["ResourcesS3Bucket"], target_config, target_config.to_storage().json_params
-                )
+                _upload_hit_resources(s3_bucket_name, target_config, target_config.to_storage().json_params)
             except Exception:
-                utils.error(
-                    "Failed when uploading resources to cluster S3 bucket {0}".format(cfn_params["ResourcesS3Bucket"])
-                )
+                utils.error("Failed when uploading resources to cluster S3 bucket {0}".format(s3_bucket_name))
             template_url = _evaluate_pcluster_template_url(target_config)
+
+        _upload_dashboard_resource(s3_bucket_name, target_config, target_config.to_storage().cfn_params)
 
         _update_cluster(
             args, cfn_client, cfn_params, stack_name, use_previous_template=not is_hit, template_url=template_url

--- a/cli/pcluster/cli_commands/update.py
+++ b/cli/pcluster/cli_commands/update.py
@@ -62,10 +62,18 @@ def execute(args):
             try:
                 _upload_hit_resources(s3_bucket_name, target_config, target_config.to_storage().json_params)
             except Exception:
-                utils.error("Failed when uploading resources to cluster S3 bucket {0}".format(s3_bucket_name))
+                utils.error("Failed when uploading hit resources to cluster S3 bucket {0}".format(s3_bucket_name))
             template_url = _evaluate_pcluster_template_url(target_config)
 
-        _upload_dashboard_resource(s3_bucket_name, target_config, target_config.to_storage().cfn_params)
+        try:
+            _upload_dashboard_resource(
+                s3_bucket_name,
+                target_config,
+                target_config.to_storage().json_params,
+                target_config.to_storage().cfn_params,
+            )
+        except Exception:
+            utils.error("Failed when uploading the dashboard resource to cluster S3 bucket {0}".format(s3_bucket_name))
 
         _update_cluster(
             args, cfn_client, cfn_params, stack_name, use_previous_template=not is_hit, template_url=template_url

--- a/cli/pcluster/cli_commands/update.py
+++ b/cli/pcluster/cli_commands/update.py
@@ -62,7 +62,7 @@ def execute(args):
             try:
                 _upload_hit_resources(s3_bucket_name, target_config, target_config.to_storage().json_params)
             except Exception:
-                utils.error("Failed when uploading hit resources to cluster S3 bucket {0}".format(s3_bucket_name))
+                utils.error("Failed when uploading resources to cluster S3 bucket {0}".format(s3_bucket_name))
             template_url = _evaluate_pcluster_template_url(target_config)
 
         try:

--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -119,8 +119,7 @@ def _upload_dashboard_resource(bucket_name, pcluster_config, json_params, cfn_pa
         raise
 
     try:
-        s3_client = boto3.client("s3")
-        s3_client.put_object(
+        boto3.client("s3").put_object(
             Bucket=bucket_name,
             Body=rendered_template,
             Key="templates/cw-dashboard-substack.rendered.cfn.yaml",

--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -61,7 +61,7 @@ def _create_bucket_with_resources(pcluster_config, storage_data):
         if utils.is_hit_enabled_scheduler(scheduler):
             _upload_hit_resources(s3_bucket_name, pcluster_config, storage_data.json_params)
 
-        _upload_dashboard_resource(s3_bucket_name, pcluster_config, storage_data.cfn_params)
+        _upload_dashboard_resource(s3_bucket_name, pcluster_config, storage_data.json_params, storage_data.cfn_params)
     except Exception:
         LOGGER.error("Unable to upload cluster resources to the S3 bucket %s.", s3_bucket_name)
         utils.delete_s3_bucket(s3_bucket_name)
@@ -100,7 +100,8 @@ def _upload_hit_resources(bucket_name, pcluster_config, json_params):
         raise
 
 
-def _upload_dashboard_resource(bucket_name, pcluster_config, cfn_params):
+def _upload_dashboard_resource(bucket_name, pcluster_config, json_params, cfn_params):
+    params = {"json_params": json_params, "cfn_params": cfn_params}
     cw_dashboard_template_url = pcluster_config.get_section("cluster").get_param_value(
         "cw_dashboard_template_url"
     ) or "{bucket_url}/templates/cw-dashboard-substack-{version}.cfn.yaml".format(
@@ -110,7 +111,7 @@ def _upload_dashboard_resource(bucket_name, pcluster_config, cfn_params):
 
     try:
         file_contents = utils.read_remote_file(cw_dashboard_template_url)
-        rendered_template = utils.render_template(file_contents, cfn_params)
+        rendered_template = utils.render_template(file_contents, params)
     except Exception as e:
         LOGGER.error(
             "Error when generating CloudWatch Dashboard template from path %s: %s", cw_dashboard_template_url, e

--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -38,11 +38,9 @@ from pcluster.constants import PCLUSTER_NAME_MAX_LENGTH, PCLUSTER_NAME_REGEX, PC
 LOGGER = logging.getLogger(__name__)
 
 
-def _create_bucket_with_resources(pcluster_config, json_params):
+def _create_bucket_with_resources(pcluster_config, storage_data):
     """Create a bucket associated to the given stack and upload specified resources."""
     scheduler = pcluster_config.get_section("cluster").get_param_value("scheduler")
-    if scheduler not in ["awsbatch", "slurm"]:
-        return None
 
     s3_bucket_name = utils.generate_random_bucket_name("parallelcluster")
     LOGGER.debug("Creating S3 bucket for cluster resources, named %s", s3_bucket_name)
@@ -61,7 +59,9 @@ def _create_bucket_with_resources(pcluster_config, json_params):
             resources = pkg_resources.resource_filename(__name__, resources_dir)
             utils.upload_resources_artifacts(s3_bucket_name, root=resources)
         if utils.is_hit_enabled_scheduler(scheduler):
-            _upload_hit_resources(s3_bucket_name, pcluster_config, json_params)
+            _upload_hit_resources(s3_bucket_name, pcluster_config, storage_data.json_params)
+
+        _upload_dashboard_resource(s3_bucket_name, pcluster_config, storage_data.cfn_params)
     except Exception:
         LOGGER.error("Unable to upload cluster resources to the S3 bucket %s.", s3_bucket_name)
         utils.delete_s3_bucket(s3_bucket_name)
@@ -98,6 +98,34 @@ def _upload_hit_resources(bucket_name, pcluster_config, json_params):
     except Exception as e:
         LOGGER.error("Error when uploading CloudFormation template to bucket %s: %s", bucket_name, e)
         raise
+
+
+def _upload_dashboard_resource(bucket_name, pcluster_config, cfn_params):
+    cw_dashboard_template_url = pcluster_config.get_section("cluster").get_param_value(
+        "cw_dashboard_template_url"
+    ) or "{bucket_url}/templates/cw-dashboard-substack-{version}.cfn.yaml".format(
+        bucket_url=utils.get_bucket_url(pcluster_config.region),
+        version=utils.get_installed_version(),
+    )
+
+    try:
+        file_contents = utils.read_remote_file(cw_dashboard_template_url)
+        rendered_template = utils.render_template(file_contents, cfn_params)
+    except Exception as e:
+        LOGGER.error(
+            "Error when generating CloudWatch Dashboard template from path %s: %s", cw_dashboard_template_url, e
+        )
+        raise
+
+    try:
+        s3_client = boto3.client("s3")
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Body=rendered_template,
+            Key="templates/cw-dashboard-substack.rendered.cfn.yaml",
+        )
+    except Exception as e:
+        LOGGER.error("Error when uploading CloudWatch Dashboard template to bucket %s: %s", bucket_name, e)
 
 
 def version():
@@ -148,7 +176,7 @@ def create(args):  # noqa: C901 FIXME!!!
         cfn_client = boto3.client("cloudformation")
         stack_name = utils.get_stack_name(args.cluster_name)
 
-        bucket_name = _create_bucket_with_resources(pcluster_config, storage_data.json_params)
+        bucket_name = _create_bucket_with_resources(pcluster_config, storage_data)
         if bucket_name:
             cfn_params["ResourcesS3Bucket"] = bucket_name
 

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -574,6 +574,19 @@ CW_LOG = {
     ])
 }
 
+DASHBOARD = {
+    "type": JsonSection,
+    "key": "dashboard",
+    "default_label": "default",
+    "params": OrderedDict([
+        ("enable", {
+            "type": BooleanJsonParam,
+            "default": True,
+            "update_policy": UpdatePolicy.SUPPORTED,
+        }),
+    ])
+}
+
 COMPUTE_RESOURCE = {
     "type": JsonSection,
     "key": "compute_resource",
@@ -885,6 +898,11 @@ CLUSTER_COMMON_PARAMS = [
         "type": SettingsCfnParam,
         "referred_section": CW_LOG,
         "update_policy": UpdatePolicy.UNSUPPORTED,
+    }),
+    ("dashboard_settings", {
+        "type": SettingsCfnParam,
+        "referred_section": DASHBOARD,
+        "update_policy": UpdatePolicy.SUPPORTED,
     }),
     # Moved from the "Access and Networking" section because its configuration is
     # dependent on multiple other parameters from within this section.

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -900,7 +900,7 @@ CLUSTER_COMMON_PARAMS = [
         "update_policy": UpdatePolicy.UNSUPPORTED,
     }),
     ("dashboard_settings", {
-        "type": SettingsCfnParam,
+        "type": SettingsJsonParam,
         "referred_section": DASHBOARD,
         "update_policy": UpdatePolicy.SUPPORTED,
     }),

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -905,6 +905,11 @@ CLUSTER_COMMON_PARAMS = [
         "validators": [url_validator],
         "update_policy": UpdatePolicy.IGNORED
     }),
+    ("cw_dashboard_template_url", {
+        # TODO add regex
+        "validators": [url_validator],
+        "update_policy": UpdatePolicy.IGNORED
+    }),
 ]
 
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -1082,9 +1082,9 @@ def read_remote_file(url):
         raise e
 
 
-def render_template(template_str, params_dict, config_version):
+def render_template(template_str, params_dict, config_version=None):
     """
-    Render a Jinjia template and return the rendered output.
+    Render a Jinja template and return the rendered output.
 
     :param template_str: Template file contents as a string
     :param params_dict: Template parameters dict

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -90,6 +90,7 @@ DEFAULT_CLUSTER_SIT_DICT = {
     "key_name": None,
     "template_url": None,
     "hit_template_url": None,
+    "cw_dashboard_template_url": None,
     "base_os": None,  # base_os does not have a default, but this is here to make testing easier
     "scheduler": None,  # The cluster does not have a default, but this is here to make testing easier
     "shared_dir": "/shared",
@@ -144,6 +145,7 @@ DEFAULT_CLUSTER_HIT_DICT = {
     "key_name": None,
     "template_url": None,
     "hit_template_url": None,
+    "cw_dashboard_template_url": None,
     "base_os": None,  # base_os does not have a default, but this is here to make testing easier
     "scheduler": None,  # The cluster does not have a default, but this is here to make testing easier
     "shared_dir": "/shared",

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -137,6 +137,7 @@ DEFAULT_CLUSTER_SIT_DICT = {
     "fsx_settings": None,
     "dcv_settings": None,
     "cw_log_settings": None,
+    "dashboard_settings": None,
     "cluster_config_metadata": {"sections": {}},
     "architecture": "x86_64",
 }
@@ -180,6 +181,7 @@ DEFAULT_CLUSTER_HIT_DICT = {
     "fsx_settings": None,
     "dcv_settings": None,
     "cw_log_settings": None,
+    "dashboard_settings": None,
     "queue_settings": None,
     "default_queue": None,
     "cluster_config_metadata": {"sections": {}},
@@ -187,6 +189,8 @@ DEFAULT_CLUSTER_HIT_DICT = {
 }
 
 DEFAULT_CW_LOG_DICT = {"enable": True, "retention_days": 14}
+
+DEFAULT_DASHBOARD_DICT = {"enable": True}
 
 DEFAULT_PCLUSTER_DICT = {"cluster": DEFAULT_CLUSTER_SIT_DICT}
 
@@ -207,6 +211,7 @@ class DefaultDict(Enum):
     fsx = DEFAULT_FSX_DICT
     dcv = DEFAULT_DCV_DICT
     cw_log = DEFAULT_CW_LOG_DICT
+    dashboard = DEFAULT_DASHBOARD_DICT
     pcluster = DEFAULT_PCLUSTER_DICT
 
 

--- a/cli/tests/pcluster/config/test_json_param_types.py
+++ b/cli/tests/pcluster/config/test_json_param_types.py
@@ -165,6 +165,10 @@ def test_config_from_json(mocker, boto3_stubber, test_datadir, pcluster_config_r
     pcluster_config.add_section(cluster_section)
     pcluster_config.refresh()
 
+    dashboard_section = pcluster_config.get_section("dashboard", "dashboard1")
+    assert_that(dashboard_section).is_not_none()
+    assert_that(dashboard_section.get_param_value("enable")).is_equal_to(False)
+
     for queue in queues:
         assert_that(pcluster_config.get_section("queue", queue)).is_not_none()
         _check_queue_section_from_json(

--- a/cli/tests/pcluster/config/test_json_param_types/s3_config.json
+++ b/cli/tests/pcluster/config/test_json_param_types/s3_config.json
@@ -164,6 +164,10 @@
     "scaling": {
       "label": "default",
       "scaledown_idletime": 10
+    },
+    "dashboard": {
+      "label": "dashboard1",
+      "enable": false
     }
   }
 }

--- a/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
@@ -7,6 +7,10 @@ enable_efa = compute
 disable_cluster_dns = true
 # disable_hyperthreading not defined, fallback to False expected
 # disable_hyperthreading = false
+dashboard_settings = dashboard1
+
+[dashboard dashboard1]
+enable = false
 
 [queue queue1]
 compute_resource_settings = q1-i1,q1-i2,q1-i3,q1-i4,q1-i5

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -501,6 +501,8 @@ def test_hit_cluster_section_from_file(mocker, config_parser_dict, expected_dict
         ("efs_settings", "test1", None, "Section .* not found in the config file"),
         ("raid_settings", "test1", None, "Section .* not found in the config file"),
         ("fsx_settings", "test1", None, "Section .* not found in the config file"),
+        ("cw_log_settings", "test1", None, "Section .* not found in the config file"),
+        ("dashboard_settings", "test1", None, "Section .* not found in the config file"),
     ],
 )
 def test_sit_cluster_param_from_file(
@@ -704,6 +706,8 @@ def test_sit_cluster_param_from_file(
         ("efs_settings", "test1", None, "Section .* not found in the config file"),
         ("raid_settings", "test1", None, "Section .* not found in the config file"),
         ("fsx_settings", "test1", None, "Section .* not found in the config file"),
+        ("cw_log_settings", "test1", None, "Section .* not found in the config file"),
+        ("dashboard_settings", "test1", None, "Section .* not found in the config file"),
     ],
 )
 def test_hit_cluster_param_from_file(

--- a/cli/tests/pcluster/config/test_section_dashboard.py
+++ b/cli/tests/pcluster/config/test_section_dashboard.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+import tests.pcluster.config.utils as utils
+from pcluster.config.mappings import DASHBOARD
+
+
+@pytest.mark.parametrize(
+    "config_parser_dict, expected_dict_params, expected_message",
+    [
+        # default
+        ({"dashboard default": {}}, {}, None),
+        # right value
+        ({"dashboard default": {"enable": "True"}}, {}, None),
+        ({"dashboard default": {"enable": "False"}}, {"enable": False}, None),
+        # invalid value
+        ({"dashboard default": {"enable": "not_a_bool"}}, None, "'enable' must be of 'bool' type"),
+        # invalid key
+        ({"dashboard default": {"invalid_key": "fake_value"}}, None, "'invalid_key' is not allowed in the .* section"),
+        (
+            {"dashboard default": {"invalid_key": "fake_value", "invalid_key2": "fake_value"}},
+            None,
+            "'invalid_key.*,invalid_key.*' are not allowed in the .* section",
+        ),
+    ],
+)
+def test_dashboard_section_from_file(mocker, config_parser_dict, expected_dict_params, expected_message):
+    """Verify that dashboard behaves as expected when parsed in a config file."""
+    utils.assert_section_from_file(mocker, DASHBOARD, config_parser_dict, expected_dict_params, expected_message)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_config_parser_dict, expected_message",
+    [
+        # default values are not written back to config files
+        ({}, {"dashboard default": {}}, "No section.*"),
+        ({"enable": True}, {"dashboard default": {"enable": True}}, "No section: 'dashboard default'"),
+        # Non-default values are written back to config files
+        ({"enable": False}, {"dashboard default": {"enable": "false"}}, None),
+    ],
+)
+def test_dashboard_settings_section_to_file(mocker, section_dict, expected_config_parser_dict, expected_message):
+    """Verify that the dashboard_settings section is as expected when writing back to a file."""
+    utils.assert_section_to_file(mocker, DASHBOARD, section_dict, expected_config_parser_dict, expected_message)
+
+
+@pytest.mark.parametrize(
+    "param_key, param_value, expected_value, expected_message",
+    [
+        # Enable parameter
+        ("enable", None, True, None),
+        ("enable", "true", True, None),
+        ("enable", "false", False, None),
+        ("enable", "not_a_bool", None, "'enable' must be of 'bool' type"),
+        ("enable", "", None, "'enable' must be of 'bool' type"),
+    ],
+)
+def test_dashboard_settings_param_from_file(mocker, param_key, param_value, expected_value, expected_message):
+    """Verify that the cw_log_settings config file section results in the correct CFN parameters."""
+    utils.assert_param_from_file(mocker, DASHBOARD, param_key, param_value, expected_value, expected_message)

--- a/cli/tests/pcluster/test_commands.py
+++ b/cli/tests/pcluster/test_commands.py
@@ -65,7 +65,9 @@ def test_create_bucket_with_resources_success(
     )
     if expect_upload_hit_resources:
         upload_hit_resources_mock.assert_called_with(bucket_name, pcluster_config_mock, storage_data.json_params)
-    upload_dashboard_resource.assert_called_with(bucket_name, pcluster_config_mock, storage_data.cfn_params)
+    upload_dashboard_resource.assert_called_with(
+        bucket_name, pcluster_config_mock, storage_data.json_params, storage_data.cfn_params
+    )
     assert_that(bucket_name).is_equal_to(expected_bucket_name)
 
 

--- a/cli/tests/pcluster/test_commands.py
+++ b/cli/tests/pcluster/test_commands.py
@@ -52,11 +52,12 @@ def test_create_bucket_with_resources_success(
     upload_resources_artifacts_mock = mocker.patch("pcluster.utils.upload_resources_artifacts")
     delete_s3_bucket_mock = mocker.patch("pcluster.utils.delete_s3_bucket")
     upload_hit_resources_mock = mocker.patch("pcluster.commands._upload_hit_resources")
+    upload_dashboard_resource = mocker.patch("pcluster.commands._upload_dashboard_resource")
     pcluster_config_mock = _mock_pcluster_config(mocker, scheduler, region)
 
     storage_data = pcluster_config_mock.to_storage()
 
-    bucket_name = _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params)
+    bucket_name = _create_bucket_with_resources(pcluster_config_mock, storage_data)
 
     delete_s3_bucket_mock.assert_not_called()
     upload_resources_artifacts_mock.assert_has_calls(
@@ -64,6 +65,7 @@ def test_create_bucket_with_resources_success(
     )
     if expect_upload_hit_resources:
         upload_hit_resources_mock.assert_called_with(bucket_name, pcluster_config_mock, storage_data.json_params)
+    upload_dashboard_resource.assert_called_with(bucket_name, pcluster_config_mock, storage_data.cfn_params)
     assert_that(bucket_name).is_equal_to(expected_bucket_name)
 
 
@@ -83,7 +85,7 @@ def test_create_bucket_with_resources_creation_failure(mocker, caplog):
     storage_data = pcluster_config_mock.to_storage()
 
     with pytest.raises(ClientError, match=error):
-        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params)
+        _create_bucket_with_resources(pcluster_config_mock, storage_data)
     delete_s3_bucket_mock.assert_not_called()
     assert_that(caplog.text).contains("Unable to create S3 bucket")
 
@@ -104,7 +106,7 @@ def test_create_bucket_with_resources_upload_failure(mocker, caplog):
     storage_data = pcluster_config_mock.to_storage()
 
     with pytest.raises(ClientError, match=error):
-        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params)
+        _create_bucket_with_resources(pcluster_config_mock, storage_data)
     # if resource upload fails we delete the bucket
     delete_s3_bucket_mock.assert_called_with(bucket_name)
     assert_that(caplog.text).contains("Unable to upload cluster resources to the S3 bucket")
@@ -128,7 +130,7 @@ def test_create_bucket_with_resources_deletion_failure(mocker, caplog):
 
     # force upload failure to trigger a bucket deletion and then check the behaviour when the deletion fails
     with pytest.raises(ClientError, match=error):
-        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params)
+        _create_bucket_with_resources(pcluster_config_mock, storage_data)
     delete_s3_bucket_mock.assert_called_with(bucket_name)
     assert_that(caplog.text).contains("Unable to upload cluster resources to the S3 bucket")
 

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -212,7 +212,7 @@ changedir =
 deps = cfn-lint
 commands =
     cfn-lint --info *.cfn.json --ignore-templates fsx-substack.cfn.json
-    cfn-lint --info *.cfn.yaml --ignore-templates compute-fleet-hit-substack.cfn.yaml
+    cfn-lint --info *.cfn.yaml --ignore-templates compute-fleet-hit-substack.cfn.yaml cw-dashboard-substack.cfn.yaml
     # W2001 Parameter ComputeSecurityGroupIngress not used. Required https://github.com/aws/aws-parallelcluster/pull/1198
     cfn-lint --info fsx-substack.cfn.json -i W2001
     cfn-lint --info networking/*.cfn.json

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -3909,6 +3909,26 @@
           "PclusterStackName": {
             "Ref": "AWS::StackName"
           },
+          "CWLogGroupName": {
+            "Fn::Sub": [
+              "/aws/parallelcluster/${cluster_name}",
+              {
+                "cluster_name": {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Fn::Split": [
+                        "parallelcluster-",
+                        {
+                          "Ref": "AWS::StackName"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          },
           "MasterInstanceId": {
             "Fn::GetAtt": [
               "MasterServerSubstack",

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -3901,6 +3901,80 @@
         }
       },
       "Condition": "CreateHITSubstack"
+    },
+    "CloudWatchDashboardSubstack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "Parameters": {
+          "PclusterStackName": {
+            "Ref": "AWS::StackName"
+          },
+          "MasterInstanceId": {
+            "Fn::GetAtt": [
+              "MasterServerSubstack",
+              "Outputs.MasterInstanceID"
+            ]
+          },
+          "EBSVolumesIds": {
+            "Fn::GetAtt": [
+              "EBSCfnStack",
+              "Outputs.Volumeids"
+            ]
+          },
+          "RAIDVolumesIds": {
+            "Fn::If": [
+              "CreateRAIDSubstack",
+              {
+                "Fn::GetAtt": [
+                  "RAIDSubstack",
+                  "Outputs.Volumeids"
+                ]
+              },
+              "NONE"
+            ]
+          },
+          "EFSFileSystemId": {
+            "Fn::If": [
+              "CreateEFSSubstack",
+              {
+                "Fn::GetAtt": [
+                  "EFSSubstack",
+                  "Outputs.FileSystemId"
+                ]
+              },
+              "NONE"
+            ]
+          },
+          "FSXFileSystemId": {
+            "Fn::If": [
+              "CreateFSXSubstack",
+              {
+                "Fn::GetAtt": [
+                  "FSXSubstack",
+                  "Outputs.FileSystemId"
+                ]
+              },
+              "NONE"
+            ]
+          }
+        },
+        "TemplateURL": {
+          "Fn::Sub": [
+            "https://${ResourcesS3Bucket}.s3.${AWS::Region}.${s3_url}/templates/cw-dashboard-substack.rendered.cfn.yaml",
+            {
+              "s3_url": {
+                "Fn::FindInMap": [
+                  "Partition2Url",
+                  {
+                    "Ref": "AWS::Partition"
+                  },
+                  "url"
+                ]
+              }
+            }
+          ]
+        }
+      }
     }
   },
   "Outputs": {

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -3935,6 +3935,12 @@
               "Outputs.MasterInstanceID"
             ]
           },
+          "MasterPrivateIP": {
+            "Fn::GetAtt": [
+              "MasterServerSubstack",
+              "Outputs.MasterPrivateIP"
+            ]
+          },
           "EBSVolumesIds": {
             "Fn::GetAtt": [
               "EBSCfnStack",

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -32,7 +32,7 @@
   {%- if empty_section.update({'bool': True}) %} {%- endif %}
   {%- for log_params in section_widgets.widgets %}
     {%- for cond_dict in log_params.cond_list %}
-      {%- if cond_dict.attr in cond_dict.attr_list %}
+      {%- if cond_dict.attr in cond_dict.attr_values %}
         {%- if empty_section.update({'bool': False}) %} {% endif %}
       {%- endif %}
     {%- endfor %}
@@ -47,10 +47,13 @@ Parameters:
   CWLogGroupName:
     Description: Name of the CloudWatch Log Group created
     Type: String
-  {#- EC2 parameters #}
+  {#- Head Node parameters #}
   MasterInstanceId:
     Description: ID of the Master instance
     Type: AWS::EC2::Instance::Id
+  MasterPrivateIP:
+    Description: Private IP of the Master instance
+    Type: String
   {#- EBS parameters #}
   EBSVolumesIds:
     Description: IDs of the EBS volumes used
@@ -287,60 +290,60 @@ Resources:
                   [{
                    'title': "jobwatcher",
                    'cond_list': [
-                   {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_list': ["sge","torque"]}
+                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_values': ["sge","torque"]}
                    ],
                    'fields': ["@timestamp", "@message"],
                    'filters':
-                     [{'attr': "@logStream", 'pattern': "jobwatcher"}],
+                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*jobwatcher"}],
                    'sort': "@timestamp desc",
                    'limit': 100
                  },
                  {
                    'title': "sqswatcher",
                    'cond_list': [
-                   {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_list': ["sge","torque"]}
+                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_values': ["sge","torque"]}
                    ],
                    'fields': ["@timestamp", "@message"],
                    'filters':
-                     [{'attr': "@logStream", 'pattern': "sqswatcher"}],
+                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sqswatcher"}],
                    'sort': "@timestamp desc",
                    'limit': 100
                  },
                  {
                    'title': "clustermgtd",
                    'cond_list': [
-                   {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
                    ],
                    'fields': ["@timestamp", "@message"],
                    'filters':
-                     [{'attr': "@logStream", 'pattern': "clustermgtd"}],
+                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*clustermgtd"}],
                    'sort': "@timestamp desc",
                    'limit': 100
                  },
                  {
                    'title': "slurm_resume",
                    'cond_list': [
-                   {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
                    ],
                    'fields': ["@timestamp", "@message"],
                    'filters':
-                     [{'attr': "@logStream", 'pattern': "slurm_resume"}],
+                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_resume"}],
                    'sort': "@timestamp desc",
                    'limit': 100
                  },
                  {
                    'title': "slurm_suspend",
                    'cond_list': [
-                   {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
                    ],
                    'fields': ["@timestamp", "@message"],
                    'filters':
-                     [{'attr': "@logStream", 'pattern': "slurm_suspend"}],
+                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_suspend"}],
                    'sort': "@timestamp desc",
                    'limit': 100
                  }
@@ -351,36 +354,36 @@ Resources:
                {
                  'title': "slurmctld",
                  'cond_list': [
-                 {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': config.Scheduler, 'attr_values': ["slurm"]}
                  ],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "slurmctld"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurmctld"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "sge-qmaster",
                  'cond_list': [
-                 {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': config.Scheduler, 'attr_list': ["sge"]}
+                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': config.Scheduler, 'attr_values': ["sge"]}
                  ],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "sge-qmaster"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sge-qmaster"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "torque-server",
                  'cond_list': [
-                 {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': config.Scheduler, 'attr_list': ["torque"]}
+                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': config.Scheduler, 'attr_values': ["torque"]}
                  ],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "torque-server"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*torque-server"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                }]
@@ -389,64 +392,64 @@ Resources:
                'widgets': [
                {
                  'title': "dcv-ext-authenticator",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "dcv-ext-authenticator"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-ext-authenticator"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "dcv-authenticator",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "dcv-authenticator"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-authenticator"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "dcv-agent",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "dcv-agent"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-agent"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "dcv-xsession",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "dcv-xsession"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-xsession"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "dcv-server",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "dcv-server"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-server"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "dcv-session-launcher",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "dcv-session-launcher"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-session-launcher"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "Xdcv",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "Xdcv"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*Xdcv"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                }]
@@ -455,55 +458,55 @@ Resources:
                'widgets': [
                {
                  'title': "system-messages",
-                 'cond_list': {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7"]},
+                 'cond_list': {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7"]},
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "system-messages"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*system-messages"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "syslog",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_list': ["ubuntu1604","ubuntu1804"]}],
+                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["ubuntu1604","ubuntu1804"]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "syslog"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*syslog"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "cfn-init",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "cfn-init"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cfn-init"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "chef-client",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "chef-client"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*chef-client"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "cloud-init",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "cloud-init$"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cloud-init$"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                },
                {
                  'title': "supervisord",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
-                   [{'attr': "@logStream", 'pattern': "supervisord"}],
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*supervisord"}],
                  'sort': "@timestamp desc",
                  'limit': 100
                }]
@@ -520,7 +523,7 @@ Resources:
               {%- for log_params in section_widgets.widgets %}
                 {%- set passed_cond = {'bool': True} %}
                 {%- for cond_dict in log_params.cond_list %}
-                  {%- if cond_dict.attr not in cond_dict.attr_list %}
+                  {%- if cond_dict.attr not in cond_dict.attr_values %}
                     {%- if passed_cond.update({'bool': False}) %} {% endif %}
                   {%- endif %}
                 {%- endfor %}
@@ -530,7 +533,7 @@ Resources:
           - !Sub '"query":"SOURCE ''${CWLogGroupName}'''
           - '| fields {{ log_params.fields|join(', ') }}'
                   {%- for filter in log_params.filters %}
-          - '| filter {{ filter.attr }} like /{{ filter.pattern }}/'
+          - !Sub '| filter {{ filter.attr }} like /{{ filter.pattern }}/'
                   {%- endfor %}
           - '| sort {{ log_params.sort }}'
           - '| limit {{ log_params.limit }}"}}'

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -15,12 +15,22 @@
   {%- if coord.update({'x': 0, 'y': coord.y+dy}) %} {%- endif %}
 {%- endmacro %}
 
+{#- Macro to reset coordinates #}
+{%- macro reset_coord() %}
+  {%- if coord.update({'x': 0, 'y': 0}) %} {%- endif %}
+{%- endmacro %}
+
 {%- set graph_width = 6 %}
 {%- set graph_height = 6 -%}
+{%- set logs_width = 24 %}
+{%- set logs_height = 6 -%}
 Parameters:
   {#- Cluster parameters #}
   PclusterStackName:
     Description: Name of the cluster to which this dashboard belongs
+    Type: String
+  CWLogGroupName:
+    Description: Name of the CloudWatch Log Group created
     Type: String
   {#- EC2 parameters #}
   MasterInstanceId:
@@ -241,5 +251,256 @@ Resources:
               {{- update_coord(graph_width, graph_height) }}
             {%- endfor %}
           {%- endif %}
+          - ']}'
+  LogsDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Join
+        - '-'
+        - - !Ref 'PclusterStackName'
+          - Logs
+      DashboardBody: !Join
+        {%- set dcv_enabled = (config.DCVOptions.split(',')[0]=='master') %}
+        - ''
+        - - '{"widgets":['
+          {{- reset_coord() }}
+          {%- set logs_params =
+            [
+              {
+                'title': "system-messages",
+                'cond_list': {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7"]},
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "system-messages"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "syslog",
+                'cond_list': [{'attr': config.BaseOS, 'attr_list': ["ubuntu1604","ubuntu1804"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "syslog"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "cfn-init",
+                'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "cfn-init"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "chef-client",
+                'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "chef-client"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "cloud-init",
+                'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "cloud-init$"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "supervisord",
+                'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "supervisord"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "jobwatcher",
+                'cond_list': [
+                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                  {'attr': config.Scheduler, 'attr_list': ["sge","torque"]}
+                ],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "jobwatcher"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "sqswatcher",
+                'cond_list': [
+                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                  {'attr': config.Scheduler, 'attr_list': ["sge","torque"]}
+                ],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "sqswatcher"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "clustermgtd",
+                'cond_list': [
+                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                  {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                ],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "clustermgtd"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "slurm_resume",
+                'cond_list': [
+                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                  {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                ],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "slurm_resume"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "slurm_suspend",
+                'cond_list': [
+                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                  {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                ],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "slurm_suspend"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "slurmctld",
+                'cond_list': [
+                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                  {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                ],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "slurmctld"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "sge-qmaster",
+                'cond_list': [
+                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                  {'attr': config.Scheduler, 'attr_list': ["sge"]}
+                ],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "sge-qmaster"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "torque-server",
+                'cond_list': [
+                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                  {'attr': config.Scheduler, 'attr_list': ["torque"]}
+                ],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "torque-server"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "dcv-authenticator",
+                'cond_list' : [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "dcv-authenticator"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "dcv-ext-authenticator",
+                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "dcv-ext-authenticator"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "dcv-server",
+                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "dcv-server"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "dcv-session-launcher",
+                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "dcv-session-launcher"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "dcv-agent",
+                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "dcv-agent"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "dcv-xsession",
+                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "dcv-xsession"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              },
+              {
+                'title': "Xdcv",
+                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                'fields': ["@timestamp", "@message"],
+                'filters':
+                  [{'attr': "@logStream", 'pattern': "Xdcv"}],
+                'sort': "@timestamp desc",
+                'limit': 100
+              }
+            ]
+          -%}
+          {%- set first_metric = {'bool': True} %}{#- #FIXME should be useless if we include header sections, or should be modified #}
+          {%- for log_params in logs_params %}
+            {%- set passed_cond = {'bool': True} %}
+            {%- for cond_dict in log_params.cond_list %}
+              {%- if cond_dict.attr not in cond_dict.attr_list %}
+                {%- if passed_cond.update({'bool': False}) %} {% endif %}
+              {%- endif %}
+            {%- endfor %}
+            {%- if passed_cond.bool %}
+          - '{% if first_metric.bool %}{{ first_metric.update({'bool': False}) or "" }}{% else %},{% endif %}{"type":"log","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ logs_width }},"height":{{ logs_height }},"properties":{"view":"table","stacked":false,'
+          - !Sub '"region":"${AWS::Region}","title":"{{ log_params.title }}",'
+          - !Sub '"query":"SOURCE ''${CWLogGroupName}'''
+          - '| fields {{ log_params.fields|join(', ') }}'
+              {%- for filter in log_params.filters %}
+          - '| filter {{ filter.attr }} like /{{ filter.pattern }}/'
+              {%- endfor %}
+          - '| sort {{ log_params.sort }}'
+          - '| limit {{ log_params.limit }}"}}'
+              {{- update_coord(logs_width, logs_height) }}
+            {%- endif %}
+          {%- endfor %}
           - ']}'
 

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -264,243 +264,262 @@ Resources:
         - ''
         - - '{"widgets":['
           {{- reset_coord() }}
-          {%- set logs_params =
+          {%- set sections_widgets =
             [
               {
-                'title': "system-messages",
-                'cond_list': {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7"]},
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "system-messages"}],
-                'sort': "@timestamp desc",
-                'limit': 100
+                'section_title': "ParallelCluster''s logs",
+                'widgets':
+                  [{
+                   'title': "jobwatcher",
+                   'cond_list': [
+                   {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_list': ["sge","torque"]}
+                   ],
+                   'fields': ["@timestamp", "@message"],
+                   'filters':
+                     [{'attr': "@logStream", 'pattern': "jobwatcher"}],
+                   'sort': "@timestamp desc",
+                   'limit': 100
+                 },
+                 {
+                   'title': "sqswatcher",
+                   'cond_list': [
+                   {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_list': ["sge","torque"]}
+                   ],
+                   'fields': ["@timestamp", "@message"],
+                   'filters':
+                     [{'attr': "@logStream", 'pattern': "sqswatcher"}],
+                   'sort': "@timestamp desc",
+                   'limit': 100
+                 },
+                 {
+                   'title': "clustermgtd",
+                   'cond_list': [
+                   {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                   ],
+                   'fields': ["@timestamp", "@message"],
+                   'filters':
+                     [{'attr': "@logStream", 'pattern': "clustermgtd"}],
+                   'sort': "@timestamp desc",
+                   'limit': 100
+                 },
+                 {
+                   'title': "slurm_resume",
+                   'cond_list': [
+                   {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                   ],
+                   'fields': ["@timestamp", "@message"],
+                   'filters':
+                     [{'attr': "@logStream", 'pattern': "slurm_resume"}],
+                   'sort': "@timestamp desc",
+                   'limit': 100
+                 },
+                 {
+                   'title': "slurm_suspend",
+                   'cond_list': [
+                   {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                   ],
+                   'fields': ["@timestamp", "@message"],
+                   'filters':
+                     [{'attr': "@logStream", 'pattern': "slurm_suspend"}],
+                   'sort': "@timestamp desc",
+                   'limit': 100
+                 }
+               ]
               },
-              {
-                'title': "syslog",
-                'cond_list': [{'attr': config.BaseOS, 'attr_list': ["ubuntu1604","ubuntu1804"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "syslog"}],
-                'sort': "@timestamp desc",
-                'limit': 100
+              {'section_title': "Scheduler''s logs",
+               'widgets': [
+               {
+                 'title': "slurmctld",
+                 'cond_list': [
+                 {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': config.Scheduler, 'attr_list': ["slurm"]}
+                 ],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "slurmctld"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "sge-qmaster",
+                 'cond_list': [
+                 {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': config.Scheduler, 'attr_list': ["sge"]}
+                 ],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "sge-qmaster"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "torque-server",
+                 'cond_list': [
+                 {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': config.Scheduler, 'attr_list': ["torque"]}
+                 ],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "torque-server"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               }]
               },
-              {
-                'title': "cfn-init",
-                'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "cfn-init"}],
-                'sort': "@timestamp desc",
-                'limit': 100
+              {'section_title': "NICE DCV integration logs",
+               'widgets': [
+               {
+                 'title': "dcv-ext-authenticator",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "dcv-ext-authenticator"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "dcv-authenticator",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "dcv-authenticator"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "dcv-agent",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "dcv-agent"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "dcv-xsession",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "dcv-xsession"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "dcv-server",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "dcv-server"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "dcv-session-launcher",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "dcv-session-launcher"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "Xdcv",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "Xdcv"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               }]
               },
-              {
-                'title': "chef-client",
-                'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "chef-client"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "cloud-init",
-                'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "cloud-init$"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "supervisord",
-                'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "supervisord"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "jobwatcher",
-                'cond_list': [
-                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                  {'attr': config.Scheduler, 'attr_list': ["sge","torque"]}
-                ],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "jobwatcher"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "sqswatcher",
-                'cond_list': [
-                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                  {'attr': config.Scheduler, 'attr_list': ["sge","torque"]}
-                ],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "sqswatcher"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "clustermgtd",
-                'cond_list': [
-                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                  {'attr': config.Scheduler, 'attr_list': ["slurm"]}
-                ],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "clustermgtd"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "slurm_resume",
-                'cond_list': [
-                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                  {'attr': config.Scheduler, 'attr_list': ["slurm"]}
-                ],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "slurm_resume"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "slurm_suspend",
-                'cond_list': [
-                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                  {'attr': config.Scheduler, 'attr_list': ["slurm"]}
-                ],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "slurm_suspend"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "slurmctld",
-                'cond_list': [
-                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                  {'attr': config.Scheduler, 'attr_list': ["slurm"]}
-                ],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "slurmctld"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "sge-qmaster",
-                'cond_list': [
-                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                  {'attr': config.Scheduler, 'attr_list': ["sge"]}
-                ],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "sge-qmaster"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "torque-server",
-                'cond_list': [
-                  {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                  {'attr': config.Scheduler, 'attr_list': ["torque"]}
-                ],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "torque-server"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "dcv-authenticator",
-                'cond_list' : [{'attr': dcv_enabled, 'attr_list': ["True"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "dcv-authenticator"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "dcv-ext-authenticator",
-                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "dcv-ext-authenticator"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "dcv-server",
-                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "dcv-server"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "dcv-session-launcher",
-                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "dcv-session-launcher"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "dcv-agent",
-                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "dcv-agent"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "dcv-xsession",
-                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "dcv-xsession"}],
-                'sort': "@timestamp desc",
-                'limit': 100
-              },
-              {
-                'title': "Xdcv",
-                'cond_list': [{'attr': dcv_enabled, 'attr_list': ["True"]}],
-                'fields': ["@timestamp", "@message"],
-                'filters':
-                  [{'attr': "@logStream", 'pattern': "Xdcv"}],
-                'sort': "@timestamp desc",
-                'limit': 100
+              {'section_title': "System''s logs",
+               'widgets': [
+               {
+                 'title': "system-messages",
+                 'cond_list': {'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7"]},
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "system-messages"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "syslog",
+                 'cond_list': [{'attr': config.BaseOS, 'attr_list': ["ubuntu1604","ubuntu1804"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "syslog"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "cfn-init",
+                 'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "cfn-init"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "chef-client",
+                 'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "chef-client"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "cloud-init",
+                 'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "cloud-init$"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "supervisord",
+                 'cond_list': [{'attr': config.BaseOS, 'attr_list': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "supervisord"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               }]
               }
             ]
           -%}
           {%- set first_metric = {'bool': True} %}{#- #FIXME should be useless if we include header sections, or should be modified #}
-          {%- for log_params in logs_params %}
-            {%- set passed_cond = {'bool': True} %}
-            {%- for cond_dict in log_params.cond_list %}
-              {%- if cond_dict.attr not in cond_dict.attr_list %}
-                {%- if passed_cond.update({'bool': False}) %} {% endif %}
-              {%- endif %}
-            {%- endfor %}
-            {%- if passed_cond.bool %}
-          - '{% if first_metric.bool %}{{ first_metric.update({'bool': False}) or "" }}{% else %},{% endif %}{"type":"log","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ logs_width }},"height":{{ logs_height }},"properties":{"view":"table","stacked":false,'
+          {%- for section_widgets in sections_widgets %}
+          - '{% if first_metric.bool %}{{ first_metric.update({'bool': False}) or "" }}{% else %},{% endif %}{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            {{ section_widgets.section_title }}\n"}}'
+            {{- update_coord_after_section(1) }}
+            {%- for log_params in section_widgets.widgets %}
+              {%- set passed_cond = {'bool': True} %}
+              {%- for cond_dict in log_params.cond_list %}
+                {%- if cond_dict.attr not in cond_dict.attr_list %}
+                  {%- if passed_cond.update({'bool': False}) %} {% endif %}
+                {%- endif %}
+              {%- endfor %}
+              {%- if passed_cond.bool %}
+          - ',{"type":"log","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ logs_width }},"height":{{ logs_height }},"properties":{"view":"table","stacked":false,'
           - !Sub '"region":"${AWS::Region}","title":"{{ log_params.title }}",'
           - !Sub '"query":"SOURCE ''${CWLogGroupName}'''
           - '| fields {{ log_params.fields|join(', ') }}'
-              {%- for filter in log_params.filters %}
+                {%- for filter in log_params.filters %}
           - '| filter {{ filter.attr }} like /{{ filter.pattern }}/'
-              {%- endfor %}
+                {%- endfor %}
           - '| sort {{ log_params.sort }}'
           - '| limit {{ log_params.limit }}"}}'
-              {{- update_coord(logs_width, logs_height) }}
-            {%- endif %}
+                {{- update_coord(logs_width, logs_height) }}
+              {%- endif %}
+            {%- endfor %}
           {%- endfor %}
           - ']}'
 

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -1,0 +1,245 @@
+{#- Automatically updated variable to define graph/header section position #}
+{%- set coord = {'x': 0, 'y': 0} %}
+
+{#- Macro to calculate coordinates for the new graph #}
+{#- It updates both x and y values if the graph doesn't fit in the given line #}
+{%- macro update_coord(dx, dy) %}
+  {%- if coord.update({'x': (coord.x+dx)}) %} {%- endif %}
+  {%- if coord.x+dx > 24 %} {#- the longest width allowed is 24 #}
+    {%- if coord.update({'x': 0, 'y': coord.y+dy}) %} {%- endif %}
+  {%- endif %}
+{%- endmacro %}
+
+{#- Macro to calculate section header coordinates #}
+{%- macro update_coord_after_section(dy) %}
+  {%- if coord.update({'x': 0, 'y': coord.y+dy}) %} {%- endif %}
+{%- endmacro %}
+
+{%- set graph_width = 6 %}
+{%- set graph_height = 6 -%}
+Parameters:
+  {#- Cluster parameters #}
+  PclusterStackName:
+    Description: Name of the cluster to which this dashboard belongs
+    Type: String
+  {#- EC2 parameters #}
+  MasterInstanceId:
+    Description: ID of the Master instance
+    Type: AWS::EC2::Instance::Id
+  {#- EBS parameters #}
+  EBSVolumesIds:
+    Description: IDs of the EBS volumes used
+    Type: CommaDelimitedList
+  {#- RAID parameters #}
+  RAIDVolumesIds:
+    Description: Volume IDs of the resulted RAID EBS volumes
+    Type: CommaDelimitedList
+  {#- EFS parameters #}
+  EFSFileSystemId:
+    Description: ID of the EFS volume used
+    Type: String
+  {#- FSx parameters #}
+  FSXFileSystemId:
+    Description: ID of the FSx volume used
+    Type: String
+Resources:
+  HeadNodeDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Join
+        - '-'
+        - - !Ref 'PclusterStackName'
+          - HeadNode
+      DashboardBody: !Join
+        - ''
+        - - '{"widgets":['
+          {#- Head Node Instance Metrics #}
+          - '{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            Head Node Instance Metrics\n"}}'
+          {%- set ec2_metrics = [{'metrics': ["CPUUtilization"], 'extra_params': ['"title":"CPU Utilization"']},
+                                 {'metrics': ["NetworkPacketsIn", "NetworkPacketsOut"], 'extra_params': ['"title":"Network Packets In/Out"']},
+                                 {'metrics': ["NetworkIn", "NetworkOut"], 'extra_params': ['"title":"Network In and Out"']},
+                                 {'metrics': ["DiskReadBytes", "DiskWriteBytes"], 'extra_params': ['"title":"Disk Read/Write Bytes"']},
+                                 {'metrics': ["DiskReadOps", "DiskWriteOps"], 'extra_params': ['"title":"Disk Read/Write Ops"']}]
+          %}
+          {{- update_coord_after_section(1) }}
+          {%- for metrics_param in ec2_metrics %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metrics_param.extra_params|join(',') }}{% if metrics_param.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+            {%- for metric in metrics_param.metrics %}
+          - !Sub '{{ '[' if loop.first else ',' }}["AWS/EC2","{{ metric }}","InstanceId","${MasterInstanceId}"]{{ ']}}' if loop.last else '' }}'
+            {%- endfor -%}
+            {{- update_coord(graph_width, graph_height) }}
+          {%- endfor -%}
+          {{- update_coord_after_section(graph_height) }}
+
+          {#- EBS metrics graphs #}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            EBS Metrics\n"}}'
+          {{- update_coord_after_section(1) }}
+
+          {#- Unconditional EBS metrics #}
+          {%- set ebs_metrics = [{'metrics': ["VolumeReadOps", "VolumeWriteOps"], 'extra_params': ['"title":"Read/Write Ops"']},
+                                 {'metrics': ["VolumeReadBytes", "VolumeWriteBytes"], 'extra_params': ['"title":"Read/Write Bytes"']},
+                                 {'metrics': ["VolumeTotalReadTime", "VolumeTotalWriteTime"], 'extra_params': ['"title":"Total Read/Write Time"']},
+                                 {'metrics': ["VolumeQueueLength"], 'extra_params': ['"title":"Queue Length"']},
+                                 {'metrics': ["VolumeIdleTime"], 'extra_params': ['"title":"Idle Time"']}]
+          -%}
+          {%- set number_of_ebs_volumes = config.NumberOfEBSVol|int -%}
+          {%- set ebs_volume_types = config.VolumeType.split(',') %}
+
+          {%- for metrics_param in ebs_metrics %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metrics_param.extra_params|join(',') }}{% if metrics_param.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+            {%- for i in range(number_of_ebs_volumes) %}
+              {%- set volume_loop = loop %}
+              {%- for metric in metrics_param.metrics %}
+          - !Sub
+            - '{% if volume_loop.first and loop.first %}[{% else %},{% endif %}["AWS/EBS","{{ metric }}","VolumeId","${EBS_Volume{{ i|int +1 }}}"]{% if volume_loop.last and loop.last %}]}}{% endif %}'
+            - EBS_Volume{{ i|int +1 }}: !Select
+                - '{{ i|int }}'
+                - !Ref 'EBSVolumesIds'
+              {%- endfor %}
+            {%- endfor %}
+          {{- update_coord(graph_width, graph_height) -}}
+          {%- endfor %}
+
+          {#- Conditional EBS metrics #}
+          {%- set ebs_metrics_conditions = [{'metric': 'VolumeConsumedReadWriteOps', 'supported_vol_types': ["io1"], 'extra_params': ['"title":"Consumed Read/Write Ops"']},
+                                            {'metric': 'VolumeThroughputPercentage', 'supported_vol_types': ["io1"], 'extra_params': ['"title":"Throughput Percentage"']},
+                                            {'metric': 'BurstBalance', 'supported_vol_types': ["gp2", "st1", "sc1"], 'extra_params': ['"title":"Burst Balance"']}]
+          %}
+          {%- for metric_condition_params in ebs_metrics_conditions %}
+            {%- set is_supported_vol_present = {'bool': False} %}
+            {%- for i in range(number_of_ebs_volumes) if not is_supported_vol_present.bool %}
+              {%- if ebs_volume_types[i] in metric_condition_params.supported_vol_types %} {#- TODO we should break, needs Loop Controls extension #}
+                {%- if is_supported_vol_present.update({'bool': True}) %} {% endif %}
+              {%- endif %}
+            {%- endfor %}
+            {%- if is_supported_vol_present.bool %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metric_condition_params.extra_params|join(',') }}{% if metric_condition_params.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+              {%- set first_metric = {'bool': True} %}
+              {%- for i in range(number_of_ebs_volumes) %}
+                {%- if ebs_volume_types[i] in metric_condition_params.supported_vol_types %}
+          - !Sub
+            - '{% if first_metric.bool %}{{ first_metric.update({'bool': False}) or "" }}[{% else %},{% endif %}["AWS/EBS","{{ metric_condition_params.metric }}","VolumeId","${EBS_Volume{{ i|int +1 }}}"]'
+            - EBS_Volume{{ i|int +1 }}: !Select
+                - '{{ i|int }}'
+                - !Ref 'EBSVolumesIds'
+                {%- endif %}
+              {%- endfor -%}
+              {{- update_coord(graph_width, graph_height) }}
+          - ']}}'
+            {%- endif %} {#- if is_supported_vol_present.bool #}
+          {%- endfor -%}
+          {{ update_coord_after_section(graph_height) }}
+
+          {#- RAID metrics graphs #}
+          {#- Unconditional RAID metrics #}
+          {%- set number_of_raid_volumes = config.RAIDOptions.split(',')[2]|int -%} {#- if NONE, converts to 0! #}
+          {%- if number_of_raid_volumes > 0 %}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            RAID Metrics\n"}}'
+              {{- update_coord_after_section(1) }}
+              {%- set raid_metrics = [{'metrics': ["VolumeReadOps", "VolumeWriteOps"], 'extra_params': ['"title":"Read/Write Ops"']},
+                                     {'metrics': ["VolumeReadBytes", "VolumeWriteBytes"], 'extra_params': ['"title":"Read/Write Bytes"']},
+                                     {'metrics': ["VolumeTotalReadTime", "VolumeTotalWriteTime"], 'extra_params': ['"title":"Total Read/Write Time"']},
+                                     {'metrics': ["VolumeQueueLength"], 'extra_params': ['"title":"Queue Length"']},
+                                     {'metrics': ["VolumeIdleTime"], 'extra_params': ['"title":"Idle Time"']}]
+              %}
+              {%- set raid_volume_type = config.RAIDOptions.split(',')[3] %}
+
+              {%- for metrics_param in raid_metrics %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metrics_param.extra_params|join(',') }}{% if metrics_param.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+                {%- for i in range(number_of_raid_volumes) %}
+                  {%- set volume_loop = loop %}
+                  {%- for metric in metrics_param.metrics %}
+          - !Sub
+            - '{% if volume_loop.first and loop.first %}[{% else %},{% endif %}["AWS/EBS","{{ metric }}","VolumeId","${RAID_Volume{{ i|int +1 }}}"]{% if volume_loop.last and loop.last %}]}}{% endif %}'
+            - RAID_Volume{{ i|int +1 }}: !Select
+                - '{{ i|int }}'
+                - !Ref 'RAIDVolumesIds'
+                  {%- endfor %}
+                {%- endfor %}
+                {{- update_coord(graph_width, graph_height) -}}
+              {%- endfor %}
+
+              {#- Conditional RAID metrics #}
+              {%- set raid_metrics_conditions_params = [{'metric': 'VolumeConsumedReadWriteOps', 'supported_vol_types': ["io1"], 'extra_params': ['"title":"Consumed Read/Write Ops"']},
+                                                {'metric': 'VolumeThroughputPercentage', 'supported_vol_types': ["io1"], 'extra_params': ['"title":"Throughput Percentage"']},
+                                                {'metric': 'BurstBalance', 'supported_vol_types': ["gp2", "st1", "sc1"], 'extra_params': ['"title":"Burst Balance"']}]
+              %}
+              {%- for metric_condition_params in raid_metrics_conditions_params %}
+                {%- if raid_volume_type in metric_condition_params.supported_vol_types %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metric_condition_params.extra_params|join(',') }}{% if metric_condition_params.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+                  {%- for i in range(number_of_raid_volumes) %}
+          - !Sub
+            - '{{ '[' if loop.first else ',' }}["AWS/EBS","{{ metric_condition_params.metric }}","VolumeId","${RAID_Volume{{ i|int +1 }}}"]{{ ']}}' if loop.last else '' }}'
+            - RAID_Volume{{ i|int +1 }}: !Select
+                - '{{ i|int }}'
+                - !Ref 'RAIDVolumesIds'
+                  {%- endfor %}
+                  {{- update_coord(graph_width, graph_height) -}}
+                {%- endif %} {#- if raid_volume_type in metric_condition_params.supported_vol_types #}
+              {%- endfor -%}
+          {%- endif %} {#- if number_of_raid_volumes > 0 #}
+          {%- set efs_shared_dir = config.EFSOptions.split(',')[0] %}
+          {%- if efs_shared_dir not in ["NONE", "/NONE"] %}
+          {# EFS metrics graphs -#}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            EFS Metrics\n"}}'
+            {%- set efs_metrics = [{'metrics': ["BurstCreditBalance"], 'extra_params': ['"title":"Burst Credit Balance"']},
+                                   {'metrics': ["ClientConnections"], 'extra_params': ['"title":"Client Connections"']},
+                                   {'metrics': ["TotalIOBytes"], 'extra_params': ['"title":"Total IO Bytes"']},
+                                   {'metrics': ["PermittedThroughput"], 'extra_params': ['"title":"Permitted Throughput"']},
+                                   {'metrics': ["DataReadIOBytes", "DataWriteIOBytes"], 'extra_params': ['"title":"Data Read/Write IO Bytes"']}]
+            -%}
+            {{ update_coord_after_section(1) }}
+            {%- for metrics_param in efs_metrics %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metrics_param.extra_params|join(',') }}{% if metrics_param.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+              {%- for metric in metrics_param.metrics %}
+          - !Sub '{% if not loop.first %},{% else %}[{% endif %}["AWS/EFS","{{ metric }}","FileSystemId","${EFSFileSystemId}"]{{ ']}}' if loop.last else '' }}'
+              {%- endfor -%}
+              {{ update_coord(graph_width, graph_height) }}
+            {%- endfor %}
+
+            {#- Conditional EFS metrics #}
+            {%- set efs_metrics_conditions_params = [{'metric': 'PercentIOLimit', 'supported_vol_types': ["generalPurpose"], 'extra_params': ['"title":"Percent IO Limit"']}] %}
+            {%- set efs_volume_type = config.EFSOptions.split(',')[2] %}
+            {%- for metric_condition_params in efs_metrics_conditions_params %}
+              {%- if efs_volume_type in metric_condition_params.supported_vol_types %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metric_condition_params.extra_params|join(',') }}{% if metric_condition_params.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+          - !Sub '[["AWS/EFS","{{ metric_condition_params.metric }}","FileSystemId","${EFSFileSystemId}"]]}}'
+              {%- endif %}
+            {%- endfor -%}
+            {{ update_coord(graph_width, graph_height) }}
+
+          {%- endif -%} {#- if efs_shared_dir not in ["NONE", "/NONE"] -#}
+          {{ update_coord_after_section(graph_height) }}
+
+          {%- set fsx_shared_dir = config.FSXOptions.split(',')[0] %}
+          {%- if fsx_shared_dir not in ["NONE", "/NONE"] %}
+          {#- FSx metrics graphs #}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            FSx Metrics\n"}}'
+            {%- set fsx_metrics = [{'metrics': ["DataReadOperations","DataWriteOperations"], 'extra_params': ['"title":"Data Read/Write Ops"','"period":300']},
+                                   {'metrics': ["DataReadBytes","DataWriteBytes"], 'extra_params': ['"title":"Data Read/Write Bytes"','"period":300']},
+                                   {'metrics': ["FreeDataStorageCapacity"], 'extra_params': ['"title":"Free Data Storage Capacity"']}]
+            -%}
+            {{ update_coord_after_section(1) }}
+            {%- for metrics_param in fsx_metrics %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metrics_param.extra_params|join(',') }}{% if metrics_param.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+              {%- for metric in metrics_param.metrics %}
+          - !Sub '{{ '[' if loop.first else ',' }}["AWS/FSx","{{ metric }}","FileSystemId","${FSXFileSystemId}"]{{ ']}}' if loop.last else '' }}'
+              {%- endfor -%}
+              {{- update_coord(graph_width, graph_height) }}
+            {%- endfor %}
+          {%- endif %}
+          - ']}'
+

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -1,6 +1,13 @@
 {#- Automatically updated variable to define graph/header section position #}
 {%- set coord = {'x': 0, 'y': 0} %}
 
+{%- set graph_width = 6 %}
+{%- set graph_height = 6 -%}
+{%- set logs_width = 24 %}
+{%- set logs_height = 6 -%}
+
+{%- set empty_section = {'bool': True} %}
+
 {#- Macro to calculate coordinates for the new graph #}
 {#- It updates both x and y values if the graph doesn't fit in the given line #}
 {%- macro update_coord(dx, dy) %}
@@ -20,10 +27,18 @@
   {%- if coord.update({'x': 0, 'y': 0}) %} {%- endif %}
 {%- endmacro %}
 
-{%- set graph_width = 6 %}
-{%- set graph_height = 6 -%}
-{%- set logs_width = 24 %}
-{%- set logs_height = 6 -%}
+{#- Macro to check if a section will not be empty #}
+{%- macro is_logs_section_empty(section_widgets) %}
+  {%- if empty_section.update({'bool': True}) %} {%- endif %}
+  {%- for log_params in section_widgets.widgets %}
+    {%- for cond_dict in log_params.cond_list %}
+      {%- if cond_dict.attr in cond_dict.attr_list %}
+        {%- if empty_section.update({'bool': False}) %} {% endif %}
+      {%- endif %}
+    {%- endfor %}
+  {%- endfor %}
+{%- endmacro -%}
+
 Parameters:
   {#- Cluster parameters #}
   PclusterStackName:
@@ -495,31 +510,34 @@ Resources:
               }
             ]
           -%}
-          {%- set first_metric = {'bool': True} %}{#- #FIXME should be useless if we include header sections, or should be modified #}
+          {%- set first_metric = {'bool': True} %}
           {%- for section_widgets in sections_widgets %}
+            {{- is_logs_section_empty(section_widgets) }}
+            {%- if not empty_section.bool %}
           - '{% if first_metric.bool %}{{ first_metric.update({'bool': False}) or "" }}{% else %},{% endif %}{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
             {{ section_widgets.section_title }}\n"}}'
             {{- update_coord_after_section(1) }}
-            {%- for log_params in section_widgets.widgets %}
-              {%- set passed_cond = {'bool': True} %}
-              {%- for cond_dict in log_params.cond_list %}
-                {%- if cond_dict.attr not in cond_dict.attr_list %}
-                  {%- if passed_cond.update({'bool': False}) %} {% endif %}
-                {%- endif %}
-              {%- endfor %}
-              {%- if passed_cond.bool %}
+              {%- for log_params in section_widgets.widgets %}
+                {%- set passed_cond = {'bool': True} %}
+                {%- for cond_dict in log_params.cond_list %}
+                  {%- if cond_dict.attr not in cond_dict.attr_list %}
+                    {%- if passed_cond.update({'bool': False}) %} {% endif %}
+                  {%- endif %}
+                {%- endfor %}
+                {%- if passed_cond.bool %}
           - ',{"type":"log","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ logs_width }},"height":{{ logs_height }},"properties":{"view":"table","stacked":false,'
           - !Sub '"region":"${AWS::Region}","title":"{{ log_params.title }}",'
           - !Sub '"query":"SOURCE ''${CWLogGroupName}'''
           - '| fields {{ log_params.fields|join(', ') }}'
-                {%- for filter in log_params.filters %}
+                  {%- for filter in log_params.filters %}
           - '| filter {{ filter.attr }} like /{{ filter.pattern }}/'
-                {%- endfor %}
+                  {%- endfor %}
           - '| sort {{ log_params.sort }}'
           - '| limit {{ log_params.limit }}"}}'
-                {{- update_coord(logs_width, logs_height) }}
-              {%- endif %}
-            {%- endfor %}
+                  {{- update_coord(logs_width, logs_height) }}
+                {%- endif %}
+              {%- endfor %}
+            {%- endif %}
           {%- endfor %}
           - ']}'
 

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -2,7 +2,7 @@
 {%- set cfn_params = config.cfn_params %}
 {%- set json_params = config.json_params %}
 
-{#- Automatically updated variable to define graph/header section position #}
+{#- Variable to define graph/header section position, updated with macros #}
 {%- set coord = {'x': 0, 'y': 0} %}
 
 {%- set graph_width = 6 %}
@@ -31,12 +31,12 @@
   {%- if coord.update({'x': 0, 'y': 0}) %} {%- endif %}
 {%- endmacro %}
 
-{#- Macro to check if a section will not be empty #}
+{#- Macro to check if a section will be empty #}
 {%- macro is_logs_section_empty(section_widgets) %}
   {%- if empty_section.update({'bool': True}) %} {%- endif %}
   {%- for log_params in section_widgets.widgets %}
-    {%- for cond_dict in log_params.cond_list %}
-      {%- if cond_dict.attr in cond_dict.attr_values %}
+    {%- for cond_dict in log_params.conditions %}
+      {%- if cond_dict.param in cond_dict.allowed_values %}
         {%- if empty_section.update({'bool': False}) %} {% endif %}
       {%- endif %}
     {%- endfor %}
@@ -75,6 +75,7 @@ Parameters:
     Description: ID of the FSx volume used
     Type: String
 Conditions:
+  {#- Enable or disable the creation of the dashboard. Default: Enable #}
   CreateDashboard: !Equals
     - 'true'
     - {% if not json_params.cluster.dashboard or json_params.cluster.dashboard.enable %}'true'{% else %}'false'{% endif %}
@@ -86,7 +87,8 @@ Resources:
       DashboardBody: !Join
         - ''
         - - '{"widgets":['
-          {#- Head Node EC2 metrics #}
+          {# Head Node EC2 metrics -#}
+
           - '{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
             Head Node EC2 Metrics\n"}}'
           {{- update_coord_after_section(1) }}
@@ -224,10 +226,10 @@ Resources:
                 {%- endif %} {#- if raid_volume_type in metric_condition_params.supported_vol_types #}
               {%- endfor -%}
           {%- endif %} {#- if number_of_raid_volumes > 0 #}
-          {%- set efs_shared_dir = cfn_params.EFSOptions.split(',')[0] %}
-          {%- if efs_shared_dir not in ["NONE", "/NONE"] %}
 
           {#- EFS metrics graphs #}
+          {%- set efs_shared_dir = cfn_params.EFSOptions.split(',')[0] %}
+          {%- if efs_shared_dir not in ["NONE", "/NONE"] %}
           - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             EFS Metrics\n"}}'
 
@@ -263,10 +265,9 @@ Resources:
           {%- endif -%} {#- if efs_shared_dir not in ["NONE", "/NONE"] -#}
           {{ update_coord_after_section(graph_height) }}
 
+          {#- FSx metrics graphs #}
           {%- set fsx_shared_dir = cfn_params.FSXOptions.split(',')[0] %}
           {%- if fsx_shared_dir not in ["NONE", "/NONE"] %}
-
-          {#- FSx metrics graphs #}
           - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             FSx Metrics\n"}}'
             {%- set fsx_metrics = [{'metrics': ["DataReadOperations","DataWriteOperations"], 'extra_params': ['"title":"Data Read/Write Ops"','"period":300']},
@@ -297,57 +298,57 @@ Resources:
                 'widgets': [
                   {
                     'title': "jobwatcher",
-                    'cond_list': [
-                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'attr': cfn_params.Scheduler, 'attr_values': ["sge","torque"]}
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["sge","torque"]}
                     ],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*jobwatcher"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*jobwatcher"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "sqswatcher",
-                    'cond_list': [
-                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'attr': cfn_params.Scheduler, 'attr_values': ["sge","torque"]}
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["sge","torque"]}
                     ],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sqswatcher"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*sqswatcher"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "clustermgtd",
-                    'cond_list': [
-                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
                     ],
                     'fields': ["@timestamp", "@message"],
                     'filters':
-                      [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*clustermgtd"}],
+                      [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*clustermgtd"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "slurm_resume",
-                    'cond_list': [
-                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
                     ],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_resume"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_resume"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "slurm_suspend",
-                    'cond_list': [
-                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
                     ],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_suspend"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_suspend"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   }
@@ -358,34 +359,34 @@ Resources:
                 'widgets': [
                   {
                     'title': "slurmctld",
-                    'cond_list': [
-                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
                     ],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurmctld"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*slurmctld"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "sge-qmaster",
-                    'cond_list': [
-                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'attr': cfn_params.Scheduler, 'attr_values': ["sge"]}
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["sge"]}
                     ],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sge-qmaster"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*sge-qmaster"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "torque-server",
-                    'cond_list': [
-                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'attr': cfn_params.Scheduler, 'attr_values': ["torque"]}
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["torque"]}
                     ],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*torque-server"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*torque-server"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   }
@@ -396,57 +397,57 @@ Resources:
                 'widgets': [
                   {
                     'title': "dcv-ext-authenticator",
-                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-ext-authenticator"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-ext-authenticator"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "dcv-authenticator",
-                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-authenticator"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-authenticator"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "dcv-agent",
-                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-agent"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-agent"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "dcv-xsession",
-                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-xsession"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-xsession"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "dcv-server",
-                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-server"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-server"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "dcv-session-launcher",
-                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-session-launcher"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-session-launcher"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "Xdcv",
-                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*Xdcv"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*Xdcv"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   }
@@ -457,49 +458,49 @@ Resources:
                 'widgets': [
                   {
                     'title': "system-messages",
-                    'cond_list': {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7"]},
+                    'conditions': {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7"]},
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*system-messages"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*system-messages"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "syslog",
-                    'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["ubuntu1604","ubuntu1804"]}],
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["ubuntu1604","ubuntu1804"]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*syslog"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*syslog"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "cfn-init",
-                    'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cfn-init"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*cfn-init"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "chef-client",
-                    'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*chef-client"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*chef-client"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "cloud-init",
-                    'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cloud-init$"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*cloud-init$"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   },
                   {
                     'title': "supervisord",
-                    'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                     'fields': ["@timestamp", "@message"],
-                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*supervisord"}],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*supervisord"}],
                     'sort': "@timestamp desc",
                     'limit': 100
                   }
@@ -514,19 +515,19 @@ Resources:
             {{ section_widgets.section_title }}\n"}}'
             {{- update_coord_after_section(1) }}
               {%- for log_params in section_widgets.widgets %}
-                {%- set passed_cond = {'bool': True} %}
-                {%- for cond_dict in log_params.cond_list %}
-                  {%- if cond_dict.attr not in cond_dict.attr_values %}
-                    {%- if passed_cond.update({'bool': False}) %} {% endif %}
+                {%- set passed_condition = {'bool': True} %}
+                {%- for cond_dict in log_params.conditions %}
+                  {%- if cond_dict.param not in cond_dict.allowed_values %}
+                    {%- if passed_condition.update({'bool': False}) %} {% endif %}
                   {%- endif %}
                 {%- endfor %}
-                {%- if passed_cond.bool %}
+                {%- if passed_condition.bool %}
           - ',{"type":"log","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ logs_width }},"height":{{ logs_height }},"properties":{"view":"table","stacked":false,'
           - !Sub '"region":"${AWS::Region}","title":"{{ log_params.title }}",'
           - !Sub '"query":"SOURCE ''${CWLogGroupName}'''
           - '| fields {{ log_params.fields|join(', ') }}'
                   {%- for filter in log_params.filters %}
-          - !Sub '| filter {{ filter.attr }} like /{{ filter.pattern }}/'
+          - !Sub '| filter {{ filter.param }} like /{{ filter.pattern }}/'
                   {%- endfor %}
           - '| sort {{ log_params.sort }}'
           - '| limit {{ log_params.limit }}"}}'

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -294,230 +294,216 @@ Resources:
             [
               {
                 'section_title': "ParallelCluster''s logs",
-                'widgets':
-                  [{
-                   'title': "jobwatcher",
-                   'cond_list': [
-                   {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': cfn_params.Scheduler, 'attr_values': ["sge","torque"]}
-                   ],
-                   'fields': ["@timestamp", "@message"],
-                   'filters':
-                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*jobwatcher"}],
-                   'sort': "@timestamp desc",
-                   'limit': 100
-                 },
-                 {
-                   'title': "sqswatcher",
-                   'cond_list': [
-                   {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': cfn_params.Scheduler, 'attr_values': ["sge","torque"]}
-                   ],
-                   'fields': ["@timestamp", "@message"],
-                   'filters':
-                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sqswatcher"}],
-                   'sort': "@timestamp desc",
-                   'limit': 100
-                 },
-                 {
-                   'title': "clustermgtd",
-                   'cond_list': [
-                   {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
-                   ],
-                   'fields': ["@timestamp", "@message"],
-                   'filters':
-                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*clustermgtd"}],
-                   'sort': "@timestamp desc",
-                   'limit': 100
-                 },
-                 {
-                   'title': "slurm_resume",
-                   'cond_list': [
-                   {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
-                   ],
-                   'fields': ["@timestamp", "@message"],
-                   'filters':
-                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_resume"}],
-                   'sort': "@timestamp desc",
-                   'limit': 100
-                 },
-                 {
-                   'title': "slurm_suspend",
-                   'cond_list': [
-                   {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
-                   ],
-                   'fields': ["@timestamp", "@message"],
-                   'filters':
-                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_suspend"}],
-                   'sort': "@timestamp desc",
-                   'limit': 100
-                 }
-               ]
+                'widgets': [
+                  {
+                    'title': "jobwatcher",
+                    'cond_list': [
+                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'attr': cfn_params.Scheduler, 'attr_values': ["sge","torque"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*jobwatcher"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "sqswatcher",
+                    'cond_list': [
+                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'attr': cfn_params.Scheduler, 'attr_values': ["sge","torque"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sqswatcher"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "clustermgtd",
+                    'cond_list': [
+                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters':
+                      [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*clustermgtd"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "slurm_resume",
+                    'cond_list': [
+                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_resume"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "slurm_suspend",
+                    'cond_list': [
+                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_suspend"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  }
+                ]
               },
-              {'section_title': "Scheduler''s logs",
-               'widgets': [
-               {
-                 'title': "slurmctld",
-                 'cond_list': [
-                 {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
-                 ],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurmctld"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "sge-qmaster",
-                 'cond_list': [
-                 {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': cfn_params.Scheduler, 'attr_values': ["sge"]}
-                 ],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sge-qmaster"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "torque-server",
-                 'cond_list': [
-                 {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': cfn_params.Scheduler, 'attr_values': ["torque"]}
-                 ],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*torque-server"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               }]
+              {
+                'section_title': "Scheduler''s logs",
+                'widgets': [
+                  {
+                    'title': "slurmctld",
+                    'cond_list': [
+                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurmctld"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "sge-qmaster",
+                    'cond_list': [
+                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'attr': cfn_params.Scheduler, 'attr_values': ["sge"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sge-qmaster"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "torque-server",
+                    'cond_list': [
+                      {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'attr': cfn_params.Scheduler, 'attr_values': ["torque"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*torque-server"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  }
+                ]
               },
-              {'section_title': "NICE DCV integration logs",
-               'widgets': [
-               {
-                 'title': "dcv-ext-authenticator",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-ext-authenticator"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "dcv-authenticator",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-authenticator"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "dcv-agent",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-agent"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "dcv-xsession",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-xsession"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "dcv-server",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-server"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "dcv-session-launcher",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-session-launcher"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "Xdcv",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*Xdcv"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               }]
+              {
+                'section_title': "NICE DCV integration logs",
+                'widgets': [
+                  {
+                    'title': "dcv-ext-authenticator",
+                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-ext-authenticator"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "dcv-authenticator",
+                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-authenticator"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "dcv-agent",
+                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-agent"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "dcv-xsession",
+                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-xsession"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "dcv-server",
+                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-server"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "dcv-session-launcher",
+                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-session-launcher"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "Xdcv",
+                    'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*Xdcv"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  }
+                ]
               },
-              {'section_title': "System''s logs",
-               'widgets': [
-               {
-                 'title': "system-messages",
-                 'cond_list': {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7"]},
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*system-messages"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "syslog",
-                 'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["ubuntu1604","ubuntu1804"]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*syslog"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "cfn-init",
-                 'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cfn-init"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "chef-client",
-                 'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*chef-client"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "cloud-init",
-                 'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cloud-init$"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "supervisord",
-                 'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*supervisord"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               }]
+              {
+                'section_title': "System''s logs",
+                'widgets': [
+                  {
+                    'title': "system-messages",
+                    'cond_list': {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7"]},
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*system-messages"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "syslog",
+                    'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["ubuntu1604","ubuntu1804"]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*syslog"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "cfn-init",
+                    'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cfn-init"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "chef-client",
+                    'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*chef-client"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "cloud-init",
+                    'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cloud-init$"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "supervisord",
+                    'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*supervisord"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  }
+                ]
               }
             ]
           -%}

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -1,3 +1,7 @@
+{#- Assign the two dictionaries to variables #}
+{%- set cfn_params = config.cfn_params %}
+{%- set json_params = config.json_params %}
+
 {#- Automatically updated variable to define graph/header section position #}
 {%- set coord = {'x': 0, 'y': 0} %}
 
@@ -70,19 +74,24 @@ Parameters:
   FSXFileSystemId:
     Description: ID of the FSx volume used
     Type: String
+Conditions:
+  CreateDashboard: !Equals
+    - 'true'
+    - {% if not json_params.cluster.dashboard or json_params.cluster.dashboard.enable %}'true'{% else %}'false'{% endif %}
 Resources:
   HeadNodeDashboard:
     Type: AWS::CloudWatch::Dashboard
     Properties:
-      DashboardName: !Join
-        - '-'
-        - - !Ref 'PclusterStackName'
-          - HeadNode
+      DashboardName: !Ref 'PclusterStackName'
       DashboardBody: !Join
         - ''
         - - '{"widgets":['
-          {#- Head Node Instance Metrics #}
+          {#- Head Node EC2 metrics #}
           - '{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            Head Node EC2 Metrics\n"}}'
+          {{- update_coord_after_section(1) }}
+          {#- Head Node Instance Metrics #}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             Head Node Instance Metrics\n"}}'
           {%- set ec2_metrics = [{'metrics': ["CPUUtilization"], 'extra_params': ['"title":"CPU Utilization"']},
                                  {'metrics': ["NetworkPacketsIn", "NetworkPacketsOut"], 'extra_params': ['"title":"Network Packets In/Out"']},
@@ -102,7 +111,7 @@ Resources:
           {{- update_coord_after_section(graph_height) }}
 
           {#- EBS metrics graphs #}
-          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             EBS Metrics\n"}}'
           {{- update_coord_after_section(1) }}
 
@@ -113,8 +122,8 @@ Resources:
                                  {'metrics': ["VolumeQueueLength"], 'extra_params': ['"title":"Queue Length"']},
                                  {'metrics': ["VolumeIdleTime"], 'extra_params': ['"title":"Idle Time"']}]
           -%}
-          {%- set number_of_ebs_volumes = config.NumberOfEBSVol|int -%}
-          {%- set ebs_volume_types = config.VolumeType.split(',') %}
+          {%- set number_of_ebs_volumes = cfn_params.NumberOfEBSVol|int -%}
+          {%- set ebs_volume_types = cfn_params.VolumeType.split(',') %}
 
           {%- for metrics_param in ebs_metrics %}
           - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
@@ -165,9 +174,9 @@ Resources:
 
           {#- RAID metrics graphs #}
           {#- Unconditional RAID metrics #}
-          {%- set number_of_raid_volumes = config.RAIDOptions.split(',')[2]|int -%} {#- if NONE, converts to 0! #}
+          {%- set number_of_raid_volumes = cfn_params.RAIDOptions.split(',')[2]|int -%} {#- if NONE, converts to 0! #}
           {%- if number_of_raid_volumes > 0 %}
-          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             RAID Metrics\n"}}'
               {{- update_coord_after_section(1) }}
               {%- set raid_metrics = [{'metrics': ["VolumeReadOps", "VolumeWriteOps"], 'extra_params': ['"title":"Read/Write Ops"']},
@@ -176,7 +185,7 @@ Resources:
                                      {'metrics': ["VolumeQueueLength"], 'extra_params': ['"title":"Queue Length"']},
                                      {'metrics': ["VolumeIdleTime"], 'extra_params': ['"title":"Idle Time"']}]
               %}
-              {%- set raid_volume_type = config.RAIDOptions.split(',')[3] %}
+              {%- set raid_volume_type = cfn_params.RAIDOptions.split(',')[3] %}
 
               {%- for metrics_param in raid_metrics %}
           - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
@@ -214,10 +223,10 @@ Resources:
                 {%- endif %} {#- if raid_volume_type in metric_condition_params.supported_vol_types #}
               {%- endfor -%}
           {%- endif %} {#- if number_of_raid_volumes > 0 #}
-          {%- set efs_shared_dir = config.EFSOptions.split(',')[0] %}
+          {%- set efs_shared_dir = cfn_params.EFSOptions.split(',')[0] %}
           {%- if efs_shared_dir not in ["NONE", "/NONE"] %}
           {# EFS metrics graphs -#}
-          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             EFS Metrics\n"}}'
             {%- set efs_metrics = [{'metrics': ["BurstCreditBalance"], 'extra_params': ['"title":"Burst Credit Balance"']},
                                    {'metrics': ["ClientConnections"], 'extra_params': ['"title":"Client Connections"']},
@@ -237,7 +246,7 @@ Resources:
 
             {#- Conditional EFS metrics #}
             {%- set efs_metrics_conditions_params = [{'metric': 'PercentIOLimit', 'supported_vol_types': ["generalPurpose"], 'extra_params': ['"title":"Percent IO Limit"']}] %}
-            {%- set efs_volume_type = config.EFSOptions.split(',')[2] %}
+            {%- set efs_volume_type = cfn_params.EFSOptions.split(',')[2] %}
             {%- for metric_condition_params in efs_metrics_conditions_params %}
               {%- if efs_volume_type in metric_condition_params.supported_vol_types %}
           - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
@@ -250,10 +259,10 @@ Resources:
           {%- endif -%} {#- if efs_shared_dir not in ["NONE", "/NONE"] -#}
           {{ update_coord_after_section(graph_height) }}
 
-          {%- set fsx_shared_dir = config.FSXOptions.split(',')[0] %}
+          {%- set fsx_shared_dir = cfn_params.FSXOptions.split(',')[0] %}
           {%- if fsx_shared_dir not in ["NONE", "/NONE"] %}
           {#- FSx metrics graphs #}
-          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             FSx Metrics\n"}}'
             {%- set fsx_metrics = [{'metrics': ["DataReadOperations","DataWriteOperations"], 'extra_params': ['"title":"Data Read/Write Ops"','"period":300']},
                                    {'metrics': ["DataReadBytes","DataWriteBytes"], 'extra_params': ['"title":"Data Read/Write Bytes"','"period":300']},
@@ -269,19 +278,13 @@ Resources:
               {{- update_coord(graph_width, graph_height) }}
             {%- endfor %}
           {%- endif %}
-          - ']}'
-  LogsDashboard:
-    Type: AWS::CloudWatch::Dashboard
-    Properties:
-      DashboardName: !Join
-        - '-'
-        - - !Ref 'PclusterStackName'
-          - Logs
-      DashboardBody: !Join
-        {%- set dcv_enabled = (config.DCVOptions.split(',')[0]=='master') %}
-        - ''
-        - - '{"widgets":['
-          {{- reset_coord() }}
+          {{- update_coord_after_section(graph_height) }}
+
+          {#- Head Node Logs #}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            Head Node Logs\n"}}'
+          {{- update_coord_after_section(1) }}
+          {%- set dcv_enabled = (cfn_params.DCVOptions.split(',')[0]=='master') %}
           {%- set sections_widgets =
             [
               {
@@ -290,8 +293,8 @@ Resources:
                   [{
                    'title': "jobwatcher",
                    'cond_list': [
-                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_values': ["sge","torque"]}
+                   {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': cfn_params.Scheduler, 'attr_values': ["sge","torque"]}
                    ],
                    'fields': ["@timestamp", "@message"],
                    'filters':
@@ -302,8 +305,8 @@ Resources:
                  {
                    'title': "sqswatcher",
                    'cond_list': [
-                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_values': ["sge","torque"]}
+                   {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': cfn_params.Scheduler, 'attr_values': ["sge","torque"]}
                    ],
                    'fields': ["@timestamp", "@message"],
                    'filters':
@@ -314,8 +317,8 @@ Resources:
                  {
                    'title': "clustermgtd",
                    'cond_list': [
-                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
+                   {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
                    ],
                    'fields': ["@timestamp", "@message"],
                    'filters':
@@ -326,8 +329,8 @@ Resources:
                  {
                    'title': "slurm_resume",
                    'cond_list': [
-                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
+                   {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
                    ],
                    'fields': ["@timestamp", "@message"],
                    'filters':
@@ -338,8 +341,8 @@ Resources:
                  {
                    'title': "slurm_suspend",
                    'cond_list': [
-                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
+                   {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
                    ],
                    'fields': ["@timestamp", "@message"],
                    'filters':
@@ -354,8 +357,8 @@ Resources:
                {
                  'title': "slurmctld",
                  'cond_list': [
-                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': config.Scheduler, 'attr_values': ["slurm"]}
+                 {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': cfn_params.Scheduler, 'attr_values': ["slurm"]}
                  ],
                  'fields': ["@timestamp", "@message"],
                  'filters':
@@ -366,8 +369,8 @@ Resources:
                {
                  'title': "sge-qmaster",
                  'cond_list': [
-                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': config.Scheduler, 'attr_values': ["sge"]}
+                 {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': cfn_params.Scheduler, 'attr_values': ["sge"]}
                  ],
                  'fields': ["@timestamp", "@message"],
                  'filters':
@@ -378,8 +381,8 @@ Resources:
                {
                  'title': "torque-server",
                  'cond_list': [
-                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': config.Scheduler, 'attr_values': ["torque"]}
+                 {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': cfn_params.Scheduler, 'attr_values': ["torque"]}
                  ],
                  'fields': ["@timestamp", "@message"],
                  'filters':
@@ -458,7 +461,7 @@ Resources:
                'widgets': [
                {
                  'title': "system-messages",
-                 'cond_list': {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7"]},
+                 'cond_list': {'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7"]},
                  'fields': ["@timestamp", "@message"],
                  'filters':
                    [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*system-messages"}],
@@ -467,7 +470,7 @@ Resources:
                },
                {
                  'title': "syslog",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["ubuntu1604","ubuntu1804"]}],
+                 'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["ubuntu1604","ubuntu1804"]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
                    [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*syslog"}],
@@ -476,7 +479,7 @@ Resources:
                },
                {
                  'title': "cfn-init",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
                    [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cfn-init"}],
@@ -485,7 +488,7 @@ Resources:
                },
                {
                  'title': "chef-client",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
                    [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*chef-client"}],
@@ -494,7 +497,7 @@ Resources:
                },
                {
                  'title': "cloud-init",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
                    [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cloud-init$"}],
@@ -503,7 +506,7 @@ Resources:
                },
                {
                  'title': "supervisord",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'cond_list': [{'attr': cfn_params.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                  'fields': ["@timestamp", "@message"],
                  'filters':
                    [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*supervisord"}],
@@ -513,11 +516,10 @@ Resources:
               }
             ]
           -%}
-          {%- set first_metric = {'bool': True} %}
           {%- for section_widgets in sections_widgets %}
             {{- is_logs_section_empty(section_widgets) }}
             {%- if not empty_section.bool %}
-          - '{% if first_metric.bool %}{{ first_metric.update({'bool': False}) or "" }}{% else %},{% endif %}{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             {{ section_widgets.section_title }}\n"}}'
             {{- update_coord_after_section(1) }}
               {%- for log_params in section_widgets.widgets %}
@@ -543,4 +545,5 @@ Resources:
             {%- endif %}
           {%- endfor %}
           - ']}'
+    Condition: CreateDashboard
 

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -173,12 +173,13 @@ Resources:
           {{ update_coord_after_section(graph_height) }}
 
           {#- RAID metrics graphs #}
-          {#- Unconditional RAID metrics #}
           {%- set number_of_raid_volumes = cfn_params.RAIDOptions.split(',')[2]|int -%} {#- if NONE, converts to 0! #}
           {%- if number_of_raid_volumes > 0 %}
           - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             RAID Metrics\n"}}'
               {{- update_coord_after_section(1) }}
+
+              {#- Unconditional RAID metrics #}
               {%- set raid_metrics = [{'metrics': ["VolumeReadOps", "VolumeWriteOps"], 'extra_params': ['"title":"Read/Write Ops"']},
                                      {'metrics': ["VolumeReadBytes", "VolumeWriteBytes"], 'extra_params': ['"title":"Read/Write Bytes"']},
                                      {'metrics': ["VolumeTotalReadTime", "VolumeTotalWriteTime"], 'extra_params': ['"title":"Total Read/Write Time"']},
@@ -225,9 +226,12 @@ Resources:
           {%- endif %} {#- if number_of_raid_volumes > 0 #}
           {%- set efs_shared_dir = cfn_params.EFSOptions.split(',')[0] %}
           {%- if efs_shared_dir not in ["NONE", "/NONE"] %}
-          {# EFS metrics graphs -#}
+
+          {#- EFS metrics graphs #}
           - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             EFS Metrics\n"}}'
+
+            {#- Unconditional EFS metrics #}
             {%- set efs_metrics = [{'metrics': ["BurstCreditBalance"], 'extra_params': ['"title":"Burst Credit Balance"']},
                                    {'metrics': ["ClientConnections"], 'extra_params': ['"title":"Client Connections"']},
                                    {'metrics': ["TotalIOBytes"], 'extra_params': ['"title":"Total IO Bytes"']},
@@ -261,6 +265,7 @@ Resources:
 
           {%- set fsx_shared_dir = cfn_params.FSXOptions.split(',')[0] %}
           {%- if fsx_shared_dir not in ["NONE", "/NONE"] %}
+
           {#- FSx metrics graphs #}
           - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             FSx Metrics\n"}}'

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -621,6 +621,9 @@ Resources:
       ServiceToken: !Ref 'UpdateWaiterFunctionArn'
     Condition: HasUpdateWaiterFunction
 Outputs:
+  MasterInstanceID:
+    Description: ID of the Master instance
+    Value: !Ref 'MasterServer'
   MasterPrivateIP:
     Description: Private IP Address of the Master host
     Value: !GetAtt 'MasterServer.PrivateIp'

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -230,4 +230,6 @@ def test_cw_dashboard_substack_rendering(tmp_path):
         "Cores": "NONE,NONE",
     }
 
-    substack_rendering(tmp_path, "cw-dashboard-substack.cfn.yaml", test_config)  # , ["-i", "W2001"]) # to ignore W2001
+    substack_rendering(tmp_path, "cw-dashboard-substack.cfn.yaml", test_config)  #FIXME , ["-i", "W2001"]) # to ignore W2001
+    #FIXME Might have to use W2001 as if the Logs dashboard is empty, we do not use variable CWLogGroupName
+    # As before, it might not be important as the test does not try to do that (and there is no point in doing that)

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -230,6 +230,8 @@ def test_cw_dashboard_substack_rendering(tmp_path):
         "Cores": "NONE,NONE",
     }
 
-    substack_rendering(tmp_path, "cw-dashboard-substack.cfn.yaml", test_config)  #FIXME , ["-i", "W2001"]) # to ignore W2001
-    #FIXME Might have to use W2001 as if the Logs dashboard is empty, we do not use variable CWLogGroupName
+    substack_rendering(
+        tmp_path, "cw-dashboard-substack.cfn.yaml", test_config
+    )  # FIXME , ["-i", "W2001"]) # to ignore W2001
+    # FIXME Might have to use W2001 as if the Logs dashboard is empty, we do not use variable CWLogGroupName
     # As before, it might not be important as the test does not try to do that (and there is no point in doing that)

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -12,6 +12,24 @@ cfn_formatter = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(cfn_formatter)
 
 
+def substack_rendering(tmp_path, template_name, test_config):
+
+    env = Environment(loader=FileSystemLoader(".."))
+    env.filters["sha1"] = lambda value: hashlib.sha1(value.strip().encode()).hexdigest()
+    template = env.get_template(template_name)
+    output_from_parsed_template = template.render(config=test_config, config_version="version")
+    rendered_file = tmp_path / template_name
+    rendered_file.write_text(output_from_parsed_template)
+
+    # Run cfn-lint
+    cfn_lint_args = ["--info", str(rendered_file)]  # TODO "-i", "W2001" could be added to ignore unused vars
+    with patch.object(sys, "argv", cfn_lint_args):
+        assert cfnlint() == 0
+
+    # Run format check
+    assert cfn_formatter.check_formatting([str(rendered_file)], "yaml")
+
+
 @pytest.mark.parametrize(
     "test_config",
     [
@@ -142,17 +160,74 @@ spec.loader.exec_module(cfn_formatter)
 )
 def test_hit_substack_rendering(tmp_path, test_config):
 
-    env = Environment(loader=FileSystemLoader(".."))
-    env.filters["sha1"] = lambda value: hashlib.sha1(value.strip().encode()).hexdigest()
-    template = env.get_template("compute-fleet-hit-substack.cfn.yaml")
-    output_from_parsed_template = template.render(config=test_config, config_version="version")
-    rendered_file = tmp_path / "compute-fleet-hit-substack.cfn.yaml"
-    rendered_file.write_text(output_from_parsed_template)
+    substack_rendering(tmp_path, "compute-fleet-hit-substack.cfn.yaml", test_config)
 
-    # Run cfn-lint
-    cfn_lint_args = ["--info", str(rendered_file)]
-    with patch.object(sys, "argv", cfn_lint_args):
-        assert cfnlint() == 0
 
-    # Run format check
-    assert cfn_formatter.check_formatting([str(rendered_file)], "yaml")
+def test_cw_dashboard_substack_rendering(tmp_path):
+    test_config = {
+        "ClusterConfigMetadata": {
+            "sections": {
+                "cluster": ["default"],
+                "dcv": ["dcv"],
+                "ebs": ["custom1", "custom2", "custom3", "custom4", "custom5"],
+                "efs": ["customfs"],
+                "fsx": ["fsx1"],
+                "raid": ["raidgp2"],
+                "scaling": ["custom"],
+                "vpc": ["default"],
+            }
+        },
+        "KeyName": "first_cluster",
+        "BaseOS": "alinux2",
+        "Scheduler": "slurm",
+        "MasterInstanceType": "t2.micro",
+        "MasterRootVolumeSize": "25",
+        "ComputeRootVolumeSize": "25",
+        "ProxyServer": "NONE",
+        "EC2IAMRoleName": "NONE",
+        "S3ReadResource": "NONE",
+        "S3ReadWriteResource": "NONE",
+        "EFA": "NONE",
+        "EphemeralDir": "/scratch",
+        "EncryptedEphemeral": "false",
+        "CustomAMI": "ami-07fb283f3083e0d00",
+        "PreInstallScript": "NONE",
+        "PreInstallArgs": "NONE",
+        "PostInstallScript": "NONE",
+        "PostInstallArgs": "NONE",
+        "ExtraJson": "{}",
+        "AdditionalCfnTemplate": "NONE",
+        "CustomChefCookbook": "NONE",
+        "IntelHPCPlatform": "false",
+        "ScaleDownIdleTime": "3",
+        "VPCId": "vpc-034545fa84d175bc0",
+        "MasterSubnetId": "subnet-021ceb759253eeb29",
+        "AccessFrom": "0.0.0.0/0",
+        "AdditionalSG": "NONE",
+        "ComputeSubnetId": "subnet-0e49d198bb500e672",
+        "ComputeSubnetCidr": "NONE",
+        "UsePublicIps": "true",
+        "VPCSecurityGroupId": "NONE",
+        "AvailabilityZone": "eu-west-1a",
+        "SharedDir": "vol1,vol2,vol3,vol4,vol5",
+        "EBSSnapshotId": "NONE,NONE,NONE,NONE,NONE",
+        "VolumeType": "gp2,io1,sc1,st1,io1",
+        "VolumeSize": "20,20,500,500,20",
+        "VolumeIOPS": "100,200,100,100,100",
+        "EBSEncryption": "false,false,false,false,false",
+        "EBSKMSKeyId": "NONE,NONE,NONE,NONE,NONE",
+        "EBSVolumeId": "NONE,NONE,NONE,NONE,NONE",
+        "NumberOfEBSVol": "5",
+        "EFSOptions": "efs,NONE,generalPurpose,NONE,NONE,false,bursting,NONE,Valid",
+        # "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE", # TODO: If we use this, should ignore W2001
+        "RAIDOptions": "raid,1,2,gp2,20,100,false,NONE",
+        "FSXOptions": "/fsx,NONE,1200,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+        "DCVOptions": "master,8443,0.0.0.0/0",
+        "CWLogOptions": "true,14",
+        "EC2IAMPolicies": "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",  # FIXME could be removed, added auto
+        # ,arn:aws:iam::aws:policy/CloudWatchFullAccess", # FIXME has been removed, we should see what is required
+        "Architecture": "x86_64",
+        "Cores": "NONE,NONE",
+    }
+
+    substack_rendering(tmp_path, "cw-dashboard-substack.cfn.yaml", test_config)  # , ["-i", "W2001"]) # to ignore W2001

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -110,6 +110,7 @@ def substack_rendering(tmp_path, template_name, test_config):
                     },
                     "scaling": {"scaledown_idletime": 10},
                     "disable_cluster_dns": False,
+                    "dashboard": {"enable": True},
                 }
             }
         ),
@@ -152,6 +153,7 @@ def substack_rendering(tmp_path, template_name, test_config):
                     },
                     "scaling": {"scaledown_idletime": 10},
                     "disable_cluster_dns": True,
+                    "dashboard": {"enable": True},
                 }
             }
         ),
@@ -164,7 +166,48 @@ def test_hit_substack_rendering(tmp_path, test_config):
 
 
 def test_cw_dashboard_substack_rendering(tmp_path):
-    test_config = {
+    json_params = {
+        "cluster": {
+            "label": "default",
+            "default_queue": "multiple_spot",
+            "queue_settings": {
+                "multiple_spot": {
+                    "compute_type": "spot",
+                    "enable_efa": False,
+                    "disable_hyperthreading": True,
+                    "placement_group": None,
+                    "compute_resource_settings": {
+                        "multiple_spot_c4.xlarge": {
+                            "instance_type": "c4.xlarge",
+                            "min_count": 0,
+                            "max_count": 10,
+                            "spot_price": None,
+                            "vcpus": 2,
+                            "gpus": 0,
+                            "enable_efa": False,
+                            "disable_hyperthreading": True,
+                            "disable_hyperthreading_via_cpu_options": True,
+                        },
+                        "multiple_spot_c5.2xlarge": {
+                            "instance_type": "c5.2xlarge",
+                            "min_count": 1,
+                            "max_count": 5,
+                            "spot_price": 1.5,
+                            "vcpus": 4,
+                            "gpus": 0,
+                            "enable_efa": False,
+                            "disable_hyperthreading": True,
+                            "disable_hyperthreading_via_cpu_options": True,
+                        },
+                    },
+                }
+            },
+            "scaling": {"scaledown_idletime": 10},
+            "disable_cluster_dns": True,
+            "dashboard": {"enable": True},
+        }
+    }
+    cfn_params = {
         "ClusterConfigMetadata": {
             "sections": {
                 "cluster": ["default"],
@@ -231,7 +274,7 @@ def test_cw_dashboard_substack_rendering(tmp_path):
     }
 
     substack_rendering(
-        tmp_path, "cw-dashboard-substack.cfn.yaml", test_config
+        tmp_path, "cw-dashboard-substack.cfn.yaml", {"json_params": json_params, "cfn_params": cfn_params}
     )  # FIXME , ["-i", "W2001"]) # to ignore W2001
     # FIXME Might have to use W2001 as if the Logs dashboard is empty, we do not use variable CWLogGroupName
     # As before, it might not be important as the test does not try to do that (and there is no point in doing that)

--- a/util/uploadTemplate.sh
+++ b/util/uploadTemplate.sh
@@ -107,7 +107,7 @@ main() {
     sed -i "s#.*aws-parallelcluster.*/templates/cw-logs-substack-\${version}.cfn.json.*#\"https://${_s3_folder_url}/cw-logs-substack.cfn.json\",#" ${_temp_dir}/aws-parallelcluster.cfn.json
     sed -i "s#.*aws-parallelcluster.*/templates/compute-fleet-substack-\${version}.cfn.yaml.*#\"https://${_s3_folder_url}/compute-fleet-substack.cfn.yaml\",#" ${_temp_dir}/aws-parallelcluster.cfn.json
     sed -i "s#.*aws-parallelcluster.*/templates/master-server-substack-\${version}.cfn.yaml.*#\"https://${_s3_folder_url}/master-server-substack.cfn.yaml\",#" ${_temp_dir}/aws-parallelcluster.cfn.json
-
+    # sed -i "s#.*aws-parallelcluster.*/templates/cw-dashboard-substack-\${version}.cfn.yaml.*#\"https://${_s3_folder_url}/cw-dashboard-substack.cfn.yaml\",#" ${_temp_dir}/aws-parallelcluster.cfn.json
     # upload templates
     aws ${_profile} --region "${_region}" s3 cp --acl public-read ${_temp_dir}/aws-parallelcluster.cfn.json s3://${_bucket}/${_templates_folder}/ || _error_exit 'Failed to push cloudformation template to S3'
     aws ${_profile} --region "${_region}" s3 cp --acl public-read --recursive --exclude "*" --include "*substack.cfn.json" --include "*substack.cfn.yaml" ${_srcdir}/cloudformation/ s3://${_bucket}/${_templates_folder}/ || _error_exit 'Failed to push substack cfn templates to S3'
@@ -116,6 +116,7 @@ main() {
     echo "Done. Add the following variables to the pcluster config file, under the [cluster ...] section"
     echo "template_url = https://${_s3_folder_url}/aws-parallelcluster.cfn.json"
     echo "hit_template_url = s3://${_bucket}/${_templates_folder}/compute-fleet-hit-substack.cfn.yaml"
+    echo "cw_dashboard_template_url = s3://${_bucket}/${_templates_folder}/cw-dashboard-substack.cfn.yaml"
     echo "custom_awsbatch_template_url = https://${_s3_folder_url}/batch-substack.cfn.json"
 }
 


### PR DESCRIPTION
When creating a cluster, one CloudWatch dashboard will be automatically created based on the config file of the user. A new cluster parameter has been added: `dashboard_settings` and a new section has been added: `dashboard`. The `dashboard` section contains only one parameter for now: `enable`. Its default value is set to true.
The dashboard contains two widget-groups at the moment:
- Head Node EC2 metrics: it contains information about the Head Node: metrics about the EC2 instance, the EBS/RAID volumes and EFS/FSx file systems. The code is flexible: it allows to add extra_parameters to properties of each widget (such as the title, as is already done). The problem with this extension is that some problems might happen when testing: if a sentence in the rendered template is too long, it will break the rendering_template test.
- CloudWatch Head Node Logs dashboard: this dashboard contains the different Head Node logs uploaded by pcluster for monitoring the cluster. The code is also flexible as it is easy to reorder sections/change them. It is even possible to easily add more filters (one might want to filter the messages so that only error messages are displayed; this could be done using `filter @message /error/`. This flexibility does not have any problem compared to the extension for the Head Node EC2 metrics.

Updating a dashboard: it is possible to update the cluster to enable/disable the dashboard.

Testing: one test is checking the jinja template rendering and another one is checking that the _upload_dashboard_resource function is called when calling _create_bucket_with_resources. Manual tests were done with sge, torque and awsbatch but most of the tests were done with slurm using HIT clusters. Updates on the enable parameter were also tested manually.

Signed-off-by: Alexandre Gobeaux <gobeaa@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.