### PR TITLE
Add FSx S3 AutoImport option

### DIFF
--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -75,6 +75,7 @@ from pcluster.config.validators import (
     fsx_id_validator,
     fsx_ignored_parameters_validator,
     fsx_imported_file_chunk_size_validator,
+    fsx_lustre_auto_import_validator,
     fsx_lustre_backup_validator,
     fsx_storage_capacity_validator,
     fsx_validator,
@@ -141,6 +142,7 @@ ALLOWED_VALUES = {
     "deployment_type": ["SCRATCH_1", "SCRATCH_2", "PERSISTENT_1"],
     "per_unit_storage_throughput": [50, 100, 200],
     "architectures": SUPPORTED_ARCHITECTURES,
+    "auto_import_policy": ["NONE", "NEW", "NEW_CHANGED"]
 }
 
 AWS = {
@@ -520,6 +522,11 @@ FSX = {
                 "allowed_values": "^(backup-[0-9a-f]{8,})$",
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
+            ("auto_import_policy", {
+                "validators": [fsx_lustre_auto_import_validator],
+                "allowed_values": ALLOWED_VALUES["auto_import_policy"],
+                "update_policy": UpdatePolicy.UNSUPPORTED
+            })
         ]
     )
 }

--- a/cli/pcluster/examples/config
+++ b/cli/pcluster/examples/config
@@ -278,3 +278,6 @@ master_subnet_id = subnet-12345678
 #export_path = s3://import-path/export-dir
 # For SCRATCH_2 and PERSISTENT_1 you can provide a KMS Key for in transit encryption
 #fsx_kms_key_id = XXXX-XXXXX-XXX-XXXXX
+# AutoImportPolicy configures how the filesystem is automatically updated with new and changed files from the linked S3 bucket
+# Valid options are NONE, NEW, NEW_CHANGED
+#auto_import_policy = NEW_CHANGED

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -82,6 +82,7 @@ DEFAULT_FSX_DICT = {
     "automatic_backup_retention_days": None,
     "copy_tags_to_backups": None,
     "fsx_backup_id": None,
+    "auto_import_policy": None,
 }
 
 DEFAULT_DCV_DICT = {"enable": None, "port": 8443, "access_from": "0.0.0.0/0"}
@@ -247,7 +248,7 @@ DEFAULT_EFS_CFN_PARAMS = {"EFSOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE
 
 DEFAULT_RAID_CFN_PARAMS = {"RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
-DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
+DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
 DEFAULT_DCV_CFN_PARAMS = {"DCVOptions": "NONE,NONE,NONE"}
 DEFAULT_CW_LOG_CFN_PARAMS = {"CWLogOptions": "true,14"}
@@ -315,7 +316,7 @@ DEFAULT_CLUSTER_SIT_CFN_PARAMS = {
     # raid
     "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # fsx
-    "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+    "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # dcv
     "DCVOptions": "NONE,NONE,NONE",
     # cw_log_settings

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -1128,7 +1128,7 @@ def test_cluster_section_to_cfn(
                     # raid
                     "RAIDOptions": "raid,NONE,2,gp2,20,100,false,NONE",
                     # fsx
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                     "Scheduler": "sge",
@@ -1194,7 +1194,7 @@ def test_cluster_section_to_cfn(
                     # raid
                     "RAIDOptions": "raid,NONE,2,gp2,20,100,false,NONE",
                     # fsx
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                 },

--- a/cli/tests/pcluster/config/test_section_fsx.py
+++ b/cli/tests/pcluster/config/test_section_fsx.py
@@ -21,21 +21,21 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
         (DefaultCfnParams["fsx"].value, DefaultDict["fsx"].value),
         ({}, DefaultDict["fsx"].value),
         (
-            {"FSXOptions": "NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE, NONE"},
+            {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"},
             DefaultDict["fsx"].value,
         ),
         (
-            {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE, NONE"},
+            {"FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"},
             DefaultDict["fsx"].value,
         ),
         (
-            {"FSXOptions": "test,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"},
+            {"FSXOptions": "test,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"},
             utils.merge_dicts(DefaultDict["fsx"].value, {"shared_dir": "test"}),
         ),
         (
             {
                 "FSXOptions": "test,test1,10,test2,20,test3,test4,test5,SCRATCH_1,"
-                "50,01:00,5,false,backup-0a1b2c3d4e5f6a7b8"
+                "50,01:00,5,false,backup-0a1b2c3d4e5f6a7b8, NEW_CHANGED"
             },
             {
                 "shared_dir": "test",
@@ -52,6 +52,7 @@ from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
                 "automatic_backup_retention_days": 5,
                 "copy_tags_to_backups": False,
                 "fsx_backup_id": "backup-0a1b2c3d4e5f6a7b8",
+                "auto_import_policy": "NEW_CHANGED",
             },
         ),
     ],
@@ -221,6 +222,10 @@ def test_fsx_section_to_cfn(mocker, section_dict, expected_cfn_params):
             "'fsx_backup_id' has an invalid value 'backup-0A1B2C3d4e5f6a7b8'",
         ),
         ("fsx_backup_id", "backup-0a1b2c3d4e5f6a7b8", "backup-0a1b2c3d4e5f6a7b8", None),
+        ("auto_import_policy", None, "NONE", None),
+        ("auto_import_policy", "NONE", "NONE", None),
+        ("auto_import_policy", "NEW", "NEW", None),
+        ("auto_import_policy", "NEW_CHANGED", "NEW_CHANGED", None),
     ],
 )
 def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, expected_message):
@@ -245,7 +250,7 @@ def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, exp
                 {
                     "MasterSubnetId": "subnet-12345678",
                     "AvailabilityZone": "mocked_avail_zone",
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                 },
             ),
         ),
@@ -257,7 +262,7 @@ def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, exp
                     "MasterSubnetId": "subnet-12345678",
                     "AvailabilityZone": "mocked_avail_zone",
                     "FSXOptions": "fsx,fs-12345678901234567,10,key1,1020,s3://test-export,"
-                    "s3://test-import,1:10:17,SCRATCH_1,50,01:00,5,false,NONE",
+                    "s3://test-import,1:10:17,SCRATCH_1,50,01:00,5,false,NONE,NONE",
                 },
             ),
         ),
@@ -271,7 +276,7 @@ def test_fsx_param_from_file(mocker, param_key, param_value, expected_value, exp
                 {
                     "MasterSubnetId": "subnet-12345678",
                     "AvailabilityZone": "mocked_avail_zone",
-                    "FSXOptions": "/fsx,NONE,3600,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+                    "FSXOptions": "/fsx,NONE,3600,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
                 },
             ),
         ),

--- a/cli/tests/pcluster/config/test_section_fsx/test_fsx_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_fsx/test_fsx_from_file_to_cfn/pcluster.config.ini
@@ -32,6 +32,7 @@ fsx_kms_key_id = key1
 imported_file_chunk_size = 1020
 export_path = s3://test-export
 import_path = s3://test-import
+auto_import_policy = NEW_CHANGED
 weekly_maintenance_start_time = 1:10:17
 deployment_type = SCRATCH_1
 per_unit_storage_throughput = 50

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -325,7 +325,7 @@
       "Default": "1"
     },
     "FSXOptions": {
-      "Description": "Comma separated list of FSx related options, 14 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id]",
+      "Description": "Comma separated list of FSx related options, 15 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id,auto_import_policy]",
       "Type": "String",
       "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },

--- a/cloudformation/fsx-substack.cfn.json
+++ b/cloudformation/fsx-substack.cfn.json
@@ -34,6 +34,23 @@
         }
       ]
     },
+    "UseAutoImportPolicy": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "14",
+                {
+                  "Ref": "FSXOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
     "UseExportPath": {
       "Fn::Not": [
         {
@@ -270,7 +287,7 @@
       "Type": "String"
     },
     "FSXOptions": {
-      "Description": "Comma separated list of fsx related options, 13 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups]",
+      "Description": "Comma separated list of fsx related options, 15 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id,auto_import_policy]",
       "Type": "CommaDelimitedList"
     },
     "SubnetId": {
@@ -309,6 +326,22 @@
           ]
         },
         "LustreConfiguration": {
+          "AutoImportPolicy": {
+            "Fn::If": [
+              "UseAutoImportPolicy",
+              {
+                "Fn::Select": [
+                  "14",
+                  {
+                    "Ref": "FSXOptions"
+                  }
+                ]
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          },
           "ExportPath": {
             "Fn::If": [
               "UseExportPath",

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -80,6 +80,7 @@ def test_fsx_lustre(
     _test_import_path(remote_command_executor, mount_dir)
     _test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir)
     _test_export_path(remote_command_executor, mount_dir, bucket_name)
+    _test_auto_import(remote_command_executor, mount_dir, bucket_name, region, fsx_fs_id)
     _test_data_repository_task(remote_command_executor, mount_dir, bucket_name, fsx_fs_id, region)
 
 
@@ -234,6 +235,20 @@ def _test_export_path(remote_command_executor, mount_dir, bucket_name):
     result = remote_command_executor.run_remote_command("cat ./file_to_export")
     assert_that(result.stdout).is_equal_to("Exported by FSx Lustre")
 
+def _test_auto_import(remote_command_executor, mount_dir, bucket_name, region, fsx_fs_id):
+    s3 = boto3.client("s3", region_name=region)
+    s3.put_object(Bucket=bucket_name, Key="fileToAutoImport", Body="AutoImported by FSx Lustre")
+    # AutoImport has a P99.9 of 1 min for new/changed files to be imported onto the filesystem
+    
+    remote_command_executor.run_remote_command("sleep 1m")
+    temp = remote_command_executor.run_remote_command("ls {mount_dir}".format(mount_dir=mount_dir))
+    logging.info("Files in the import path " + temp.stdout)
+    fsx = boto3.client("fsx", region_name=region)
+
+    filesystem = fsx.describe_file_systems(FileSystemIds=[fsx_fs_id]).get("FileSystems")[0].get("LustreConfiguration")
+    logging.info("Filesystem info " + str(filesystem))
+    result = remote_command_executor.run_remote_command("cat {mount_dir}/fileToAutoImport".format(mount_dir=mount_dir))
+    assert_that(result.stdout).is_equal_to("AutoImported by FSx Lustre")
 
 @retry(
     retry_on_result=lambda result: result.get("Lifecycle") in ["PENDING", "EXECUTING", "CANCELLING"],

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
@@ -38,3 +38,4 @@ deployment_type = {{ deployment_type }}
 {% if per_unit_storage_throughput %}
 per_unit_storage_throughput = {{ per_unit_storage_throughput }}
 {% endif %}
+auto_import_policy = NEW_CHANGED


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allow S3-linked FSx filesystems to enable AutoImport.

AutoImport is a new FSx feature that allows customers to configure their Amazon FSx for Lustre file system to automatically import metadata of objects that are added to or changed in the linked S3 bucket after file system creation. 

For more details, please see https://docs.aws.amazon.com/fsx/latest/LustreGuide/autoimport-data-repo.html.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
