### PR TITLE
Fix `pcluster status` output when master is stopped

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -353,8 +353,7 @@ def _poll_master_server_state(stack_name):
             LOGGER.error("Cannot retrieve master node status. Exiting...")
             sys.exit(1)
         master_id = instances[0].get("InstanceId")
-        instance = ec2.describe_instance_status(InstanceIds=[master_id]).get("InstanceStatuses")[0]
-        state = instance.get("InstanceState").get("Name")
+        state = instances[0].get("State").get("Name")
         sys.stdout.write("\rMasterServer: %s" % state.upper())
         sys.stdout.flush()
         while state not in ["running", "stopped", "terminated", "shutting-down"]:
@@ -483,7 +482,7 @@ def status(args):  # noqa: C901 FIXME!!!
                 state = _poll_master_server_state(stack_name)
                 if state == "running":
                     _print_stack_outputs(stack)
-                    _print_compute_fleet_status(args.cluster_name, stack)
+                _print_compute_fleet_status(args.cluster_name, stack)
             elif stack.get("StackStatus") in ["ROLLBACK_COMPLETE", "CREATE_FAILED", "DELETE_FAILED"]:
                 events = utils.get_stack_events(stack_name)
                 for event in events:

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -752,12 +752,17 @@ def _describe_cluster_instances(stack_name, filter_by_node_type=None, filter_by_
     return instances
 
 
-def _describe_cluster_instances_iterator(stack_name, filter_by_node_type=None, filter_by_name=None):
+def _describe_cluster_instances_iterator(
+    stack_name,
+    filter_by_node_type=None,
+    filter_by_name=None,
+    instance_state=("pending", "running", "stopping", "stopped"),
+):
     try:
         ec2 = boto3.client("ec2")
         filters = [
             {"Name": "tag:Application", "Values": [stack_name]},
-            {"Name": "instance-state-name", "Values": ["running"]},
+            {"Name": "instance-state-name", "Values": list(instance_state)},
         ]
         if filter_by_node_type:
             filters.append({"Name": "tag:aws-parallelcluster-node-type", "Values": [filter_by_node_type]})

--- a/cli/tests/pcluster/utils/test_pcluster_utils.py
+++ b/cli/tests/pcluster/utils/test_pcluster_utils.py
@@ -575,13 +575,14 @@ def test_get_supported_architectures_for_instance_type(mocker, instance_type, su
     ],
 )
 def test_describe_cluster_instances(boto3_stubber, node_type, expected_fallback, expected_response, expected_instances):
+    instance_state_list = ["pending", "running", "stopping", "stopped"]
     mocked_requests = [
         MockedBoto3Request(
             method="describe_instances",
             expected_params={
                 "Filters": [
                     {"Name": "tag:Application", "Values": ["test-cluster"]},
-                    {"Name": "instance-state-name", "Values": ["running"]},
+                    {"Name": "instance-state-name", "Values": instance_state_list},
                     {"Name": "tag:aws-parallelcluster-node-type", "Values": [str(node_type)]},
                 ]
             },
@@ -595,7 +596,7 @@ def test_describe_cluster_instances(boto3_stubber, node_type, expected_fallback,
                 expected_params={
                     "Filters": [
                         {"Name": "tag:Application", "Values": ["test-cluster"]},
-                        {"Name": "instance-state-name", "Values": ["running"]},
+                        {"Name": "instance-state-name", "Values": instance_state_list},
                         {"Name": "tag:Name", "Values": [str(node_type)]},
                     ]
                 },


### PR DESCRIPTION
Before
```
$ pcluster status mycluster
Status: CREATE_COMPLETE
Cannot retrieve master node status. Exiting...
```
After
```
$ pcluster status mycluster
Status: CREATE_COMPLETE
MasterServer: STOPPED
ComputeFleetStatus: STOPPED
```

This also fix output for `pcluster instances` command
Before
```
$ pcluster instances mycluster

```
After
```
$ pcluster instances mycluster
MasterServer         i-xxxx
```

This fix https://github.com/aws/aws-parallelcluster/issues/2067
 
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
