### PR TITLE
integ-tests: move pmix test into main slurm test

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -353,12 +353,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
-    test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
-      dimensions:
-        - regions: ["ap-southeast-2"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]
-          schedulers: ["slurm"]
         - regions: ["ap-northeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: {{ common.OSS_COMMERCIAL_ARM }}


### PR DESCRIPTION
This reduces the number of created clusters by incorporating pmix test into main Slurm one

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
