### PR TITLE
Fix ResourcesS3Bucket can't be retrieved during SIT update

### DIFF
--- a/cli/pcluster/cli_commands/update.py
+++ b/cli/pcluster/cli_commands/update.py
@@ -227,10 +227,9 @@ def _restore_cfn_only_params(cfn_boto3_client, args, cfn_params, stack_name, tar
     elif scheduler == "awsbatch":
         LOGGER.info("reset_desired flag does not work with awsbatch scheduler")
 
-    if scheduler in {"awsbatch", "slurm"}:
-        # Autofill ResourcesS3Bucket cfn param
-        params = utils.get_stack(stack_name, cfn_boto3_client).get("Parameters")
-        cfn_params["ResourcesS3Bucket"] = utils.get_cfn_param(params, "ResourcesS3Bucket")
+    # Autofill ResourcesS3Bucket cfn param
+    params = utils.get_stack(stack_name, cfn_boto3_client).get("Parameters")
+    cfn_params["ResourcesS3Bucket"] = utils.get_cfn_param(params, "ResourcesS3Bucket")
 
 
 def _restore_desired_size(cfn_params, stack_name, scheduler):


### PR DESCRIPTION
* Remove the condition for scheduler, so cluster with sge and torque will retrieve the ResourcesS3Bucket param during pcluster update.

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
