### PR TITLE
Fix report column rendering in case of "False" values

### DIFF
--- a/cli/pcluster/update/update_command.py
+++ b/cli/pcluster/update/update_command.py
@@ -136,9 +136,9 @@ def _print_check_report(patch_allowed, check_rows, forced):
         report_rows.append(
             [
                 "{0}{1}".format(report_row_num_str, "*" if failed else ""),
-                utils.ellipsize(check_row[1], 30),
-                utils.ellipsize(check_row[2], 30) if check_row[2] else "-",
-                utils.ellipsize(check_row[3], 30) if check_row[3] else "-",
+                _format_report_column(check_row[1]),
+                _format_report_column(check_row[2]),
+                _format_report_column(check_row[3]),
             ]
         )
 
@@ -175,6 +175,11 @@ def _print_check_details(patch_allowed, report_row_details):
         )
     else:
         print("Congratulations! The new configuration can be safely applied to your cluster.")
+
+
+def _format_report_column(value):
+    """Format the provided change value to fit the report table."""
+    return utils.ellipsize(value, 30) if value is not None else "-"
 
 
 def _restore_cfn_only_params(cfn_boto3_client, args, cfn_params, stack_name, target_config):

--- a/cli/tests/pcluster/cli_commands/test_pcluster_update.py
+++ b/cli/tests/pcluster/cli_commands/test_pcluster_update.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from assertpy import assert_that
+
+from pcluster.update.update_command import _format_report_column
+
+
+@pytest.mark.parametrize(
+    "value, expected_output",
+    [
+        (None, "-"),
+        (False, "False"),
+        (True, "True"),
+        ("Long long long long long long text", "Long long long long long lo..."),
+    ],
+)
+def test_format_change_value(value, expected_output):
+    assert_that(_format_report_column(value)).is_equal_to(expected_output)


### PR DESCRIPTION
A "-" was shown in changs report of pcluster update if the original value was boolean False.
Formatting logic now covered by test.
Further tests will be added to increase the covering of the command's behavior

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
