### PR TITLE
Add missing condition for MasterPublicIp Output

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2790,6 +2790,13 @@
           "MasterENI": {
             "Ref": "MasterENI"
           },
+          "MasterPublicIp": {
+            "Fn::If": [
+              "MasterPublicIp",
+              true,
+              false
+            ]
+          },
           "ImageId": {
             "Fn::If": [
               "UseCustomAMI",

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2790,7 +2790,7 @@
           "MasterENI": {
             "Ref": "MasterENI"
           },
-          "MasterPublicIp": {
+          "UseMasterPublicIp": {
             "Fn::If": [
               "MasterPublicIp",
               true,

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -24,7 +24,7 @@ Parameters:
     Type: String
   MasterENI:
     Type: String
-  MasterPublicIp:
+  UseMasterPublicIp:
     Type: String
   ImageId:
     Type: AWS::EC2::Image::Id
@@ -221,8 +221,8 @@ Conditions:
     - !Equals
       - !Ref 'UpdateWaiterFunctionArn'
       - NONE
-  MasterPublicIp: !Equals
-    - !Ref 'MasterPublicIp'
+  HasMasterPublicIp: !Equals
+    - !Ref 'UseMasterPublicIp'
     - 'true'
 Resources:
   MasterServer:
@@ -627,7 +627,7 @@ Outputs:
   MasterPublicIP:
     Description: Public IP Address of the Master host
     Value: !GetAtt 'MasterServer.PublicIp'
-    Condition: MasterPublicIp
+    Condition: HasMasterPublicIp
   MasterPrivateDnsName:
     Description: Private DNS name of the Master host
     Value: !GetAtt 'MasterServer.PrivateDnsName'

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -24,6 +24,8 @@ Parameters:
     Type: String
   MasterENI:
     Type: String
+  MasterPublicIp:
+    Type: String
   ImageId:
     Type: AWS::EC2::Image::Id
   IamInstanceProfile:
@@ -219,6 +221,9 @@ Conditions:
     - !Equals
       - !Ref 'UpdateWaiterFunctionArn'
       - NONE
+  MasterPublicIp: !Equals
+    - !Ref 'MasterPublicIp'
+    - 'true'
 Resources:
   MasterServer:
     Type: AWS::EC2::Instance
@@ -622,6 +627,7 @@ Outputs:
   MasterPublicIP:
     Description: Public IP Address of the Master host
     Value: !GetAtt 'MasterServer.PublicIp'
+    Condition: MasterPublicIp
   MasterPrivateDnsName:
     Description: Private DNS name of the Master host
     Value: !GetAtt 'MasterServer.PrivateDnsName'


### PR DESCRIPTION
The Master Public IP from the MasterServer resource is only available if MasterPublicIp condition is verified.

We lost this condition [when created two substacks](https://github.com/aws/aws-parallelcluster/commit/1bd129fdb9b06e9920857776c8be0cb4c527aeeb) for the master and the computes.

