### PR TITLE
Enable `-r/--region` command line args for `pcluster dcv connect` and `pcluster ssh`

### DIFF
--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -429,6 +429,7 @@ Variables substituted::
     pdcv_connect = dcv_subparsers.add_parser(
         "connect", help="Permits to connect to the master node through an interactive session by using NICE DCV."
     )
+    _addarg_region(pdcv_connect)
     pdcv_connect.add_argument("cluster_name", help="Name of the cluster to connect to")
     pdcv_connect.add_argument(
         "--key-path", "-k", dest="key_path", help="Key path of the SSH key to use for the connection"

--- a/cli/pcluster/cli.py
+++ b/cli/pcluster/cli.py
@@ -339,6 +339,7 @@ Variables substituted::
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=ssh_example,
     )
+    _addarg_region(pssh)
     pssh.add_argument("cluster_name", help="Name of the cluster to connect to.")
     pssh.add_argument("-d", "--dryrun", action="store_true", default=False, help="Prints command and exits.")
     pssh.set_defaults(func=ssh)

--- a/cli/pcluster/createami.py
+++ b/cli/pcluster/createami.py
@@ -306,10 +306,6 @@ def _validate_createami_args_ami_compatibility(args):
 def create_ami(args):
     LOGGER.info("Building AWS ParallelCluster AMI. This could take a while...")
 
-    # Ensure AWS_DEFAULT_REGION env is set.
-    # Set it explicitly if the CLI arg was passed. Otherwise let the config object do it.
-    if args.region:
-        os.environ["AWS_DEFAULT_REGION"] = args.region
     pcluster_config = PclusterConfig(config_file=args.config_file, fail_on_file_absence=True)
 
     ami_info = _validate_createami_args_ami_compatibility(args)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
