### PR TITLE
Avoid logging CFN params twice when creating a cluster

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -153,7 +153,6 @@ def create(args):  # noqa: C901 FIXME!!!
             cfn_params["ResourcesS3Bucket"] = bucket_name
 
         LOGGER.info("Creating stack named: %s", stack_name)
-        LOGGER.debug(cfn_params)
 
         # determine the CloudFormation Template URL to use
         template_url = _evaluate_pcluster_template_url(pcluster_config, preferred_template_url=args.template_url)


### PR DESCRIPTION
Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
