### PR TITLE
Upgrade x86_64 CodeBuild image

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ CHANGELOG
 
 * Enable support for NICE DCV in GovCloud regions.
 
+**CHANGES**
+
+* Upgrade image used by CodeBuild environment when building container images for Batch clusters.
+
 2.9.1
 =====
 

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -646,7 +646,7 @@
             "Fn::If": [
               "UseArmCodeBuildImage",
               "aws/codebuild/amazonlinux2-aarch64-standard:1.0",
-              "aws/codebuild/amazonlinux2-x86_64-standard:1.0"
+              "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
             ]
           },
           "Type": {


### PR DESCRIPTION
There are two reasons to upgrade this image. The x86_64 image we
currently use is deprecated, and this deprecated image is not supported
in govcloud. In order to support that partition we need to use a newer
image.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
