### PR TITLE
Add the some tests for torque-slurm-wrapper

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -428,9 +428,7 @@ class TorqueCommands(SchedulerCommands):
         assert_that(status).is_equal_to("0")
 
     def compute_nodes_count(self):  # noqa: D102
-        result = self._remote_command_executor.run_remote_command(
-            "echo $(( $(/opt/torque/bin/pbsnodes -l all | wc -l) - 1))"
-        )
+        result = self._remote_command_executor.run_remote_command("echo $(( $(pbsnodes -l all | wc -l) - 1))")
         # split()[-1] to extract last line and trim whitespaces
         return int(result.stdout.split()[-1])
 

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/torque_job.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/torque_job.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "qsub executed successfully"


### PR DESCRIPTION
* Test torque job submit command in slurm cluster(qsub)
* Show the computing nodes information by torque command in slurm cluster(pbsnodes)

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
