### PR TITLE
Fix condition to set cfn_scheduler_slots

### DIFF
--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -7,7 +7,7 @@ Parameters:
   MasterCoreCount:
     Type: CommaDelimitedList
   ComputeCoreCount:
-    Type: CommaDelimitedList
+    Type: String
   RootDevice:
     Type: String
   RootVolumeSize:
@@ -126,6 +126,14 @@ Conditions:
         - !Select
           - '0'
           - !Ref 'MasterCoreCount'
+        - NONE
+  DisableComputeHyperthreading: !Not
+    - !Or
+      - !Equals
+        - !Ref 'ComputeCoreCount'
+        - '-1'
+      - !Equals
+        - !Ref 'ComputeCoreCount'
         - NONE
   DisableMasterHyperthreadingViaCpuOptions: !And
     - !Condition 'DisableMasterHyperthreading'
@@ -477,10 +485,8 @@ Resources:
                   cfn_raid_vol_ids: !Ref 'RAIDVolIds'
                   cfn_raid_parameters: !Ref 'RAIDOptions'
                   cfn_scheduler_slots: !If
-                    - DisableMasterHyperthreading
-                    - !Select
-                      - '0'
-                      - !Ref 'ComputeCoreCount'
+                    - DisableComputeHyperthreading
+                    - !Ref 'ComputeCoreCount'
                     - !Ref 'AWS::NoValue'
                   cfn_disable_hyperthreading_manually: !If
                     - DisableMasterHyperthreadingManually


### PR DESCRIPTION
* cfn_scheduler_slots depends on DisableComputeHyperthreading condition
* on Master stack the property ComputeCoreCount contains only the core count and not the boolean to specify if compute supports disabling hyperthreading via CPU options

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
