### PR TITLE
Use torque in place of slurm for SIT test

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -198,7 +198,7 @@ test-suites:
           instances: ["c5n.18xlarge"]
           # EFA not working on Centos6
           oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]
-          schedulers: ["sge", "slurm"]
+          schedulers: ["sge", "torque"]
   iam_policies:
     test_iam_policies.py::test_iam_policies:
       dimensions:

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -26,7 +26,7 @@ from tests.common.utils import fetch_instance_slots
 @pytest.mark.regions(["us-east-1", "us-gov-west-1"])
 @pytest.mark.instances(["c5n.18xlarge", "p3dn.24xlarge", "i3en.24xlarge"])
 @pytest.mark.skip_oss(["centos6"])
-@pytest.mark.schedulers(["sge", "slurm"])
+@pytest.mark.schedulers(["sge", "torque"])
 def test_sit_efa(region, scheduler, instance, os, pcluster_config_reader, clusters_factory, test_datadir, architecture):
     """
     Test all EFA Features.


### PR DESCRIPTION
Slurm is not the right scheduler for the `test_sit_efa`.
We're already testing Slurm in `test_hit_efa`.
