### PR TITLE
Resolve dependency conflict on Python 3.4

### DIFF
--- a/cli/requirements34.txt
+++ b/cli/requirements34.txt
@@ -1,4 +1,4 @@
-boto3==1.15.18
+boto3>=1.14.3
 future>=0.18.2
 tabulate==0.8.5
 ipaddress>=1.0.22

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -24,7 +24,7 @@ def readme():
 VERSION = "2.9.1"
 REQUIRES = [
     "setuptools",
-    "boto3==1.15.18" if sys.version_info.major == 3 and sys.version_info.minor <= 4 else "boto3>=1.15.18",
+    "boto3>=1.14.3",
     "future>=0.16.0,<=0.18.2",
     "tabulate==0.8.5" if sys.version_info.major == 3 and sys.version_info.minor <= 4 else "tabulate>=0.8.2,<=0.8.7",
     "ipaddress>=1.0.22",

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -5,5 +5,4 @@ pytest-datadir
 pytest-html
 pytest-mock
 assertpy
-codecov
 recordclass

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -10,7 +10,9 @@ envlist =
 passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT
 whitelist_externals =
     bash
-deps = -rtests/requirements.txt
+deps =
+    -rtests/requirements.txt
+    py38: codecov
 commands =
     bash ./tests/pcluster/test.sh
     py{27,34,35,36,37,38}: py.test -l -v --basetemp={envtmpdir} --html=report.html --cov=awsbatch  --cov=pcluster tests/


### PR DESCRIPTION
It is caused by an upgrade of boto3. boto3 and codecov have disjoint version requirements for urllib. To solve the conflict, this commit will only install codecov on Python 3.8.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
