### PR TITLE
Add pre/post install options in integration test

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -72,6 +72,8 @@ def pytest_addoption(parser):
     parser.addoption("--custom-awsbatchcli-package", help="url to a custom awsbatch cli package")
     parser.addoption("--custom-node-package", help="url to a custom node package")
     parser.addoption("--custom-ami", help="custom AMI to use in the tests")
+    parser.addoption("--pre-install", help="url to pre install script")
+    parser.addoption("--post-install", help="url to post install script")
     parser.addoption("--vpc-stack", help="Name of an existing vpc stack.")
     parser.addoption("--cluster", help="Use an existing cluster instead of creating one.")
     parser.addoption(
@@ -326,7 +328,14 @@ def _add_custom_packages_configs(cluster_config, request):
     config.read(cluster_config)
     cluster_template = "cluster {0}".format(config.get("global", "cluster_template", fallback="default"))
 
-    for custom_option in ["template_url", "custom_awsbatch_template_url", "custom_chef_cookbook", "custom_ami"]:
+    for custom_option in [
+        "template_url",
+        "custom_awsbatch_template_url",
+        "custom_chef_cookbook",
+        "custom_ami",
+        "pre_install",
+        "post_install",
+    ]:
         if request.config.getoption(custom_option) and custom_option not in config[cluster_template]:
             config[cluster_template][custom_option] = request.config.getoption(custom_option)
 

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -67,6 +67,8 @@ TEST_DEFAULTS = {
     "custom_awsbatch_template_url": None,
     "custom_awsbatchcli_url": None,
     "custom_ami": None,
+    "pre_install": None,
+    "post_install": None,
     "vpc_stack": None,
     "cluster": None,
     "no_delete": False,
@@ -191,6 +193,10 @@ def _init_argparser():
     )
     parser.add_argument(
         "--custom-ami", help="custom AMI to use for all tests.", default=TEST_DEFAULTS.get("custom_ami")
+    )
+    parser.add_argument("--pre-install", help="URL to a pre install script", default=TEST_DEFAULTS.get("pre_install"))
+    parser.add_argument(
+        "--post-install", help="URL to a post install script", default=TEST_DEFAULTS.get("post_install")
     )
     parser.add_argument("--vpc-stack", help="Name of an existing vpc stack.", default=TEST_DEFAULTS.get("vpc_stack"))
     parser.add_argument(
@@ -324,7 +330,6 @@ def _get_pytest_args(args, regions, log_file, out_dir):
 
     _set_custom_packages_args(args, pytest_args)
     _set_custom_stack_args(args, pytest_args)
-
     return pytest_args
 
 
@@ -349,6 +354,12 @@ def _set_custom_packages_args(args, pytest_args):
 
     if args.custom_ami:
         pytest_args.extend(["--custom-ami", args.custom_ami])
+
+    if args.pre_install:
+        pytest_args.extend(["--pre-install", args.pre_install])
+
+    if args.post_install:
+        pytest_args.extend(["--post-install", args.post_install])
 
 
 def _set_custom_stack_args(args, pytest_args):


### PR DESCRIPTION
--pre-install URL to a pre install script (default: None)
--post-install URL to a post install script (default: None)

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
