### PR TITLE
 Add section label verifiers

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -129,7 +129,6 @@ ALLOWED_VALUES = {
             r"(\/([0-9]|[1-2][0-9]|3[0-2]))$",
     "efs_fs_id": r"^fs-[0-9a-z]{8}$|^fs-[0-9a-z]{17}|NONE$",
     "file_path": r"^\/?[^\/.\\][^\/\\]*(\/[^\/.\\][^\/]*)*$",
-    "queue_settings": r"^[a-zA-Z][a-zA-Z0-9-]{0,29}(,\s*[a-zA-Z][a-zA-Z0-9-]{0,29})*$",
     "fsx_fs_id": r"^fs-[0-9a-z]{17}|NONE$",
     "greater_than_25": r"^([0-9]+[0-9]{2}|[3-9][0-9]|2[5-9])$",
     "security_group_id": r"^sg-[0-9a-z]{8}$|^sg-[0-9a-z]{17}$",
@@ -1016,7 +1015,6 @@ CLUSTER_HIT = {
             ("queue_settings", {
                 "type": SettingsJsonParam,
                 "referred_section": QUEUE,
-                "allowed_values": ALLOWED_VALUES["queue_settings"],
                 "validators": [queue_settings_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED,
             }),

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -83,6 +83,22 @@ class Param(ABC):
         """Load the param from the related storage data structure."""
         pass
 
+    def _validate_section_label(self):
+        """
+        Validate the section label.
+
+        Verifies that the section label begins by a letter, contains only alphanumeric characters and hyphens
+        and if its length is at most 30.
+        """
+        if self.section_label != "" and not re.match(r"^[a-zA-Z][a-zA-Z0-9-\\_]{0,29}$", self.section_label):
+            LOGGER.error(
+                (
+                    "Failed validation for section {0} {1}. Section names can be at most 30 chars long,"
+                    " must begin with a letter and only contain alphanumeric characters, hyphens and underscores."
+                ).format(self.section_key, self.section_label)
+            )
+            sys.exit(1)
+
     def from_file(self, config_parser):
         """
         Initialize parameter value from config_parser.
@@ -91,6 +107,10 @@ class Param(ABC):
         """
         section_name = get_file_section_name(self.section_key, self.section_label)
         if config_parser.has_option(section_name, self.key):
+
+            if self.section_key not in ["aws", "global", "aliases"]:
+                self._validate_section_label()
+
             self.value = config_parser.get(section_name, self.key)
             self._check_allowed_values()
 

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -1075,6 +1075,16 @@ def queue_settings_validator(param_key, param_value, pcluster_config):
     if scheduler != "slurm":
         errors.append("queue_settings is supported only with slurm scheduler")
 
+    for label in param_value.split(","):
+        if re.match("[A-Z]", label) or re.match("^default$", label) or "_" in label:
+            errors.append(
+                (
+                    "Invalid queue name '{0}'. Queue section names can be at most 30 chars long, must begin with"
+                    " a letter and only contain lowercase letters, digits and hyphens. It is forbidden to use"
+                    " 'default' as a queue section name."
+                ).format(label)
+            )
+
     return errors, []
 
 

--- a/cli/tests/pcluster/config/test_param_types.py
+++ b/cli/tests/pcluster/config/test_param_types.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from assertpy import assert_that
+
+from pcluster.config.param_types import Param
+
+
+class TestParam:
+    @pytest.mark.parametrize(
+        "section_label, should_trigger_error",
+        [
+            ("LongSectionNameJust1CharTooLong", True),
+            ("Longest-Possible_Section-Name1", False),
+            ("1BeginWithNumber", True),
+            ("_BeginsWithUnderscore", True),
+            ("Contains spaces", True),
+        ],
+    )
+    def test_validate_section_label(self, section_label, should_trigger_error, mocker, caplog):
+        error_msg = (
+            "Failed validation for section queue {0}. Section names can be at most 30 chars long,"
+            " must begin with a letter and only contain alphanumeric characters, hyphens and underscores."
+        ).format(section_label)
+        mocker.patch.object(Param, "__abstractmethods__", new_callable=set)
+        param = Param("queue", section_label, None, {}, None, None)
+        if should_trigger_error:
+            with pytest.raises(SystemExit):
+                param._validate_section_label()
+            assert_that(caplog.text).contains(error_msg)
+        else:
+            param._validate_section_label()
+            for record in caplog.records:
+                assert record.levelname != "ERROR"

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -708,34 +708,6 @@ def test_sit_cluster_param_from_file(
         ("efs_settings", "test1", None, "Section .* not found in the config file"),
         ("raid_settings", "test1", None, "Section .* not found in the config file"),
         ("fsx_settings", "test1", None, "Section .* not found in the config file"),
-        ("queue_settings", "test1", None, "Section .* not found in the config file"),
-        ("queue_settings", "test1,test2", None, "Section .* not found in the config file"),
-        (
-            "queue_settings",
-            "test1,    LongestQueueNameThatIsPossible,    LongestQueueNameThatIsPossible",
-            None,
-            "Section .* not found in the config file",
-        ),
-        (
-            "queue_settings",
-            "test1,2test",
-            None,
-            ("ERROR: The configuration parameter 'queue_settings' has an invalid value .*"),
-        ),
-        (
-            "queue_settings",
-            "LongQueueNameJustOneCharTooLong",
-            None,
-            ("ERROR: The configuration parameter 'queue_settings' has an invalid value .*"),
-        ),
-        (
-            "queue_settings",
-            "test1,test2,LongQueueNameJustOneCharTooLong",
-            None,
-            ("ERROR: The configuration parameter 'queue_settings' has an invalid value .*"),
-        ),
-        ("queue_settings", "test1,test2,test-3", None, "Section .* not found in the config file"),
-        ("queue_settings", "LongestQueueNameThatIsPossible", None, "Section .* not found in the config file"),
     ],
 )
 def test_hit_cluster_param_from_file(


### PR DESCRIPTION
Before this commit, section labels were not verified. Now we verify that the section labels start with a letter, contain only alphanumeric characters, hyphens and underscores (except for the queue labels which should not contain underscores (it is filtered in the queue_settings validator). Concerning the queue label, another check has been made: it should not consist only of the string 'default' (either in lower case, upper case, or a mix of the two) but it can contain it (for example, my-default-queue is allowed). Some tests have also been added.

Signed-off-by: Alexandre Gobeaux <gobeaa@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
