### PR TITLE
Delay the error raise by inconsistent cookbook version to recipe execution

### DIFF
--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -368,7 +368,8 @@ Resources:
               if [ -f /opt/parallelcluster/.bootstrapped ]; then
                 installed_version=$(cat /opt/parallelcluster/.bootstrapped)
                 if [ "${!cookbook_version}" != "${!installed_version}" ]; then
-                  error_exit "This AMI was created with ${!installed_version}, but is trying to be used with ${!cookbook_version}. Please either use an AMI created with ${!cookbook_version} or change your ParallelCluster to ${!installed_version}"
+                  # This case is not allowed to create a cluster, error will raise inside cookbook logic
+                  bootstrap_instance
                 fi
               else
                 bootstrap_instance

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -459,7 +459,8 @@ Resources:
               if [ -f /opt/parallelcluster/.bootstrapped ]; then
                 installed_version=$(cat /opt/parallelcluster/.bootstrapped)
                 if [ "${!cookbook_version}" != "${!installed_version}" ]; then
-                  error_exit "This AMI was created with ${!installed_version}, but is trying to be used with ${!cookbook_version}. Please either use an AMI created with ${!cookbook_version} or change your ParallelCluster to ${!installed_version}"
+                  # This case is not allowed to create a cluster, error will raise inside cookbook logic
+                  bootstrap_instance
                 fi
               else
                 bootstrap_instance

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -439,7 +439,8 @@ Resources:
               if [ -f /opt/parallelcluster/.bootstrapped ]; then
                 installed_version=$(cat /opt/parallelcluster/.bootstrapped)
                 if [ "${!cookbook_version}" != "${!installed_version}" ]; then
-                  error_exit "This AMI was created with ${!installed_version}, but is trying to be used with ${!cookbook_version}. Please either use an AMI created with ${!cookbook_version} or change your ParallelCluster to ${!installed_version}"
+                  # This case is not allowed to create a cluster, error will raise inside cookbook logic
+                  bootstrap_instance
                 fi
               else
                 bootstrap_instance


### PR DESCRIPTION
We want to only compare the version number in .bootstrapped file while storing the whole "aws-parallelcluster-cookbook-<Version>" string. Therefore, string split is needed, which is easier to implement in cookbook than in bash

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
