### PR TITLE
Fix wrong section labels when loading configuration from cfn.

### DIFF
--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -742,8 +742,12 @@ class ClusterConfigMetadataCfnParam(JsonCfnParam):
         self.__section_resources.store(section_key, section_labels)
         LOGGER.debug("Automatic labels generated: {0}".format(str(section_labels)))
         # Refresh param value
-        self.refresh()
+        self.__resources_to_value()
         return self.__section_resources.resources(section_key)
+
+    def __resources_to_value(self):
+        """Sync data from internal resources structure to param value."""
+        self.value["sections"] = self.__section_resources.resources()
 
 
 class BaseOSCfnParam(CfnParam):

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -18,11 +18,29 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
 
 
 @pytest.mark.parametrize(
-    "cfn_params_dict, expected_section_dict",
+    "cfn_params_dict, expected_section_dict, expected_section_label",
     [
         (
             {},
             utils.merge_dicts(DefaultDict["cluster_sit"].value, {"additional_iam_policies": [], "architecture": None}),
+            "default",
+        ),
+        (
+            utils.merge_dicts(
+                DefaultCfnParams["cluster_sit"].value,
+                {"ClusterConfigMetadata": "{'sections': {'cluster': ['custom_cluster_label']}}"},
+            ),
+            # Cluster section with custom label
+            utils.merge_dicts(
+                DefaultDict["cluster_sit"].value,
+                {
+                    "additional_iam_policies": ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"],
+                    "base_os": "alinux2",
+                    "scheduler": "slurm",
+                    "cluster_config_metadata": {"sections": {"cluster": ["custom_cluster_label"]}},
+                },
+            ),
+            "custom_cluster_label",
         ),
         (
             DefaultCfnParams["cluster_sit"].value,
@@ -34,6 +52,7 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
                     "scheduler": "slurm",
                 },
             ),
+            "default",
         ),
         # awsbatch defaults
         (
@@ -69,12 +88,13 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
                     ],
                 },
             ),
+            "default",
         ),
     ],
 )
-def test_sit_cluster_section_from_cfn(mocker, cfn_params_dict, expected_section_dict):
+def test_sit_cluster_section_from_cfn(mocker, cfn_params_dict, expected_section_dict, expected_section_label):
     """Test conversion from CFN input parameters."""
-    utils.assert_section_from_cfn(mocker, CLUSTER_SIT, cfn_params_dict, expected_section_dict)
+    utils.assert_section_from_cfn(mocker, CLUSTER_SIT, cfn_params_dict, expected_section_dict, expected_section_label)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -163,7 +163,9 @@ def assert_param_validator(
             assert_that(capsys.readouterr().out).matches(expected_warning)
 
 
-def assert_section_from_cfn(mocker, section_definition, cfn_params_dict, expected_section_dict):
+def assert_section_from_cfn(
+    mocker, section_definition, cfn_params_dict, expected_section_dict, expected_section_label="default"
+):
     def mock_get_avail_zone(subnet_id):
         # Mock az detection by returning a mock az if subnet has a value
         return "my-avail-zone" if subnet_id and subnet_id != "NONE" else None
@@ -180,7 +182,7 @@ def assert_section_from_cfn(mocker, section_definition, cfn_params_dict, expecte
     section = section_type(section_definition, pcluster_config).from_storage(storage_params)
 
     if section.label:
-        assert_that(section.label).is_equal_to("default")
+        assert_that(section.label).is_equal_to(expected_section_label)
 
     # update expected dictionary
     default_dict = get_default_dict(section_definition)


### PR DESCRIPTION
A refresh operation on the config metadata was called during configuration loading, which was overriding the labels coming from CloudFormation. This commit fixes the issue by replacing the refresh call with a more specific sync between section resources and section labels.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
