### PR TITLE
Create Route53 hosted zone within the cluster

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1639,7 +1639,7 @@
               "Sid": "DynamoDBTable",
               "Action": [
                 "dynamodb:PutItem",
-                "dynamodb:Query",
+                "dynamodb:BatchWriteItem",
                 "dynamodb:GetItem",
                 "dynamodb:DeleteItem",
                 "dynamodb:DescribeTable"
@@ -1648,6 +1648,51 @@
               "Resource": [
                 {
                   "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${AWS::StackName}"
+                }
+              ]
+            },
+            {
+              "Sid": "DynamoDBTableQuery",
+              "Action": [
+                "dynamodb:Query"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${AWS::StackName}"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${AWS::StackName}/index/*"
+                }
+              ]
+            },
+            {
+              "Fn::If": [
+                "CreateHITSubstack",
+                {
+                  "Sid": "Route53Add",
+                  "Action": [
+                    "route53:ChangeResourceRecordSets"
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:route53:::hostedzone/${ClusterHostedZone}",
+                        {
+                          "ClusterHostedZone": {
+                            "Fn::GetAtt": [
+                              "ComputeFleetHITSubstack",
+                              "Outputs.ClusterHostedZone"
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Ref": "AWS::NoValue"
                 }
               ]
             },
@@ -2439,27 +2484,74 @@
                   "Sid": "S3BucketPolicy"
                 },
                 {
-                  "Sid": "DescribeInstances",
-                  "Effect": "Allow",
-                  "Action": [
-                    "ec2:DescribeInstances"
-                  ],
-                  "Resource": "*"
+                  "Fn::If": [
+                    "CreateHITSubstack",
+                    {
+                      "Sid": "DescribeInstances",
+                      "Effect": "Allow",
+                      "Action": [
+                        "ec2:DescribeInstances"
+                      ],
+                      "Resource": "*"
+                    },
+                    {
+                      "Ref": "AWS::NoValue"
+                    }
+                  ]
                 },
                 {
-                  "Sid": "FleetTerminatePolicy",
-                  "Effect": "Allow",
-                  "Action": [
-                    "ec2:TerminateInstances"
-                  ],
-                  "Resource": "*",
-                  "Condition": {
-                    "StringEquals": {
-                      "ec2:ResourceTag/Application": {
-                        "Ref": "AWS::StackName"
+                  "Fn::If": [
+                    "CreateHITSubstack",
+                    {
+                      "Sid": "FleetTerminatePolicy",
+                      "Effect": "Allow",
+                      "Action": [
+                        "ec2:TerminateInstances"
+                      ],
+                      "Resource": "*",
+                      "Condition": {
+                        "StringEquals": {
+                          "ec2:ResourceTag/Application": {
+                            "Ref": "AWS::StackName"
+                          }
+                        }
                       }
+                    },
+                    {
+                      "Ref": "AWS::NoValue"
                     }
-                  }
+                  ]
+                },
+                {
+                  "Fn::If": [
+                    "CreateHITSubstack",
+                    {
+                      "Sid": "Route53DeletePolicy",
+                      "Effect": "Allow",
+                      "Action": [
+                        "route53:ListResourceRecordSets",
+                        "route53:ChangeResourceRecordSets"
+                      ],
+                      "Resource": [
+                        {
+                          "Fn::Sub": [
+                            "arn:${AWS::Partition}:route53:::hostedzone/${ClusterHostedZone}",
+                            {
+                              "ClusterHostedZone": {
+                                "Fn::GetAtt": [
+                                  "ComputeFleetHITSubstack",
+                                  "Outputs.ClusterHostedZone"
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "Ref": "AWS::NoValue"
+                    }
+                  ]
                 }
               ],
               "Version": "2012-10-17"
@@ -2485,6 +2577,28 @@
         }
       },
       "Condition": "HasResourcesS3Bucket"
+    },
+    "CleanupResourcesDNSRecordsCustomResource": {
+      "Type": "AWS::CloudFormation::CustomResource",
+      "Properties": {
+        "ClusterHostedZone": {
+          "Fn::GetAtt": [
+            "ComputeFleetHITSubstack",
+            "Outputs.ClusterHostedZone"
+          ]
+        },
+        "Action": "DELETE_DNS_RECORDS",
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CleanupResourcesFunction",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "CloudWatchLogsSubstack"
+      ],
+      "Condition": "CreateHITSubstack"
     },
     "TerminateComputeFleetCustomResource": {
       "Type": "AWS::CloudFormation::CustomResource",
@@ -2892,6 +3006,30 @@
           },
           "ProxyServer": {
             "Ref": "ProxyServer"
+          },
+          "ClusterDNSDomain": {
+            "Fn::If": [
+              "CreateHITSubstack",
+              {
+                "Fn::GetAtt": [
+                  "ComputeFleetHITSubstack",
+                  "Outputs.ClusterDNSDomain"
+                ]
+              },
+              ""
+            ]
+          },
+          "ClusterHostedZone": {
+            "Fn::If": [
+              "CreateHITSubstack",
+              {
+                "Fn::GetAtt": [
+                  "ComputeFleetHITSubstack",
+                  "Outputs.ClusterHostedZone"
+                ]
+              },
+              ""
+            ]
           },
           "MaxSize": {
             "Ref": "MaxSize"
@@ -3602,6 +3740,26 @@
           "ProxyServer": {
             "Ref": "ProxyServer"
           },
+          "ClusterDNSDomain": {
+            "Fn::Sub": [
+              "${ClusterName}.parallelcluster",
+              {
+                "ClusterName": {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Fn::Split": [
+                        "parallelcluster-",
+                        {
+                          "Ref": "AWS::StackName"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          },
           "IntelHPCPlatform": {
             "Ref": "IntelHPCPlatform"
           },
@@ -3700,6 +3858,9 @@
               true,
               false
             ]
+          },
+          "VPCId": {
+            "Ref": "VPCId"
           }
         },
         "TemplateURL": {

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -52,6 +52,8 @@ Parameters:
     Type: String
   ProxyServer:
     Type: String
+  ClusterDNSDomain:
+    Type: String
   IntelHPCPlatform:
     Type: String
   CWLoggingEnabled:
@@ -74,6 +76,8 @@ Parameters:
     Type: List<AWS::EC2::SecurityGroup::Id>
   AssociatePublicIpAddress:
     Type: String
+  VPCId:
+    Type: AWS::EC2::VPC::Id
 Conditions:
   UseProxy: !Not
     - !Equals
@@ -259,6 +263,9 @@ Resources:
                         "cfn_ephemeral_dir": "${EphemeralDir}",
                         "cfn_shared_dir": "${SharedDir}",
                         "cfn_proxy": "${ProxyServer}",
+                        "cfn_ddb_table": "${DynamoDBTable}",
+                        "cfn_dns_domain": "${ClusterDNSDomain}",
+                        "cfn_hosted_zone": "${ClusterHostedZone}",
                         "cfn_node_type": "ComputeFleet",
                         "cfn_cluster_user": "${OSUser}",
                         "enable_intel_hpc_platform": "${IntelHPCPlatform}",
@@ -292,6 +299,7 @@ Resources:
                 echo "Reporting instance as unhealthy and dumping logs to ${!log_dir}/${!instance_id}.tar.gz"
                 tar -czf ${!log_dir}/${!instance_id}.tar.gz /var/log
                 # TODO: add possibility to disable this behavior
+                sleep 10
                 aws --region ${!region} ec2 terminate-instances --instance-ids ${!instance_id}
                 exit 1
               }
@@ -321,7 +329,7 @@ Resources:
                 [[ ${!_region} =~ ^cn- ]] && s3_url="cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
                 which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz; easy_install -U /tmp/aws-cfn-bootstrap-latest.tar.gz)
                 mkdir -p /etc/chef && chown -R root:root /etc/chef
-                curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn")/archives/chef/chef-install.sh | bash -s -- -v ${!chef_version}
+                curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn" || exit 0)/archives/cinc/cinc-install.sh | bash -s -- -v ${!chef_version}
                 /opt/cinc/embedded/bin/gem install --no-document berkshelf:${!berkshelf_version}
                 curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
                 curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${!cookbook_url}.date
@@ -415,4 +423,18 @@ Resources:
           Projection:
             ProjectionType: KEYS_ONLY
       BillingMode: PAY_PER_REQUEST
+  ClusterHostedZone:
+    Type: AWS::Route53::HostedZone
+    Properties:
+      Name: !Ref 'ClusterDNSDomain'
+      VPCs:
+        - VPCId: !Ref 'VPCId'
+          VPCRegion: !Ref 'AWS::Region'
+Outputs:
+  ClusterHostedZone:
+    Description: Id of the private hosted zone created within the cluster
+    Value: !Ref 'ClusterHostedZone'
+  ClusterDNSDomain:
+    Description: DNS Domain of the private hosted zone created within the cluster
+    Value: !Ref 'ClusterDNSDomain'
 

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -407,7 +407,7 @@ Resources:
                 [[ ${!_region} =~ ^cn- ]] && s3_url="cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
                 which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz; easy_install -U /tmp/aws-cfn-bootstrap-latest.tar.gz)
                 mkdir -p /etc/chef && chown -R root:root /etc/chef
-                curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn")/archives/chef/chef-install.sh | bash -s -- -v ${!chef_version}
+                curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn" || exit 0)/archives/cinc/cinc-install.sh | bash -s -- -v ${!chef_version}
                 /opt/cinc/embedded/bin/gem install --no-document berkshelf:${!berkshelf_version}
                 curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
                 curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${!cookbook_url}.date

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -70,6 +70,10 @@ Parameters:
     Type: String
   ProxyServer:
     Type: String
+  ClusterDNSDomain:
+    Type: String
+  ClusterHostedZone:
+    Type: String
   MaxSize:
     Type: Number
   DynamoDBTable:
@@ -364,7 +368,7 @@ Resources:
                 [[ ${!_region} =~ ^cn- ]] && s3_url="cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
                 which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz; easy_install -U /tmp/aws-cfn-bootstrap-latest.tar.gz)
                 mkdir -p /etc/chef && chown -R root:root /etc/chef
-                curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn")/archives/chef/chef-install.sh | bash -s -- -v ${!chef_version}
+                curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn" || exit 0)/archives/cinc/cinc-install.sh | bash -s -- -v ${!chef_version}
                 /opt/cinc/embedded/bin/gem install --no-document berkshelf:${!berkshelf_version}
                 curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
                 curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${!cookbook_url}.date
@@ -459,6 +463,8 @@ Resources:
                   cfn_ephemeral_dir: !Ref 'EphemeralDir'
                   cfn_shared_dir: !Ref 'SharedDir'
                   cfn_proxy: !Ref 'ProxyServer'
+                  cfn_dns_domain: !Ref 'ClusterDNSDomain'
+                  cfn_hosted_zone: !Ref 'ClusterHostedZone'
                   cfn_max_queue_size: !Ref 'MaxSize'
                   compute_instance_type: !Ref 'ComputeInstanceType'
                   cfn_node_type: MasterServer

--- a/cloudformation/utils/cfn_formatter.py
+++ b/cloudformation/utils/cfn_formatter.py
@@ -74,7 +74,10 @@ def check_formatting(filenames, format):
             formatted_doc = FORMAT_TO_PARSING_FUNC[format](file)
             if formatted_doc != data:
                 has_failures = True
-                print("FAILED: fix formatting for file {filename}".format(filename=file))
+                print(
+                    "FAILED: fix formatting for file {filename} and "
+                    "double check newlines at the end of the file".format(filename=file)
+                )
                 for line in difflib.unified_diff(formatted_doc.splitlines(), data.splitlines()):
                     print(line)
             else:


### PR DESCRIPTION
Add Route53 hosted zone and Lambda cleanup function

A new private hosted zone is created within the cluster.
The domain name is: `<clustername>.parallelcluster`.

We extended the cleanup Lambda function to delete DNS record because the hosted zone cannot be deleted if there are DNS record on it.

Right now the DNS domain name is passed as input of the HITSubstack and propagated as output.
Both HostedZone Id and domain name are output of the substack.
The hosted zone is required by node daemons to add record sets for new nodes and by Lambda function to delete the record set before cluster deletion.

Other changes:
+ Added policy to permit secondary index queries in dynamodb and permissions for route53 updates
+ Added condition for HIT related policies: DescribeInstances and FleetTerminatePolicy

For all OSes:
+ Cluster creation
+ Job submission/completion
+ dig +search for short name and dig for fqdn in custom domain
+ ssh short name from master to compute and viceversa
+ verified resolv.conf in both master and compute
+ verified compute has the right hostname from the custom domain

Specific tests:
+ Cluster deletion with 1 record set
+ Cluster deletion without record sets