### PR TITLE
Split Lambda cleanup functions and add possibility to disable Route53 creation

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -1023,6 +1023,11 @@ CLUSTER_HIT = {
                 "validators": [disable_hyperthreading_validator, disable_hyperthreading_architecture_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
+            ("disable_cluster_dns", {
+                "type": BooleanJsonParam,
+                "default": False,
+                "update_policy": UpdatePolicy.UNSUPPORTED
+            }),
         ]
     )
 }

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -169,6 +169,7 @@ DEFAULT_CLUSTER_HIT_DICT = {
     "custom_chef_cookbook": None,
     "disable_hyperthreading": None,
     "enable_intel_hpc_platform": False,
+    "disable_cluster_dns": False,
     "scaling_settings": "default",
     "vpc_settings": "default",
     "ebs_settings": None,

--- a/cli/tests/pcluster/config/test_json_param_types/s3_config.json
+++ b/cli/tests/pcluster/config/test_json_param_types/s3_config.json
@@ -2,6 +2,7 @@
   "cluster": {
     "label": "default",
     "default_queue": "None",
+    "disable_cluster_dns": true,
     "queue_settings": {
       "queue1": {
         "compute_type": "ondemand",

--- a/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
@@ -4,6 +4,7 @@ cluster_template = default
 [cluster default]
 queue_settings = {{queue_settings}}
 enable_efa = compute
+disable_cluster_dns = true
 # disable_hyperthreading not defined, fallback to False expected
 # disable_hyperthreading = false
 

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -163,9 +163,10 @@ def test_sit_cluster_section_from_file(mocker, config_parser_dict, expected_dict
         ),
         # right value
         (
-            {"cluster default": {"key_name": "test"}},
+            {"cluster default": {"key_name": "test", "disable_cluster_dns": True}},
             {
                 "key_name": "test",
+                "disable_cluster_dns": True,
                 "additional_iam_policies": [],
                 "architecture": None,
                 "scheduler": "slurm",

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1315,6 +1315,13 @@
               "false"
             ]
           },
+          "CreateCleanupRoute53FunctionLogGroup": {
+            "Fn::If": [
+              "CreateHITSubstack",
+              "true",
+              "false"
+            ]
+          },
           "CreateAWSBatchLogGroups": {
             "Fn::If": [
               "CreateAWSBatchStack",
@@ -1652,51 +1659,6 @@
               ]
             },
             {
-              "Sid": "DynamoDBTableQuery",
-              "Action": [
-                "dynamodb:Query"
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${AWS::StackName}"
-                },
-                {
-                  "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${AWS::StackName}/index/*"
-                }
-              ]
-            },
-            {
-              "Fn::If": [
-                "CreateHITSubstack",
-                {
-                  "Sid": "Route53Add",
-                  "Action": [
-                    "route53:ChangeResourceRecordSets"
-                  ],
-                  "Effect": "Allow",
-                  "Resource": [
-                    {
-                      "Fn::Sub": [
-                        "arn:${AWS::Partition}:route53:::hostedzone/${ClusterHostedZone}",
-                        {
-                          "ClusterHostedZone": {
-                            "Fn::GetAtt": [
-                              "ComputeFleetHITSubstack",
-                              "Outputs.ClusterHostedZone"
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "Ref": "AWS::NoValue"
-                }
-              ]
-            },
-            {
               "Sid": "S3GetObj",
               "Action": [
                 "s3:GetObject"
@@ -1815,6 +1777,21 @@
                 },
                 {
                   "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/*"
+                }
+              ]
+            },
+            {
+              "Sid": "DynamoDBTableQuery",
+              "Action": [
+                "dynamodb:Query"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${AWS::StackName}"
+                },
+                {
+                  "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${AWS::StackName}/index/*"
                 }
               ]
             }
@@ -2521,37 +2498,6 @@
                       "Ref": "AWS::NoValue"
                     }
                   ]
-                },
-                {
-                  "Fn::If": [
-                    "CreateHITSubstack",
-                    {
-                      "Sid": "Route53DeletePolicy",
-                      "Effect": "Allow",
-                      "Action": [
-                        "route53:ListResourceRecordSets",
-                        "route53:ChangeResourceRecordSets"
-                      ],
-                      "Resource": [
-                        {
-                          "Fn::Sub": [
-                            "arn:${AWS::Partition}:route53:::hostedzone/${ClusterHostedZone}",
-                            {
-                              "ClusterHostedZone": {
-                                "Fn::GetAtt": [
-                                  "ComputeFleetHITSubstack",
-                                  "Outputs.ClusterHostedZone"
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "Ref": "AWS::NoValue"
-                    }
-                  ]
                 }
               ],
               "Version": "2012-10-17"
@@ -2577,28 +2523,6 @@
         }
       },
       "Condition": "HasResourcesS3Bucket"
-    },
-    "CleanupResourcesDNSRecordsCustomResource": {
-      "Type": "AWS::CloudFormation::CustomResource",
-      "Properties": {
-        "ClusterHostedZone": {
-          "Fn::GetAtt": [
-            "ComputeFleetHITSubstack",
-            "Outputs.ClusterHostedZone"
-          ]
-        },
-        "Action": "DELETE_DNS_RECORDS",
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "CleanupResourcesFunction",
-            "Arn"
-          ]
-        }
-      },
-      "DependsOn": [
-        "CloudWatchLogsSubstack"
-      ],
-      "Condition": "CreateHITSubstack"
     },
     "TerminateComputeFleetCustomResource": {
       "Type": "AWS::CloudFormation::CustomResource",
@@ -3115,11 +3039,24 @@
           "ResourcesS3Bucket": {
             "Ref": "ResourcesS3Bucket"
           },
-          "DependsOnTerminateComputeFleetCustomResource": {
+          "DependsOnCustomResources": {
             "Fn::If": [
               "CreateHITSubstack",
               {
-                "Ref": "TerminateComputeFleetCustomResource"
+                "Fn::Sub": [
+                  "DependsOn${fleetTermination}And${route53cleanup}",
+                  {
+                    "fleetTermination": {
+                      "Ref": "TerminateComputeFleetCustomResource"
+                    },
+                    "route53cleanup": {
+                      "Fn::GetAtt": [
+                        "ComputeFleetHITSubstack",
+                        "Outputs.CleanupRoute53CustomResource"
+                      ]
+                    }
+                  }
+                ]
               },
               ""
             ]
@@ -3742,7 +3679,7 @@
           },
           "ClusterDNSDomain": {
             "Fn::Sub": [
-              "${ClusterName}.parallelcluster",
+              "${ClusterName}.pcluster",
               {
                 "ClusterName": {
                   "Fn::Select": [
@@ -3861,6 +3798,18 @@
           },
           "VPCId": {
             "Ref": "VPCId"
+          },
+          "RootRole": {
+            "Fn::If": [
+              "UseEC2IAMRole",
+              "NONE",
+              {
+                "Ref": "RootRole"
+              }
+            ]
+          },
+          "ResourcesS3Bucket": {
+            "Ref": "ResourcesS3Bucket"
           }
         },
         "TemplateURL": {

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -78,10 +78,18 @@ Parameters:
     Type: String
   VPCId:
     Type: AWS::EC2::VPC::Id
+  RootRole:
+    Type: String
+  ResourcesS3Bucket:
+    Type: String
 Conditions:
   UseProxy: !Not
     - !Equals
       - !Ref 'ProxyServer'
+      - NONE
+  AddRoute53IamPolicies: !Not
+    - !Equals
+      - !Ref 'RootRole'
       - NONE
 Resources:
 {%- for queue, queue_config in queues.items() %}
@@ -264,8 +272,8 @@ Resources:
                         "cfn_shared_dir": "${SharedDir}",
                         "cfn_proxy": "${ProxyServer}",
                         "cfn_ddb_table": "${DynamoDBTable}",
-                        "cfn_dns_domain": "${ClusterDNSDomain}",
-                        "cfn_hosted_zone": "${ClusterHostedZone}",
+                        "cfn_dns_domain": {% if config.cluster.disable_cluster_dns == False %}"${ClusterDNSDomain}"{% else %}""{% endif %},
+                        "cfn_hosted_zone": {% if config.cluster.disable_cluster_dns == False %}"${ClusterHostedZone}"{% else %}""{% endif %},
                         "cfn_node_type": "ComputeFleet",
                         "cfn_cluster_user": "${OSUser}",
                         "enable_intel_hpc_platform": "${IntelHPCPlatform}",
@@ -300,6 +308,7 @@ Resources:
                 echo "Reporting instance as unhealthy and dumping logs to ${!log_dir}/${!instance_id}.tar.gz"
                 tar -czf ${!log_dir}/${!instance_id}.tar.gz /var/log
                 # TODO: add possibility to disable this behavior
+                # wait logs flush before signaling the failure
                 sleep 10
                 aws --region ${!region} ec2 terminate-instances --instance-ids ${!instance_id}
                 exit 1
@@ -424,6 +433,7 @@ Resources:
           Projection:
             ProjectionType: KEYS_ONLY
       BillingMode: PAY_PER_REQUEST
+  {%- if config.cluster.disable_cluster_dns == False %}
   ClusterHostedZone:
     Type: AWS::Route53::HostedZone
     Properties:
@@ -431,11 +441,98 @@ Resources:
       VPCs:
         - VPCId: !Ref 'VPCId'
           VPCRegion: !Ref 'AWS::Region'
+  ParallelClusterHITRoute53Policies:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: parallelcluster-hit-route53
+      PolicyDocument:
+        Statement:
+          - Sid: Route53Add
+            Action:
+              - route53:ChangeResourceRecordSets
+            Effect: Allow
+            Resource:
+              - !Sub
+                - arn:${AWS::Partition}:route53:::hostedzone/${ClusterHostedZone}
+                - ClusterHostedZone: !Ref 'ClusterHostedZone'
+      Roles:
+        - !Ref 'RootRole'
+    Condition: AddRoute53IamPolicies
+  CleanupRoute53Function:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub
+        - pcluster-CleanupRoute53-${StackId}
+        - StackId: !Select
+            - '2'
+            - !Split
+              - /
+              - !Ref 'AWS::StackId'
+      Code:
+        S3Bucket: !Ref 'ResourcesS3Bucket'
+        S3Key: custom_resources_code/artifacts.zip
+      Handler: cleanup_resources.handler
+      MemorySize: 128
+      Role: !GetAtt 'CleanupRoute53FunctionExecutionRole.Arn'
+      Runtime: python3.8
+      Timeout: 900
+  CleanupRoute53CustomResource:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ClusterHostedZone: !Ref 'ClusterHostedZone'
+      Action: DELETE_DNS_RECORDS
+      ServiceToken: !GetAtt 'CleanupRoute53Function.Arn'
+  CleanupRoute53FunctionExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+        Version: '2012-10-17'
+      Path: /
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Effect: Allow
+                Resource: !Sub 'arn:${AWS::Partition}:logs:*:*:*'
+                Sid: CloudWatchLogsPolicy
+              - Sid: Route53DeletePolicy
+                Effect: Allow
+                Action:
+                  - route53:ListResourceRecordSets
+                  - route53:ChangeResourceRecordSets
+                Resource:
+                  - !Sub
+                    - arn:${AWS::Partition}:route53:::hostedzone/${ClusterHostedZone}
+                    - ClusterHostedZone: !Ref 'ClusterHostedZone'
+            Version: '2012-10-17'
+          PolicyName: LambdaPolicy
+  {%- endif %}
+Metadata:
+  RootRole: !Ref 'RootRole'
+  VPCId: !Ref 'VPCId'
+  ClusterDNSDomain: !Ref 'ClusterDNSDomain'
+  ResourcesS3Bucket: !Ref 'ResourcesS3Bucket'
+  AddRoute53IamPolicies: !If
+    - AddRoute53IamPolicies
+    - true
+    - false
 Outputs:
   ClusterHostedZone:
     Description: Id of the private hosted zone created within the cluster
-    Value: !Ref 'ClusterHostedZone'
+    Value: {% if config.cluster.disable_cluster_dns == False %}!Ref 'ClusterHostedZone'{% else %}''{% endif %}
   ClusterDNSDomain:
     Description: DNS Domain of the private hosted zone created within the cluster
-    Value: !Ref 'ClusterDNSDomain'
+    Value: {% if config.cluster.disable_cluster_dns == False %}!Ref 'ClusterDNSDomain'{% else %}''{% endif %}
+  CleanupRoute53CustomResource:
+    Description: ARN of the custom resource to cleanup Route53
+    Value: {% if config.cluster.disable_cluster_dns == False %}!Ref 'CleanupRoute53CustomResource'{% else %}''{% endif %}
 

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -377,6 +377,8 @@ Resources:
                 mkdir -p ${!log_dir}
                 echo "Reporting instance as unhealthy and dumping logs to ${!log_dir}/${!instance_id}.tar.gz"
                 tar -czf ${!log_dir}/${!instance_id}.tar.gz /var/log
+                # wait logs flush before signaling the failure
+                sleep 10
                 aws --region ${!region} autoscaling set-instance-health --instance-id ${!instance_id} --health-status Unhealthy
                 cfn-signal --exit-code=1 --reason="$1" --stack=${AWS::StackName} --role=${IamRoleName} --resource=ComputeFleet --region=${!region}
                 exit 1

--- a/cloudformation/cw-logs-substack.cfn.json
+++ b/cloudformation/cw-logs-substack.cfn.json
@@ -26,6 +26,14 @@
         "true"
       ]
     },
+    "CreateCleanupRoute53FunctionLogGroup": {
+      "Fn::Equals": [
+        {
+          "Ref": "CreateCleanupRoute53FunctionLogGroup"
+        },
+        "true"
+      ]
+    },
     "CreateAWSBatchLogGroups": {
       "Fn::Equals": [
         {
@@ -54,6 +62,10 @@
     },
     "CreateCleanupResourcesFunctionLogGroup": {
       "Description": "Set to true in order to create the log group for CreateCleanupResourcesFunction",
+      "Type": "String"
+    },
+    "CreateCleanupRoute53FunctionLogGroup": {
+      "Description": "Set to true in order to create the log group for CreateCleanupRoute53Function",
       "Type": "String"
     },
     "CreateAWSBatchLogGroups": {
@@ -105,6 +117,28 @@
         }
       },
       "Condition": "CreateCleanupResourcesFunctionLogGroup"
+    },
+    "CleanupRoute53FunctionLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": "/aws/lambda/pcluster-CleanupRoute53-${MainStackUniqueId}"
+        },
+        "RetentionInDays": {
+          "Fn::Select": [
+            "1",
+            {
+              "Fn::Split": [
+                ",",
+                {
+                  "Ref": "CWLogOptions"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "Condition": "CreateCleanupRoute53FunctionLogGroup"
     },
     "CodeBuildLogGroup": {
       "Type": "AWS::Logs::LogGroup",

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -104,7 +104,7 @@ Parameters:
     Type: String
   ResourcesS3Bucket:
     Type: String
-  DependsOnTerminateComputeFleetCustomResource:
+  DependsOnCustomResources:
     Type: String
     Description: This is needed to set a conditional dependency on the TerminateComputeFleetCustomResource
       used with HIT
@@ -339,6 +339,8 @@ Resources:
 
               function error_exit
               {
+                # wait logs flush before signaling the failure
+                sleep 10
                 cfn-signal --exit-code=1 --reason="$1" --stack=${AWS::StackName} --role=${IamRoleName} --resource=MasterServer --region=${AWS::Region}
                 exit 1
               }
@@ -542,4 +544,4 @@ Outputs:
     Description: Private DNS name of the Master host
     Value: !GetAtt 'MasterServer.PrivateDnsName'
 Metadata:
-  DependsOnTerminateComputeFleetCustomResource: !Ref 'DependsOnTerminateComputeFleetCustomResource'
+  DependsOnCustomResources: !Ref 'DependsOnCustomResources'

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -3,6 +3,7 @@ import importlib.util
 import sys
 from unittest.mock import patch
 
+import pytest
 from cfnlint.__main__ import main as cfnlint
 from jinja2 import Environment, FileSystemLoader
 
@@ -11,76 +12,123 @@ cfn_formatter = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(cfn_formatter)
 
 
-def test_hit_substack_rendering(tmp_path):
-    test_config = {
-        "cluster": {
-            "label": "default",
-            "default_queue": "multiple_spot",
-            "queue_settings": {
-                "multiple_spot": {
-                    "compute_type": "spot",
-                    "enable_efa": False,
-                    "disable_hyperthreading": True,
-                    "placement_group": None,
-                    "compute_resource_settings": {
-                        "multiple_spot_c4.xlarge": {
-                            "instance_type": "c4.xlarge",
-                            "min_count": 0,
-                            "max_count": 10,
-                            "spot_price": None,
-                            "vcpus": 2,
-                            "gpus": 0,
+@pytest.mark.parametrize(
+    "test_config",
+    [
+        (
+            {
+                "cluster": {
+                    "label": "default",
+                    "default_queue": "multiple_spot",
+                    "queue_settings": {
+                        "multiple_spot": {
+                            "compute_type": "spot",
                             "enable_efa": False,
+                            "disable_hyperthreading": True,
+                            "placement_group": None,
+                            "compute_resource_settings": {
+                                "multiple_spot_c4.xlarge": {
+                                    "instance_type": "c4.xlarge",
+                                    "min_count": 0,
+                                    "max_count": 10,
+                                    "spot_price": None,
+                                    "vcpus": 2,
+                                    "gpus": 0,
+                                    "enable_efa": False,
+                                },
+                                "multiple_spot_c5.2xlarge": {
+                                    "instance_type": "c5.2xlarge",
+                                    "min_count": 1,
+                                    "max_count": 5,
+                                    "spot_price": 1.5,
+                                    "vcpus": 4,
+                                    "gpus": 0,
+                                    "enable_efa": False,
+                                },
+                            },
                         },
-                        "multiple_spot_c5.2xlarge": {
-                            "instance_type": "c5.2xlarge",
-                            "min_count": 1,
-                            "max_count": 5,
-                            "spot_price": 1.5,
-                            "vcpus": 4,
-                            "gpus": 0,
-                            "enable_efa": False,
-                        },
-                    },
-                },
-                "efa": {
-                    "compute_resource_settings": {
-                        "efa_c5n.18xlarge": {
-                            "instance_type": "c5n.18xlarge",
-                            "min_count": 0,
-                            "max_count": 5,
-                            "spot_price": None,
-                            "vcpus": 36,
-                            "gpus": 0,
+                        "efa": {
+                            "compute_resource_settings": {
+                                "efa_c5n.18xlarge": {
+                                    "instance_type": "c5n.18xlarge",
+                                    "min_count": 0,
+                                    "max_count": 5,
+                                    "spot_price": None,
+                                    "vcpus": 36,
+                                    "gpus": 0,
+                                    "enable_efa": True,
+                                }
+                            },
+                            "compute_type": "ondemand",
                             "enable_efa": True,
+                            "disable_hyperthreading": True,
+                            "placement_group": "DYNAMIC",
                         },
-                    },
-                    "compute_type": "ondemand",
-                    "enable_efa": True,
-                    "disable_hyperthreading": True,
-                    "placement_group": "DYNAMIC",
-                },
-                "gpu": {
-                    "compute_resource_settings": {
-                        "gpu_g3.8xlarge": {
-                            "instance_type": "g3.8xlarge",
-                            "min_count": 0,
-                            "max_count": 5,
-                            "spot_price": None,
-                            "vcpus": 16,
-                            "gpus": 2,
+                        "gpu": {
+                            "compute_resource_settings": {
+                                "gpu_g3.8xlarge": {
+                                    "instance_type": "g3.8xlarge",
+                                    "min_count": 0,
+                                    "max_count": 5,
+                                    "spot_price": None,
+                                    "vcpus": 16,
+                                    "gpus": 2,
+                                    "enable_efa": False,
+                                }
+                            },
+                            "compute_type": "ondemand",
                             "enable_efa": False,
+                            "disable_hyperthreading": True,
+                            "placement_group": None,
                         },
                     },
-                    "compute_type": "ondemand",
-                    "enable_efa": False,
-                    "disable_hyperthreading": True,
-                    "placement_group": None,
-                },
-            },
-            "scaling": {"scaledown_idletime": 10},
-        }
-    }
+                    "scaling": {"scaledown_idletime": 10},
+                    "disable_cluster_dns": False,
+                }
+            }
+        ),
+        (
+            {
+                "cluster": {
+                    "label": "default",
+                    "default_queue": "multiple_spot",
+                    "queue_settings": {
+                        "multiple_spot": {
+                            "compute_type": "spot",
+                            "enable_efa": False,
+                            "disable_hyperthreading": True,
+                            "placement_group": None,
+                            "compute_resource_settings": {
+                                "multiple_spot_c4.xlarge": {
+                                    "instance_type": "c4.xlarge",
+                                    "min_count": 0,
+                                    "max_count": 10,
+                                    "spot_price": None,
+                                    "vcpus": 2,
+                                    "gpus": 0,
+                                    "enable_efa": False,
+                                },
+                                "multiple_spot_c5.2xlarge": {
+                                    "instance_type": "c5.2xlarge",
+                                    "min_count": 1,
+                                    "max_count": 5,
+                                    "spot_price": 1.5,
+                                    "vcpus": 4,
+                                    "gpus": 0,
+                                    "enable_efa": False,
+                                },
+                            },
+                        }
+                    },
+                    "scaling": {"scaledown_idletime": 10},
+                    "disable_cluster_dns": True,
+                }
+            }
+        ),
+    ],
+    ids=["complete", "without_route53"],
+)
+def test_hit_substack_rendering(tmp_path, test_config):
 
     env = Environment(loader=FileSystemLoader(".."))
     env.filters["sha1"] = lambda value: hashlib.sha1(value.strip().encode()).hexdigest()


### PR DESCRIPTION
# Lambda split
The lambda to cleanup the S3 Bucket must be executed as soon as possible instead the lambda functions to terminate the instances and to cleanup the route53 must be executed after the master is stopped to avoid other instances or record set to be added after the Lambda execution.

Moved the Lambda related code and the policy specific to HIT in the compute fleet hit substack.
We are creating a policy in the substack and attaching it to the RootRole if the customer is not using a custom EC2 IAM Role

The trick to have a dependency in the Master substack is to add the TerminateComputeFleetCustomResource and the CleanupRoute53CustomResource as custom parameter "DependsOnCustomResources".

# Disabling Route53 creation
From now it is possible to add `disable_cluster_dns = True` as configuration parameter to avoid the creation of the Route53 resource and related Lambda cleanup function.

To have a valid substack when Route53 resource is not created we  are using input parameters as metadata.

