### PR TITLE
Add referred_section_labels property to SettingsParam

### DIFF
--- a/cli/pcluster/config/json_param_types.py
+++ b/cli/pcluster/config/json_param_types.py
@@ -146,7 +146,7 @@ class SettingsJsonParam(SettingsParam):
             }
         """
         if self.value:
-            labels = self.value.split(",")
+            labels = self.referred_section_labels
 
             for label in labels:
                 section = self.pcluster_config.get_section(self.referred_section_key, label.strip())
@@ -235,9 +235,9 @@ class QueueJsonSection(JsonSection):
             # None value at cluster level is converted to False at queue level
             self.get_param("enable_efa").value = cluster_enable_efa == "compute"
 
-        compute_resource_labels = self.get_param_value("compute_resource_settings")
+        compute_resource_labels = self.get_param("compute_resource_settings").referred_section_labels
         if compute_resource_labels:
-            for compute_resource_label in compute_resource_labels.split(","):
+            for compute_resource_label in compute_resource_labels:
                 compute_resource_section = self.pcluster_config.get_section("compute_resource", compute_resource_label)
                 self.refresh_compute_resource(compute_resource_section)
 

--- a/cli/pcluster/config/param_types.py
+++ b/cli/pcluster/config/param_types.py
@@ -408,6 +408,11 @@ class SettingsParam(Param):
             # create section
             section.to_file(config_parser)
 
+    @property
+    def referred_section_labels(self):
+        """Return the referred section labels as a list of stripped element."""
+        return [label.strip() for label in self.value.split(",")] if self.value else []
+
 
 # ---------------------- Section ---------------------- #
 class Section(ABC):

--- a/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
@@ -29,7 +29,7 @@ initial_count = 2
 instance_type = i3en.24xlarge
 
 [queue queue2]
-compute_resource_settings = q2-i1,q2-i2,q2-i3
+compute_resource_settings = q2-i1, q2-i2,    q2-i3   # extra spaces added to check for labels stripping
 compute_type = spot
 enable_efa = false
 disable_hyperthreading = false


### PR DESCRIPTION
This new property allows to retrieve section labels as an array, so that callers don't have to deal with splitting and stripping strings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
