### PR TITLE
Make ResourcesS3Bucket mandatory and remove related conditions

### DIFF
--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -305,8 +305,7 @@
     },
     "ResourcesS3Bucket": {
       "Description": "S3 bucket where resources needed by the stack are located. The bucket gets deleted on stack deletion.",
-      "Type": "String",
-      "Default": "NONE"
+      "Type": "String"
     },
     "RAIDOptions": {
       "Description": "Comma Separated List of RAID related options, 8 parameters in total, [shared_dir,raid_type,num_of_raid_volumes,volume_type,volume_size,volume_iops,encrypted,ebs_kms_key_id]",
@@ -743,18 +742,6 @@
         "awsbatch"
       ]
     },
-    "HasResourcesS3Bucket": {
-      "Fn::Not": [
-        {
-          "Fn::Equals": [
-            {
-              "Ref": "ResourcesS3Bucket"
-            },
-            "NONE"
-          ]
-        }
-      ]
-    },
     "EnableDCV": {
       "Fn::Equals": [
         {
@@ -779,16 +766,6 @@
           "Ref": "Architecture"
         },
         "arm64"
-      ]
-    },
-    "CreateCleanupResourcesFunction": {
-      "Fn::Or": [
-        {
-          "Condition": "HasResourcesS3Bucket"
-        },
-        {
-          "Condition": "CreateHITSubstack"
-        }
       ]
     }
   },
@@ -1289,13 +1266,6 @@
                   }
                 ]
               }
-            ]
-          },
-          "CreateCleanupResourcesFunctionLogGroup": {
-            "Fn::If": [
-              "CreateCleanupResourcesFunction",
-              "true",
-              "false"
             ]
           },
           "CreateCleanupRoute53FunctionLogGroup": {
@@ -2484,8 +2454,7 @@
             "PolicyName": "LambdaPolicy"
           }
         ]
-      },
-      "Condition": "CreateCleanupResourcesFunction"
+      }
     },
     "CleanupResourcesS3BucketCustomResource": {
       "Type": "AWS::CloudFormation::CustomResource",
@@ -2500,8 +2469,7 @@
             "Arn"
           ]
         }
-      },
-      "Condition": "HasResourcesS3Bucket"
+      }
     },
     "TerminateComputeFleetCustomResource": {
       "Type": "AWS::CloudFormation::CustomResource",
@@ -2562,8 +2530,7 @@
         },
         "Runtime": "python3.8",
         "Timeout": 900
-      },
-      "Condition": "CreateCleanupResourcesFunction"
+      }
     },
     "RAIDSubstack": {
       "Type": "AWS::CloudFormation::Stack",
@@ -4051,8 +4018,7 @@
       "Description": "S3 user bucket where AWS ParallelCluster resources are stored",
       "Value": {
         "Ref": "ResourcesS3Bucket"
-      },
-      "Condition": "HasResourcesS3Bucket"
+      }
     },
     "BatchComputeEnvironmentArn": {
       "Value": {

--- a/cloudformation/cw-logs-substack.cfn.json
+++ b/cloudformation/cw-logs-substack.cfn.json
@@ -18,14 +18,6 @@
         "true"
       ]
     },
-    "CreateCleanupResourcesFunctionLogGroup": {
-      "Fn::Equals": [
-        {
-          "Ref": "CreateCleanupResourcesFunctionLogGroup"
-        },
-        "true"
-      ]
-    },
     "CreateCleanupRoute53FunctionLogGroup": {
       "Fn::Equals": [
         {
@@ -58,10 +50,6 @@
     },
     "MainStackUniqueId": {
       "Description": "Final 36 digits of the main CloudFormation stack id",
-      "Type": "String"
-    },
-    "CreateCleanupResourcesFunctionLogGroup": {
-      "Description": "Set to true in order to create the log group for CreateCleanupResourcesFunction",
       "Type": "String"
     },
     "CreateCleanupRoute53FunctionLogGroup": {
@@ -115,8 +103,7 @@
             }
           ]
         }
-      },
-      "Condition": "CreateCleanupResourcesFunctionLogGroup"
+      }
     },
     "CleanupRoute53FunctionLogGroup": {
       "Type": "AWS::Logs::LogGroup",


### PR DESCRIPTION
I'm removing the NONE default value for `ResourcesS3Bucket` input param.
The S3 bucket is required:
* for AWS Batch to store docker resources and CFN rendered template for the dashboard
* for Slurm to store CFN rendered template for HIT substack and the dashboard
* for Torque and SGE to store CFN rendered template for the dashboard

# CFN changes
* Removed `HasResourcesS3Bucket` condition because it will be always `true`
* Removed `CreateCleanupResourcesFunction` condition because it will be always `true`
* Removed `CreateCleanupResourcesFunctionLogGroup` input param to `cw-logs-substack`
  because we always have the cleanup function so we always need to create the log group for it.


