### PR TITLE
Set chef log level to info on master node

### DIFF
--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -501,7 +501,7 @@ Resources:
           commands:
             chef:
               command: chef-client --local-mode --config /etc/chef/client.rb --log_level
-                auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes
+                info --force-formatter --no-color --chef-zero-port 8889 --json-attributes
                 /etc/chef/dna.json --override-runlist aws-parallelcluster::_prep_env
                 | tee -a /var/log/chef-client.log
               cwd: /etc/chef
@@ -513,7 +513,7 @@ Resources:
           commands:
             chef:
               command: chef-client --local-mode --config /etc/chef/client.rb --log_level
-                auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes
+                info --force-formatter --no-color --chef-zero-port 8889 --json-attributes
                 /etc/chef/dna.json | tee -a /var/log/chef-client.log
               cwd: /etc/chef
         shellRunPostInstall:
@@ -524,7 +524,7 @@ Resources:
           commands:
             chef:
               command: chef-client --local-mode --config /etc/chef/client.rb --log_level
-                auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes
+                info --force-formatter --no-color --chef-zero-port 8889 --json-attributes
                 /etc/chef/dna.json --override-runlist aws-parallelcluster::finalize
                 | tee -a /var/log/chef-client.log
               cwd: /etc/chef


### PR DESCRIPTION
This will increase the size of chef log output from about 100K to 500K with the advantage of speeding up troubleshooting.
I'm not changing the log level on compute nodes in order to avoid a more significant growth in the uploaded CloudWatch logs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
