### PR TITLE
Choose availability zone(s) offering desired instance types

### DIFF
--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -20,7 +20,7 @@ from pcluster.config.resource_map import ResourceMap
 from pcluster.constants import PCLUSTER_ISSUES_LINK
 from pcluster.utils import (
     error,
-    get_avail_zone,
+    get_availability_zone_of_subnet,
     get_cfn_param,
     get_efs_mount_target_id,
     get_file_section_name,
@@ -571,7 +571,7 @@ class AvailabilityZoneCfnParam(CfnParam):
         section_name = get_file_section_name(self.section_key, self.section_label)
         if config_parser.has_option(section_name, subnet_parameter):
             subnet_id = config_parser.get(section_name, subnet_parameter)
-            self.value = get_avail_zone(subnet_id)
+            self.value = get_availability_zone_of_subnet(subnet_id)
             self._check_allowed_values()
 
     def to_file(self, config_parser, write_defaults=False):
@@ -596,7 +596,7 @@ class MasterAvailabilityZoneCfnParam(AvailabilityZoneCfnParam):
     def from_cfn_params(self, cfn_params):
         """Initialize the Availability zone by checking the Compute Subnet from cfn."""
         master_subnet_id = get_cfn_param(cfn_params, "MasterSubnetId")
-        self.value = get_avail_zone(master_subnet_id)
+        self.value = get_availability_zone_of_subnet(master_subnet_id)
         return self
 
 
@@ -617,7 +617,7 @@ class ComputeAvailabilityZoneCfnParam(AvailabilityZoneCfnParam):
     def from_cfn_params(self, cfn_params):
         """Initialize the Availability zone by checking the Compute Subnet from cfn."""
         compute_subnet_id = get_cfn_param(cfn_params, "ComputeSubnetId")
-        self.value = get_avail_zone(compute_subnet_id)
+        self.value = get_availability_zone_of_subnet(compute_subnet_id)
         return self
 
 

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -29,7 +29,7 @@ default_cluster_params = {
 
 def _do_mocking_for_tests(mocker):
     """Perform the mocking common to all of these test cases."""
-    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_availability_zone_of_subnet", return_value="mocked_avail_zone")
     mocker.patch(
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type", return_value=["x86_64"]
     )

--- a/cli/tests/pcluster/config/test_json_param_types.py
+++ b/cli/tests/pcluster/config/test_json_param_types.py
@@ -127,7 +127,7 @@ def test_config_from_json(mocker, boto3_stubber, test_datadir, pcluster_config_r
         # Mock az detection by returning a mock az if subnet has a value
         return "my-avail-zone" if subnet_id and subnet_id != "NONE" else None
 
-    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", mock_get_avail_zone)
+    mocker.patch("pcluster.config.cfn_param_types.get_availability_zone_of_subnet", mock_get_avail_zone)
 
     # Created expected json params based on active queues
     expected_json_params = _prepare_json_config(queues, test_datadir)

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -1168,7 +1168,7 @@ def test_sit_cluster_from_file_to_cfn(mocker, pcluster_config_reader, settings_l
         side_effect=lambda efs_fs_id, avail_zone: "master_mt" if avail_zone == "mocked_avail_zone" else None,
     )
     mocker.patch(
-        "pcluster.config.cfn_param_types.get_avail_zone",
+        "pcluster.config.cfn_param_types.get_availability_zone_of_subnet",
         side_effect=lambda subnet: "mocked_avail_zone" if subnet == "subnet-12345678" else "some_other_az",
     )
 

--- a/cli/tests/pcluster/config/test_section_dcv.py
+++ b/cli/tests/pcluster/config/test_section_dcv.py
@@ -124,5 +124,5 @@ def test_dcv_param_from_file(mocker, param_key, param_value, expected_value, exp
 def test_dcv_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
     """Unit tests for parsing EFS related options."""
     mocker.patch("pcluster.config.cfn_param_types.get_efs_mount_target_id", return_value="mount_target_id")
-    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_availability_zone_of_subnet", return_value="mocked_avail_zone")
     utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)

--- a/cli/tests/pcluster/config/test_section_efs.py
+++ b/cli/tests/pcluster/config/test_section_efs.py
@@ -229,5 +229,5 @@ def test_efs_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, ex
         "pcluster.config.cfn_param_types.get_efs_mount_target_id",
         side_effect=lambda efs_fs_id, avail_zone: "master_mt" if avail_zone == "mocked_avail_zone" else None,
     )
-    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_availability_zone_of_subnet", return_value="mocked_avail_zone")
     utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)

--- a/cli/tests/pcluster/config/test_section_fsx.py
+++ b/cli/tests/pcluster/config/test_section_fsx.py
@@ -280,5 +280,5 @@ def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, exp
 def test_fsx_from_file_to_cfn(mocker, pcluster_config_reader, settings_label, expected_cfn_params):
     """Unit tests for parsing EFS related options."""
     mocker.patch("pcluster.config.cfn_param_types.get_efs_mount_target_id", return_value="mount_target_id")
-    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_availability_zone_of_subnet", return_value="mocked_avail_zone")
     utils.assert_section_params(mocker, pcluster_config_reader, settings_label, expected_cfn_params)

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -69,7 +69,7 @@ def test_mapping_consistency():
 
 def test_example_config_consistency(mocker):
     """Validate example file and try to convert to CFN."""
-    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", return_value="mocked_avail_zone")
+    mocker.patch("pcluster.config.cfn_param_types.get_availability_zone_of_subnet", return_value="mocked_avail_zone")
     mocker.patch(
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type", return_value=["x86_64"]
     )

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -111,7 +111,7 @@ def get_mock_pcluster_config_patches(scheduler, extra_patches=None):
         "pcluster.config.validators.get_supported_instance_types": master_instances,
         "pcluster.config.validators.get_supported_compute_instance_types": compute_instances,
         "pcluster.config.validators.get_supported_architectures_for_instance_type": architectures,
-        "pcluster.config.cfn_param_types.get_avail_zone": "mocked_avail_zone",
+        "pcluster.config.cfn_param_types.get_availability_zone_of_subnet": "mocked_avail_zone",
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type": architectures,
         "pcluster.config.validators.get_instance_vcpus": 1,
     }
@@ -195,7 +195,7 @@ def assert_section_from_cfn(
         # Mock az detection by returning a mock az if subnet has a value
         return "my-avail-zone" if subnet_id and subnet_id != "NONE" else None
 
-    mocker.patch("pcluster.config.cfn_param_types.get_avail_zone", mock_get_avail_zone)
+    mocker.patch("pcluster.config.cfn_param_types.get_availability_zone_of_subnet", mock_get_avail_zone)
     cfn_params = []
     for cfn_key, cfn_value in cfn_params_dict.items():
         cfn_params.append({"ParameterKey": cfn_key, "ParameterValue": cfn_value})

--- a/cli/tests/pcluster/configure/data/aws_api_responses/describe_instance_type_offerings_euw1.json
+++ b/cli/tests/pcluster/configure/data/aws_api_responses/describe_instance_type_offerings_euw1.json
@@ -1,0 +1,34 @@
+{
+    "InstanceTypeOfferings": [
+        {
+            "InstanceType": "t2.nano",
+            "LocationType": "region",
+            "Location": "eu-west-1"
+        },
+        {
+            "InstanceType": "t2.micro",
+            "LocationType": "region",
+            "Location": "eu-west-1"
+        },
+        {
+            "InstanceType": "t2.large",
+            "LocationType": "region",
+            "Location": "eu-west-1"
+        },
+        {
+            "InstanceType": "c5.xlarge",
+            "LocationType": "region",
+            "Location": "eu-west-1"
+        },
+        {
+            "InstanceType": "g3.8xlarge",
+            "LocationType": "region",
+            "Location": "eu-west-1"
+        },
+        {
+            "InstanceType": "m6g.xlarge",
+            "LocationType": "region",
+            "Location": "eu-west-1"
+        }
+    ]
+}

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/output.txt
@@ -44,10 +44,12 @@ Allowed values for Operating System:
 5. ubuntu1604
 6. ubuntu1804
 Allowed values for VPC ID:
-1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
-2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
-3. vpc-34567891 | default | 3 subnets inside
-4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+  #  id            name                                 number_of_subnets
+---  ------------  ---------------------------------  -------------------
+  1  vpc-12345678  ParallelClusterVPC-20190625135738                    2
+  2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
+  3  vpc-34567891  default                                              3
+  4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet
 2. Master and compute fleet in the same public subnet

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_filtered_subnets_by_az/original_config_file.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_filtered_subnets_by_az/original_config_file.ini
@@ -1,0 +1,25 @@
+[aws]
+aws_region_name = eu-west-1
+
+[cluster default]
+key_name = key3
+vpc_settings = default
+scheduler = torque
+master_instance_type = t2.nano
+compute_instance_type = t2.large
+max_queue_size = 14
+initial_queue_size = 13
+maintain_initial_size = true
+
+[vpc default]
+vpc_id = vpc-34567891
+master_subnet_id = subnet-34567891
+compute_subnet_id = subnet-45678912
+
+[global]
+cluster_template = default
+update_check = true
+sanity_check = true
+
+[aliases]
+ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
@@ -1,4 +1,4 @@
-INFO: Configuration file {{ CONFIG_FILE }} will be written.
+WARNING: Configuration file {{ CONFIG_FILE }} will be overwritten.
 Press CTRL-C to interrupt the procedure.
 
 
@@ -31,6 +31,13 @@ Allowed values for Scheduler:
 2. torque
 3. slurm
 4. awsbatch
+Allowed values for Operating System:
+1. alinux
+2. alinux2
+3. centos6
+4. centos7
+5. ubuntu1604
+6. ubuntu1804
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------
@@ -38,5 +45,15 @@ Allowed values for VPC ID:
   2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
+Note:  2 subnet(s) is/are not listed, because the instance type is not in their availability zone(s)
+Allowed values for Master Subnet ID:
+  #  id               name      size  availability_zone
+---  ---------------  ------  ------  -------------------
+  1  subnet-45678912            4096  eu-west-1a
+Note:  2 subnet(s) is/are not listed, because the instance type is not in their availability zone(s)
+Allowed values for Compute Subnet ID:
+  #  id               name      size  availability_zone
+---  ---------------  ------  ------  -------------------
+  1  subnet-45678912            4096  eu-west-1a
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.ini
@@ -1,0 +1,25 @@
+[aws]
+aws_region_name = eu-west-1
+
+[cluster default]
+key_name = key3
+vpc_settings = default
+scheduler = torque
+master_instance_type = t2.nano
+compute_instance_type = t2.large
+max_queue_size = 14
+initial_queue_size = 13
+maintain_initial_size = true
+base_os = alinux2
+
+[vpc default]
+vpc_id = vpc-34567891
+master_subnet_id = subnet-45678912
+
+[global]
+cluster_template = default
+update_check = true
+sanity_check = true
+
+[aliases]
+ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
@@ -39,15 +39,21 @@ Allowed values for Operating System:
 5. ubuntu1604
 6. ubuntu1804
 Allowed values for VPC ID:
-1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
-2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
-3. vpc-34567891 | default | 3 subnets inside
-4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+  #  id            name                                 number_of_subnets
+---  ------------  ---------------------------------  -------------------
+  1  vpc-12345678  ParallelClusterVPC-20190625135738                    2
+  2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
+  3  vpc-34567891  default                                              3
+  4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Allowed values for Master Subnet ID:
-1. subnet-12345678 | ParallelClusterPublicSubnet | Subnet size: 256
-2. subnet-23456789 | ParallelClusterPrivateSubnet | Subnet size: 4096
+  #  id               name                            size  availability_zone
+---  ---------------  ----------------------------  ------  -------------------
+  1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
+  2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
 Allowed values for Compute Subnet ID:
-1. subnet-12345678 | ParallelClusterPublicSubnet | Subnet size: 256
-2. subnet-23456789 | ParallelClusterPrivateSubnet | Subnet size: 4096
+  #  id               name                            size  availability_zone
+---  ---------------  ----------------------------  ------  -------------------
+  1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
+  2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/output.txt
@@ -32,15 +32,21 @@ Allowed values for Scheduler:
 3. slurm
 4. awsbatch
 Allowed values for VPC ID:
-1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
-2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
-3. vpc-34567891 | default | 3 subnets inside
-4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+  #  id            name                                 number_of_subnets
+---  ------------  ---------------------------------  -------------------
+  1  vpc-12345678  ParallelClusterVPC-20190625135738                    2
+  2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
+  3  vpc-34567891  default                                              3
+  4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Allowed values for Master Subnet ID:
-1. subnet-12345678 | ParallelClusterPublicSubnet | Subnet size: 256
-2. subnet-23456789 | ParallelClusterPrivateSubnet | Subnet size: 4096
+  #  id               name                            size  availability_zone
+---  ---------------  ----------------------------  ------  -------------------
+  1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
+  2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
 Allowed values for Compute Subnet ID:
-1. subnet-12345678 | ParallelClusterPublicSubnet | Subnet size: 256
-2. subnet-23456789 | ParallelClusterPrivateSubnet | Subnet size: 4096
+  #  id               name                            size  availability_zone
+---  ---------------  ----------------------------  ------  -------------------
+  1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
+  2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_available_no_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_available_no_input_no_automation_no_errors_with_config_file/output.txt
@@ -22,15 +22,21 @@ Allowed values for Operating System:
 5. ubuntu1604
 6. ubuntu1804
 Allowed values for VPC ID:
-1. vpc-abcdefgh | ParallelClusterVPC-20190625135738 | 2 subnets inside
-2. vpc-bcdefghi | ParallelClusterVPC-20190624105051 | 0 subnets inside
-3. vpc-cdefghij | default | 3 subnets inside
-4. vpc-abdbabcb | ParallelClusterVPC-20190626095403 | 1 subnets inside
+  #  id            name                                 number_of_subnets
+---  ------------  ---------------------------------  -------------------
+  1  vpc-abcdefgh  ParallelClusterVPC-20190625135738                    2
+  2  vpc-bcdefghi  ParallelClusterVPC-20190624105051                    0
+  3  vpc-cdefghij  default                                              3
+  4  vpc-abdbabcb  ParallelClusterVPC-20190626095403                    1
 Allowed values for Master Subnet ID:
-1. subnet-77777777 | ParallelClusterPublicSubnet | Subnet size: 256
-2. subnet-66666666 | ParallelClusterPrivateSubnet | Subnet size: 4096
+  #  id               name                            size  availability_zone
+---  ---------------  ----------------------------  ------  -------------------
+  1  subnet-77777777  ParallelClusterPublicSubnet      256  cn-north-1a
+  2  subnet-66666666  ParallelClusterPrivateSubnet    4096  cn-north-1a
 Allowed values for Compute Subnet ID:
-1. subnet-77777777 | ParallelClusterPublicSubnet | Subnet size: 256
-2. subnet-66666666 | ParallelClusterPrivateSubnet | Subnet size: 4096
+  #  id               name                            size  availability_zone
+---  ---------------  ----------------------------  ------  -------------------
+  1  subnet-77777777  ParallelClusterPublicSubnet      256  cn-north-1a
+  2  subnet-66666666  ParallelClusterPrivateSubnet    4096  cn-north-1a
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/output.txt
@@ -39,15 +39,21 @@ Allowed values for Operating System:
 5. ubuntu1604
 6. ubuntu1804
 Allowed values for VPC ID:
-1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
-2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
-3. vpc-34567891 | default | 3 subnets inside
-4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+  #  id            name                                 number_of_subnets
+---  ------------  ---------------------------------  -------------------
+  1  vpc-12345678  ParallelClusterVPC-20190625135738                    2
+  2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
+  3  vpc-34567891  default                                              3
+  4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Allowed values for Master Subnet ID:
-1. subnet-12345678 | ParallelClusterPublicSubnet | Subnet size: 256
-2. subnet-23456789 | ParallelClusterPrivateSubnet | Subnet size: 4096
+  #  id               name                            size  availability_zone
+---  ---------------  ----------------------------  ------  -------------------
+  1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
+  2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
 Allowed values for Compute Subnet ID:
-1. subnet-12345678 | ParallelClusterPublicSubnet | Subnet size: 256
-2. subnet-23456789 | ParallelClusterPrivateSubnet | Subnet size: 4096
+  #  id               name                            size  availability_zone
+---  ---------------  ----------------------------  ------  -------------------
+  1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
+  2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
@@ -39,10 +39,12 @@ Allowed values for Operating System:
 5. ubuntu1604
 6. ubuntu1804
 Allowed values for VPC ID:
-1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
-2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
-3. vpc-34567891 | default | 3 subnets inside
-4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+  #  id            name                                 number_of_subnets
+---  ------------  ---------------------------------  -------------------
+  1  vpc-12345678  ParallelClusterVPC-20190625135738                    2
+  2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
+  3  vpc-34567891  default                                              3
+  4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet
 2. Master and compute fleet in the same public subnet

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
@@ -39,10 +39,13 @@ Allowed values for Operating System:
 5. ubuntu1604
 6. ubuntu1804
 Allowed values for VPC ID:
-1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
-2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
-3. vpc-34567891 | default | 3 subnets inside
-4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+  #  id            name                                 number_of_subnets
+---  ------------  ---------------------------------  -------------------
+  1  vpc-12345678  ParallelClusterVPC-20190625135738                    2
+  2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
+  3  vpc-34567891  default                                              3
+  4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
+There are no qualified subnets. Starting automatic creation of subnets...
 Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet
 2. Master and compute fleet in the same public subnet

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
@@ -39,10 +39,12 @@ Allowed values for Operating System:
 5. ubuntu1604
 6. ubuntu1804
 Allowed values for VPC ID:
-1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
-2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
-3. vpc-34567891 | default | 3 subnets inside
-4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+  #  id            name                                 number_of_subnets
+---  ------------  ---------------------------------  -------------------
+  1  vpc-12345678  ParallelClusterVPC-20190625135738                    2
+  2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
+  3  vpc-34567891  default                                              3
+  4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet
 2. Master and compute fleet in the same public subnet

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/output.txt
@@ -39,17 +39,23 @@ Allowed values for Operating System:
 5. ubuntu1604
 6. ubuntu1804
 Allowed values for VPC ID:
-1. vpc-12345678 | ParallelClusterVPC-20190625135738 | 2 subnets inside
-2. vpc-23456789 | ParallelClusterVPC-20190624105051 | 0 subnets inside
-3. vpc-34567891 | default | 3 subnets inside
-4. vpc-45678912 | ParallelClusterVPC-20190626095403 | 1 subnets inside
+  #  id            name                                 number_of_subnets
+---  ------------  ---------------------------------  -------------------
+  1  vpc-12345678  ParallelClusterVPC-20190625135738                    2
+  2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
+  3  vpc-34567891  default                                              3
+  4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Allowed values for Master Subnet ID:
-1. subnet-34567891 | Subnet size: 4096
-2. subnet-45678912 | Subnet size: 4096
-3. subnet-56789123 | Subnet size: 4096
+  #  id               name      size  availability_zone
+---  ---------------  ------  ------  -------------------
+  1  subnet-34567891            4096  eu-west-1b
+  2  subnet-45678912            4096  eu-west-1a
+  3  subnet-56789123            4096  eu-west-1c
 Allowed values for Compute Subnet ID:
-1. subnet-34567891 | Subnet size: 4096
-2. subnet-45678912 | Subnet size: 4096
-3. subnet-56789123 | Subnet size: 4096
+  #  id               name      size  availability_zone
+---  ---------------  ------  ------  -------------------
+  1  subnet-34567891            4096  eu-west-1b
+  2  subnet-45678912            4096  eu-west-1a
+  3  subnet-56789123            4096  eu-west-1c
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure_utils.py
+++ b/cli/tests/pcluster/configure/test_pcluster_configure_utils.py
@@ -16,12 +16,8 @@ from pcluster.configure.utils import get_default_suggestion
         ("Operating System", [], "alinux2", None),
         ("Operating System", ["centos7", "centos6", "ubuntu1804"], "alinux2", None),
         # Ensure first item is selected from first nested list/tuple
-        ("fake-parameter", [["a", "b"], ["c", "d"]], "a", None),
-        ("fake-parameter", [("a", "b"), ("c", "d")], "a", None),
-        ("fake-parameter", (["a", "b"], ["c", "d"]), "a", None),
-        ("fake-parameter", (("a", "b"), ("c", "d")), "a", None),
-        ("fake-parameter", (["a", "b"], ("c", "d")), "a", None),
-        ("fake-parameter", [["a", "b"], ("c", "d")], "a", None),
+        ("fake-parameter", [{"id": "a", "key2": "b"}, {"id": "c", "key3": "d"}], "a", None),
+        ("fake-parameter", ({"id": "a", "key2": "b"}, {"id": "c", "key3": "d"}), "a", None),
         # Ensure first item is selected from flat lists/tuples
         ("fake-parameter", ["a", "b", "c", "d"], "a", None),
         ("fake-parameter", ("a", "b", "c", "d"), "a", None),
@@ -32,10 +28,6 @@ from pcluster.configure.utils import get_default_suggestion
         # tuples/lists are assumed to be non-empty
         ("fake-parameter", [], None, IndexError),
         ("fake-parameter", (), None, IndexError),
-        ("fake-parameter", [[]], None, IndexError),
-        ("fake-parameter", [()], None, IndexError),
-        ("fake-parameter", (()), None, IndexError),
-        ("fake-parameter", ([]), None, IndexError),
     ],
 )
 def test_get_default_suggestion(parameter, options, expected_suggestion, expected_exception):


### PR DESCRIPTION
This pull request is for pcluster configure, and will:
1. During automate subnets creation, automatically specify availability zone(s) offering desired instance types.
   If there is no single availability zone offering instance types both of master and compute node, stop pcluster configure
2. During manually subnets selection, only list subnets whose availability zone(s) offering desired instance types.
   If there is no qualified subnet to be selected, switch to automate subnets creation.
3. Change listed objects displayed in prompt_iterable from list of tuples to list of OrderedDict.
   Therefore change VPCs/Subnets' display format from list to table.
4. Call describe_instance_type_offerings() to validate input instance types.
   Keep original validator until further notice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
