### PR TITLE
Include user tags in HIT substack launch templates

### DIFF
--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -1101,7 +1101,7 @@ def read_remote_file(url):
         raise e
 
 
-def render_template(template_str, params_dict, config_version):
+def render_template(template_str, params_dict, config_version, tags):
     """
     Render a Jinjia template and return the rendered output.
 
@@ -1112,7 +1112,7 @@ def render_template(template_str, params_dict, config_version):
         environment = Environment(loader=BaseLoader)
         environment.filters["sha1"] = lambda value: hashlib.sha1(value.strip().encode()).hexdigest()
         template = environment.from_string(template_str)
-        output_from_parsed_template = template.render(config=params_dict, config_version=config_version)
+        output_from_parsed_template = template.render(config=params_dict, config_version=config_version, tags=tags)
         return output_from_parsed_template
     except Exception as e:
         LOGGER.error("Error when rendering template: %s", e)

--- a/cli/tests/pcluster/test_commands.py
+++ b/cli/tests/pcluster/test_commands.py
@@ -56,14 +56,14 @@ def test_create_bucket_with_resources_success(
 
     storage_data = pcluster_config_mock.to_storage()
 
-    bucket_name = _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params)
+    bucket_name = _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params, {})
 
     delete_s3_bucket_mock.assert_not_called()
     upload_resources_artifacts_mock.assert_has_calls(
         [mocker.call(bucket_name, root=pkg_resources.resource_filename(utils.__name__, dir)) for dir in expected_dirs]
     )
     if expect_upload_hit_resources:
-        upload_hit_resources_mock.assert_called_with(bucket_name, pcluster_config_mock, storage_data.json_params)
+        upload_hit_resources_mock.assert_called_with(bucket_name, pcluster_config_mock, storage_data.json_params, {})
     assert_that(bucket_name).is_equal_to(expected_bucket_name)
 
 
@@ -83,7 +83,7 @@ def test_create_bucket_with_resources_creation_failure(mocker, caplog):
     storage_data = pcluster_config_mock.to_storage()
 
     with pytest.raises(ClientError, match=error):
-        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params)
+        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params, {})
     delete_s3_bucket_mock.assert_not_called()
     assert_that(caplog.text).contains("Unable to create S3 bucket")
 
@@ -104,7 +104,7 @@ def test_create_bucket_with_resources_upload_failure(mocker, caplog):
     storage_data = pcluster_config_mock.to_storage()
 
     with pytest.raises(ClientError, match=error):
-        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params)
+        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params, {})
     # if resource upload fails we delete the bucket
     delete_s3_bucket_mock.assert_called_with(bucket_name)
     assert_that(caplog.text).contains("Unable to upload cluster resources to the S3 bucket")
@@ -128,7 +128,7 @@ def test_create_bucket_with_resources_deletion_failure(mocker, caplog):
 
     # force upload failure to trigger a bucket deletion and then check the behaviour when the deletion fails
     with pytest.raises(ClientError, match=error):
-        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params)
+        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params, {})
     delete_s3_bucket_mock.assert_called_with(bucket_name)
     assert_that(caplog.text).contains("Unable to upload cluster resources to the S3 bucket")
 

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -157,6 +157,28 @@ Resources:
                 Value: !Ref 'FilesystemTagValue'
               - Key: aws-parallelcluster-node-type
                 Value: Compute
+    {%- for tag in tags %}
+              - Key: {{ tag.Key }}
+                Value: {{ tag.Value }}
+    {%- endfor %}
+          - ResourceType: volume
+            Tags:
+              - Key: ClusterName
+                Value: !Select
+                  - '1'
+                  - !Split
+                    - parallelcluster-
+                    - !Ref 'MainStackName'
+              - Key: QueueName
+                Value: {{ queue }}
+              - Key: Application
+                Value: !Ref 'MainStackName'
+              - Key: aws-parallelcluster-node-type
+                Value: Compute
+    {%- for tag in tags %}
+              - Key: {{ tag.Key }}
+                Value: {{ tag.Value }}
+    {%- endfor %}
         BlockDeviceMappings:
           - DeviceName: /dev/xvdba
             VirtualName: ephemeral0

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -298,6 +298,19 @@ Resources:
             Ebs:
               VolumeSize: !Ref 'RootVolumeSize'
               VolumeType: gp2
+        TagSpecifications:
+          - ResourceType: volume
+            Tags:
+              - Key: ClusterName
+                Value: !Select
+                  - '1'
+                  - !Split
+                    - parallelcluster-
+                    - !Ref 'MainStackName'
+              - Key: Application
+                Value: !Ref 'MainStackName'
+              - Key: aws-parallelcluster-node-type
+                Value: Compute
         UserData: !Base64
           Fn::Sub:
             - |

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -326,6 +326,18 @@ Resources:
                 Value: !Ref 'NetworkingTagValue'
               - Key: aws-parallelcluster-filesystem
                 Value: !Ref 'FilesystemTagValue'
+          - ResourceType: volume
+            Tags:
+              - Key: ClusterName
+                Value: !Select
+                  - '1'
+                  - !Split
+                    - parallelcluster-
+                    - !Ref 'MainStackName'
+              - Key: Application
+                Value: !Ref 'MainStackName'
+              - Key: aws-parallelcluster-node-type
+                Value: Master
         NetworkInterfaces:
           - NetworkInterfaceId: !Ref 'MasterENI'
             DeviceIndex: 0

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -145,7 +145,9 @@ def test_hit_substack_rendering(tmp_path, test_config):
     env = Environment(loader=FileSystemLoader(".."))
     env.filters["sha1"] = lambda value: hashlib.sha1(value.strip().encode()).hexdigest()
     template = env.get_template("compute-fleet-hit-substack.cfn.yaml")
-    output_from_parsed_template = template.render(config=test_config, config_version="version")
+    output_from_parsed_template = template.render(
+        config=test_config, config_version="version", tags=[{"Key": "TagKey", "Value": "TagValue"}]
+    )
     rendered_file = tmp_path / "compute-fleet-hit-substack.cfn.yaml"
     rendered_file.write_text(output_from_parsed_template)
 

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -33,6 +33,8 @@ class Cluster:
         self.create_complete = False
         self.__cfn_outputs = None
         self.__cfn_resources = None
+        self.__head_node_substack_cfn_resources = None
+        self.__ebs_substack_cfn_resources = None
 
     def __repr__(self):
         attrs = ", ".join(["{key}={value}".format(key=key, value=repr(value)) for key, value in self.__dict__.items()])
@@ -63,8 +65,7 @@ class Cluster:
         logging.info("Cluster {0} updated successfully".format(self.name))
 
         # reset cached properties
-        self.__cfn_outputs = None
-        self.__cfn_resources = None
+        self._reset_cached_properties()
 
         return result
 
@@ -127,15 +128,19 @@ class Cluster:
             )
             raise
 
-    def instances(self):
+    def instances(self, desired_instance_role=None):
         """Run pcluster stop and return the result."""
+        if desired_instance_role and desired_instance_role not in ("MasterServer", "ComputeFleet"):
+            raise ValueError
         cmd_args = ["pcluster", "instances", "--config", self.config_file, self.name]
         try:
             result = run_command(cmd_args, log_error=False)
             logging.info("Get cluster {0} instances successfully".format(self.name))
             cluster_instances = []
             for entry in result.stdout.splitlines():
-                cluster_instances.append(entry.split()[1])
+                instance_role, instance_id = entry.split()
+                if not desired_instance_role or desired_instance_role == instance_role:
+                    cluster_instances.append(instance_id)
             return cluster_instances
         except subprocess.CalledProcessError as e:
             logging.error(
@@ -199,6 +204,37 @@ class Cluster:
             self.__cfn_resources = retrieve_cfn_resources(self.cfn_name, self.region)
         return self.__cfn_resources
 
+    @property
+    def head_node_substack_cfn_resources(self):
+        """
+        Return the CloudFormation stack resources for the cluster's head node substack.
+        Resources are retrieved only once and then cached.
+        """
+        if not self.__head_node_substack_cfn_resources:
+            self.__head_node_substack_cfn_resources = retrieve_cfn_resources(
+                self.cfn_resources.get("MasterServerSubstack"), self.region
+            )
+        return self.__head_node_substack_cfn_resources
+
+    @property
+    def ebs_substack_cfn_resources(self):
+        """
+        Return the CloudFormation stack resources for the cluster's EBS substack.
+        Resources are retrieved only once and then cached.
+        """
+        if not self.__ebs_substack_cfn_resources:
+            self.__ebs_substack_cfn_resources = retrieve_cfn_resources(
+                self.cfn_resources.get("EBSCfnStack"), self.region
+            )
+        return self.__ebs_substack_cfn_resources
+
+    def _reset_cached_properties(self):
+        """Discard cached data."""
+        self.__cfn_outputs = None
+        self.__cfn_resources = None
+        self.__head_node_substack_cfn_resources = None
+        self.__ebs_substack_cfn_resources = None
+
 
 class ClustersFactory:
     """Manage creation and destruction of pcluster clusters."""
@@ -207,10 +243,11 @@ class ClustersFactory:
         self.__created_clusters = {}
         self._keep_logs_on_failure = keep_logs_on_failure
 
-    def create_cluster(self, cluster):
+    def create_cluster(self, cluster, extra_args=None):
         """
         Create a cluster with a given config.
         :param cluster: cluster to create.
+        :param extra_args: list of strings; extra args to pass to `pcluster create`
         """
         name = cluster.name
         config = cluster.config_file
@@ -220,7 +257,11 @@ class ClustersFactory:
         # create the cluster
         logging.info("Creating cluster {0} with config {1}".format(name, config))
         self.__created_clusters[name] = cluster
-        result = run_command(["pcluster", "create", "--norollback", "--config", config, name], timeout=7200)
+        create_cmd_args = ["pcluster", "create", "--norollback", "--config", config]
+        if extra_args:
+            create_cmd_args.extend(extra_args)
+        create_cmd_args.append(name)
+        result = run_command(create_cmd_args, timeout=7200)
         if "Status: {0} - CREATE_COMPLETE".format(cluster.cfn_name) not in result.stdout:
             error = "Cluster creation failed for {0} with output: {1}".format(name, result.stdout)
             logging.error(error)

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -236,7 +236,7 @@ def clusters_factory(request):
     """
     factory = ClustersFactory(keep_logs_on_failure=request.config.getoption("keep_logs_on_cluster_failure"))
 
-    def _cluster_factory(cluster_config):
+    def _cluster_factory(cluster_config, extra_args=None):
         cluster_config = _write_cluster_config_to_outdir(request, cluster_config)
         cluster = Cluster(
             name=request.config.getoption("cluster")
@@ -250,7 +250,7 @@ def clusters_factory(request):
             ssh_key=request.config.getoption("key_path"),
         )
         if not request.config.getoption("cluster"):
-            factory.create_cluster(cluster)
+            factory.create_cluster(cluster, extra_args=extra_args)
         return cluster
 
     yield _cluster_factory

--- a/tests/integration-tests/tests/tags/test_tag_propagation.py
+++ b/tests/integration-tests/tests/tags/test_tag_propagation.py
@@ -1,0 +1,263 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+# import logging
+
+import json
+import logging
+import subprocess as sp
+
+import boto3
+import pytest
+from assertpy import assert_that
+
+
+@pytest.mark.regions(["ap-southeast-1"])
+@pytest.mark.instances(["c5.xlarge"])
+@pytest.mark.oss(["alinux2"])
+@pytest.mark.schedulers(["slurm", "torque", "awsbatch"])
+@pytest.mark.usefixtures("region", "instance")
+def test_tag_propagation(pcluster_config_reader, clusters_factory, scheduler, os):
+    """
+    Verify tags from various sources are propagated to the expected resources.
+
+    The following resources are checked for tags:
+    - main CFN stack
+    - head node substack
+    - head node
+    - head node's root EBS volume
+    - compute node (traditional schedulers)
+    - compute node's root EBS volume (traditional schedulers)
+    - shared EBS volume
+    """
+    config_file_tags = {"ConfigFileTag": "ConfigFileTagValue"}
+    command_line_tags = {"CommandLineTag": "CommandLineTagValue"}
+    version_tags = {"Version": get_pcluster_version()}
+    cluster_config = pcluster_config_reader(tags=json.dumps(config_file_tags))
+    cluster = clusters_factory(cluster_config, extra_args=["--tags", json.dumps(command_line_tags)])
+    cluster_name_tags = {"ClusterName": cluster.name}
+
+    test_cases = [
+        {
+            "resource": "Main CloudFormation Stack",
+            "tag_getter": get_main_stack_tags,
+            "expected_tags": (version_tags, config_file_tags, command_line_tags),
+        },
+        {
+            "resource": "Head Node CloudFormation Stack",
+            "tag_getter": get_head_node_substack_tags,
+            "expected_tags": (version_tags, config_file_tags, command_line_tags),
+        },
+        {
+            "resource": "ComputeFleet CloudFormation Stack",
+            "tag_getter": get_compute_fleet_substack_tags,
+            "tag_getter_kwargs": {"cluster": cluster, "scheduler": scheduler},
+            "expected_tags": (version_tags, config_file_tags, command_line_tags),
+        },
+        {
+            "resource": "Head Node",
+            "tag_getter": get_head_node_tags,
+            "expected_tags": (cluster_name_tags, {"Name": "Master", "aws-parallelcluster-node-type": "Master"}),
+        },
+        {
+            "resource": "Head Node Root Volume",
+            "tag_getter": get_head_node_root_volume_tags,
+            "expected_tags": (cluster_name_tags, {"aws-parallelcluster-node-type": "Master"}),
+            "tag_getter_kwargs": {"cluster": cluster, "os": os},
+        },
+        {
+            "resource": "Compute Node",
+            "tag_getter": get_compute_node_tags,
+            "expected_tags": (
+                cluster_name_tags,
+                {"Name": "Compute", "aws-parallelcluster-node-type": "Compute"},
+                config_file_tags,
+                command_line_tags,
+            ),
+            "skip": scheduler == "awsbatch",
+        },
+        {
+            "resource": "Compute Node Root Volume",
+            "tag_getter": get_compute_node_root_volume_tags,
+            "expected_tags": (
+                cluster_name_tags,
+                {"aws-parallelcluster-node-type": "Compute"},
+                config_file_tags if scheduler == "slurm" else {},
+                command_line_tags if scheduler == "slurm" else {},
+            ),
+            "tag_getter_kwargs": {"cluster": cluster, "os": os},
+            "skip": scheduler == "awsbatch",
+        },
+        {
+            "resource": "Shared EBS Volume",
+            "tag_getter": get_shared_volume_tags,
+            "expected_tags": (version_tags, config_file_tags, command_line_tags),
+        },
+    ]
+    for test_case in test_cases:
+        if test_case.get("skip"):
+            continue
+        logging.info("Verifying tags were propagated to %s", test_case.get("resource"))
+        tag_getter = test_case.get("tag_getter")
+        # Assume tag getters use lone cluster object arg if none explicitly given
+        tag_getter_args = test_case.get("tag_getter_kwargs", {"cluster": cluster})
+        observed_tags = tag_getter(**tag_getter_args)
+        expected_tags = test_case["expected_tags"]
+        assert_that(observed_tags).contains(*convert_tags_dicts_to_tags_list(expected_tags))
+
+
+def convert_tags_dicts_to_tags_list(tags_dicts):
+    """Convert dicts of the form {key: value} to a list like [{"Key": key, "Value": value}]."""
+    tags_list = []
+    for tags_dict in tags_dicts:
+        tags_list.extend([{"Key": key, "Value": value} for key, value in tags_dict.items()])
+    return tags_list
+
+
+def get_cloudformation_tags(region, stack_name):
+    """
+    Return the tags for the CFN stack with the given name
+
+    The returned values is a list like the following:
+    [
+        {'Key': 'Key2', 'Value': 'Value2'},
+        {'Key': 'Key1', 'Value': 'Value1'},
+    ]
+    """
+    cfn_client = boto3.client("cloudformation", region_name=region)
+    response = cfn_client.describe_stacks(StackName=stack_name)
+    return response["Stacks"][0]["Tags"]
+
+
+def get_main_stack_tags(cluster):
+    """Return the tags for the cluster's main CFN stack."""
+    return get_cloudformation_tags(cluster.region, cluster.cfn_name)
+
+
+def get_head_node_substack_name(cluster):
+    """Return the name of the given cluster's head node's substack."""
+    return cluster.cfn_resources.get("MasterServerSubstack")
+
+
+def get_head_node_substack_tags(cluster):
+    """Return the tags for the given cluster's head node's CFN stack."""
+    return get_cloudformation_tags(cluster.region, get_head_node_substack_name(cluster))
+
+
+def get_compute_fleet_substack_name(cluster, scheduler):
+    """Return the name of the given cluster's compute fleet substack."""
+    scheduler_to_compute_fleet_logical_stack_name = {
+        "slurm": "ComputeFleetHITSubstack",
+        "sge": "ComputeFleetSubstack",
+        "torque": "ComputeFleetSubstack",
+        "awsbatch": "AWSBatchStack",
+    }
+    return cluster.cfn_resources.get(scheduler_to_compute_fleet_logical_stack_name[scheduler])
+
+
+def get_compute_fleet_substack_tags(cluster, scheduler):
+    """Return the tags for the given cluster's compute fleet CFN stack."""
+    return get_cloudformation_tags(cluster.region, get_compute_fleet_substack_name(cluster, scheduler))
+
+
+def get_head_node_instance_id(cluster):
+    """Return the given cluster's head node's instance ID."""
+    return cluster.head_node_substack_cfn_resources.get("MasterServer")
+
+
+def get_ec2_instance_tags(instance_id, region):
+    """Return a list of tags associated with the given EC2 instance."""
+    logging.info("Getting tags for instance %s", instance_id)
+    return (
+        boto3.client("ec2", region_name=region)
+        .describe_instances(InstanceIds=[instance_id])
+        .get("Reservations")[0]
+        .get("Instances")[0]
+        .get("Tags")
+    )
+
+
+def get_root_volume_id(instance_id, region, os):
+    """Return the root EBS volume's ID for the given EC2 instance."""
+    logging.info("Getting root volume for instance %s", instance_id)
+    os_to_root_volume_device = {
+        # These are taken from the main CFN template
+        "centos6": "/dev/sda1",
+        "centos7": "/dev/sda1",
+        "alinux": "/dev/xvda",
+        "alinux2": "/dev/xvda",
+        "ubuntu1604": "/dev/sda1",
+        "ubuntu1804": "/dev/sda1",
+    }
+    block_device_mappings = (
+        boto3.client("ec2", region_name=region)
+        .describe_instances(InstanceIds=[instance_id])
+        .get("Reservations")[0]
+        .get("Instances")[0]
+        .get("BlockDeviceMappings")
+    )
+    matching_devices = [
+        device_mapping
+        for device_mapping in block_device_mappings
+        if device_mapping.get("DeviceName") == os_to_root_volume_device[os]
+    ]
+    assert_that(matching_devices).is_length(1)
+    return matching_devices[0].get("Ebs").get("VolumeId")
+
+
+def get_tags_for_volume(volume_id, region):
+    """Return the tags attached to the given EBS volume."""
+    logging.info("Getting tags for volume %s", volume_id)
+    return boto3.client("ec2", region_name=region).describe_volumes(VolumeIds=[volume_id]).get("Volumes")[0].get("Tags")
+
+
+def get_head_node_root_volume_tags(cluster, os):
+    """Return the given cluster's head node's root volume's tags."""
+    head_node_instance_id = get_head_node_instance_id(cluster)
+    root_volume_id = get_root_volume_id(head_node_instance_id, cluster.region, os)
+    return get_tags_for_volume(root_volume_id, cluster.region)
+
+
+def get_head_node_tags(cluster):
+    """Return the given cluster's head node's tags."""
+    head_node_instance_id = get_head_node_instance_id(cluster)
+    return get_ec2_instance_tags(head_node_instance_id, cluster.region)
+
+
+def get_compute_node_root_volume_tags(cluster, os):
+    """Return the given cluster's compute node's root volume's tags."""
+    compute_nodes = cluster.instances(desired_instance_role="ComputeFleet")
+    assert_that(compute_nodes).is_length(1)
+    root_volume_id = get_root_volume_id(compute_nodes[0], cluster.region, os)
+    return get_tags_for_volume(root_volume_id, cluster.region)
+
+
+def get_compute_node_tags(cluster):
+    """Return the given cluster's compute node's tags."""
+    compute_nodes = cluster.instances(desired_instance_role="ComputeFleet")
+    assert_that(compute_nodes).is_length(1)
+    return get_ec2_instance_tags(compute_nodes[0], cluster.region)
+
+
+def get_ebs_volume_tags(volume_id, region):
+    """Return the tags associated with the given EBS volume."""
+    return boto3.client("ec2", region_name=region).describe_volumes(VolumeIds=[volume_id]).get("Volumes")[0].get("Tags")
+
+
+def get_shared_volume_tags(cluster):
+    """Return the given cluster's EBS volume's tags."""
+    shared_volume = cluster.ebs_substack_cfn_resources.get("Volume1")
+    return get_ebs_volume_tags(shared_volume, cluster.region)
+
+
+def get_pcluster_version():
+    """Return the installed version of the pclsuter CLI."""
+    return sp.check_output("pcluster version".split()).decode().strip()

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.ini
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.ini
@@ -1,0 +1,27 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+{% if scheduler == "awsbatch" %}
+min_vcpus = 4
+desired_vcpus = 4
+{% else %}
+initial_queue_size = 1
+maintain_initial_size = true
+{% endif %}
+tags = {{ tags }}
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false


### PR DESCRIPTION
CFN does not currently support tag propagation to launch templates. See
https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/184
for details.

Work around this by including the tags when rendering the template.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
