### PR TITLE
Add queue name to dna.json

### DIFF
--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -262,7 +262,8 @@ Resources:
                         "cfn_node_type": "ComputeFleet",
                         "cfn_cluster_user": "${OSUser}",
                         "enable_intel_hpc_platform": "${IntelHPCPlatform}",
-                        "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}"
+                        "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}",
+                        "scheduler_queue_name": "{{ queue }}"
                       },
                       "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
                     }


### PR DESCRIPTION
Needed in order to make this info available to pre/post_install scripts through `/etc/parallelcluster/cfnconfig`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
