### PR TITLE
integ-tests: review tests dimensions and rebalance across regions

### DIFF
--- a/tests/integration-tests/configs/common.jinja2
+++ b/tests/integration-tests/configs/common.jinja2
@@ -15,4 +15,3 @@
 {%- set INSTANCES_DEFAULT_X86 = ["c5.xlarge"] -%}
 {%- set INSTANCES_DEFAULT_ARM = ["m6g.xlarge"] -%}
 {%- set INSTANCES_DEFAULT = ["c5.xlarge", "m6g.xlarge"] -%}
-

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -242,14 +242,22 @@ test-suites:
         - regions: {{ common.REGIONS_COMMERCIAL }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
-          schedulers: {{ common.SCHEDULERS_TRAD }}
+          schedulers: ["slurm", "sge"]
         - regions: {{ common.REGIONS_CHINA }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.OSS_CHINA_X86 }}
-          schedulers: {{ common.SCHEDULERS_TRAD }}
+          schedulers: ["slurm", "sge"]
         - regions: {{ common.REGIONS_GOVCLOUD }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.OSS_GOVCLOUD_X86 }}
+          schedulers: ["slurm", "sge"]
+        - regions: ["ap-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["torque"]
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM }}
           schedulers: {{ common.SCHEDULERS_TRAD }}
     test_scaling.py::test_nodewatcher_terminates_failing_node:
       dimensions:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -86,6 +86,13 @@ test-suites:
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["alinux2"]
+  dashboard:
+    test_dashboard.py::test_dashboard:
+      dimensions:
+        - regions: ["ap-northeast-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7"]
+          schedulers: ["slurm"]
   dcv:
     test_dcv.py::test_dcv_configuration:
       dimensions:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -340,11 +340,17 @@ test-suites:
           # FSx is only supported on ARM instances for Ubuntu 18.04 and Amazon Linux 2
           oss: ["alinux2", "ubuntu1804"]
           schedulers: ["slurm"]
+    test_fsx_lustre.py::test_fsx_lustre_configuration_options:
+      dimensions:
+        - regions: ["ap-northeast-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
     test_fsx_lustre.py::test_fsx_lustre_backup:
       dimensions:
         - regions: ["us-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]  # FSx is not supported on CentOS 6
+          oss: {{ common.OSS_ONE_PER_DISTRO }}
           schedulers: ["sge"]
         - regions: ["us-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -210,7 +210,7 @@ test-suites:
           oss: ["alinux2"]
           schedulers: ["slurm", "awsbatch"]
   runtime_bake:
-    test_runtime_bake.py::test_runtime_bake:
+    test_runtime_bake.py::test_runtime_bake:  # These are currently skipped
       dimensions:
         {%- for os, scheduler in [("alinux", "slurm"), ("alinux2", "torque"), ("centos7", "sge")] %}
         - regions: ["eu-west-2"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -11,7 +11,7 @@ test-suites:
   cli_commands:
     test_cli_commands.py::test_hit_cli_commands:
       dimensions:
-        - regions: ["us-east-2"]
+        - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu1804"]
           schedulers: ["slurm"]
@@ -25,10 +25,14 @@ test-suites:
     test_cloudwatch_logging.py::test_cloudwatch_logging:
       dimensions:
         # 1) run the test for all of the schedulers with alinux2
-        - regions: ["ca-central-1"]
+        - regions: ["cn-northwest-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
-          schedulers: {{ common.SCHEDULERS_ALL }}
+          schedulers: {{ common.SCHEDULERS_TRAD }}
+        - regions: ["us-gov-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["awsbatch"]
         # 2) run the test for all of the OSes with slurm
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -41,58 +45,73 @@ test-suites:
           schedulers: ["slurm"]
   configure:
     test_pcluster_configure.py::test_pcluster_configure:
-      dimensions: # TODO: too many tests
-        - regions: ["us-east-1"]
+      dimensions:
+        - regions: ["ap-southeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: {{ common.OSS_ONE_PER_DISTRO }}
           schedulers: ["slurm", "sge"]
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
-          schedulers: ["slurm", "sge"]
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
         # Do not run on ARM + Batch
         # pcluster configure always picks optimal and Batch does not support ARM for optimal for now
-        - regions: ["us-east-1"]
+        - regions: ["us-gov-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_BATCH }}
+          oss: ["alinux2"]
           schedulers: ["awsbatch"]
     test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
       dimensions:
-        - regions: ["us-east-1"]
+        - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
   createami:
     test_createami.py::test_createami:
-      dimensions: # TODO: run in single region
-        {%- for region, os in [("eu-west-1", "alinux"), ("us-west-1", "alinux2"), ("us-west-2", "centos7"), ("eu-west-2", "ubuntu1604"), ("us-east-1", "ubuntu1804"), ("us-gov-east-1", "ubuntu1604"), ("us-gov-west-1", "ubuntu1804"), ("cn-northwest-1", "alinux2")] %}
-        - regions: ["{{ region }}"]
+      dimensions:
+        - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["{{ os }}"]
-        {%- endfor %}
+          oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]
+        - regions: ["us-gov-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1604", "ubuntu1804"]
+        - regions: ["cn-northwest-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
     test_createami.py::test_createami_post_install:
-      dimensions: # TODO: run in a single region
-        - regions: ["us-west-2"]
+      dimensions:
+        - regions: ["ap-southeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["centos7"]
-        - regions: ["eu-west-2"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu1804"]
+          oss: ["centos7", "ubuntu1804"]
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["alinux2"]
   dcv:
     test_dcv.py::test_dcv_configuration:
-      dimensions: # TODO: run in single region
-        {%- for region, instance, os in [("cn-northwest-1", "c5.xlarge", "alinux2"), ("us-gov-west-1", "c5.xlarge", "ubuntu1804"), ("eu-west-1", "g3.8xlarge", "alinux2"), ("eu-west-1", "g3.8xlarge", "centos7"), ("eu-west-1", "g3.8xlarge", "ubuntu1804"), ("eu-west-1", "m6g.xlarge", "alinux2"), ("eu-west-1", "m6g.xlarge", "ubuntu1804")] %}
-        - regions: ["{{ region }}"]
-          instances: ["{{ instance }}"]
-          oss: ["{{ os }}"]
+      dimensions:
+        # DCV on GPU enabled instance
+        - regions: ["eu-west-1"]
+          instances: ["g3.8xlarge"]
+          oss: ["alinux2", "centos7", "ubuntu1804"]
           schedulers: ["slurm"]
-        {%- endfor %}
+        # DCV on ARM
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["alinux2", "ubuntu1804"]
+          schedulers: ["slurm"]
+        # DCV in cn regions and non GPU enabled instance
+        - regions: ["cn-northwest-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+        # DCV in gov-cloud regions and non GPU enabled instance
+        - regions: ["us-gov-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1804"]
+          schedulers: ["slurm"]
     test_dcv.py::test_dcv_with_remote_access:
       dimensions:
-        - regions: ["eu-west-1"]
+        - regions: ["ap-southeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["centos7"]
           schedulers: ["sge"]
@@ -140,7 +159,7 @@ test-suites:
           oss: ["alinux2"]
           schedulers: ["slurm"]
     test_efa.py::test_sit_efa:
-      dimensions: # TODO review regions
+      dimensions:
         - regions: ["us-east-1"]
           instances: ["c5n.18xlarge"]
           # EFA not working on Centos6
@@ -149,7 +168,8 @@ test-suites:
   iam_policies:
     test_iam_policies.py::test_iam_policies:
       dimensions:
-        - regions: ["ap-northeast-2"]
+        - regions: ["eu-north-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["slurm", "awsbatch"]
   intel_hpc:
@@ -161,7 +181,7 @@ test-suites:
           schedulers: ["slurm"]
   networking:
     test_cluster_networking.py::test_cluster_in_private_subnet:
-      dimensions: # TODO: move to single block
+      dimensions:
         - regions: ["us-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
@@ -178,16 +198,28 @@ test-suites:
         - regions: ["eu-central-1", "us-gov-east-1", "cn-northwest-1"]
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
-        - regions: ["us-east-2"]
+        - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["slurm", "awsbatch"]
   runtime_bake:
     test_runtime_bake.py::test_runtime_bake:
-      dimensions: # TODO: simplify dimensions
-        {%- for region, instance, os, scheduler in [("eu-west-2", "c5.xlarge", "alinux", "slurm"), ("eu-west-3", "c5.xlarge", "alinux2", "torque"), ("us-east-2", "c5.xlarge", "centos7", "sge"), ("us-east-1", "c5.xlarge", "ubuntu1604", "slurm"), ("eu-west-1", "c5.xlarge", "ubuntu1804", "sge"), ("us-gov-east-1", "c5.xlarge", "ubuntu1604", "slurm"), ("us-gov-west-1", "c5.xlarge", "ubuntu1804", "sge"), ("us-east-1", "m6g.xlarge", "ubuntu1804", "sge"), ("eu-west-1", "m6g.xlarge", "alinux2", "slurm")] %}
-        - regions: ["{{ region }}"]
-          instances: ["{{ instance }}"]
+      dimensions:
+        {%- for os, scheduler in [("alinux", "slurm"), ("alinux2", "torque"), ("centos7", "sge")] %}
+        - regions: ["eu-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["{{ os }}"]
+          schedulers: ["{{ scheduler }}"]
+        {%- endfor %}
+        {%- for os, scheduler in [("ubuntu1604", "slurm"), ("ubuntu1804", "sge")] %}
+        - regions: ["us-gov-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["{{ os }}"]
+          schedulers: ["{{ scheduler }}"]
+        {%- endfor %}
+        {%- for os, scheduler in [("ubuntu1804", "sge"), ("alinux2", "slurm")] %}
+        - regions: ["us-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["{{ os }}"]
           schedulers: ["{{ scheduler }}"]
         {%- endfor %}
@@ -220,21 +252,21 @@ test-suites:
           schedulers: ["sge", "torque"]
     test_mpi.py::test_mpi:  # TODO: move outside of the scaling dir
       dimensions:
-        - regions: ["us-east-1"]  # TODO: change region
+        - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm", "sge"]
-        - regions: ["us-east-1"]  # TODO: change region
+        - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: {{ common.OSS_COMMERCIAL_ARM }}
           schedulers: ["slurm", "sge"]
     test_mpi.py::test_mpi_ssh:
       dimensions:
-        - regions: ["eu-west-1"]
+        - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]  # Known ssh issue on CentOS6+SLURM
           schedulers: ["slurm"]
-        - regions: ["eu-west-1"]
+        - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["sge"]
@@ -251,17 +283,17 @@ test-suites:
           schedulers: ["sge"]
     test_torque.py::test_torque:
       dimensions:
-        - regions: ["us-west-2"]
+        - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["torque"]
-        - regions: ["us-west-2"]
+        - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: {{ common.OSS_COMMERCIAL_ARM }}
           schedulers: ["torque"]
     test_awsbatch.py::test_awsbatch:
       dimensions:
-        - regions: {{ common.REGIONS_ALL }}
+        - regions: ["eu-north-1", "ap-south-1", "us-gov-west-1", "cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
@@ -279,9 +311,9 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
-    test_slurm.py::test_slurm_pmix:
+    test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
       dimensions:
-        - regions: ["eu-west-1"]
+        - regions: ["ap-southeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]
           schedulers: ["slurm"]
@@ -294,12 +326,12 @@ test-suites:
       dimensions:
         - regions: ["us-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_ONE_PER_DISTRO }}
+          oss: ["centos7"]
           schedulers: ["sge", "slurm"]
   storage:
     test_fsx_lustre.py::test_fsx_lustre:
       dimensions:
-        - regions: ["eu-west-1"]
+        - regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]  # FSx is not supported on CentOS 6
           schedulers: ["slurm"]
@@ -341,7 +373,7 @@ test-suites:
           schedulers: ["awsbatch"]
     test_raid.py::test_raid_fault_tolerance_mode:
       dimensions:
-        - regions: ["us-gov-west-1", "cn-northwest-1"]  # TODO: china only?
+        - regions: ["cn-northwest-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
@@ -391,7 +423,7 @@ test-suites:
           schedulers: ["torque"]
     test_ebs.py::test_ebs_snapshot:
       dimensions:
-        - regions: ["ap-northeast-2"]
+        - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["sge"]
@@ -415,13 +447,13 @@ test-suites:
           schedulers: ["awsbatch"]
     test_update.py::test_update_hit:
       dimensions:
-        - regions: ["eu-central-1"]
+        - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
     test_update.py::test_update_sit:
       dimensions:
-        - regions: ["eu-west-1"]
+        - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["centos7"]
           schedulers: ["sge"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -189,6 +189,7 @@ def _log_collected_tests(session):
         out_dir = session.config.getoption("output_dir")
         with open(f"{out_dir}/collected_tests.txt", "a") as out_f:
             out_f.write("\n".join(collected_tests))
+            out_f.write("\n")
 
 
 def pytest_exception_interact(node, call, report):

--- a/tests/integration-tests/tests/dashboard/test_dashboard.py
+++ b/tests/integration-tests/tests/dashboard/test_dashboard.py
@@ -15,7 +15,7 @@ from assertpy import assert_that
 from botocore.exceptions import ClientError
 
 
-@pytest.mark.dimensions("eu-west-1", "c5.xlarge", "centos7", "slurm")
+@pytest.mark.dimensions("us-east-2", "c5.xlarge", "centos7", "slurm")
 @pytest.mark.usefixtures("instance", "os", "scheduler")
 @pytest.mark.parametrize("dashboard_enabled, cw_log_enabled", [(True, True), (True, False), (False, False)])
 def test_dashboard(

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
@@ -30,20 +30,5 @@ use_public_ips = false
 [fsx fsx]
 shared_dir = {{ mount_dir }}
 storage_capacity = {{ storage_capacity }}
-imported_file_chunk_size = 1024
 import_path = s3://{{ bucket_name }}
 export_path = s3://{{ bucket_name }}/export_dir
-weekly_maintenance_start_time = 1:00:00
-deployment_type = {{ deployment_type }}
-{% if per_unit_storage_throughput %}
-per_unit_storage_throughput = {{ per_unit_storage_throughput }}
-{% endif %}
-{% if auto_import_policy %}
-auto_import_policy = {{ auto_import_policy }}
-{% endif %}
-{% if drive_cache_type %}
-drive_cache_type = {{ drive_cache_type }}
-{% endif %}
-{% if storage_type %}
-storage_type = {{ storage_type }}
-{% endif %}

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.ini
@@ -1,0 +1,49 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+{% if scheduler == "awsbatch" %}
+min_vcpus = 4
+desired_vcpus = 4
+{% else %}
+initial_queue_size = 1
+maintain_initial_size = true
+{% endif %}
+fsx_settings = fsx
+s3_read_resource = arn:aws:s3:::{{ bucket_name }}/*
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
+
+[fsx fsx]
+shared_dir = {{ mount_dir }}
+storage_capacity = {{ storage_capacity }}
+imported_file_chunk_size = 1024
+import_path = s3://{{ bucket_name }}
+export_path = s3://{{ bucket_name }}/export_dir
+weekly_maintenance_start_time = 1:00:00
+deployment_type = {{ deployment_type }}
+{% if per_unit_storage_throughput %}
+per_unit_storage_throughput = {{ per_unit_storage_throughput }}
+{% endif %}
+{% if auto_import_policy %}
+auto_import_policy = {{ auto_import_policy }}
+{% endif %}
+{% if drive_cache_type %}
+drive_cache_type = {{ drive_cache_type }}
+{% endif %}
+{% if storage_type %}
+storage_type = {{ storage_type }}
+{% endif %}

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/s3_test_file
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/s3_test_file
@@ -1,0 +1,1 @@
+Downloaded by FSx Lustre


### PR DESCRIPTION
- *test_scaling.py::test_multiple_jobs_submission*: (from 363 to 257) removed torque from all regions and moved to a single region. Added ARM instances in a single region.
- *test_cli_commands.py::test_hit_cli_commands*: changed region to rebalance number of tests
- *test_cloudwatch_logging.py::test_cloudwatch_logging*: moved some of the tests to cn and govcloud regions since there were no cloudwatch tests running in those partitions. 
- *test_pcluster_configure.py::test_pcluster_configure*: (from 19 to 9 tests)
  - rebalanced regions (also moved one test case to govcloud)
  - testing one os per distribution rather than all OSes
  - testing only one scheduler with ARM instances
  - test only alinux2 with awsbatch scheduler
- *test_createami.py*: only rebalanced regions
- *test_dashboard.py::test_dashboard*: added tests
- *test_dcv.py*: only rebalanced regions
- *test_iam_policies.py::test_iam_policies*:  only rebalanced regions
- *test_multi_cidr.py::test_multi_cidr*:  only rebalanced regions
- *test_runtime_bake.py::test_runtime_bake*: (from 9 to 7 tests)
  - rebalanced regions
  - only running ubuntu1604/1804 in govcloud and not also in commercial
- *test_mpi.py*:  only rebalanced regions
- *test_torque.py::test_torque*:  only rebalanced regions
- *test_awsbatch.py::test_awsbatch*: (from 23 to 6 tests) changed from running in all regions/all partitions to running in 1 region per partition + opt-in
- *test_slurm.py::test_slurm_pmix*:  only rebalanced regions
- *test_spot.py::test_spot_default*: (from 6 to 2 tests) changed from one os per distro to centos7 only. There is no dependency on the OS. The test only creates a cluster of type Spot.
- *test_fsx_lustre.py*: (from 49 to 18 tests) I did some refactoring in order to have the tests for the default FSx iterate over all OSes (so that we verify the client functionalities in all OSes) while I moved the parametrizations of different FSx options to a different test case which runs for a single OS. This significantly reduced the amount of FSx tests. Also changed the FSx backup test to run only for a single OS per distro.
- *test_raid.py*:  only rebalanced regions
- *test_ebs.py*: only rebalanced regions
- *test_update.py*: only rebalanced regions

***
Here is a summary of the number of tests running for each region before and after the rebalance/review. Worth noticing the fact that the region with the highest number of tests went from 93 to 38 thanks to the redistribution. This will make the integration tests suite run in about half the time.

BEFORE:
```
664 total
      93 tests_outputs/1603101918.299413.out/eu-west-1/collected_tests.txt
      69 tests_outputs/1603101918.299413.out/us-east-1/collected_tests.txt
      44 tests_outputs/1603101918.299413.out/us-west-2/collected_tests.txt
      41 tests_outputs/1603101918.299413.out/eu-central-1/collected_tests.txt
      30 tests_outputs/1603101918.299413.out/sa-east-1/collected_tests.txt
      29 tests_outputs/1603101918.299413.out/us-west-1/collected_tests.txt
      29 tests_outputs/1603101918.299413.out/us-east-2/collected_tests.txt
      29 tests_outputs/1603101918.299413.out/eu-west-2/collected_tests.txt
      28 tests_outputs/1603101918.299413.out/ap-northeast-1/collected_tests.txt
      27 tests_outputs/1603101918.299413.out/ap-south-1/collected_tests.txt
      26 tests_outputs/1603101918.299413.out/eu-west-3/collected_tests.txt
      25 tests_outputs/1603101918.299413.out/ca-central-1/collected_tests.txt
      25 tests_outputs/1603101918.299413.out/ap-east-1/collected_tests.txt
      23 tests_outputs/1603101918.299413.out/cn-north-1/collected_tests.txt
      23 tests_outputs/1603101918.299413.out/ap-southeast-1/collected_tests.txt
      22 tests_outputs/1603101918.299413.out/us-gov-east-1/collected_tests.txt
      22 tests_outputs/1603101918.299413.out/ap-northeast-2/collected_tests.txt
      21 tests_outputs/1603101918.299413.out/us-gov-west-1/collected_tests.txt
      20 tests_outputs/1603101918.299413.out/cn-northwest-1/collected_tests.txt
      19 tests_outputs/1603101918.299413.out/eu-north-1/collected_tests.txt
      19 tests_outputs/1603101918.299413.out/ap-southeast-2/collected_tests.txt
```

```
 363 test_scaling.py::
  49 test_fsx_lustre.py::
  27 test_mpi.py::
  23 test_awsbatch.py::
  20 test_ebs.py::
  19 test_pcluster_configure.py::
  16 test_efs.py::
  14 test_raid.py::
  13 test_slurm.py::
  11 test_efa.py::
  11 test_createami.py::
  11 test_cloudwatch_logging.py::
   9 test_runtime_bake.py::
   9 test_disable_hyperthreading.py::
   9 test_dcv.py::
   8 test_update.py::
   8 test_torque.py::
   8 test_sge.py::
   6 test_spot.py::
   6 test_networking.py::
   6 test_dns.py::
   6 test_cfn_init.py::
   3 test_tag_propagation.py::
   2 test_multi_cidr.py::
   2 test_iam_policies.py::
   2 test_cluster_networking.py::
   2 test_cli_commands.py::
   1 test_intel_hpc.py::
```

AFTER:
```
     496 total
      32 tests_outputs/1603124426.974109.out/us-east-1/collected_tests.txt
      30 tests_outputs/1603124426.974109.out/eu-west-1/collected_tests.txt
      30 tests_outputs/1603124426.974109.out/ap-east-1/collected_tests.txt
      28 tests_outputs/1603124426.974109.out/eu-central-1/collected_tests.txt
      28 tests_outputs/1603124426.974109.out/ca-central-1/collected_tests.txt
      27 tests_outputs/1603124426.974109.out/us-west-2/collected_tests.txt
      27 tests_outputs/1603124426.974109.out/us-west-1/collected_tests.txt
      27 tests_outputs/1603124426.974109.out/ap-south-1/collected_tests.txt
      23 tests_outputs/1603124426.974109.out/us-east-2/collected_tests.txt
      23 tests_outputs/1603124426.974109.out/sa-east-1/collected_tests.txt
      23 tests_outputs/1603124426.974109.out/eu-west-3/collected_tests.txt
      23 tests_outputs/1603124426.974109.out/eu-west-2/collected_tests.txt
      22 tests_outputs/1603124426.974109.out/ap-southeast-1/collected_tests.txt
      21 tests_outputs/1603124426.974109.out/eu-north-1/collected_tests.txt
      21 tests_outputs/1603124426.974109.out/ap-southeast-2/collected_tests.txt
      21 tests_outputs/1603124426.974109.out/ap-northeast-1/collected_tests.txt
      19 tests_outputs/1603124426.974109.out/cn-north-1/collected_tests.txt
      18 tests_outputs/1603124426.974109.out/us-gov-east-1/collected_tests.txt
      18 tests_outputs/1603124426.974109.out/cn-northwest-1/collected_tests.txt
      18 tests_outputs/1603124426.974109.out/ap-northeast-2/collected_tests.txt
      17 tests_outputs/1603124426.974109.out/us-gov-west-1/collected_tests.txt
```

```
 257 test_scaling.py::
  27 test_mpi.py::
  20 test_ebs.py::
  18 test_fsx_lustre.py::
  16 test_efs.py::
  13 test_slurm.py::
  13 test_raid.py::
  11 test_efa.py::
  11 test_createami.py::
  11 test_cloudwatch_logging.py::
   9 test_pcluster_configure.py::
   9 test_disable_hyperthreading.py::
   9 test_dcv.py::
   8 test_update.py::
   8 test_torque.py::
   8 test_sge.py::
   7 test_runtime_bake.py::
   6 test_networking.py::
   6 test_dns.py::
   6 test_cfn_init.py::
   6 test_awsbatch.py::
   3 test_tag_propagation.py::
   3 test_dashboard.py::
   2 test_spot.py::
   2 test_multi_cidr.py::
   2 test_iam_policies.py::
   2 test_cluster_networking.py::
   2 test_cli_commands.py::
   1 test_intel_hpc.py::
```


***
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
