### PR TITLE
Stop log error when getting availability zone for "NONE" subnet

### DIFF
--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -393,6 +393,8 @@ def get_availability_zone_of_subnet(subnet_id):
     :param subnet_id: the id of the subnet.
     :return: a strings of availability zone name
     """
+    if subnet_id == "NONE":
+        return None
     if not hasattr(get_availability_zone_of_subnet, "cache"):
         get_availability_zone_of_subnet.cache = {}
     cache = get_availability_zone_of_subnet.cache


### PR DESCRIPTION
If master and compute nodes are in the same subnet, the function can be called with "NONE" subnet_id because compute subnet is not specified.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
