### PR TITLE
Add CloudWatch dashboard (Head Node EC2 Metrics and Head Node Logs)

### DIFF
--- a/cli/pcluster/cli_commands/update.py
+++ b/cli/pcluster/cli_commands/update.py
@@ -22,7 +22,7 @@ from tabulate import tabulate
 
 import pcluster.utils as utils
 from pcluster.cluster_model import ClusterModel
-from pcluster.commands import _evaluate_pcluster_template_url, _upload_hit_resources
+from pcluster.commands import _evaluate_pcluster_template_url, _upload_dashboard_resource, _upload_hit_resources
 from pcluster.config.config_patch import ConfigPatch
 from pcluster.config.pcluster_config import PclusterConfig
 from pcluster.config.update_policy import UpdatePolicy
@@ -54,18 +54,18 @@ def execute(args):
         cfn_client = boto3.client("cloudformation")
         _restore_cfn_only_params(cfn_client, args, cfn_params, stack_name, target_config)
 
+        s3_bucket_name = cfn_params["ResourcesS3Bucket"]
+
         is_hit = utils.is_hit_enabled_cluster(base_config.cfn_stack)
         template_url = None
         if is_hit:
             try:
-                _upload_hit_resources(
-                    cfn_params["ResourcesS3Bucket"], target_config, target_config.to_storage().json_params
-                )
+                _upload_hit_resources(s3_bucket_name, target_config, target_config.to_storage().json_params)
             except Exception:
-                utils.error(
-                    "Failed when uploading resources to cluster S3 bucket {0}".format(cfn_params["ResourcesS3Bucket"])
-                )
+                utils.error("Failed when uploading resources to cluster S3 bucket {0}".format(s3_bucket_name))
             template_url = _evaluate_pcluster_template_url(target_config)
+
+        _upload_dashboard_resource(s3_bucket_name, target_config, target_config.to_storage().cfn_params)
 
         _update_cluster(
             args, cfn_client, cfn_params, stack_name, use_previous_template=not is_hit, template_url=template_url

--- a/cli/pcluster/cli_commands/update.py
+++ b/cli/pcluster/cli_commands/update.py
@@ -22,7 +22,7 @@ from tabulate import tabulate
 
 import pcluster.utils as utils
 from pcluster.cluster_model import ClusterModel
-from pcluster.commands import _evaluate_pcluster_template_url, _upload_dashboard_resource, _upload_hit_resources
+from pcluster.commands import evaluate_pcluster_template_url, upload_dashboard_resource, upload_hit_resources
 from pcluster.config.config_patch import ConfigPatch
 from pcluster.config.pcluster_config import PclusterConfig
 from pcluster.config.update_policy import UpdatePolicy
@@ -60,13 +60,13 @@ def execute(args):
         template_url = None
         if is_hit:
             try:
-                _upload_hit_resources(s3_bucket_name, target_config, target_config.to_storage().json_params)
+                upload_hit_resources(s3_bucket_name, target_config, target_config.to_storage().json_params)
             except Exception:
                 utils.error("Failed when uploading resources to cluster S3 bucket {0}".format(s3_bucket_name))
-            template_url = _evaluate_pcluster_template_url(target_config)
+            template_url = evaluate_pcluster_template_url(target_config)
 
         try:
-            _upload_dashboard_resource(
+            upload_dashboard_resource(
                 s3_bucket_name,
                 target_config,
                 target_config.to_storage().json_params,

--- a/cli/pcluster/cli_commands/update.py
+++ b/cli/pcluster/cli_commands/update.py
@@ -65,7 +65,15 @@ def execute(args):
                 utils.error("Failed when uploading resources to cluster S3 bucket {0}".format(s3_bucket_name))
             template_url = _evaluate_pcluster_template_url(target_config)
 
-        _upload_dashboard_resource(s3_bucket_name, target_config, target_config.to_storage().cfn_params)
+        try:
+            _upload_dashboard_resource(
+                s3_bucket_name,
+                target_config,
+                target_config.to_storage().json_params,
+                target_config.to_storage().cfn_params,
+            )
+        except Exception:
+            utils.error("Failed when uploading the dashboard resource to cluster S3 bucket {0}".format(s3_bucket_name))
 
         _update_cluster(
             args, cfn_client, cfn_params, stack_name, use_previous_template=not is_hit, template_url=template_url

--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -59,9 +59,9 @@ def _create_bucket_with_resources(pcluster_config, storage_data, tags):
                 resources = pkg_resources.resource_filename(__name__, resources_dir)
                 utils.upload_resources_artifacts(s3_bucket_name, root=resources)
             if utils.is_hit_enabled_scheduler(scheduler):
-                _upload_hit_resources(s3_bucket_name, pcluster_config, storage_data.json_params, tags)
+                upload_hit_resources(s3_bucket_name, pcluster_config, storage_data.json_params, tags)
 
-        _upload_dashboard_resource(s3_bucket_name, pcluster_config, storage_data.json_params, storage_data.cfn_params)
+        upload_dashboard_resource(s3_bucket_name, pcluster_config, storage_data.json_params, storage_data.cfn_params)
     except Exception:
         LOGGER.error("Unable to upload cluster resources to the S3 bucket %s.", s3_bucket_name)
         utils.delete_s3_bucket(s3_bucket_name)
@@ -70,7 +70,7 @@ def _create_bucket_with_resources(pcluster_config, storage_data, tags):
     return s3_bucket_name
 
 
-def _upload_hit_resources(bucket_name, pcluster_config, json_params, tags=None):
+def upload_hit_resources(bucket_name, pcluster_config, json_params, tags=None):
     if tags is None:
         tags = []
     hit_template_url = pcluster_config.get_section("cluster").get_param_value(
@@ -102,7 +102,7 @@ def _upload_hit_resources(bucket_name, pcluster_config, json_params, tags=None):
         raise
 
 
-def _upload_dashboard_resource(bucket_name, pcluster_config, json_params, cfn_params):
+def upload_dashboard_resource(bucket_name, pcluster_config, json_params, cfn_params):
     params = {"json_params": json_params, "cfn_params": cfn_params}
     cw_dashboard_template_url = pcluster_config.get_section("cluster").get_param_value(
         "cw_dashboard_template_url"
@@ -188,7 +188,7 @@ def create(args):  # noqa: C901 FIXME!!!
         LOGGER.info("Creating stack named: %s", stack_name)
 
         # determine the CloudFormation Template URL to use
-        template_url = _evaluate_pcluster_template_url(pcluster_config, preferred_template_url=args.template_url)
+        template_url = evaluate_pcluster_template_url(pcluster_config, preferred_template_url=args.template_url)
 
         # append extra parameters from command-line
         if args.extra_parameters:
@@ -239,7 +239,7 @@ def create(args):  # noqa: C901 FIXME!!!
         sys.exit(1)
 
 
-def _evaluate_pcluster_template_url(pcluster_config, preferred_template_url=None):
+def evaluate_pcluster_template_url(pcluster_config, preferred_template_url=None):
     """
     Determine the CloudFormation Template URL to use.
 

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -927,6 +927,11 @@ CLUSTER_COMMON_PARAMS = [
         "validators": [url_validator],
         "update_policy": UpdatePolicy.IGNORED
     }),
+    ("cw_dashboard_template_url", {
+        # TODO add regex
+        "validators": [url_validator],
+        "update_policy": UpdatePolicy.IGNORED
+    }),
 ]
 
 

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -595,6 +595,19 @@ CW_LOG = {
     ])
 }
 
+DASHBOARD = {
+    "type": JsonSection,
+    "key": "dashboard",
+    "default_label": "default",
+    "params": OrderedDict([
+        ("enable", {
+            "type": BooleanJsonParam,
+            "default": True,
+            "update_policy": UpdatePolicy.SUPPORTED,
+        }),
+    ])
+}
+
 COMPUTE_RESOURCE = {
     "type": JsonSection,
     "key": "compute_resource",
@@ -907,6 +920,11 @@ CLUSTER_COMMON_PARAMS = [
         "type": SettingsCfnParam,
         "referred_section": CW_LOG,
         "update_policy": UpdatePolicy.UNSUPPORTED,
+    }),
+    ("dashboard_settings", {
+        "type": SettingsJsonParam,
+        "referred_section": DASHBOARD,
+        "update_policy": UpdatePolicy.SUPPORTED,
     }),
     # Moved from the "Access and Networking" section because its configuration is
     # dependent on multiple other parameters from within this section.

--- a/cli/pcluster/createami.py
+++ b/cli/pcluster/createami.py
@@ -35,6 +35,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 import pcluster.utils as utils
+from pcluster.commands import evaluate_pcluster_template_url
 from pcluster.config.pcluster_config import PclusterConfig
 
 if sys.version_info[0] >= 3:
@@ -43,21 +44,6 @@ else:
     from urllib import urlretrieve  # pylint: disable=no-name-in-module
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _evaluate_pcluster_template_url(pcluster_config, preferred_template_url=None):
-    """
-    Determine the CloudFormation Template URL to use.
-
-    Order is 1) preferred_template_url 2) Config file 3) default for version + region.
-
-    :param pcluster_config: PclusterConfig, it can contain the template_url
-    :param preferred_template_url: preferred template url to use, if not None
-    :return: the evaluated template url
-    """
-    configured_template_url = pcluster_config.get_section("cluster").get_param_value("template_url")
-
-    return preferred_template_url or configured_template_url or _get_default_template_url(pcluster_config.region)
 
 
 def _get_cookbook_url(region, template_url, args, tmpdir):
@@ -345,7 +331,7 @@ def create_ami(args):
         LOGGER.info("VPC ID: %s", vpc_id)
         LOGGER.info("Subnet ID: %s", subnet_id)
 
-        template_url = _evaluate_pcluster_template_url(pcluster_config)
+        template_url = evaluate_pcluster_template_url(pcluster_config)
 
         tmp_dir = mkdtemp()
         cookbook_dir = _get_cookbook_dir(aws_region, template_url, args, tmp_dir)

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -1101,9 +1101,9 @@ def read_remote_file(url):
         raise e
 
 
-def render_template(template_str, params_dict, config_version, tags):
+def render_template(template_str, params_dict, config_version=None, tags):
     """
-    Render a Jinjia template and return the rendered output.
+    Render a Jinja template and return the rendered output.
 
     :param template_str: Template file contents as a string
     :param params_dict: Template parameters dict

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -1101,7 +1101,7 @@ def read_remote_file(url):
         raise e
 
 
-def render_template(template_str, params_dict, config_version=None, tags):
+def render_template(template_str, params_dict, tags, config_version=None):
     """
     Render a Jinja template and return the rendered output.
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -1111,6 +1111,7 @@ def render_template(template_str, params_dict, tags, config_version=None):
     try:
         environment = Environment(loader=BaseLoader)
         environment.filters["sha1"] = lambda value: hashlib.sha1(value.strip().encode()).hexdigest()
+        environment.filters["bool"] = lambda value: value.lower() == "true"
         template = environment.from_string(template_str)
         output_from_parsed_template = template.render(config=params_dict, config_version=config_version, tags=tags)
         return output_from_parsed_template

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -139,6 +139,7 @@ DEFAULT_CLUSTER_SIT_DICT = {
     "fsx_settings": None,
     "dcv_settings": None,
     "cw_log_settings": None,
+    "dashboard_settings": None,
     "cluster_config_metadata": {"sections": {}},
     "architecture": "x86_64",
 }
@@ -182,6 +183,7 @@ DEFAULT_CLUSTER_HIT_DICT = {
     "fsx_settings": None,
     "dcv_settings": None,
     "cw_log_settings": None,
+    "dashboard_settings": None,
     "queue_settings": None,
     "default_queue": None,
     "cluster_config_metadata": {"sections": {}},
@@ -189,6 +191,8 @@ DEFAULT_CLUSTER_HIT_DICT = {
 }
 
 DEFAULT_CW_LOG_DICT = {"enable": True, "retention_days": 14}
+
+DEFAULT_DASHBOARD_DICT = {"enable": True}
 
 DEFAULT_PCLUSTER_DICT = {"cluster": DEFAULT_CLUSTER_SIT_DICT}
 
@@ -209,6 +213,7 @@ class DefaultDict(Enum):
     fsx = DEFAULT_FSX_DICT
     dcv = DEFAULT_DCV_DICT
     cw_log = DEFAULT_CW_LOG_DICT
+    dashboard = DEFAULT_DASHBOARD_DICT
     pcluster = DEFAULT_PCLUSTER_DICT
 
 

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -93,6 +93,7 @@ DEFAULT_CLUSTER_SIT_DICT = {
     "key_name": None,
     "template_url": None,
     "hit_template_url": None,
+    "cw_dashboard_template_url": None,
     "base_os": None,  # base_os does not have a default, but this is here to make testing easier
     "scheduler": None,  # The cluster does not have a default, but this is here to make testing easier
     "shared_dir": "/shared",
@@ -146,6 +147,7 @@ DEFAULT_CLUSTER_HIT_DICT = {
     "key_name": None,
     "template_url": None,
     "hit_template_url": None,
+    "cw_dashboard_template_url": None,
     "base_os": None,  # base_os does not have a default, but this is here to make testing easier
     "scheduler": None,  # The cluster does not have a default, but this is here to make testing easier
     "shared_dir": "/shared",

--- a/cli/tests/pcluster/config/test_json_param_types.py
+++ b/cli/tests/pcluster/config/test_json_param_types.py
@@ -154,6 +154,10 @@ def test_config_from_json(mocker, boto3_stubber, test_datadir, pcluster_config_r
     pcluster_config.add_section(cluster_section)
     pcluster_config.refresh()
 
+    dashboard_section = pcluster_config.get_section("dashboard", "dashboard1")
+    assert_that(dashboard_section).is_not_none()
+    assert_that(dashboard_section.get_param_value("enable")).is_equal_to(False)
+
     for queue in queues:
         assert_that(pcluster_config.get_section("queue", queue)).is_not_none()
         _check_queue_section_from_json(

--- a/cli/tests/pcluster/config/test_json_param_types/s3_config.json
+++ b/cli/tests/pcluster/config/test_json_param_types/s3_config.json
@@ -164,6 +164,10 @@
     "scaling": {
       "label": "default",
       "scaledown_idletime": 10
+    },
+    "dashboard": {
+      "label": "dashboard1",
+      "enable": false
     }
   }
 }

--- a/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
@@ -7,6 +7,10 @@ enable_efa = compute
 disable_cluster_dns = true
 # disable_hyperthreading not defined, fallback to False expected
 # disable_hyperthreading = false
+dashboard_settings = dashboard1
+
+[dashboard dashboard1]
+enable = false
 
 [queue queue1]
 compute_resource_settings = q1-i1,q1-i2,q1-i3,q1-i4,q1-i5

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -494,6 +494,8 @@ def test_hit_cluster_section_from_file(mocker, config_parser_dict, expected_dict
         ("efs_settings", "test1", None, "Section .* not found in the config file"),
         ("raid_settings", "test1", None, "Section .* not found in the config file"),
         ("fsx_settings", "test1", None, "Section .* not found in the config file"),
+        ("cw_log_settings", "test1", None, "Section .* not found in the config file"),
+        ("dashboard_settings", "test1", None, "Section .* not found in the config file"),
     ],
 )
 def test_sit_cluster_param_from_file(
@@ -697,6 +699,8 @@ def test_sit_cluster_param_from_file(
         ("efs_settings", "test1", None, "Section .* not found in the config file"),
         ("raid_settings", "test1", None, "Section .* not found in the config file"),
         ("fsx_settings", "test1", None, "Section .* not found in the config file"),
+        ("cw_log_settings", "test1", None, "Section .* not found in the config file"),
+        ("dashboard_settings", "test1", None, "Section .* not found in the config file"),
     ],
 )
 def test_hit_cluster_param_from_file(

--- a/cli/tests/pcluster/config/test_section_dashboard.py
+++ b/cli/tests/pcluster/config/test_section_dashboard.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+import tests.pcluster.config.utils as utils
+from pcluster.config.mappings import DASHBOARD
+
+
+@pytest.mark.parametrize(
+    "config_parser_dict, expected_dict_params, expected_message",
+    [
+        # default
+        ({"dashboard default": {}}, {}, None),
+        # right value
+        ({"dashboard default": {"enable": "True"}}, {}, None),
+        ({"dashboard default": {"enable": "False"}}, {"enable": False}, None),
+        # invalid value
+        ({"dashboard default": {"enable": "not_a_bool"}}, None, "'enable' must be of 'bool' type"),
+        # invalid key
+        ({"dashboard default": {"invalid_key": "fake_value"}}, None, "'invalid_key' is not allowed in the .* section"),
+        (
+            {"dashboard default": {"invalid_key": "fake_value", "invalid_key2": "fake_value"}},
+            None,
+            "'invalid_key.*,invalid_key.*' are not allowed in the .* section",
+        ),
+    ],
+)
+def test_dashboard_section_from_file(mocker, config_parser_dict, expected_dict_params, expected_message):
+    """Verify that dashboard behaves as expected when parsed in a config file."""
+    utils.assert_section_from_file(mocker, DASHBOARD, config_parser_dict, expected_dict_params, expected_message)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_config_parser_dict, expected_message",
+    [
+        # default values are not written back to config files
+        ({}, {"dashboard default": {}}, "No section.*"),
+        ({"enable": True}, {"dashboard default": {"enable": True}}, "No section: 'dashboard default'"),
+        # Non-default values are written back to config files
+        ({"enable": False}, {"dashboard default": {"enable": "false"}}, None),
+    ],
+)
+def test_dashboard_settings_section_to_file(mocker, section_dict, expected_config_parser_dict, expected_message):
+    """Verify that the dashboard_settings section is as expected when writing back to a file."""
+    utils.assert_section_to_file(mocker, DASHBOARD, section_dict, expected_config_parser_dict, expected_message)
+
+
+@pytest.mark.parametrize(
+    "param_key, param_value, expected_value, expected_message",
+    [
+        # Enable parameter
+        ("enable", None, True, None),
+        ("enable", "true", True, None),
+        ("enable", "false", False, None),
+        ("enable", "not_a_bool", None, "'enable' must be of 'bool' type"),
+        ("enable", "", None, "'enable' must be of 'bool' type"),
+    ],
+)
+def test_dashboard_settings_param_from_file(mocker, param_key, param_value, expected_value, expected_message):
+    """Verify that the cw_log_settings config file section results in the correct CFN parameters."""
+    utils.assert_param_from_file(mocker, DASHBOARD, param_key, param_value, expected_value, expected_message)

--- a/cli/tests/pcluster/test_commands.py
+++ b/cli/tests/pcluster/test_commands.py
@@ -64,8 +64,10 @@ def test_create_bucket_with_resources_success(
         [mocker.call(bucket_name, root=pkg_resources.resource_filename(utils.__name__, dir)) for dir in expected_dirs]
     )
     if expect_upload_hit_resources:
-        upload_hit_resources_mock.assert_called_with(bucket_name, pcluster_config_mock, storage_data, {})
-    upload_dashboard_resource.assert_called_with(bucket_name, pcluster_config_mock, storage_data.cfn_params)
+        upload_hit_resources_mock.assert_called_with(bucket_name, pcluster_config_mock, storage_data.json_params, {})
+    upload_dashboard_resource.assert_called_with(
+        bucket_name, pcluster_config_mock, storage_data.json_params, storage_data.cfn_params
+    )
     assert_that(bucket_name).is_equal_to(expected_bucket_name)
 
 

--- a/cli/tests/pcluster/test_commands.py
+++ b/cli/tests/pcluster/test_commands.py
@@ -52,18 +52,20 @@ def test_create_bucket_with_resources_success(
     upload_resources_artifacts_mock = mocker.patch("pcluster.utils.upload_resources_artifacts")
     delete_s3_bucket_mock = mocker.patch("pcluster.utils.delete_s3_bucket")
     upload_hit_resources_mock = mocker.patch("pcluster.commands._upload_hit_resources")
+    upload_dashboard_resource = mocker.patch("pcluster.commands._upload_dashboard_resource")
     pcluster_config_mock = _mock_pcluster_config(mocker, scheduler, region)
 
     storage_data = pcluster_config_mock.to_storage()
 
-    bucket_name = _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params, {})
+    bucket_name = _create_bucket_with_resources(pcluster_config_mock, storage_data, {})
 
     delete_s3_bucket_mock.assert_not_called()
     upload_resources_artifacts_mock.assert_has_calls(
         [mocker.call(bucket_name, root=pkg_resources.resource_filename(utils.__name__, dir)) for dir in expected_dirs]
     )
     if expect_upload_hit_resources:
-        upload_hit_resources_mock.assert_called_with(bucket_name, pcluster_config_mock, storage_data.json_params, {})
+        upload_hit_resources_mock.assert_called_with(bucket_name, pcluster_config_mock, storage_data, {})
+    upload_dashboard_resource.assert_called_with(bucket_name, pcluster_config_mock, storage_data.cfn_params)
     assert_that(bucket_name).is_equal_to(expected_bucket_name)
 
 
@@ -83,7 +85,7 @@ def test_create_bucket_with_resources_creation_failure(mocker, caplog):
     storage_data = pcluster_config_mock.to_storage()
 
     with pytest.raises(ClientError, match=error):
-        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params, {})
+        _create_bucket_with_resources(pcluster_config_mock, storage_data, {})
     delete_s3_bucket_mock.assert_not_called()
     assert_that(caplog.text).contains("Unable to create S3 bucket")
 
@@ -104,7 +106,7 @@ def test_create_bucket_with_resources_upload_failure(mocker, caplog):
     storage_data = pcluster_config_mock.to_storage()
 
     with pytest.raises(ClientError, match=error):
-        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params, {})
+        _create_bucket_with_resources(pcluster_config_mock, storage_data, {})
     # if resource upload fails we delete the bucket
     delete_s3_bucket_mock.assert_called_with(bucket_name)
     assert_that(caplog.text).contains("Unable to upload cluster resources to the S3 bucket")
@@ -128,7 +130,7 @@ def test_create_bucket_with_resources_deletion_failure(mocker, caplog):
 
     # force upload failure to trigger a bucket deletion and then check the behaviour when the deletion fails
     with pytest.raises(ClientError, match=error):
-        _create_bucket_with_resources(pcluster_config_mock, storage_data.json_params, {})
+        _create_bucket_with_resources(pcluster_config_mock, storage_data, {})
     delete_s3_bucket_mock.assert_called_with(bucket_name)
     assert_that(caplog.text).contains("Unable to upload cluster resources to the S3 bucket")
 

--- a/cli/tests/pcluster/test_commands.py
+++ b/cli/tests/pcluster/test_commands.py
@@ -51,8 +51,8 @@ def test_create_bucket_with_resources_success(
     mocker.patch("pcluster.utils.create_s3_bucket")
     upload_resources_artifacts_mock = mocker.patch("pcluster.utils.upload_resources_artifacts")
     delete_s3_bucket_mock = mocker.patch("pcluster.utils.delete_s3_bucket")
-    upload_hit_resources_mock = mocker.patch("pcluster.commands._upload_hit_resources")
-    upload_dashboard_resource = mocker.patch("pcluster.commands._upload_dashboard_resource")
+    upload_hit_resources_mock = mocker.patch("pcluster.commands.upload_hit_resources")
+    upload_dashboard_resource = mocker.patch("pcluster.commands.upload_dashboard_resource")
     pcluster_config_mock = _mock_pcluster_config(mocker, scheduler, region)
 
     storage_data = pcluster_config_mock.to_storage()

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -228,7 +228,7 @@ changedir =
 deps = cfn-lint
 commands =
     cfn-lint --info *.cfn.json --ignore-templates fsx-substack.cfn.json
-    cfn-lint --info *.cfn.yaml --ignore-templates compute-fleet-hit-substack.cfn.yaml
+    cfn-lint --info *.cfn.yaml --ignore-templates compute-fleet-hit-substack.cfn.yaml cw-dashboard-substack.cfn.yaml
     # W2001 Parameter ComputeSecurityGroupIngress not used. Required https://github.com/aws/aws-parallelcluster/pull/1198
     cfn-lint --info fsx-substack.cfn.json -i W2001
     cfn-lint --info networking/*.cfn.json

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -3876,6 +3876,80 @@
         }
       },
       "Condition": "CreateHITSubstack"
+    },
+    "CloudWatchDashboardSubstack": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "Parameters": {
+          "PclusterStackName": {
+            "Ref": "AWS::StackName"
+          },
+          "MasterInstanceId": {
+            "Fn::GetAtt": [
+              "MasterServerSubstack",
+              "Outputs.MasterInstanceID"
+            ]
+          },
+          "EBSVolumesIds": {
+            "Fn::GetAtt": [
+              "EBSCfnStack",
+              "Outputs.Volumeids"
+            ]
+          },
+          "RAIDVolumesIds": {
+            "Fn::If": [
+              "CreateRAIDSubstack",
+              {
+                "Fn::GetAtt": [
+                  "RAIDSubstack",
+                  "Outputs.Volumeids"
+                ]
+              },
+              "NONE"
+            ]
+          },
+          "EFSFileSystemId": {
+            "Fn::If": [
+              "CreateEFSSubstack",
+              {
+                "Fn::GetAtt": [
+                  "EFSSubstack",
+                  "Outputs.FileSystemId"
+                ]
+              },
+              "NONE"
+            ]
+          },
+          "FSXFileSystemId": {
+            "Fn::If": [
+              "CreateFSXSubstack",
+              {
+                "Fn::GetAtt": [
+                  "FSXSubstack",
+                  "Outputs.FileSystemId"
+                ]
+              },
+              "NONE"
+            ]
+          }
+        },
+        "TemplateURL": {
+          "Fn::Sub": [
+            "https://${ResourcesS3Bucket}.s3.${AWS::Region}.${s3_url}/templates/cw-dashboard-substack.rendered.cfn.yaml",
+            {
+              "s3_url": {
+                "Fn::FindInMap": [
+                  "Partition2Url",
+                  {
+                    "Ref": "AWS::Partition"
+                  },
+                  "url"
+                ]
+              }
+            }
+          ]
+        }
+      }
     }
   },
   "Outputs": {

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -3884,10 +3884,36 @@
           "PclusterStackName": {
             "Ref": "AWS::StackName"
           },
+          "CWLogGroupName": {
+            "Fn::Sub": [
+              "/aws/parallelcluster/${cluster_name}",
+              {
+                "cluster_name": {
+                  "Fn::Select": [
+                    "1",
+                    {
+                      "Fn::Split": [
+                        "parallelcluster-",
+                        {
+                          "Ref": "AWS::StackName"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          },
           "MasterInstanceId": {
             "Fn::GetAtt": [
               "MasterServerSubstack",
               "Outputs.MasterInstanceID"
+            ]
+          },
+          "MasterPrivateIP": {
+            "Fn::GetAtt": [
+              "MasterServerSubstack",
+              "Outputs.MasterPrivateIP"
             ]
           },
           "EBSVolumesIds": {

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -1,0 +1,245 @@
+{#- Automatically updated variable to define graph/header section position #}
+{%- set coord = {'x': 0, 'y': 0} %}
+
+{#- Macro to calculate coordinates for the new graph #}
+{#- It updates both x and y values if the graph doesn't fit in the given line #}
+{%- macro update_coord(dx, dy) %}
+  {%- if coord.update({'x': (coord.x+dx)}) %} {%- endif %}
+  {%- if coord.x+dx > 24 %} {#- the longest width allowed is 24 #}
+    {%- if coord.update({'x': 0, 'y': coord.y+dy}) %} {%- endif %}
+  {%- endif %}
+{%- endmacro %}
+
+{#- Macro to calculate section header coordinates #}
+{%- macro update_coord_after_section(dy) %}
+  {%- if coord.update({'x': 0, 'y': coord.y+dy}) %} {%- endif %}
+{%- endmacro %}
+
+{%- set graph_width = 6 %}
+{%- set graph_height = 6 -%}
+Parameters:
+  {#- Cluster parameters #}
+  PclusterStackName:
+    Description: Name of the cluster to which this dashboard belongs
+    Type: String
+  {#- EC2 parameters #}
+  MasterInstanceId:
+    Description: ID of the Master instance
+    Type: AWS::EC2::Instance::Id
+  {#- EBS parameters #}
+  EBSVolumesIds:
+    Description: IDs of the EBS volumes used
+    Type: CommaDelimitedList
+  {#- RAID parameters #}
+  RAIDVolumesIds:
+    Description: Volume IDs of the resulted RAID EBS volumes
+    Type: CommaDelimitedList
+  {#- EFS parameters #}
+  EFSFileSystemId:
+    Description: ID of the EFS volume used
+    Type: String
+  {#- FSx parameters #}
+  FSXFileSystemId:
+    Description: ID of the FSx volume used
+    Type: String
+Resources:
+  HeadNodeDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Join
+        - '-'
+        - - !Ref 'PclusterStackName'
+          - HeadNode
+      DashboardBody: !Join
+        - ''
+        - - '{"widgets":['
+          {#- Head Node Instance Metrics #}
+          - '{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            Head Node Instance Metrics\n"}}'
+          {%- set ec2_metrics = [{'metrics': ["CPUUtilization"], 'extra_params': ['"title":"CPU Utilization"']},
+                                 {'metrics': ["NetworkPacketsIn", "NetworkPacketsOut"], 'extra_params': ['"title":"Network Packets In/Out"']},
+                                 {'metrics': ["NetworkIn", "NetworkOut"], 'extra_params': ['"title":"Network In and Out"']},
+                                 {'metrics': ["DiskReadBytes", "DiskWriteBytes"], 'extra_params': ['"title":"Disk Read/Write Bytes"']},
+                                 {'metrics': ["DiskReadOps", "DiskWriteOps"], 'extra_params': ['"title":"Disk Read/Write Ops"']}]
+          %}
+          {{- update_coord_after_section(1) }}
+          {%- for metrics_param in ec2_metrics %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metrics_param.extra_params|join(',') }}{% if metrics_param.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+            {%- for metric in metrics_param.metrics %}
+          - !Sub '{{ '[' if loop.first else ',' }}["AWS/EC2","{{ metric }}","InstanceId","${MasterInstanceId}"]{{ ']}}' if loop.last else '' }}'
+            {%- endfor -%}
+            {{- update_coord(graph_width, graph_height) }}
+          {%- endfor -%}
+          {{- update_coord_after_section(graph_height) }}
+
+          {#- EBS metrics graphs #}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            EBS Metrics\n"}}'
+          {{- update_coord_after_section(1) }}
+
+          {#- Unconditional EBS metrics #}
+          {%- set ebs_metrics = [{'metrics': ["VolumeReadOps", "VolumeWriteOps"], 'extra_params': ['"title":"Read/Write Ops"']},
+                                 {'metrics': ["VolumeReadBytes", "VolumeWriteBytes"], 'extra_params': ['"title":"Read/Write Bytes"']},
+                                 {'metrics': ["VolumeTotalReadTime", "VolumeTotalWriteTime"], 'extra_params': ['"title":"Total Read/Write Time"']},
+                                 {'metrics': ["VolumeQueueLength"], 'extra_params': ['"title":"Queue Length"']},
+                                 {'metrics': ["VolumeIdleTime"], 'extra_params': ['"title":"Idle Time"']}]
+          -%}
+          {%- set number_of_ebs_volumes = config.NumberOfEBSVol|int -%}
+          {%- set ebs_volume_types = config.VolumeType.split(',') %}
+
+          {%- for metrics_param in ebs_metrics %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metrics_param.extra_params|join(',') }}{% if metrics_param.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+            {%- for i in range(number_of_ebs_volumes) %}
+              {%- set volume_loop = loop %}
+              {%- for metric in metrics_param.metrics %}
+          - !Sub
+            - '{% if volume_loop.first and loop.first %}[{% else %},{% endif %}["AWS/EBS","{{ metric }}","VolumeId","${EBS_Volume{{ i|int +1 }}}"]{% if volume_loop.last and loop.last %}]}}{% endif %}'
+            - EBS_Volume{{ i|int +1 }}: !Select
+                - '{{ i|int }}'
+                - !Ref 'EBSVolumesIds'
+              {%- endfor %}
+            {%- endfor %}
+          {{- update_coord(graph_width, graph_height) -}}
+          {%- endfor %}
+
+          {#- Conditional EBS metrics #}
+          {%- set ebs_metrics_conditions = [{'metric': 'VolumeConsumedReadWriteOps', 'supported_vol_types': ["io1"], 'extra_params': ['"title":"Consumed Read/Write Ops"']},
+                                            {'metric': 'VolumeThroughputPercentage', 'supported_vol_types': ["io1"], 'extra_params': ['"title":"Throughput Percentage"']},
+                                            {'metric': 'BurstBalance', 'supported_vol_types': ["gp2", "st1", "sc1"], 'extra_params': ['"title":"Burst Balance"']}]
+          %}
+          {%- for metric_condition_params in ebs_metrics_conditions %}
+            {%- set is_supported_vol_present = {'bool': False} %}
+            {%- for i in range(number_of_ebs_volumes) if not is_supported_vol_present.bool %}
+              {%- if ebs_volume_types[i] in metric_condition_params.supported_vol_types %} {#- TODO we should break, needs Loop Controls extension #}
+                {%- if is_supported_vol_present.update({'bool': True}) %} {% endif %}
+              {%- endif %}
+            {%- endfor %}
+            {%- if is_supported_vol_present.bool %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metric_condition_params.extra_params|join(',') }}{% if metric_condition_params.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+              {%- set first_metric = {'bool': True} %}
+              {%- for i in range(number_of_ebs_volumes) %}
+                {%- if ebs_volume_types[i] in metric_condition_params.supported_vol_types %}
+          - !Sub
+            - '{% if first_metric.bool %}{{ first_metric.update({'bool': False}) or "" }}[{% else %},{% endif %}["AWS/EBS","{{ metric_condition_params.metric }}","VolumeId","${EBS_Volume{{ i|int +1 }}}"]'
+            - EBS_Volume{{ i|int +1 }}: !Select
+                - '{{ i|int }}'
+                - !Ref 'EBSVolumesIds'
+                {%- endif %}
+              {%- endfor -%}
+              {{- update_coord(graph_width, graph_height) }}
+          - ']}}'
+            {%- endif %} {#- if is_supported_vol_present.bool #}
+          {%- endfor -%}
+          {{ update_coord_after_section(graph_height) }}
+
+          {#- RAID metrics graphs #}
+          {#- Unconditional RAID metrics #}
+          {%- set number_of_raid_volumes = config.RAIDOptions.split(',')[2]|int -%} {#- if NONE, converts to 0! #}
+          {%- if number_of_raid_volumes > 0 %}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            RAID Metrics\n"}}'
+              {{- update_coord_after_section(1) }}
+              {%- set raid_metrics = [{'metrics': ["VolumeReadOps", "VolumeWriteOps"], 'extra_params': ['"title":"Read/Write Ops"']},
+                                     {'metrics': ["VolumeReadBytes", "VolumeWriteBytes"], 'extra_params': ['"title":"Read/Write Bytes"']},
+                                     {'metrics': ["VolumeTotalReadTime", "VolumeTotalWriteTime"], 'extra_params': ['"title":"Total Read/Write Time"']},
+                                     {'metrics': ["VolumeQueueLength"], 'extra_params': ['"title":"Queue Length"']},
+                                     {'metrics': ["VolumeIdleTime"], 'extra_params': ['"title":"Idle Time"']}]
+              %}
+              {%- set raid_volume_type = config.RAIDOptions.split(',')[3] %}
+
+              {%- for metrics_param in raid_metrics %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metrics_param.extra_params|join(',') }}{% if metrics_param.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+                {%- for i in range(number_of_raid_volumes) %}
+                  {%- set volume_loop = loop %}
+                  {%- for metric in metrics_param.metrics %}
+          - !Sub
+            - '{% if volume_loop.first and loop.first %}[{% else %},{% endif %}["AWS/EBS","{{ metric }}","VolumeId","${RAID_Volume{{ i|int +1 }}}"]{% if volume_loop.last and loop.last %}]}}{% endif %}'
+            - RAID_Volume{{ i|int +1 }}: !Select
+                - '{{ i|int }}'
+                - !Ref 'RAIDVolumesIds'
+                  {%- endfor %}
+                {%- endfor %}
+                {{- update_coord(graph_width, graph_height) -}}
+              {%- endfor %}
+
+              {#- Conditional RAID metrics #}
+              {%- set raid_metrics_conditions_params = [{'metric': 'VolumeConsumedReadWriteOps', 'supported_vol_types': ["io1"], 'extra_params': ['"title":"Consumed Read/Write Ops"']},
+                                                {'metric': 'VolumeThroughputPercentage', 'supported_vol_types': ["io1"], 'extra_params': ['"title":"Throughput Percentage"']},
+                                                {'metric': 'BurstBalance', 'supported_vol_types': ["gp2", "st1", "sc1"], 'extra_params': ['"title":"Burst Balance"']}]
+              %}
+              {%- for metric_condition_params in raid_metrics_conditions_params %}
+                {%- if raid_volume_type in metric_condition_params.supported_vol_types %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metric_condition_params.extra_params|join(',') }}{% if metric_condition_params.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+                  {%- for i in range(number_of_raid_volumes) %}
+          - !Sub
+            - '{{ '[' if loop.first else ',' }}["AWS/EBS","{{ metric_condition_params.metric }}","VolumeId","${RAID_Volume{{ i|int +1 }}}"]{{ ']}}' if loop.last else '' }}'
+            - RAID_Volume{{ i|int +1 }}: !Select
+                - '{{ i|int }}'
+                - !Ref 'RAIDVolumesIds'
+                  {%- endfor %}
+                  {{- update_coord(graph_width, graph_height) -}}
+                {%- endif %} {#- if raid_volume_type in metric_condition_params.supported_vol_types #}
+              {%- endfor -%}
+          {%- endif %} {#- if number_of_raid_volumes > 0 #}
+          {%- set efs_shared_dir = config.EFSOptions.split(',')[0] %}
+          {%- if efs_shared_dir not in ["NONE", "/NONE"] %}
+          {# EFS metrics graphs -#}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            EFS Metrics\n"}}'
+            {%- set efs_metrics = [{'metrics': ["BurstCreditBalance"], 'extra_params': ['"title":"Burst Credit Balance"']},
+                                   {'metrics': ["ClientConnections"], 'extra_params': ['"title":"Client Connections"']},
+                                   {'metrics': ["TotalIOBytes"], 'extra_params': ['"title":"Total IO Bytes"']},
+                                   {'metrics': ["PermittedThroughput"], 'extra_params': ['"title":"Permitted Throughput"']},
+                                   {'metrics': ["DataReadIOBytes", "DataWriteIOBytes"], 'extra_params': ['"title":"Data Read/Write IO Bytes"']}]
+            -%}
+            {{ update_coord_after_section(1) }}
+            {%- for metrics_param in efs_metrics %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metrics_param.extra_params|join(',') }}{% if metrics_param.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+              {%- for metric in metrics_param.metrics %}
+          - !Sub '{% if not loop.first %},{% else %}[{% endif %}["AWS/EFS","{{ metric }}","FileSystemId","${EFSFileSystemId}"]{{ ']}}' if loop.last else '' }}'
+              {%- endfor -%}
+              {{ update_coord(graph_width, graph_height) }}
+            {%- endfor %}
+
+            {#- Conditional EFS metrics #}
+            {%- set efs_metrics_conditions_params = [{'metric': 'PercentIOLimit', 'supported_vol_types': ["generalPurpose"], 'extra_params': ['"title":"Percent IO Limit"']}] %}
+            {%- set efs_volume_type = config.EFSOptions.split(',')[2] %}
+            {%- for metric_condition_params in efs_metrics_conditions_params %}
+              {%- if efs_volume_type in metric_condition_params.supported_vol_types %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metric_condition_params.extra_params|join(',') }}{% if metric_condition_params.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+          - !Sub '[["AWS/EFS","{{ metric_condition_params.metric }}","FileSystemId","${EFSFileSystemId}"]]}}'
+              {%- endif %}
+            {%- endfor -%}
+            {{ update_coord(graph_width, graph_height) }}
+
+          {%- endif -%} {#- if efs_shared_dir not in ["NONE", "/NONE"] -#}
+          {{ update_coord_after_section(graph_height) }}
+
+          {%- set fsx_shared_dir = config.FSXOptions.split(',')[0] %}
+          {%- if fsx_shared_dir not in ["NONE", "/NONE"] %}
+          {#- FSx metrics graphs #}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            FSx Metrics\n"}}'
+            {%- set fsx_metrics = [{'metrics': ["DataReadOperations","DataWriteOperations"], 'extra_params': ['"title":"Data Read/Write Ops"','"period":300']},
+                                   {'metrics': ["DataReadBytes","DataWriteBytes"], 'extra_params': ['"title":"Data Read/Write Bytes"','"period":300']},
+                                   {'metrics': ["FreeDataStorageCapacity"], 'extra_params': ['"title":"Free Data Storage Capacity"']}]
+            -%}
+            {{ update_coord_after_section(1) }}
+            {%- for metrics_param in fsx_metrics %}
+          - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
+            {{ metrics_param.extra_params|join(',') }}{% if metrics_param.extra_params|length > 0 %},{% endif %}"region":"${AWS::Region}","metrics":'
+              {%- for metric in metrics_param.metrics %}
+          - !Sub '{{ '[' if loop.first else ',' }}["AWS/FSx","{{ metric }}","FileSystemId","${FSXFileSystemId}"]{{ ']}}' if loop.last else '' }}'
+              {%- endfor -%}
+              {{- update_coord(graph_width, graph_height) }}
+            {%- endfor %}
+          {%- endif %}
+          - ']}'
+

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -286,22 +286,21 @@ Resources:
           {%- endif %}
           {{- update_coord_after_section(graph_height) }}
 
-          {#- Head Node Logs #}
+          {#- Head Node Logs, only if CW Logs are enabled #}
+          {%- set cw_logs_enabled = cfn_params.CWLogOptions.split(',')[0] | bool %}
+          {%- if cw_logs_enabled %}
           - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
             Head Node Logs\n"}}'
-          {{- update_coord_after_section(1) }}
-          {%- set dcv_enabled = (cfn_params.DCVOptions.split(',')[0]=='master') %}
-          {%- set sections_widgets =
+            {{- update_coord_after_section(1) }}
+            {%- set dcv_enabled = (cfn_params.DCVOptions.split(',')[0]=='master') %}
+            {%- set sections_widgets =
             [
               {
                 'section_title': "ParallelCluster''s logs",
                 'widgets': [
                   {
                     'title': "jobwatcher",
-                    'conditions': [
-                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'param': cfn_params.Scheduler, 'allowed_values': ["sge","torque"]}
-                    ],
+                    'conditions': [{'param': cfn_params.Scheduler, 'allowed_values': ["sge","torque"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*jobwatcher"}],
                     'sort': "@timestamp desc",
@@ -309,10 +308,7 @@ Resources:
                   },
                   {
                     'title': "sqswatcher",
-                    'conditions': [
-                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'param': cfn_params.Scheduler, 'allowed_values': ["sge","torque"]}
-                    ],
+                    'conditions': [{'param': cfn_params.Scheduler, 'allowed_values': ["sge","torque"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*sqswatcher"}],
                     'sort': "@timestamp desc",
@@ -320,10 +316,7 @@ Resources:
                   },
                   {
                     'title': "clustermgtd",
-                    'conditions': [
-                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
-                    ],
+                    'conditions': [{'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters':
                       [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*clustermgtd"}],
@@ -332,10 +325,7 @@ Resources:
                   },
                   {
                     'title': "slurm_resume",
-                    'conditions': [
-                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
-                    ],
+                    'conditions': [{'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_resume"}],
                     'sort': "@timestamp desc",
@@ -343,10 +333,7 @@ Resources:
                   },
                   {
                     'title': "slurm_suspend",
-                    'conditions': [
-                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
-                    ],
+                    'conditions': [{'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_suspend"}],
                     'sort': "@timestamp desc",
@@ -359,10 +346,7 @@ Resources:
                 'widgets': [
                   {
                     'title': "slurmctld",
-                    'conditions': [
-                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
-                    ],
+                    'conditions': [{'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*slurmctld"}],
                     'sort': "@timestamp desc",
@@ -371,7 +355,6 @@ Resources:
                   {
                     'title': "sge-qmaster",
                     'conditions': [
-                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
                       {'param': cfn_params.Scheduler, 'allowed_values': ["sge"]}
                     ],
                     'fields': ["@timestamp", "@message"],
@@ -381,10 +364,7 @@ Resources:
                   },
                   {
                     'title': "torque-server",
-                    'conditions': [
-                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                      {'param': cfn_params.Scheduler, 'allowed_values': ["torque"]}
-                    ],
+                    'conditions': [{'param': cfn_params.Scheduler, 'allowed_values': ["torque"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*torque-server"}],
                     'sort': "@timestamp desc",
@@ -458,7 +438,7 @@ Resources:
                 'widgets': [
                   {
                     'title': "system-messages",
-                    'conditions': {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7"]},
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*system-messages"}],
                     'sort': "@timestamp desc",
@@ -474,7 +454,6 @@ Resources:
                   },
                   {
                     'title': "cfn-init",
-                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*cfn-init"}],
                     'sort': "@timestamp desc",
@@ -482,7 +461,6 @@ Resources:
                   },
                   {
                     'title': "chef-client",
-                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*chef-client"}],
                     'sort': "@timestamp desc",
@@ -490,7 +468,6 @@ Resources:
                   },
                   {
                     'title': "cloud-init",
-                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*cloud-init$"}],
                     'sort': "@timestamp desc",
@@ -498,7 +475,6 @@ Resources:
                   },
                   {
                     'title': "supervisord",
-                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
                     'fields': ["@timestamp", "@message"],
                     'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*supervisord"}],
                     'sort': "@timestamp desc",
@@ -507,35 +483,43 @@ Resources:
                 ]
               }
             ]
-          -%}
-          {%- for section_widgets in sections_widgets %}
-            {{- is_logs_section_empty(section_widgets) }}
-            {%- if not empty_section.bool %}
+            -%}
+            {%- for section_widgets in sections_widgets %}
+              {{- is_logs_section_empty(section_widgets) }}
+              {%- if not empty_section.bool %}
           - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             {{ section_widgets.section_title }}\n"}}'
-            {{- update_coord_after_section(1) }}
-              {%- for log_params in section_widgets.widgets %}
-                {%- set passed_condition = {'bool': True} %}
-                {%- for cond_dict in log_params.conditions %}
-                  {%- if cond_dict.param not in cond_dict.allowed_values %}
-                    {%- if passed_condition.update({'bool': False}) %} {% endif %}
-                  {%- endif %}
-                {%- endfor %}
-                {%- if passed_condition.bool %}
+              {{- update_coord_after_section(1) }}
+                {%- for log_params in section_widgets.widgets %}
+                  {%- set passed_condition = {'bool': True} %}
+                  {%- for cond_dict in log_params.conditions %}
+                    {%- if cond_dict.param not in cond_dict.allowed_values %}
+                      {%- if passed_condition.update({'bool': False}) %} {% endif %}
+                    {%- endif %}
+                  {%- endfor %}
+                  {%- if passed_condition.bool %}
           - ',{"type":"log","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ logs_width }},"height":{{ logs_height }},"properties":{"view":"table","stacked":false,'
           - !Sub '"region":"${AWS::Region}","title":"{{ log_params.title }}",'
           - !Sub '"query":"SOURCE ''${CWLogGroupName}'''
           - '| fields {{ log_params.fields|join(', ') }}'
-                  {%- for filter in log_params.filters %}
+                    {%- for filter in log_params.filters %}
           - !Sub '| filter {{ filter.param }} like /{{ filter.pattern }}/'
-                  {%- endfor %}
+                    {%- endfor %}
           - '| sort {{ log_params.sort }}'
           - '| limit {{ log_params.limit }}"}}'
-                  {{- update_coord(logs_width, logs_height) }}
-                {%- endif %}
-              {%- endfor %}
-            {%- endif %}
-          {%- endfor %}
+                    {{- update_coord(logs_width, logs_height) }}
+                  {%- endif %}
+                {%- endfor %}
+              {%- endif %}
+            {%- endfor %}
+          {%- endif %}
           - ']}'
     Condition: CreateDashboard
+Metadata:
+  {#- The following metadata are needed because if CW log is disabled these variables are not used elsewhere. #}
+  MasterPrivateIP: !Ref 'MasterPrivateIP'
+  RAIDVolumesIds: !Ref 'RAIDVolumesIds'
+  EFSFileSystemId: !Ref 'EFSFileSystemId'
+  FSXFileSystemId: !Ref 'FSXFileSystemId'
+  CWLogGroupName: !Ref 'CWLogGroupName'
 

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -1,6 +1,13 @@
 {#- Automatically updated variable to define graph/header section position #}
 {%- set coord = {'x': 0, 'y': 0} %}
 
+{%- set graph_width = 6 %}
+{%- set graph_height = 6 -%}
+{%- set logs_width = 24 %}
+{%- set logs_height = 6 -%}
+
+{%- set empty_section = {'bool': True} %}
+
 {#- Macro to calculate coordinates for the new graph #}
 {#- It updates both x and y values if the graph doesn't fit in the given line #}
 {%- macro update_coord(dx, dy) %}
@@ -15,17 +22,38 @@
   {%- if coord.update({'x': 0, 'y': coord.y+dy}) %} {%- endif %}
 {%- endmacro %}
 
-{%- set graph_width = 6 %}
-{%- set graph_height = 6 -%}
+{#- Macro to reset coordinates #}
+{%- macro reset_coord() %}
+  {%- if coord.update({'x': 0, 'y': 0}) %} {%- endif %}
+{%- endmacro %}
+
+{#- Macro to check if a section will not be empty #}
+{%- macro is_logs_section_empty(section_widgets) %}
+  {%- if empty_section.update({'bool': True}) %} {%- endif %}
+  {%- for log_params in section_widgets.widgets %}
+    {%- for cond_dict in log_params.cond_list %}
+      {%- if cond_dict.attr in cond_dict.attr_values %}
+        {%- if empty_section.update({'bool': False}) %} {% endif %}
+      {%- endif %}
+    {%- endfor %}
+  {%- endfor %}
+{%- endmacro -%}
+
 Parameters:
   {#- Cluster parameters #}
   PclusterStackName:
     Description: Name of the cluster to which this dashboard belongs
     Type: String
-  {#- EC2 parameters #}
+  CWLogGroupName:
+    Description: Name of the CloudWatch Log Group created
+    Type: String
+  {#- Head Node parameters #}
   MasterInstanceId:
     Description: ID of the Master instance
     Type: AWS::EC2::Instance::Id
+  MasterPrivateIP:
+    Description: Private IP of the Master instance
+    Type: String
   {#- EBS parameters #}
   EBSVolumesIds:
     Description: IDs of the EBS volumes used
@@ -241,5 +269,278 @@ Resources:
               {{- update_coord(graph_width, graph_height) }}
             {%- endfor %}
           {%- endif %}
+          - ']}'
+  LogsDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Join
+        - '-'
+        - - !Ref 'PclusterStackName'
+          - Logs
+      DashboardBody: !Join
+        {%- set dcv_enabled = (config.DCVOptions.split(',')[0]=='master') %}
+        - ''
+        - - '{"widgets":['
+          {{- reset_coord() }}
+          {%- set sections_widgets =
+            [
+              {
+                'section_title': "ParallelCluster''s logs",
+                'widgets':
+                  [{
+                   'title': "jobwatcher",
+                   'cond_list': [
+                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_values': ["sge","torque"]}
+                   ],
+                   'fields': ["@timestamp", "@message"],
+                   'filters':
+                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*jobwatcher"}],
+                   'sort': "@timestamp desc",
+                   'limit': 100
+                 },
+                 {
+                   'title': "sqswatcher",
+                   'cond_list': [
+                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_values': ["sge","torque"]}
+                   ],
+                   'fields': ["@timestamp", "@message"],
+                   'filters':
+                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sqswatcher"}],
+                   'sort': "@timestamp desc",
+                   'limit': 100
+                 },
+                 {
+                   'title': "clustermgtd",
+                   'cond_list': [
+                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
+                   ],
+                   'fields': ["@timestamp", "@message"],
+                   'filters':
+                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*clustermgtd"}],
+                   'sort': "@timestamp desc",
+                   'limit': 100
+                 },
+                 {
+                   'title': "slurm_resume",
+                   'cond_list': [
+                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
+                   ],
+                   'fields': ["@timestamp", "@message"],
+                   'filters':
+                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_resume"}],
+                   'sort': "@timestamp desc",
+                   'limit': 100
+                 },
+                 {
+                   'title': "slurm_suspend",
+                   'cond_list': [
+                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
+                   ],
+                   'fields': ["@timestamp", "@message"],
+                   'filters':
+                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_suspend"}],
+                   'sort': "@timestamp desc",
+                   'limit': 100
+                 }
+               ]
+              },
+              {'section_title': "Scheduler''s logs",
+               'widgets': [
+               {
+                 'title': "slurmctld",
+                 'cond_list': [
+                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': config.Scheduler, 'attr_values': ["slurm"]}
+                 ],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurmctld"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "sge-qmaster",
+                 'cond_list': [
+                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': config.Scheduler, 'attr_values': ["sge"]}
+                 ],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sge-qmaster"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "torque-server",
+                 'cond_list': [
+                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                 {'attr': config.Scheduler, 'attr_values': ["torque"]}
+                 ],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*torque-server"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               }]
+              },
+              {'section_title': "NICE DCV integration logs",
+               'widgets': [
+               {
+                 'title': "dcv-ext-authenticator",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-ext-authenticator"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "dcv-authenticator",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-authenticator"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "dcv-agent",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-agent"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "dcv-xsession",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-xsession"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "dcv-server",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-server"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "dcv-session-launcher",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-session-launcher"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "Xdcv",
+                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*Xdcv"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               }]
+              },
+              {'section_title': "System''s logs",
+               'widgets': [
+               {
+                 'title': "system-messages",
+                 'cond_list': {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7"]},
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*system-messages"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "syslog",
+                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["ubuntu1604","ubuntu1804"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*syslog"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "cfn-init",
+                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cfn-init"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "chef-client",
+                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*chef-client"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "cloud-init",
+                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cloud-init$"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               },
+               {
+                 'title': "supervisord",
+                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                 'fields': ["@timestamp", "@message"],
+                 'filters':
+                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*supervisord"}],
+                 'sort': "@timestamp desc",
+                 'limit': 100
+               }]
+              }
+            ]
+          -%}
+          {%- set first_metric = {'bool': True} %}
+          {%- for section_widgets in sections_widgets %}
+            {{- is_logs_section_empty(section_widgets) }}
+            {%- if not empty_section.bool %}
+          - '{% if first_metric.bool %}{{ first_metric.update({'bool': False}) or "" }}{% else %},{% endif %}{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            {{ section_widgets.section_title }}\n"}}'
+            {{- update_coord_after_section(1) }}
+              {%- for log_params in section_widgets.widgets %}
+                {%- set passed_cond = {'bool': True} %}
+                {%- for cond_dict in log_params.cond_list %}
+                  {%- if cond_dict.attr not in cond_dict.attr_values %}
+                    {%- if passed_cond.update({'bool': False}) %} {% endif %}
+                  {%- endif %}
+                {%- endfor %}
+                {%- if passed_cond.bool %}
+          - ',{"type":"log","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ logs_width }},"height":{{ logs_height }},"properties":{"view":"table","stacked":false,'
+          - !Sub '"region":"${AWS::Region}","title":"{{ log_params.title }}",'
+          - !Sub '"query":"SOURCE ''${CWLogGroupName}'''
+          - '| fields {{ log_params.fields|join(', ') }}'
+                  {%- for filter in log_params.filters %}
+          - !Sub '| filter {{ filter.attr }} like /{{ filter.pattern }}/'
+                  {%- endfor %}
+          - '| sort {{ log_params.sort }}'
+          - '| limit {{ log_params.limit }}"}}'
+                  {{- update_coord(logs_width, logs_height) }}
+                {%- endif %}
+              {%- endfor %}
+            {%- endif %}
+          {%- endfor %}
           - ']}'
 

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -1,4 +1,8 @@
-{#- Automatically updated variable to define graph/header section position #}
+{#- Assign the two dictionaries to variables #}
+{%- set cfn_params = config.cfn_params %}
+{%- set json_params = config.json_params %}
+
+{#- Variable to define graph/header section position, updated with macros #}
 {%- set coord = {'x': 0, 'y': 0} %}
 
 {%- set graph_width = 6 %}
@@ -27,12 +31,12 @@
   {%- if coord.update({'x': 0, 'y': 0}) %} {%- endif %}
 {%- endmacro %}
 
-{#- Macro to check if a section will not be empty #}
+{#- Macro to check if a section will be empty #}
 {%- macro is_logs_section_empty(section_widgets) %}
   {%- if empty_section.update({'bool': True}) %} {%- endif %}
   {%- for log_params in section_widgets.widgets %}
-    {%- for cond_dict in log_params.cond_list %}
-      {%- if cond_dict.attr in cond_dict.attr_values %}
+    {%- for cond_dict in log_params.conditions %}
+      {%- if cond_dict.param in cond_dict.allowed_values %}
         {%- if empty_section.update({'bool': False}) %} {% endif %}
       {%- endif %}
     {%- endfor %}
@@ -70,19 +74,26 @@ Parameters:
   FSXFileSystemId:
     Description: ID of the FSx volume used
     Type: String
+Conditions:
+  {#- Enable or disable the creation of the dashboard. Default: Enable #}
+  CreateDashboard: !Equals
+    - 'true'
+    - {% if not json_params.cluster.dashboard or json_params.cluster.dashboard.enable %}'true'{% else %}'false'{% endif %}
 Resources:
   HeadNodeDashboard:
     Type: AWS::CloudWatch::Dashboard
     Properties:
-      DashboardName: !Join
-        - '-'
-        - - !Ref 'PclusterStackName'
-          - HeadNode
+      DashboardName: !Ref 'PclusterStackName'
       DashboardBody: !Join
         - ''
         - - '{"widgets":['
-          {#- Head Node Instance Metrics #}
+          {# Head Node EC2 metrics -#}
+
           - '{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            Head Node EC2 Metrics\n"}}'
+          {{- update_coord_after_section(1) }}
+          {#- Head Node Instance Metrics #}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             Head Node Instance Metrics\n"}}'
           {%- set ec2_metrics = [{'metrics': ["CPUUtilization"], 'extra_params': ['"title":"CPU Utilization"']},
                                  {'metrics': ["NetworkPacketsIn", "NetworkPacketsOut"], 'extra_params': ['"title":"Network Packets In/Out"']},
@@ -102,7 +113,7 @@ Resources:
           {{- update_coord_after_section(graph_height) }}
 
           {#- EBS metrics graphs #}
-          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             EBS Metrics\n"}}'
           {{- update_coord_after_section(1) }}
 
@@ -113,8 +124,8 @@ Resources:
                                  {'metrics': ["VolumeQueueLength"], 'extra_params': ['"title":"Queue Length"']},
                                  {'metrics': ["VolumeIdleTime"], 'extra_params': ['"title":"Idle Time"']}]
           -%}
-          {%- set number_of_ebs_volumes = config.NumberOfEBSVol|int -%}
-          {%- set ebs_volume_types = config.VolumeType.split(',') %}
+          {%- set number_of_ebs_volumes = cfn_params.NumberOfEBSVol|int -%}
+          {%- set ebs_volume_types = cfn_params.VolumeType.split(',') %}
 
           {%- for metrics_param in ebs_metrics %}
           - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
@@ -164,19 +175,20 @@ Resources:
           {{ update_coord_after_section(graph_height) }}
 
           {#- RAID metrics graphs #}
-          {#- Unconditional RAID metrics #}
-          {%- set number_of_raid_volumes = config.RAIDOptions.split(',')[2]|int -%} {#- if NONE, converts to 0! #}
+          {%- set number_of_raid_volumes = cfn_params.RAIDOptions.split(',')[2]|int -%} {#- if NONE, converts to 0! #}
           {%- if number_of_raid_volumes > 0 %}
-          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             RAID Metrics\n"}}'
               {{- update_coord_after_section(1) }}
+
+              {#- Unconditional RAID metrics #}
               {%- set raid_metrics = [{'metrics': ["VolumeReadOps", "VolumeWriteOps"], 'extra_params': ['"title":"Read/Write Ops"']},
                                      {'metrics': ["VolumeReadBytes", "VolumeWriteBytes"], 'extra_params': ['"title":"Read/Write Bytes"']},
                                      {'metrics': ["VolumeTotalReadTime", "VolumeTotalWriteTime"], 'extra_params': ['"title":"Total Read/Write Time"']},
                                      {'metrics': ["VolumeQueueLength"], 'extra_params': ['"title":"Queue Length"']},
                                      {'metrics': ["VolumeIdleTime"], 'extra_params': ['"title":"Idle Time"']}]
               %}
-              {%- set raid_volume_type = config.RAIDOptions.split(',')[3] %}
+              {%- set raid_volume_type = cfn_params.RAIDOptions.split(',')[3] %}
 
               {%- for metrics_param in raid_metrics %}
           - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
@@ -214,11 +226,14 @@ Resources:
                 {%- endif %} {#- if raid_volume_type in metric_condition_params.supported_vol_types #}
               {%- endfor -%}
           {%- endif %} {#- if number_of_raid_volumes > 0 #}
-          {%- set efs_shared_dir = config.EFSOptions.split(',')[0] %}
+
+          {#- EFS metrics graphs #}
+          {%- set efs_shared_dir = cfn_params.EFSOptions.split(',')[0] %}
           {%- if efs_shared_dir not in ["NONE", "/NONE"] %}
-          {# EFS metrics graphs -#}
-          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             EFS Metrics\n"}}'
+
+            {#- Unconditional EFS metrics #}
             {%- set efs_metrics = [{'metrics': ["BurstCreditBalance"], 'extra_params': ['"title":"Burst Credit Balance"']},
                                    {'metrics': ["ClientConnections"], 'extra_params': ['"title":"Client Connections"']},
                                    {'metrics': ["TotalIOBytes"], 'extra_params': ['"title":"Total IO Bytes"']},
@@ -237,7 +252,7 @@ Resources:
 
             {#- Conditional EFS metrics #}
             {%- set efs_metrics_conditions_params = [{'metric': 'PercentIOLimit', 'supported_vol_types': ["generalPurpose"], 'extra_params': ['"title":"Percent IO Limit"']}] %}
-            {%- set efs_volume_type = config.EFSOptions.split(',')[2] %}
+            {%- set efs_volume_type = cfn_params.EFSOptions.split(',')[2] %}
             {%- for metric_condition_params in efs_metrics_conditions_params %}
               {%- if efs_volume_type in metric_condition_params.supported_vol_types %}
           - !Sub ',{"type":"metric","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ graph_width }},"height":{{ graph_height }},"properties":{"view":"timeSeries","stacked":false,
@@ -250,10 +265,10 @@ Resources:
           {%- endif -%} {#- if efs_shared_dir not in ["NONE", "/NONE"] -#}
           {{ update_coord_after_section(graph_height) }}
 
-          {%- set fsx_shared_dir = config.FSXOptions.split(',')[0] %}
-          {%- if fsx_shared_dir not in ["NONE", "/NONE"] %}
           {#- FSx metrics graphs #}
-          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+          {%- set fsx_shared_dir = cfn_params.FSXOptions.split(',')[0] %}
+          {%- if fsx_shared_dir not in ["NONE", "/NONE"] %}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             FSx Metrics\n"}}'
             {%- set fsx_metrics = [{'metrics': ["DataReadOperations","DataWriteOperations"], 'extra_params': ['"title":"Data Read/Write Ops"','"period":300']},
                                    {'metrics': ["DataReadBytes","DataWriteBytes"], 'extra_params': ['"title":"Data Read/Write Bytes"','"period":300']},
@@ -269,271 +284,250 @@ Resources:
               {{- update_coord(graph_width, graph_height) }}
             {%- endfor %}
           {%- endif %}
-          - ']}'
-  LogsDashboard:
-    Type: AWS::CloudWatch::Dashboard
-    Properties:
-      DashboardName: !Join
-        - '-'
-        - - !Ref 'PclusterStackName'
-          - Logs
-      DashboardBody: !Join
-        {%- set dcv_enabled = (config.DCVOptions.split(',')[0]=='master') %}
-        - ''
-        - - '{"widgets":['
-          {{- reset_coord() }}
+          {{- update_coord_after_section(graph_height) }}
+
+          {#- Head Node Logs #}
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+            Head Node Logs\n"}}'
+          {{- update_coord_after_section(1) }}
+          {%- set dcv_enabled = (cfn_params.DCVOptions.split(',')[0]=='master') %}
           {%- set sections_widgets =
             [
               {
                 'section_title': "ParallelCluster''s logs",
-                'widgets':
-                  [{
-                   'title': "jobwatcher",
-                   'cond_list': [
-                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_values': ["sge","torque"]}
-                   ],
-                   'fields': ["@timestamp", "@message"],
-                   'filters':
-                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*jobwatcher"}],
-                   'sort': "@timestamp desc",
-                   'limit': 100
-                 },
-                 {
-                   'title': "sqswatcher",
-                   'cond_list': [
-                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_values': ["sge","torque"]}
-                   ],
-                   'fields': ["@timestamp", "@message"],
-                   'filters':
-                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sqswatcher"}],
-                   'sort': "@timestamp desc",
-                   'limit': 100
-                 },
-                 {
-                   'title': "clustermgtd",
-                   'cond_list': [
-                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
-                   ],
-                   'fields': ["@timestamp", "@message"],
-                   'filters':
-                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*clustermgtd"}],
-                   'sort': "@timestamp desc",
-                   'limit': 100
-                 },
-                 {
-                   'title': "slurm_resume",
-                   'cond_list': [
-                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
-                   ],
-                   'fields': ["@timestamp", "@message"],
-                   'filters':
-                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_resume"}],
-                   'sort': "@timestamp desc",
-                   'limit': 100
-                 },
-                 {
-                   'title': "slurm_suspend",
-                   'cond_list': [
-                   {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                   {'attr': config.Scheduler, 'attr_values': ["slurm"]}
-                   ],
-                   'fields': ["@timestamp", "@message"],
-                   'filters':
-                     [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_suspend"}],
-                   'sort': "@timestamp desc",
-                   'limit': 100
-                 }
-               ]
+                'widgets': [
+                  {
+                    'title': "jobwatcher",
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["sge","torque"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*jobwatcher"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "sqswatcher",
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["sge","torque"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*sqswatcher"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "clustermgtd",
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters':
+                      [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*clustermgtd"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "slurm_resume",
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_resume"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "slurm_suspend",
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*slurm_suspend"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  }
+                ]
               },
-              {'section_title': "Scheduler''s logs",
-               'widgets': [
-               {
-                 'title': "slurmctld",
-                 'cond_list': [
-                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': config.Scheduler, 'attr_values': ["slurm"]}
-                 ],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*slurmctld"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "sge-qmaster",
-                 'cond_list': [
-                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': config.Scheduler, 'attr_values': ["sge"]}
-                 ],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*sge-qmaster"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "torque-server",
-                 'cond_list': [
-                 {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
-                 {'attr': config.Scheduler, 'attr_values': ["torque"]}
-                 ],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*torque-server"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               }]
+              {
+                'section_title': "Scheduler''s logs",
+                'widgets': [
+                  {
+                    'title': "slurmctld",
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["slurm"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*slurmctld"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "sge-qmaster",
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["sge"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*sge-qmaster"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "torque-server",
+                    'conditions': [
+                      {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]},
+                      {'param': cfn_params.Scheduler, 'allowed_values': ["torque"]}
+                    ],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*torque-server"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  }
+                ]
               },
-              {'section_title': "NICE DCV integration logs",
-               'widgets': [
-               {
-                 'title': "dcv-ext-authenticator",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-ext-authenticator"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "dcv-authenticator",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-authenticator"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "dcv-agent",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-agent"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "dcv-xsession",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-xsession"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "dcv-server",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-server"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "dcv-session-launcher",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-session-launcher"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "Xdcv",
-                 'cond_list': [{'attr': dcv_enabled, 'attr_values': [True]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*Xdcv"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               }]
+              {
+                'section_title': "NICE DCV integration logs",
+                'widgets': [
+                  {
+                    'title': "dcv-ext-authenticator",
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-ext-authenticator"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "dcv-authenticator",
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-authenticator"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "dcv-agent",
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-agent"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "dcv-xsession",
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-xsession"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "dcv-server",
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-server"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "dcv-session-launcher",
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*dcv-session-launcher"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "Xdcv",
+                    'conditions': [{'param': dcv_enabled, 'allowed_values': [True]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*Xdcv"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  }
+                ]
               },
-              {'section_title': "System''s logs",
-               'widgets': [
-               {
-                 'title': "system-messages",
-                 'cond_list': {'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7"]},
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*system-messages"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "syslog",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["ubuntu1604","ubuntu1804"]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*syslog"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "cfn-init",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cfn-init"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "chef-client",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*chef-client"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "cloud-init",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*cloud-init$"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               },
-               {
-                 'title': "supervisord",
-                 'cond_list': [{'attr': config.BaseOS, 'attr_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
-                 'fields': ["@timestamp", "@message"],
-                 'filters':
-                   [{'attr': "@logStream", 'pattern': "${MasterPrivateIP}.*supervisord"}],
-                 'sort': "@timestamp desc",
-                 'limit': 100
-               }]
+              {
+                'section_title': "System''s logs",
+                'widgets': [
+                  {
+                    'title': "system-messages",
+                    'conditions': {'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7"]},
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*system-messages"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "syslog",
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["ubuntu1604","ubuntu1804"]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*syslog"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "cfn-init",
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*cfn-init"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "chef-client",
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*chef-client"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "cloud-init",
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*cloud-init$"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  },
+                  {
+                    'title': "supervisord",
+                    'conditions': [{'param': cfn_params.BaseOS, 'allowed_values': ["alinux","alinux2","centos6","centos7","ubuntu1604","ubuntu1804"]}],
+                    'fields': ["@timestamp", "@message"],
+                    'filters': [{'param': "@logStream", 'pattern': "${MasterPrivateIP}.*supervisord"}],
+                    'sort': "@timestamp desc",
+                    'limit': 100
+                  }
+                ]
               }
             ]
           -%}
-          {%- set first_metric = {'bool': True} %}
           {%- for section_widgets in sections_widgets %}
             {{- is_logs_section_empty(section_widgets) }}
             {%- if not empty_section.bool %}
-          - '{% if first_metric.bool %}{{ first_metric.update({'bool': False}) or "" }}{% else %},{% endif %}{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n#
+          - ',{"type":"text","x":{{ coord.x }},"y":{{ coord.y }},"width":24,"height":1,"properties":{"markdown":"\n##
             {{ section_widgets.section_title }}\n"}}'
             {{- update_coord_after_section(1) }}
               {%- for log_params in section_widgets.widgets %}
-                {%- set passed_cond = {'bool': True} %}
-                {%- for cond_dict in log_params.cond_list %}
-                  {%- if cond_dict.attr not in cond_dict.attr_values %}
-                    {%- if passed_cond.update({'bool': False}) %} {% endif %}
+                {%- set passed_condition = {'bool': True} %}
+                {%- for cond_dict in log_params.conditions %}
+                  {%- if cond_dict.param not in cond_dict.allowed_values %}
+                    {%- if passed_condition.update({'bool': False}) %} {% endif %}
                   {%- endif %}
                 {%- endfor %}
-                {%- if passed_cond.bool %}
+                {%- if passed_condition.bool %}
           - ',{"type":"log","x":{{ coord.x }},"y":{{ coord.y }},"width":{{ logs_width }},"height":{{ logs_height }},"properties":{"view":"table","stacked":false,'
           - !Sub '"region":"${AWS::Region}","title":"{{ log_params.title }}",'
           - !Sub '"query":"SOURCE ''${CWLogGroupName}'''
           - '| fields {{ log_params.fields|join(', ') }}'
                   {%- for filter in log_params.filters %}
-          - !Sub '| filter {{ filter.attr }} like /{{ filter.pattern }}/'
+          - !Sub '| filter {{ filter.param }} like /{{ filter.pattern }}/'
                   {%- endfor %}
           - '| sort {{ log_params.sort }}'
           - '| limit {{ log_params.limit }}"}}'
@@ -543,4 +537,5 @@ Resources:
             {%- endif %}
           {%- endfor %}
           - ']}'
+    Condition: CreateDashboard
 

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -633,6 +633,9 @@ Resources:
       ServiceToken: !Ref 'UpdateWaiterFunctionArn'
     Condition: HasUpdateWaiterFunction
 Outputs:
+  MasterInstanceID:
+    Description: ID of the Master instance
+    Value: !Ref 'MasterServer'
   MasterPrivateIP:
     Description: Private IP Address of the Master host
     Value: !GetAtt 'MasterServer.PrivateIp'

--- a/cloudformation/tests/requirements.txt
+++ b/cloudformation/tests/requirements.txt
@@ -2,3 +2,4 @@ pytest
 jinja2
 cfn-lint
 cfn-flip
+assertpy

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -112,6 +112,7 @@ def substack_rendering(tmp_path, template_name, test_config):
                     },
                     "scaling": {"scaledown_idletime": 10},
                     "disable_cluster_dns": False,
+                    "dashboard": {"enable": True},
                 }
             }
         ),
@@ -154,6 +155,7 @@ def substack_rendering(tmp_path, template_name, test_config):
                     },
                     "scaling": {"scaledown_idletime": 10},
                     "disable_cluster_dns": True,
+                    "dashboard": {"enable": True},
                 }
             }
         ),
@@ -166,7 +168,48 @@ def test_hit_substack_rendering(tmp_path, test_config):
 
 
 def test_cw_dashboard_substack_rendering(tmp_path):
-    test_config = {
+    json_params = {
+        "cluster": {
+            "label": "default",
+            "default_queue": "multiple_spot",
+            "queue_settings": {
+                "multiple_spot": {
+                    "compute_type": "spot",
+                    "enable_efa": False,
+                    "disable_hyperthreading": True,
+                    "placement_group": None,
+                    "compute_resource_settings": {
+                        "multiple_spot_c4.xlarge": {
+                            "instance_type": "c4.xlarge",
+                            "min_count": 0,
+                            "max_count": 10,
+                            "spot_price": None,
+                            "vcpus": 2,
+                            "gpus": 0,
+                            "enable_efa": False,
+                            "disable_hyperthreading": True,
+                            "disable_hyperthreading_via_cpu_options": True,
+                        },
+                        "multiple_spot_c5.2xlarge": {
+                            "instance_type": "c5.2xlarge",
+                            "min_count": 1,
+                            "max_count": 5,
+                            "spot_price": 1.5,
+                            "vcpus": 4,
+                            "gpus": 0,
+                            "enable_efa": False,
+                            "disable_hyperthreading": True,
+                            "disable_hyperthreading_via_cpu_options": True,
+                        },
+                    },
+                }
+            },
+            "scaling": {"scaledown_idletime": 10},
+            "disable_cluster_dns": True,
+            "dashboard": {"enable": True},
+        }
+    }
+    cfn_params = {
         "ClusterConfigMetadata": {
             "sections": {
                 "cluster": ["default"],
@@ -233,7 +276,7 @@ def test_cw_dashboard_substack_rendering(tmp_path):
     }
 
     substack_rendering(
-        tmp_path, "cw-dashboard-substack.cfn.yaml", test_config
+        tmp_path, "cw-dashboard-substack.cfn.yaml", {"json_params": json_params, "cfn_params": cfn_params}
     )  # FIXME , ["-i", "W2001"]) # to ignore W2001
     # FIXME Might have to use W2001 as if the Logs dashboard is empty, we do not use variable CWLogGroupName
     # As before, it might not be important as the test does not try to do that (and there is no point in doing that)

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -232,4 +232,8 @@ def test_cw_dashboard_substack_rendering(tmp_path):
         "Cores": "NONE,NONE",
     }
 
-    substack_rendering(tmp_path, "cw-dashboard-substack.cfn.yaml", test_config)  # , ["-i", "W2001"]) # to ignore W2001
+    substack_rendering(
+        tmp_path, "cw-dashboard-substack.cfn.yaml", test_config
+    )  # FIXME , ["-i", "W2001"]) # to ignore W2001
+    # FIXME Might have to use W2001 as if the Logs dashboard is empty, we do not use variable CWLogGroupName
+    # As before, it might not be important as the test does not try to do that (and there is no point in doing that)

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -12,6 +12,26 @@ cfn_formatter = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(cfn_formatter)
 
 
+def substack_rendering(tmp_path, template_name, test_config):
+
+    env = Environment(loader=FileSystemLoader(".."))
+    env.filters["sha1"] = lambda value: hashlib.sha1(value.strip().encode()).hexdigest()
+    template = env.get_template(template_name)
+    output_from_parsed_template = template.render(
+        config=test_config, config_version="version", tags=[{"Key": "TagKey", "Value": "TagValue"}]
+    )
+    rendered_file = tmp_path / template_name
+    rendered_file.write_text(output_from_parsed_template)
+
+    # Run cfn-lint
+    cfn_lint_args = ["--info", str(rendered_file)]  # TODO "-i", "W2001" could be added to ignore unused vars
+    with patch.object(sys, "argv", cfn_lint_args):
+        assert cfnlint() == 0
+
+    # Run format check
+    assert cfn_formatter.check_formatting([str(rendered_file)], "yaml")
+
+
 @pytest.mark.parametrize(
     "test_config",
     [
@@ -142,19 +162,74 @@ spec.loader.exec_module(cfn_formatter)
 )
 def test_hit_substack_rendering(tmp_path, test_config):
 
-    env = Environment(loader=FileSystemLoader(".."))
-    env.filters["sha1"] = lambda value: hashlib.sha1(value.strip().encode()).hexdigest()
-    template = env.get_template("compute-fleet-hit-substack.cfn.yaml")
-    output_from_parsed_template = template.render(
-        config=test_config, config_version="version", tags=[{"Key": "TagKey", "Value": "TagValue"}]
-    )
-    rendered_file = tmp_path / "compute-fleet-hit-substack.cfn.yaml"
-    rendered_file.write_text(output_from_parsed_template)
+    substack_rendering(tmp_path, "compute-fleet-hit-substack.cfn.yaml", test_config)
 
-    # Run cfn-lint
-    cfn_lint_args = ["--info", str(rendered_file)]
-    with patch.object(sys, "argv", cfn_lint_args):
-        assert cfnlint() == 0
 
-    # Run format check
-    assert cfn_formatter.check_formatting([str(rendered_file)], "yaml")
+def test_cw_dashboard_substack_rendering(tmp_path):
+    test_config = {
+        "ClusterConfigMetadata": {
+            "sections": {
+                "cluster": ["default"],
+                "dcv": ["dcv"],
+                "ebs": ["custom1", "custom2", "custom3", "custom4", "custom5"],
+                "efs": ["customfs"],
+                "fsx": ["fsx1"],
+                "raid": ["raidgp2"],
+                "scaling": ["custom"],
+                "vpc": ["default"],
+            }
+        },
+        "KeyName": "first_cluster",
+        "BaseOS": "alinux2",
+        "Scheduler": "slurm",
+        "MasterInstanceType": "t2.micro",
+        "MasterRootVolumeSize": "25",
+        "ComputeRootVolumeSize": "25",
+        "ProxyServer": "NONE",
+        "EC2IAMRoleName": "NONE",
+        "S3ReadResource": "NONE",
+        "S3ReadWriteResource": "NONE",
+        "EFA": "NONE",
+        "EphemeralDir": "/scratch",
+        "EncryptedEphemeral": "false",
+        "CustomAMI": "ami-07fb283f3083e0d00",
+        "PreInstallScript": "NONE",
+        "PreInstallArgs": "NONE",
+        "PostInstallScript": "NONE",
+        "PostInstallArgs": "NONE",
+        "ExtraJson": "{}",
+        "AdditionalCfnTemplate": "NONE",
+        "CustomChefCookbook": "NONE",
+        "IntelHPCPlatform": "false",
+        "ScaleDownIdleTime": "3",
+        "VPCId": "vpc-034545fa84d175bc0",
+        "MasterSubnetId": "subnet-021ceb759253eeb29",
+        "AccessFrom": "0.0.0.0/0",
+        "AdditionalSG": "NONE",
+        "ComputeSubnetId": "subnet-0e49d198bb500e672",
+        "ComputeSubnetCidr": "NONE",
+        "UsePublicIps": "true",
+        "VPCSecurityGroupId": "NONE",
+        "AvailabilityZone": "eu-west-1a",
+        "SharedDir": "vol1,vol2,vol3,vol4,vol5",
+        "EBSSnapshotId": "NONE,NONE,NONE,NONE,NONE",
+        "VolumeType": "gp2,io1,sc1,st1,io1",
+        "VolumeSize": "20,20,500,500,20",
+        "VolumeIOPS": "100,200,100,100,100",
+        "EBSEncryption": "false,false,false,false,false",
+        "EBSKMSKeyId": "NONE,NONE,NONE,NONE,NONE",
+        "EBSVolumeId": "NONE,NONE,NONE,NONE,NONE",
+        "NumberOfEBSVol": "5",
+        "EFSOptions": "efs,NONE,generalPurpose,NONE,NONE,false,bursting,NONE,Valid",
+        # "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE", # TODO: If we use this, should ignore W2001
+        "RAIDOptions": "raid,1,2,gp2,20,100,false,NONE",
+        "FSXOptions": "/fsx,NONE,1200,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+        "DCVOptions": "master,8443,0.0.0.0/0",
+        "CWLogOptions": "true,14",
+        "EC2IAMPolicies": "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",  # FIXME could be removed, added auto
+        # ,arn:aws:iam::aws:policy/CloudWatchFullAccess", # FIXME has been removed, we should see what is required
+        "Architecture": "x86_64",
+        "Cores": "NONE,NONE",
+    }
+
+    substack_rendering(tmp_path, "cw-dashboard-substack.cfn.yaml", test_config)  # , ["-i", "W2001"]) # to ignore W2001

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -4,6 +4,7 @@ import sys
 from unittest.mock import patch
 
 import pytest
+from assertpy import assert_that
 from cfnlint.__main__ import main as cfnlint
 from jinja2 import Environment, FileSystemLoader
 
@@ -16,6 +17,7 @@ def substack_rendering(tmp_path, template_name, test_config):
 
     env = Environment(loader=FileSystemLoader(".."))
     env.filters["sha1"] = lambda value: hashlib.sha1(value.strip().encode()).hexdigest()
+    env.filters["bool"] = lambda value: value.lower() == "true"
     template = env.get_template(template_name)
     output_from_parsed_template = template.render(
         config=test_config, config_version="version", tags=[{"Key": "TagKey", "Value": "TagValue"}]
@@ -30,6 +32,8 @@ def substack_rendering(tmp_path, template_name, test_config):
 
     # Run format check
     assert cfn_formatter.check_formatting([str(rendered_file)], "yaml")
+
+    return output_from_parsed_template
 
 
 @pytest.mark.parametrize(
@@ -167,7 +171,86 @@ def test_hit_substack_rendering(tmp_path, test_config):
     substack_rendering(tmp_path, "compute-fleet-hit-substack.cfn.yaml", test_config)
 
 
-def test_cw_dashboard_substack_rendering(tmp_path):
+@pytest.mark.parametrize(
+    "os, scheduler, dashboard_enabled, ebs_shared_dir, ebs_volume_type, raid_options,"
+    "fsx_options, efs_options, dcv_options, cw_log_options",
+    [
+        (
+            "centos7",
+            "slurm",
+            True,
+            "vol1,vol2,vol3,vol4,vol5",
+            "gp2,io1,sc1,st1,gp2",  # No io1 metrics
+            "raid,1,2,gp2,20,100,false,NONE",
+            "/fsx,NONE,1200,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "efs,NONE,generalPurpose,NONE,NONE,false,bursting,NONE,Valid",
+            "master,8443,0.0.0.0/0",
+            "true,14",
+        ),
+        (
+            "alinux",
+            "sge",
+            True,
+            "vol1,NONE,NONE,NONE,NONE",  # single ebs section
+            "io1,io1,io1,io1,io1",  # No gp2,sc1,st1 metrics
+            "raid,1,2,io1,20,100,false,NONE",  # No gp2,sc1,st1 metrics
+            "/fsx,NONE,1200,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "efs,NONE,maxIO,NONE,NONE,false,bursting,NONE,Valid",  # No conditional EFS metric (maxIO)
+            "master,8443,0.0.0.0/0",
+            "true,14",
+        ),
+        (
+            "ubuntu1804",
+            "torque",
+            True,
+            "shared",  # No ebs section
+            "standard,standard,standard,standard,standard",
+            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",  # No RAID metrics
+            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",  # No FSx metrics
+            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",  # No EFS metrics
+            "NONE,NONE,NONE",  # No DCV logs
+            "true,14",
+        ),
+        (
+            "alinux2",
+            "awsbatch",
+            True,
+            "shared",
+            "sc1,st1,gp2,sc1,st1",
+            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "NONE,NONE,NONE",
+            "false,14",  # No Head Node Logs
+        ),
+        (
+            "ubuntu1604",
+            "slurm",
+            False,  # No dashboard
+            "vol1,vol2,vol3,vol4,vol5",
+            "NONE,NONE,NONE,NONE,NONE",
+            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "NONE,NONE,NONE",
+            "false,14",
+        ),
+    ],
+    ids=["all_enabled", "condition_on_resources", "missing_resources_and_logs", "no_cw_logs", "no_dashboard"],
+)
+def test_cw_dashboard_substack_rendering(
+    tmp_path,
+    os,
+    scheduler,
+    dashboard_enabled,
+    ebs_shared_dir,
+    ebs_volume_type,
+    raid_options,
+    fsx_options,
+    efs_options,
+    dcv_options,
+    cw_log_options,
+):
     json_params = {
         "cluster": {
             "label": "default",
@@ -206,7 +289,7 @@ def test_cw_dashboard_substack_rendering(tmp_path):
             },
             "scaling": {"scaledown_idletime": 10},
             "disable_cluster_dns": True,
-            "dashboard": {"enable": True},
+            "dashboard": {"enable": dashboard_enabled},
         }
     }
     cfn_params = {
@@ -223,8 +306,8 @@ def test_cw_dashboard_substack_rendering(tmp_path):
             }
         },
         "KeyName": "first_cluster",
-        "BaseOS": "alinux2",
-        "Scheduler": "slurm",
+        "BaseOS": os,
+        "Scheduler": scheduler,
         "MasterInstanceType": "t2.micro",
         "MasterRootVolumeSize": "25",
         "ComputeRootVolumeSize": "25",
@@ -254,29 +337,150 @@ def test_cw_dashboard_substack_rendering(tmp_path):
         "UsePublicIps": "true",
         "VPCSecurityGroupId": "NONE",
         "AvailabilityZone": "eu-west-1a",
-        "SharedDir": "vol1,vol2,vol3,vol4,vol5",
+        "SharedDir": ebs_shared_dir,
         "EBSSnapshotId": "NONE,NONE,NONE,NONE,NONE",
-        "VolumeType": "gp2,io1,sc1,st1,io1",
+        "VolumeType": ebs_volume_type,
         "VolumeSize": "20,20,500,500,20",
         "VolumeIOPS": "100,200,100,100,100",
         "EBSEncryption": "false,false,false,false,false",
         "EBSKMSKeyId": "NONE,NONE,NONE,NONE,NONE",
         "EBSVolumeId": "NONE,NONE,NONE,NONE,NONE",
         "NumberOfEBSVol": "5",
-        "EFSOptions": "efs,NONE,generalPurpose,NONE,NONE,false,bursting,NONE,Valid",
-        # "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE", # TODO: If we use this, should ignore W2001
-        "RAIDOptions": "raid,1,2,gp2,20,100,false,NONE",
-        "FSXOptions": "/fsx,NONE,1200,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
-        "DCVOptions": "master,8443,0.0.0.0/0",
-        "CWLogOptions": "true,14",
-        "EC2IAMPolicies": "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",  # FIXME could be removed, added auto
-        # ,arn:aws:iam::aws:policy/CloudWatchFullAccess", # FIXME has been removed, we should see what is required
+        "EFSOptions": efs_options,
+        "RAIDOptions": raid_options,
+        "FSXOptions": fsx_options,
+        "DCVOptions": dcv_options,
+        "CWLogOptions": cw_log_options,
+        "EC2IAMPolicies": "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
         "Architecture": "x86_64",
         "Cores": "NONE,NONE",
     }
 
-    substack_rendering(
+    rendered_template = substack_rendering(
         tmp_path, "cw-dashboard-substack.cfn.yaml", {"json_params": json_params, "cfn_params": cfn_params}
-    )  # FIXME , ["-i", "W2001"]) # to ignore W2001
-    # FIXME Might have to use W2001 as if the Logs dashboard is empty, we do not use variable CWLogGroupName
-    # As before, it might not be important as the test does not try to do that (and there is no point in doing that)
+    )
+
+    _verify_ec2_metrics_conditions(
+        rendered_template, ebs_shared_dir, ebs_volume_type, raid_options, efs_options, fsx_options
+    )
+    _verify_head_node_logs_conditions(rendered_template, cw_log_options, os, scheduler, dcv_options)
+
+
+def _verify_ec2_metrics_conditions(
+    rendered_template, ebs_shared_dir, ebs_volume_type, raid_options, efs_options, fsx_options
+):
+    """Verify conditions related to EC2 metrics."""
+    if ebs_shared_dir.split(",")[0] != "NONE":
+        assert_that(rendered_template).contains("EBS Metrics")
+    else:
+        assert_that(rendered_template).does_not_contain("EBS Metrics")
+
+    if raid_options.split(",")[0] != "NONE":
+        assert_that(rendered_template).contains("RAID Metrics")
+    else:
+        assert_that(rendered_template).does_not_contain("RAID Metrics")
+
+    # conditional EBS metrics
+    if any("io1" in options for options in [ebs_volume_type, raid_options]):
+        assert_that(rendered_template).contains("Consumed Read/Write Ops")
+        assert_that(rendered_template).contains("Throughput Percentage")
+    else:
+        assert_that(rendered_template).does_not_contain("Consumed Read/Write Ops")
+        assert_that(rendered_template).does_not_contain("Throughput Percentage")
+
+    # conditional EBS and RAID metrics
+    ebs_burst_balance = any(vol_type in ebs_volume_type for vol_type in ["gp1", "st1", "sc1"])
+    raid_burst_balance = any(vol_type in raid_options for vol_type in ["gp1", "st1", "sc1"])
+    if ebs_burst_balance or raid_burst_balance:
+        assert_that(rendered_template).contains("Burst Balance")
+    else:
+        assert_that(rendered_template).does_not_contain("Burst Balance")
+
+    if efs_options.split(",")[0] != "NONE":
+        assert_that(rendered_template).contains("EFS Metrics")
+
+        # conditional EFS metrics
+        if "generalPurpose" in efs_options:
+            assert_that(rendered_template).contains("PercentIOLimit")
+        else:
+            assert_that(rendered_template).does_not_contain("PercentIOLimit")
+    else:
+        assert_that(rendered_template).does_not_contain("EFS Metrics")
+
+    if fsx_options.split(",")[0] != "NONE":
+        assert_that(rendered_template).contains("FSx Metrics")
+    else:
+        assert_that(rendered_template).does_not_contain("FSx Metrics")
+
+
+def _verify_head_node_logs_conditions(rendered_template, cw_log_options, os, scheduler, dcv_options):
+    """Verify conditions related to the Head Node Logs section."""
+    if cw_log_options.split(",")[0] != "false":
+        assert_that(rendered_template).contains("Head Node Logs")
+
+        # Conditional Scheduler logs
+        if scheduler == "slurm":
+            assert_that(rendered_template).contains("clustermgtd")
+            assert_that(rendered_template).contains("slurm_resume")
+            assert_that(rendered_template).contains("slurm_suspend")
+            assert_that(rendered_template).contains("slurmctld")
+            assert_that(rendered_template).does_not_contain("jobwatcher")
+            assert_that(rendered_template).does_not_contain("sqswatcher")
+            assert_that(rendered_template).does_not_contain("sge-qmaster")
+            assert_that(rendered_template).does_not_contain("torque-server")
+        elif scheduler == "sge":
+            assert_that(rendered_template).contains("jobwatcher")
+            assert_that(rendered_template).contains("sqswatcher")
+            assert_that(rendered_template).contains("sge-qmaster")
+            assert_that(rendered_template).does_not_contain("torque-server")
+            assert_that(rendered_template).does_not_contain("clustermgtd")
+            assert_that(rendered_template).does_not_contain("slurm_resume")
+            assert_that(rendered_template).does_not_contain("slurm_suspend")
+            assert_that(rendered_template).does_not_contain("slurmctld")
+        elif scheduler == "torque":
+            assert_that(rendered_template).contains("jobwatcher")
+            assert_that(rendered_template).contains("sqswatcher")
+            assert_that(rendered_template).contains("torque-server")
+            assert_that(rendered_template).does_not_contain("sge-qmaster")
+            assert_that(rendered_template).does_not_contain("clustermgtd")
+            assert_that(rendered_template).does_not_contain("slurm_resume")
+            assert_that(rendered_template).does_not_contain("slurm_suspend")
+            assert_that(rendered_template).does_not_contain("slurmctld")
+        else:  # scheduler == "awsbatch"
+            assert_that(rendered_template).does_not_contain("jobwatcher")
+            assert_that(rendered_template).does_not_contain("sqswatcher")
+            assert_that(rendered_template).does_not_contain("torque-server")
+            assert_that(rendered_template).does_not_contain("sge-qmaster")
+            assert_that(rendered_template).does_not_contain("clustermgtd")
+            assert_that(rendered_template).does_not_contain("slurm_resume")
+            assert_that(rendered_template).does_not_contain("slurm_suspend")
+            assert_that(rendered_template).does_not_contain("slurmctld")
+
+        # conditional DCV logs
+        if dcv_options.split(",")[0] != "NONE":
+            assert_that(rendered_template).contains("NICE DCV integration logs")
+            assert_that(rendered_template).contains("dcv-ext-authenticator")
+            assert_that(rendered_template).contains("dcv-authenticator")
+            assert_that(rendered_template).contains("dcv-agent")
+            assert_that(rendered_template).contains("dcv-xsession")
+            assert_that(rendered_template).contains("dcv-server")
+            assert_that(rendered_template).contains("dcv-session-launcher")
+            assert_that(rendered_template).contains("Xdcv")
+        else:
+            assert_that(rendered_template).does_not_contain("NICE DCV integration logs")
+
+        # Conditional System logs
+        if os in ["alinux", "alinux2", "centos6", "centos7"]:
+            assert_that(rendered_template).contains("system-messages")
+            assert_that(rendered_template).does_not_contain("syslog")
+        elif os in ["ubuntu1604", "ubuntu1804"]:
+            assert_that(rendered_template).contains("syslog")
+            assert_that(rendered_template).does_not_contain("system-messages")
+
+        assert_that(rendered_template).contains("cfn-init")
+        assert_that(rendered_template).contains("chef-client")
+        assert_that(rendered_template).contains("cloud-init")
+        assert_that(rendered_template).contains("supervisord")
+
+    else:
+        assert_that(rendered_template).does_not_contain("Head Node Logs")

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -71,6 +71,7 @@ def pytest_addoption(parser):
     parser.addoption("--custom-awsbatch-template-url", help="url to a custom awsbatch template")
     parser.addoption("--template-url", help="url to a custom cfn template")
     parser.addoption("--hit-template-url", help="url to a custom HIT cfn template")
+    parser.addoption("--cw-dashboard-template-url", help="url to a custom Dashboard cfn template")
     parser.addoption("--custom-awsbatchcli-package", help="url to a custom awsbatch cli package")
     parser.addoption("--custom-node-package", help="url to a custom node package")
     parser.addoption("--custom-ami", help="custom AMI to use in the tests")
@@ -364,6 +365,7 @@ def add_custom_packages_configs(cluster_config, request, region):
     for custom_option in [
         "template_url",
         "hit_template_url",
+        "cw_dashboard_template_url",
         "custom_chef_cookbook",
         "custom_ami",
         "pre_install",

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -56,6 +56,7 @@ TEST_DEFAULTS = {
     "custom_template_url": None,
     "custom_awsbatchcli_url": None,
     "custom_hit_template_url": None,
+    "custom_cw_dashboard_template_url": None,
     "custom_ami": None,
     "pre_install": None,
     "post_install": None,
@@ -222,6 +223,11 @@ def _init_argparser():
         help="URL to a custom hit cfn template.",
         default=TEST_DEFAULTS.get("custom_hit_template_url"),
         type=_is_url,
+    )
+    custom_group.add_argument(
+        "--custom-cw-dashboard-template-url",
+        help="URL to a custom dashboard cfn template.",
+        default=TEST_DEFAULTS.get("custom_cw_dashboard_template_url"),
     )
     custom_group.add_argument(
         "--custom-awsbatchcli-url",
@@ -425,6 +431,9 @@ def _set_custom_packages_args(args, pytest_args):  # noqa: C901
 
     if args.custom_hit_template_url:
         pytest_args.extend(["--hit-template-url", args.custom_hit_template_url])
+
+    if args.custom_cw_dashboard_template_url:
+        pytest_args.extend(["--cw-dashboard-template-url", args.custom_cw_dashboard_template_url])
 
     if args.custom_awsbatchcli_url:
         pytest_args.extend(["--custom-awsbatchcli-package", args.custom_awsbatchcli_url])

--- a/tests/integration-tests/tests/dashboard/__init__.py
+++ b/tests/integration-tests/tests/dashboard/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.

--- a/tests/integration-tests/tests/dashboard/test_dashboard.py
+++ b/tests/integration-tests/tests/dashboard/test_dashboard.py
@@ -1,0 +1,47 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import boto3
+import pytest
+from assertpy import assert_that
+from botocore.exceptions import ClientError
+
+
+@pytest.mark.dimensions("eu-west-1", "c5.xlarge", "centos7", "slurm")
+@pytest.mark.usefixtures("instance", "os", "scheduler")
+@pytest.mark.parametrize("dashboard_enabled, cw_log_enabled", [(True, True), (True, False), (False, False)])
+def test_dashboard(
+    dashboard_enabled,
+    cw_log_enabled,
+    region,
+    pcluster_config_reader,
+    clusters_factory,
+    test_datadir,
+):
+    cluster_config = pcluster_config_reader(
+        dashboard_enabled=str(dashboard_enabled).lower(),
+        cw_log_enabled=str(cw_log_enabled).lower(),
+    )
+    cluster = clusters_factory(cluster_config)
+    cw_client = boto3.client("cloudwatch", region_name=region)
+
+    if dashboard_enabled:
+        response = cw_client.get_dashboard(DashboardName=cluster.cfn_name)
+        assert_that(response["DashboardName"]).is_equal_to(cluster.cfn_name)
+        if cw_log_enabled:
+            assert_that(response["DashboardBody"]).contains("Head Node Logs")
+        else:
+            assert_that(response["DashboardBody"]).does_not_contain("Head Node Logs")
+    else:
+        try:
+            cw_client.get_dashboard(DashboardName=cluster.cfn_name)
+        except ClientError as e:
+            assert_that(e.response["Error"]["Code"]).is_equal_to("ResourceNotFound")

--- a/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.ini
+++ b/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.ini
@@ -1,0 +1,25 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+initial_queue_size = 0
+dashboard_settings = test
+cw_log_settings = test
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+
+[dashboard test]
+enable = {{ dashboard_enabled }}
+
+[cw_log test]
+enable = {{ cw_log_enabled }}

--- a/util/uploadTemplate.sh
+++ b/util/uploadTemplate.sh
@@ -116,6 +116,7 @@ main() {
     echo "Done. Add the following variables to the pcluster config file, under the [cluster ...] section"
     echo "template_url = https://${_s3_folder_url}/aws-parallelcluster.cfn.json"
     echo "hit_template_url = s3://${_bucket}/${_templates_folder}/compute-fleet-hit-substack.cfn.yaml"
+    echo "cw_dashboard_template_url = s3://${_bucket}/${_templates_folder}/cw-dashboard-substack.cfn.yaml"
 }
 
 main "$@"


### PR DESCRIPTION
# Add CloudWatch dashboard for head node EC2 metrics

When creating a cluster, a CloudWatch dashboard will be automatically created.
It contains information about the Head Node: metrics about the EC2 instance, the EBS/RAID volumes and EFS/FSx file systems.
The code is flexible: it allows to add `extra_parameters` to properties of each widget (such as the title, as is already done).

### Tests

* Added test to check the jinja template rendering
* Added test to check that the function is called when calling `_create_bucket_with_resources`.
* Manual tests done with sge, torque and awsbatch but most of the tests were done with slurm.
* If changing the code (e.g. by adding extra_parameters) some problems might happen when testing: if a sentence in the rendered template is too long, it will break the `rendering_template` test.

# Add CloudWatch Logs Dashboard 
This new dashboard contains all the useful logs that are available with AWS ParallelCluster.
The code is flexible and makes it possible to add easily other logs in the future but also makes it possible to choose the filters we apply to the log (only see warnings for example by modifying the regex).

We only show the logs of the Head Node.

# Unify dashboards and permit to disable dashboard

### Enabling/disabling the dashboard
Before this commit, we were creating two different dashboards, one for the EC2 metrics and one for the logs.
Both the dashboard were automatically created with the cluster.
Now, the two dashboards have been unified into a single one and the user can choose to enable (default behaviour) or disable it.

Changes:
* A new parameter `dashboard_settings` in the `cluster` section
* A new `dashboard` section
* A new `enable` boolean param in the `dashboard` section

### Updating the cluster
During a `pcluster update` the dashboard will be updated accordingly to the new settings.
It is also possible to enable/disable the dashboard during the update.

### Tests
* Added tests for the new cluster parameter `dashboard_settings` and for the new section `dashboard`.
* Adapted template rendering tests.


# Add Head Node logs only if CW Logs are enabled and add tests

The logs file are present in CloudWatch only if the cw_log feature is enabled.

### Unit Tests

Added more unit tests for dashboard substack rendering:
Now we're testing all the conditions that change the rendered template.
* CloudWatch logs: if not enabled we don't add the logs widgets
* DCV: conditional log files
* EBS and RAID volume type: conditional EC2 metrics
* EFS performance mode: conditional EC2 metric
* Dashboard enabled: global condition for the substack

### Integration Tests
Extended `test_runner` to specify a custom dashboard template url 
This new parameter is required, because the dashboard template is rendered starting from a source template that is not yet available in the official ParallelCluster S3 buckets.

Added integration tests for the following use cases:
* dashboard created and contain Head Node Logs
* dashboard created without Head Node Logs (CW logs feature disabled)
* dashboard not created

### Manual Tests
* dashboard with default configuration
* dashboard created without Head Node Logs (CW logs feature disabled)


# Additional info

This patch replaces: https://github.com/aws/aws-parallelcluster/pull/1941

Changes:
* _Add CloudWatch dashboard for head node metrics_, is the same as before: https://github.com/aws/aws-parallelcluster/pull/1941/commits/c927134ec31931dd93ee6774d3832532d527ba2d
* _Add CloudWatch Logs Dashboard_ includes the 3 old commits:
    * intermediate commit to test sections https://github.com/aws/aws-parallelcluster/pull/1941/commits/4ae7d5b26325146fe9779dd71275745a20471698
    * Handle empty sections in Logs Dashboard … https://github.com/aws/aws-parallelcluster/pull/1941/commits/4424892f7d6303a62a2ff539feb7d7c7a6e84a68
    * Filter Head Node logs … https://github.com/aws/aws-parallelcluster/pull/1941/commits/efd976f834a362513d34469ee73db2274cda036c
* _Unify dashboards and permit to disable dashboard_ includes the following commits:
  * Enable/disable dashboard + fix update + tests … https://github.com/aws/aws-parallelcluster/pull/1941/commits/9d8683d856db281f727bcb3663573b3902892e1b
  * Better format cw-dashboard-substack.cfn.yaml … https://github.com/aws/aws-parallelcluster/pull/1941/commits/07bc66b7c3c0e2f464c0ce426c2f68687fdb7ace
  * Fix Param type of dashboard_settings and Better format cw-dashboard-s… … https://github.com/aws/aws-parallelcluster/pull/1941/commits/a3ee6919808266ca1d16d5bf5a55db686c4e5f83
  * Fix variable names … https://github.com/aws/aws-parallelcluster/pull/1941/commits/362ede7c5da34ec5f68e54f64b22dcb37f32d56a
  * Add dashboard section test …  https://github.com/aws/aws-parallelcluster/pull/1941/commits/c7067c34d5ecc5b94de677896bccca2606cb2989
* _Extend test_runner to specify a custom dashboard template url_ is a new commit to support integration tests