### PR TITLE
Rename _prep_env recipe and create prep_env_slurm

### DIFF
--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -380,7 +380,7 @@ Resources:
               jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' > /etc/chef/dna.json || ( echo "jq not installed or invalid extra_json"; cp /tmp/dna.json /etc/chef/dna.json)
               {
                 pushd /etc/chef &&
-                chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::_prep_env &&
+                chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::prep_env &&
                 /opt/parallelcluster/scripts/fetch_and_run -preinstall &&
                 chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json &&
                 /opt/parallelcluster/scripts/fetch_and_run -postinstall &&

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -454,7 +454,7 @@ Resources:
               jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' > /etc/chef/dna.json || ( echo "jq not installed or invalid extra_json"; cp /tmp/dna.json /etc/chef/dna.json)
               {
                 pushd /etc/chef &&
-                chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::_prep_env &&
+                chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::prep_env &&
                 /opt/parallelcluster/scripts/fetch_and_run -preinstall &&
                 chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json &&
                 /opt/parallelcluster/scripts/fetch_and_run -postinstall &&

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -504,7 +504,7 @@ Resources:
             chef:
               command: chef-client --local-mode --config /etc/chef/client.rb --log_level
                 info --force-formatter --no-color --chef-zero-port 8889 --json-attributes
-                /etc/chef/dna.json --override-runlist aws-parallelcluster::_prep_env
+                /etc/chef/dna.json --override-runlist aws-parallelcluster::prep_env
                 | tee -a /var/log/chef-client.log && exit ${PIPESTATUS[0]}
               cwd: /etc/chef
         shellRunPreInstall:


### PR DESCRIPTION
Rename _prep_env recipe to prep_env and create prep_env_slurm

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
