### PR TITLE
Leave disable_hyperthreading in cluster section when converting to HIT

### DIFF
--- a/cli/pcluster/config/hit_converter.py
+++ b/cli/pcluster/config/hit_converter.py
@@ -70,10 +70,6 @@ class HitConverter:
                     "compute" == sit_cluster_section.get_param("enable_efa").value,
                 )
                 self._copy_param_value(
-                    sit_cluster_section.get_param("disable_hyperthreading"),
-                    queue_section.get_param("disable_hyperthreading"),
-                )
-                self._copy_param_value(
                     sit_cluster_section.get_param("placement_group"), queue_section.get_param("placement_group")
                 )
 
@@ -102,17 +98,15 @@ class HitConverter:
 
                 # SIT initial size is copied to min_count or to initial_count based on SIT maintain_initial_size
                 sit_initial_size_param = sit_cluster_section.get_param("initial_queue_size")
-                sit_maintain_initial_size_param = sit_cluster_section.get_param("maintain_initial_size")
+                sit_maintain_initial_size_param = sit_cluster_section.get_param_value("maintain_initial_size")
                 compute_resource_size_param_key = "min_count" if sit_maintain_initial_size_param else "initial_count"
                 self._copy_param_value(
                     sit_initial_size_param, compute_resource_section.get_param(compute_resource_size_param_key),
                 )
 
-                # Copy all cluster params except enable_efa and disable_hyperthreading (already set at queue level)
+                # Copy all cluster params except enable_efa (already set at queue level)
                 hit_cluster_param_keys = [
-                    param_key
-                    for param_key in hit_cluster_section.params.keys()
-                    if param_key not in ["disable_hyperthreading", "enable_efa"]
+                    param_key for param_key in hit_cluster_section.params.keys() if param_key not in ["enable_efa"]
                 ]
                 for param_key in sit_cluster_section.params.keys():
                     if param_key in hit_cluster_param_keys:

--- a/cli/pcluster/configure/easyconfig.py
+++ b/cli/pcluster/configure/easyconfig.py
@@ -303,6 +303,11 @@ def _convert_config(pcluster_config):
             compute_resource_section = pcluster_config.get_section("compute_resource", "default")
             _reset_config_params(compute_resource_section, ["initial_count"])
 
+            # cluster's disable_hyperthreading's HIT default is None instead of False
+            cluster_section = pcluster_config.get_section("cluster")
+            if not cluster_section.get_param_value("disable_hyperthreading"):
+                _reset_config_params(cluster_section, ["disable_hyperthreading"])
+
 
 class SchedulerHandler:
     """Handle question scheduler related."""

--- a/cli/tests/pcluster/config/test_hit_converter.py
+++ b/cli/tests/pcluster/config/test_hit_converter.py
@@ -51,9 +51,8 @@ def boto3_stubber_path():
                     "scheduler": "slurm",
                     "master_root_volume_size": 30,
                     "compute_root_volume_size": 35,
-                    # disable_hyperthreading and enable_efa must be set to None in converted cluster section
                     "enable_efa": None,
-                    "disable_hyperthreading": None,
+                    "disable_hyperthreading": True,
                 },
                 "queue compute": {
                     "compute_type": "ondemand",
@@ -69,7 +68,7 @@ def boto3_stubber_path():
                     "max_count": 10,
                     "initial_count": 2,
                     "spot_price": 0.4,
-                    "vcpus": 96,
+                    "vcpus": 48,
                     "gpus": 0,
                     "enable_efa": True,
                 },
@@ -98,15 +97,14 @@ def boto3_stubber_path():
                     "scheduler": "slurm",
                     "master_root_volume_size": 35,
                     "compute_root_volume_size": 40,
-                    # disable_hyperthreading and enable_efa must be set to None in converted cluster section
                     "enable_efa": None,
-                    "disable_hyperthreading": None,
+                    "disable_hyperthreading": False,
                 },
                 "queue compute": {
                     "compute_type": "ondemand",
                     "enable_efa": False,
                     "disable_hyperthreading": False,
-                    "placement_group": None,
+                    "placement_group": "",
                     "compute_resource_settings": "default",
                 },
                 "compute_resource default": {
@@ -196,4 +194,4 @@ def test_hit_converter(boto3_stubber, src_config_dict, dst_config_dict):
         assert_that(src_section).is_not_none()
 
         for param_key, param_value in section.items():
-            assert_that(src_section.get_param_value(param_key) == param_value)
+            assert_that(src_section.get_param_value(param_key)).is_equal_to(param_value)


### PR DESCRIPTION
disable_hyperthreading parameter must better be left into cluster section when converting the configuration, since in HIT model setting it to True means disabling Hyperthreading also in master node.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
