### PR TITLE
Increase timeout when waiting for all computes to terminate

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -420,7 +420,7 @@ def _retrieve_slurm_dummy_nodes(remote_command_executor, gres=False):
     return len(remote_command_executor.run_remote_command(retrieve_dummy_nodes_command).stdout.split("\n"))
 
 
-@retry(wait_fixed=seconds(20), stop_max_delay=minutes(7))
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(10))
 def _assert_no_nodes_in_scheduler(scheduler_commands):
     assert_that(scheduler_commands.compute_nodes_count()).is_equal_to(0)
 


### PR DESCRIPTION
This is meant to be a temporary change. It's purpose is to avoid false
failures due to compute node termination events taking longer than
expected to reach the SQS queue.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
