### PR TITLE
Add CentOS 8 support

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -360,7 +360,7 @@ Variables substituted::
         dest="base_ami_os",
         required=True,
         help="Specifies the OS of the base AMI. "
-        "Valid options are: alinux, ubuntu1604, ubuntu1804, centos6, centos7.",
+        "Valid options are: alinux, ubuntu1604, ubuntu1804, centos6, centos7, centos8.",
     )
     pami.add_argument(
         "-i",

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -697,7 +697,7 @@ CLUSTER_COMMON_PARAMS = [
     ("base_os", {
         "type": BaseOSCfnParam,
         "cfn_param_mapping": "BaseOS",
-        "allowed_values": ["alinux", "alinux2", "ubuntu1604", "ubuntu1804", "centos6", "centos7"],
+        "allowed_values": ["alinux", "alinux2", "ubuntu1604", "ubuntu1804", "centos6", "centos7", "centos8"],
         "validators": [base_os_validator, architecture_os_validator],
         "required": True,
         "update_policy": UpdatePolicy.UNSUPPORTED
@@ -824,6 +824,7 @@ CLUSTER_COMMON_PARAMS = [
         "update_policy": UpdatePolicy.UNSUPPORTED,
     }),
     ("tags", {
+        # There is no cfn_param_mapping because it's not converted to a CFN Input parameter
         "type": JsonCfnParam,
         "update_policy": UpdatePolicy.UNSUPPORTED,
     }),

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -61,8 +61,8 @@ FSX_MESSAGES = {
 }
 
 FSX_SUPPORTED_ARCHITECTURES_OSES = {
-    "x86_64": ["centos7", "ubuntu1604", "ubuntu1804", "alinux", "alinux2"],
-    "arm64": ["ubuntu1804", "alinux2"],
+    "x86_64": ["centos7", "centos8", "ubuntu1604", "ubuntu1804", "alinux", "alinux2"],
+    "arm64": ["ubuntu1804", "alinux2", "centos8"],
 }
 
 EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS = {
@@ -1020,7 +1020,7 @@ def intel_hpc_os_validator(param_key, param_value, pcluster_config):
     errors = []
     warnings = []
 
-    allowed_oses = ["centos7"]
+    allowed_oses = ["centos7", "centos8"]
 
     cluster_section = pcluster_config.get_section("cluster")
     if param_value and cluster_section.get_param_value("base_os") not in allowed_oses:

--- a/cli/pcluster/dcv/utils.py
+++ b/cli/pcluster/dcv/utils.py
@@ -15,7 +15,10 @@ DCV_CONNECT_SCRIPT = "/opt/parallelcluster/scripts/pcluster_dcv_connect.sh"
 
 def get_supported_dcv_os(architecture):
     """Return a list of all the operating system supported by DCV."""
-    architectures_dict = {"x86_64": ["centos7", "ubuntu1804", "alinux2"], "arm64": ["ubuntu1804", "alinux2"]}
+    architectures_dict = {
+        "x86_64": ["centos7", "centos8", "ubuntu1804", "alinux2"],
+        "arm64": ["ubuntu1804", "alinux2", "centos8"],
+    }
     return architectures_dict.get(architecture, [])
 
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -505,13 +505,13 @@ def get_supported_os_for_scheduler(scheduler):
     """
     oses = ["alinux", "alinux2"]
     if scheduler != "awsbatch":
-        oses.extend(["centos6", "centos7", "ubuntu1604", "ubuntu1804"])
+        oses.extend(["centos6", "centos7", "centos8", "ubuntu1604", "ubuntu1804"])
     return list(oses)
 
 
 def get_supported_os_for_architecture(architecture):
     """Return list of supported OSes for the specified architecture."""
-    oses = ["alinux2", "ubuntu1804"]
+    oses = ["alinux2", "ubuntu1804", "centos8"]
     if architecture == "x86_64":
         oses.extend(["centos6", "centos7", "alinux", "ubuntu1604"])
     return oses

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -283,6 +283,7 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
         # verify awsbatch supported OSes
         ("eu-west-1", "centos6", "awsbatch", "scheduler supports the following Operating Systems"),
         ("eu-west-1", "centos7", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("eu-west-1", "centos8", "awsbatch", "scheduler supports the following Operating Systems"),
         ("eu-west-1", "ubuntu1604", "awsbatch", "scheduler supports the following Operating Systems"),
         ("eu-west-1", "ubuntu1804", "awsbatch", "scheduler supports the following Operating Systems"),
         ("eu-west-1", "alinux", "awsbatch", None),
@@ -290,6 +291,7 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
         # verify sge supports all the OSes
         ("eu-west-1", "centos6", "sge", None),
         ("eu-west-1", "centos7", "sge", None),
+        ("eu-west-1", "centos8", "sge", None),
         ("eu-west-1", "ubuntu1604", "sge", None),
         ("eu-west-1", "ubuntu1804", "sge", None),
         ("eu-west-1", "alinux", "sge", None),
@@ -297,6 +299,7 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
         # verify slurm supports all the OSes
         ("eu-west-1", "centos6", "slurm", None),
         ("eu-west-1", "centos7", "slurm", None),
+        ("eu-west-1", "centos8", "slurm", None),
         ("eu-west-1", "ubuntu1604", "slurm", None),
         ("eu-west-1", "ubuntu1804", "slurm", None),
         ("eu-west-1", "alinux", "slurm", None),
@@ -304,6 +307,7 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
         # verify torque supports all the OSes
         ("eu-west-1", "centos6", "torque", None),
         ("eu-west-1", "centos7", "torque", None),
+        ("eu-west-1", "centos8", "torque", None),
         ("eu-west-1", "ubuntu1604", "torque", None),
         ("eu-west-1", "ubuntu1804", "torque", None),
         ("eu-west-1", "alinux", "torque", None),
@@ -1059,8 +1063,14 @@ def test_fsx_id_validator(mocker, boto3_stubber, fsx_vpc, ip_permissions, networ
 @pytest.mark.parametrize(
     "section_dict, expected_message",
     [
+        ({"enable_intel_hpc_platform": "true", "base_os": "centos6"}, "it is required to set the 'base_os'"),
         ({"enable_intel_hpc_platform": "true", "base_os": "centos7"}, None),
+        ({"enable_intel_hpc_platform": "true", "base_os": "centos8"}, None),
         ({"enable_intel_hpc_platform": "true", "base_os": "alinux"}, "it is required to set the 'base_os'"),
+        ({"enable_intel_hpc_platform": "true", "base_os": "alinux2"}, "it is required to set the 'base_os'"),
+        ({"enable_intel_hpc_platform": "true", "base_os": "ubuntu1604"}, "it is required to set the 'base_os'"),
+        ({"enable_intel_hpc_platform": "true", "base_os": "ubuntu1804"}, "it is required to set the 'base_os'"),
+        # intel hpc disabled, you can use any os
         ({"enable_intel_hpc_platform": "false", "base_os": "alinux"}, None),
     ],
 )
@@ -1334,15 +1344,18 @@ def test_shared_dir_validator(mocker, section_dict, expected_message):
         ("centos6", "t2.medium", None, "Please double check the 'base_os' configuration parameter", None),
         ("ubuntu1604", "t2.medium", None, "Please double check the 'base_os' configuration parameter", None),
         ("centos7", "t2.medium", None, None, None),
+        ("centos8", "t2.medium", None, None, None),
         ("ubuntu1804", "t2.medium", None, None, None),
         ("ubuntu1804", "t2.medium", "1.2.3.4/32", None, None),
         ("centos7", "t2.medium", "0.0.0.0/0", None, None),
+        ("centos8", "t2.medium", "0.0.0.0/0", None, None),
         ("alinux2", "t2.medium", None, None, None),
         ("alinux2", "t2.nano", None, None, "is recommended to use an instance type with at least"),
         ("alinux2", "t2.micro", None, None, "is recommended to use an instance type with at least"),
         ("ubuntu1804", "m6g.xlarge", None, None, None),
         ("alinux2", "m6g.xlarge", None, None, None),
         ("centos7", "m6g.xlarge", None, "Please double check the 'base_os' configuration parameter", None),
+        ("centos8", "m6g.xlarge", None, None, None),
     ],
 )
 def test_dcv_enabled_validator(
@@ -1376,10 +1389,12 @@ def test_dcv_enabled_validator(
         ("x86_64", "alinux", None),
         ("x86_64", "alinux2", None),
         ("x86_64", "centos7", None),
+        ("x86_64", "centos8", None),
         ("x86_64", "ubuntu1604", None),
         ("x86_64", "ubuntu1804", None),
         ("arm64", "ubuntu1804", None),
         ("arm64", "alinux2", None),
+        ("arm64", "centos8", None),
         # Unsupported combinations
         (
             "UnsupportedArchitecture",
@@ -1462,6 +1477,7 @@ def test_maintain_initial_size_validator(mocker, section_dict, expected_message)
     [
         ("alinux2", None),
         ("centos7", None),
+        ("centos8", None),
         ("ubuntu1604", None),
         ("ubuntu1804", None),
         ("centos6", "centos6.*will reach end-of-life in late 2020"),
@@ -1810,13 +1826,15 @@ def test_intel_hpc_architecture_validator(mocker, enabled, architecture, expecte
         ("alinux2", "x86_64", []),
         ("centos6", "x86_64", []),
         ("centos7", "x86_64", []),
+        ("centos8", "x86_64", []),
         ("ubuntu1604", "x86_64", []),
         ("ubuntu1804", "x86_64", []),
-        # Only a subset of OSes supported for x86_64
+        # Only a subset of OSes supported for arm64
         ("alinux", "arm64", ["arm64 is only supported for the following operating systems"]),
         ("alinux2", "arm64", []),
         ("centos6", "arm64", ["arm64 is only supported for the following operating systems"]),
         ("centos7", "arm64", ["arm64 is only supported for the following operating systems"]),
+        ("centos8", "arm64", []),
         ("ubuntu1604", "arm64", ["arm64 is only supported for the following operating systems"]),
         ("ubuntu1804", "arm64", []),
     ],

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/output.txt
@@ -41,8 +41,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
@@ -36,8 +36,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
@@ -36,8 +36,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_available_no_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_available_no_input_no_automation_no_errors_with_config_file/output.txt
@@ -19,8 +19,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/output.txt
@@ -36,8 +36,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
@@ -36,8 +36,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
@@ -36,8 +36,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
@@ -36,8 +36,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
@@ -36,8 +36,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet
 2. Master and compute fleet in the same public subnet

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
@@ -36,8 +36,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 There are no VPC for the given region. Starting automatic creation of VPC and subnets...
 Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
@@ -36,8 +36,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 There are no VPC for the given region. Starting automatic creation of VPC and subnets...
 Allowed values for Network Configuration:
 1. Master in a public subnet and compute fleet in a private subnet

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/output.txt
@@ -36,8 +36,9 @@ Allowed values for Operating System:
 2. alinux2
 3. centos6
 4. centos7
-5. ubuntu1604
-6. ubuntu1804
+5. centos8
+6. ubuntu1604
+7. ubuntu1804
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/configure/test_pcluster_configure_utils.py
+++ b/cli/tests/pcluster/configure/test_pcluster_configure_utils.py
@@ -14,7 +14,7 @@ from pcluster.configure.utils import get_default_suggestion
         ("Scheduler", ["sge", "torque", "awsbatch"], "slurm", None),
         ("Operating System", None, "alinux2", None),
         ("Operating System", [], "alinux2", None),
-        ("Operating System", ["centos7", "centos6", "ubuntu1804"], "alinux2", None),
+        ("Operating System", ["centos8", "centos7", "centos6", "ubuntu1804"], "alinux2", None),
         # Ensure first item is selected from first nested list/tuple
         ("fake-parameter", [{"id": "a", "key2": "b"}, {"id": "c", "key3": "d"}], "a", None),
         ("fake-parameter", ({"id": "a", "key2": "b"}, {"id": "c", "key3": "d"}), "a", None),

--- a/cli/tests/pcluster/utils/test_pcluster_utils.py
+++ b/cli/tests/pcluster/utils/test_pcluster_utils.py
@@ -443,10 +443,10 @@ def test_create_s3_bucket(region, create_error_message, configure_error_message,
 @pytest.mark.parametrize(
     "architecture, supported_oses",
     [
-        ("x86_64", ["alinux", "alinux2", "centos6", "centos7", "ubuntu1604", "ubuntu1804"]),
-        ("arm64", ["alinux2", "ubuntu1804"]),
+        ("x86_64", ["alinux", "alinux2", "centos6", "centos7", "centos8", "ubuntu1604", "ubuntu1804"]),
+        ("arm64", ["alinux2", "ubuntu1804", "centos8"]),
         # doesn't check architecture's validity, only whether it's x86_64 or not
-        ("madeup-architecture", ["alinux2", "ubuntu1804"]),
+        ("madeup-architecture", ["alinux2", "ubuntu1804", "centos8"]),
     ],
 )
 def test_get_supported_os_for_architecture(architecture, supported_oses):
@@ -459,12 +459,12 @@ def test_get_supported_os_for_architecture(architecture, supported_oses):
 @pytest.mark.parametrize(
     "scheduler, supported_oses",
     [
-        ("sge", ["alinux", "alinux2", "centos6", "centos7", "ubuntu1604", "ubuntu1804"]),
-        ("slurm", ["alinux", "alinux2", "centos6", "centos7", "ubuntu1604", "ubuntu1804"]),
-        ("torque", ["alinux", "alinux2", "centos6", "centos7", "ubuntu1604", "ubuntu1804"]),
+        ("sge", ["alinux", "alinux2", "centos6", "centos7", "centos8", "ubuntu1604", "ubuntu1804"]),
+        ("slurm", ["alinux", "alinux2", "centos6", "centos7", "centos8", "ubuntu1604", "ubuntu1804"]),
+        ("torque", ["alinux", "alinux2", "centos6", "centos7", "centos8", "ubuntu1604", "ubuntu1804"]),
         ("awsbatch", ["alinux2", "alinux"]),
         # doesn't check architecture's validity, only whether it's awsbatch or not
-        ("madeup-scheduler", ["alinux", "alinux2", "centos6", "centos7", "ubuntu1604", "ubuntu1804"]),
+        ("madeup-scheduler", ["alinux", "alinux2", "centos6", "centos7", "centos8", "ubuntu1604", "ubuntu1804"]),
     ],
 )
 def test_get_supported_os_for_scheduler(scheduler, supported_oses):

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -200,6 +200,7 @@
       "AllowedValues": [
         "centos6",
         "centos7",
+        "centos8",
         "alinux",
         "alinux2",
         "ubuntu1604",
@@ -1155,6 +1156,10 @@
         "RootDevice": "/dev/sda1"
       },
       "centos7": {
+        "User": "centos",
+        "RootDevice": "/dev/sda1"
+      },
+      "centos8": {
         "User": "centos",
         "RootDevice": "/dev/sda1"
       },

--- a/tests/integration-tests/conftest_markers.py
+++ b/tests/integration-tests/conftest_markers.py
@@ -20,6 +20,7 @@ UNSUPPORTED_DIMENSIONS = [
     ("ap-east-1", "c4.xlarge", "*", "*"),
     ("*", "*", "centos6", "awsbatch"),
     ("*", "*", "centos7", "awsbatch"),
+    ("*", "*", "centos8", "awsbatch"),
     ("*", "*", "ubuntu1804", "awsbatch"),
     ("*", "*", "ubuntu1604", "awsbatch"),
     ("us-gov-west-1", "*", "*", "awsbatch"),

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -50,7 +50,7 @@ TEST_DEFAULTS = {
         "sa-east-1",
         "eu-west-3",
     ],
-    "oss": ["alinux", "alinux2", "centos6", "centos7", "ubuntu1804", "ubuntu1604"],
+    "oss": ["alinux", "alinux2", "centos6", "centos7", "centos8", "ubuntu1804", "ubuntu1604"],
     "schedulers": ["sge", "slurm", "torque", "awsbatch"],
     "instances": ["c4.xlarge", "c5.xlarge"],
     "dry_run": False,

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init.py
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init.py
@@ -24,7 +24,7 @@ from tests.common.schedulers_common import get_scheduler_commands
 @pytest.mark.regions(["eu-central-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["slurm", "sge"])
-@pytest.mark.oss(["centos7", "alinux2", "ubuntu1804"])
+@pytest.mark.oss(["centos7", "centos8", "alinux2", "ubuntu1804"])
 @pytest.mark.usefixtures("os", "instance")
 def test_replace_compute_on_failure(
     region, scheduler, pcluster_config_reader, clusters_factory, s3_bucket_factory, test_datadir

--- a/tests/integration-tests/tests/common/mpi_common.py
+++ b/tests/integration-tests/tests/common/mpi_common.py
@@ -10,6 +10,7 @@ OS_TO_ARCHITECTURE_TO_OPENMPI_MODULE = {
     "alinux": {"x86_64": "openmpi"},
     "alinux2": {"x86_64": "openmpi", "arm64": "openmpi"},
     "centos7": {"x86_64": "openmpi"},
+    "centos8": {"x86_64": "openmpi", "arm64": "openmpi"},
     "ubuntu1604": {"x86_64": "openmpi"},
     "centos6": {"x86_64": "openmpi-x86_64"},
     "ubuntu1804": {"x86_64": "openmpi", "arm64": "openmpi"},

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -17,7 +17,8 @@ from retrying import retry
 OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "alinux": {"name": "amzn-ami-hvm-*.*.*.*-*-gp2", "owners": ["amazon"]},
     "alinux2": {"name": "amzn2-ami-hvm-*.*.*.*-*-gp2", "owners": ["amazon"]},
-    "centos7": {"name": "CentOS Linux 7 * HVM EBS ENA *", "owners": ["410186602215"]},
+    "centos7": {"name": "CentOS 7.*", "owners": ["125523088429"]},
+    "centos8": {"name": "CentOS 8.*", "owners": ["125523088429"]},
     "ubuntu1404": {
         "name": "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-*-server-*",
         "owners": ["099720109477", "513442679011", "837727238323"],

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -22,6 +22,7 @@ from tests.common.utils import retrieve_latest_ami
 @pytest.mark.dimensions("eu-west-1", "c5.xlarge", "alinux", "*")
 @pytest.mark.dimensions("us-west-1", "c5.xlarge", "alinux2", "*")
 @pytest.mark.dimensions("us-west-2", "c5.xlarge", "centos7", "*")
+@pytest.mark.dimensions("us-west-2", "c5.xlarge", "centos8", "*")
 @pytest.mark.dimensions("eu-west-2", "c5.xlarge", "ubuntu1604", "*")
 @pytest.mark.dimensions("us-east-1", "c5.xlarge", "ubuntu1804", "*")
 @pytest.mark.dimensions("us-gov-east-1", "c5.xlarge", "ubuntu1604", "*")

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -28,9 +28,11 @@ DCV_CONNECT_SCRIPT = "/opt/parallelcluster/scripts/pcluster_dcv_connect.sh"
 @pytest.mark.dimensions("cn-northwest-1", "c4.xlarge", "ubuntu1804", "slurm")
 @pytest.mark.dimensions("eu-west-1", "g3.8xlarge", "alinux2", "slurm")
 @pytest.mark.dimensions("eu-west-1", "g3.8xlarge", "centos7", "slurm")
+@pytest.mark.dimensions("eu-west-1", "g3.8xlarge", "centos8", "slurm")
 @pytest.mark.dimensions("eu-west-1", "g3.8xlarge", "ubuntu1804", "slurm")
 @pytest.mark.dimensions("eu-west-1", "m6g.xlarge", "alinux2", "slurm")
 @pytest.mark.dimensions("eu-west-1", "m6g.xlarge", "centos7", "slurm")
+@pytest.mark.dimensions("eu-west-1", "m6g.xlarge", "centos8", "slurm")
 @pytest.mark.dimensions("eu-west-1", "m6g.xlarge", "ubuntu1804", "slurm")
 def test_dcv_configuration(
     region,
@@ -59,6 +61,7 @@ def test_dcv_configuration(
     "dcv_port, access_from, shared_dir", [(8443, "0.0.0.0/0", "/shared"), (5678, "192.168.1.1/32", "/myshared")]
 )
 @pytest.mark.dimensions("eu-west-1", "c5.xlarge", "centos7", "sge")
+@pytest.mark.dimensions("eu-west-2", "c5.xlarge", "centos8", "sge")
 def test_dcv_with_remote_access(
     dcv_port,
     access_from,

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
@@ -40,6 +40,7 @@ def test_sit_disable_hyperthreading(region, scheduler, instance, os, pcluster_co
 @pytest.mark.dimensions("us-west-1", "m4.xlarge", "alinux2", "slurm")
 @pytest.mark.dimensions("us-west-1", "m4.xlarge", "ubuntu1604", "slurm")
 @pytest.mark.dimensions("us-west-1", "m4.xlarge", "centos7", "slurm")
+@pytest.mark.dimensions("us-west-2", "m4.xlarge", "centos8", "slurm")
 # HT disabled via CpuOptions
 @pytest.mark.dimensions("us-west-1", "c5.xlarge", "ubuntu1804", "slurm")
 def test_hit_disable_hyperthreading(region, scheduler, instance, os, pcluster_config_reader, clusters_factory):

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
@@ -22,7 +22,7 @@ from tests.common.utils import fetch_instance_slots
 
 @pytest.mark.regions(["us-east-1"])
 @pytest.mark.instances(["c5n.18xlarge"])
-@pytest.mark.oss(["centos7"])
+@pytest.mark.oss(["centos7", "centos8"])
 @pytest.mark.schedulers(["slurm"])
 def test_intel_hpc(region, scheduler, instance, os, pcluster_config_reader, clusters_factory, test_datadir):
     """Test Intel Cluster Checker"""

--- a/tests/integration-tests/tests/runtime_bake/test_runtime_bake.py
+++ b/tests/integration-tests/tests/runtime_bake/test_runtime_bake.py
@@ -21,6 +21,7 @@ from tests.common.utils import retrieve_latest_ami
 @pytest.mark.dimensions("eu-west-2", "c5.xlarge", "alinux", "slurm")
 @pytest.mark.dimensions("eu-west-3", "c5.xlarge", "alinux2", "torque")
 @pytest.mark.dimensions("us-east-2", "c5.xlarge", "centos7", "sge")
+@pytest.mark.dimensions("us-east-2", "c5.xlarge", "centos8", "sge")
 @pytest.mark.dimensions("us-east-1", "c5.xlarge", "ubuntu1604", "slurm")
 @pytest.mark.dimensions("eu-west-1", "c5.xlarge", "ubuntu1804", "sge")
 @pytest.mark.dimensions("us-gov-east-1", "c5.xlarge", "ubuntu1604", "slurm")

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -82,7 +82,7 @@ def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clu
 @pytest.mark.regions(["sa-east-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["sge", "torque"])
-@pytest.mark.oss(["alinux2", "centos7", "ubuntu1804"])
+@pytest.mark.oss(["alinux2", "centos7", "centos8", "ubuntu1804"])
 @pytest.mark.usefixtures("region", "instance")
 @pytest.mark.nodewatcher
 def test_nodewatcher_terminates_failing_node(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):
@@ -125,7 +125,7 @@ def test_nodewatcher_terminates_failing_node(scheduler, region, pcluster_config_
 @pytest.mark.regions(["us-west-1"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["slurm"])
-@pytest.mark.oss(["alinux2", "centos7", "ubuntu1804"])
+@pytest.mark.oss(["alinux2", "centos7", "centos8", "ubuntu1804"])
 @pytest.mark.usefixtures("region", "os", "instance")
 @pytest.mark.hit_scaling
 def test_hit_scaling(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):

--- a/tests/integration-tests/tests/spot/test_spot.py
+++ b/tests/integration-tests/tests/spot/test_spot.py
@@ -19,7 +19,7 @@ from tests.common.schedulers_common import get_scheduler_commands
 @pytest.mark.regions(["us-west-2"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["sge", "slurm"])
-@pytest.mark.oss(["centos7", "alinux2", "ubuntu1804"])
+@pytest.mark.oss(["centos7", "centos8", "alinux2", "ubuntu1804"])
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
 def test_spot_default(scheduler, pcluster_config_reader, clusters_factory):
     """Test that a cluster with spot instances can be created with default spot_price_value."""

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -39,6 +39,7 @@ def test_ebs_single(scheduler, pcluster_config_reader, clusters_factory):
 # centos6 does not support GPT
 @pytest.mark.dimensions("ap-northeast-2", "c5.xlarge", "alinux2", "sge")
 @pytest.mark.dimensions("cn-northwest-1", "c4.xlarge", "ubuntu1804", "slurm")
+@pytest.mark.dimensions("eu-west-1", "c5.xlarge", "centos8", "slurm")
 @pytest.mark.usefixtures("os", "instance")
 def test_ebs_snapshot(
     request, vpc_stacks, region, scheduler, pcluster_config_reader, clusters_factory, snapshots_factory
@@ -70,6 +71,7 @@ def test_ebs_snapshot(
 # cn-north-1 does not support KMS
 @pytest.mark.dimensions("ca-central-1", "c5.xlarge", "alinux2", "awsbatch")
 @pytest.mark.dimensions("ca-central-1", "c5.xlarge", "ubuntu1804", "slurm")
+@pytest.mark.dimensions("eu-west-2", "c5.xlarge", "centos8", "slurm")
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_ebs_multiple(scheduler, pcluster_config_reader, clusters_factory):
     mount_dirs = ["/ebs_mount_dir_{0}".format(i) for i in range(0, 5)]

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -315,6 +315,7 @@ def get_username_for_os(os):
         "alinux2": "ec2-user",
         "centos6": "centos",
         "centos7": "centos",
+        "centos8": "centos",
         "ubuntu1604": "ubuntu",
         "ubuntu1804": "ubuntu",
     }

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -33,6 +33,7 @@ DISTROS = OrderedDict(
         ("alinux2", "amzn2"),
         ("centos6", "centos6"),
         ("centos7", "centos7"),
+        ("centos8", "centos8"),
         ("ubuntu1604", "ubuntu-1604"),
         ("ubuntu1804", "ubuntu-1804"),
     ]


### PR DESCRIPTION
## Changes
* Added centos8 as `allowed_values` for `base_os` in `mappings.py`
* Updated CLI help for `createami` command
* Updated `AllowedValues` list for `BaseOS` parameter and `OSFeatures` mapping in CFN template
* Updated `generate-ami-list.py` script

## Validators

### Supported features (TO BE TESTED)
* Added as supported ARM OS (`get_supported_os_for_architecture` and `get_supported_os_for_scheduler`). See https://www.centos.org/download/aws-images/
* Added in FSX supported OSes, for both x86_64 and arm64 architecture (`FSX_SUPPORTED_ARCHITECTURES_OSES`)
* Added as Intel HPC supported OSes, for both x86_64 and arm64 architecture (`intel_hpc_os_validator`)
* Added as supported OS for DCV, for both x86_64 and arm64 architecture (`get_supported_dcv_os`)

### Unsupported features
* EFA not yet available, OS not added to the list in `efa_validator`
* Added as unsupported OS for AWS Batch
* FPGA Developer AMI not available, not added to custom ami and `test_createami`.

## Tests
* Updated unit tests according to previous changes.
* Updated CentOS AMI names in `OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP`
* ebs_single, efs_same_az, fsx_lustre, fsx_lustre_backup, raid_performance_mode are already testing all the OSes
* Explicitly added integration tests for:
  * cfn_init
  * mpi
  * createami
  * disable_hyperthreading
  * intel_hpc
  * runtime_bake
  * scaling
  * hit_scaling
  * spot
  * ebs_multiple
  * ebs_snapshot
