### PR TITLE
Fix sns subscription

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1460,18 +1460,21 @@
     },
     "SNS": {
       "Type": "AWS::SNS::Topic",
+      "Condition": "CreateComputeFleet"
+    },
+    "SNSSubscription": {
+      "Type": "AWS::SNS::Subscription",
       "Properties": {
-        "Subscription": [
-          {
-            "Endpoint": {
-              "Fn::GetAtt": [
-                "SQS",
-                "Arn"
-              ]
-            },
-            "Protocol": "sqs"
-          }
-        ]
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "SQS",
+            "Arn"
+          ]
+        },
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "SNS"
+        }
       },
       "Condition": "CreateComputeFleet"
     },


### PR DESCRIPTION
As reported in [this issue](https://github.com/serverless/serverless/issues/5149) SNS subscription resource is not deleted when defined "inline" inside the SNSTopic resource. Explicitly declaring a SNS Subscription resource fixes the problem.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
