### PR TITLE
integ-tests: Remove references to S3 configuration files

### DIFF
--- a/tests/integration-tests/benchmarks/common/util.py
+++ b/tests/integration-tests/benchmarks/common/util.py
@@ -9,14 +9,8 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-import json
-
-import boto3
+from utils import get_instance_info
 
 
 def get_instance_vcpus(region, instance):
-    bucket_name = "{0}-aws-parallelcluster".format(region)
-    s3 = boto3.resource("s3", region_name=region)
-    instances_file_content = s3.Object(bucket_name, "instances/instances.json").get()["Body"].read()
-    instances = json.loads(instances_file_content)
-    return int(instances[instance]["vcpus"])
+    return get_instance_info(instance, region).get("VCpuInfo").get("DefaultVCpus")

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -8,11 +8,9 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-import json
-import logging
-
 import boto3
 from retrying import retry
+from utils import get_instance_info
 
 OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "alinux": {"name": "amzn-ami-hvm-*.*.*.*-*-gp2", "owners": ["amazon"]},
@@ -58,15 +56,5 @@ def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64"):
 
 
 @retry(stop_max_attempt_number=3, wait_fixed=5000)
-def fetch_instance_slots(region, instance_type, slots="vcpus"):
-    bucket_name = "{0}-aws-parallelcluster".format(region)
-    try:
-        s3 = boto3.resource("s3", region_name=region)
-        instances_file_content = s3.Object(bucket_name, "instances/instances.json").get()["Body"].read()
-        instances = json.loads(instances_file_content)
-        return int(instances[instance_type][slots])
-    except Exception as e:
-        logging.critical(
-            "Could not load instance mapping file from S3 bucket {0}. Failed with exception: {1}".format(bucket_name, e)
-        )
-        raise
+def fetch_instance_slots(region, instance_type):
+    return get_instance_info(instance_type, region).get("VCpuInfo").get("DefaultVCpus")


### PR DESCRIPTION
This commit removes references to the S3 configuration files in the
integration tests code. These files are no longer used by the CLI as of
6c4233e8 (or the node daemons as of ea93012).

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
