### PR TITLE
integ-tests: implement support to select integration tests to run with a YAML config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,11 @@ matrix:
     python: 3.6
     stage: linters
     env: TOXENV=cfn-format-check,cfn-lint,cfn-tests
+ - name: Validate integration tests configs
+   python: 3.6
+   stage: linters
+   env: TOXENV=validate-test-configs
+   script: cd tests/integration-tests && tox
 
 install:
   - pip install tox-travis

--- a/tests/integration-tests/configs/common.jinja2
+++ b/tests/integration-tests/configs/common.jinja2
@@ -1,0 +1,18 @@
+{%- set REGIONS_COMMERCIAL = ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "eu-north-1"] -%}
+{%- set REGIONS_CHINA = ["cn-north-1", "cn-northwest-1"] -%}
+{%- set REGIONS_GOVCLOUD = ["us-gov-west-1", "us-gov-east-1"] -%}
+{%- set REGIONS_ALL = REGIONS_COMMERCIAL + REGIONS_CHINA + REGIONS_GOVCLOUD -%}
+{%- set SCHEDULERS_ALL = ["slurm", "sge", "torque", "awsbatch"] -%}
+{%- set SCHEDULERS_TRAD = ["slurm", "sge", "torque"] -%}
+{%- set OSS_BATCH = ["alinux", "alinux2"] -%}
+{%- set OSS_COMMERCIAL_X86 = ["alinux", "alinux2", "centos7", "centos6", "ubuntu1604", "ubuntu1804"] -%}
+{%- set OSS_CHINA_X86 = ["alinux", "alinux2", "ubuntu1604", "ubuntu1804"] -%}
+{%- set OSS_GOVCLOUD_X86 = ["alinux", "alinux2", "ubuntu1604", "ubuntu1804"] -%}
+{%- set OSS_COMMERCIAL_ARM = ["alinux2", "ubuntu1804"] -%}
+{%- set OSS_CHINA_ARM = [] -%}
+{%- set OSS_GOVCLOUD_ARM = [] -%}
+{%- set OSS_ONE_PER_DISTRO = ["centos7", "alinux2", "ubuntu1804"] -%}
+{%- set INSTANCES_DEFAULT_X86 = ["c5.xlarge"] -%}
+{%- set INSTANCES_DEFAULT_ARM = ["m6g.xlarge"] -%}
+{%- set INSTANCES_DEFAULT = ["c5.xlarge", "m6g.xlarge"] -%}
+

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -1,0 +1,427 @@
+{%- import 'common.jinja2' as common -%}
+---
+test-suites:
+  cfn-init:
+    test_cfn_init.py::test_replace_compute_on_failure:
+      dimensions:
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_ONE_PER_DISTRO }}
+          schedulers: ["slurm", "sge"]
+  cli_commands:
+    test_cli_commands.py::test_hit_cli_commands:
+      dimensions:
+        - regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1804"]
+          schedulers: ["slurm"]
+    test_cli_commands.py::test_sit_cli_commands:
+      dimensions:
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7"]
+          schedulers: ["sge"]
+  cloudwatch_logging:
+    test_cloudwatch_logging.py::test_cloudwatch_logging:
+      dimensions:
+        # 1) run the test for all of the schedulers with alinux2
+        - regions: ["ca-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: {{ common.SCHEDULERS_ALL }}
+        # 2) run the test for all of the OSes with slurm
+        - regions: ["ap-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+        # 3) run the test for a single scheduler-OS combination on an ARM instance
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+  configure:
+    test_pcluster_configure.py::test_pcluster_configure:
+      dimensions: # TODO: too many tests
+        - regions: ["us-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm", "sge"]
+        - regions: ["us-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          schedulers: ["slurm", "sge"]
+        # Do not run on ARM + Batch
+        # pcluster configure always picks optimal and Batch does not support ARM for optimal for now
+        - regions: ["us-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_BATCH }}
+          schedulers: ["awsbatch"]
+    test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
+      dimensions:
+        - regions: ["us-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+  createami:
+    test_createami.py::test_createami:
+      dimensions: # TODO: run in single region
+        {%- for region, os in [("eu-west-1", "alinux"), ("us-west-1", "alinux2"), ("us-west-2", "centos7"), ("eu-west-2", "ubuntu1604"), ("us-east-1", "ubuntu1804"), ("us-gov-east-1", "ubuntu1604"), ("us-gov-west-1", "ubuntu1804"), ("cn-northwest-1", "alinux2")] %}
+        - regions: ["{{ region }}"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["{{ os }}"]
+        {%- endfor %}
+    test_createami.py::test_createami_post_install:
+      dimensions: # TODO: run in a single region
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7"]
+        - regions: ["eu-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1804"]
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["alinux2"]
+  dcv:
+    test_dcv.py::test_dcv_configuration:
+      dimensions: # TODO: run in single region
+        {%- for region, instance, os in [("cn-northwest-1", "c5.xlarge", "alinux2"), ("us-gov-west-1", "c5.xlarge", "ubuntu1804"), ("eu-west-1", "g3.8xlarge", "alinux2"), ("eu-west-1", "g3.8xlarge", "centos7"), ("eu-west-1", "g3.8xlarge", "ubuntu1804"), ("eu-west-1", "m6g.xlarge", "alinux2"), ("eu-west-1", "m6g.xlarge", "ubuntu1804")] %}
+        - regions: ["{{ region }}"]
+          instances: ["{{ instance }}"]
+          oss: ["{{ os }}"]
+          schedulers: ["slurm"]
+        {%- endfor %}
+    test_dcv.py::test_dcv_with_remote_access:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7"]
+          schedulers: ["sge"]
+  disable_hyperthreading:
+    test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
+      dimensions:
+        # Manually disabled HT
+        - regions: ["us-west-1"]
+          instances: ["m4.xlarge"]
+          oss: ["alinux2", "centos7", "ubuntu1604"]
+          schedulers: ["slurm"]
+        # HT disabled via CpuOptions
+        - regions: ["us-west-1"]
+          instances: ["c5.xlarge"]
+          oss: ["ubuntu1804"]
+          schedulers: ["slurm"]
+    test_disable_hyperthreading.py::test_sit_disable_hyperthreading:
+      dimensions:
+        # Manually disabled HT
+        {%- for os, scheduler in [("alinux", "sge"), ("centos6", "torque"), ("ubuntu1804", "sge")] %}
+        - regions: ["sa-east-1"]
+          instances: ["m4.xlarge"]
+          oss: ["{{ os }}"]
+          schedulers: ["{{ scheduler }}"]
+        {%- endfor %}
+        # HT disabled via CpuOptions
+        {%- for os, scheduler in [("alinux2", "sge"), ("centos7", "torque")] %}
+        - regions: ["sa-east-1"]
+          instances: ["c5.xlarge"]
+          oss: ["{{ os }}"]
+          schedulers: ["{{ scheduler }}"]
+        {%- endfor %}
+  dns:
+    test_dns.py::test_hit_no_cluster_dns_mpi:
+      dimensions:
+        - regions: ["eu-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+  efa:
+    test_efa.py::test_hit_efa:
+      dimensions:
+        - regions: ["us-east-1"]
+          instances: ["c5n.18xlarge"]
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+    test_efa.py::test_sit_efa:
+      dimensions: # TODO review regions
+        - regions: ["us-east-1"]
+          instances: ["c5n.18xlarge"]
+          # EFA not working on Centos6
+          oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]
+          schedulers: ["sge", "slurm"]
+  iam_policies:
+    test_iam_policies.py::test_iam_policies:
+      dimensions:
+        - regions: ["ap-northeast-2"]
+          oss: ["alinux2"]
+          schedulers: ["slurm", "awsbatch"]
+  intel_hpc:
+    test_intel_hpc.py::test_intel_hpc:
+      dimensions:
+        - regions: ["us-east-1"]
+          instances: ["c5n.18xlarge"]
+          oss: ["centos7"]
+          schedulers: ["slurm"]
+  networking:
+    test_cluster_networking.py::test_cluster_in_private_subnet:
+      dimensions: # TODO: move to single block
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+        - regions: ["eu-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7"]
+          schedulers: ["sge"]
+    test_networking.py::test_public_network_topology:
+      dimensions:
+        - regions: ["eu-central-1", "us-gov-east-1", "cn-northwest-1"]
+    test_networking.py::test_public_private_network_topology:
+      dimensions:
+        - regions: ["eu-central-1", "us-gov-east-1", "cn-northwest-1"]
+    test_multi_cidr.py::test_multi_cidr:
+      dimensions:
+        - regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm", "awsbatch"]
+  runtime_bake:
+    test_runtime_bake.py::test_runtime_bake:
+      dimensions: # TODO: simplify dimensions
+        {%- for region, instance, os, scheduler in [("eu-west-2", "c5.xlarge", "alinux", "slurm"), ("eu-west-3", "c5.xlarge", "alinux2", "torque"), ("us-east-2", "c5.xlarge", "centos7", "sge"), ("us-east-1", "c5.xlarge", "ubuntu1604", "slurm"), ("eu-west-1", "c5.xlarge", "ubuntu1804", "sge"), ("us-gov-east-1", "c5.xlarge", "ubuntu1604", "slurm"), ("us-gov-west-1", "c5.xlarge", "ubuntu1804", "sge"), ("us-east-1", "m6g.xlarge", "ubuntu1804", "sge"), ("eu-west-1", "m6g.xlarge", "alinux2", "slurm")] %}
+        - regions: ["{{ region }}"]
+          instances: ["{{ instance }}"]
+          oss: ["{{ os }}"]
+          schedulers: ["{{ scheduler }}"]
+        {%- endfor %}
+  scaling:
+    test_scaling.py::test_hit_scaling:
+      dimensions:
+        - regions: ["us-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_ONE_PER_DISTRO }}
+          schedulers: ["slurm"]
+    test_scaling.py::test_multiple_jobs_submission:
+      dimensions:
+        - regions: {{ common.REGIONS_COMMERCIAL }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: {{ common.SCHEDULERS_TRAD }}
+        - regions: {{ common.REGIONS_CHINA }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_CHINA_X86 }}
+          schedulers: {{ common.SCHEDULERS_TRAD }}
+        - regions: {{ common.REGIONS_GOVCLOUD }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_GOVCLOUD_X86 }}
+          schedulers: {{ common.SCHEDULERS_TRAD }}
+    test_scaling.py::test_nodewatcher_terminates_failing_node:
+      dimensions:
+        - regions: ["sa-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_ONE_PER_DISTRO }}
+          schedulers: ["sge", "torque"]
+    test_mpi.py::test_mpi:  # TODO: move outside of the scaling dir
+      dimensions:
+        - regions: ["us-east-1"]  # TODO: change region
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm", "sge"]
+        - regions: ["us-east-1"]  # TODO: change region
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          schedulers: ["slurm", "sge"]
+    test_mpi.py::test_mpi_ssh:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]  # Known ssh issue on CentOS6+SLURM
+          schedulers: ["slurm"]
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["sge"]
+  schedulers:
+    test_sge.py::test_sge:
+      dimensions:
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["sge"]
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          schedulers: ["sge"]
+    test_torque.py::test_torque:
+      dimensions:
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["torque"]
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          schedulers: ["torque"]
+    test_awsbatch.py::test_awsbatch:
+      dimensions:
+        - regions: {{ common.REGIONS_ALL }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["awsbatch"]
+        - regions: ["ap-southeast-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux"]
+          schedulers: ["awsbatch"]
+        - regions: ["ap-northeast-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["alinux2"]
+          schedulers: ["awsbatch"]
+    test_slurm.py::test_slurm:
+      dimensions:
+        - regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+    test_slurm.py::test_slurm_pmix:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]
+          schedulers: ["slurm"]
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          schedulers: ["slurm"]
+  spot:
+    test_spot.py::test_spot_default:
+      dimensions:
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_ONE_PER_DISTRO }}
+          schedulers: ["sge", "slurm"]
+  storage:
+    test_fsx_lustre.py::test_fsx_lustre:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]  # FSx is not supported on CentOS 6
+          schedulers: ["slurm"]
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          # FSx is only supported on ARM instances for Ubuntu 18.04 and Amazon Linux 2
+          oss: ["alinux2", "ubuntu1804"]
+          schedulers: ["slurm"]
+    test_fsx_lustre.py::test_fsx_lustre_backup:
+      dimensions:
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]  # FSx is not supported on CentOS 6
+          schedulers: ["sge"]
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          # FSx is only supported on ARM instances for Ubuntu 18.04 and Amazon Linux 2
+          oss: ["alinux2", "ubuntu1804"]
+          schedulers: ["sge"]
+    test_efs.py::test_efs_compute_az:
+      dimensions:
+        - regions: ["us-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm", "awsbatch"]
+    test_efs.py::test_efs_same_az:
+      dimensions:
+        - regions: ["ap-northeast-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+        - regions: ["cn-north-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_CHINA_X86 }}
+          schedulers: ["slurm"]
+        - regions: ["ap-northeast-1", "cn-north-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_BATCH }}
+          schedulers: ["awsbatch"]
+    test_raid.py::test_raid_fault_tolerance_mode:
+      dimensions:
+        - regions: ["us-gov-west-1", "cn-northwest-1"]  # TODO: china only?
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+    test_raid.py::test_raid_performance_mode:
+      dimensions:
+        - regions: ["ap-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["sge"]
+        - regions: ["us-gov-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_GOVCLOUD_X86 }}
+          schedulers: ["sge"]
+        - regions: ["ap-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_BATCH }}
+          schedulers: ["awsbatch"]
+    test_ebs.py::test_default_ebs:
+      dimensions:
+        - regions: ["cn-northwest-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux"]
+          schedulers: ["slurm"]
+    test_ebs.py::test_ebs_multiple:
+      dimensions:
+        - regions: ["ca-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["awsbatch"]
+        - regions: ["ca-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1804"]
+          schedulers: ["slurm"]
+    test_ebs.py::test_ebs_single:
+      dimensions:
+        {%- for region, oss in [("eu-west-3", common.OSS_COMMERCIAL_X86), ("cn-north-1", common.OSS_CHINA_X86), ("us-gov-west-1", common.OSS_GOVCLOUD_X86)] %}
+        - regions: ["{{ region }}"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ oss }}
+          schedulers: ["sge"]
+        {%- endfor %}
+    test_ebs.py::test_ebs_single_empty:
+      dimensions:
+        - regions: ["us-gov-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1604"]
+          schedulers: ["torque"]
+    test_ebs.py::test_ebs_snapshot:
+      dimensions:
+        - regions: ["ap-northeast-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["sge"]
+        - regions: ["cn-northwest-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1804"]
+          schedulers: ["slurm"]
+  tags:
+    test_tag_propagation.py::test_tag_propagation:
+      dimensions:
+        - regions: ["ap-southeast-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm", "torque", "awsbatch"]
+  update:
+    test_update.py::test_update_awsbatch:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["awsbatch"]
+    test_update.py::test_update_hit:
+      dimensions:
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+    test_update.py::test_update_sit:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7"]
+          schedulers: ["sge"]

--- a/tests/integration-tests/conftest_tests_config.py
+++ b/tests/integration-tests/conftest_tests_config.py
@@ -1,0 +1,78 @@
+import logging
+import os
+from itertools import product
+
+from conftest_markers import DIMENSIONS_MARKER_ARGS
+from framework.tests_configuration.config_utils import get_enabled_tests
+
+
+def parametrize_from_config(metafunc):
+    """
+    Apply parametrization to all test functions loaded by pytest.
+
+    The functions discovered by pytest are matched against the ones declared in the test config file. When a match
+    if found, meaning the test is enabled, the dimensions declared in the config file are applied to the test function.
+    """
+    tests_config = metafunc.config.getoption("tests_config")
+    test_collection_name = metafunc.definition.nodeid.split(os.path.sep)[0]
+    test_name = metafunc.definition.nodeid.split(os.path.sep)[1]
+    if test_collection_name in tests_config["test-suites"]:
+        if test_name in tests_config["test-suites"][test_collection_name]:
+            configured_dimensions_items = tests_config["test-suites"][test_collection_name][test_name]["dimensions"]
+            argnames, argvalues = _get_combinations_of_dimensions_values(configured_dimensions_items)
+            if argvalues:
+                metafunc.parametrize(argnames, argvalues, scope="class")
+
+
+def _get_combinations_of_dimensions_values(configured_dimensions_items):
+    """
+    Given a list of dict defining the configured test dimensions it computes all combinations of dimension
+    values in order to parametrize the tests.
+
+    E.g.
+    configured_dimensions_items =
+      [{'instances': ['inst1'], 'oss': ['os1', 'os2'], 'regions': ['region1', 'region2'], 'schedulers': ['s']},
+       {'instances': ['inst2', 'inst3'], 'oss': ['os1'], 'regions': ['region3'], 'schedulers': ['s']}]
+
+    Produces the following output:
+      argvalues = [('region1', 'inst1', 'os1', 's'), ('region1', 'inst1', 'os2', 's'), ('region2', 'inst1', 'os1', 's'),
+                   ('region2', 'inst1', 'os2', 's'), ('region3', 'inst2', 'os1', 's'), ('region3', 'inst3', 'os1', 's')]
+    """
+    argnames = list(DIMENSIONS_MARKER_ARGS)
+    argvalues = []
+    for item in configured_dimensions_items:
+        dimensions_values = []
+        for dim in DIMENSIONS_MARKER_ARGS:
+            values = item.get(f"{dim}s")
+            if values:
+                dimensions_values.append(values)
+            elif dim in argnames:
+                argnames.remove(dim)
+        argvalues.extend(list(product(*dimensions_values)))
+
+    return argnames, argvalues
+
+
+def remove_disabled_tests(config, items):
+    """Remove all tests that are not defined in the config file"""
+    enabled_tests = get_enabled_tests(config.getoption("tests_config"))
+    for item in list(items):
+        if item.nodeid.split("[")[0] not in enabled_tests:
+            logging.warning("Skipping test %s because not defined in config", item.nodeid)
+            items.remove(item)
+
+
+def apply_cli_dimensions_filtering(config, items):
+    """Filter tests based on dimensions passed as cli arguments."""
+    allowed_values = {}
+    for dimension in DIMENSIONS_MARKER_ARGS:
+        allowed_values[dimension] = config.getoption(dimension + "s")
+    for item in list(items):
+        for dimension in DIMENSIONS_MARKER_ARGS:
+            # callspec is not set if parametrization did not happen
+            if hasattr(item, "callspec"):
+                arg_value = item.callspec.params.get(dimension)
+                if allowed_values[dimension]:
+                    if arg_value not in allowed_values[dimension]:
+                        items.remove(item)
+                        break

--- a/tests/integration-tests/framework/__init__.py
+++ b/tests/integration-tests/framework/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration-tests/framework/tests_configuration/__init__.py
+++ b/tests/integration-tests/framework/tests_configuration/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration-tests/framework/tests_configuration/config_generator.py
+++ b/tests/integration-tests/framework/tests_configuration/config_generator.py
@@ -1,0 +1,60 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+import os
+from collections import OrderedDict
+from pathlib import Path
+
+import argparse
+from framework.tests_configuration.config_utils import discover_all_test_functions
+from jinja2 import Environment, FileSystemLoader
+
+package_directory = os.path.dirname(os.path.abspath(__file__))
+CONFIG_STUB_FILE = f"{package_directory}/config_stub.yaml.jinja2"
+
+
+def _auto_generate_config(tests_root_dir):
+    test_functions = discover_all_test_functions(tests_root_dir)
+
+    sorted_test_functions = OrderedDict()
+    for key in sorted(test_functions):
+        sorted_test_functions[key] = test_functions[key]
+
+    config_dir = os.path.dirname(CONFIG_STUB_FILE)
+    config_name = os.path.basename(CONFIG_STUB_FILE)
+    file_loader = FileSystemLoader(config_dir)
+    env = Environment(loader=file_loader)
+    rendered_template = env.get_template(config_name).render(test_functions=sorted_test_functions)
+
+    return rendered_template
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="%(levelname)s - %(message)s", level=logging.DEBUG)
+
+    parser = argparse.ArgumentParser(
+        description="Utility module used to generate stub for tests config. "
+        "All existing integration tests are automatically discovered and a test config file is "
+        "automatically generated from them.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--output-file", help="File where to write the generated config.", required=True)
+    parser.add_argument(
+        "--tests-root-dir",
+        help="Root dir where integration tests are defined",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    generated_config = _auto_generate_config(args.tests_root_dir)
+    logging.info("Writing generated config to %s", args.output_file)
+    Path(args.output_file).write_text(generated_config)

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -1,0 +1,62 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+import os
+from functools import lru_cache
+
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+
+def read_config_file(config_file, print_rendered=False):
+    """
+    Read the test config file and apply Jinja rendering.
+    Multiple invocations of the same function within the same process produce the same rendering output. This is done
+    in order to produce a consistent result in case random values are selected in jinja templating logic.
+
+    :param config_file: path to the config file to read
+    :param print_rendered: log rendered config file
+    :return: a dict containig the parsed config file
+    """
+    logging.info("Parsing config file: %s", config_file)
+    rendered_config = _render_config_file(config_file)
+    try:
+        return yaml.load(rendered_config, Loader=yaml.SafeLoader)
+    except Exception:
+        logging.exception("Failed when reading config file %s", config_file)
+        print_rendered = True
+        raise
+    finally:
+        if print_rendered:
+            logging.info("Dumping rendered template:\n%s", rendered_config)
+
+
+def dump_rendered_config_file(config):
+    """Write config to file"""
+    return yaml.dump(config, default_flow_style=False)
+
+
+@lru_cache(maxsize=None)
+def _render_config_file(config_file):
+    """
+    Apply Jinja rendering to the specified config file.
+
+    Multiple invocations of this function with same args will produce the same rendering output.
+    """
+    try:
+        config_dir = os.path.dirname(config_file)
+        config_name = os.path.basename(config_file)
+        file_loader = FileSystemLoader(config_dir)
+        return Environment(loader=file_loader).get_template(config_name).render()
+    except Exception:
+        logging.error("Failed when rendering config file %s", config_file)
+        raise

--- a/tests/integration-tests/framework/tests_configuration/config_schema.yaml
+++ b/tests/integration-tests/framework/tests_configuration/config_schema.yaml
@@ -1,0 +1,56 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+# This file defines the yaml schema validated by pykwalify
+# https://pykwalify.readthedocs.io/en/master/
+type: map
+mapping:
+  test-suites:
+    type: map
+    required:  yes
+    mapping:
+      regex;(.+):
+        type: map
+        required: yes
+        mapping:
+          regex;(.+\.py::.+):
+            type: map
+            required: yes
+            mapping:
+              dimensions:
+                type: seq
+                required: yes
+                sequence:
+                  - type: map
+                    required: yes
+                    mapping:
+                      regions:
+                        type: seq
+                        required: yes
+                        sequence:
+                          - type: str
+                      instances:
+                        type: seq
+                        required: no
+                        sequence:
+                          - type: str
+                      oss:
+                        type: seq
+                        required: no
+                        allowempty: False
+                        sequence:
+                          - type: str
+                      schedulers:
+                        type: seq
+                        required: no
+                        sequence:
+                          - type: str

--- a/tests/integration-tests/framework/tests_configuration/config_stub.yaml.jinja2
+++ b/tests/integration-tests/framework/tests_configuration/config_stub.yaml.jinja2
@@ -1,0 +1,14 @@
+{% raw %}{%- import 'common.jinja2' as common -%}{% endraw %}
+---
+test-suites:
+{%- for feature, tests in test_functions.items() %}
+  {{ feature }}:
+    {%- for test in tests %}
+    {{ test }}:
+      dimensions:
+        - regions: []
+          instances: []
+          oss: []
+          schedulers: []
+    {%- endfor %}
+{%- endfor %}

--- a/tests/integration-tests/framework/tests_configuration/config_utils.py
+++ b/tests/integration-tests/framework/tests_configuration/config_utils.py
@@ -1,0 +1,83 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import json
+import logging
+import os
+from collections import OrderedDict
+from importlib._bootstrap import module_from_spec
+from importlib._bootstrap_external import spec_from_file_location
+from pathlib import Path
+
+
+def get_enabled_tests(config):
+    """
+    Build a set containing all tests defined in the config file.
+
+    Each entry of the set is in the format {test-suite}/{test-module}::{test-function},
+    e.g. 'cfn-init/test_cfn_init.py::test_replace_compute_on_failure'
+    """
+    enabled_test_suites = config.get("test-suites")
+    enabled_tests = set()
+    for suite, tests in enabled_test_suites.items():
+        for test in tests.keys():
+            enabled_tests.add("{0}/{1}".format(suite, test))
+
+    return enabled_tests
+
+
+def get_all_regions(config):
+    """Retrieve a set of all regions used by the declared integration tests."""
+    regions = set()
+    for feature in config.get("test-suites").values():
+        for test in feature.values():
+            for dimensions_config in test.values():
+                for dimensions_group in dimensions_config:
+                    regions.update(dimensions_group.get("regions", []))
+    return regions
+
+
+def discover_all_test_functions(tests_root_dir):
+    """
+    Discover all defined test functions by dynamically loading all test modules.
+
+    e.g. of the returned dict:
+    {
+      "cloudwatch_logging": [
+        "test_cloudwatch_logging.py::test_cloudwatch_logging"
+      ],
+      "dcv": [
+        "test_dcv.py::test_dcv_configuration",
+        "test_dcv.py::test_dcv_with_remote_access"
+      ],
+      ...
+    }
+
+    :param tests_root_dir: root dir where looking for test modules.
+    :return: a dict containing the discovered test modules and test functions.
+    """
+    logging.info("Collecting all existing test functions")
+    test_module_paths = list(Path(tests_root_dir).rglob("test_*.py"))
+    discovered_test_functions = OrderedDict()
+    for module_path in test_module_paths:
+        module_filename = os.path.basename(str(module_path))
+        module_dirname = os.path.split(os.path.dirname(str(module_path)))[-1]
+        spec = spec_from_file_location(os.path.splitext(module_filename)[0], module_path)
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+        test_functions = filter(lambda func_name: func_name.startswith("test_"), dir(module))
+        test_functions_identifiers = [f"{module_filename}::{test_function}" for test_function in test_functions]
+        discovered_test_functions[module_dirname] = (
+            discovered_test_functions.get(module_dirname, []) + test_functions_identifiers
+        )
+
+    logging.info("Discovered following test functions:\n%s", json.dumps(discovered_test_functions, indent=2))
+    return discovered_test_functions

--- a/tests/integration-tests/framework/tests_configuration/config_validator.py
+++ b/tests/integration-tests/framework/tests_configuration/config_validator.py
@@ -1,0 +1,109 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+import os
+
+import argparse
+from assertpy import assert_that, soft_assertions
+from framework.tests_configuration.config_renderer import dump_rendered_config_file, read_config_file
+from framework.tests_configuration.config_utils import discover_all_test_functions
+from pykwalify.core import Core
+
+package_directory = os.path.dirname(os.path.abspath(__file__))
+CONFIG_SCHEMA = f"{package_directory}/config_schema.yaml"
+
+
+def assert_valid_config(config, tests_root_dir):
+    """
+    Validate the provided test config file by performing the following actions:
+    - Validate the YAML schema of the config
+    - Check that the tests defined in the config file actually exist
+    - Check that the provided dimensions are not all empty
+
+    :param config: dict containing the parsed config file
+    :param tests_root_dir: root dir where integration tests are defined
+    """
+    _validate_against_schema(config)
+    _check_declared_tests_exist(config, tests_root_dir)
+    _check_no_empty_dimension_lists(config)
+
+
+def _check_no_empty_dimension_lists(config):
+    """Verify that at least one dimension is not an empty list"""
+    logging.info("Checking provided dimensions are valid")
+    for feature in config.get("test-suites").values():
+        for test_name, test in feature.items():
+            for dimensions_config in test.values():
+                for dimensions_group in dimensions_config:
+                    if [] in dimensions_group.values():
+                        logging.error("Values assigned to dimensions in test %s cannot be empty", test_name)
+                        raise AssertionError
+
+
+def _validate_against_schema(config):
+    """Verify that config file is compliant with the defined schema"""
+    logging.info("Validating config file against the schema")
+    try:
+        c = Core(source_data=config, schema_files=[CONFIG_SCHEMA])
+        c.validate(raise_exception=True)
+    except Exception as e:
+        logging.error("Failed when validating schema: %s", e)
+        logging.info("Dumping rendered template:\n%s", dump_rendered_config_file(config))
+        raise
+
+
+def _check_declared_tests_exist(config, tests_root_dir):
+    """Check that all the tests declared in the config file correspond to actual valid test functions"""
+    logging.info("Checking that configured tests exist")
+    test_functions = discover_all_test_functions(tests_root_dir)
+    try:
+        with soft_assertions():
+            for dirname, configured_tests in config["test-suites"].items():
+                assert_that(test_functions).contains_key(dirname)
+                assert_that(test_functions.get(dirname, [])).contains(*[test for test in configured_tests.keys()])
+    except AssertionError as e:
+        logging.error("Some of the configured tests do not exist: %s", e)
+        raise
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="%(levelname)s - %(message)s", level=logging.DEBUG)
+    logging.getLogger("pykwalify").setLevel(logging.INFO)
+
+    parser = argparse.ArgumentParser(
+        description="Validate tests config.", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--tests-config-file",
+        help="Tests config file to validate",
+    )
+    group.add_argument(
+        "--tests-configs-dir",
+        help="Directory containing tests config files to validate",
+    )
+    parser.add_argument(
+        "--tests-root-dir",
+        help="Root dir where integration tests are defined",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    if args.tests_config_file:
+        assert_valid_config(read_config_file(args.tests_config_file, print_rendered=True), args.tests_root_dir)
+    else:
+        for filename in os.listdir(args.tests_configs_dir):
+            if filename.endswith(".yaml.jinja2") or filename.endswith(".yaml"):
+                assert_valid_config(
+                    read_config_file(os.path.join(args.tests_configs_dir, filename), print_rendered=True),
+                    args.tests_root_dir,
+                )

--- a/tests/integration-tests/reports_generator.py
+++ b/tests/integration-tests/reports_generator.py
@@ -55,7 +55,7 @@ def generate_junitxml_merged_report(test_results_dir):
     Merge all junitxml generated reports in a single one.
     :param test_results_dir: output dir containing the junitxml reports to merge.
     """
-    merged_xml = None
+    merged_xml = JUnitXml()
     for dir, _, files in os.walk(test_results_dir):
         for file in files:
             if file.endswith("results.xml"):

--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -5,6 +5,7 @@ boto3
 fabric
 jinja2
 junitparser
+pykwalify
 pexpect
 pytest
 pytest-datadir
@@ -12,6 +13,7 @@ pytest-html
 pytest-rerunfailures
 pytest-sugar
 pytest-xdist
+PyYAML
 retrying
 troposphere
 untangle

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -15,6 +15,7 @@ import multiprocessing
 import os
 import sys
 import time
+import urllib.request
 from tempfile import TemporaryDirectory
 
 import argparse
@@ -166,37 +167,47 @@ def _init_argparser():
         "--output-dir", help="Directory where tests outputs are generated", default=TEST_DEFAULTS.get("output_dir")
     )
     parser.add_argument(
-        "--custom-node-url", help="URL to a custom node package.", default=TEST_DEFAULTS.get("custom_node_url")
+        "--custom-node-url",
+        help="URL to a custom node package.",
+        default=TEST_DEFAULTS.get("custom_node_url"),
+        type=_is_url,
     )
     parser.add_argument(
         "--custom-cookbook-url",
         help="URL to a custom cookbook package.",
         default=TEST_DEFAULTS.get("custom_cookbook_url"),
+        type=_is_url,
     )
     parser.add_argument(
         "--createami-custom-cookbook-url",
         help="URL to a custom cookbook package for the createami command.",
         default=TEST_DEFAULTS.get("createami_custom_cookbook_url"),
+        type=_is_url,
     )
     parser.add_argument(
-        "--custom-template-url", help="URL to a custom cfn template.", default=TEST_DEFAULTS.get("custom_template_url")
+        "--custom-template-url",
+        help="URL to a custom cfn template.",
+        default=TEST_DEFAULTS.get("custom_template_url"),
+        type=_is_url,
     )
     parser.add_argument(
         "--custom-hit-template-url",
         help="URL to a custom hit cfn template.",
         default=TEST_DEFAULTS.get("custom_hit_template_url"),
+        type=_is_url,
     )
     parser.add_argument(
         "--custom-awsbatchcli-url",
         help="URL to a custom awsbatch cli package.",
         default=TEST_DEFAULTS.get("custom_awsbatchcli_url"),
+        type=_is_url,
     )
     parser.add_argument(
         "--custom-ami", help="custom AMI to use for all tests.", default=TEST_DEFAULTS.get("custom_ami")
     )
-    parser.add_argument("--pre-install", help="URL to a pre install script", default=TEST_DEFAULTS.get("pre_install"))
+    parser.add_argument("--pre-install", help="URL to a pre install script", default=TEST_DEFAULTS.get("pre_install"), type=_is_url)
     parser.add_argument(
-        "--post-install", help="URL to a post install script", default=TEST_DEFAULTS.get("post_install")
+        "--post-install", help="URL to a post install script", default=TEST_DEFAULTS.get("post_install"), type=_is_url
     )
     parser.add_argument("--vpc-stack", help="Name of an existing vpc stack.", default=TEST_DEFAULTS.get("vpc_stack"))
     parser.add_argument(
@@ -250,6 +261,14 @@ def _init_argparser():
 def _is_file(value):
     if not os.path.isfile(value):
         raise argparse.ArgumentTypeError("'{0}' is not a valid key".format(value))
+    return value
+
+
+def _is_url(value):
+    try:
+        urllib.request.urlopen(value)
+    except Exception:
+        raise argparse.ArgumentTypeError("'{0}' is not a valid url".format(value))
     return value
 
 

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -20,6 +20,10 @@ from tempfile import TemporaryDirectory
 
 import argparse
 import pytest
+from assertpy import assert_that
+from framework.tests_configuration.config_renderer import dump_rendered_config_file, read_config_file
+from framework.tests_configuration.config_utils import get_all_regions
+from framework.tests_configuration.config_validator import assert_valid_config
 from reports_generator import generate_cw_report, generate_json_report, generate_junitxml_merged_report
 
 logger = logging.getLogger()
@@ -35,25 +39,10 @@ TEST_DEFAULTS = {
     "parallelism": None,
     "retry_on_failures": False,
     "features": "",  # empty string means all
-    "regions": [
-        "us-east-1",
-        "us-east-2",
-        "us-west-1",
-        "us-west-2",
-        "ca-central-1",
-        "eu-west-1",
-        "eu-west-2",
-        "eu-central-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ap-northeast-1",
-        "ap-south-1",
-        "sa-east-1",
-        "eu-west-3",
-    ],
-    "oss": ["alinux", "alinux2", "centos6", "centos7", "ubuntu1804", "ubuntu1604"],
-    "schedulers": ["sge", "slurm", "torque", "awsbatch"],
-    "instances": ["c4.xlarge", "c5.xlarge"],
+    "regions": [],
+    "oss": [],
+    "schedulers": [],
+    "instances": [],
     "dry_run": False,
     "reports": [],
     "cw_region": "us-east-1",
@@ -79,6 +68,7 @@ TEST_DEFAULTS = {
     "stackname_suffix": "",
     "keep_logs_on_cluster_failure": False,
     "keep_logs_on_test_failure": False,
+    "tests_root_dir": "./tests",
 }
 
 
@@ -87,15 +77,27 @@ def _init_argparser():
         description="Run integration tests suite.", formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
+    parser.add_argument("--key-name", help="Key to use for EC2 instances", required=True)
+    parser.add_argument("--key-path", help="Path to the key to use for SSH connections", required=True, type=_is_file)
+    parser.add_argument(
+        "-n", "--parallelism", help="Tests parallelism for every region.", default=TEST_DEFAULTS.get("parallelism")
+    )
+    parser.add_argument(
+        "--sequential",
+        help="Run tests in a single process. When not specified tests will spawn a process for each region under test.",
+        action="store_true",
+        default=TEST_DEFAULTS.get("sequential"),
+    )
     parser.add_argument(
         "--credential",
         action="append",
-        help="STS credential endpoint, in the format <region>,<endpoint>,<ARN>,<externalId>. "
-        "Could be specified multiple times.",
+        help="STS credential to assume when running tests in a specific region."
+        "Credentials need to be in the format <region>,<endpoint>,<ARN>,<externalId> and can"
+        " be specified multiple times. <region> represents the region credentials are used for, <endpoint> is the sts "
+        " endpoint to contact in order to assume credentials, <account-id> is the id of the account where the role to "
+        " assume is defined, <externalId> is the id to use when assuming the role. "
+        "(e.g. ap-east-1,https://sts.us-east-1.amazonaws.com,arn:aws:iam::<account-id>:role/role-to-assume,externalId)",
         required=False,
-    )
-    parser.add_argument(
-        "-n", "--parallelism", help="Tests parallelism for every region.", default=TEST_DEFAULTS.get("parallelism")
     )
     parser.add_argument(
         "--retry-on-failures",
@@ -104,30 +106,47 @@ def _init_argparser():
         default=TEST_DEFAULTS.get("retry_on_failures"),
     )
     parser.add_argument(
-        "--dry-run",
-        help="Only show the list of tests that would run with specified options.",
-        action="store_true",
-        default=TEST_DEFAULTS.get("dry_run"),
+        "--tests-root-dir",
+        help="Root dir where integration tests are defined",
+        default=TEST_DEFAULTS.get("tests_root_dir"),
     )
-    parser.add_argument(
-        "--sequential",
-        help="Run tests in a single process. When not specified tests will run concurrently in all regions.",
-        action="store_true",
-        default=TEST_DEFAULTS.get("sequential"),
-    )
-    parser.add_argument("--key-name", help="Key to use for EC2 instances", required=True)
-    parser.add_argument("--key-path", help="Path to the key to use for SSH connections", required=True, type=_is_file)
 
     dimensions_group = parser.add_argument_group("Test dimensions")
     dimensions_group.add_argument(
-        "-i", "--instances", help="AWS instances under test.", default=TEST_DEFAULTS.get("instances"), nargs="+"
+        "-c",
+        "--tests-config",
+        help="Config file that specifies the tests to run and the dimensions to enable for each test. "
+        "Note that when a config file is used the following flags are ignored: instances, regions, oss, schedulers. "
+        "Refer to the docs for further details on the config format.",
+        type=_test_config_file,
     )
-    dimensions_group.add_argument("-o", "--oss", help="OSs under test.", default=TEST_DEFAULTS.get("oss"), nargs="+")
     dimensions_group.add_argument(
-        "-s", "--schedulers", help="Schedulers under test.", default=TEST_DEFAULTS.get("schedulers"), nargs="+"
+        "-i",
+        "--instances",
+        help="AWS instances under test. Ignored when tests-config is used.",
+        default=TEST_DEFAULTS.get("instances"),
+        nargs="*",
     )
     dimensions_group.add_argument(
-        "-r", "--regions", help="AWS region where tests are executed.", default=TEST_DEFAULTS.get("regions"), nargs="+"
+        "-o",
+        "--oss",
+        help="OSs under test. Ignored when tests-config is used.",
+        default=TEST_DEFAULTS.get("oss"),
+        nargs="*",
+    )
+    dimensions_group.add_argument(
+        "-s",
+        "--schedulers",
+        help="Schedulers under test. Ignored when tests-config is used.",
+        default=TEST_DEFAULTS.get("schedulers"),
+        nargs="*",
+    )
+    dimensions_group.add_argument(
+        "-r",
+        "--regions",
+        help="AWS regions where tests are executed. Ignored when tests-config is used.",
+        default=TEST_DEFAULTS.get("regions"),
+        nargs="*",
     )
     dimensions_group.add_argument(
         "-f",
@@ -213,10 +232,10 @@ def _init_argparser():
         "--custom-ami", help="custom AMI to use for all tests.", default=TEST_DEFAULTS.get("custom_ami")
     )
     custom_group.add_argument(
-        "--pre-install", help="URL to a pre install script", default=TEST_DEFAULTS.get("pre_install"), type=_is_url
+        "--pre-install", help="URL to a pre install script", default=TEST_DEFAULTS.get("pre_install")
     )
     custom_group.add_argument(
-        "--post-install", help="URL to a post install script", default=TEST_DEFAULTS.get("post_install"), type=_is_url
+        "--post-install", help="URL to a post install script", default=TEST_DEFAULTS.get("post_install")
     )
 
     banchmarks_group = parser.add_argument_group("Benchmarks")
@@ -269,13 +288,19 @@ def _init_argparser():
         help="set a suffix in the integration tests stack names",
         default=TEST_DEFAULTS.get("stackname_suffix"),
     )
+    debug_group.add_argument(
+        "--dry-run",
+        help="Only show the list of tests that would run with specified options.",
+        action="store_true",
+        default=TEST_DEFAULTS.get("dry_run"),
+    )
 
     return parser
 
 
 def _is_file(value):
     if not os.path.isfile(value):
-        raise argparse.ArgumentTypeError("'{0}' is not a valid key".format(value))
+        raise argparse.ArgumentTypeError("'{0}' is not a valid file".format(value))
     return value
 
 
@@ -285,6 +310,15 @@ def _is_url(value):
     except Exception:
         raise argparse.ArgumentTypeError("'{0}' is not a valid url".format(value))
     return value
+
+
+def _test_config_file(value):
+    _is_file(value)
+    try:
+        config = read_config_file(value)
+        return config
+    except Exception:
+        raise argparse.ArgumentTypeError("'{0}' is not a valid test config".format(value))
 
 
 def _join_with_not(args):
@@ -306,7 +340,7 @@ def _join_with_not(args):
         yield current
 
 
-def _get_pytest_args(args, regions, log_file, out_dir):
+def _get_pytest_args(args, regions, log_file, out_dir):  # noqa: C901
     pytest_args = ["-s", "-vv", "-l"]
 
     if args.benchmarks:
@@ -315,7 +349,7 @@ def _get_pytest_args(args, regions, log_file, out_dir):
         pytest_args.append("--benchmarks-target-capacity={0}".format(args.benchmarks_target_capacity))
         pytest_args.append("--benchmarks-max-time={0}".format(args.benchmarks_max_time))
     else:
-        pytest_args.append("--rootdir=./tests")
+        pytest_args.extend(["--rootdir", args.tests_root_dir])
         pytest_args.append("--ignore=./benchmarks")
 
     # Show all tests durations
@@ -323,6 +357,8 @@ def _get_pytest_args(args, regions, log_file, out_dir):
     # Run only tests with the given markers
     pytest_args.append("-m")
     pytest_args.append(" or ".join(list(_join_with_not(args.features))))
+    if args.tests_config:
+        _set_tests_config_args(args, pytest_args, out_dir)
     pytest_args.append("--regions")
     pytest_args.extend(regions)
     pytest_args.append("--instances")
@@ -407,30 +443,38 @@ def _set_custom_stack_args(args, pytest_args):
         pytest_args.append("--no-delete")
 
 
-def _get_pytest_regionalized_args(region, args):
+def _set_tests_config_args(args, pytest_args, out_dir):
+    # Dump the rendered file to avoid re-rendering in pytest processes
+    rendered_config_file = f"{args.output_dir}/{out_dir}/tests_config.yaml"
+    with open(rendered_config_file, "x") as text_file:
+        text_file.write(dump_rendered_config_file(args.tests_config))
+    pytest_args.extend(["--tests-config-file", rendered_config_file])
+
+
+def _get_pytest_regionalized_args(region, args, our_dir, logs_dir):
     return _get_pytest_args(
         args=args,
         regions=[region],
-        log_file="{0}/{1}.log".format(LOGS_DIR, region),
-        out_dir="{0}/{1}".format(OUT_DIR, region),
+        log_file="{0}/{1}.log".format(logs_dir, region),
+        out_dir="{0}/{1}".format(our_dir, region),
     )
 
 
-def _get_pytest_non_regionalized_args(args):
+def _get_pytest_non_regionalized_args(args, out_dir, logs_dir):
     return _get_pytest_args(
-        args=args, regions=args.regions, log_file="{0}/all_regions.log".format(LOGS_DIR), out_dir=OUT_DIR
+        args=args, regions=args.regions, log_file="{0}/all_regions.log".format(logs_dir), out_dir=out_dir
     )
 
 
-def _run_test_in_region(region, args):
-    out_dir = "{base_dir}/{out_dir}/{region}".format(base_dir=args.output_dir, out_dir=OUT_DIR, region=region)
-    os.makedirs(out_dir, exist_ok=True)
+def _run_test_in_region(region, args, out_dir, logs_dir):
+    out_dir_region = "{base_dir}/{out_dir}/{region}".format(base_dir=args.output_dir, out_dir=out_dir, region=region)
+    os.makedirs(out_dir_region, exist_ok=True)
 
     # Redirect stdout to file
     if not args.show_output:
-        sys.stdout = open("{0}/pytest.out".format(out_dir), "w")
+        sys.stdout = open("{0}/pytest.out".format(out_dir_region), "w")
 
-    pytest_args_regionalized = _get_pytest_regionalized_args(region, args)
+    pytest_args_regionalized = _get_pytest_regionalized_args(region, args, out_dir, logs_dir)
     with TemporaryDirectory() as temp_dir:
         pytest_args_regionalized.extend(["--basetemp", temp_dir])
         logger.info("Starting tests in region {0} with params {1}".format(region, pytest_args_regionalized))
@@ -448,8 +492,12 @@ def _make_logging_dirs(base_dir):
 
 def _run_parallel(args):
     jobs = []
-    for region in args.regions:
-        p = multiprocessing.Process(target=_run_test_in_region, args=[region, args])
+    if args.regions:
+        enabled_regions = args.regions
+    else:
+        enabled_regions = get_all_regions(args.tests_config)
+    for region in enabled_regions:
+        p = multiprocessing.Process(target=_run_test_in_region, args=(region, args, OUT_DIR, LOGS_DIR))
         jobs.append(p)
         p.start()
 
@@ -467,13 +515,25 @@ def _check_args(args):
             )
             exit(1)
 
+    if not args.tests_config:
+        assert_that(args.regions).is_not_empty()
+        assert_that(args.instances).is_not_empty()
+        assert_that(args.oss).is_not_empty()
+        assert_that(args.schedulers).is_not_empty()
+    else:
+        try:
+            assert_valid_config(args.tests_config, args.tests_root_dir)
+            logger.info("Found valid config file:\n%s", dump_rendered_config_file(args.tests_config))
+        except Exception:
+            raise argparse.ArgumentTypeError("'{0}' is not a valid test config".format(args.tests_config))
+
 
 def _run_sequential(args):
     # Redirect stdout to file
     if not args.show_output:
         sys.stdout = open("{0}/{1}/pytest.out".format(args.output_dir, OUT_DIR), "w")
 
-    pytest_args_non_regionalized = _get_pytest_non_regionalized_args(args)
+    pytest_args_non_regionalized = _get_pytest_non_regionalized_args(args, OUT_DIR, LOGS_DIR)
     logger.info("Starting tests with params {0}".format(pytest_args_non_regionalized))
     pytest.main(pytest_args_non_regionalized)
 

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -12,11 +12,10 @@ import logging
 import sys
 
 import boto3
+import pkg_resources
 from botocore.exceptions import ClientError
 from retrying import retry
 from utils import get_instance_info
-
-from pcluster.utils import get_installed_version
 
 LOGGER = logging.getLogger(__name__)
 
@@ -68,7 +67,8 @@ def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64"):
     try:
         if ami_type == "pcluster":
             ami_name = "aws-parallelcluster-{version}-{ami_name}".format(
-                version=get_installed_version(), ami_name=AMI_TYPE_DICT.get(ami_type).get(os).get("name")
+                version=_get_installed_parallelcluste_version(),
+                ami_name=AMI_TYPE_DICT.get(ami_type).get(os).get("name"),
             )
         else:
             ami_name = AMI_TYPE_DICT.get(ami_type).get(os).get("name")
@@ -93,3 +93,8 @@ def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64"):
 @retry(stop_max_attempt_number=3, wait_fixed=5000)
 def fetch_instance_slots(region, instance_type):
     return get_instance_info(instance_type, region).get("VCpuInfo").get("DefaultVCpus")
+
+
+def _get_installed_parallelcluste_version():
+    """Get the version of the installed aws-parallelcluster package."""
+    return pkg_resources.get_distribution("aws-parallelcluster").version

--- a/tests/integration-tests/tests/iam_policies/test_iam_policies/test_iam_policies/pcluster.config.ini
+++ b/tests/integration-tests/tests/iam_policies/test_iam_policies/test_iam_policies/pcluster.config.ini
@@ -9,6 +9,8 @@ key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
 additional_iam_policies = {{ iam_policies }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
 base_os = {{ os }}
 
 [vpc parallelcluster-vpc]

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -83,7 +83,7 @@ def test_multiple_jobs_submission(scheduler, region, pcluster_config_reader, clu
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["sge", "torque"])
 @pytest.mark.oss(["alinux2", "centos7", "ubuntu1804"])
-@pytest.mark.usefixtures("region", "instance")
+@pytest.mark.usefixtures("region", "instance", "os")
 @pytest.mark.nodewatcher
 def test_nodewatcher_terminates_failing_node(scheduler, region, pcluster_config_reader, clusters_factory, test_datadir):
     # slurm test use more nodes because of internal request to test in multi-node settings

--- a/tests/integration-tests/tox.ini
+++ b/tests/integration-tests/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+toxworkdir=../../.tox
+
+[testenv:validate-test-configs]
+basepython = python3
+skip_install = true
+deps = -r requirements.txt
+commands =
+    python -m framework.tests_configuration.config_validator {posargs:--tests-configs-dir configs/} --tests-root-dir tests/
+
+[testenv:generate-test-config]
+basepython = python3
+skip_install = true
+deps = -r requirements.txt
+commands =
+    python -m framework.tests_configuration.config_generator --output-file {posargs} --tests-root-dir tests/


### PR DESCRIPTION
Please take a look at the README file included in this PR in order to understand what are the new features introduced by this change. 

Below I reported a more detailed explanation of the reasons that drove this change.

***
# Integration Testing Framework - Tests Config 

## How do we currently configure integration tests?

**tl;dr;** Tests when defined are decorated with some annotations that declare dimensions they are allowed to run against. Later at test submission time a list of dimensions to test (regions, instances, oss, schedulers) needs to be passed to the cli. The end result is that an intersection of the input and the declared dimensions is what determine what tests are ran.

https://github.com/aws/aws-parallelcluster/blob/develop/tests/integration-tests/README.md#specify-tests-dimensions

## What are the current limitations?

With the current approach, when integration tests are defined they are decorated with some annotations that specify the dimensions (regions, instances, schedulers, oses) they are allowed to run against. Later at test submission time, for each dimension, a list of values is provided in order to globally define the allowed dimensions for the specific test run. The end result is that an intersection of the input dimensions and the test function whitelisted dimensions is what determine what tests are executed.
 This approach was reasonable when having a reduced amount of tests and most of all when we didn’t need to run different tests suites for various types of validations. Currently we are facing the following limitations:

- It is hard to understand what tests are going to be executed given a set of input dimensions. A dryrun option makes it possible to obtain that list but this results in a tedious and error prone process especially when establishing the dimensions you want to run a test against
- With a growing number of tests it is hard to selectively choose the dimensions for each test and at the same time distribute the number of clusters we create across all AWS regions. When tests are not uniformly distributed the overall runtime is going to be affected by the slowest region.
- It is not possible to dynamically change the tests to execute without performing a code change. This is very useful now that we want to maintain different test configs to run against different versions, branches or features.
- In case of an issue it is hard to simply run a single or a subset of tests against specific dimensions.
- It is hard to have a clear overview of the existing tests and the related dimensions they are tested against. This makes it harder to design new tests or rebalance existing ones in order to reduce the overall runtime

## Solution

Have a configuration file that defines the test suites to execute and the dimensions for each test. The configuration file supports jinja2 templating engine in order to enable additional features such picking random dimensions and uniformly distribute tests cross regions.



- The following file is not required but an example of how to use jinja2 to collect common variables in a single common place

```
{%- set REGIONS_COMMERCIAL = ["us-east-1", "eu-west-1", "..."] -%}
{%- set OSS_COMMERCIAL = ["alinux", "centos7", "..."] -%}
{%- set INSTANCES_COMMERCIAL = ["c5.xlarge", "..."] -%}
{%- set INSTANCES_EFA = ["c5n.18xlarge", "p3dn.24xlarge", "i3en.24xlarge"] -%}
{%- set SCHEDULERS_ALL = ["slurm", "sge", "torque", "awsbatch"] -%}
{%- set SCHEDULERS_TRAD = ["slurm", "sge", "torque"] -%}
```

- The following config declares the tests suites to run and ideally we are going to have one definition per partition in our code base. Additionally when developing you can have your config file to run specific tests.

```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  cfn-init:
    test_cfn_init.py::test_replace_compute_on_failure:
      dimensions:
        - regions:
            - {{ common.REGIONS_COMMERCIAL|random }}
          instances:
            - {{ common.INSTANCES_COMMERCIAL|random }}
          oss: {{ common.OSS_COMMERCIAL }}
          schedulers:
            - {{ common.SCHEDULERS_TRAD|random }}
        - regions:
            - us-east-1
          instances:
            - c5n.16xlarge
          oss:
            - centos7
          schedulers:
            - sge
  efa:
    test_efa.py::test_efa:
      dimensions:
        - regions:
            - {{ common.REGIONS_COMMERCIAL|random }}
          instances: {{ common.INSTANCES_EFA }}
          oss:
            - alinux
            - centos7
            - ubuntu1604
          schedulers:
            - sge
            - slurm
  scaling:
    test_scaling.py::test_multiple_jobs_submission:
      dimensions:
        - regions: {{ common.REGIONS_COMMERCIAL }}
          instances: {{ common.INSTANCES_COMMERCIAL }}
          oss: {{ common.OSS_COMMERCIAL }}
          schedulers: {{ common.SCHEDULERS_TRAD }}
```

- Tests are submitted with the following command:

```
python -m test_runner \
    --key-name "ec2-key-name" \
    --key-path "~/.ssh/ec2-key.pem" \
    --tests-config "path/to/config"
```

The features flag can still be used to select specific test suites from a broader config file although you can have your config file when developing.

- Tests configs for our recurrent tests run can be committed inside our code base. For example we can have 3 configs for develop tests (develop-china.conf, develop-commercial.conf, develop-govcloud.conf) and 3 configs for tests against the latest released version (prod-china.conf, prod-commercial.conf, prod-govcloud.conf). Jenkins will select the appropriate config in its daily test runs. Moreover jenkins can accept a custom config files to allow ad hoc test runs (at the beginning this can be provided in a text field and in the future we can also allow s3 urls).

## FAQ

**Why YAML?**
 Because we can add comments to the config file and it’s more compact than json

**Why dimensions is an array of objects?**
 Because for every object in the array, tests are executed for all combinations of the given dimensions. For example let’s suppose you want to run a given tests for all schedulers but only a subset for awsbatch. You can do it with something like:

```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  my-test:
    test_something.py::test_something_works:
      dimensions:
        - regions: {{ common.REGIONS_COMMERCIAL }}
          instances: {{ common.INSTANCES_COMMERCIAL }}
          oss: {{ common.OSS_COMMERCIAL }}
          schedulers: {{ common.SCHEDULERS_TRAD }}
        - regions:
            - us-east-1
          instances:
            - t2.micro
          oss:
            - centos7
          schedulers:
            - awsbatch
```


**How can this be extended to support AZs specification?**
 The idea is to allow to specifies AZs together with the regions as shown below:

```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  my-test:
    test_something.py::test_something_works:
      dimensions:
        - regions:
            - us-east-1
              - use1-az6
              - use1-az2
            - eu-west-1
          instances: {{ common.INSTANCES_COMMERCIAL }}
          oss: {{ common.OSS_COMMERCIAL }}
          schedulers: {{ common.SCHEDULERS_TRAD }}
```

- when not specified a random AZ is picked. 
- when multiple AZs are specified tests will run in multiple AZs


**Why using a template engine for the configurations?**

- To reduce the size of the config file
- To have a single place where to define shared dimensions
- To have the possibilities to apply functions such as random selection in arrays


**Why randomly selecting a region?**

- To better distribute tests across regions and reduce overall execution time
- Over time we increase coverage for features that are tested in a single region per partition

The downside is that test metrics can be affected

***
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
