### PR TITLE
Bug fixes: ebs settings from_cfn referred section labels, missing tags arg

### DIFF
--- a/cli/pcluster/commands.py
+++ b/cli/pcluster/commands.py
@@ -70,7 +70,9 @@ def _create_bucket_with_resources(pcluster_config, json_params, tags):
     return s3_bucket_name
 
 
-def _upload_hit_resources(bucket_name, pcluster_config, json_params, tags):
+def _upload_hit_resources(bucket_name, pcluster_config, json_params, tags=None):
+    if tags is None:
+        tags = []
     hit_template_url = pcluster_config.get_section("cluster").get_param_value(
         "hit_template_url"
     ) or "{bucket_url}/templates/compute-fleet-hit-substack-{version}.cfn.yaml".format(

--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -951,7 +951,11 @@ class EBSSettingsCfnParam(SettingsCfnParam):
                             param_type = param_definition.get("type", CfnParam)
                             cfn_value = get_cfn_param(cfn_params, cfn_converter).split(",")[index]
                             param = param_type(
-                                self.section_key, self.section_label, param_key, param_definition, self.pcluster_config
+                                referred_section.key,
+                                referred_section.label,
+                                param_key,
+                                param_definition,
+                                self.pcluster_config,
                             ).from_cfn_value(cfn_value)
                             referred_section.add_param(param)
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -857,7 +857,7 @@ def get_master_server_state(stack_name):
     :param stack_name: The name of the cloudformation stack
     :return master server state name
     """
-    instances = describe_cluster_instances(stack_name, filter_by_name="Master")
+    instances = describe_cluster_instances(stack_name, "Master")
     if not instances:
         error("MasterServer not running.")
     return instances[0].get("State").get("Name")

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -152,6 +152,20 @@ commands =
         ../util/ \
         {posargs}
 
+[testenv:pylint-permissive]
+deps =
+    {[testenv:pylint]deps}
+commands =
+    pylint \
+        --disable=all \
+        --enable=no-value-for-parameter \
+        setup.py \
+        awsbatch/ \
+        pcluster/ \
+        pcluster/resources/custom_resources/custom_resources_code/ \
+        ../util/ \
+        {posargs}
+
 # Vulture finds unused code in python: https://github.com/jendrikseipp/vulture
 [testenv:vulture]
 basepython = python3
@@ -187,6 +201,7 @@ deps =
     {[testenv:black-check]deps}
     {[testenv:isort-check]deps}
     {[testenv:flake8]deps}
+    {[testenv:pylint-permissive]deps}
     # {[testenv:pylint]deps}
     # {[testenv:bandit]deps}
     # {[testenv:readme]deps}
@@ -194,6 +209,7 @@ commands =
     {[testenv:black-check]commands}
     {[testenv:isort-check]commands}
     {[testenv:flake8]commands}
+    {[testenv:pylint-permissive]commands}
     # {[testenv:pylint]commands}
     # {[testenv:bandit]commands}
     # {[testenv:readme]commands}


### PR DESCRIPTION
Two issues are addressed by this PR:
1. EBSSettingsCfnParam.from_storage was passing the cluster section's key and label when creating param objects to represent the referred EBS sections. Change that to pass those constructors the section key and label for the referred EBS section instead.
2. A call to `_upload_hit_resources` in update.py was missing the mandatory `tags` arg. Make that arg optional instead.

In an effort to avoid errors like 2. in the future, the last commit in this PR adds a pylint check to the code-linters tox environment that we require to pass for every PR. Right now that check only looks for that specific type of error, but over time we can add more.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
