### PR TITLE
Create GitHub workflow to enforce changelog updates on every PR

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,15 @@
+name: Pull Request Workflow
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request 
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: dangoslen/changelog-enforcer@v1.4.0
+      with:
+        changeLogPath: CHANGELOG.md
+        skipLabel: skip-changelog-update


### PR DESCRIPTION
This workflow runs for every PR and enforces the Changelog to be updated.
To override this check you can assign the `skip-changelog-update` to the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
