### PR TITLE
Fix cfn_scheduler_slots in pcluster update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ CHANGELOG
 - Enable queue resizing on update without requiring to stop the compute fleet. Stopping the compute fleet is only
   necessary when existing instances risk to be terminated.
 
+**BUG FIXES**
+
+- Fix cfn_scheduler_slots don't update when updating compute instance type by ``pcluster update``. 
+
 2.9.1
 -----
 

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -75,6 +75,7 @@ from pcluster.config.validators import (
     efa_validator,
     efs_id_validator,
     efs_validator,
+    extra_json_validator,
     fsx_architecture_os_validator,
     fsx_id_validator,
     fsx_ignored_parameters_validator,
@@ -853,7 +854,11 @@ CLUSTER_COMMON_PARAMS = [
     ("extra_json", {
         "type": ExtraJsonCfnParam,
         "cfn_param_mapping": "ExtraJson",
-        "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP,
+        "validators": [extra_json_validator],
+        "update_policy": UpdatePolicy(
+            UpdatePolicy.UNSUPPORTED,
+            fail_reason=UpdatePolicy.FAIL_REASONS["extra_json_update"],
+        )
     }),
     ("additional_cfn_template", {
         "cfn_param_mapping": "AdditionalCfnTemplate",

--- a/cli/pcluster/config/update_policy.py
+++ b/cli/pcluster/config/update_policy.py
@@ -90,6 +90,11 @@ UpdatePolicy.FAIL_REASONS = {
     "ebs_volume_resize": "Updating the file system after a resize operation requires commands specific to your "
     "operating system.",
     "ebs_sections_change": "EBS sections cannot be added or removed during a 'pcluster update' operation",
+    "extra_json_update": lambda change, patch: "Updating the extra_json parameter is not supported because it only "
+    "applies updates to compute nodes. If you still want to proceed, first stop the cluster with the "
+    "following command:\n{0} -c {1} {2} and then run an update with the --force flag".format(
+        "pcluster stop", patch.config_file, patch.cluster_name
+    ),
 }
 
 # Common action_needed messages

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -352,6 +352,19 @@ def disable_hyperthreading_architecture_validator(param_key, param_value, pclust
     return errors, warnings
 
 
+def extra_json_validator(param_key, param_value, pcluster_config):
+    errors = []
+    warnings = []
+
+    if param_value and param_value.get("cluster") and param_value.get("cluster").get("cfn_scheduler_slots"):
+        warnings.append(
+            "It is highly recommended to use the disable_hyperthreading parameter in order to control the "
+            "hyper-threading configuration in the cluster rather than using cfn_scheduler_slots in extra_json"
+        )
+
+    return errors, warnings
+
+
 def dcv_enabled_validator(param_key, param_value, pcluster_config):
     errors = []
     warnings = []

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -2565,3 +2565,28 @@ def test_duplicate_shared_dir_validator(
     }
 
     utils.assert_param_validator(mocker, config_parser_dict, expected_error=expected_message)
+
+
+@pytest.mark.parametrize(
+    "extra_json, expected_message",
+    [
+        (
+            {"extra_json": {"cluster": {"cfn_scheduler_slots": "1"}}},
+            "It is highly recommended to use the disable_hyperthreading parameter in order to control the "
+            "hyper-threading configuration in the cluster rather than using cfn_scheduler_slots in extra_json",
+        ),
+        (
+            {"extra_json": {"cluster": {"cfn_scheduler_slots": "vcpus"}}},
+            "It is highly recommended to use the disable_hyperthreading parameter in order to control the "
+            "hyper-threading configuration in the cluster rather than using cfn_scheduler_slots in extra_json",
+        ),
+        (
+            {"extra_json": {"cluster": {"cfn_scheduler_slots": "cores"}}},
+            "It is highly recommended to use the disable_hyperthreading parameter in order to control the "
+            "hyper-threading configuration in the cluster rather than using cfn_scheduler_slots in extra_json",
+        ),
+    ],
+)
+def test_extra_json_validator(mocker, capsys, extra_json, expected_message):
+    config_parser_dict = {"cluster default": extra_json}
+    utils.assert_param_validator(mocker, config_parser_dict, capsys=capsys, expected_warning=expected_message)

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -538,7 +538,7 @@ Resources:
                   }
                 - SchedulerSlots: !If
                     - DisableComputeHyperthreading
-                    - !Ref 'ComputeCoreCount'
+                    - cores
                     - vcpus
                   DisableHyperthreadingManually: !If
                     - DisableMasterHyperthreadingManually


### PR DESCRIPTION
* pass cores rather than an integer to dna.json when disable_hyperthreading = true
* add validator for case extra json {"cfn_scheduler_slots" = number}, give a warning
* add unit test for new validator
* add extra json update policy 

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
