### PR TITLE
Warn user to delete S3 bucket

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -198,6 +198,11 @@ def create(args):  # noqa: C901 FIXME!!!
         sys.exit(1)
     except KeyboardInterrupt:
         LOGGER.info("\nExiting...")
+        if bucket_name:
+            LOGGER.info(
+                "Your S3 bucket named %s was not deleted. Do not forget to delete it when deleting your cluster.",
+                bucket_name,
+            )
         sys.exit(0)
     except KeyError as e:
         LOGGER.critical("ERROR: KeyError - reason:\n%s", e)


### PR DESCRIPTION
Before this commit, if the user tried to cancel the cluster creation, he would not be aware that his bucket would not be deleted and would end up deleting his cluster and having multiple unused S3 buckets on his account.

Signed-off-by: Alexandre Gobeaux <gobeaa@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
