### PR TITLE
Do not load json config on start/stop

### DIFF
--- a/cli/pcluster/cli_commands/delete.py
+++ b/cli/pcluster/cli_commands/delete.py
@@ -136,13 +136,13 @@ def _terminate_cluster_nodes(stack_name):
         ec2 = boto3.client("ec2", config=Config(retries={"max_attempts": 10}))
 
         for instance_ids in _describe_instance_ids_iterator(stack_name):
-            LOGGER.debug("Terminating instances %s", instance_ids)
+            LOGGER.info("Terminating following instances: %s", instance_ids)
             if instance_ids:
                 ec2.terminate_instances(InstanceIds=instance_ids)
 
         LOGGER.debug("Compute fleet clean-up: COMPLETED")
     except Exception as e:
-        LOGGER.error("Failed when terminating EC2 instances with error %s", e)
+        LOGGER.error("Failed when checking for running EC2 instances with error: %s", e)
 
 
 def _describe_instance_ids_iterator(stack_name, instance_state=("pending", "running", "stopping", "stopped")):

--- a/cli/pcluster/cli_commands/start.py
+++ b/cli/pcluster/cli_commands/start.py
@@ -32,7 +32,11 @@ LOGGER = logging.getLogger(__name__)
 def start(args):
     """Start cluster compute fleet."""
     pcluster_config = PclusterConfig(
-        config_file=args.config_file, cluster_name=args.cluster_name, auto_refresh=False, enforce_version=False
+        config_file=args.config_file,
+        cluster_name=args.cluster_name,
+        auto_refresh=False,
+        enforce_version=False,
+        skip_load_json_config=True,
     )
     pcluster_config.cluster_model.get_start_command(pcluster_config).start(args, pcluster_config)
 

--- a/cli/pcluster/cli_commands/stop.py
+++ b/cli/pcluster/cli_commands/stop.py
@@ -30,7 +30,11 @@ LOGGER = logging.getLogger(__name__)
 def stop(args):
     """Stop cluster compute fleet."""
     pcluster_config = PclusterConfig(
-        config_file=args.config_file, cluster_name=args.cluster_name, auto_refresh=False, enforce_version=False
+        config_file=args.config_file,
+        cluster_name=args.cluster_name,
+        auto_refresh=False,
+        enforce_version=False,
+        skip_load_json_config=True,
     )
     pcluster_config.cluster_model.get_stop_command(pcluster_config).stop(args, pcluster_config)
 

--- a/cli/pcluster/config/pcluster_config.py
+++ b/cli/pcluster/config/pcluster_config.py
@@ -55,6 +55,7 @@ class PclusterConfig(object):
         cluster_name=None,
         auto_refresh=True,
         enforce_version=True,
+        skip_load_json_config=False,
     ):
         """
         Initialize object, from file, from a CFN Stack or from the internal mapping.
@@ -80,6 +81,7 @@ class PclusterConfig(object):
         self.cfn_stack = None
         self.__sections = OrderedDict({})
         self.__enforce_version = enforce_version
+        self.__skip_load_json_config = skip_load_json_config
 
         # always parse the configuration file if there, to get AWS section
         self._init_config_parser(config_file, fail_on_file_absence)
@@ -427,7 +429,7 @@ class PclusterConfig(object):
                 )
 
             cfn_params = self.cfn_stack.get("Parameters")
-            json_params = self.__load_json_config(self.cfn_stack)
+            json_params = self.__load_json_config(self.cfn_stack) if not self.__skip_load_json_config else None
 
             # Infer cluster model and load cluster section accordingly
             cluster_model = infer_cluster_model(cfn_stack=self.cfn_stack)


### PR DESCRIPTION
The main reason behind this change is that we don't want the start/stop command to require a downloadof the json config, which would imply a dependency on the cluster s3 bucket and cluster json configuration. This allows us to:
1. have a working start/stop also when the bucket is deleted
2. have a minimal policy for start/stop that does not require s3 access

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
