### PR TITLE
integ-tests: run test_multi_cidr for a single OS

### DIFF
--- a/tests/integration-tests/tests/networking/test_multi_cidr.py
+++ b/tests/integration-tests/tests/networking/test_multi_cidr.py
@@ -4,6 +4,7 @@ import pytest
 @pytest.mark.regions(["us-east-2"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["slurm", "awsbatch"])
+@pytest.mark.oss(["alinux2"])
 @pytest.mark.usefixtures("os", "instance", "scheduler", "region")
 def test_multi_cidr(pcluster_config_reader, clusters_factory):
     """


### PR DESCRIPTION
Not needed to run this test on all supported OSes since there is no dependency on the specific OS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
