### PR TITLE
Fix json settings param from_storage logic

### DIFF
--- a/cli/tests/pcluster/config/test_json_param_types.py
+++ b/cli/tests/pcluster/config/test_json_param_types.py
@@ -170,7 +170,6 @@ def test_config_from_json(mocker, boto3_stubber, test_datadir, pcluster_config_r
         _check_queue_section_from_json(
             expected_json_params, pcluster_config, pcluster_config.get_section("queue", queue)
         )
-    pass
 
 
 def _check_queue_section_from_json(json_config, pcluster_config, queue_section):


### PR DESCRIPTION
JSonSettingsParam was not correctly restoring its value and referred sections when single sections were involved.

Once dashboard patch will be merged remember to add these lines to test_json_param_types/test_config_from_json:

    dashboard_section = pcluster_config.get_section("dashboard", "dashboard1")
    assert_that(dashboard_section).is_not_none()
    assert_that(dashboard_section.get_param_value("enable")).is_equal_to(False)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
