### PR TITLE
Manually disable hyperthreading when CpuOptions aren't supported

### DIFF
--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -22,10 +22,12 @@ from pcluster.utils import (
     error,
     get_avail_zone,
     get_cfn_param,
+    get_default_threads_per_core,
     get_efs_mount_target_id,
     get_file_section_name,
     get_instance_vcpus,
     get_supported_architectures_for_instance_type,
+    ht_should_be_disabled_via_cpu_options,
 )
 
 
@@ -634,7 +636,7 @@ class DisableHyperThreadingCfnParam(BoolCfnParam):
             cfn_converter = self.definition.get("cfn_param_mapping", None)
             if cfn_converter and cfn_params:
                 cores = get_cfn_param(cfn_params, cfn_converter)
-                if cores and cores != "NONE,NONE":
+                if cores and not cores.startswith("NONE,NONE"):
                     cores = int(cores.split(",")[0])
                     self.value = cores > 0
         except (ValueError, IndexError):
@@ -642,35 +644,68 @@ class DisableHyperThreadingCfnParam(BoolCfnParam):
 
         return self
 
+    @staticmethod
+    def _get_cfn_params_for_instance_type(instance_type):
+        """
+        Return a pair describing whether or not to disable HT for the instance_type and how to do so.
+
+        The first item in the pair is an integer representing a core count for the instance type when
+        HT is disabled (or "NONE" if it shouldn't be disabled). The second item is a boolean expressing
+        if HT should be disabled via CPU Options for the given instance type.
+        """
+        default_threads_per_core = get_default_threads_per_core(instance_type)
+        if default_threads_per_core == 1:
+            # no action is required to disable hyperthreading
+            cores = "NONE"
+        else:
+            cores = get_instance_vcpus(instance_type) // default_threads_per_core
+
+        return cores, ht_should_be_disabled_via_cpu_options(instance_type, default_threads_per_core)
+
     def to_cfn(self):
         """
-        Define the Cores CFN parameter as a tuple (cores_master,cores_compute) if disable_hyperthreading = true.
+        Define the Cores CFN parameter if disable_hyperthreading = true.
 
-        :return: string (cores_master,cores_compute)
+        :return: string (cores_master,cores_compute,master_supports_cpu_options,compute_supports_cpu_options)
         """
-        cfn_params = {self.definition.get("cfn_param_mapping"): "NONE,NONE"}
-
+        cfn_params = {self.definition.get("cfn_param_mapping"): "NONE,NONE,NONE,NONE"}
         cluster_config = self.pcluster_config.get_section(self.section_key)
         if self.value:
             master_instance_type = cluster_config.get_param_value("master_instance_type")
-            master_cores = get_instance_vcpus(master_instance_type) // 2
+            master_cores, disable_master_ht_via_cpu_options = self._get_cfn_params_for_instance_type(
+                master_instance_type
+            )
 
             if self.pcluster_config.cluster_model.name == "SIT":
                 # compute_instance_type parameter is valid only in SIT clusters
                 compute_instance_type = cluster_config.get_param_value("compute_instance_type")
-                compute_cores = get_instance_vcpus(compute_instance_type) // 2
+                compute_cores, disable_compute_ht_via_cpu_options = self._get_cfn_params_for_instance_type(
+                    compute_instance_type
+                )
             else:
                 compute_instance_type = None
                 compute_cores = 0
+                disable_compute_ht_via_cpu_options = False
 
-            if master_cores < 0 or compute_cores < 0:
-                self.pcluster_config.error(
-                    "For disable_hyperthreading, unable to get number of vcpus for {0} instance. "
-                    "Please open an issue {1}".format(
-                        master_instance_type if master_cores < 0 else compute_instance_type, PCLUSTER_ISSUES_LINK
+            for node_label, cores, instance_type in [
+                ("master", master_cores, master_instance_type),
+                ("compute", compute_cores, compute_instance_type)
+            ]:
+                if isinstance(cores, int) and cores < 0:
+                    self.pcluster_config.error(
+                        "For disable_hyperthreading, unable to get number of vcpus for {0} instance type {1}. "
+                        "Please open an issue {2}".format(
+                            node_label, instance_type, PCLUSTER_ISSUES_LINK
+                        )
                     )
-                )
-            cfn_params.update({self.definition.get("cfn_param_mapping"): "{0},{1}".format(master_cores, compute_cores)})
+            cfn_params.update(
+                {self.definition.get("cfn_param_mapping"): "{0},{1},{2},{3}".format(
+                    master_cores,
+                    compute_cores,
+                    str(disable_master_ht_via_cpu_options).lower(),
+                    str(disable_compute_ht_via_cpu_options).lower(),
+                )}
+            )
 
         return cfn_params
 

--- a/cli/pcluster/config/json_param_types.py
+++ b/cli/pcluster/config/json_param_types.py
@@ -255,8 +255,8 @@ class QueueJsonSection(JsonSection):
             # Set vcpus according to queue's disable_hyperthreading and instance features
             ht_disabled = self.get_param_value("disable_hyperthreading")
             vcpus_info = instance_type.get("VCpuInfo")
-            default_cores = vcpus_info.get("DefaultCores")
-            vcpus = default_cores if ht_disabled and default_cores else vcpus_info.get("DefaultVCpus")
+            default_threads_per_core = utils.get_default_threads_per_core(instance_type_param.value, instance_type)
+            vcpus = vcpus_info.get("DefaultVCpus") // default_threads_per_core
             compute_resource_section.get_param("vcpus").value = vcpus
 
             # Set gpus according to instance features
@@ -276,21 +276,22 @@ class QueueJsonSection(JsonSection):
             # Set disable_hyperthreading according to queues' disable_hyperthreading and instance features
             compute_resource_section.get_param("disable_hyperthreading").value = (
                 ht_disabled
-                and default_cores is not None
-                and vcpus_info.get("DefaultCores") != vcpus_info.get("DefaultVCpus")
+                and default_threads_per_core != 1
+            )
+
+            # On some instance types, hyperthreading must be disabled manually rather than
+            # through the CpuOptions of a launch template.
+            compute_resource_section.get_param("disable_hyperthreading_via_cpu_options").value = (
+                utils.ht_should_be_disabled_via_cpu_options(
+                    instance_type_param.value,
+                    utils.get_default_threads_per_core(instance_type_param.value, instance_type),
+                )
             )
 
             # Set initial_count to min_count if not manually set
             initial_count_param = compute_resource_section.get_param("initial_count")
             if initial_count_param.value is None:
                 initial_count_param.value = compute_resource_section.get_param_value("min_count")
-
-            # FIXME: These warnings can now be safely moved to validators as they are no longer dependent on API calls
-            if ht_disabled and not compute_resource_section.get_param_value("disable_hyperthreading"):
-                self.pcluster_config.warn(
-                    "Hyperthreading was disabled on queue '{0}', but disabling hyperthreading on instance type '{1}' "
-                    "is not currently supported by ParallelCluster.".format(self.label, instance_type_param.value)
-                )
 
             if enable_efa and not compute_resource_section.get_param_value("enable_efa"):
                 self.pcluster_config.warn(

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -627,6 +627,13 @@ COMPUTE_RESOURCE = {
             "visibility": Visibility.PRIVATE,
             "default": False
         }),
+        ("disable_hyperthreading_via_cpu_options", {
+            "type": BooleanJsonParam,
+            # This param is managed automatically
+            "update_policy": UpdatePolicy.IGNORED,
+            "visibility": Visibility.PRIVATE,
+            "default": False
+        }),
     ])
 }
 

--- a/cli/pcluster/models/hit/hit_cluster_model.py
+++ b/cli/pcluster/models/hit/hit_cluster_model.py
@@ -12,7 +12,7 @@ from botocore.exceptions import ClientError
 
 from pcluster.cluster_model import ClusterModel
 from pcluster.config import mappings
-from pcluster.utils import get_instance_type
+from pcluster.utils import get_default_threads_per_core, get_instance_type, ht_should_be_disabled_via_cpu_options
 
 
 class HITClusterModel(ClusterModel):
@@ -54,7 +54,14 @@ class HITClusterModel(ClusterModel):
         master_vcpus = vcpus_info.get("DefaultVCpus")
 
         master_cpu_options = {"CoreCount": master_vcpus // 2, "ThreadsPerCore": 1} if disable_hyperthreading else {}
-
+        master_threads_per_core = get_default_threads_per_core(master_instance_type)
+        master_cpu_options = (
+            {"CoreCount": master_vcpus // master_threads_per_core, "ThreadsPerCore": 1}
+            if disable_hyperthreading and ht_should_be_disabled_via_cpu_options(
+                master_instance_type, master_threads_per_core
+            )
+            else {}
+        )
         try:
             latest_alinux_ami_id = self._get_latest_alinux_ami_id()
 
@@ -86,10 +93,14 @@ class HITClusterModel(ClusterModel):
                     "compute_resource", compute_resource_settings.split(",")[0]
                 )
 
+                disable_hyperthreading = (
+                    compute_resource_section.get_param_value("disable_hyperthreading")
+                    and compute_resource_section.get_param_value("disable_hyperthreading_via_cpu_options")
+                )
                 self.__test_compute_resource(
                     pcluster_config,
                     compute_resource_section,
-                    disable_hyperthreading=compute_resource_section.get_param_value("disable_hyperthreading"),
+                    disable_hyperthreading=disable_hyperthreading,
                     ami_id=latest_alinux_ami_id,
                     subnet=compute_subnet,
                     security_groups_ids=security_groups_ids,

--- a/cli/pcluster/models/sit/sit_cluster_model.py
+++ b/cli/pcluster/models/sit/sit_cluster_model.py
@@ -12,7 +12,11 @@ from botocore.exceptions import ClientError
 
 from pcluster.cluster_model import ClusterModel
 from pcluster.config import mappings
-from pcluster.utils import get_instance_vcpus
+from pcluster.utils import (
+    get_default_threads_per_core,
+    get_instance_vcpus,
+    ht_should_be_disabled_via_cpu_options,
+)
 
 
 class SITClusterModel(ClusterModel):
@@ -59,9 +63,23 @@ class SITClusterModel(ClusterModel):
         # Initialize CpuOptions
         disable_hyperthreading = cluster_section.get_param_value("disable_hyperthreading")
         master_vcpus = get_instance_vcpus(master_instance_type)
+        master_threads_per_core = get_default_threads_per_core(master_instance_type)
         compute_vcpus = get_instance_vcpus(compute_instance_type)
-        master_cpu_options = {"CoreCount": master_vcpus // 2, "ThreadsPerCore": 1} if disable_hyperthreading else {}
-        compute_cpu_options = {"CoreCount": compute_vcpus // 2, "ThreadsPerCore": 1} if disable_hyperthreading else {}
+        compute_threads_per_core = get_default_threads_per_core(compute_instance_type)
+        master_cpu_options = (
+            {"CoreCount": master_vcpus // master_threads_per_core, "ThreadsPerCore": 1}
+            if disable_hyperthreading and ht_should_be_disabled_via_cpu_options(
+                master_instance_type, master_threads_per_core
+            )
+            else {}
+        )
+        compute_cpu_options = (
+            {"CoreCount": compute_vcpus // compute_threads_per_core, "ThreadsPerCore": 1}
+            if disable_hyperthreading and ht_should_be_disabled_via_cpu_options(
+                compute_instance_type, compute_threads_per_core
+            )
+            else {}
+        )
 
         # Initialize Placement Group Logic
         placement_group = cluster_section.get_param_value("placement_group")

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -335,7 +335,7 @@
       "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },
     "Cores": {
-      "Description": "Comma seperated string of [master cores], [compute cores]. If set to -1,-1 or NONE,NONE no CpuOptions are set.",
+      "Description": "Comma seperated string of [master cores], [compute cores], [master instance type supports disabling hyperthreading via CPU options], [compute instance type supports disabling hyperthreading via CPU options].",
       "Type": "CommaDelimitedList",
       "Default": "NONE,NONE"
     },
@@ -2691,11 +2691,26 @@
             "Ref": "ComputeInstanceType"
           },
           "MasterCoreCount": {
-            "Fn::Select": [
-              "0",
-              {
-                "Ref": "Cores"
-              }
+            "Fn::Join": [
+              ",",
+              [
+                {
+                  "Fn::Select": [
+                    "0",
+                    {
+                      "Ref": "Cores"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    "2",
+                    {
+                      "Ref": "Cores"
+                    }
+                  ]
+                }
+              ]
             ]
           },
           "ComputeCoreCount": {
@@ -3114,11 +3129,26 @@
             ]
           },
           "ComputeCoreCount": {
-            "Fn::Select": [
-              "1",
-              {
-                "Ref": "Cores"
-              }
+            "Fn::Join": [
+              ",",
+              [
+                {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Ref": "Cores"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    "3",
+                    {
+                      "Ref": "Cores"
+                    }
+                  ]
+                }
+              ]
             ]
           },
           "SNSTopic": {

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -128,8 +128,8 @@ Resources:
   {%- endif %}
         ImageId: !Ref 'ImageId'
         CpuOptions:
-          CoreCount: {{ compute_resource.vcpus if compute_resource.disable_hyperthreading else "!Ref 'AWS::NoValue'" }}
-          ThreadsPerCore: {{ 1 if compute_resource.disable_hyperthreading else "!Ref 'AWS::NoValue'" }}
+          CoreCount: {{ compute_resource.vcpus if compute_resource.disable_hyperthreading and compute_resource.disable_master_ht_via_cpu_options else "!Ref 'AWS::NoValue'" }}
+          ThreadsPerCore: {{ 1 if compute_resource.disable_hyperthreading and compute_resource.disable_master_ht_via_cpu_options else "!Ref 'AWS::NoValue'" }}
         Monitoring:
           Enabled: false
         TagSpecifications:
@@ -265,7 +265,8 @@ Resources:
                         "cfn_fsx_fs_id": "${FSXId}",
                         "cfn_fsx_options": "${FSXOptions}",
                         "cfn_scheduler": "${Scheduler}",
-                        "cfn_scheduler_slots": "{{ 'cores' if compute_resource.disable_hyperthreading else 'vcpus' }}",
+                        "cfn_scheduler_slots": "{{ compute_resource.vcpus }}",
+                        "cfn_disable_hyperthreading_manually": "{{ compute_resource.disable_hyperthreading and not compute_resource.disable_hyperthreading_via_cpu_options }}",
                         "cfn_scaledown_idletime": "{{ scaling_config.scaledown_idletime }}",
                         "cfn_encrypted_ephemeral": "${EncryptedEphemeral}",
                         "cfn_ephemeral_dir": "${EphemeralDir}",

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -5,7 +5,7 @@ Parameters:
   ComputeSubnetId:
     Type: String
   ComputeCoreCount:
-    Type: String
+    Type: CommaDelimitedList
   SNSTopic:
     Type: String
   RootDevice:
@@ -110,11 +110,26 @@ Conditions:
   DisableComputeHyperthreading: !Not
     - !Or
       - !Equals
-        - !Ref 'ComputeCoreCount'
+        - !Select
+          - '0'
+          - !Ref 'ComputeCoreCount'
         - '-1'
       - !Equals
-        - !Ref 'ComputeCoreCount'
+        - !Select
+          - '0'
+          - !Ref 'ComputeCoreCount'
         - NONE
+  DisableComputeHyperthreadingViaCpuOptions: !And
+    - !Condition DisableComputeHyperthreading
+    - !Equals
+      - !Select
+        - '1'
+        - !Ref 'ComputeCoreCount'
+      - 'true'
+  DisableComputeHyperthreadingManually: !And
+    - !Condition DisableComputeHyperthreading
+    - !Not
+      - !Condition DisableComputeHyperthreadingViaCpuOptions
   UseSpotInstances: !Equals
     - !Ref 'ClusterType'
     - spot
@@ -217,11 +232,13 @@ Resources:
         ImageId: !Ref 'ImageId'
         CpuOptions:
           CoreCount: !If
-            - DisableComputeHyperthreading
-            - !Ref 'ComputeCoreCount'
+            - DisableComputeHyperthreadingViaCpuOptions
+            - !Select
+              - '0'
+              - !Ref 'ComputeCoreCount'
             - !Ref 'AWS::NoValue'
           ThreadsPerCore: !If
-            - DisableComputeHyperthreading
+            - DisableComputeHyperthreadingViaCpuOptions
             - 1
             - !Ref 'AWS::NoValue'
         Monitoring:
@@ -337,6 +354,7 @@ Resources:
                         "cfn_fsx_options": "${FSXOptions}",
                         "cfn_scheduler": "${Scheduler}",
                         "cfn_scheduler_slots": "${SchedulerSlots}",
+                        "cfn_disable_hyperthreading_manually": "${DisableHyperthreadingManually}",
                         "cfn_scaledown_idletime": "${ScaleDownIdleTime}",
                         "cfn_encrypted_ephemeral": "${EncryptedEphemeral}",
                         "cfn_ephemeral_dir": "${EphemeralDir}",
@@ -479,8 +497,14 @@ Resources:
                 - 'false'
               SchedulerSlots: !If
                 - DisableComputeHyperthreading
-                - !Ref 'ComputeCoreCount'
+                - !Select
+                  - '0'
+                  - !Ref 'ComputeCoreCount'
                 - vcpus
+              DisableHyperthreadingManually: !If
+                - DisableComputeHyperthreadingManually
+                - 'true'
+                - 'false'
 Outputs:
   ASGName:
     Value: !Ref 'ComputeFleet'

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -5,7 +5,7 @@ Parameters:
   ComputeInstanceType:
     Type: String
   MasterCoreCount:
-    Type: String
+    Type: CommaDelimitedList
   ComputeCoreCount:
     Type: String
   RootDevice:
@@ -112,11 +112,26 @@ Conditions:
   DisableMasterHyperthreading: !Not
     - !Or
       - !Equals
-        - !Ref 'MasterCoreCount'
+        - !Select
+          - '0'
+          - !Ref 'MasterCoreCount'
         - '-1'
       - !Equals
-        - !Ref 'MasterCoreCount'
+        - !Select
+          - '0'
+          - !Ref 'MasterCoreCount'
         - NONE
+  DisableMasterHyperthreadingViaCpuOptions: !And
+    - !Condition DisableMasterHyperthreading
+    - !Equals
+      - !Select
+        - '1'
+        - !Ref 'MasterCoreCount'
+      - 'true'
+  DisableMasterHyperthreadingManually: !And
+    - !Condition DisableMasterHyperthreading
+    - !Not
+      - !Condition DisableMasterHyperthreadingViaCpuOptions
   IsMasterInstanceEbsOpt: !Not
     - !Or
       - !Or
@@ -204,11 +219,13 @@ Resources:
         InstanceType: !Ref 'MasterInstanceType'
         CpuOptions:
           CoreCount: !If
-            - DisableMasterHyperthreading
-            - !Ref 'MasterCoreCount'
+            - DisableMasterHyperthreadingViaCpuOptions
+            - !Select
+              - '0'
+              - !Ref 'MasterCoreCount'
             - !Ref 'AWS::NoValue'
           ThreadsPerCore: !If
-            - DisableMasterHyperthreading
+            - DisableMasterHyperthreadingViaCpuOptions
             - 1
             - !Ref 'AWS::NoValue'
         BlockDeviceMappings:
@@ -447,8 +464,15 @@ Resources:
                   cfn_raid_parameters: !Ref 'RAIDOptions'
                   cfn_scheduler_slots: !If
                     - DisableMasterHyperthreading
-                    - !Ref 'ComputeCoreCount'
+                    - !Ref 'ComputeCoreCount'  # TODO: why is the
+                                               # compute core count
+                                               # used on the master
+                                               # server?
                     - !Ref 'AWS::NoValue'
+                  cfn_disable_hyperthreading_manually: !If
+                    - DisableMasterHyperthreadingManually
+                    - 'true'
+                    - 'false'
                   cfn_base_os: !Ref 'OS'
                   cfn_preinstall: !Ref 'PreInstallScript'
                   cfn_preinstall_args: !Ref 'PreInstallArgs'


### PR DESCRIPTION
*.metal instance types don't support the use of CpuOptions. Since that
was previously the only way disabling hyperthreading was supported by
ParallelCluster, the only way to disable hyperthreading on these
instances was to use a pre- or post-install script to utilize the
approach described
[here](https://aws.amazon.com/blogs/compute/disabling-intel-hyper-threading-technology-on-amazon-linux/).

This change enables hyperthreading to be disabled on metal instance
types by running the script from the link above as part of the
configuration process.

It also avoids attempting to disable hyperthreading via either
CpuOptions or the script when an instance type's deafult
ThreadsPerCore according to EC2's DescribeInstanceTypes API has a
value of 1. Previously cluster creation would have failed in such a
case.

There are some known issues with this change:
* The function that guesses whether or not hyperthreading can be
disabled via CpuOptions assumes that it can for any non-metal instance
type with a default ThreadsPerCore of > 1. This is known to be false
for at least one case: cc2.8xlarge. There are probably others.
* In the event that DescribeInstanceTypes doesn't contain the
information, the function that returns an instance type's default
ThreadsPerCore assumes a value of either 1 or 2 depending on the
instance type's supported architectures. Currently this information is
only missing from the API for .metal instances.

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
