### PR TITLE
Disable FPGA AMI for createami test

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -90,7 +90,7 @@ test-suites:
       dimensions:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]
+          oss: ["alinux", "alinux2", "ubuntu1604", "ubuntu1804"] # temporary disable FPGA AMI since there is not enough free space on root partition
         - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu1604", "ubuntu1804"]

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -42,8 +42,7 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
 OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
     "alinux": {"name": "Deep Learning Base AMI (Amazon Linux)*", "owners": ["amazon"]},
     "alinux2": {"name": "Deep Learning Base AMI (Amazon Linux 2)*", "owners": ["amazon"]},
-    # temporary disable FPGA AMI since there is not enough free space on root partition
-    # "centos7": {"name": "FPGA Developer AMI*", "owners": ["679593333241"]},
+    "centos7": {"name": "FPGA Developer AMI*", "owners": ["679593333241"]},
     "ubuntu1604": {"name": "Deep Learning Base AMI (Ubuntu 16.04)*", "owners": ["amazon"]},
     "ubuntu1804": {"name": "Deep Learning Base AMI (Ubuntu 18.04)*", "owners": ["amazon"]},
 }


### PR DESCRIPTION
Disable FPGA AMI since there is not enough free space on root partition.
Currently there is no automatic way to increase the size when calling createami process.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
