### PR TITLE
Disallow using AMIs created by other versions of pcluster by AMI_name…

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -33,6 +33,7 @@ from pcluster.utils import (
     get_supported_os_for_architecture,
     get_supported_os_for_scheduler,
     paginate_boto3,
+    validate_pcluster_version_based_on_ami_name,
 )
 
 LOGFILE_LOGGER = logging.getLogger("cli_log_file")
@@ -655,6 +656,7 @@ def ec2_ami_validator(param_key, param_value, pcluster_config):
     # Make sure AMI exists
     try:
         image_info = boto3.client("ec2").describe_images(ImageIds=[param_value]).get("Images")[0]
+        validate_pcluster_version_based_on_ami_name(image_info.get("Name"))
     except ClientError as e:
         errors.append(
             "Unable to get information for AMI {0}: {1}. Check value of parameter {2}.".format(

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -771,6 +771,19 @@ def get_info_for_amis(ami_ids):
         error(e.response.get("Error").get("Message"))
 
 
+def validate_pcluster_version_based_on_ami_name(ami_name):
+    match = re.match(r"(.*)aws-parallelcluster-(\d+\.\d+\.\d+)(.*)", ami_name)
+    if match:
+        if match.group(2) != get_installed_version():
+            error(
+                "This AMI was created with version {0} of ParallelCluster,"
+                " but is trying to be used with version {1}. Please either use an AMI created with "
+                "version {1} or change your ParallelCluster to version {0}".format(
+                    match.group(2), get_installed_version()
+                )
+            )
+
+
 def get_instance_types_info(instance_types, fail_on_error=True):
     """Return InstanceTypes list returned by EC2's DescribeInstanceTypes API."""
     try:

--- a/cli/tests/pcluster/utils/test_pcluster_utils.py
+++ b/cli/tests/pcluster/utils/test_pcluster_utils.py
@@ -667,3 +667,29 @@ def test_is_hit_enabled_cluster(scheduler, expected_is_hit_enabled):
 )
 def test_get_bucket_url(region, expected_url):
     assert_that(get_bucket_url(region)).is_equal_to(expected_url)
+
+
+@pytest.mark.parametrize(
+    "ami_name, error_expected, expected_message",
+    [
+        # Compatible ami name
+        ("ami-xxxaws-parallelcluster-2.9.0xxx", False, ""),
+        ("ami-aws-parallelcluster-2.9.0", False, ""),
+        ("ami-name-one", False, ""),
+        ("aws-parallelcluster-2.9.0-ubuntu-1804-lts-hvm-x86_64-202009142226", False, ""),
+        # Incompatible ami name
+        (
+            "ami-aws-parallelcluster-0.0.0",
+            True,
+            "This AMI was created with version 0.0.0 of ParallelCluster, but is trying to be used with version 2.9.0."
+            " Please either use an AMI created with version 2.9.0 or change your ParallelCluster to version 0.0.0",
+        ),
+    ],
+)
+def test_validate_pcluster_version_based_on_ami_name(mocker, ami_name, error_expected, expected_message):
+    mocker.patch("pcluster.utils.get_installed_version", return_value="2.9.0")
+    if error_expected:
+        with pytest.raises(SystemExit, match=expected_message):
+            utils.validate_pcluster_version_based_on_ami_name(ami_name)
+    else:
+        utils.validate_pcluster_version_based_on_ami_name(ami_name)

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -365,7 +365,7 @@ Resources:
               if [ -f /opt/parallelcluster/.bootstrapped ]; then
                 installed_version=$(cat /opt/parallelcluster/.bootstrapped)
                 if [ "${!parallelcluster_version}" != "${!installed_version}" ]; then
-                  bootstrap_instance
+                  error_exit "This AMI was created with ${!installed_version}, but is trying to be used with ${!parallelcluster_version}. Please either use an AMI created with ${!parallelcluster_version} or change your ParallelCluster to ${!installed_version}"
                 fi
               else
                 bootstrap_instance

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -456,7 +456,7 @@ Resources:
               if [ -f /opt/parallelcluster/.bootstrapped ]; then
                 installed_version=$(cat /opt/parallelcluster/.bootstrapped)
                 if [ "${!parallelcluster_version}" != "${!installed_version}" ]; then
-                  bootstrap_instance
+                  error_exit "This AMI was created with ${!installed_version}, but is trying to be used with ${!parallelcluster_version}. Please either use an AMI created with ${!parallelcluster_version} or change your ParallelCluster to ${!installed_version}"
                 fi
               else
                 bootstrap_instance

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -439,7 +439,7 @@ Resources:
               if [ -f /opt/parallelcluster/.bootstrapped ]; then
                 installed_version=$(cat /opt/parallelcluster/.bootstrapped)
                 if [ "${!parallelcluster_version}" != "${!installed_version}" ]; then
-                  bootstrap_instance
+                  error_exit "This AMI was created with ${!installed_version}, but is trying to be used with ${!parallelcluster_version}. Please either use an AMI created with ${!parallelcluster_version} or change your ParallelCluster to ${!installed_version}"
                 fi
               else
                 bootstrap_instance


### PR DESCRIPTION
… if the name contains pcluster version

As a result, a AMI created by other versions of pcluster cannot be used as a BASE_AMI in AMI creation or a custom_AMI in cluster creation. However, if the AMI_name does not contain pcluster version, the code in CLI package has to allow the AMI and leave the validation to CloudFormation and Cookbook stage.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
