### PR TITLE
Validator for multiple "shared_dir"

### DIFF
--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -1203,8 +1203,8 @@ class VolumeSizeParam(IntCfnParam):
         """
         We need this method to check whether the user have an input on ebs volume_size.
 
-        If the volume_size is not specified by an user, we will crate an EBS volume with default volume size. The
-        default volume size would be 20 if it is not created from a specified snapshot, Otherwise it will be equal to
+        If the volume_size is not specified by an user, we will create an EBS volume with default volume size. The
+        default volume size would be 20 if it is not created from a specified snapshot, otherwise it will be equal to
         the size of the specified EBS snapshot.
         """
         section = self.pcluster_config.get_section(self.section_key, self.section_label)

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -56,6 +56,7 @@ from pcluster.config.validators import (
     dcv_enabled_validator,
     disable_hyperthreading_architecture_validator,
     disable_hyperthreading_validator,
+    duplicate_shared_dir_validator,
     ebs_settings_validator,
     ebs_volume_iops_validator,
     ebs_volume_size_snapshot_validator,
@@ -97,6 +98,7 @@ from pcluster.config.validators import (
 )
 from pcluster.constants import CIDR_ALL_IPS, FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT, SUPPORTED_ARCHITECTURES
 
+CLUSTER_COMMON_VALIDATORS = [duplicate_shared_dir_validator]
 # This file contains a definition of all the sections and the parameters configurable by the user
 # in the configuration file.
 
@@ -933,7 +935,7 @@ CLUSTER_SIT = {
     "key": "cluster",
     "default_label": "default",
     "cluster_model": "SIT",
-    "validators": [cluster_validator],
+    "validators": [cluster_validator] + CLUSTER_COMMON_VALIDATORS,
     "params": OrderedDict(
         CLUSTER_COMMON_PARAMS + [
             ("placement_group", {
@@ -1030,6 +1032,7 @@ CLUSTER_HIT = {
     "key": "cluster",
     "default_label": "default",
     "cluster_model": "HIT",
+    "validators": CLUSTER_COMMON_VALIDATORS,
     "params": OrderedDict(
         CLUSTER_COMMON_PARAMS + [
             ("default_queue", {

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -1523,3 +1523,28 @@ def validate_storage_type_options(
                     FSX_SSD_THROUGHPUT
                 )
             )
+
+
+def duplicate_shared_dir_validator(section_key, section_label, pcluster_config):
+    errors = []
+    warnings = []
+    config_parser = pcluster_config.config_parser
+    section = pcluster_config.get_section(section_key, section_label)
+    if config_parser:
+        shared_dir_in_cluster = config_parser.has_option(get_file_section_name("cluster", section_label), "shared_dir")
+        ebs_settings_in_cluster = config_parser.has_option(
+            get_file_section_name("cluster", section_label), "ebs_settings"
+        )
+        if shared_dir_in_cluster and ebs_settings_in_cluster:
+            list_of_ebs_sections = []
+            for ebs_section_label in section.get_param_value("ebs_settings").split(","):
+                ebs_section = pcluster_config.get_section("ebs", ebs_section_label.strip())
+                list_of_ebs_sections.append(ebs_section)
+            # if there is only one EBS section configured, check whether "shared_dir" is in the EBS section
+            if len(list_of_ebs_sections) == 1 and list_of_ebs_sections[0].get_param_value("shared_dir"):
+                errors.append("'shared_dir' can not be specified both in cluster section and EBS section")
+            # if there are multiple EBS sections configured, provide an error message
+            elif len(list_of_ebs_sections) > 1:
+                errors.append("'shared_dir' can not be specified in cluster section when using multiple EBS volumes")
+
+    return errors, warnings

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -2505,3 +2505,62 @@ def test_ebs_volume_size_snapshot_validator(
     utils.assert_param_validator(
         mocker, config_parser_dict, expected_error=expected_error, capsys=capsys, expected_warning=expected_warning
     )
+
+
+@pytest.mark.parametrize(
+    "cluster_section_dict, ebs_section_dict1, ebs_section_dict2, expected_message",
+    [
+        (
+            {"shared_dir": "shared_directory", "ebs_settings": "vol1"},
+            {"volume_size": 30},
+            {},
+            None,
+        ),
+        (
+            {"shared_dir": "shared_directory", "ebs_settings": "vol1"},
+            {"shared_dir": "shared_directory1"},
+            {},
+            "'shared_dir' can not be specified both in cluster section and EBS section",
+        ),
+        (
+            {"shared_dir": "shared_directory", "ebs_settings": "vol1, vol2"},
+            {"shared_dir": "shared_directory1", "volume_size": 30},
+            {"shared_dir": "shared_directory2", "volume_size": 30},
+            "'shared_dir' can not be specified in cluster section when using multiple EBS volumes",
+        ),
+        (
+            {"ebs_settings": "vol1, vol2"},
+            {"shared_dir": "shared_directory1", "volume_size": 30},
+            {"shared_dir": "shared_directory2", "volume_size": 30},
+            None,
+        ),
+        (
+            {"ebs_settings": "vol1"},
+            {"volume_size": 30},
+            {},
+            None,
+        ),
+        (
+            {"ebs_settings": "vol1"},
+            {},
+            {},
+            None,
+        ),
+        (
+            {"shared_dir": "shared_directory"},
+            {},
+            {},
+            None,
+        ),
+    ],
+)
+def test_duplicate_shared_dir_validator(
+    mocker, cluster_section_dict, ebs_section_dict1, ebs_section_dict2, expected_message
+):
+    config_parser_dict = {
+        "cluster default": cluster_section_dict,
+        "ebs vol1": ebs_section_dict1,
+        "ebs vol2": ebs_section_dict2,
+    }
+
+    utils.assert_param_validator(mocker, config_parser_dict, expected_error=expected_message)


### PR DESCRIPTION
Signed-off-by: chenwany <chenwany@amazon.com>

*Description of changes:* 
Before this change, when user specify single EBS section, "shared_dir" can be specified together both in the cluster section and EBS section.  Only the "shared_dir" specified in the EBS section would be used without telling the customer about that. This change adds a validator to check the following cases:
When using single EBS section, "shared_dir" can not be specified both in cluster section and EBS section. 
When using multiple EBS sections, "shared_dir" can not be specified in the cluster section.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
