### PR TITLE
Add S3 Read policy when pre/post install is passed as S3 URL

### DIFF
--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -87,7 +87,9 @@ def test_single_param_change(
     dst_dict.update(default_cluster_params)
     dst_dict[param_key] = dst_param_value
     dst_config_file = pcluster_config_reader(dst_config_file, **dst_dict)
-    dst_conf = PclusterConfig(config_file=dst_config_file,)
+    dst_conf = PclusterConfig(
+        config_file=dst_config_file,
+    )
 
     expected_change = Change(
         section_key, section_label, param_key, src_param_value, dst_param_value, change_update_policy
@@ -127,7 +129,10 @@ def test_multiple_param_changes(mocker, pcluster_config_reader, test_datadir):
     ]
 
     _check_patch(
-        src_conf, dst_conf, expected_changes, UpdatePolicy.UNSUPPORTED,
+        src_conf,
+        dst_conf,
+        expected_changes,
+        UpdatePolicy.UNSUPPORTED,
     )
 
 

--- a/cli/tests/pcluster/config/test_runtime.py
+++ b/cli/tests/pcluster/config/test_runtime.py
@@ -17,7 +17,10 @@ from pcluster.config.pcluster_config import PclusterConfig
 def test_update_sections(mocker, pcluster_config_reader):
     mocker.patch("pcluster.config.param_types.get_supported_architectures_for_instance_type", return_value=["x86_64"])
     pcluster_config = PclusterConfig(
-        cluster_label="default", config_file=pcluster_config_reader(), fail_on_file_absence=True, fail_on_error=True,
+        cluster_label="default",
+        config_file=pcluster_config_reader(),
+        fail_on_file_absence=True,
+        fail_on_error=True,
     )
 
     ebs1 = pcluster_config.get_section("ebs", "ebs1")

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -20,7 +20,10 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
 @pytest.mark.parametrize(
     "cfn_params_dict, expected_section_dict",
     [
-        ({}, utils.merge_dicts(DefaultDict["cluster"].value, {"additional_iam_policies": []}),),
+        (
+            {},
+            utils.merge_dicts(DefaultDict["cluster"].value, {"additional_iam_policies": []}),
+        ),
         (
             DefaultCfnParams["cluster"].value,
             utils.merge_dicts(
@@ -427,7 +430,8 @@ def test_cluster_section_to_file(mocker, section_dict, expected_config_parser_di
 
 
 @pytest.mark.parametrize(
-    "section_dict, expected_cfn_params", [(DefaultDict["cluster"].value, DefaultCfnParams["cluster"].value)],
+    "section_dict, expected_cfn_params",
+    [(DefaultDict["cluster"].value, DefaultCfnParams["cluster"].value)],
 )
 def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
     utils.set_default_values_for_required_cluster_section_params(section_dict)
@@ -716,7 +720,10 @@ def test_cluster_section_to_cfn(mocker, section_dict, expected_cfn_params):
                 },
             ),
         ),
-        ("cw_log", utils.merge_dicts(DefaultCfnParams["cluster"].value, {"CWLogOptions": "true,1"}),),
+        (
+            "cw_log",
+            utils.merge_dicts(DefaultCfnParams["cluster"].value, {"CWLogOptions": "true,1"}),
+        ),
         (
             "all-settings",
             utils.merge_dicts(

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -124,7 +124,12 @@ def mock_pcluster_config(mocker, scheduler=None, extra_patches=None, patch_funcs
 
 
 def assert_param_validator(
-    mocker, config_parser_dict, expected_error=None, capsys=None, expected_warning=None, extra_patches=None,
+    mocker,
+    config_parser_dict,
+    expected_error=None,
+    capsys=None,
+    expected_warning=None,
+    extra_patches=None,
 ):
     config_parser = configparser.ConfigParser()
 

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -314,14 +314,14 @@ def pcluster_config_reader(test_datadir, vpc_stacks, region, request):
         env = Environment(loader=file_loader)
         rendered_template = env.get_template(config_file).render(**{**kwargs, **default_values})
         config_file_path.write_text(rendered_template)
-        _add_custom_packages_configs(config_file_path, request)
+        _add_custom_packages_configs(config_file_path, request, region)
         _enable_sanity_check_if_unset(config_file_path)
         return config_file_path
 
     return _config_renderer
 
 
-def _add_custom_packages_configs(cluster_config, request):
+def _add_custom_packages_configs(cluster_config, request, region):
     config = configparser.ConfigParser()
     config.read(cluster_config)
     cluster_template = "cluster {0}".format(config.get("global", "cluster_template", fallback="default"))
@@ -329,6 +329,8 @@ def _add_custom_packages_configs(cluster_config, request):
     for custom_option in ["template_url", "custom_awsbatch_template_url", "custom_chef_cookbook", "custom_ami"]:
         if request.config.getoption(custom_option) and custom_option not in config[cluster_template]:
             config[cluster_template][custom_option] = request.config.getoption(custom_option)
+            if custom_option in ["pre_install", "post_install"]:
+                _add_policy_for_pre_post_install(cluster_template, config, custom_option, request, region)
 
     extra_json = json.loads(config.get(cluster_template, "extra_json", fallback="{}"))
     for extra_json_custom_option in ["custom_awsbatchcli_package", "custom_node_package"]:
@@ -345,6 +347,33 @@ def _add_custom_packages_configs(cluster_config, request):
 
     with cluster_config.open(mode="w") as f:
         config.write(f)
+
+
+def _add_policy_for_pre_post_install(cluster_template, config, custom_option, request, region):
+    match = re.match(r"s3://(.*?)/(.*)", request.config.getoption(custom_option))
+    if not match or len(match.groups()) < 2:
+        logging.info("{0} script is not an S3 URL".format(custom_option))
+    else:
+        additional_iam_policies = "arn:" + _get_arn_partition(region) + ":iam::aws:policy/AmazonS3ReadOnlyAccess"
+        logging.info(
+            "{0} script is an S3 URL, adding additional_iam_policies={1}".format(custom_option, additional_iam_policies)
+        )
+
+        if "additional_iam_policies" not in config[cluster_template]:
+            config[cluster_template]["additional_iam_policies"] = additional_iam_policies
+        else:
+            config[cluster_template]["additional_iam_policies"] = (
+                config[cluster_template]["additional_iam_policies"] + ", " + additional_iam_policies
+            )
+
+
+def _get_arn_partition(region):
+    if region.startswith("us-gov-"):
+        return "aws-us-gov"
+    elif region.startswith("cn-"):
+        return "aws-cn"
+    else:
+        return "aws"
 
 
 def _enable_sanity_check_if_unset(cluster_config):

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -91,7 +91,13 @@ class RemoteCommandExecutor:
         return result
 
     def run_remote_script(
-        self, script_file, args=None, log_error=True, additional_files=None, hide=False, timeout=None,
+        self,
+        script_file,
+        args=None,
+        log_error=True,
+        additional_files=None,
+        hide=False,
+        timeout=None,
     ):
         """
         Execute a script remotely on the cluster master node.

--- a/tests/integration-tests/tests/common/scaling_common.py
+++ b/tests/integration-tests/tests/common/scaling_common.py
@@ -135,7 +135,9 @@ def get_stack(stack_name, region, cfn_client=None):
     """
     if not cfn_client:
         cfn_client = boto3.client("cloudformation", region_name=region)
-    return cfn_client.describe_stacks(StackName=stack_name,).get("Stacks")[0]
+    return cfn_client.describe_stacks(StackName=stack_name,).get(
+        "Stacks"
+    )[0]
 
 
 def get_stack_output_value(stack_outputs, output_key):

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -92,7 +92,11 @@ def test_fsx_lustre(
 @pytest.mark.skip_dimensions("*", "m6g.xlarge", "centos7", "*")
 @pytest.mark.skip_dimensions("*", "m6g.xlarge", "ubuntu1604", "*")
 def test_fsx_lustre_backup(
-    region, pcluster_config_reader, clusters_factory, test_datadir, os,
+    region,
+    pcluster_config_reader,
+    clusters_factory,
+    test_datadir,
+    os,
 ):
     """
     Test FSx Lustre backup feature. As part of this test, following steps are performed
@@ -143,7 +147,9 @@ def test_fsx_lustre_backup(
 
     # Restore backup into a new cluster
     cluster_config_restore = pcluster_config_reader(
-        config_file="pcluster_restore_fsx.config.ini", mount_dir=mount_dir, fsx_backup_id=manual_backup.get("BackupId"),
+        config_file="pcluster_restore_fsx.config.ini",
+        mount_dir=mount_dir,
+        fsx_backup_id=manual_backup.get("BackupId"),
     )
 
     cluster_restore = clusters_factory(cluster_config_restore)

--- a/util/sync_buckets.py
+++ b/util/sync_buckets.py
@@ -79,10 +79,16 @@ def _parse_args():
         default="{region}-aws-parallelcluster",
     )
     parser.add_argument(
-        "--src-bucket", type=str, help="Source bucket", required=True,
+        "--src-bucket",
+        type=str,
+        help="Source bucket",
+        required=True,
     )
     parser.add_argument(
-        "--src-bucket-region", type=str, help="Source bucket region", required=True,
+        "--src-bucket-region",
+        type=str,
+        help="Source bucket region",
+        required=True,
     )
     parser.add_argument("--src-files", help="Files to sync", nargs="+", required=True)
     parser.add_argument(


### PR DESCRIPTION
Add S3 Read policy as additional_iam_policies when post/pre install script is passed as S3 URL to integration test run.
This will allow the cluster to read from the specified bucket where the pre/post installation script is located

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
