### PR TITLE
integ-tests: add sleep after starting cluster in update test

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -186,6 +186,7 @@ def test_update_hit(region, scheduler, pcluster_config_reader, clusters_factory,
     time.sleep(60)  # wait for the cluster to stop
     cluster.update()
     cluster.start()
+    time.sleep(90)  # wait for the cluster to start
 
     assert_initial_conditions(scheduler_commands, 1, 0, partition="queue1")
 


### PR DESCRIPTION
Needed to give the cluster some time to start before checking assertions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
