### PR TITLE
Add DynamoDB table definition for HIT stacks

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1359,8 +1359,12 @@
     "SQS": {
       "Type": "AWS::SQS::Queue",
       "Properties": {
-        "MessageRetentionPeriod": 1209600
-      }
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": {
+          "Ref": "AWS::StackName"
+        }
+      },
+      "Condition": "CreateComputeFleet"
     },
     "FSXSubstack": {
       "Type": "AWS::CloudFormation::Stack",
@@ -1452,7 +1456,8 @@
             "Ref": "SQS"
           }
         ]
-      }
+      },
+      "Condition": "CreateComputeFleet"
     },
     "SNS": {
       "Type": "AWS::SNS::Topic",
@@ -1468,13 +1473,17 @@
             "Protocol": "sqs"
           }
         ]
-      }
+      },
+      "Condition": "CreateComputeFleet"
     },
     "DynamoDBTable": {
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
       "DeletionPolicy": "Delete",
       "Properties": {
+        "TableName": {
+          "Ref": "AWS::StackName"
+        },
         "AttributeDefinitions": [
           {
             "AttributeName": "instanceId",
@@ -1508,7 +1517,8 @@
             }
           ]
         }
-      }
+      },
+      "Condition": "CreateComputeFleet"
     },
     "RootRole": {
       "Type": "AWS::IAM::Role",
@@ -1620,10 +1630,7 @@
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": [
-                    "SQS",
-                    "Arn"
-                  ]
+                  "Fn::Sub": "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${AWS::StackName}"
                 }
               ]
             },
@@ -1668,7 +1675,7 @@
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${DynamoDBTable}"
+                  "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${AWS::StackName}"
                 }
               ]
             },
@@ -2916,13 +2923,10 @@
             "Ref": "MaxSize"
           },
           "DynamoDBTable": {
-            "Ref": "DynamoDBTable"
+            "Ref": "AWS::StackName"
           },
           "SQSQueueName": {
-            "Fn::GetAtt": [
-              "SQS",
-              "QueueName"
-            ]
+            "Ref": "AWS::StackName"
           },
           "DCVEnabled": {
             "Fn::If": [

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -713,14 +713,6 @@
         }
       ]
     },
-    "GovCloudRegion": {
-      "Fn::Equals": [
-        {
-          "Ref": "AWS::Partition"
-        },
-        "aws-us-gov"
-      ]
-    },
     "CreateComputeFleet": {
       "Fn::Not": [
         {
@@ -1496,27 +1488,7 @@
             "KeyType": "HASH"
           }
         ],
-        "BillingMode": {
-          "Fn::If": [
-            "GovCloudRegion",
-            {
-              "Ref": "AWS::NoValue"
-            },
-            "PAY_PER_REQUEST"
-          ]
-        },
-        "ProvisionedThroughput": {
-          "Fn::If": [
-            "GovCloudRegion",
-            {
-              "ReadCapacityUnits": 5,
-              "WriteCapacityUnits": 5
-            },
-            {
-              "Ref": "AWS::NoValue"
-            }
-          ]
-        }
+        "BillingMode": "PAY_PER_REQUEST"
       },
       "Condition": "CreateComputeFleet"
     },

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -393,4 +393,26 @@ Resources:
       Strategy: cluster
   {%- endif %}
 {%- endfor %}
+  DynamoDBTable:
+    Type: AWS::DynamoDB::Table
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Delete
+    Properties:
+      TableName: !Ref 'MainStackName'
+      AttributeDefinitions:
+        - AttributeName: Id
+          AttributeType: S
+        - AttributeName: InstanceId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: Id
+          KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: InstanceId
+          KeySchema:
+            - AttributeName: InstanceId
+              KeyType: HASH
+          Projection:
+            ProjectionType: KEYS_ONLY
+      BillingMode: PAY_PER_REQUEST
 


### PR DESCRIPTION
- Define a DynamoDB table to be used with the new heterogeneous instance types logic. The table defines a GSI on the InstanceId attribute so that the look-up can be performed efficiently on that value.
- As part of this PR the DDB billing mode in GovCloud regions is being set to PAY_PER_REQUEST in order to be aligned to the other partitions. In the past this mode was not available in GovCloud regions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
