### PR TITLE
Revert "integ-tests: update Slurm version"

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -292,7 +292,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type):
 def _test_slurm_version(remote_command_executor):
     logging.info("Testing Slurm Version")
     version = remote_command_executor.run_remote_command("sinfo -V").stdout
-    assert_that(version).is_equal_to("slurm 20.02.5")
+    assert_that(version).is_equal_to("slurm 20.02.4")
 
 
 def _test_job_dependencies(slurm_commands, region, stack_name, scaledown_idletime):


### PR DESCRIPTION
This reverts commit e1e98614e50817c29c04eeb4397e59119069251a.

We are skiping this version of slurm due to a regression in the
interpretation of strings passed to the `--constraint` arg of `sbatch`
and related commands.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
