### PR TITLE
Fail cluster creation at chef-client failure

### DIFF
--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -505,7 +505,7 @@ Resources:
               command: chef-client --local-mode --config /etc/chef/client.rb --log_level
                 info --force-formatter --no-color --chef-zero-port 8889 --json-attributes
                 /etc/chef/dna.json --override-runlist aws-parallelcluster::_prep_env
-                | tee -a /var/log/chef-client.log
+                | tee -a /var/log/chef-client.log && exit ${PIPESTATUS[0]}
               cwd: /etc/chef
         shellRunPreInstall:
           commands:
@@ -516,7 +516,7 @@ Resources:
             chef:
               command: chef-client --local-mode --config /etc/chef/client.rb --log_level
                 info --force-formatter --no-color --chef-zero-port 8889 --json-attributes
-                /etc/chef/dna.json | tee -a /var/log/chef-client.log
+                /etc/chef/dna.json | tee -a /var/log/chef-client.log && exit ${PIPESTATUS[0]}
               cwd: /etc/chef
         shellRunPostInstall:
           commands:
@@ -528,7 +528,7 @@ Resources:
               command: chef-client --local-mode --config /etc/chef/client.rb --log_level
                 info --force-formatter --no-color --chef-zero-port 8889 --json-attributes
                 /etc/chef/dna.json --override-runlist aws-parallelcluster::finalize
-                | tee -a /var/log/chef-client.log
+                | tee -a /var/log/chef-client.log && exit ${PIPESTATUS[0]}
               cwd: /etc/chef
             bootstrap:
               command: '[ ! -f /opt/parallelcluster/.bootstrapped ] && echo ${parallelcluster_version}


### PR DESCRIPTION
After the addition of the `tee` command execution in pipe with the chef-client execution the cluster creation was having success also if there were errors.

We might use `set -e pipefail;` but it doesn't work in dash shells, so we're using the approach of exiting by using the `PIPESTATUS[0]`


Not tested in case of failures.