### PR TITLE
Fix queue name validator to properly check for capital letters

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -1102,7 +1102,7 @@ def queue_settings_validator(param_key, param_value, pcluster_config):
         errors.append("queue_settings is supported only with slurm scheduler")
 
     for label in param_value.split(","):
-        if re.match("[A-Z]", label) or re.match("^default$", label) or "_" in label:
+        if re.search("[A-Z]", label) or re.match("^default$", label) or "_" in label:
             errors.append(
                 (
                     "Invalid queue name '{0}'. Queue section names can be at most 30 chars long, must begin with"

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -1518,6 +1518,14 @@ def test_base_os_validator(mocker, capsys, base_os, expected_warning):
                 " 'default' as a queue section name."
             ),
         ),
+        (
+            {"scheduler": "slurm", "queue_settings": "aQUEUEa"},
+            (
+                "Invalid queue name 'aQUEUEa'. Queue section names can be at most 30 chars long, must begin with"
+                " a letter and only contain lowercase letters, digits and hyphens. It is forbidden to use"
+                " 'default' as a queue section name."
+            ),
+        ),
         ({"scheduler": "slurm", "queue_settings": "my-default-queue"}, None),
     ],
 )


### PR DESCRIPTION
re.match in Python expects that match to be at the beginning of the string.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
