### PR TITLE
Provide OS type specified by a user to CFN templates of compute nodes

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2867,7 +2867,7 @@
           "EFA": {
             "Ref": "EFA"
           },
-          "OS": {
+          "BaseOS": {
             "Ref": "BaseOS"
           },
           "OSUser": {
@@ -3321,6 +3321,9 @@
           "EFA": {
             "Ref": "EFA"
           },
+          "BaseOS": {
+            "Ref": "BaseOS"
+          },
           "OSUser": {
             "Fn::FindInMap": [
               "OSFeatures",
@@ -3672,6 +3675,9 @@
           },
           "IamInstanceProfile": {
             "Ref": "RootInstanceProfile"
+          },
+          "BaseOS": {
+            "Ref": "BaseOS"
           },
           "OSUser": {
             "Fn::FindInMap": [

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -22,6 +22,8 @@ Parameters:
     Type: AWS::EC2::Image::Id
   IamInstanceProfile:
     Type: String
+  BaseOS:
+    Type: String
   OSUser:
     Type: String
   PreInstallScript:
@@ -255,6 +257,7 @@ Resources:
                         "stack_name": "${MainStackName}",
                         "enable_efa": "{{ 'efa' if compute_resource.enable_efa else 'NONE' }}",
                         "cfn_raid_parameters": "${RAIDOptions}",
+                        "cfn_base_os": "${BaseOS}",
                         "cfn_preinstall": "${PreInstallScript}",
                         "cfn_preinstall_args": "${PreInstallArgs}",
                         "cfn_postinstall": "${PostInstallScript}",

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -32,6 +32,8 @@ Parameters:
     Type: String
   EFA:
     Type: String
+  BaseOS:
+    Type: String
   OSUser:
     Type: String
   PreInstallScript:
@@ -343,6 +345,7 @@ Resources:
                         "stack_name": "${MainStackName}",
                         "enable_efa": "${EFA}",
                         "cfn_raid_parameters": "${RAIDOptions}",
+                        "cfn_base_os": "${BaseOS}",
                         "cfn_preinstall": "${PreInstallScript}",
                         "cfn_preinstall_args": "${PreInstallArgs}",
                         "cfn_postinstall": "${PostInstallScript}",

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -36,7 +36,7 @@ Parameters:
     Type: String
   EFA:
     Type: String
-  OS:
+  BaseOS:
     Type: String
   OSUser:
     Type: String
@@ -497,7 +497,7 @@ Resources:
                     - DisableMasterHyperthreadingManually
                     - 'true'
                     - 'false'
-                  cfn_base_os: !Ref 'OS'
+                  cfn_base_os: !Ref 'BaseOS'
                   cfn_preinstall: !Ref 'PreInstallScript'
                   cfn_preinstall_args: !Ref 'PreInstallArgs'
                   cfn_postinstall: !Ref 'PostInstallScript'


### PR DESCRIPTION
This commit will enable validation of OSs provided by the user is consistent with the actual OS of a custom AMI.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
