### PR TITLE
Stop using S3 configuration files

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -32,6 +32,7 @@ from pcluster.utils import (
     get_supported_instance_types,
     get_supported_os_for_architecture,
     get_supported_os_for_scheduler,
+    is_instance_type_format,
     paginate_boto3,
     validate_pcluster_version_based_on_ami_name,
 )
@@ -947,15 +948,27 @@ def instances_architecture_compatibility_validator(param_key, param_value, pclus
     errors = []
     warnings = []
 
-    compute_architectures = get_supported_architectures_for_instance_type(param_value)
     master_architecture = pcluster_config.get_section("cluster").get_param_value("architecture")
-    if master_architecture not in compute_architectures:
-        errors.append(
-            "The specified compute_instance_type ({0}) supports the architectures {1}, none of which are "
-            "compatible with the architecture supported by the master_instance_type ({2}).".format(
-                param_value, compute_architectures, master_architecture
+    # When awsbatch is used as the scheduler, compute_instance_type can contain a CSV list.
+    compute_instance_types = param_value.split(",")
+    for compute_instance_type in compute_instance_types:
+        # When awsbatch is used as the scheduler instance families can be used.
+        # Don't attempt to validate architectures for instance families, as it would require
+        # guessing a valid instance type from within the family.
+        if not is_instance_type_format(compute_instance_type) and compute_instance_type != "optimal":
+            LOGFILE_LOGGER.debug(
+                "Not validating architecture compatibility for compute_instance_type {0} because it does not have the "
+                "expected format".format(compute_instance_type)
             )
-        )
+            continue
+        compute_architectures = get_supported_architectures_for_instance_type(compute_instance_type)
+        if master_architecture not in compute_architectures:
+            errors.append(
+                "The specified compute_instance_type ({0}) supports the architectures {1}, none of which are "
+                "compatible with the architecture supported by the master_instance_type ({2}).".format(
+                    compute_instance_type, compute_architectures, master_architecture
+                )
+            )
 
     return errors, warnings
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -31,11 +31,11 @@ from urllib.parse import urlparse
 
 import boto3
 import pkg_resources
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, EndpointConnectionError
 from jinja2 import BaseLoader, Environment
 
 from pcluster.cli_commands.compute_fleet_status_manager import ComputeFleetStatus, ComputeFleetStatusManager
-from pcluster.constants import PCLUSTER_ISSUES_LINK, PCLUSTER_STACK_PREFIX, SUPPORTED_ARCHITECTURES
+from pcluster.constants import PCLUSTER_STACK_PREFIX, SUPPORTED_ARCHITECTURES
 
 LOGGER = logging.getLogger(__name__)
 
@@ -240,59 +240,6 @@ def upload_resources_artifacts(bucket_name, root):
             bucket.upload_file(os.path.join(root, res), res)
 
 
-def _get_json_from_s3(region, file_name):
-    """
-    Get pricing file (if none) and parse content as json.
-
-    :param region: AWS Region
-    :param file_name the object name to get
-    :return: a json object representing the file content
-    :raises ClientError if unable to download the file
-    :raises ValueError if unable to decode the file content
-    """
-    bucket_name = "{0}-aws-parallelcluster".format(region)
-
-    file_contents = boto3.resource("s3").Object(bucket_name, file_name).get()["Body"].read().decode("utf-8")
-    return json.loads(file_contents)
-
-
-def get_supported_features(region, feature):
-    """
-    Get a json object containing the attributes supported by a feature, for example.
-
-    {
-        "Features": {
-            "efa": {
-                "instances": ["c5n.18xlarge", "p3dn.24xlarge", "i3en.24xlarge"],
-                "baseos": ["alinux", "centos7"],
-                "schedulers": ["sge", "slurm", "torque"]
-            },
-            "batch": {
-                "instances": ["r3.8xlarge", ..., "m5.4xlarge"]
-            }
-        }
-    }
-
-    :param region: AWS Region
-    :param feature: the feature to search for, i.e. "efa" "awsbatch"
-    :return: json object containing all the attributes supported by feature
-    """
-    try:
-        features = _get_json_from_s3(region, "features/feature_whitelist.json")
-        supported_features = features.get("Features").get(feature)
-    except (ValueError, ClientError, KeyError) as e:
-        if isinstance(e, ClientError):
-            code = e.response.get("Error").get("Code")
-            if code == "InvalidAccessKeyId":
-                error(e.response.get("Error").get("Message"))
-        error(
-            "Failed validate {0}. This is probably a bug on our end. "
-            "Please submit an issue {1}".format(feature, PCLUSTER_ISSUES_LINK)
-        )
-
-    return supported_features
-
-
 def get_instance_vcpus(instance_type):
     """
     Get number of vcpus for the given instance type.
@@ -311,16 +258,144 @@ def get_instance_vcpus(instance_type):
 
 
 def get_supported_instance_types():
-    """
-    Get supported instance types.
+    """Return the list of instance types available in the given region."""
+    ec2_client = boto3.client("ec2")
+    try:
+        return [
+            offering.get("InstanceType") for offering in paginate_boto3(ec2_client.describe_instance_type_offerings)
+        ]
+    except ClientError as client_err:
+        error(
+            "Error when getting supported instance types via DescribeInstanceTypeOfferings: {0}".format(
+                client_err.response.get("Error").get("Message")
+            )
+        )
 
-    :return: the list of supported instance types
+
+class BatchErrorMessageParsingException(Exception):
+    """Exception for errors getting supported Batch instance types from CreateComputeEnvironment."""
+
+    pass
+
+
+def _call_create_compute_environment_with_bad_instance_type():
+    """
+    Call CreateComputeEnvironment with a nonexistent instance type.
+
+    For more information on why this would be done, see the docstring for
+    _get_supported_instance_types_create_compute_environment_error_message.
+    """
+    batch_client = boto3.client("batch")
+    nonexistent_instance_type = "p8.84xlarge"
+    batch_client.create_compute_environment(
+        computeEnvironmentName="dummy",
+        type="MANAGED",
+        computeResources={
+            "type": "EC2",
+            "minvCpus": 0,
+            "maxvCpus": 0,
+            "instanceTypes": [nonexistent_instance_type],
+            "subnets": ["subnet-12345"],  # security group, subnet and role aren't checked
+            "securityGroupIds": ["sg-12345"],
+            "instanceRole": "ecsInstanceRole",
+        },
+        serviceRole="AWSBatchServiceRole",
+    )
+
+
+def _get_cce_emsg_containing_supported_instance_types():
+    """
+    Call CreateComputeEnvironment with nonexistent instance type and return error message.
+
+    The returned error message is expected to have a list of supported instance types.
     """
     try:
-        instances = _get_json_from_s3(get_region(), "instances/instances.json")
-        return instances.keys()
-    except (ValueError, ClientError):
-        error("Unable to retrieve the list of supported instance types.")
+        _call_create_compute_environment_with_bad_instance_type()
+    except ClientError as e:
+        # This is the expected behavior
+        return e.response.get("Error").get("Message")
+    except EndpointConnectionError:
+        raise BatchErrorMessageParsingException(
+            "Could not connect to the batch endpoint for region %s. Probably Batch is not available.", get_region()
+        )
+    else:
+        # TODO: need to delete the compute environment?
+        raise BatchErrorMessageParsingException(
+            "Attempting to create a Batch ComputeEnvironment using a nonexistent instance type did not result "
+            "in an error as expected."
+        )
+
+
+def _parse_supported_instance_types_and_families_from_cce_emsg(emsg):
+    """
+    Parse the supported instance types emsg, obtained by calling CreateComputeEnvironment.
+
+    The string is expected to have the following format:
+    Instance type can only be one of [r3, r4, m6g.xlarge, r5, optimal, ...]
+    """
+    match = re.search(r"be\s+one\s+of\s*\[(.*[0-9a-z.\-]+.*,.*)\]", emsg)
+    if match:
+        return [instance_type_token.strip() for instance_type_token in match.group(1).split(",")]
+    else:
+        raise BatchErrorMessageParsingException(
+            "Could not parse supported instance types from the following: {0}".format(emsg)
+        )
+
+
+def is_instance_type_format(candidate):
+    """Return a boolean describing whether or not candidate is of the format of an instance type."""
+    return re.search(r"^([a-z0-9\-]+)\.", candidate) is not None
+
+
+def _get_instance_families_from_types(instance_types):
+    """Return a list of instance families represented by the given list of instance types."""
+    families = set()
+    for instance_type in instance_types:
+        match = re.search(r"^([a-z0-9\-]+)\.", instance_type)
+        if match:
+            families.add(match.group(1))
+        else:
+            LOGGER.debug("Unable to parse instance family for instance type {0}".format(instance_type))
+    return list(families)
+
+
+def _instance_types_and_families_are_supported(candidate_types_and_families, known_types_and_families):
+    """Return a boolean describing whether the given instance types and families are known to be supported."""
+    unknowns = [candidate for candidate in candidate_types_and_families if candidate not in known_types_and_families]
+    if unknowns:
+        LOGGER.debug("Found the following unknown instance types/families: {0}".format(" ".join(unknowns)))
+    return not unknowns
+
+
+def get_supported_batch_instance_types():
+    """
+    Get the instance types supported by Batch in the desired region.
+
+    This is done by calling Batch's CreateComputeEnvironment with a bad
+    instance type and parsing the error message.
+    """
+    supported_instance_types = get_supported_instance_types()
+    supported_instance_families = _get_instance_families_from_types(supported_instance_types)
+    supported_instance_types_and_families = supported_instance_types + supported_instance_families
+    try:
+        emsg = _get_cce_emsg_containing_supported_instance_types()
+        parsed_instance_types_and_families = _parse_supported_instance_types_and_families_from_cce_emsg(emsg)
+        if _instance_types_and_families_are_supported(
+            parsed_instance_types_and_families, supported_instance_types_and_families
+        ):
+            supported_batch_types = parsed_instance_types_and_families
+        else:
+            supported_batch_types = supported_instance_types_and_families
+    except Exception as exception:
+        # When the instance types supported by Batch can't be parsed from an error message,
+        # log the reason for the failure and return instead a list of all instance types
+        # supported in the region.
+        LOGGER.debug(
+            "Failed to parse supported Batch instance types from a CreateComputeEnvironment "
+            "error message: {0}".format(exception)
+        )
+        supported_batch_types = supported_instance_types_and_families
+    return supported_batch_types
 
 
 def get_supported_compute_instance_types(scheduler):
@@ -330,12 +405,7 @@ def get_supported_compute_instance_types(scheduler):
     :param scheduler: the scheduler for which we want to know the supported compute instance types or families
     :return: the list of supported instance types and families
     """
-    instances = (
-        get_supported_features(get_region(), "batch").get("instances")
-        if scheduler == "awsbatch"
-        else get_supported_instance_types()
-    )
-    return instances
+    return get_supported_batch_instance_types() if scheduler == "awsbatch" else get_supported_instance_types()
 
 
 def get_supported_az_for_one_instance_type(instance_type):

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -24,6 +24,7 @@ from pcluster.config.validators import (
     EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS,
     FSX_MESSAGES,
     FSX_SUPPORTED_ARCHITECTURES_OSES,
+    LOGFILE_LOGGER,
     architecture_os_validator,
     compute_resource_validator,
     disable_hyperthreading_architecture_validator,
@@ -40,10 +41,6 @@ from tests.pcluster.config.defaults import DefaultDict
 @pytest.fixture()
 def boto3_stubber_path():
     return "pcluster.config.validators.boto3"
-
-
-def _mock_efa_supported_instances(mocker):
-    mocker.patch("pcluster.config.validators.get_supported_features", return_value={"instances": ["t2.large"]})
 
 
 @pytest.mark.parametrize(
@@ -1765,7 +1762,7 @@ def run_architecture_validator_test(
     param_name,
     param_val,
     validator,
-    expected_message,
+    expected_messages,
 ):
     """Run a test for a validator that's concerned with the architecture param."""
     mocked_pcluster_config = make_pcluster_config_mock(mocker, config)
@@ -1776,18 +1773,18 @@ def run_architecture_validator_test(
         constrained_param_name
     )
     assert_that(len(warnings)).is_equal_to(0)
-    assert_that(len(errors)).is_equal_to(0 if expected_message is None else 1)
-    if expected_message:
-        assert_that(errors[0]).matches(re.escape(expected_message))
+    assert_that(len(errors)).is_equal_to(len(expected_messages))
+    for error, expected_message in zip(errors, expected_messages):
+        assert_that(error).matches(re.escape(expected_message))
 
 
 @pytest.mark.parametrize(
     "enabled, architecture, expected_message",
     [
-        (True, "x86_64", None),
-        (True, "arm64", "instance types and an AMI that support these architectures"),
-        (False, "x86_64", None),
-        (False, "arm64", None),
+        (True, "x86_64", []),
+        (True, "arm64", ["instance types and an AMI that support these architectures"]),
+        (False, "x86_64", []),
+        (False, "arm64", []),
     ],
 )
 def test_intel_hpc_architecture_validator(mocker, enabled, architecture, expected_message):
@@ -1809,19 +1806,19 @@ def test_intel_hpc_architecture_validator(mocker, enabled, architecture, expecte
     "base_os, architecture, expected_message",
     [
         # All OSes supported for x86_64
-        ("alinux", "x86_64", None),
-        ("alinux2", "x86_64", None),
-        ("centos6", "x86_64", None),
-        ("centos7", "x86_64", None),
-        ("ubuntu1604", "x86_64", None),
-        ("ubuntu1804", "x86_64", None),
+        ("alinux", "x86_64", []),
+        ("alinux2", "x86_64", []),
+        ("centos6", "x86_64", []),
+        ("centos7", "x86_64", []),
+        ("ubuntu1604", "x86_64", []),
+        ("ubuntu1804", "x86_64", []),
         # Only a subset of OSes supported for x86_64
-        ("alinux", "arm64", "arm64 is only supported for the following operating systems"),
-        ("alinux2", "arm64", None),
-        ("centos6", "arm64", "arm64 is only supported for the following operating systems"),
-        ("centos7", "arm64", "arm64 is only supported for the following operating systems"),
-        ("ubuntu1604", "arm64", "arm64 is only supported for the following operating systems"),
-        ("ubuntu1804", "arm64", None),
+        ("alinux", "arm64", ["arm64 is only supported for the following operating systems"]),
+        ("alinux2", "arm64", []),
+        ("centos6", "arm64", ["arm64 is only supported for the following operating systems"]),
+        ("centos7", "arm64", ["arm64 is only supported for the following operating systems"]),
+        ("ubuntu1604", "arm64", ["arm64 is only supported for the following operating systems"]),
+        ("ubuntu1804", "arm64", []),
     ],
 )
 def test_architecture_os_validator(mocker, base_os, architecture, expected_message):
@@ -1835,10 +1832,14 @@ def test_architecture_os_validator(mocker, base_os, architecture, expected_messa
 @pytest.mark.parametrize(
     "disable_hyperthreading, architecture, expected_message",
     [
-        (True, "x86_64", None),
-        (False, "x86_64", None),
-        (True, "arm64", "disable_hyperthreading is only supported on instance types that support these architectures"),
-        (False, "arm64", None),
+        (True, "x86_64", []),
+        (False, "x86_64", []),
+        (
+            True,
+            "arm64",
+            ["disable_hyperthreading is only supported on instance types that support these architectures"],
+        ),
+        (False, "arm64", []),
     ],
 )
 def test_disable_hyperthreading_architecture_validator(mocker, disable_hyperthreading, architecture, expected_message):
@@ -1856,30 +1857,68 @@ def test_disable_hyperthreading_architecture_validator(mocker, disable_hyperthre
 
 
 @pytest.mark.parametrize(
-    "master_architecture, compute_architecture, expected_message",
+    "master_architecture, compute_architecture, compute_instance_type, expected_message",
     [
-        ("x86_64", "x86_64", None),
-        ("x86_64", "arm64", "none of which are compatible with the architecture supported by the master_instance_type"),
-        ("arm64", "x86_64", "none of which are compatible with the architecture supported by the master_instance_type"),
-        ("arm64", "arm64", None),
+        # Single compute_instance_type
+        ("x86_64", "x86_64", "c5.xlarge", []),
+        (
+            "x86_64",
+            "arm64",
+            "m6g.xlarge",
+            ["none of which are compatible with the architecture supported by the master_instance_type"],
+        ),
+        (
+            "arm64",
+            "x86_64",
+            "c5.xlarge",
+            ["none of which are compatible with the architecture supported by the master_instance_type"],
+        ),
+        ("arm64", "arm64", "m6g.xlarge", []),
+        ("x86_64", "x86_64", "optimal", []),
+        # Function to get supported architectures shouldn't be called because compute_instance_type arg
+        # are instance families.
+        ("x86_64", None, "m6g", []),
+        ("x86_64", None, "c5", []),
+        # The validator must handle the case where compute_instance_type is a CSV list
+        ("arm64", "arm64", "m6g.xlarge,r6g.xlarge", []),
+        (
+            "x86_64",
+            "arm64",
+            "m6g.xlarge,r6g.xlarge",
+            ["none of which are compatible with the architecture supported by the master_instance_type"] * 2,
+        ),
     ],
 )
 def test_instances_architecture_compatibility_validator(
-    mocker, master_architecture, compute_architecture, expected_message
+    mocker, caplog, master_architecture, compute_architecture, compute_instance_type, expected_message
 ):
-    mocker.patch(
+    def internal_is_instance_type(itype):
+        return "." in itype or itype == "optimal"
+
+    supported_architectures_patch = mocker.patch(
         "pcluster.config.validators.get_supported_architectures_for_instance_type", return_value=[compute_architecture]
     )
+    is_instance_type_patch = mocker.patch(
+        "pcluster.config.validators.is_instance_type_format", side_effect=internal_is_instance_type
+    )
+    logger_patch = mocker.patch.object(LOGFILE_LOGGER, "debug")
     run_architecture_validator_test(
         mocker,
         {"cluster": {"architecture": master_architecture}},
         "cluster",
         "architecture",
         "compute_instance_type",
-        "some_instance_type",
+        compute_instance_type,
         instances_architecture_compatibility_validator,
         expected_message,
     )
+    compute_instance_types = compute_instance_type.split(",")
+    non_instance_families = [
+        instance_type for instance_type in compute_instance_types if internal_is_instance_type(instance_type)
+    ]
+    assert_that(supported_architectures_patch.call_count).is_equal_to(len(non_instance_families))
+    assert_that(logger_patch.call_count).is_equal_to(len(compute_instance_types) - len(non_instance_families))
+    assert_that(is_instance_type_patch.call_count).is_equal_to(len(compute_instance_types))
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/utils/test_pcluster_utils.py
+++ b/cli/tests/pcluster/utils/test_pcluster_utils.py
@@ -1,10 +1,13 @@
 """This module provides unit tests for the functions in the pcluster.utils module."""
 
 import json
+import logging
+from itertools import product
+from re import escape
 
 import pytest
 from assertpy import assert_that
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, EndpointConnectionError
 
 import pcluster.utils as utils
 from pcluster.utils import get_bucket_url
@@ -693,3 +696,258 @@ def test_validate_pcluster_version_based_on_ami_name(mocker, ami_name, error_exp
             utils.validate_pcluster_version_based_on_ami_name(ami_name)
     else:
         utils.validate_pcluster_version_based_on_ami_name(ami_name)
+
+
+@pytest.mark.parametrize("scheduler", ["slurm", "sge", "torque", "awsbatch"])
+def test_get_supported_compute_instance_types(mocker, scheduler):
+    """Verify that the correct function to get supported instance types is called based on the scheduler used."""
+    batch_function_patch = mocker.patch("pcluster.utils.get_supported_batch_instance_types")
+    traditional_scheduler_function_patch = mocker.patch("pcluster.utils.get_supported_instance_types")
+    utils.get_supported_compute_instance_types(scheduler)
+    if scheduler == "awsbatch":
+        assert_that(batch_function_patch.call_count).is_equal_to(1)
+        traditional_scheduler_function_patch.assert_not_called()
+    else:
+        assert_that(traditional_scheduler_function_patch.call_count).is_equal_to(1)
+        batch_function_patch.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "raise_error_api_function, raise_error_parsing_function, types_parsed_from_emsg_are_known",
+    product([True, False], repeat=3),
+)
+def test_get_supported_batch_instance_types(
+    mocker, raise_error_api_function, raise_error_parsing_function, types_parsed_from_emsg_are_known
+):
+    """Verify functions are called and errors are handled as expected when getting supported batch instance types."""
+    # Dummy values
+    dummy_error_message = "dummy error message"
+    dummy_batch_instance_types = ["batch-instance-type"]
+    dummy_batch_instance_families = ["batch-instance-family"]
+    dummy_all_instance_types = dummy_batch_instance_types + ["non-batch-instance-type"]
+    dummy_all_instance_families = dummy_batch_instance_families + ["non-batch-instance-family"]
+    # Mock all functions called by the function
+    api_function_patch = mocker.patch(
+        "pcluster.utils._get_cce_emsg_containing_supported_instance_types",
+        side_effect=utils.BatchErrorMessageParsingException
+        if raise_error_api_function
+        else lambda: dummy_error_message,
+    )
+    parsing_function_patch = mocker.patch(
+        "pcluster.utils._parse_supported_instance_types_and_families_from_cce_emsg",
+        side_effect=utils.BatchErrorMessageParsingException
+        if raise_error_parsing_function
+        else lambda emsg: dummy_batch_instance_types + dummy_batch_instance_families,
+    )
+    supported_instance_types_patch = mocker.patch(
+        "pcluster.utils.get_supported_instance_types", return_value=dummy_all_instance_types
+    )
+    get_instance_families_patch = mocker.patch(
+        "pcluster.utils._get_instance_families_from_types", return_value=dummy_all_instance_families
+    )
+    candidates_are_supported_patch = mocker.patch(
+        "pcluster.utils._instance_types_and_families_are_supported", return_value=types_parsed_from_emsg_are_known
+    )
+    returned_value = utils.get_supported_batch_instance_types()
+    # The functions that call the Batch CreateComputeEnvironment API, and those that get all
+    # supported instance types and families should always be called.
+    assert_that(api_function_patch.call_count).is_equal_to(1)
+    assert_that(supported_instance_types_patch.call_count).is_equal_to(1)
+    get_instance_families_patch.assert_called_with(dummy_all_instance_types)
+    # The function that parses the error message returned by the Batch API is only called if the
+    # function that calls the API succeeds.
+    if raise_error_api_function:
+        parsing_function_patch.assert_not_called()
+    else:
+        parsing_function_patch.assert_called_with(dummy_error_message)
+    # The function that ensures the values parsed from the CCE error message are valid is only called if
+    # the API call and parsing succeed.
+    if any([raise_error_api_function, raise_error_parsing_function]):
+        candidates_are_supported_patch.assert_not_called()
+    else:
+        candidates_are_supported_patch.assert_called_with(
+            dummy_batch_instance_types + dummy_batch_instance_families,
+            dummy_all_instance_types + dummy_all_instance_families,
+        )
+    # If either of the functions don't succeed, get_supported_instance_types return value should be
+    # used as a fallback.
+    assert_that(returned_value).is_equal_to(
+        dummy_all_instance_types + dummy_all_instance_families
+        if any([raise_error_api_function, raise_error_parsing_function, not types_parsed_from_emsg_are_known])
+        else dummy_batch_instance_types + dummy_batch_instance_families
+    )
+
+
+@pytest.mark.parametrize(
+    "api_emsg, match_expected, expected_return_value",
+    [
+        # Positives
+        # Expected format using various instance types
+        ("be one of [u-6tb1.metal, i3en.metal-2tb]", True, ["u-6tb1.metal", "i3en.metal-2tb"]),
+        ("be one of [i3en.metal-2tb, u-6tb1.metal]", True, ["i3en.metal-2tb", "u-6tb1.metal"]),
+        ("be one of [c5n.xlarge, m6g.xlarge]", True, ["c5n.xlarge", "m6g.xlarge"]),
+        # Whitespace within the brackets shouldn't matter
+        ("be one of [c5.xlarge,m6g.xlarge]", True, ["c5.xlarge", "m6g.xlarge"]),
+        ("be one of [   c5.xlarge,     m6g.xlarge]", True, ["c5.xlarge", "m6g.xlarge"]),
+        ("be one of [c5.xlarge    ,m6g.xlarge    ]", True, ["c5.xlarge", "m6g.xlarge"]),
+        # Instance families as well as types must be handled.
+        ("be one of [  c5    ,    m6g  ]", True, ["c5", "m6g"]),
+        # The amount of whitespace between the words preceding the brackets doesn't matter.
+        ("be one of      [c5.xlarge, m6g.xlarge]", True, ["c5.xlarge", "m6g.xlarge"]),
+        ("be one of[c5.xlarge, m6g.xlarge]", True, ["c5.xlarge", "m6g.xlarge"]),
+        ("     be            one     of[c5.xlarge, m6g.xlarge]", True, ["c5.xlarge", "m6g.xlarge"]),
+        # Negatives
+        # Brackets are what's used to determine where the instance type list starts.
+        # If there are no brackets, there will be no match.
+        ("be one of (c5.xlarge, m6g.xlarge)", False, None),
+        ("be one of [c5.xlarge, m6g.xlarge", False, None),
+        ("be one of c5.xlarge, m6g.xlarge]", False, None),
+        # A comma must be used within the brackets.
+        ("be one of [c5.xlarge| m6g.xlarge]", False, None),
+    ],
+)
+def test_parse_supported_instance_types_and_families_from_cce_emsg(api_emsg, match_expected, expected_return_value):
+    """Verify parsing supported instance types from the CreateComputeEnvironment error message works as expected."""
+    if match_expected:
+        assert_that(utils._parse_supported_instance_types_and_families_from_cce_emsg(api_emsg)).is_equal_to(
+            expected_return_value
+        )
+    else:
+        with pytest.raises(
+            utils.BatchErrorMessageParsingException,
+            match="Could not parse supported instance types from the following: {0}".format(escape(api_emsg)),
+        ):
+            utils._parse_supported_instance_types_and_families_from_cce_emsg(api_emsg)
+
+
+@pytest.mark.parametrize("error_type", [ClientError, EndpointConnectionError(endpoint_url="dummy_endpoint"), None])
+def test_get_cce_emsg_containing_supported_instance_types(mocker, boto3_stubber, error_type):
+    """Verify CreateComputeEnvironment call to get error message with supported instance types behaves as expected."""
+    dummy_error_message = "dummy message"
+    call_api_patch = None
+    if error_type == ClientError:
+        mocked_requests = [
+            MockedBoto3Request(
+                method="create_compute_environment",
+                expected_params={
+                    "computeEnvironmentName": "dummy",
+                    "type": "MANAGED",
+                    "computeResources": {
+                        "type": "EC2",
+                        "minvCpus": 0,
+                        "maxvCpus": 0,
+                        "instanceTypes": ["p8.84xlarge"],
+                        "subnets": ["subnet-12345"],
+                        "securityGroupIds": ["sg-12345"],
+                        "instanceRole": "ecsInstanceRole",
+                    },
+                    "serviceRole": "AWSBatchServiceRole",
+                },
+                response=dummy_error_message,
+                generate_error=True,
+            )
+        ]
+        boto3_stubber("batch", mocked_requests)
+    else:
+        call_api_patch = mocker.patch(
+            "pcluster.utils._call_create_compute_environment_with_bad_instance_type",
+            side_effect=error_type,
+        )
+
+    if error_type == ClientError:
+        return_value = utils._get_cce_emsg_containing_supported_instance_types()
+        assert_that(return_value).is_equal_to(dummy_error_message)
+    else:
+        expected_message = (
+            "Could not connect to the batch endpoint"
+            if isinstance(error_type, EndpointConnectionError)
+            else "did not result in an error as expected"
+        )
+        with pytest.raises(utils.BatchErrorMessageParsingException, match=expected_message):
+            utils._get_cce_emsg_containing_supported_instance_types()
+        assert_that(call_api_patch.call_count).is_equal_to(1)
+
+
+@pytest.mark.parametrize("generate_error", [True, False])
+def test_get_supported_instance_types(mocker, boto3_stubber, generate_error):
+    """Verify that get_supported_instance_types behaves as expected."""
+    dummy_message = "dummy error message"
+    dummy_instance_types = ["c5.xlarge", "m6g.xlarge"]
+    error_patch = mocker.patch("pcluster.utils.error")
+    mocked_requests = [
+        MockedBoto3Request(
+            method="describe_instance_type_offerings",
+            expected_params={},
+            response=dummy_message
+            if generate_error
+            else {"InstanceTypeOfferings": [{"InstanceType": instance_type} for instance_type in dummy_instance_types]},
+            generate_error=generate_error,
+        )
+    ]
+    boto3_stubber("ec2", mocked_requests)
+    return_value = utils.get_supported_instance_types()
+    if generate_error:
+        expected_error_message = (
+            "Error when getting supported instance types via DescribeInstanceTypeOfferings: {0}".format(dummy_message)
+        )
+        error_patch.assert_called_with(expected_error_message)
+    else:
+        assert_that(return_value).is_equal_to(dummy_instance_types)
+        error_patch.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "candidates, knowns",
+    [
+        (["c5.xlarge", "m6g"], ["c5.xlarge", "c5", "m6g.xlarge", "m6g"]),
+        (["bad-candidate"], ["c5.xlarge", "c5", "m6g.xlarge", "m6g"]),
+    ],
+)
+def test_instance_types_and_families_are_supported(caplog, candidates, knowns):
+    """Verify function that describes whether all given instance types/families are supported behaves as expected."""
+    caplog.set_level(logging.DEBUG)
+    unknown_candidates = [candidate for candidate in candidates if candidate not in knowns]
+    expected_return_value = not unknown_candidates
+    observed_return_value = utils._instance_types_and_families_are_supported(candidates, knowns)
+    assert_that(observed_return_value).is_equal_to(expected_return_value)
+    if unknown_candidates:
+        log_msg = "Found the following unknown instance types/families: {0}".format(" ".join(unknown_candidates))
+        assert_that(caplog.text).contains(log_msg)
+
+
+@pytest.mark.parametrize(
+    "instance_types, error_expected, expected_return_value",
+    [
+        (["m6g.xlarge"], False, ["m6g"]),
+        (["m6g.xlarge", "m6g-."], False, ["m6g", "m6g-"]),
+        (["m6g.xlarge", ".2xlarge"], True, ["m6g"]),
+    ],
+)
+def test_get_instance_families_from_types(caplog, instance_types, error_expected, expected_return_value):
+    """Verify the function that parses instance families from instance types works as expected."""
+    error_message_prefix = "Unable to parse instance family for instance type"
+    caplog.set_level(logging.DEBUG)
+    assert_that(utils._get_instance_families_from_types(instance_types)).contains_only(*expected_return_value)
+    if error_expected:
+        assert_that(caplog.text).contains(error_message_prefix)
+    else:
+        assert_that(caplog.text).does_not_contain(error_message_prefix)
+
+
+@pytest.mark.parametrize(
+    "candidate, expected_return_value",
+    [
+        ("m6g.xlarge", True),
+        ("c5n.xlarge", True),
+        ("i3en.metal-2tb", True),
+        ("u-6tb1.metal", True),
+        ("m6g", False),
+        ("c5n", False),
+        ("u-6tb1", False),
+        ("i3en", False),
+        ("optimal", False),
+    ],
+)
+def test_is_instance_type_format(candidate, expected_return_value):
+    """Verify function that decides whether or not a string represents an instance type behaves as expected."""
+    assert_that(utils.is_instance_type_format(candidate)).is_equal_to(expected_return_value)

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1583,7 +1583,8 @@
                 "ec2:AttachVolume",
                 "ec2:DescribeInstanceAttribute",
                 "ec2:DescribeInstanceStatus",
-                "ec2:DescribeInstances"
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceTypes"
               ],
               "Effect": "Allow",
               "Resource": [


### PR DESCRIPTION
* Use DescribeInstanceTypes and DescribeInstanceTypeOfferings to
validate instance types and get vCPU info.
* For validating compute instance types to be used with Batch, work
around the lack of an API by attmepting to create a compute
environment using a nonexistent instance type, and then parse the
supported instance types for the given region from the error
message. If this information cannot be obtained in this way, fall back
to using the list of available instance types in the region.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
