### PR TITLE
Revert "Pin pytest to <6.1"

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -6,7 +6,7 @@ fabric
 jinja2
 junitparser
 pexpect
-pytest<6.1
+pytest
 pytest-datadir
 pytest-html
 pytest-rerunfailures


### PR DESCRIPTION
This reverts commit 977df5d6b634d260803451f4fafbdc2213ce8afb.

The upstream issue appears to have been fixed. See [here](https://github.com/pytest-dev/pytest-rerunfailures/issues/128).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
