### PR TITLE
Add Centos8 as supported OS for EFA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ CHANGELOG
 
 **CHANGES**
 
+- Upgrade EFA installer to version 1.10.1
+  - EFA configuration: ``efa-config-1.5`` (from efa-config-1.4)
+  - EFA profile: ``efa-profile-1.1`` (from efa-profile-1.0.0)
+  - EFA kernel module: ``efa-1.10.2`` (from efa-1.6.0)
+  - RDMA core: ``rdma-core-31.amzn0`` (from rdma-core-28.amzn0)
+  - Libfabric: ``libfabric-1.11.1amazon1.1`` (from libfabric-1.10.1amazon1.1)
+  - Open MPI: ``openmpi40-aws-4.0.5`` (from openmpi40-aws-4.0.3)
+  - Unifies installer runtime options across x86 and aarch64
+  - Introduces ``-g/--enable-gdr`` switch to install packages with GPUDirect RDMA support
+  - Updates to OMPI collectives decision file packaging, migrated from efa-config to efa-profile
+  - Introduces CentOS 8 support
 - CentOS 6 is no longer supported.
 - Upgrade image used by CodeBuild environment when building container images for Batch clusters.
 - Enable queue resizing on update without requiring to stop the compute fleet. Stopping the compute fleet is only

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -437,13 +437,6 @@ def efa_validator(param_key, param_value, pcluster_config):
         if cluster_section.get_param_value("placement_group") is None:
             warnings.append("You may see better performance using a cluster placement group.")
 
-    allowed_oses = ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]
-    if cluster_section.get_param_value("base_os") not in allowed_oses:
-        errors.append(
-            "When using 'enable_efa = {0}' it is required to set the 'base_os' parameter "
-            "to one of the following values : {1}".format(param_value, allowed_oses)
-        )
-
     allowed_schedulers = ["sge", "slurm", "torque"]
     if cluster_section.get_param_value("scheduler") not in allowed_schedulers:
         errors.append(

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -198,8 +198,7 @@ test-suites:
       dimensions:
         - regions: ["us-east-1"]
           instances: ["c5n.18xlarge"]
-          # TODO: use INSTANCES_DEFAULT_X86 once there is centos8 support for efa
-          oss: ["alinux", "alinux2", "centos7", "ubuntu1604", "ubuntu1804"]
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
           # Torque is not supported by OpenMPI distributed with EFA
           # Slurm test is to verify EFA works correctly when using the SIT model in the config file
           schedulers: ["sge", "slurm"]


### PR DESCRIPTION
The `allowed_oses` condition is no longer needed because all the OSes are supported.

