### PR TITLE
Remove pytest pin

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -6,10 +6,7 @@ fabric
 jinja2
 junitparser
 pexpect
-# Pinning pytest because latest version 5.4 breaks pytest-rerunfailures
-# https://github.com/pytest-dev/pytest-rerunfailures/issues/103
-# https://github.com/pytest-dev/pytest-rerunfailures/issues/105
-pytest==5.3.5
+pytest
 pytest-datadir
 pytest-html
 pytest-rerunfailures


### PR DESCRIPTION
New version of pytest-xdist (2.0.0) has requirement pytest>=6.0.0

Pytest was pinned to 5.3.5 because of https://github.com/pytest-dev/pytest-rerunfailures/issues/103, that is now fixed.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
