### PR TITLE
Update templates for Centos 8

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -800,6 +800,7 @@
         "alinux2": "ami-0b1789c8ce0e1361b",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-077765bb0704a0311"
       },
@@ -808,6 +809,7 @@
         "alinux2": "ami-0b2c7869c84cfcdf9",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-00365e484738ebfc4"
       },
@@ -816,6 +818,7 @@
         "alinux2": "ami-054760536d417dada",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-0245dc69c9831273b"
       },
@@ -824,6 +827,7 @@
         "alinux2": "UNSUPPORTED",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "UNSUPPORTED"
       },
@@ -832,6 +836,7 @@
         "alinux2": "ami-07170e86bf56428f0",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-086409235ff4baa23"
       },
@@ -840,6 +845,7 @@
         "alinux2": "ami-013a7edc0a01fccb2",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-005ab53bf0c5f8f5e"
       },
@@ -848,6 +854,7 @@
         "alinux2": "ami-05d7a684db818a384",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-07d8e1334a6f6b595"
       },
@@ -856,6 +863,7 @@
         "alinux2": "ami-080c38cd77eedcf80",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-0fcf422aa9d3da933"
       },
@@ -864,6 +872,7 @@
         "alinux2": "UNSUPPORTED",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "UNSUPPORTED"
       },
@@ -872,6 +881,7 @@
         "alinux2": "UNSUPPORTED",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "UNSUPPORTED"
       },
@@ -880,6 +890,7 @@
         "alinux2": "ami-05725353e212666a7",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-0c264a73a23db3d6a"
       },
@@ -888,6 +899,7 @@
         "alinux2": "ami-0bffc4468662970ec",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-0824e994bb3e2f427"
       },
@@ -896,6 +908,7 @@
         "alinux2": "ami-06965b7902525f263",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-0419acd7b79be283d"
       },
@@ -904,6 +917,7 @@
         "alinux2": "ami-0f426bc942ffa4154",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-080db9e83e8efe8ee"
       },
@@ -912,6 +926,7 @@
         "alinux2": "ami-01d75aec60c2b82ee",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-0d0e91fff6ec507b1"
       },
@@ -920,6 +935,7 @@
         "alinux2": "ami-0ad2863a224e142ac",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-0472fae97c22cd2ed"
       },
@@ -928,6 +944,7 @@
         "alinux2": "ami-0c34a1866d05f5238",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-0cc3c142964f114f2"
       },
@@ -936,6 +953,7 @@
         "alinux2": "ami-0f1ee909e278123a7",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-021db7ec0de2fb7f9"
       },
@@ -944,6 +962,7 @@
         "alinux2": "UNSUPPORTED",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "UNSUPPORTED"
       },
@@ -952,6 +971,7 @@
         "alinux2": "UNSUPPORTED",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "UNSUPPORTED"
       },
@@ -960,6 +980,7 @@
         "alinux2": "ami-042e035e4412ae42e",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-08751b4bc3cb9c492"
       },
@@ -968,6 +989,7 @@
         "alinux2": "ami-0aedc96abdfbb5c95",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "ami-0b5fad00eb5ae0040"
       }
@@ -978,6 +1000,7 @@
         "alinux2": "ami-0bda3885c81b36ec3",
         "centos6": "ami-061182a1ab5ebc92f",
         "centos7": "ami-0ef7db728059ec829",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-0137edcd2c94cceb4",
         "ubuntu1804": "ami-008836ef6499dde3d"
       },
@@ -986,6 +1009,7 @@
         "alinux2": "ami-018f60df4947b9d80",
         "centos6": "ami-04752a36d4423c007",
         "centos7": "ami-0a1a5d0499582d741",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-05df0664af290b377",
         "ubuntu1804": "ami-0f549f0237e23ca08"
       },
@@ -994,6 +1018,7 @@
         "alinux2": "ami-0e7ac39721c047810",
         "centos6": "ami-074d24583f4c2d9aa",
         "centos7": "ami-0d80f933f49d19d8f",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-0e51d1204cc730c44",
         "ubuntu1804": "ami-099a831afd43acd61"
       },
@@ -1002,6 +1027,7 @@
         "alinux2": "UNSUPPORTED",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "UNSUPPORTED",
         "ubuntu1804": "UNSUPPORTED"
       },
@@ -1010,6 +1036,7 @@
         "alinux2": "ami-00c1ae06cd84eb4e1",
         "centos6": "ami-0f20ac5a3c949fad6",
         "centos7": "ami-0de2d00af74becbbe",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-07ccf5288bd8652c1",
         "ubuntu1804": "ami-002f78a294f33cd6d"
       },
@@ -1018,6 +1045,7 @@
         "alinux2": "ami-02ff1f11961b57b08",
         "centos6": "ami-04d2232b9bf74336a",
         "centos7": "ami-0b33c58a15fa2eba5",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-00355b4eeda4b3bac",
         "ubuntu1804": "ami-076e66f2b36bd336b"
       },
@@ -1026,6 +1054,7 @@
         "alinux2": "ami-0a726e265859b6e70",
         "centos6": "ami-0e04fed02a8b90712",
         "centos7": "ami-0148479404e4f87ad",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-0dfab2bfc2ed1ab14",
         "ubuntu1804": "ami-029f7ab8bf22e6ecd"
       },
@@ -1034,6 +1063,7 @@
         "alinux2": "ami-04dd037b7d4ea811c",
         "centos6": "ami-07109635321746c67",
         "centos7": "ami-084ad8397539615b1",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-00dd298f92c1f3e1f",
         "ubuntu1804": "ami-095b77cea4b9b192d"
       },
@@ -1042,6 +1072,7 @@
         "alinux2": "ami-0ae3a0d3fb699260d",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-047a454a069fb7a4c",
         "ubuntu1804": "ami-03c86977a45c5ee3d"
       },
@@ -1050,6 +1081,7 @@
         "alinux2": "ami-00f21a5ab45d5269c",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-0f4e8991e84303d0c",
         "ubuntu1804": "ami-01956b33ed76ba372"
       },
@@ -1058,6 +1090,7 @@
         "alinux2": "ami-044b8c505d00a095d",
         "centos6": "ami-024e870cb2d591469",
         "centos7": "ami-00e337df0810b8600",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-01457f904a9f99900",
         "ubuntu1804": "ami-0475c99e836035bbc"
       },
@@ -1066,6 +1099,7 @@
         "alinux2": "ami-032646dc4e018d4ce",
         "centos6": "ami-09c5e1981d0c8e2a9",
         "centos7": "ami-0245ac58f1f766d43",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-0bfdec0bbb9795147",
         "ubuntu1804": "ami-07ae3ac812216bca5"
       },
@@ -1074,6 +1108,7 @@
         "alinux2": "ami-0f70f45b2398b8327",
         "centos6": "ami-0f5d96a9cfb7923e6",
         "centos7": "ami-0b2c1929139662d8f",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-035714aae4ddbc12e",
         "ubuntu1804": "ami-031fc85763a7fcf36"
       },
@@ -1082,6 +1117,7 @@
         "alinux2": "ami-04b52e173a28e2c3f",
         "centos6": "ami-00dd7695035bbe196",
         "centos7": "ami-035b29d8442570457",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-06a38766b95a38342",
         "ubuntu1804": "ami-0e396cd9257a057c2"
       },
@@ -1090,6 +1126,7 @@
         "alinux2": "ami-023fdf59b1b9f9e7b",
         "centos6": "ami-0391f4b219627a927",
         "centos7": "ami-08862b25e184c29c1",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-049deeaf3cf441bbf",
         "ubuntu1804": "ami-03540ba9d4506c681"
       },
@@ -1098,6 +1135,7 @@
         "alinux2": "ami-052f02c460d5379d7",
         "centos6": "ami-0b95aef1aa29a6325",
         "centos7": "ami-059b58852dfb4e68a",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-0fd6d6f83a89f20ab",
         "ubuntu1804": "ami-06a51dea3077464fa"
       },
@@ -1106,6 +1144,7 @@
         "alinux2": "ami-0927e675ddd8094bc",
         "centos6": "ami-006e29fa34278d9f1",
         "centos7": "ami-0e0b3193dc5f27d30",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-0d73b9449a3b0f9ea",
         "ubuntu1804": "ami-02a4a88e7295748c0"
       },
@@ -1114,6 +1153,7 @@
         "alinux2": "ami-0db2c740e9cfda206",
         "centos6": "ami-0fda3f34e174720bf",
         "centos7": "ami-09094215d9c4e8272",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-00ee10596e02c312d",
         "ubuntu1804": "ami-02474ad2a86361abe"
       },
@@ -1122,6 +1162,7 @@
         "alinux2": "ami-03ca3310850fd4dae",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-08402c16f9cb21b05",
         "ubuntu1804": "ami-07c54dcf2a9b0430b"
       },
@@ -1130,6 +1171,7 @@
         "alinux2": "ami-01b7db87ca3d0235d",
         "centos6": "UNSUPPORTED",
         "centos7": "UNSUPPORTED",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-09a381edce0180444",
         "ubuntu1804": "ami-0839f4f2731c7d912"
       },
@@ -1138,6 +1180,7 @@
         "alinux2": "ami-0c283443a1ebb5c17",
         "centos6": "ami-0c531c0dcd5a21194",
         "centos7": "ami-0b37b8636efa15100",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-0bc695b19eef12bdd",
         "ubuntu1804": "ami-06a04e18c875e3995"
       },
@@ -1146,6 +1189,7 @@
         "alinux2": "ami-09975e5a942d87be0",
         "centos6": "ami-076c28670516219e0",
         "centos7": "ami-0bbb41e6db63dee98",
+        "centos8": "UNSUPPORTED",
         "ubuntu1604": "ami-051b005bbcdda7bcd",
         "ubuntu1804": "ami-0f9033d6d728baaf3"
       }

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -332,16 +332,20 @@ Resources:
               }
               function bootstrap_instance
               {
+                which dnf 2>/dev/null; dnf=$?
                 which yum 2>/dev/null; yum=$?
                 which apt-get 2>/dev/null; apt=$?
-                if [ "${!yum}" == "0" ]; then
-                  yum -y groupinstall development && yum -y install curl wget jq awscli
+                if [ "${!dnf}" == "0" ]; then
+                  dnf -y groupinstall development && dnf -y install curl wget jq python3-pip
+                  pip3 install awscli --upgrade --user
+                elif [ "${!yum}" == "0" ]; then
+                  yum -y groupinstall development && yum -y install curl wget jq awscli python3-pip
                 fi
                 if [ "${!apt}" == "0" ]; then
-                  apt-cache search build-essential; apt-get clean; apt-get update; apt-get -y install build-essential curl wget jq python-setuptools awscli
+                  apt-cache search build-essential; apt-get clean; apt-get update; apt-get -y install build-essential curl wget jq python-setuptools awscli python3-pip
                 fi
                 [[ ${!_region} =~ ^cn- ]] && s3_url="cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
-                which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz; easy_install -U /tmp/aws-cfn-bootstrap-latest.tar.gz)
+                which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-py3-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz; pip3 install -U /tmp/aws-cfn-bootstrap-py3-latest.tar.gz)
                 mkdir -p /etc/chef && chown -R root:root /etc/chef
                 curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn" || exit 0)/archives/cinc/cinc-install.sh | bash -s -- -v ${!chef_version}
                 /opt/cinc/embedded/bin/gem install --no-document berkshelf:${!berkshelf_version}
@@ -400,7 +404,7 @@ Resources:
             - YumProxy: !If
                 - UseProxy
                 - !Ref 'ProxyServer'
-                - _none_
+                - ''
               AptProxy: !If
                 - UseProxy
                 - !Ref 'ProxyServer'

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -419,16 +419,20 @@ Resources:
               }
               function bootstrap_instance
               {
+                which dnf 2>/dev/null; dnf=$?
                 which yum 2>/dev/null; yum=$?
                 which apt-get 2>/dev/null; apt=$?
-                if [ "${!yum}" == "0" ]; then
-                  yum -y groupinstall development && yum -y install curl wget jq awscli
+                if [ "${!dnf}" == "0" ]; then
+                  dnf -y groupinstall development && dnf -y install curl wget jq python3-pip
+                  pip3 install awscli --upgrade --user
+                elif [ "${!yum}" == "0" ]; then
+                  yum -y groupinstall development && yum -y install curl wget jq awscli python3-pip
                 fi
                 if [ "${!apt}" == "0" ]; then
-                  apt-cache search build-essential; apt-get clean; apt-get update; apt-get -y install build-essential curl wget jq python-setuptools awscli
+                  apt-cache search build-essential; apt-get clean; apt-get update; apt-get -y install build-essential curl wget jq python-setuptools awscli python3-pip
                 fi
                 [[ ${!_region} =~ ^cn- ]] && s3_url="cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
-                which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz; easy_install -U /tmp/aws-cfn-bootstrap-latest.tar.gz)
+                which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-py3-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz; pip3 install -U /tmp/aws-cfn-bootstrap-py3-latest.tar.gz)
                 mkdir -p /etc/chef && chown -R root:root /etc/chef
                 curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn" || exit 0)/archives/cinc/cinc-install.sh | bash -s -- -v ${!chef_version}
                 /opt/cinc/embedded/bin/gem install --no-document berkshelf:${!berkshelf_version}
@@ -493,7 +497,7 @@ Resources:
             - YumProxy: !If
                 - UseProxy
                 - !Ref 'ProxyServer'
-                - _none_
+                - ''
               AptProxy: !If
                 - UseProxy
                 - !Ref 'ProxyServer'

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -399,16 +399,20 @@ Resources:
               }
               function bootstrap_instance
               {
+                which dnf 2>/dev/null; dnf=$?
                 which yum 2>/dev/null; yum=$?
                 which apt-get 2>/dev/null; apt=$?
-                if [ "${!yum}" == "0" ]; then
-                  yum -y groupinstall development && yum -y install curl wget jq awscli
+                if [ "${!dnf}" == "0" ]; then
+                  dnf -y groupinstall development && dnf -y install curl wget jq python3-pip
+                  pip3 install awscli --upgrade --user
+                elif [ "${!yum}" == "0" ]; then
+                  yum -y groupinstall development && yum -y install curl wget jq awscli python3-pip
                 fi
                 if [ "${!apt}" == "0" ]; then
-                  apt-cache search build-essential; apt-get clean; apt-get update; apt-get -y install build-essential curl wget jq python-setuptools awscli
+                  apt-cache search build-essential; apt-get clean; apt-get update; apt-get -y install build-essential curl wget jq python-setuptools awscli python3-pip
                 fi
                 [[ ${!_region} =~ ^cn- ]] && s3_url="cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
-                which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz; easy_install -U /tmp/aws-cfn-bootstrap-latest.tar.gz)
+                which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-py3-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz; pip3 install -U /tmp/aws-cfn-bootstrap-py3-latest.tar.gz)
                 mkdir -p /etc/chef && chown -R root:root /etc/chef
                 curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn" || exit 0)/archives/cinc/cinc-install.sh | bash -s -- -v ${!chef_version}
                 /opt/cinc/embedded/bin/gem install --no-document berkshelf:${!berkshelf_version}
@@ -457,7 +461,7 @@ Resources:
             - YumProxy: !If
                 - UseProxy
                 - !Ref 'ProxyServer'
-                - _none_
+                - ''
               AptProxy: !If
                 - UseProxy
                 - !Ref 'ProxyServer'


### PR DESCRIPTION
* Prepare templates for Centos 8 support by adding placeholder AMI mappings
* Modify templates to use aws-cfn-bootstrap-py3-latest and install python3-pip to be used when installing aws-cfn-bootstrap with python3
* Modify templates to use dnf instead of yum when possible

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
