### PR TITLE
Fix failing tests for validation of pcluster version

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -77,12 +77,14 @@ test-suites:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu1804"]
+          oss: ["ubuntu1804"]  # os must be different from centos7 to test os validation logic when wrong os is provided
+          schedulers: ["slurm"]
     test_create.py::test_create_wrong_pcluster_version:
       dimensions:
         - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux"]
+          schedulers: ["slurm"]
   createami:
     test_createami.py::test_createami:
       dimensions:
@@ -107,7 +109,7 @@ test-suites:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux"]
+          oss: ["alinux"]  # os must be different from alinux2 to test os validation logic when wrong os is provided
     test_createami.py::test_createami_wrong_pcluster_version:
       dimensions:
         - regions: ["ca-central-1"]

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -9,7 +9,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import sys
 
 import boto3
 import pkg_resources
@@ -81,16 +80,16 @@ def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64"):
         return amis[0]["ImageId"]
     except ClientError as e:
         LOGGER.critical(e.response.get("Error").get("Message"))
-        sys.exit(1)
+        raise
     except AttributeError as e:
         LOGGER.critical("Error no attribute {0} in dict: {1}".format(os, e))
-        sys.exit(1)
+        raise
     except IndexError as e:
         LOGGER.critical("Error no ami retrieved: {0}".format(e))
-        sys.exit(1)
+        raise
 
 
-def retrieve_pcluster_ami_without_standard_naming(region, os, version="2.8.1", architecture="x86_64"):
+def retrieve_pcluster_ami_without_standard_naming(region, os, version, architecture):
     try:
         client = boto3.client("ec2", region_name=region)
         ami_name = f"ami-for-testing-pcluster-version-validation-without-standard-naming-{version}-{os}"
@@ -123,13 +122,13 @@ def retrieve_pcluster_ami_without_standard_naming(region, os, version="2.8.1", a
 
     except ClientError as e:
         LOGGER.critical(e.response.get("Error").get("Message"))
-        sys.exit(1)
+        raise
     except AttributeError as e:
         LOGGER.critical("Error no attribute {0} in dict: {1}".format(os, e))
-        sys.exit(1)
+        raise
     except IndexError as e:
         LOGGER.critical("Error no ami retrieved: {0}".format(e))
-        sys.exit(1)
+        raise
 
 
 @retry(stop_max_attempt_number=3, wait_fixed=5000)

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -11,29 +11,29 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 
+import boto3
 import pytest
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 from utils import get_username_for_os
 
 from tests.common.assertions import assert_errors_in_logs
-from tests.common.utils import (
-    get_installed_parallelcluster_version,
-    retrieve_latest_ami,
-    retrieve_pcluster_ami_without_standard_naming,
-)
+from tests.common.utils import get_installed_parallelcluster_version, retrieve_latest_ami
 
 
 @pytest.mark.dimensions("eu-central-1", "c5.xlarge", "ubuntu1804", "*")
-def test_create_wrong_os(region, os, pcluster_config_reader, clusters_factory, architecture, instance):
+@pytest.mark.usefixtures("instance", "scheduler")
+def test_create_wrong_os(region, os, pcluster_config_reader, clusters_factory, architecture):
     """Test error message when os provide is different from the os of custom AMI"""
     # ubuntu1804 is specified in the config file but an AMI of centos7 is provided
     wrong_os = "centos7"
     logging.info("Asserting os fixture is different from wrong_os variable")
     assert_that(os != wrong_os).is_true()
-    custom_ami = retrieve_latest_ami(region, wrong_os, ami_type="remarkable", architecture=architecture)
+    custom_ami = retrieve_latest_ami(region, wrong_os, ami_type="pcluster", architecture=architecture)
     cluster_config = pcluster_config_reader(custom_ami=custom_ami)
     cluster = clusters_factory(cluster_config, raise_on_error=False)
+
+    _assert_head_node_is_running(region, cluster)
     username = get_username_for_os(wrong_os)
     remote_command_executor = RemoteCommandExecutor(cluster, username=username)
 
@@ -46,7 +46,10 @@ def test_create_wrong_os(region, os, pcluster_config_reader, clusters_factory, a
 
 
 @pytest.mark.dimensions("ca-central-1", "c5.xlarge", "alinux", "*")
-def test_create_wrong_pcluster_version(region, os, pcluster_config_reader, clusters_factory, architecture, instance):
+@pytest.mark.usefixtures("instance", "os", "scheduler")
+def test_create_wrong_pcluster_version(
+    region, pcluster_config_reader, clusters_factory, pcluster_ami_without_standard_naming
+):
     """Test error message when AMI provided was baked by a pcluster whose version is different from current version"""
     current_version = get_installed_parallelcluster_version()
     wrong_version = "2.8.1"
@@ -54,16 +57,29 @@ def test_create_wrong_pcluster_version(region, os, pcluster_config_reader, clust
     assert_that(current_version != wrong_version).is_true()
     # Retrieve an AMI without 'aws-parallelcluster-<version>' in its name.
     # Therefore, we can bypass the version check in CLI and test version check of .bootstrapped file in Cookbook.
-    wrong_ami = retrieve_pcluster_ami_without_standard_naming(
-        region, os, version=wrong_version, architecture=architecture
-    )
+    wrong_ami = pcluster_ami_without_standard_naming(wrong_version)
     cluster_config = pcluster_config_reader(custom_ami=wrong_ami)
     cluster = clusters_factory(cluster_config, raise_on_error=False)
+
+    _assert_head_node_is_running(region, cluster)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     logging.info("Verifying error in logs")
     assert_errors_in_logs(
         remote_command_executor,
-        ["/var/log/cfn-init.log"],
+        ["/var/log/cloud-init-output.log"],
         ["RuntimeError", fr"AMI was created.+{wrong_version}.+is.+used.+{current_version}"],
     )
+
+
+def _assert_head_node_is_running(region, cluster):
+    logging.info("Asserting the head node is running")
+    head_node_state = (
+        boto3.client("ec2", region_name=region)
+        .describe_instances(Filters=[{"Name": "ip-address", "Values": [cluster.master_ip]}])
+        .get("Reservations")[0]
+        .get("Instances")[0]
+        .get("State")
+        .get("Name")
+    )
+    assert_that(head_node_state).is_equal_to("running")

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.ini
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.ini
@@ -8,7 +8,7 @@ aws_region_name = {{ region }}
 base_os = {{ os }}
 key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
-scheduler = slurm
+scheduler =  {{ scheduler }}
 master_instance_type = {{ instance }}
 custom_ami = {{ custom_ami }}
 master_root_volume_size = 100
@@ -17,3 +17,5 @@ compute_root_volume_size = 100
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.ini
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.ini
@@ -8,7 +8,7 @@ aws_region_name = {{ region }}
 base_os = {{ os }}
 key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
-scheduler = slurm
+scheduler = {{ scheduler }}
 master_instance_type = {{ instance }}
 custom_ami = {{ custom_ami }}
 master_root_volume_size = 100
@@ -17,3 +17,5 @@ compute_root_volume_size = 100
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/createami/test_createami/test_createami_wrong_os/pcluster.config.ini
+++ b/tests/integration-tests/tests/createami/test_createami/test_createami_wrong_os/pcluster.config.ini
@@ -9,3 +9,6 @@ base_os = {{ os }}
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
+

--- a/tests/integration-tests/tests/createami/test_createami/test_createami_wrong_pcluster_version/pcluster.config.ini
+++ b/tests/integration-tests/tests/createami/test_createami/test_createami_wrong_pcluster_version/pcluster.config.ini
@@ -9,3 +9,5 @@ base_os = {{ os }}
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false


### PR DESCRIPTION
This commit will
1. Amend a merged pull request: #2141.
2. Use private subnet for compute node and set use_public_ips to false to reduce usage of EIP for tests created in the merged PR
3. Use raise instead of sys.exit() if errors occur
4. Use a fixture for the AMI created during test for validation of pcluster version, so that it will be cleaned up after the tests end.
5. Since the tests are testing failing cases of cluster creation, assert the head node is running before asserting content of logs inside the node to facilitate debug in the future.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
