### PR TITLE
Fix extra json "cluster" vs "cfncluster" in pcluster update

### DIFF
--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -309,15 +309,15 @@ class ExtraJsonCfnParam(JsonCfnParam):
             self.value["cfncluster"] = self.value.pop("cluster")
         return self.get_string_value()
 
-    def to_file(self, config_parser, write_defaults=False):
-        """Set parameter in the config_parser in the right section.
+    def refresh(self):
+        """
+        Refresh the extra_jason.
 
         The extra_json configuration parameter can contain both "cfncluster" or "cluster" keys but
-        we are writing "cluster" in the file to suggest the users the recommended syntax.
+        we are using "cluster" in CLI to suggest the users the recommended syntax.
         """
         if self.value and "cfncluster" in self.value:
             self.value["cluster"] = self.value.pop("cfncluster")
-        super(ExtraJsonCfnParam, self).to_file(config_parser)
 
 
 class SharedDirCfnParam(CfnParam):

--- a/cli/tests/pcluster/config/test_param_to_file.py
+++ b/cli/tests/pcluster/config/test_param_to_file.py
@@ -43,12 +43,6 @@ from tests.pcluster.config.utils import get_cfnparam_definition, get_mocked_pclu
             {"cluster": {"cfn_scheduler_slots": "cores"}},
             '{"cluster": {"cfn_scheduler_slots": "cores"}}',
         ),
-        (
-            CLUSTER_SIT,
-            "extra_json",
-            {"cfncluster": {"cfn_scheduler_slots": "cores"}},
-            '{"cluster": {"cfn_scheduler_slots": "cores"}}',
-        ),
     ],
 )
 def test_param_to_file(mocker, section_definition, param_key, param_value, expected_value):

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/original_config_file.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/original_config_file.ini
@@ -10,6 +10,7 @@ compute_instance_type = t2.nano
 max_queue_size = 14
 initial_queue_size = 13
 maintain_initial_size = true
+extra_json = {"cfncluster": {"key": "value"}}
 
 [vpc default]
 vpc_id = vpc-12345678

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/pcluster.config.ini
@@ -11,6 +11,7 @@ max_queue_size = 14
 initial_queue_size = 13
 maintain_initial_size = true
 base_os = alinux2
+extra_json = {"cluster": {"key": "value"}}
 
 [vpc default]
 vpc_id = vpc-12345678


### PR DESCRIPTION
This is a compatibility fix. We have been allowing user to either use "cluster" and "cfncluster" in extra json field. And we are encouraging user to use "cluster". This commit will make sure we use "cluster" everywhere in CLI and only transform it to "cfncluster" when we want to send it to CloudFormation.
Notice: if auto_refresh == False, you may get cfncluster when reading from a config file.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
