### PR TITLE
hit converter: fix conversion of vpc and scaling sections

### DIFF
--- a/cli/pcluster/config/hit_converter.py
+++ b/cli/pcluster/config/hit_converter.py
@@ -151,7 +151,7 @@ class HitConverter:
         :param hit_cluster_section: The new HIT cluster section
         """
         for default_section in self.default_sections:
-            self.pcluster_config.remove_section(default_section.key)
+            self.pcluster_config.remove_section(default_section.key, "default")
             default_section.parent_section = hit_cluster_section
             self.pcluster_config.add_section(default_section)
 


### PR DESCRIPTION
Conversion was only working if vpc and scaling sections were defined with the `default` label.

Otherwise conversion was failing with the following error:
```
pcluster create -c /Users/fdm/.parallelcluster/config.ini -nr status
Beginning cluster creation for cluster: status
Unexpected error of type Exception: More than one section with key vpc
Traceback (most recent call last):
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/cli.py", line 456, in main
    args.func(args)
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/cli.py", line 37, in create
    pcluster.create(args)
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/commands.py", line 120, in create
    HitConverter(pcluster_config).convert()
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/config/hit_converter.py", line 124, in convert
    self._restore_default_sections(hit_cluster_section)
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/config/hit_converter.py", line 154, in _restore_default_sections
    self.pcluster_config.remove_section(default_section.key)
  File "/Users/fdm/workspace/cfncluster/cfncluster/cli/pcluster/config/pcluster_config.py", line 220, in remove_section
    raise Exception("More than one section with key {0}".format(section_key))
Exception: More than one section with key vpc
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
