### PR TITLE
Change method to check if job is completed

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -278,7 +278,7 @@ def _gpu_test_scaleup(remote_command_executor, region, asg_name, stack_name, sca
     assert_scaling_worked(slurm_commands, region, stack_name, scaledown_idletime, expected_max=4, expected_final=0)
     # Assert jobs were completed
     for job_id in job_ids:
-        slurm_commands.assert_job_succeeded(job_id)
+        _assert_job_completed(remote_command_executor, job_id)
 
 
 def _test_slurm_version(remote_command_executor):


### PR DESCRIPTION
Differently from `assert_job_succeeded`, the `_assert_job_completed` method will take into account the fact that a completed job may have been be purged from the Slurm job database (according to MinJobAge). This situation may occur when the time window between job completion and cluster scaledown is greater than the MinJobAge (default 5 min).

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
