### PR TITLE
Manually disable hyperthreading when CpuOptions aren't supported

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -627,6 +627,13 @@ COMPUTE_RESOURCE = {
             "visibility": Visibility.PRIVATE,
             "default": False
         }),
+        ("disable_hyperthreading_via_cpu_options", {
+            "type": BooleanJsonParam,
+            # This param is managed automatically
+            "update_policy": UpdatePolicy.IGNORED,
+            "visibility": Visibility.PRIVATE,
+            "default": False
+        }),
     ])
 }
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -933,6 +933,38 @@ def get_instance_type(instance_type):
         raise e
 
 
+def get_default_threads_per_core(instance_type, instance_info=None):
+    """Return the default threads per core for the given instance type."""
+    # NOTE: currently, .metal instances do not contain the DefaultThreadsPerCore
+    #       attribute in their VCpuInfo section. This is a known issue with the
+    #       ec2 DescribeInstanceTypes API. For these instance types an assumption
+    #       is made that if the instance's supported architectures list includes
+    #       x86_64 then the default is 2, otherwise it's 1.
+    if instance_info is None:
+        instance_info = get_instance_type(instance_type)
+    threads_per_core = instance_info.get("VCpuInfo", {}).get("DefaultThreadsPerCore")
+    if threads_per_core is None:
+        supported_architectures = instance_info.get("ProcessorInfo", {}).get("SupportedArchitectures", [])
+        threads_per_core = 2 if "x86_64" in supported_architectures else 1
+    return threads_per_core
+
+
+def disable_ht_via_cpu_options(instance_type, default_threads_per_core=None):
+    """Return a boolean describing whether hyperthreading should be disabled via CPU options for instance_type."""
+    if default_threads_per_core is None:
+        default_threads_per_core = get_default_threads_per_core(instance_type)
+    return all(
+        [
+            # If default threads per core is 1, HT doesn't need to be disabled
+            default_threads_per_core > 1,
+            # Currently, hyperthreading must be disabled manually on *.metal instances
+            not (
+                instance_type.endswith(".metal") or instance_type.startswith("m4.") or instance_type in ["cc2.8xlarge"]
+            ),
+        ]
+    )
+
+
 def is_hit_enabled_scheduler(scheduler):
     return scheduler in ["slurm"]
 

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -286,7 +286,7 @@ DEFAULT_CLUSTER_SIT_CFN_PARAMS = {
     "CustomChefCookbook": "NONE",
     "CustomAWSBatchTemplateURL": "NONE",
     "NumberOfEBSVol": "1",
-    "Cores": "NONE,NONE",
+    "Cores": "NONE,NONE,NONE,NONE",
     "IntelHPCPlatform": "false",
     # "ResourcesS3Bucket": "NONE",  # parameter added by the CLI
     # scaling
@@ -351,7 +351,7 @@ DEFAULT_CLUSTER_HIT_CFN_PARAMS = {
     "AdditionalCfnTemplate": "NONE",
     "CustomChefCookbook": "NONE",
     "NumberOfEBSVol": "1",
-    "Cores": "NONE,NONE",
+    "Cores": "NONE,NONE,NONE,NONE",
     "IntelHPCPlatform": "false",
     # "ResourcesS3Bucket": "NONE",  # parameter added by the CLI
     # scaling

--- a/cli/tests/pcluster/config/test_hit_converter.py
+++ b/cli/tests/pcluster/config/test_hit_converter.py
@@ -165,7 +165,7 @@ def test_hit_converter(boto3_stubber, src_config_dict, dst_config_dict):
                     "InstanceTypes": [
                         {
                             "InstanceType": instance_type,
-                            "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48},
+                            "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48, "DefaultThreadsPerCore": 2},
                             "NetworkInfo": {"EfaSupported": True},
                         }
                     ]

--- a/cli/tests/pcluster/config/test_json_param_types.py
+++ b/cli/tests/pcluster/config/test_json_param_types.py
@@ -30,8 +30,11 @@ DESCRIBE_INSTANCE_TYPES_RESPONSES = {
         "InstanceTypes": [
             {
                 "InstanceType": "c4.xlarge",
-                "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2},
+                "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2, "DefaultThreadsPerCore": 2},
                 "NetworkInfo": {"EfaSupported": False},
+                "ProcessorInfo": {
+                    "SupportedArchitectures": ["x86_64"],
+                },
             }
         ]
     },
@@ -44,6 +47,9 @@ DESCRIBE_INSTANCE_TYPES_RESPONSES = {
                 "VCpuInfo": {"DefaultVCpus": 96},
                 "GpuInfo": {"Gpus": [{"Name": "T4", "Manufacturer": "NVIDIA", "Count": 8}]},
                 "NetworkInfo": {"EfaSupported": True},
+                "ProcessorInfo": {
+                    "SupportedArchitectures": ["x86_64"],
+                },
             }
         ]
     },
@@ -53,8 +59,39 @@ DESCRIBE_INSTANCE_TYPES_RESPONSES = {
         "InstanceTypes": [
             {
                 "InstanceType": "i3en.24xlarge",
-                "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48},
+                "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48, "DefaultThreadsPerCore": 2},
                 "NetworkInfo": {"EfaSupported": True},
+                "ProcessorInfo": {
+                    "SupportedArchitectures": ["x86_64"],
+                },
+            }
+        ]
+    },
+    # Disable hyperthreading: not supported
+    # EFA: not supported
+    "t2.xlarge": {
+        "InstanceTypes": [
+            {
+                "InstanceType": "t2.xlarge",
+                "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 4, "DefaultThreadsPerCore": 1},
+                "NetworkInfo": {"EfaSupported": False},
+                "ProcessorInfo": {
+                    "SupportedArchitectures": ["x86_64"],
+                },
+            }
+        ]
+    },
+    # Disable hyperthreading: not supported
+    # EFA: not supported
+    "m6g.xlarge": {
+        "InstanceTypes": [
+            {
+                "InstanceType": "m6g.xlarge",
+                "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 4, "DefaultThreadsPerCore": 1},
+                "NetworkInfo": {"EfaSupported": False},
+                "ProcessorInfo": {
+                    "SupportedArchitectures": ["arm64"],
+                },
             }
         ]
     },
@@ -72,15 +109,15 @@ def boto3_stubber_path():
         (
             ["queue1"],
             "WARNING: EFA was enabled on queue 'queue1', but instance type 'c4.xlarge' does not support EFA.\n"
-            "WARNING: Hyperthreading was disabled on queue 'queue1', but disabling hyperthreading on instance type "
-            "'g4dn.metal' is not currently supported by ParallelCluster.\n",
+            "WARNING: EFA was enabled on queue 'queue1', but instance type 't2.xlarge' does not support EFA.\n"
+            "WARNING: EFA was enabled on queue 'queue1', but instance type 'm6g.xlarge' does not support EFA.\n",
         ),
         (["queue2"], ""),
         (
             ["queue1", "queue2"],
             "WARNING: EFA was enabled on queue 'queue1', but instance type 'c4.xlarge' does not support EFA.\n"
-            "WARNING: Hyperthreading was disabled on queue 'queue1', but disabling hyperthreading on instance type "
-            "'g4dn.metal' is not currently supported by ParallelCluster.\n",
+            "WARNING: EFA was enabled on queue 'queue1', but instance type 't2.xlarge' does not support EFA.\n"
+            "WARNING: EFA was enabled on queue 'queue1', but instance type 'm6g.xlarge' does not support EFA.\n",
         ),
         ([], ""),
         (["queue3"], ""),

--- a/cli/tests/pcluster/config/test_json_param_types/s3_config.json
+++ b/cli/tests/pcluster/config/test_json_param_types/s3_config.json
@@ -19,7 +19,8 @@
             "vcpus": 2,
             "gpus": 0,
             "enable_efa": false,
-            "disable_hyperthreading": true
+            "disable_hyperthreading": true,
+            "disable_hyperthreading_via_cpu_options": true
           },
           "q1-i2": {
             "instance_type": "g4dn.metal",
@@ -27,10 +28,11 @@
             "max_count": 10,
             "initial_count": 2,
             "spot_price": 0,
-            "vcpus": 96,
+            "vcpus": 48,
             "gpus": 8,
             "enable_efa": true,
-            "disable_hyperthreading": false
+            "disable_hyperthreading": true,
+            "disable_hyperthreading_via_cpu_options": false
           },
           "q1-i3": {
             "instance_type": "i3en.24xlarge",
@@ -41,7 +43,32 @@
             "vcpus": 48,
             "gpus": 0,
             "enable_efa": true,
-            "disable_hyperthreading": true
+            "disable_hyperthreading": true,
+            "disable_hyperthreading_via_cpu_options": true
+          },
+          "q1-i4": {
+            "instance_type": "t2.xlarge",
+            "min_count": 0,
+            "max_count": 10,
+            "initial_count": 0,
+            "spot_price": 0,
+            "vcpus": 4,
+            "gpus": 0,
+            "enable_efa": false,
+            "disable_hyperthreading": false,
+            "disable_hyperthreading_via_cpu_options": false
+          },
+          "q1-i5": {
+            "instance_type": "m6g.xlarge",
+            "min_count": 0,
+            "max_count": 10,
+            "initial_count": 0,
+            "spot_price": 0,
+            "vcpus": 4,
+            "gpus": 0,
+            "enable_efa": false,
+            "disable_hyperthreading": false,
+            "disable_hyperthreading_via_cpu_options": false
           }
         }
       },
@@ -60,7 +87,8 @@
             "vcpus": 4,
             "gpus": 0,
             "enable_efa": false,
-            "disable_hyperthreading": false
+            "disable_hyperthreading": false,
+            "disable_hyperthreading_via_cpu_options": false
           },
           "q2-i2": {
             "instance_type": "g4dn.metal",
@@ -71,7 +99,8 @@
             "vcpus": 96,
             "gpus": 8,
             "enable_efa": false,
-            "disable_hyperthreading": false
+            "disable_hyperthreading": false,
+            "disable_hyperthreading_via_cpu_options": false
           },
           "q2-i3": {
             "instance_type": "i3en.24xlarge",
@@ -82,7 +111,32 @@
             "vcpus": 96,
             "gpus": 0,
             "enable_efa": false,
-            "disable_hyperthreading": false
+            "disable_hyperthreading": false,
+            "disable_hyperthreading_via_cpu_options": false
+          },
+          "q2-i4": {
+            "instance_type": "t2.xlarge",
+            "min_count": 0,
+            "max_count": 10,
+            "initial_count": 0,
+            "spot_price": 0,
+            "vcpus": 4,
+            "gpus": 0,
+            "enable_efa": false,
+            "disable_hyperthreading": false,
+            "disable_hyperthreading_via_cpu_options": false
+          },
+          "q2-i5": {
+            "instance_type": "m6g.xlarge",
+            "min_count": 0,
+            "max_count": 10,
+            "initial_count": 0,
+            "spot_price": 0,
+            "vcpus": 4,
+            "gpus": 0,
+            "enable_efa": false,
+            "disable_hyperthreading": false,
+            "disable_hyperthreading_via_cpu_options": false
           }
         }
       },
@@ -101,7 +155,8 @@
             "vcpus": 96,
             "gpus": 0,
             "enable_efa": true,
-            "disable_hyperthreading": false
+            "disable_hyperthreading": false,
+            "disable_hyperthreading_via_cpu_options": false
           }
         }
       }

--- a/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
@@ -9,7 +9,7 @@ disable_cluster_dns = true
 # disable_hyperthreading = false
 
 [queue queue1]
-compute_resource_settings = q1-i1,q1-i2,q1-i3
+compute_resource_settings = q1-i1,q1-i2,q1-i3,q1-i4,q1-i5
 compute_type = ondemand
 enable_efa = true
 disable_hyperthreading = true
@@ -28,8 +28,14 @@ initial_count = 2
 [compute_resource q1-i3]
 instance_type = i3en.24xlarge
 
+[compute_resource q1-i4]
+instance_type = t2.xlarge
+
+[compute_resource q1-i5]
+instance_type = m6g.xlarge
+
 [queue queue2]
-compute_resource_settings = q2-i1, q2-i2,    q2-i3   # extra spaces added to check for labels stripping
+compute_resource_settings = q2-i1, q2-i2,    q2-i3 ,q2-i4   ,q2-i5   # extra spaces added to check for labels stripping
 compute_type = spot
 enable_efa = false
 disable_hyperthreading = false
@@ -46,6 +52,12 @@ spot_price = 0.5
 [compute_resource q2-i3]
 instance_type = i3en.24xlarge
 spot_price = 0.6
+
+[compute_resource q2-i4]
+instance_type = t2.xlarge
+
+[compute_resource q2-i5]
+instance_type = m6g.xlarge
 
 [queue queue3]
 compute_resource_settings = q3-i1

--- a/cli/tests/pcluster/config/test_utils.py
+++ b/cli/tests/pcluster/config/test_utils.py
@@ -26,9 +26,7 @@ def test_get_instance_vcpus(boto3_stubber, valid_instance_type, expected_vcpus):
     mocked_requests = [
         MockedBoto3Request(
             method="describe_instance_types",
-            response={
-                "InstanceTypes": [{"InstanceType": "g4dn.metal", "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48}}]
-            },
+            response={"InstanceTypes": [{"InstanceType": "g4dn.metal", "VCpuInfo": {"DefaultVCpus": 96}}]},
             expected_params={"InstanceTypes": [instance_type]},
             generate_error=not valid_instance_type,
         )

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -357,7 +357,11 @@ def assert_section_params(mocker, pcluster_config_reader, settings_label, expect
         "pcluster.utils.get_instance_type",
         return_value={
             "InstanceType": "t2.micro",
-            "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2},
+            "VCpuInfo": {
+                "DefaultVCpus": 1,
+                "DefaultCores": 1,
+                "DefaultThreadsPerCore": 1,
+            },
             "NetworkInfo": {"EfaSupported": False},
         },
     )

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -335,9 +335,9 @@
       "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },
     "Cores": {
-      "Description": "Comma seperated string of [master cores], [compute cores]. If set to -1,-1 or NONE,NONE no CpuOptions are set.",
+      "Description": "Comma seperated string of [master cores], [compute cores], [master instance type supports disabling hyperthreading via CPU options], [compute instance type supports disabling hyperthreading via CPU options].",
       "Type": "CommaDelimitedList",
-      "Default": "NONE,NONE"
+      "Default": "NONE,NONE,NONE,NONE"
     },
     "EFA": {
       "Description": "Enable EFA on the compute nodes, enable_efa = compute",
@@ -2691,11 +2691,26 @@
             "Ref": "ComputeInstanceType"
           },
           "MasterCoreCount": {
-            "Fn::Select": [
-              "0",
-              {
-                "Ref": "Cores"
-              }
+            "Fn::Join": [
+              ",",
+              [
+                {
+                  "Fn::Select": [
+                    "0",
+                    {
+                      "Ref": "Cores"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    "2",
+                    {
+                      "Ref": "Cores"
+                    }
+                  ]
+                }
+              ]
             ]
           },
           "ComputeCoreCount": {
@@ -3138,11 +3153,26 @@
             ]
           },
           "ComputeCoreCount": {
-            "Fn::Select": [
-              "1",
-              {
-                "Ref": "Cores"
-              }
+            "Fn::Join": [
+              ",",
+              [
+                {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Ref": "Cores"
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    "3",
+                    {
+                      "Ref": "Cores"
+                    }
+                  ]
+                }
+              ]
             ]
           },
           "SNSTopic": {

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -128,8 +128,8 @@ Resources:
   {%- endif %}
         ImageId: !Ref 'ImageId'
         CpuOptions:
-          CoreCount: {{ compute_resource.vcpus if compute_resource.disable_hyperthreading else "!Ref 'AWS::NoValue'" }}
-          ThreadsPerCore: {{ 1 if compute_resource.disable_hyperthreading else "!Ref 'AWS::NoValue'" }}
+          CoreCount: {{ compute_resource.vcpus if compute_resource.disable_hyperthreading_via_cpu_options else "!Ref 'AWS::NoValue'" }}
+          ThreadsPerCore: {{ 1 if compute_resource.disable_hyperthreading_via_cpu_options else "!Ref 'AWS::NoValue'" }}
         Monitoring:
           Enabled: false
         TagSpecifications:
@@ -265,7 +265,8 @@ Resources:
                         "cfn_fsx_fs_id": "${FSXId}",
                         "cfn_fsx_options": "${FSXOptions}",
                         "cfn_scheduler": "${Scheduler}",
-                        "cfn_scheduler_slots": "{{ 'cores' if compute_resource.disable_hyperthreading else 'vcpus' }}",
+                        "cfn_scheduler_slots": "{{ compute_resource.vcpus }}",
+                        "cfn_disable_hyperthreading_manually": "{{ (compute_resource.disable_hyperthreading and not compute_resource.disable_hyperthreading_via_cpu_options) | lower }}",
                         "cfn_scaledown_idletime": "{{ scaling_config.scaledown_idletime }}",
                         "cfn_encrypted_ephemeral": "${EncryptedEphemeral}",
                         "cfn_ephemeral_dir": "${EphemeralDir}",

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -5,7 +5,7 @@ Parameters:
   ComputeSubnetId:
     Type: String
   ComputeCoreCount:
-    Type: String
+    Type: CommaDelimitedList
   SNSTopic:
     Type: String
   RootDevice:
@@ -110,11 +110,26 @@ Conditions:
   DisableComputeHyperthreading: !Not
     - !Or
       - !Equals
-        - !Ref 'ComputeCoreCount'
+        - !Select
+          - '0'
+          - !Ref 'ComputeCoreCount'
         - '-1'
       - !Equals
-        - !Ref 'ComputeCoreCount'
+        - !Select
+          - '0'
+          - !Ref 'ComputeCoreCount'
         - NONE
+  DisableComputeHyperthreadingViaCpuOptions: !And
+    - !Condition 'DisableComputeHyperthreading'
+    - !Equals
+      - !Select
+        - '1'
+        - !Ref 'ComputeCoreCount'
+      - 'true'
+  DisableComputeHyperthreadingManually: !And
+    - !Condition 'DisableComputeHyperthreading'
+    - !Not
+      - !Condition 'DisableComputeHyperthreadingViaCpuOptions'
   UseSpotInstances: !Equals
     - !Ref 'ClusterType'
     - spot
@@ -217,11 +232,13 @@ Resources:
         ImageId: !Ref 'ImageId'
         CpuOptions:
           CoreCount: !If
-            - DisableComputeHyperthreading
-            - !Ref 'ComputeCoreCount'
+            - DisableComputeHyperthreadingViaCpuOptions
+            - !Select
+              - '0'
+              - !Ref 'ComputeCoreCount'
             - !Ref 'AWS::NoValue'
           ThreadsPerCore: !If
-            - DisableComputeHyperthreading
+            - DisableComputeHyperthreadingViaCpuOptions
             - 1
             - !Ref 'AWS::NoValue'
         Monitoring:
@@ -337,6 +354,7 @@ Resources:
                         "cfn_fsx_options": "${FSXOptions}",
                         "cfn_scheduler": "${Scheduler}",
                         "cfn_scheduler_slots": "${SchedulerSlots}",
+                        "cfn_disable_hyperthreading_manually": "${DisableHyperthreadingManually}",
                         "cfn_scaledown_idletime": "${ScaleDownIdleTime}",
                         "cfn_encrypted_ephemeral": "${EncryptedEphemeral}",
                         "cfn_ephemeral_dir": "${EphemeralDir}",
@@ -479,8 +497,14 @@ Resources:
                 - 'false'
               SchedulerSlots: !If
                 - DisableComputeHyperthreading
-                - !Ref 'ComputeCoreCount'
+                - !Select
+                  - '0'
+                  - !Ref 'ComputeCoreCount'
                 - vcpus
+              DisableHyperthreadingManually: !If
+                - DisableComputeHyperthreadingManually
+                - 'true'
+                - 'false'
 Outputs:
   ASGName:
     Value: !Ref 'ComputeFleet'

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -5,9 +5,9 @@ Parameters:
   ComputeInstanceType:
     Type: String
   MasterCoreCount:
-    Type: String
+    Type: CommaDelimitedList
   ComputeCoreCount:
-    Type: String
+    Type: CommaDelimitedList
   RootDevice:
     Type: String
   RootVolumeSize:
@@ -118,11 +118,26 @@ Conditions:
   DisableMasterHyperthreading: !Not
     - !Or
       - !Equals
-        - !Ref 'MasterCoreCount'
+        - !Select
+          - '0'
+          - !Ref 'MasterCoreCount'
         - '-1'
       - !Equals
-        - !Ref 'MasterCoreCount'
+        - !Select
+          - '0'
+          - !Ref 'MasterCoreCount'
         - NONE
+  DisableMasterHyperthreadingViaCpuOptions: !And
+    - !Condition 'DisableMasterHyperthreading'
+    - !Equals
+      - !Select
+        - '1'
+        - !Ref 'MasterCoreCount'
+      - 'true'
+  DisableMasterHyperthreadingManually: !And
+    - !Condition 'DisableMasterHyperthreading'
+    - !Not
+      - !Condition 'DisableMasterHyperthreadingViaCpuOptions'
   IsMasterInstanceEbsOpt: !Not
     - !Or
       - !Or
@@ -214,11 +229,13 @@ Resources:
         InstanceType: !Ref 'MasterInstanceType'
         CpuOptions:
           CoreCount: !If
-            - DisableMasterHyperthreading
-            - !Ref 'MasterCoreCount'
+            - DisableMasterHyperthreadingViaCpuOptions
+            - !Select
+              - '0'
+              - !Ref 'MasterCoreCount'
             - !Ref 'AWS::NoValue'
           ThreadsPerCore: !If
-            - DisableMasterHyperthreading
+            - DisableMasterHyperthreadingViaCpuOptions
             - 1
             - !Ref 'AWS::NoValue'
         BlockDeviceMappings:
@@ -461,8 +478,14 @@ Resources:
                   cfn_raid_parameters: !Ref 'RAIDOptions'
                   cfn_scheduler_slots: !If
                     - DisableMasterHyperthreading
-                    - !Ref 'ComputeCoreCount'
+                    - !Select
+                      - '0'
+                      - !Ref 'ComputeCoreCount'
                     - !Ref 'AWS::NoValue'
+                  cfn_disable_hyperthreading_manually: !If
+                    - DisableMasterHyperthreadingManually
+                    - 'true'
+                    - 'false'
                   cfn_base_os: !Ref 'OS'
                   cfn_preinstall: !Ref 'PreInstallScript'
                   cfn_preinstall_args: !Ref 'PreInstallArgs'

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -35,6 +35,8 @@ spec.loader.exec_module(cfn_formatter)
                                     "vcpus": 2,
                                     "gpus": 0,
                                     "enable_efa": False,
+                                    "disable_hyperthreading": True,
+                                    "disable_hyperthreading_via_cpu_options": False,
                                 },
                                 "multiple_spot_c5.2xlarge": {
                                     "instance_type": "c5.2xlarge",
@@ -44,6 +46,8 @@ spec.loader.exec_module(cfn_formatter)
                                     "vcpus": 4,
                                     "gpus": 0,
                                     "enable_efa": False,
+                                    "disable_hyperthreading": True,
+                                    "disable_hyperthreading_via_cpu_options": True,
                                 },
                             },
                         },
@@ -57,6 +61,8 @@ spec.loader.exec_module(cfn_formatter)
                                     "vcpus": 36,
                                     "gpus": 0,
                                     "enable_efa": True,
+                                    "disable_hyperthreading": True,
+                                    "disable_hyperthreading_via_cpu_options": True,
                                 }
                             },
                             "compute_type": "ondemand",
@@ -74,6 +80,8 @@ spec.loader.exec_module(cfn_formatter)
                                     "vcpus": 16,
                                     "gpus": 2,
                                     "enable_efa": False,
+                                    "disable_hyperthreading": True,
+                                    "disable_hyperthreading_via_cpu_options": True,
                                 }
                             },
                             "compute_type": "ondemand",
@@ -107,6 +115,8 @@ spec.loader.exec_module(cfn_formatter)
                                     "vcpus": 2,
                                     "gpus": 0,
                                     "enable_efa": False,
+                                    "disable_hyperthreading": True,
+                                    "disable_hyperthreading_via_cpu_options": True,
                                 },
                                 "multiple_spot_c5.2xlarge": {
                                     "instance_type": "c5.2xlarge",
@@ -116,6 +126,8 @@ spec.loader.exec_module(cfn_formatter)
                                     "vcpus": 4,
                                     "gpus": 0,
                                     "enable_efa": False,
+                                    "disable_hyperthreading": True,
+                                    "disable_hyperthreading_via_cpu_options": True,
                                 },
                             },
                         }


### PR DESCRIPTION
*.metal instance types don't support the use of CpuOptions. Since that was previously the only way disabling hyperthreading was supported by ParallelCluster, the only way to disable hyperthreading on these instances was to use a pre- or post-install script to utilize the approach described [here](https://aws.amazon.com/blogs/compute/disabling-intel-hyper-threading-technology-on-amazon-linux/).

This change enables hyperthreading to be disabled on metal instance types by running the script from the link above as part of the configuration process.

It also avoids attempting to disable hyperthreading via either CpuOptions or the script when an instance type's deafult ThreadsPerCore according to EC2's DescribeInstanceTypes API has a value of 1. Previously cluster creation would have failed in such a case.

There are some known issues with this change:
* The function that guesses whether or not hyperthreading can be disabled via CpuOptions assumes that it can for any non-metal instance type with a default ThreadsPerCore of > 1. This is known to be false for at least one case: cc2.8xlarge. There are probably others. CpuOptions support can be found [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-optimize-cpu.html)
* In the event that DescribeInstanceTypes doesn't contain the information, the function that returns an instance type's default ThreadsPerCore assumes a value of either 1 or 2 depending on the instance type's supported architectures. Currently this information is only missing from the API for .metal instances.

Signed-off-by: Tim Lane <tilne@amazon.com>
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
