### PR TITLE
Update internal_ticket_replica.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/internal_ticket_replica.md
+++ b/.github/ISSUE_TEMPLATE/internal_ticket_replica.md
@@ -1,6 +1,6 @@
 ---
 name: Known Issue Report
-about: ''
+about: 'Report known issues on github'
 title: ''
 labels: 'known-issue-report'
 assignees: ''


### PR DESCRIPTION
The 'About' section of the header can't be blank apparently. Is there a way I can test this?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
