### PR TITLE
integ-tests: move test_fsx_lustre_configuration_options test to us-east-2

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -357,7 +357,7 @@ test-suites:
           schedulers: ["slurm"]
     test_fsx_lustre.py::test_fsx_lustre_configuration_options:
       dimensions:
-        - regions: ["ap-northeast-1"]
+        - regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["slurm"]


### PR DESCRIPTION
ap-northeast-1 has 1 AZ where FSx is not supported


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
