### PR TITLE
Move one FSx test in China region

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -378,13 +378,17 @@ test-suites:
       dimensions:
         - regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["alinux2", "centos7", "centos8", "ubuntu1604", "ubuntu1804"]
           schedulers: ["slurm"]
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           # FSx is only supported on ARM instances for Ubuntu 18.04, Amazon Linux 2 and CentOS 8
           oss: ["alinux2", "ubuntu1804", "centos8"]
           schedulers: ["slurm"]
+        - regions: [ "cn-north-1" ]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: [ "alinux" ]
+          schedulers: [ "slurm" ]
     test_fsx_lustre.py::test_fsx_lustre_configuration_options:
       dimensions:
         - regions: ["us-east-2"]

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
@@ -19,7 +19,13 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 fsx_settings = fsx
+{% if region.startswith("cn-") %}
+s3_read_resource = arn:aws-cn:s3:::{{ bucket_name }}/*
+{% elif region.startswith("us-gov-") %}
+s3_read_resource = arn:aws-us-gov:s3:::{{ bucket_name }}/*
+{% else %}
 s3_read_resource = arn:aws:s3:::{{ bucket_name }}/*
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
@@ -32,3 +38,8 @@ shared_dir = {{ mount_dir }}
 storage_capacity = {{ storage_capacity }}
 import_path = s3://{{ bucket_name }}
 export_path = s3://{{ bucket_name }}/export_dir
+{% if region.startswith("cn-") %}
+# the only deployment_type supported in China regions is PERSISTENT_1
+deployment_type = PERSISTENT_1
+per_unit_storage_throughput = 200
+{% endif %}


### PR DESCRIPTION
Move test_fsx_lustre for alinux from us-east-2 to cn-north-1

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
