### PR TITLE
Remove unnecessary parameters from generated HIT configuration file

### DIFF
--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.ini
@@ -24,12 +24,9 @@ compute_subnet_id = subnet-23456789
 use_public_ips = false
 
 [queue compute]
-enable_efa = False
-disable_hyperthreading = False
 compute_resource_settings = default
 
 [compute_resource default]
 instance_type = t2.micro
 min_count = 13
 max_count = 14
-initial_count = 13

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.ini
@@ -22,12 +22,9 @@ vpc_id = vpc-12345678
 master_subnet_id = subnet-12345678
 
 [queue compute]
-enable_efa = False
-disable_hyperthreading = False
 compute_resource_settings = default
 
 [compute_resource default]
 instance_type = t2.micro
 min_count = 13
 max_count = 14
-initial_count = 13

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/pcluster.config.ini
@@ -24,12 +24,9 @@ sanity_check = true
 ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
 
 [queue compute]
-enable_efa = False
-disable_hyperthreading = False
 compute_resource_settings = default
 
 [compute_resource default]
 instance_type = m6g.xlarge
 min_count = 7
 max_count = 18
-initial_count = 7


### PR DESCRIPTION
disable_hyperthreading, enable_efa and initial_count can be safely removed from the config file as their values can be inferred from other configuration parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
