### PR TITLE
hit converter: set default queue name to compute

### DIFF
--- a/cli/pcluster/config/hit_converter.py
+++ b/cli/pcluster/config/hit_converter.py
@@ -56,10 +56,10 @@ class HitConverter:
 
                 # Create default queue section
                 queue_section = QueueJsonSection(
-                    mappings.QUEUE, self.pcluster_config, section_label="default", parent_section=hit_cluster_section
+                    mappings.QUEUE, self.pcluster_config, section_label="compute", parent_section=hit_cluster_section
                 )
                 self.pcluster_config.add_section(queue_section)
-                hit_cluster_section.get_param("queue_settings").value = "default"
+                hit_cluster_section.get_param("queue_settings").value = "compute"
 
                 self._copy_param_value(
                     sit_cluster_section.get_param("cluster_type"), queue_section.get_param("compute_type")

--- a/cli/tests/pcluster/config/test_hit_converter.py
+++ b/cli/tests/pcluster/config/test_hit_converter.py
@@ -55,7 +55,7 @@ def boto3_stubber_path():
                     "enable_efa": None,
                     "disable_hyperthreading": None,
                 },
-                "queue default": {
+                "queue compute": {
                     "compute_type": "ondemand",
                     "enable_efa": True,
                     "disable_hyperthreading": True,
@@ -102,7 +102,7 @@ def boto3_stubber_path():
                     "enable_efa": None,
                     "disable_hyperthreading": None,
                 },
-                "queue default": {
+                "queue compute": {
                     "compute_type": "ondemand",
                     "enable_efa": False,
                     "disable_hyperthreading": False,

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.ini
@@ -15,7 +15,7 @@ base_os = centos6
 scheduler = slurm
 master_instance_type = t2.nano
 vpc_settings = default
-queue_settings = default
+queue_settings = compute
 
 [vpc default]
 vpc_id = vpc-12345678
@@ -23,7 +23,7 @@ master_subnet_id = subnet-12345678
 compute_subnet_id = subnet-23456789
 use_public_ips = false
 
-[queue default]
+[queue compute]
 enable_efa = False
 disable_hyperthreading = False
 compute_resource_settings = default

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.ini
@@ -15,13 +15,13 @@ base_os = centos6
 scheduler = slurm
 master_instance_type = t2.nano
 vpc_settings = default
-queue_settings = default
+queue_settings = compute
 
 [vpc default]
 vpc_id = vpc-12345678
 master_subnet_id = subnet-12345678
 
-[queue default]
+[queue compute]
 enable_efa = False
 disable_hyperthreading = False
 compute_resource_settings = default

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/pcluster.config.ini
@@ -8,7 +8,7 @@ vpc_settings = default
 scheduler = slurm
 master_instance_type = m6g.xlarge
 additional_iam_policies = arn:aws-cn:iam::aws:policy/CloudWatchAgentServerPolicy
-queue_settings = default
+queue_settings = compute
 
 [vpc default]
 vpc_id = vpc-34567891
@@ -23,7 +23,7 @@ sanity_check = true
 [aliases]
 ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
 
-[queue default]
+[queue compute]
 enable_efa = False
 disable_hyperthreading = False
 compute_resource_settings = default


### PR DESCRIPTION
Set queue name to compute when converter is applied. This is to be consistent with the default name that was previously used for Slurm partition

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
