### PR TITLE
integ-tests: fix pcluster_configure and iam_policies tests

### DIFF
--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -181,7 +181,7 @@ def assert_config_contains_expected_values(
     else:
         param_validators += [
             {"section_name": "cluster default", "parameter_name": "initial_queue_size", "expected_value": 1},
-            {"section_name": "cluster default", "parameter_name": "maintain_initial_size", "expected_value": True},
+            {"section_name": "cluster default", "parameter_name": "maintain_initial_size", "expected_value": "true"},
             {"section_name": "cluster default", "parameter_name": "compute_instance_type", "expected_value": instance},
         ]
 

--- a/tests/integration-tests/tests/configure/test_pcluster_configure/test_pcluster_configure_avoid_bad_subnets/pcluster.config.ini
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure/test_pcluster_configure_avoid_bad_subnets/pcluster.config.ini
@@ -7,11 +7,11 @@ aws_region_name = {{ region }}
 [cluster default]
 base_os = alinux2
 key_name = {{ key_name }}
-vpc_settings = parallelcluster-vpc
+vpc_settings = default
 scheduler = slurm
 master_instance_type = t2.micro
 
-[vpc parallelcluster-vpc]
+[vpc default]
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ wrong_subnet_id }}
 compute_subnet_id = {{ wrong_subnet_id }}

--- a/tests/integration-tests/tests/iam_policies/test_iam_policies.py
+++ b/tests/integration-tests/tests/iam_policies/test_iam_policies.py
@@ -21,7 +21,7 @@ from tests.common.assertions import assert_no_errors_in_logs
 @pytest.mark.regions(["ap-northeast-2"])
 @pytest.mark.schedulers(["slurm", "awsbatch"])
 @pytest.mark.oss(["alinux2"])
-@pytest.mark.usefixtures("os")
+@pytest.mark.usefixtures("os", "instance")
 def test_iam_policies(region, scheduler, pcluster_config_reader, clusters_factory):
     """Test IAM Policies"""
     cluster_config = pcluster_config_reader(


### PR DESCRIPTION
A minor fixed required after: https://github.com/aws/aws-parallelcluster/pull/2136/commits/01f3b846954d4a4a5dce7d55f4e80102d9213649

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
