### PR TITLE
Include 'optimal' in fallback value for valid Batch compute instance types

### DIFF
--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -367,12 +367,7 @@ def _get_instance_families_from_types(instance_types):
 
 def _batch_instance_types_and_families_are_supported(candidate_types_and_families, known_types_and_families):
     """Return a boolean describing whether the instance types and families parsed from Batch API are known."""
-    known_exceptions = ["optimal"]
-    unknowns = [
-        candidate
-        for candidate in candidate_types_and_families
-        if candidate not in known_types_and_families + known_exceptions
-    ]
+    unknowns = [candidate for candidate in candidate_types_and_families if candidate not in known_types_and_families]
     if unknowns:
         LOGGER.debug("Found the following unknown instance types/families: {0}".format(" ".join(unknowns)))
     return not unknowns
@@ -387,7 +382,8 @@ def get_supported_batch_instance_types():
     """
     supported_instance_types = get_supported_instance_types()
     supported_instance_families = _get_instance_families_from_types(supported_instance_types)
-    supported_instance_types_and_families = supported_instance_types + supported_instance_families
+    known_exceptions = ["optimal"]
+    supported_instance_types_and_families = supported_instance_types + supported_instance_families + known_exceptions
     try:
         emsg = _get_cce_emsg_containing_supported_instance_types()
         parsed_instance_types_and_families = _parse_supported_instance_types_and_families_from_cce_emsg(emsg)


### PR DESCRIPTION
**Summary**

This commit ensures that `optimal` is not determined to be an invalid
value when the CLI can't guarantee that the set of instance types and
families parsed from a CCE error message

**Details**

As of 6c4233e8, supported values for the `compute_instance_type` are
parsed from the error message resulting from calling Batch's
CreateComputeEnvironment API with a nonexistent instance type.

In order to ensure that the values parsed from this error message aren't
invalid (due to, for example, a modification to the CCE error message
format), they are validated against the instance types and families
returned by EC2's DescribeInstanceTypeOfferings API. In the event that
any of the instance types and families parsed from the CCE error message
aren't in the set returned by the EC2 API, the code assumes that there's
an issue with the CCE error message parsing, and returns the set
returned by the EC2 API instead.

This change adds `optimal` to the set of instance types and families
returned by the EC2 APIs that is used for both validating the values
parsed from the CCE error message and as the fallback value when this
validation fails. This is essentially an extension of the change made in
e7099774, which accounted for 'optimal' when validating the parsed
values but didn't include it in the fallback value.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
