### PR TITLE
Add disable_hyperthreading private parameter to compute_resource section

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -620,6 +620,13 @@ COMPUTE_RESOURCE = {
             "visibility": Visibility.PRIVATE,
             "default": False
         }),
+        ("disable_hyperthreading", {
+            "type": BooleanJsonParam,
+            # This param is managed automatically
+            "update_policy": UpdatePolicy.IGNORED,
+            "visibility": Visibility.PRIVATE,
+            "default": False
+        }),
     ])
 }
 

--- a/cli/pcluster/models/hit/hit_cluster_model.py
+++ b/cli/pcluster/models/hit/hit_cluster_model.py
@@ -89,7 +89,7 @@ class HITClusterModel(ClusterModel):
                 self.__test_compute_resource(
                     pcluster_config,
                     compute_resource_section,
-                    disable_hyperthreading=queue_section.get_param_value("disable_hyperthreading"),
+                    disable_hyperthreading=compute_resource_section.get_param_value("disable_hyperthreading"),
                     ami_id=latest_alinux_ami_id,
                     subnet=compute_subnet,
                     security_groups_ids=security_groups_ids,

--- a/cli/tests/pcluster/config/test_json_param_types/s3_config.json
+++ b/cli/tests/pcluster/config/test_json_param_types/s3_config.json
@@ -17,7 +17,8 @@
             "spot_price": 0,
             "vcpus": 2,
             "gpus": 0,
-            "enable_efa": false
+            "enable_efa": false,
+            "disable_hyperthreading": true
           },
           "q1-i2": {
             "instance_type": "g4dn.metal",
@@ -27,7 +28,8 @@
             "spot_price": 0,
             "vcpus": 96,
             "gpus": 8,
-            "enable_efa": true
+            "enable_efa": true,
+            "disable_hyperthreading": false
           },
           "q1-i3": {
             "instance_type": "i3en.24xlarge",
@@ -37,7 +39,8 @@
             "spot_price": 0,
             "vcpus": 48,
             "gpus": 0,
-            "enable_efa": true
+            "enable_efa": true,
+            "disable_hyperthreading": true
           }
         }
       },
@@ -55,7 +58,8 @@
             "spot_price": 0.4,
             "vcpus": 4,
             "gpus": 0,
-            "enable_efa": false
+            "enable_efa": false,
+            "disable_hyperthreading": false
           },
           "q2-i2": {
             "instance_type": "g4dn.metal",
@@ -65,7 +69,8 @@
             "spot_price": 0.5,
             "vcpus": 96,
             "gpus": 8,
-            "enable_efa": false
+            "enable_efa": false,
+            "disable_hyperthreading": false
           },
           "q2-i3": {
             "instance_type": "i3en.24xlarge",
@@ -75,7 +80,8 @@
             "spot_price": 0.6,
             "vcpus": 96,
             "gpus": 0,
-            "enable_efa": false
+            "enable_efa": false,
+            "disable_hyperthreading": false
           }
         }
       },
@@ -93,7 +99,8 @@
             "spot_price": 0.4,
             "vcpus": 96,
             "gpus": 0,
-            "enable_efa": true
+            "enable_efa": true,
+            "disable_hyperthreading": false
           }
         }
       }

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -116,8 +116,8 @@ Resources:
   {%- endif %}
         ImageId: !Ref 'ImageId'
         CpuOptions:
-          CoreCount: {{ compute_resource.vcpus if queue_config.disable_hyperthreading else "!Ref 'AWS::NoValue'" }}
-          ThreadsPerCore: {{ 1 if queue_config.disable_hyperthreading else "!Ref 'AWS::NoValue'" }}
+          CoreCount: {{ compute_resource.vcpus if compute_resource.disable_hyperthreading else "!Ref 'AWS::NoValue'" }}
+          ThreadsPerCore: {{ 1 if compute_resource.disable_hyperthreading else "!Ref 'AWS::NoValue'" }}
         Monitoring:
           Enabled: false
         TagSpecifications:
@@ -253,7 +253,7 @@ Resources:
                         "cfn_fsx_fs_id": "${FSXId}",
                         "cfn_fsx_options": "${FSXOptions}",
                         "cfn_scheduler": "${Scheduler}",
-                        "cfn_scheduler_slots": "{{ 'cores' if queue_config.disable_hyperthreading else 'vcpus' }}",
+                        "cfn_scheduler_slots": "{{ 'cores' if compute_resource.disable_hyperthreading else 'vcpus' }}",
                         "cfn_scaledown_idletime": "{{ scaling_config.scaledown_idletime }}",
                         "cfn_encrypted_ephemeral": "${EncryptedEphemeral}",
                         "cfn_ephemeral_dir": "${EphemeralDir}",


### PR DESCRIPTION
Similarly to `enable_efa`, this new private parameter tells if hyperthreading is actually disabled for the specific compute resource, independently from parent's `queue` section settings.

This new information allows to fix dryrun tests and the compute fleet cfn template.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.