### PR TITLE
Change FSX storage capacity validator warning to error messages

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -306,15 +306,15 @@ def fsx_storage_capacity_validator(section_key, section_label, pcluster_config):
         errors.append("When specifying 'fsx' section, the 'storage_capacity' option must be specified")
     elif deployment_type == "SCRATCH_1":
         if not (storage_capacity == 1200 or storage_capacity == 2400 or storage_capacity % 3600 == 0):
-            warnings.append("Capacity for FSx SCRATCH_1 filesystem is 1,200 GB, 2,400 GB or increments of 3,600 GB")
+            errors.append("Capacity for FSx SCRATCH_1 filesystem is 1,200 GB, 2,400 GB or increments of 3,600 GB")
     elif deployment_type == "PERSISTENT_1" and storage_type == "HDD":
         if per_unit_storage_throughput == 12 and not (storage_capacity % 6000 == 0):
-            warnings.append("Capacity for FSx PERSISTENT HDD 12 MB/s/TiB file systems is increments of 6,000 GiB")
+            errors.append("Capacity for FSx PERSISTENT HDD 12 MB/s/TiB file systems is increments of 6,000 GiB")
         elif per_unit_storage_throughput == 40 and not (storage_capacity % 1800 == 0):
-            warnings.append("Capacity for FSx PERSISTENT HDD 40 MB/s/TiB file systems is increments of 1,800 GiB")
+            errors.append("Capacity for FSx PERSISTENT HDD 40 MB/s/TiB file systems is increments of 1,800 GiB")
     elif deployment_type in ["SCRATCH_2", "PERSISTENT_1"]:
         if not (storage_capacity == 1200 or storage_capacity % 2400 == 0):
-            warnings.append(
+            errors.append(
                 "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB"
             )
 

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -978,26 +978,26 @@ def test_fsx_validator(mocker, boto3_stubber, section_dict, bucket, expected_err
     [
         (
             {"storage_capacity": 1, "deployment_type": "SCRATCH_1"},
-            None,
             "Capacity for FSx SCRATCH_1 filesystem is 1,200 GB, 2,400 GB or increments of 3,600 GB",
+            None,
         ),
         ({"storage_capacity": 1200, "deployment_type": "SCRATCH_1"}, None, None),
         ({"storage_capacity": 2400, "deployment_type": "SCRATCH_1"}, None, None),
         ({"storage_capacity": 3600, "deployment_type": "SCRATCH_1"}, None, None),
         (
             {"storage_capacity": 3600, "deployment_type": "SCRATCH_2"},
-            None,
             "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+            None,
         ),
         (
             {"storage_capacity": 3600, "deployment_type": "PERSISTENT_1", "per_unit_storage_throughput": 50},
-            None,
             "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+            None,
         ),
         (
             {"storage_capacity": 3601, "deployment_type": "PERSISTENT_1", "per_unit_storage_throughput": 50},
-            None,
             "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+            None,
         ),
         ({"storage_capacity": 7200}, None, None),
         (
@@ -1012,8 +1012,8 @@ def test_fsx_validator(mocker, boto3_stubber, section_dict, bucket, expected_err
                 "storage_capacity": 1801,
                 "per_unit_storage_throughput": 40,
             },
-            None,
             "Capacity for FSx PERSISTENT HDD 40 MB/s/TiB file systems is increments of 1,800 GiB",
+            None,
         ),
         (
             {
@@ -1022,8 +1022,8 @@ def test_fsx_validator(mocker, boto3_stubber, section_dict, bucket, expected_err
                 "storage_capacity": 6001,
                 "per_unit_storage_throughput": 12,
             },
-            None,
             "Capacity for FSx PERSISTENT HDD 12 MB/s/TiB file systems is increments of 6,000 GiB",
+            None,
         ),
         (
             {


### PR DESCRIPTION
When the storage capacity doesn't meet the requirement, before we only warn users that they are wrongly configured, and the creation will fail on the creating cloudformation stack process. 

Change all the warning messages into error messages in `storage_capacity` validator. After this change, the creation will fail earlier if storage capacity doesn't meet the requirement.
