### PR TITLE
Centos8: Fix yum proxy setting

### DIFF
--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -222,7 +222,16 @@ Resources:
 
               #!/bin/bash -x
 
-              which yum && echo "proxy=${YumProxy}" >> /etc/yum.conf || echo "Not yum system"
+              which dnf 2>/dev/null; dnf=$?
+              which yum 2>/dev/null; yum=$?
+
+              if [ "${!dnf}" == "0" ]; then
+                echo "proxy=${DnfProxy}" >> /etc/dnf/dnf.conf
+              elif [ "${!yum}" == "0" ]; then
+                echo "proxy=${YumProxy}" >> /etc/yum.conf
+              else
+                echo "Not yum system"
+              fi
 
               which apt-get && echo "Acquire::http::Proxy \"${AptProxy}\";" >> /etc/apt/apt.conf || echo "Not apt system"
 
@@ -402,6 +411,10 @@ Resources:
               # End of file
               --==BOUNDARY==
             - YumProxy: !If
+                - UseProxy
+                - !Ref 'ProxyServer'
+                - _none_
+              DnfProxy: !If
                 - UseProxy
                 - !Ref 'ProxyServer'
                 - ''

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -310,7 +310,16 @@ Resources:
 
               #!/bin/bash -x
 
-              which yum && echo "proxy=${YumProxy}" >> /etc/yum.conf || echo "Not yum system"
+              which dnf 2>/dev/null; dnf=$?
+              which yum 2>/dev/null; yum=$?
+
+              if [ "${!dnf}" == "0" ]; then
+                echo "proxy=${DnfProxy}" >> /etc/dnf/dnf.conf
+              elif [ "${!yum}" == "0" ]; then
+                echo "proxy=${YumProxy}" >> /etc/yum.conf
+              else
+                echo "Not yum system"
+              fi
 
               which apt-get && echo "Acquire::http::Proxy \"${AptProxy}\";" >> /etc/apt/apt.conf || echo "Not apt system"
 
@@ -495,6 +504,10 @@ Resources:
               # End of file
               --==BOUNDARY==
             - YumProxy: !If
+                - UseProxy
+                - !Ref 'ProxyServer'
+                - _none_
+              DnfProxy: !If
                 - UseProxy
                 - !Ref 'ProxyServer'
                 - ''

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -353,7 +353,16 @@ Resources:
 
               #!/bin/bash -x
 
-              which yum && echo "proxy=${YumProxy}" >> /etc/yum.conf || echo "Not yum system"
+              which dnf 2>/dev/null; dnf=$?
+              which yum 2>/dev/null; yum=$?
+
+              if [ "${!dnf}" == "0" ]; then
+                echo "proxy=${DnfProxy}" >> /etc/dnf/dnf.conf
+              elif [ "${!yum}" == "0" ]; then
+                echo "proxy=${YumProxy}" >> /etc/yum.conf
+              else
+                echo "Not yum system"
+              fi
 
               which apt-get && echo "Acquire::http::Proxy \"${AptProxy}\";" >> /etc/apt/apt.conf || echo "Not apt system"
 
@@ -459,6 +468,10 @@ Resources:
               # End of file
               --==BOUNDARY==
             - YumProxy: !If
+                - UseProxy
+                - !Ref 'ProxyServer'
+                - _none_
+              DnfProxy: !If
                 - UseProxy
                 - !Ref 'ProxyServer'
                 - ''


### PR DESCRIPTION
* Revert yum proxy setting changes introduced in c81bf97f7486a8eff9d901549e0b5454980465d1
* Restore `proxy=_none_` as default proxy setting for yum
* Add custom logic to use `proxy=` (empty string) instead of `proxy=_none_` when dnf system. `proxy=_none_` will break dnf.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
