### PR TITLE
integ-tests: test ebs volume created from snapshot with larger size

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -1444,7 +1444,7 @@ def ebs_volume_size_snapshot_validator(section_key, section_label, pcluster_conf
     Validate the following cases.
 
     The EBS snapshot is in "completed" state if it is specified
-    If user specified the volume size, the volume must be larger than then volume size of the EBS snapshot
+    If users specify the volume size, the volume must be not smaller than the volume size of the EBS snapshot
     """
     errors = []
     warnings = []
@@ -1462,10 +1462,17 @@ def ebs_volume_size_snapshot_validator(section_key, section_label, pcluster_conf
                     "Unable to get volume size for snapshot {snapshot_id}".format(snapshot_id=ebs_snapshot_id)
                 )
             elif volume_size < snapshot_volume_size:
-                errors.append("The EBS volume size must not be smaller than the volume size of EBS snapshot.")
+                errors.append(
+                    "The EBS volume size of the section '{section_label}' must not be smaller than "
+                    "{snapshot_volume_size}, because it is the size of the provided snapshot {ebs_snapshot_id}".format(
+                        section_label=section_label,
+                        snapshot_volume_size=snapshot_volume_size,
+                        ebs_snapshot_id=ebs_snapshot_id,
+                    )
+                )
             elif volume_size > snapshot_volume_size:
                 warnings.append(
-                    "The specifed volume size is larger than snapshot size. In order to use the full capacity of the "
+                    "The specified volume size is larger than snapshot size. In order to use the full capacity of the "
                     "volume, you'll need to manually resize the partition "
                     "according to this doc: "
                     "https://{partition_url}/AWSEC2/latest/UserGuide/recognize-expanded-volume-linux.html".format(

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -2411,7 +2411,7 @@ def test_ebs_volume_iops_validator(mocker, section_dict, expected_message):
             50,
             "completed",
             "aws-cn",
-            "The specifed volume size is larger than snapshot size. In order to use the full capacity of the "
+            "The specified volume size is larger than snapshot size. In order to use the full capacity of the "
             "volume, you'll need to manually resize the partition "
             "according to this doc: "
             "https://docs.amazonaws.cn/AWSEC2/latest/UserGuide/recognize-expanded-volume-linux.html",
@@ -2423,7 +2423,7 @@ def test_ebs_volume_iops_validator(mocker, section_dict, expected_message):
             50,
             "completed",
             "aws-us-gov",
-            "The specifed volume size is larger than snapshot size. In order to use the full capacity of the "
+            "The specified volume size is larger than snapshot size. In order to use the full capacity of the "
             "volume, you'll need to manually resize the partition "
             "according to this doc: "
             "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/recognize-expanded-volume-linux.html",
@@ -2446,7 +2446,8 @@ def test_ebs_volume_iops_validator(mocker, section_dict, expected_message):
             "completed",
             "aws-us-gov",
             None,
-            "The EBS volume size must not be smaller than the volume size of EBS snapshot",
+            "The EBS volume size of the section 'default' must not be smaller than 120, because it is the size of the "
+            "provided snapshot snap-1234567891abcdef0",
             False,
         ),
         (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

-  Add integration test to test the size of volume matches its actual size after it is created from a snapshot.
- Change the error message of ebs_volume_size_snapshot_validator when the volume size is smaller than the snapshot size. Give a more detailed and clear error message by mentioning the section label, snapshot size and snapshot id in the error message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
