### PR TITLE
Restore compatibility of start/stop/instances with older cluster versions

### DIFF
--- a/cli/pcluster/cli_commands/start.py
+++ b/cli/pcluster/cli_commands/start.py
@@ -31,11 +31,10 @@ LOGGER = logging.getLogger(__name__)
 
 def start(args):
     """Start cluster compute fleet."""
-    pcluster_config = PclusterConfig(config_file=args.config_file, cluster_name=args.cluster_name, auto_refresh=False)
-    cluster_section = pcluster_config.get_section("cluster")
-    scheduler = cluster_section.get_param_value("scheduler")
-
-    SCHEDULER_TO_START_COMMAND_MAP[scheduler]().start(args, pcluster_config)
+    pcluster_config = PclusterConfig(
+        config_file=args.config_file, cluster_name=args.cluster_name, auto_refresh=False, enforce_version=False
+    )
+    pcluster_config.cluster_model.get_start_command(pcluster_config).start(args, pcluster_config)
 
 
 class StartCommand(ABC):
@@ -119,11 +118,3 @@ class HITStartCommand(StartCommand):
             )
         except Exception as e:
             error("Failed when starting compute fleet with error: {}".format(e))
-
-
-SCHEDULER_TO_START_COMMAND_MAP = {
-    "awsbatch": AWSBatchStartCommand,
-    "sge": SITStartCommand,
-    "torque": SITStartCommand,
-    "slurm": HITStartCommand,
-}

--- a/cli/pcluster/cli_commands/stop.py
+++ b/cli/pcluster/cli_commands/stop.py
@@ -29,11 +29,10 @@ LOGGER = logging.getLogger(__name__)
 
 def stop(args):
     """Stop cluster compute fleet."""
-    pcluster_config = PclusterConfig(config_file=args.config_file, cluster_name=args.cluster_name, auto_refresh=False)
-    cluster_section = pcluster_config.get_section("cluster")
-    scheduler = cluster_section.get_param_value("scheduler")
-
-    SCHEDULER_TO_STOP_COMMAND_MAP[scheduler]().stop(args, pcluster_config)
+    pcluster_config = PclusterConfig(
+        config_file=args.config_file, cluster_name=args.cluster_name, auto_refresh=False, enforce_version=False
+    )
+    pcluster_config.cluster_model.get_stop_command(pcluster_config).stop(args, pcluster_config)
 
 
 class StopCommand(ABC):
@@ -94,11 +93,3 @@ class HITStopCommand(StopCommand):
             )
         except Exception as e:
             error("Failed when stopping compute fleet with error: {}".format(e))
-
-
-SCHEDULER_TO_STOP_COMMAND_MAP = {
-    "awsbatch": AWSBatchStopCommand,
-    "sge": SITStopCommand,
-    "torque": SITStopCommand,
-    "slurm": HITStopCommand,
-}

--- a/cli/pcluster/cli_commands/update.py
+++ b/cli/pcluster/cli_commands/update.py
@@ -53,8 +53,7 @@ def execute(args):
         cfn_client = boto3.client("cloudformation")
         _restore_cfn_only_params(cfn_client, args, cfn_params, stack_name, target_config)
 
-        scheduler = target_config.get_section("cluster").get_param_value("scheduler")
-        is_hit = utils.is_hit_enabled_cluster(scheduler)
+        is_hit = utils.is_hit_enabled_cluster(base_config.cfn_stack)
         template_url = None
         if is_hit:
             try:
@@ -214,7 +213,7 @@ def _restore_cfn_only_params(cfn_boto3_client, args, cfn_params, stack_name, tar
 
     scheduler = cluster_section.get_param_value("scheduler")
     # Autofill DesiredSize cfn param
-    if not args.reset_desired and not utils.is_hit_enabled_cluster(scheduler):
+    if not args.reset_desired and not utils.is_hit_enabled_scheduler(scheduler):
         _restore_desired_size(cfn_params, stack_name, scheduler)
     elif scheduler == "awsbatch":
         LOGGER.info("reset_desired flag does not work with awsbatch scheduler")

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -427,10 +427,10 @@ class PclusterConfig(object):
                 )
 
             cfn_params = self.cfn_stack.get("Parameters")
-            json_params = self.__load_json_config(cfn_params)
+            json_params = self.__load_json_config(self.cfn_stack)
 
             # Infer cluster model and load cluster section accordingly
-            cluster_model = infer_cluster_model(cfn_params=cfn_params)
+            cluster_model = infer_cluster_model(cfn_stack=self.cfn_stack)
             section = ClusterCfnSection(
                 section_definition=cluster_model.get_cluster_section_definition(), pcluster_config=self
             )
@@ -463,12 +463,11 @@ class PclusterConfig(object):
         """Get the Availability zone of the Compute Subnet."""
         return self.get_section("vpc").get_param_value("compute_availability_zone")
 
-    def __load_json_config(self, cfn_params):
+    def __load_json_config(self, cfn_stack):
         """Retrieve Json configuration params from the S3 bucket linked from the cfn params."""
         json_config = None
-        scheduler = get_cfn_param(cfn_params, "Scheduler")
-        if is_hit_enabled_cluster(scheduler):
-            s3_bucket_name = get_cfn_param(cfn_params, "ResourcesS3Bucket")
+        if is_hit_enabled_cluster(cfn_stack):
+            s3_bucket_name = get_cfn_param(cfn_stack.get("Parameters"), "ResourcesS3Bucket")
 
             if not s3_bucket_name or s3_bucket_name == "NONE":
                 self.error("Unable to retrieve configuration: ResourceS3Bucket not available.")

--- a/cli/pcluster/models/hit/hit_cluster_model.py
+++ b/cli/pcluster/models/hit/hit_cluster_model.py
@@ -25,6 +25,18 @@ class HITClusterModel(ClusterModel):
         """Get the cluster section definition used by the cluster model."""
         return mappings.CLUSTER_HIT
 
+    def get_start_command(self, pcluster_config):
+        """Get the start command for the HIT cluster."""
+        from pcluster.cli_commands.start import HITStartCommand
+
+        return HITStartCommand()
+
+    def get_stop_command(self, pcluster_config):
+        """Get the stop command for the HIT cluster."""
+        from pcluster.cli_commands.stop import HITStopCommand
+
+        return HITStopCommand()
+
     def test_configuration(self, pcluster_config):
         """Try to launch the requested instances (in dry-run mode) to verify configuration parameters."""
         cluster_section = pcluster_config.get_section("cluster")

--- a/cli/pcluster/models/sit/sit_cluster_model.py
+++ b/cli/pcluster/models/sit/sit_cluster_model.py
@@ -25,6 +25,30 @@ class SITClusterModel(ClusterModel):
         """Get the cluster section definition used by the cluster model."""
         return mappings.CLUSTER_SIT
 
+    def get_start_command(self, pcluster_config):
+        """Get the start command for a SIT cluster."""
+        cluster_section = pcluster_config.get_section("cluster")
+        if cluster_section.get_param_value("scheduler") == "awsbatch":
+            from pcluster.cli_commands.start import AWSBatchStartCommand
+
+            return AWSBatchStartCommand()
+        else:
+            from pcluster.cli_commands.start import SITStartCommand
+
+            return SITStartCommand()
+
+    def get_stop_command(self, pcluster_config):
+        """Get the stop command for a SIT cluster."""
+        cluster_section = pcluster_config.get_section("cluster")
+        if cluster_section.get_param_value("scheduler") == "awsbatch":
+            from pcluster.cli_commands.stop import AWSBatchStopCommand
+
+            return AWSBatchStopCommand()
+        else:
+            from pcluster.cli_commands.stop import SITStopCommand
+
+            return SITStopCommand()
+
     def test_configuration(self, pcluster_config):
         """
         Try to launch the requested instances (in dry-run mode) to verify configuration parameters.

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -914,7 +914,7 @@ def get_base_additional_iam_policies():
 def cluster_has_running_capacity(stack_name):
     stack = get_stack(stack_name)
     scheduler = get_cfn_param(stack.get("Parameters", []), "Scheduler")
-    if is_hit_enabled_cluster(scheduler):
+    if is_hit_enabled_cluster(stack):
         return ComputeFleetStatusManager(get_cluster_name(stack_name)).get_status() != ComputeFleetStatus.STOPPED
     else:
         return (
@@ -933,8 +933,14 @@ def get_instance_type(instance_type):
         raise e
 
 
-def is_hit_enabled_cluster(scheduler):
+def is_hit_enabled_scheduler(scheduler):
     return scheduler in ["slurm"]
+
+
+def is_hit_enabled_cluster(cfn_stack):
+    scheduler = get_cfn_param(cfn_stack.get("Parameters"), "Scheduler")
+    version = get_stack_version(cfn_stack)
+    return is_hit_enabled_scheduler(scheduler) and version >= "2.9.0"
 
 
 def read_remote_file(url):

--- a/cli/tests/pcluster/config/test_hit_converter.py
+++ b/cli/tests/pcluster/config/test_hit_converter.py
@@ -14,7 +14,7 @@ from assertpy import assert_that
 
 from pcluster.cluster_model import ClusterModel
 from pcluster.config.hit_converter import HitConverter
-from pcluster.utils import is_hit_enabled_cluster
+from pcluster.utils import is_hit_enabled_scheduler
 from tests.common import MockedBoto3Request
 from tests.pcluster.config.utils import init_pcluster_config_from_configparser
 
@@ -157,7 +157,7 @@ def test_hit_converter(boto3_stubber, src_config_dict, dst_config_dict):
     scheduler = src_config_dict["cluster default"]["scheduler"]
     instance_type = src_config_dict["cluster default"]["compute_instance_type"]
 
-    if is_hit_enabled_cluster(scheduler):
+    if is_hit_enabled_scheduler(scheduler):
         mocked_requests = [
             MockedBoto3Request(
                 method="describe_instance_types",

--- a/cli/tests/pcluster/utils/test_pcluster_utils.py
+++ b/cli/tests/pcluster/utils/test_pcluster_utils.py
@@ -655,7 +655,7 @@ def test_get_master_server_ips(mocker, master_instance, expected_ip, error):
 )
 def test_is_hit_enabled_cluster(scheduler, expected_is_hit_enabled):
     """Verify that the expected schedulers are hit enabled."""
-    assert_that(utils.is_hit_enabled_cluster(scheduler)).is_equal_to(expected_is_hit_enabled)
+    assert_that(utils.is_hit_enabled_scheduler(scheduler)).is_equal_to(expected_is_hit_enabled)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Changed the function to discriminate between HIT and SIT models by adding a check on the cluster version. Disabled version enforcement for start/stop/instances commands.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
