### PR TITLE
integ-tests: test disable_hyperthreading via CpuOptions with sge and torque

### DIFF
--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
@@ -21,9 +21,13 @@ from tests.common.schedulers_common import get_scheduler_commands
 from tests.common.utils import fetch_instance_slots
 
 
+# Manually disabled HT
 @pytest.mark.dimensions("sa-east-1", "m4.xlarge", "alinux", "sge")
 @pytest.mark.dimensions("sa-east-1", "m4.xlarge", "centos6", "torque")
 @pytest.mark.dimensions("sa-east-1", "m4.xlarge", "ubuntu1804", "sge")
+# HT disabled via CpuOptions
+@pytest.mark.dimensions("sa-east-1", "c5.xlarge", "alinux2", "sge")
+@pytest.mark.dimensions("sa-east-1", "c5.xlarge", "centos7", "torque")
 def test_sit_disable_hyperthreading(region, scheduler, instance, os, pcluster_config_reader, clusters_factory):
     """Test Disable Hyperthreading for SIT clusters."""
     slots_per_instance = fetch_instance_slots(region, instance)


### PR DESCRIPTION
We were not testing disabling HyperThreading via CpuOptions with Sge and Torque schedulers

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
