### PR TITLE
integ-tests: test AMI validations (OS validation and pcluster version validation)

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -66,6 +66,17 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
+  create:
+    test_create.py::test_create_wrong_os:
+      dimensions:
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1804"]
+    test_create.py::test_create_wrong_pcluster_version:
+      dimensions:
+        - regions: ["ca-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux"]
   createami:
     test_createami.py::test_createami:
       dimensions:
@@ -86,6 +97,16 @@ test-suites:
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["alinux2"]
+    test_createami.py::test_createami_wrong_os:
+      dimensions:
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux"]
+    test_createami.py::test_createami_wrong_pcluster_version:
+      dimensions:
+        - regions: ["ca-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux"]
   dashboard:
     test_dashboard.py::test_dashboard:
       dimensions:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -265,7 +265,7 @@ def clusters_factory(request):
     """
     factory = ClustersFactory(keep_logs_on_failure=request.config.getoption("keep_logs_on_cluster_failure"))
 
-    def _cluster_factory(cluster_config, extra_args=None):
+    def _cluster_factory(cluster_config, extra_args=None, raise_on_error=True):
         cluster_config = _write_cluster_config_to_outdir(request, cluster_config)
         cluster = Cluster(
             name=request.config.getoption("cluster")
@@ -279,7 +279,7 @@ def clusters_factory(request):
             ssh_key=request.config.getoption("key_path"),
         )
         if not request.config.getoption("cluster"):
-            factory.create_cluster(cluster, extra_args=extra_args)
+            factory.create_cluster(cluster, extra_args=extra_args, raise_on_error=raise_on_error)
         return cluster
 
     yield _cluster_factory

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -27,8 +27,9 @@ class RemoteCommandExecutionError(Exception):
 class RemoteCommandExecutor:
     """Execute remote commands on the cluster master node."""
 
-    def __init__(self, cluster):
-        username = get_username_for_os(cluster.os)
+    def __init__(self, cluster, username=None):
+        if not username:
+            username = get_username_for_os(cluster.os)
         self.__connection = Connection(
             host=cluster.master_ip,
             user=username,

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -62,6 +62,17 @@ def assert_no_errors_in_logs(remote_command_executor, scheduler):
             assert_that(log).does_not_contain(error_level)
 
 
+def assert_errors_in_logs(remote_command_executor, log_files, expected_errors):
+    # assert every expected error exists in at least one of the log files
+    __tracebackhide__ = True
+
+    log = ""
+    for log_file in log_files:
+        log += remote_command_executor.run_remote_command("cat {0}".format(log_file), hide=True).stdout
+    for message in expected_errors:
+        assert_that(log).matches(message)
+
+
 def assert_no_node_in_ec2(region, stack_name, instance_types=None):
     assert_that(get_compute_nodes_count(stack_name, region, instance_types)).is_equal_to(0)
 

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+
+import pytest
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+from utils import get_username_for_os
+
+from tests.common.assertions import assert_errors_in_logs
+from tests.common.utils import (
+    get_installed_parallelcluster_version,
+    retrieve_latest_ami,
+    retrieve_pcluster_ami_without_standard_naming,
+)
+
+
+@pytest.mark.dimensions("eu-central-1", "c5.xlarge", "ubuntu1804", "*")
+def test_create_wrong_os(region, os, pcluster_config_reader, clusters_factory, architecture, instance):
+    """Test error message when os provide is different from the os of custom AMI"""
+    # ubuntu1804 is specified in the config file but an AMI of centos7 is provided
+    wrong_os = "centos7"
+    logging.info("Asserting os fixture is different from wrong_os variable")
+    assert_that(os != wrong_os).is_true()
+    custom_ami = retrieve_latest_ami(region, wrong_os, ami_type="remarkable", architecture=architecture)
+    cluster_config = pcluster_config_reader(custom_ami=custom_ami)
+    cluster = clusters_factory(cluster_config, raise_on_error=False)
+    username = get_username_for_os(wrong_os)
+    remote_command_executor = RemoteCommandExecutor(cluster, username=username)
+
+    logging.info("Verifying error in logs")
+    assert_errors_in_logs(
+        remote_command_executor,
+        ["/var/log/cfn-init.log"],
+        ["RuntimeError", fr"custom AMI.+{wrong_os}.+base.+os.+config file.+{os}"],
+    )
+
+
+@pytest.mark.dimensions("ca-central-1", "c5.xlarge", "alinux", "*")
+def test_create_wrong_pcluster_version(region, os, pcluster_config_reader, clusters_factory, architecture, instance):
+    """Test error message when AMI provided was baked by a pcluster whose version is different from current version"""
+    current_version = get_installed_parallelcluster_version()
+    wrong_version = "2.8.1"
+    logging.info("Asserting wrong_version is different from current_version")
+    assert_that(current_version != wrong_version).is_true()
+    # Retrieve an AMI without 'aws-parallelcluster-<version>' in its name.
+    # Therefore, we can bypass the version check in CLI and test version check of .bootstrapped file in Cookbook.
+    wrong_ami = retrieve_pcluster_ami_without_standard_naming(
+        region, os, version=wrong_version, architecture=architecture
+    )
+    cluster_config = pcluster_config_reader(custom_ami=wrong_ami)
+    cluster = clusters_factory(cluster_config, raise_on_error=False)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    logging.info("Verifying error in logs")
+    assert_errors_in_logs(
+        remote_command_executor,
+        ["/var/log/cfn-init.log"],
+        ["RuntimeError", fr"AMI was created.+{wrong_version}.+is.+used.+{current_version}"],
+    )

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.ini
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.ini
@@ -1,0 +1,19 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = slurm
+master_instance_type = {{ instance }}
+custom_ami = {{ custom_ami }}
+master_root_volume_size = 100
+compute_root_volume_size = 100
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.ini
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.ini
@@ -1,0 +1,19 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = slurm
+master_instance_type = {{ instance }}
+custom_ami = {{ custom_ami }}
+master_root_volume_size = 100
+compute_root_volume_size = 100
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -10,12 +10,19 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+import logging
+
+import pexpect
 import pytest
 from assertpy import assert_that
 from packaging import version
 from utils import run_command
 
-from tests.common.utils import retrieve_latest_ami
+from tests.common.utils import (
+    get_installed_parallelcluster_version,
+    retrieve_latest_ami,
+    retrieve_pcluster_ami_without_standard_naming,
+)
 
 
 @pytest.mark.dimensions("eu-west-1", "c5.xlarge", "alinux", "*")
@@ -55,29 +62,13 @@ def test_createami(region, os, instance, request, pcluster_config_reader, vpc_st
         + networking_args
     )
 
-    assert_that(
-        any(
-            "downloading https://{0}-aws-parallelcluster.s3".format(region).lower() in s.lower()
-            for s in pcluster_createami_result.stdout.split("\n")
-        )
-    ).is_true()
-    assert_that(
-        any("chef.io/chef/install.sh".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
-    ).is_false()
-    assert_that(
-        any("packages.chef.io".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
-    ).is_false()
-    assert_that(
-        any(
-            "Thank you for installing Cinc Client".lower() in s.lower()
-            for s in pcluster_createami_result.stdout.split("\n")
-        )
-    ).is_true()
-    assert_that(
-        any("Starting Cinc Client".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
-    ).is_true()
-
-    assert_that(pcluster_createami_result.stdout).does_not_contain("No custom AMI created")
+    stdout_lower = pcluster_createami_result.stdout.lower()
+    assert_that(stdout_lower).contains("downloading https://{0}-aws-parallelcluster.s3".format(region))
+    assert_that(stdout_lower).does_not_contain("chef.io/chef/install.sh")
+    assert_that(stdout_lower).does_not_contain("packages.chef.io")
+    assert_that(stdout_lower).contains("thank you for installing cinc client")
+    assert_that(stdout_lower).contains("starting cinc client")
+    assert_that(stdout_lower).does_not_contain("no custom ami created")
 
 
 @pytest.mark.dimensions("us-west-2", "c5.xlarge", "centos7", "*")
@@ -116,8 +107,74 @@ def test_createami_post_install(
         + post_install_args
     )
 
-    assert_that(
-        any("No post install script".lower() in s.lower() for s in pcluster_createami_result.stdout.split("\n"))
-    ).is_false()
+    stdout_lower = pcluster_createami_result.stdout.lower()
+    assert_that(stdout_lower).does_not_contain("no post install script")
+    assert_that(stdout_lower).does_not_contain("no custom ami created")
 
-    assert_that(pcluster_createami_result.stdout).does_not_contain("No custom AMI created")
+
+@pytest.mark.dimensions("eu-central-1", "c5.xlarge", "alinux", "*")
+def test_createami_wrong_os(region, os, instance, request, pcluster_config_reader, vpc_stack, architecture):
+    """Test error message when os provide is different from the os of custom AMI"""
+    cluster_config = pcluster_config_reader()
+
+    # alinux is specified in the config file but an AMI of alinux2 is provided
+    wrong_os = "alinux2"
+    logging.info("Asserting os fixture is different from wrong_os variable")
+    assert_that(os != wrong_os).is_true()
+    base_ami = retrieve_latest_ami(region, wrong_os, ami_type="pcluster", architecture=architecture)
+
+    # Networking
+    vpc_id = vpc_stack.cfn_outputs["VpcId"]
+    subnet_id = vpc_stack.cfn_outputs["PublicSubnetId"]
+    networking_args = f"--vpc-id {vpc_id} --subnet-id {subnet_id}"
+
+    # Custom Cookbook
+    custom_cookbook = request.config.getoption("createami_custom_chef_cookbook")
+    custom_cookbook_args = "" if not custom_cookbook else f"-cc {custom_cookbook}"
+
+    command = (
+        f"pcluster createami -ai {base_ami} -os {os} -r {region} -c {cluster_config.as_posix()} "
+        f"{custom_cookbook_args} -i {instance} {networking_args}"
+    )
+    createami_process = pexpect.spawn(command, timeout=600)
+    logging.info("Verifying errors in stdout")
+    createami_process.expect("RuntimeError")
+    createami_process.expect(fr"custom AMI.+{wrong_os}.+base.+os.+config file.+{os}")
+    createami_process.expect("No custom AMI created")
+    createami_process.close()
+
+
+@pytest.mark.dimensions("ca-central-1", "c5.xlarge", "alinux", "*")
+def test_createami_wrong_pcluster_version(
+    region, os, instance, request, pcluster_config_reader, vpc_stack, architecture
+):
+    """Test error message when AMI provided was baked by a pcluster whose version is different from current version"""
+    cluster_config = pcluster_config_reader()
+    current_version = get_installed_parallelcluster_version()
+    wrong_version = "2.8.1"
+    logging.info("Asserting wrong_version is different from current_version")
+    assert_that(current_version != wrong_version).is_true()
+    # Retrieve an AMI without 'aws-parallelcluster-<version>' in its name.
+    # Therefore, we can bypass the version check in CLI and test version check of .bootstrapped file in Cookbook.
+    wrong_ami = retrieve_pcluster_ami_without_standard_naming(
+        region, os, version=wrong_version, architecture=architecture
+    )
+    # Networking
+    vpc_id = vpc_stack.cfn_outputs["VpcId"]
+    subnet_id = vpc_stack.cfn_outputs["PublicSubnetId"]
+    networking_args = f"--vpc-id {vpc_id} --subnet-id {subnet_id}"
+
+    # Custom Cookbook
+    custom_cookbook = request.config.getoption("createami_custom_chef_cookbook")
+    custom_cookbook_args = "" if not custom_cookbook else f"-cc {custom_cookbook}"
+
+    command = (
+        f"pcluster createami -ai {wrong_ami} -os {os} -r {region} -c {cluster_config.as_posix()} "
+        f"{custom_cookbook_args} -i {instance} {networking_args}"
+    )
+    createami_process = pexpect.spawn(command, timeout=600)
+    logging.info("Verifying errors in stdout")
+    createami_process.expect("RuntimeError")
+    createami_process.expect(fr"AMI was created.+{wrong_version}.+is.+used.+{os}")
+    createami_process.expect("No custom AMI created")
+    createami_process.close()

--- a/tests/integration-tests/tests/createami/test_createami/test_createami_wrong_os/pcluster.config.ini
+++ b/tests/integration-tests/tests/createami/test_createami/test_createami_wrong_os/pcluster.config.ini
@@ -1,0 +1,11 @@
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+base_os = {{ os }}
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}

--- a/tests/integration-tests/tests/createami/test_createami/test_createami_wrong_pcluster_version/pcluster.config.ini
+++ b/tests/integration-tests/tests/createami/test_createami/test_createami_wrong_pcluster_version/pcluster.config.ini
@@ -1,0 +1,11 @@
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+base_os = {{ os }}
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -28,7 +28,7 @@ def retry_if_subprocess_error(exception):
     return isinstance(exception, subprocess.CalledProcessError)
 
 
-def run_command(command, capture_output=True, log_error=True, env=None, timeout=None):
+def run_command(command, capture_output=True, log_error=True, env=None, timeout=None, raise_on_error=True):
     """Execute shell command."""
     if isinstance(command, str):
         command = shlex.split(command)
@@ -45,11 +45,13 @@ def run_command(command, capture_output=True, log_error=True, env=None, timeout=
                     " ".join(command), result.stderr, result.stdout
                 )
             )
-        raise
+        if raise_on_error:
+            raise
     except subprocess.TimeoutExpired:
         if log_error:
             logging.error("Command {0} timed out after {1} sec".format(" ".join(command), timeout))
-        raise
+        if raise_on_error:
+            raise
 
     return result
 


### PR DESCRIPTION
1. If an AMI was baked by another version of pcluster and is trying to be used by current pcluster, pcluster should detect the difference, fail the creation and give a message
2. If OS provided by a user is different from the actual OS of an AMI, pcluster should detect the fail the creation and give a message

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
