### PR TITLE
Extend projection of InstanceId key to ALL the keys

### DIFF
--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -431,7 +431,7 @@ Resources:
             - AttributeName: InstanceId
               KeyType: HASH
           Projection:
-            ProjectionType: KEYS_ONLY
+            ProjectionType: ALL
       BillingMode: PAY_PER_REQUEST
   {%- if config.cluster.disable_cluster_dns == False %}
   ClusterHostedZone:


### PR DESCRIPTION
We need to retrieve all the keys because we're saving in the table the master ip and the master hostname too.

