### PR TITLE
Add support for P4d Instance type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 - Add support for CentOS 8 in all Commercial regions.
 - Enable support for NICE DCV in GovCloud regions.
 - Enable support for AWS Batch scheduler in GovCloud regions.
+- Add support for P4d instance type 
 - Add ``-r/-region`` arg to ``pcluster configure``. If this arg is provided, configuration will skip region selection.
 
 **CHANGES**
@@ -28,6 +29,7 @@ CHANGELOG
 - Upgrade image used by CodeBuild environment when building container images for Batch clusters.
 - Enable queue resizing on update without requiring to stop the compute fleet. Stopping the compute fleet is only
   necessary when existing instances risk to be terminated.
+- Upgrade NVIDIA driver to version 450.80.02
 - Remove default region us-east-1. After the change, pcluster will adhere to the following lookup order for region:
   1. ```-r/--region``` arg.
   2. ``AWS_DEFAULT_REGION`` environment variable.

--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -27,6 +27,7 @@ from pcluster.utils import (
     get_ebs_snapshot_info,
     get_efs_mount_target_id,
     get_file_section_name,
+    get_instance_network_interfaces,
     get_instance_vcpus,
     get_supported_architectures_for_instance_type,
 )
@@ -1067,6 +1068,25 @@ class EBSSettingsCfnParam(SettingsCfnParam):
         # We always have at least one EBS volume
         # FIXME: remove NumberOfEBSVol Parameter and use EBS section params to manage EBS Volumes in cfn template
         cfn_params["NumberOfEBSVol"] = str(max(number_of_ebs_sections, 1))
+
+
+class NetworkInterfacesCountCfnParam(CommaSeparatedCfnParam):
+    """
+    Class to manage NetworkInterfacesCount Cfn param.
+
+    The internal value is a list of two items, which respectively indicate the number of network interfaces to activate
+    on master and compute nodes.
+    """
+
+    def refresh(self):
+        """Compute the number of network interfaces for master and compute nodes."""
+        cluster_section = self.pcluster_config.get_section("cluster")
+        self.value = [
+            str(get_instance_network_interfaces(cluster_section.get_param_value("master_instance_type"))),
+            str(get_instance_network_interfaces(cluster_section.get_param_value("compute_instance_type")))
+            if self.pcluster_config.cluster_model.name == "SIT"
+            else "1",
+        ]
 
 
 # ---------------------- Sections ---------------------- #

--- a/cli/pcluster/config/hit_converter.py
+++ b/cli/pcluster/config/hit_converter.py
@@ -80,6 +80,11 @@ class HitConverter:
                     "compute" == sit_cluster_section.get_param("enable_efa").value,
                 )
                 self._copy_param_value(
+                    sit_cluster_section.get_param("enable_efa_gdr"),
+                    queue_section.get_param("enable_efa_gdr"),
+                    "compute" == sit_cluster_section.get_param("enable_efa_gdr").value,
+                )
+                self._copy_param_value(
                     sit_cluster_section.get_param("placement_group"), queue_section.get_param("placement_group")
                 )
 
@@ -120,9 +125,11 @@ class HitConverter:
                     sit_initial_size_param, compute_resource_section.get_param(compute_resource_size_param_key)
                 )
 
-                # Copy all cluster params except enable_efa (already set at queue level)
+                # Copy all cluster params except enable_efa and enable_efa_gdr (already set at queue level)
                 hit_cluster_param_keys = [
-                    param_key for param_key in hit_cluster_section.params.keys() if param_key not in ["enable_efa"]
+                    param_key
+                    for param_key in hit_cluster_section.params.keys()
+                    if param_key not in ["enable_efa", "enable_efa_gdr"]
                 ]
                 for param_key in sit_cluster_section.params.keys():
                     if param_key in hit_cluster_param_keys:

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -29,6 +29,7 @@ from pcluster.config.cfn_param_types import (
     IntCfnParam,
     MaintainInitialSizeCfnParam,
     MasterAvailabilityZoneCfnParam,
+    NetworkInterfacesCountCfnParam,
     QueueSizeCfnParam,
     SettingsCfnParam,
     SharedDirCfnParam,
@@ -74,6 +75,7 @@ from pcluster.config.validators import (
     ec2_subnet_id_validator,
     ec2_volume_validator,
     ec2_vpc_id_validator,
+    efa_gdr_validator,
     efa_validator,
     efs_id_validator,
     efs_validator,
@@ -659,7 +661,21 @@ COMPUTE_RESOURCE = {
             "visibility": Visibility.PRIVATE,
             "default": 0
         }),
+        ("network_interfaces", {
+            "type": IntJsonParam,
+            # This param is managed automatically
+            "update_policy": UpdatePolicy.IGNORED,
+            "visibility": Visibility.PRIVATE,
+            "default": 0
+        }),
         ("enable_efa", {
+            "type": BooleanJsonParam,
+            # This param is managed automatically
+            "update_policy": UpdatePolicy.IGNORED,
+            "visibility": Visibility.PRIVATE,
+            "default": False
+        }),
+        ("enable_efa_gdr", {
             "type": BooleanJsonParam,
             # This param is managed automatically
             "update_policy": UpdatePolicy.IGNORED,
@@ -697,6 +713,10 @@ QUEUE = {
             "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP
         }),
         ("enable_efa", {
+            "type": BooleanJsonParam,
+            "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP,
+        }),
+        ("enable_efa_gdr", {
             "type": BooleanJsonParam,
             "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP,
         }),
@@ -811,6 +831,12 @@ CLUSTER_COMMON_PARAMS = [
         "allowed_values": ["compute"],
         "cfn_param_mapping": "EFA",
         "validators": [efa_validator],
+        "update_policy": UpdatePolicy.UNSUPPORTED
+    }),
+    ("enable_efa_gdr", {
+        "allowed_values": ["compute"],
+        "cfn_param_mapping": "EFAGDR",
+        "validators": [efa_gdr_validator],
         "update_policy": UpdatePolicy.UNSUPPORTED
     }),
     ("ephemeral_dir", {
@@ -961,6 +987,14 @@ CLUSTER_COMMON_PARAMS = [
         # TODO add regex
         "validators": [url_validator],
         "update_policy": UpdatePolicy.IGNORED
+    }),
+    ("network_interfaces_count", {
+        "type": NetworkInterfacesCountCfnParam,
+        "default": ["1", "1"],
+        "cfn_param_mapping": "NetworkInterfacesCount",
+        # This param is managed automatically
+        "update_policy": UpdatePolicy.IGNORED,
+        "visibility": Visibility.PRIVATE,
     }),
 ]
 

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -25,6 +25,7 @@ from pcluster.utils import (
     get_ebs_snapshot_info,
     get_efs_mount_target_id,
     get_file_section_name,
+    get_instance_network_interfaces,
     get_instance_vcpus,
     get_partition,
     get_region,
@@ -1065,6 +1066,15 @@ def compute_instance_type_validator(param_key, param_value, pcluster_config):
                     )
     else:
         errors, warnings = ec2_instance_type_validator(param_key, param_value, pcluster_config)
+
+        instance_nics = get_instance_network_interfaces(param_value)
+        if instance_nics > 1:
+            errors.append(
+                "The instance type '{0}' has {1} Network Interfaces. "
+                "Instances with multiple network interfaces are currently not supported with '{2}' scheduler".format(
+                    param_value, instance_nics, scheduler
+                )
+            )
 
     return errors, warnings
 

--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -1067,14 +1067,14 @@ def compute_instance_type_validator(param_key, param_value, pcluster_config):
     else:
         errors, warnings = ec2_instance_type_validator(param_key, param_value, pcluster_config)
 
-        instance_nics = get_instance_network_interfaces(param_value)
-        if instance_nics > 1:
-            errors.append(
-                "The instance type '{0}' has {1} Network Interfaces. "
-                "Instances with multiple network interfaces are currently not supported with '{2}' scheduler".format(
-                    param_value, instance_nics, scheduler
+        if scheduler != "slurm":
+            # Multiple NICs instance types are currently supported only with Slurm clusters
+            instance_nics = get_instance_network_interfaces(param_value)
+            if instance_nics > 1:
+                errors.append(
+                    "The instance type '{0}' has {1} Network Interfaces. Instances with multiple network interfaces "
+                    "are currently not supported with '{2}' scheduler".format(param_value, instance_nics, scheduler)
                 )
-            )
 
     return errors, warnings
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -258,7 +258,7 @@ def upload_resources_artifacts(bucket_name, root):
             bucket.upload_file(os.path.join(root, res), res)
 
 
-def get_instance_vcpus(instance_type):
+def get_instance_vcpus(instance_type, instance_info=None):
     """
     Get number of vcpus for the given instance type.
 
@@ -266,8 +266,10 @@ def get_instance_vcpus(instance_type):
     :return: the number of vcpus or -1 if the instance type cannot be found
     """
     try:
-        instance_type_info = get_instance_type(instance_type)
-        vcpus_info = instance_type_info.get("VCpuInfo")
+        if not instance_info:
+            instance_info = get_instance_type(instance_type)
+
+        vcpus_info = instance_info.get("VCpuInfo")
         vcpus = vcpus_info.get("DefaultVCpus")
     except (ClientError):
         vcpus = -1

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -1178,10 +1178,6 @@ def get_instance_network_interfaces(instance_type, instance_info=None):
     # Until maximumNetworkCards is not available, 1 is a safe value for all instance types
     needed_interfaces = int(instance_info.get("NetworkInfo").get("MaximumNetworkCards", 1))
 
-    # FIXME: temporary patch for P4d instances - remove after new API is GA
-    if instance_type == "p4d.24xlarge" and needed_interfaces == 1:
-        needed_interfaces = 4
-
     return needed_interfaces
 
 
@@ -1194,8 +1190,5 @@ def get_instance_gpus(instance_type, instance_info=None):
 
     # Currently adding up all gpus. To be reviewed if the case of heterogeneous GPUs arises.
     gpus = sum([gpus.get("Count") for gpus in gpu_info.get("Gpus")]) if gpu_info else 0
-    # FIXME: temporary patch for P4d instances - remove after new API is GA
-    if instance_type == "p4d.24xlarge" and gpus == 0:
-        gpus = 8
 
     return gpus

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -1068,7 +1068,7 @@ def disable_ht_via_cpu_options(instance_type, default_threads_per_core=None):
     """Return a boolean describing whether hyperthreading should be disabled via CPU options for instance_type."""
     if default_threads_per_core is None:
         default_threads_per_core = get_default_threads_per_core(instance_type)
-    return all(
+    res = all(
         [
             # If default threads per core is 1, HT doesn't need to be disabled
             default_threads_per_core > 1,
@@ -1078,6 +1078,7 @@ def disable_ht_via_cpu_options(instance_type, default_threads_per_core=None):
             ),
         ]
     )
+    return res
 
 
 def is_hit_enabled_scheduler(scheduler):
@@ -1165,3 +1166,34 @@ def get_ebs_snapshot_info(ebs_snapshot_id, raise_exceptions=False):
                 ebs_snapshot_id, e.response.get("Error").get("Message")
             )
         )
+
+
+def get_instance_network_interfaces(instance_type, instance_info=None):
+    """Return the number of network interfaces to configure for the instance type."""
+    if not instance_info:
+        instance_info = get_instance_type(instance_type)
+
+    # Until maximumNetworkCards is not available, 1 is a safe value for all instance types
+    needed_interfaces = int(instance_info.get("NetworkInfo").get("MaximumNetworkCards", 1))
+
+    # FIXME: temporary patch for P4d instances - remove after new API is GA
+    if instance_type == "p4d.24xlarge" and needed_interfaces == 1:
+        needed_interfaces = 4
+
+    return needed_interfaces
+
+
+def get_instance_gpus(instance_type, instance_info=None):
+    """Return the number of GPUs provided by the instance type."""
+    if not instance_info:
+        instance_info = get_instance_type(instance_type)
+
+    gpu_info = instance_info.get("GpuInfo", None)
+
+    # Currently adding up all gpus. To be reviewed if the case of heterogeneous GPUs arises.
+    gpus = sum([gpus.get("Count") for gpus in gpu_info.get("Gpus")]) if gpu_info else 0
+    # FIXME: temporary patch for P4d instances - remove after new API is GA
+    if instance_type == "p4d.24xlarge" and gpus == 0:
+        gpus = 8
+
+    return gpus

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,4 +1,4 @@
-boto3>=1.14.3
+boto3>=1.16.14
 future>=0.18.2
 tabulate>=0.8.2,<=0.8.7
 ipaddress>=1.0.22

--- a/cli/requirements34.txt
+++ b/cli/requirements34.txt
@@ -1,4 +1,4 @@
-boto3>=1.14.3
+boto3>=1.16.14
 future>=0.18.2
 tabulate==0.8.5
 ipaddress>=1.0.22

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -24,7 +24,7 @@ def readme():
 VERSION = "2.9.1"
 REQUIRES = [
     "setuptools",
-    "boto3>=1.14.3",
+    "boto3>=1.16.14",
     "future>=0.16.0,<=0.18.2",
     "tabulate==0.8.5" if sys.version_info.major == 3 and sys.version_info.minor <= 4 else "tabulate>=0.8.2,<=0.8.7",
     "ipaddress>=1.0.22",

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -118,6 +118,7 @@ DEFAULT_CLUSTER_SIT_DICT = {
     "s3_read_resource": None,
     "s3_read_write_resource": None,
     "enable_efa": None,
+    "enable_efa_gdr": None,
     "ephemeral_dir": "/scratch",
     "encrypted_ephemeral": False,
     "custom_ami": None,
@@ -142,6 +143,7 @@ DEFAULT_CLUSTER_SIT_DICT = {
     "dashboard_settings": None,
     "cluster_config_metadata": {"sections": {}},
     "architecture": "x86_64",
+    "network_interfaces_count": ["1", "1"],
 }
 
 DEFAULT_CLUSTER_HIT_DICT = {
@@ -161,6 +163,7 @@ DEFAULT_CLUSTER_HIT_DICT = {
     "s3_read_resource": None,
     "s3_read_write_resource": None,
     "enable_efa": None,
+    "enable_efa_gdr": None,
     "ephemeral_dir": "/scratch",
     "encrypted_ephemeral": False,
     "custom_ami": None,
@@ -188,6 +191,7 @@ DEFAULT_CLUSTER_HIT_DICT = {
     "default_queue": None,
     "cluster_config_metadata": {"sections": {}},
     "architecture": "x86_64",
+    "network_interfaces_count": ["1", "1"],
 }
 
 DEFAULT_CW_LOG_DICT = {"enable": True, "retention_days": 14}
@@ -220,8 +224,8 @@ class DefaultDict(Enum):
 # ------------------ Default CFN parameters ------------------ #
 
 # number of CFN parameters created by the PclusterConfig object.
-CFN_SIT_CONFIG_NUM_OF_PARAMS = 58
-CFN_HIT_CONFIG_NUM_OF_PARAMS = 50
+CFN_SIT_CONFIG_NUM_OF_PARAMS = 60
+CFN_HIT_CONFIG_NUM_OF_PARAMS = 52
 
 # CFN parameters created by the pcluster CLI
 CFN_CLI_RESERVED_PARAMS = ["ResourcesS3Bucket"]
@@ -285,6 +289,7 @@ DEFAULT_CLUSTER_SIT_CFN_PARAMS = {
     "S3ReadResource": "NONE",
     "S3ReadWriteResource": "NONE",
     "EFA": "NONE",
+    "EFAGDR": "NONE",
     "EphemeralDir": "/scratch",
     "EncryptedEphemeral": "false",
     "CustomAMI": "NONE",
@@ -333,6 +338,7 @@ DEFAULT_CLUSTER_SIT_CFN_PARAMS = {
     "ClusterConfigMetadata": "{'sections': {}}",
     # architecture
     "Architecture": "x86_64",
+    "NetworkInterfacesCount": "1,1",
 }
 
 
@@ -350,6 +356,7 @@ DEFAULT_CLUSTER_HIT_CFN_PARAMS = {
     "S3ReadResource": "NONE",
     "S3ReadWriteResource": "NONE",
     "EFA": "NONE",
+    "EFAGDR": "NONE",
     "EphemeralDir": "/scratch",
     "EncryptedEphemeral": "false",
     "CustomAMI": "NONE",
@@ -398,6 +405,7 @@ DEFAULT_CLUSTER_HIT_CFN_PARAMS = {
     "ClusterConfigMetadata": "{'sections': {}}",
     # architecture
     "Architecture": "x86_64",
+    "NetworkInterfacesCount": "1,1",
 }
 
 

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -35,6 +35,7 @@ def _do_mocking_for_tests(mocker):
     mocker.patch(
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type", return_value=["x86_64"]
     )
+    mocker.patch("pcluster.config.cfn_param_types.get_instance_network_interfaces", return_value=1)
 
 
 def _check_patch(src_conf, dst_conf, expected_changes, expected_patch_policy):

--- a/cli/tests/pcluster/config/test_hit_converter.py
+++ b/cli/tests/pcluster/config/test_hit_converter.py
@@ -166,9 +166,11 @@ def boto3_stubber_path():
         ),
     ],
 )
-def test_hit_converter(boto3_stubber, src_config_dict, dst_config_dict):
+def test_hit_converter(mocker, boto3_stubber, src_config_dict, dst_config_dict):
     scheduler = src_config_dict["cluster default"]["scheduler"]
     instance_type = src_config_dict["cluster default"]["compute_instance_type"]
+
+    mocker.patch("pcluster.config.cfn_param_types.get_instance_network_interfaces", return_value=1)
 
     if is_hit_enabled_scheduler(scheduler):
         mocked_requests = [

--- a/cli/tests/pcluster/config/test_json_param_types/s3_config.json
+++ b/cli/tests/pcluster/config/test_json_param_types/s3_config.json
@@ -7,6 +7,7 @@
       "queue1": {
         "compute_type": "ondemand",
         "enable_efa": true,
+        "enable_efa_gdr": true,
         "disable_hyperthreading": true,
         "placement_group": null,
         "compute_resource_settings": {
@@ -20,7 +21,9 @@
             "gpus": 0,
             "enable_efa": false,
             "disable_hyperthreading": true,
-            "disable_hyperthreading_via_cpu_options": true
+            "disable_hyperthreading_via_cpu_options": true,
+            "network_interfaces": 1,
+            "enable_efa_gdr": false
           },
           "q1-i2": {
             "instance_type": "g4dn.metal",
@@ -32,7 +35,9 @@
             "gpus": 8,
             "enable_efa": true,
             "disable_hyperthreading": true,
-            "disable_hyperthreading_via_cpu_options": false
+            "disable_hyperthreading_via_cpu_options": false,
+            "network_interfaces": 1,
+            "enable_efa_gdr": true
           },
           "q1-i3": {
             "instance_type": "i3en.24xlarge",
@@ -44,7 +49,9 @@
             "gpus": 0,
             "enable_efa": true,
             "disable_hyperthreading": true,
-            "disable_hyperthreading_via_cpu_options": true
+            "disable_hyperthreading_via_cpu_options": true,
+            "network_interfaces": 1,
+            "enable_efa_gdr": false
           },
           "q1-i4": {
             "instance_type": "t2.xlarge",
@@ -56,7 +63,9 @@
             "gpus": 0,
             "enable_efa": false,
             "disable_hyperthreading": false,
-            "disable_hyperthreading_via_cpu_options": false
+            "disable_hyperthreading_via_cpu_options": false,
+            "network_interfaces": 1,
+            "enable_efa_gdr": false
           },
           "q1-i5": {
             "instance_type": "m6g.xlarge",
@@ -68,13 +77,16 @@
             "gpus": 0,
             "enable_efa": false,
             "disable_hyperthreading": false,
-            "disable_hyperthreading_via_cpu_options": false
+            "disable_hyperthreading_via_cpu_options": false,
+            "network_interfaces": 1,
+            "enable_efa_gdr": false
           }
         }
       },
       "queue2": {
         "compute_type": "spot",
         "enable_efa": false,
+        "enable_efa_gdr": false,
         "disable_hyperthreading": false,
         "placement_group": "DYNAMIC",
         "compute_resource_settings": {
@@ -88,7 +100,9 @@
             "gpus": 0,
             "enable_efa": false,
             "disable_hyperthreading": false,
-            "disable_hyperthreading_via_cpu_options": false
+            "disable_hyperthreading_via_cpu_options": false,
+            "network_interfaces": 1,
+            "enable_efa_gdr": false
           },
           "q2-i2": {
             "instance_type": "g4dn.metal",
@@ -100,7 +114,9 @@
             "gpus": 8,
             "enable_efa": false,
             "disable_hyperthreading": false,
-            "disable_hyperthreading_via_cpu_options": false
+            "disable_hyperthreading_via_cpu_options": false,
+            "network_interfaces": 1,
+            "enable_efa_gdr": false
           },
           "q2-i3": {
             "instance_type": "i3en.24xlarge",
@@ -112,7 +128,9 @@
             "gpus": 0,
             "enable_efa": false,
             "disable_hyperthreading": false,
-            "disable_hyperthreading_via_cpu_options": false
+            "disable_hyperthreading_via_cpu_options": false,
+            "network_interfaces": 1,
+            "enable_efa_gdr": false
           },
           "q2-i4": {
             "instance_type": "t2.xlarge",
@@ -124,7 +142,9 @@
             "gpus": 0,
             "enable_efa": false,
             "disable_hyperthreading": false,
-            "disable_hyperthreading_via_cpu_options": false
+            "disable_hyperthreading_via_cpu_options": false,
+            "network_interfaces": 1,
+            "enable_efa_gdr": false
           },
           "q2-i5": {
             "instance_type": "m6g.xlarge",
@@ -136,13 +156,16 @@
             "gpus": 0,
             "enable_efa": false,
             "disable_hyperthreading": false,
-            "disable_hyperthreading_via_cpu_options": false
+            "disable_hyperthreading_via_cpu_options": false,
+            "network_interfaces": 1,
+            "enable_efa_gdr": false
           }
         }
       },
       "queue3": {
         "compute_type": "spot",
         "enable_efa": true,
+        "enable_efa_gdr": true,
         "disable_hyperthreading": false,
         "placement_group": "DYNAMIC",
         "compute_resource_settings": {
@@ -156,7 +179,23 @@
             "gpus": 0,
             "enable_efa": true,
             "disable_hyperthreading": false,
-            "disable_hyperthreading_via_cpu_options": false
+            "disable_hyperthreading_via_cpu_options": false,
+            "network_interfaces": 1,
+            "enable_efa_gdr": false
+          },
+          "q3-i2": {
+            "instance_type": "p4d.24xlarge",
+            "min_count": 0,
+            "max_count": 10,
+            "initial_count": 0,
+            "spot_price": 0,
+            "vcpus": 96,
+            "gpus": 8,
+            "enable_efa": true,
+            "disable_hyperthreading": false,
+            "disable_hyperthreading_via_cpu_options": false,
+            "network_interfaces": 4,
+            "enable_efa_gdr": true
           }
         }
       }

--- a/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
@@ -4,10 +4,12 @@ cluster_template = default
 [cluster default]
 queue_settings = {{queue_settings}}
 enable_efa = compute
+enable_efa_gdr = compute
 disable_cluster_dns = true
 # disable_hyperthreading not defined, fallback to False expected
 # disable_hyperthreading = false
 dashboard_settings = dashboard1
+master_instance_type = c4.xlarge
 
 [dashboard dashboard1]
 enable = false
@@ -16,6 +18,7 @@ enable = false
 compute_resource_settings = q1-i1,q1-i2,q1-i3,q1-i4,q1-i5
 compute_type = ondemand
 enable_efa = true
+enable_efa_gdr = true
 disable_hyperthreading = true
 
 [compute_resource q1-i1]
@@ -42,6 +45,7 @@ instance_type = m6g.xlarge
 compute_resource_settings = q2-i1, q2-i2,    q2-i3 ,q2-i4   ,q2-i5   # extra spaces added to check for labels stripping
 compute_type = spot
 enable_efa = false
+enable_efa_gdr = false
 disable_hyperthreading = false
 placement_group = DYNAMIC
 
@@ -64,10 +68,12 @@ instance_type = t2.xlarge
 instance_type = m6g.xlarge
 
 [queue queue3]
-compute_resource_settings = q3-i1
+compute_resource_settings = q3-i1, q3-i2
 compute_type = spot
 # enable_efa should be inherited from cluster section
 # enable_efa = true
+# enable_efa_gdr should be inherited from cluster section
+# enable_efa_gdr = true
 # disable_hyperthreading should be inherited from cluster section
 # disable_hyperthreading = false
 placement_group = DYNAMIC
@@ -75,3 +81,6 @@ placement_group = DYNAMIC
 [compute_resource q3-i1]
 instance_type = i3en.24xlarge
 spot_price = 0.4
+
+[compute_resource q3-i2]
+instance_type = p4d.24xlarge

--- a/cli/tests/pcluster/config/test_runtime.py
+++ b/cli/tests/pcluster/config/test_runtime.py
@@ -20,6 +20,7 @@ def test_update_sections(mocker, pcluster_config_reader):
     mocker.patch(
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type", return_value=["x86_64"]
     )
+    mocker.patch("pcluster.config.cfn_param_types.get_instance_network_interfaces", return_value=1)
     pcluster_config = PclusterConfig(
         cluster_label="default", config_file=pcluster_config_reader(), fail_on_file_absence=True, fail_on_error=True
     )

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -74,6 +74,7 @@ def test_example_config_consistency(mocker):
     mocker.patch(
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type", return_value=["x86_64"]
     )
+    mocker.patch("pcluster.config.cfn_param_types.get_instance_network_interfaces", return_value=1)
     pcluster_config = PclusterConfig(config_file=utils.get_pcluster_config_example(), fail_on_file_absence=True)
 
     cfn_params = pcluster_config.to_cfn()
@@ -90,7 +91,7 @@ def test_defaults_consistency():
 
     # verify that the number of parameters in the template is lower than the limit of 60 parameters
     # https://docs.aws.amazon.com/en_us/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
-    assert_that(template_num_of_params).is_less_than_or_equal_to(60)
+    assert_that(template_num_of_params).is_less_than_or_equal_to(61)
 
     # verify number of parameters used for tests with number of parameters in CFN template
     total_number_of_params = CFN_SIT_CONFIG_NUM_OF_PARAMS + len(CFN_CLI_RESERVED_PARAMS)

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -99,12 +99,13 @@ def test_ec2_instance_type_validator(mocker, instance_type, expected_message):
         ("awsbatch", "t2", None),  # t2 family
         ("awsbatch", "optimal", None),
         ("sge", "p4d.24xlarge", "has 4 Network Interfaces."),
+        ("slurm", "p4d.24xlarge", None),
     ],
 )
 def test_compute_instance_type_validator(mocker, scheduler, instance_type, expected_message):
     config_parser_dict = {"cluster default": {"scheduler": scheduler, "compute_instance_type": instance_type}}
     extra_patches = {
-        "pcluster.config.cfn_param_types.get_instance_network_interfaces": 4 if instance_type == "p4d.s4xlarge" else 1,
+        "pcluster.config.validators.get_instance_network_interfaces": 4 if instance_type == "p4d.24xlarge" else 1,
     }
     utils.assert_param_validator(mocker, config_parser_dict, expected_message, extra_patches=extra_patches)
 

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -98,11 +98,15 @@ def test_ec2_instance_type_validator(mocker, instance_type, expected_message):
         ("awsbatch", "c4.xlarge", "is not supported"),
         ("awsbatch", "t2", None),  # t2 family
         ("awsbatch", "optimal", None),
+        ("sge", "p4d.24xlarge", "has 4 Network Interfaces."),
     ],
 )
 def test_compute_instance_type_validator(mocker, scheduler, instance_type, expected_message):
     config_parser_dict = {"cluster default": {"scheduler": scheduler, "compute_instance_type": instance_type}}
-    utils.assert_param_validator(mocker, config_parser_dict, expected_message)
+    extra_patches = {
+        "pcluster.config.cfn_param_types.get_instance_network_interfaces": 4 if instance_type == "p4d.s4xlarge" else 1,
+    }
+    utils.assert_param_validator(mocker, config_parser_dict, expected_message, extra_patches=extra_patches)
 
 
 def test_ec2_key_pair_validator(mocker, boto3_stubber):

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -102,7 +102,7 @@ def assert_param_from_file(
 def get_mock_pcluster_config_patches(scheduler, extra_patches=None):
     """Return mocks for a set of functions that should be mocked by default because they access the network."""
     architectures = ["x86_64"]
-    master_instances = ["t2.micro", "t2.large", "c4.xlarge"]
+    master_instances = ["t2.micro", "t2.large", "c4.xlarge", "p4d.24xlarge"]
     compute_instances = ["t2.micro", "t2.large", "t2", "optimal"] if scheduler == "awsbatch" else master_instances
     patches = {
         "pcluster.config.validators.get_supported_instance_types": master_instances,

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -111,6 +111,7 @@ def get_mock_pcluster_config_patches(scheduler, extra_patches=None):
         "pcluster.config.cfn_param_types.get_availability_zone_of_subnet": "mocked_avail_zone",
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type": architectures,
         "pcluster.config.validators.get_instance_vcpus": 1,
+        "pcluster.config.cfn_param_types.get_instance_network_interfaces": 1,
     }
     if extra_patches:
         patches = merge_dicts(patches, extra_patches)
@@ -243,8 +244,7 @@ def get_mocked_pcluster_config(mocker, auto_refresh=False):
         # We need to provide a region to PclusterConfig to avoid no region exception.
         # Which region to provide is arbitrary.
         os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-    pcluster_config = PclusterConfig(config_file="wrong-file")
-    pcluster_config.auto_refresh = auto_refresh
+    pcluster_config = PclusterConfig(config_file="wrong-file", auto_refresh=auto_refresh)
     return pcluster_config
 
 

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.ini
@@ -25,6 +25,7 @@ use_public_ips = false
 
 [queue compute]
 enable_efa = false
+enable_efa_gdr = false
 compute_resource_settings = default
 
 [compute_resource default]

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.ini
@@ -23,6 +23,7 @@ master_subnet_id = subnet-12345678
 
 [queue compute]
 enable_efa = false
+enable_efa_gdr = false
 compute_resource_settings = default
 
 [compute_resource default]

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/pcluster.config.ini
@@ -24,6 +24,7 @@ ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
 
 [queue compute]
 enable_efa = false
+enable_efa_gdr = false
 compute_resource_settings = default
 
 [compute_resource default]

--- a/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_sit_full/expected_output.ini
+++ b/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_sit_full/expected_output.ini
@@ -82,6 +82,7 @@ queue_settings = compute
 [queue compute]
 compute_type = spot
 enable_efa = true
+enable_efa_gdr = false
 placement_group = DYNAMIC
 compute_resource_settings = default
 

--- a/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_sit_simple/expected_output.ini
+++ b/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_sit_simple/expected_output.ini
@@ -25,6 +25,7 @@ queue_settings = compute
 
 [queue compute]
 enable_efa = false
+enable_efa_gdr = false
 compute_resource_settings = default
 
 [compute_resource default]

--- a/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_unrelated_sections/expected_output.ini
+++ b/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_unrelated_sections/expected_output.ini
@@ -82,6 +82,7 @@ queue_settings = compute
 [queue compute]
 compute_type = spot
 enable_efa = true
+enable_efa_gdr = false
 placement_group = DYNAMIC
 compute_resource_settings = default
 

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -338,6 +338,11 @@
       "Type": "String",
       "Default": "NONE"
     },
+    "EFAGDR": {
+      "Description": "Enable EFA GPUDirect Support on the compute nodes, enable_efa_gdr = compute",
+      "Type": "String",
+      "Default": "NONE"
+    },
     "DCVOptions": {
       "Description": "Comma separated list of NICE DCV related options, 3 parameters in total, [enabled,port,access_from]",
       "Type": "String",
@@ -355,6 +360,11 @@
       "Description": "Comma separated list of CloudWatch logging, 2 parameters in total, [enabled, retention_days]",
       "Type": "String",
       "Default": "true,14"
+    },
+    "NetworkInterfacesCount": {
+      "Description": "Comma separated string of [master network interfaces], [compute network interfaces].",
+      "Type": "CommaDelimitedList",
+      "Default": "1,1"
     }
   },
   "Conditions": {
@@ -2633,8 +2643,51 @@
           "MasterInstanceType": {
             "Ref": "MasterInstanceType"
           },
+          "MasterSecurityGroups": {
+            "Fn::Join": [
+              ",",
+              [
+                {
+                  "Fn::If": [
+                    "CreateSecurityGroups",
+                    {
+                      "Ref": "MasterSecurityGroup"
+                    },
+                    {
+                      "Ref": "AWS::NoValue"
+                    }
+                  ]
+                },
+                {
+                  "Fn::If": [
+                    "AddAdditionalSG",
+                    {
+                      "Ref": "AdditionalSG"
+                    },
+                    {
+                      "Ref": "AWS::NoValue"
+                    }
+                  ]
+                },
+                {
+                  "Fn::If": [
+                    "UseExistingSecurityGroup",
+                    {
+                      "Ref": "VPCSecurityGroupId"
+                    },
+                    {
+                      "Ref": "AWS::NoValue"
+                    }
+                  ]
+                }
+              ]
+            ]
+          },
           "ComputeInstanceType": {
             "Ref": "ComputeInstanceType"
+          },
+          "MasterSubnetId": {
+            "Ref": "MasterSubnetId"
           },
           "MasterCoreCount": {
             "Fn::Join": [
@@ -3052,6 +3105,14 @@
               },
               "NONE"
             ]
+          },
+          "MasterNetworkInterfacesCount": {
+            "Fn::Select": [
+              "0",
+              {
+                "Ref": "NetworkInterfacesCount"
+              }
+            ]
           }
         },
         "TemplateURL": {
@@ -3263,6 +3324,9 @@
           "EFA": {
             "Ref": "EFA"
           },
+          "EFAGDR": {
+            "Ref": "EFAGDR"
+          },
           "BaseOS": {
             "Ref": "BaseOS"
           },
@@ -3465,6 +3529,14 @@
             "Fn::GetAtt": [
               "MasterServerSubstack",
               "Outputs.MasterPrivateIP"
+            ]
+          },
+          "ComputeNetworkInterfacesCount": {
+            "Fn::Select": [
+              "1",
+              {
+                "Ref": "NetworkInterfacesCount"
+              }
             ]
           }
         },

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -93,6 +93,9 @@ Conditions:
     - !Equals
       - !Ref 'RootRole'
       - NONE
+  UseAssociatePublicIpAddress: !Equals
+    - !Ref 'AssociatePublicIpAddress'
+    - true
 Resources:
 {%- for queue, queue_config in queues.items() %}
   {%- for compute_resource in queue_config.compute_resource_settings.values() %}
@@ -110,11 +113,20 @@ Resources:
       LaunchTemplateData:
         InstanceType: {{ instance_type }}
         NetworkInterfaces:
-          - DeviceIndex: 0
-            InterfaceType: {{ 'efa' if compute_resource.enable_efa else "!Ref 'AWS::NoValue'" }}
+          {%- for device_index in range(compute_resource.network_interfaces) %}
+          - DeviceIndex: {{device_index}}
+            {%- if device_index == 0 %}
+            AssociatePublicIpAddress: !If
+              - UseAssociatePublicIpAddress
+              - true
+              - {% if compute_resource.network_interfaces == 1 %}false{% else %}!Ref 'AWS::NoValue'{% endif %}
+            {%- else %}
+            NetworkCardIndex: {{device_index}}
+            {%- endif %}
+            InterfaceType: {% if compute_resource.enable_efa %}efa{% else %}!Ref 'AWS::NoValue'{% endif %}
             Groups: !Ref 'ComputeSecurityGroups'
-            AssociatePublicIpAddress: !Ref 'AssociatePublicIpAddress'
             SubnetId: !Ref 'ComputeSubnetId'
+          {%- endfor %}
         Placement:
           GroupName: {% if queue_config.placement_group == "DYNAMIC" %}!Ref 'PlacementGroup{{ queue | sha1 | truncate(16, True, "") | capitalize }}'{% elif queue_config.placement_group %}{{ queue_config.placement_group }}{% else %}!Ref 'AWS::NoValue'{% endif %}
         KeyName: !Ref 'KeyName'
@@ -313,7 +325,8 @@ Resources:
                         "cfn_cluster_user": "${OSUser}",
                         "enable_intel_hpc_platform": "${IntelHPCPlatform}",
                         "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}",
-                        "scheduler_queue_name": "{{ queue }}"
+                        "scheduler_queue_name": "{{ queue }}",
+                        "enable_efa_gdr": "{{ 'compute' if compute_resource.enable_efa_gdr else 'NONE' }}"
                       },
                       "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
                     }

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -249,6 +249,7 @@ Resources:
           - !If
             - UseNIC1
             - DeviceIndex: 1
+              NetworkCardIndex: 1
               InterfaceType: !If
                 - EnableEFA
                 - efa
@@ -259,6 +260,7 @@ Resources:
           - !If
             - UseNIC2
             - DeviceIndex: 2
+              NetworkCardIndex: 2
               InterfaceType: !If
                 - EnableEFA
                 - efa
@@ -269,6 +271,7 @@ Resources:
           - !If
             - UseNIC3
             - DeviceIndex: 3
+              NetworkCardIndex: 3
               InterfaceType: !If
                 - EnableEFA
                 - efa
@@ -599,6 +602,11 @@ Resources:
                 - DisableComputeHyperthreadingManually
                 - 'true'
                 - 'false'
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
 Outputs:
   ASGName:
     Value: !Ref 'ComputeFleet'

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -32,6 +32,8 @@ Parameters:
     Type: String
   EFA:
     Type: String
+  EFAGDR:
+    Type: String
   BaseOS:
     Type: String
   OSUser:
@@ -104,6 +106,8 @@ Parameters:
     Type: String
   MasterPrivateIP:
     Type: String
+  ComputeNetworkInterfacesCount:
+    Type: Number
 Conditions:
   EnableEFA: !Not
     - !Equals
@@ -147,6 +151,25 @@ Conditions:
     - !Equals
       - !Ref 'PlacementGroup'
       - NONE
+  UseNIC1: !Not
+    - !Equals
+      - !Ref 'ComputeNetworkInterfacesCount'
+      - '1'
+  UseNIC2: !And
+    - !Not
+      - !Equals
+        - !Ref 'ComputeNetworkInterfacesCount'
+        - '2'
+    - !Condition 'UseNIC1'
+  UseNIC3: !And
+    - !Not
+      - !Equals
+        - !Ref 'ComputeNetworkInterfacesCount'
+        - '3'
+    - !Condition 'UseNIC2'
+  UseAssociatePublicIpAddress: !Equals
+    - !Ref 'AssociatePublicIpAddress'
+    - true
 Resources:
   ComputeFleet:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -215,7 +238,44 @@ Resources:
               - efa
               - !Ref 'AWS::NoValue'
             Groups: !Ref 'ComputeSecurityGroups'
-            AssociatePublicIpAddress: !Ref 'AssociatePublicIpAddress'
+            SubnetId: !Ref 'ComputeSubnetId'
+            AssociatePublicIpAddress: !If
+              - UseAssociatePublicIpAddress
+              - true
+              - !If
+                - UseNIC1
+                - !Ref 'AWS::NoValue'
+                - false
+          - !If
+            - UseNIC1
+            - DeviceIndex: 1
+              InterfaceType: !If
+                - EnableEFA
+                - efa
+                - !Ref 'AWS::NoValue'
+              Groups: !Ref 'ComputeSecurityGroups'
+              SubnetId: !Ref 'ComputeSubnetId'
+            - !Ref 'AWS::NoValue'
+          - !If
+            - UseNIC2
+            - DeviceIndex: 2
+              InterfaceType: !If
+                - EnableEFA
+                - efa
+                - !Ref 'AWS::NoValue'
+              Groups: !Ref 'ComputeSecurityGroups'
+              SubnetId: !Ref 'ComputeSubnetId'
+            - !Ref 'AWS::NoValue'
+          - !If
+            - UseNIC3
+            - DeviceIndex: 3
+              InterfaceType: !If
+                - EnableEFA
+                - efa
+                - !Ref 'AWS::NoValue'
+              Groups: !Ref 'ComputeSecurityGroups'
+              SubnetId: !Ref 'ComputeSubnetId'
+            - !Ref 'AWS::NoValue'
         InstanceType: !Ref 'ComputeInstanceType'
         KeyName: !Ref 'KeyName'
         IamInstanceProfile:
@@ -391,7 +451,8 @@ Resources:
                         "cfn_node_type": "ComputeFleet",
                         "cfn_cluster_user": "${OSUser}",
                         "enable_intel_hpc_platform": "${IntelHPCPlatform}",
-                        "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}"
+                        "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}",
+                        "enable_efa_gdr": "${EFAGDR}",
                       },
                       "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
                     }

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -116,7 +116,17 @@ Parameters:
       trigger cfn-hup with metadata changes.
   UpdateWaiterFunctionArn:
     Type: String
+  MasterSubnetId:
+    Type: String
+  MasterNetworkInterfacesCount:
+    Type: Number
+  MasterSecurityGroups:
+    Type: List<AWS::EC2::SecurityGroup::Id>
 Conditions:
+  EnableEFA: !Not
+    - !Equals
+      - !Ref 'EFA'
+      - NONE
   DisableMasterHyperthreading: !Not
     - !Or
       - !Equals
@@ -224,6 +234,22 @@ Conditions:
   HasMasterPublicIp: !Equals
     - !Ref 'UseMasterPublicIp'
     - 'true'
+  UseNIC1: !Not
+    - !Equals
+      - !Ref 'MasterNetworkInterfacesCount'
+      - '1'
+  UseNIC2: !And
+    - !Not
+      - !Equals
+        - !Ref 'MasterNetworkInterfacesCount'
+        - '2'
+    - !Condition 'UseNIC1'
+  UseNIC3: !And
+    - !Not
+      - !Equals
+        - !Ref 'MasterNetworkInterfacesCount'
+        - '3'
+    - !Condition 'UseNIC2'
 Resources:
   MasterServer:
     Type: AWS::EC2::Instance
@@ -341,6 +367,36 @@ Resources:
         NetworkInterfaces:
           - NetworkInterfaceId: !Ref 'MasterENI'
             DeviceIndex: 0
+          - !If
+            - UseNIC1
+            - DeviceIndex: 1
+              NetworkCardIndex: 1
+              InterfaceType: !Ref 'AWS::NoValue'
+              Groups: !Ref 'MasterSecurityGroups'
+              SubnetId: !Ref 'MasterSubnetId'
+            - !Ref 'AWS::NoValue'
+          - !If
+            - UseNIC2
+            - DeviceIndex: 2
+              NetworkCardIndex: 1
+              InterfaceType: !If
+                - EnableEFA
+                - efa
+                - !Ref 'AWS::NoValue'
+              Groups: !Ref 'MasterSecurityGroups'
+              SubnetId: !Ref 'MasterSubnetId'
+            - !Ref 'AWS::NoValue'
+          - !If
+            - UseNIC3
+            - DeviceIndex: 3
+              NetworkCardIndex: 3
+              InterfaceType: !If
+                - EnableEFA
+                - efa
+                - !Ref 'AWS::NoValue'
+              Groups: !Ref 'MasterSecurityGroups'
+              SubnetId: !Ref 'MasterSubnetId'
+            - !Ref 'AWS::NoValue'
         ImageId: !Ref 'ImageId'
         EbsOptimized: !If
           - IsMasterInstanceEbsOpt

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -373,7 +373,7 @@ Resources:
           - !If
             - UseNIC2
             - DeviceIndex: 2
-              NetworkCardIndex: 1
+              NetworkCardIndex: 2
               Groups: !Ref 'MasterSecurityGroups'
               SubnetId: !Ref 'MasterSubnetId'
             - !Ref 'AWS::NoValue'

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -123,10 +123,6 @@ Parameters:
   MasterSecurityGroups:
     Type: List<AWS::EC2::SecurityGroup::Id>
 Conditions:
-  EnableEFA: !Not
-    - !Equals
-      - !Ref 'EFA'
-      - NONE
   DisableMasterHyperthreading: !Not
     - !Or
       - !Equals
@@ -371,7 +367,6 @@ Resources:
             - UseNIC1
             - DeviceIndex: 1
               NetworkCardIndex: 1
-              InterfaceType: !Ref 'AWS::NoValue'
               Groups: !Ref 'MasterSecurityGroups'
               SubnetId: !Ref 'MasterSubnetId'
             - !Ref 'AWS::NoValue'
@@ -379,10 +374,6 @@ Resources:
             - UseNIC2
             - DeviceIndex: 2
               NetworkCardIndex: 1
-              InterfaceType: !If
-                - EnableEFA
-                - efa
-                - !Ref 'AWS::NoValue'
               Groups: !Ref 'MasterSecurityGroups'
               SubnetId: !Ref 'MasterSubnetId'
             - !Ref 'AWS::NoValue'
@@ -390,10 +381,6 @@ Resources:
             - UseNIC3
             - DeviceIndex: 3
               NetworkCardIndex: 3
-              InterfaceType: !If
-                - EnableEFA
-                - efa
-                - !Ref 'AWS::NoValue'
               Groups: !Ref 'MasterSecurityGroups'
               SubnetId: !Ref 'MasterSubnetId'
             - !Ref 'AWS::NoValue'
@@ -548,6 +535,10 @@ Resources:
                 - !Ref 'ProxyServer'
                 - 'false'
     Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
       Comment: AWS ParallelCluster Master server
       AWS::CloudFormation::Init:
         configSets:

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -48,6 +48,7 @@ def substack_rendering(tmp_path, template_name, test_config):
                         "multiple_spot": {
                             "compute_type": "spot",
                             "enable_efa": False,
+                            "enable_efa_gdr": False,
                             "disable_hyperthreading": True,
                             "placement_group": None,
                             "compute_resource_settings": {
@@ -59,8 +60,10 @@ def substack_rendering(tmp_path, template_name, test_config):
                                     "vcpus": 2,
                                     "gpus": 0,
                                     "enable_efa": False,
+                                    "enable_efa_gdr": False,
                                     "disable_hyperthreading": True,
                                     "disable_hyperthreading_via_cpu_options": False,
+                                    "network_interfaces": 1,
                                 },
                                 "multiple_spot_c5.2xlarge": {
                                     "instance_type": "c5.2xlarge",
@@ -70,8 +73,10 @@ def substack_rendering(tmp_path, template_name, test_config):
                                     "vcpus": 4,
                                     "gpus": 0,
                                     "enable_efa": False,
+                                    "enable_efa_gdr": False,
                                     "disable_hyperthreading": True,
                                     "disable_hyperthreading_via_cpu_options": True,
+                                    "network_interfaces": 1,
                                 },
                             },
                         },
@@ -85,12 +90,15 @@ def substack_rendering(tmp_path, template_name, test_config):
                                     "vcpus": 36,
                                     "gpus": 0,
                                     "enable_efa": True,
+                                    "enable_efa_gdr": False,
                                     "disable_hyperthreading": True,
                                     "disable_hyperthreading_via_cpu_options": True,
+                                    "network_interfaces": 1,
                                 }
                             },
                             "compute_type": "ondemand",
                             "enable_efa": True,
+                            "enable_efa_gdr": False,
                             "disable_hyperthreading": True,
                             "placement_group": "DYNAMIC",
                         },
@@ -104,12 +112,15 @@ def substack_rendering(tmp_path, template_name, test_config):
                                     "vcpus": 16,
                                     "gpus": 2,
                                     "enable_efa": False,
+                                    "enable_efa_gdr": False,
                                     "disable_hyperthreading": True,
                                     "disable_hyperthreading_via_cpu_options": True,
+                                    "network_interfaces": 1,
                                 }
                             },
                             "compute_type": "ondemand",
                             "enable_efa": False,
+                            "enable_efa_gdr": False,
                             "disable_hyperthreading": True,
                             "placement_group": None,
                         },
@@ -129,6 +140,7 @@ def substack_rendering(tmp_path, template_name, test_config):
                         "multiple_spot": {
                             "compute_type": "spot",
                             "enable_efa": False,
+                            "enable_efa_gdr": False,
                             "disable_hyperthreading": True,
                             "placement_group": None,
                             "compute_resource_settings": {
@@ -140,8 +152,10 @@ def substack_rendering(tmp_path, template_name, test_config):
                                     "vcpus": 2,
                                     "gpus": 0,
                                     "enable_efa": False,
+                                    "enable_efa_gdr": False,
                                     "disable_hyperthreading": True,
                                     "disable_hyperthreading_via_cpu_options": True,
+                                    "network_interfaces": 1,
                                 },
                                 "multiple_spot_c5.2xlarge": {
                                     "instance_type": "c5.2xlarge",
@@ -151,9 +165,12 @@ def substack_rendering(tmp_path, template_name, test_config):
                                     "vcpus": 4,
                                     "gpus": 0,
                                     "enable_efa": False,
+                                    "enable_efa_gdr": False,
                                     "disable_hyperthreading": True,
                                     "disable_hyperthreading_via_cpu_options": True,
+                                    "network_interfaces": 1,
                                 },
+                                # TODO: add test for multiple NICs
                             },
                         }
                     },

--- a/tests/integration-tests/configs/p4d.yaml
+++ b/tests/integration-tests/configs/p4d.yaml
@@ -1,0 +1,41 @@
+{%- import 'common.jinja2' as common -%}
+  {%- set regions = ["us-east-1"] -%}
+  {%- set instances = ["p4d.24xlarge"] -%}
+
+---
+test-suites:
+  efa:
+    test_efa.py::test_sit_efa:
+      dimensions:
+        - regions: {{ regions }}
+          instances: {{ instances }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          # Torque is not supported by OpenMPI distributed with EFA
+          schedulers: ["sge", "slurm"]
+  dns:
+    test_dns.py::test_hit_no_cluster_dns_mpi:
+      dimensions:
+        - regions: {{ regions }}
+          instances: {{ instances }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+  scaling:
+    test_mpi.py::test_mpi_ssh:
+      dimensions:
+        - regions: {{ regions }}
+          instances: {{ instances }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+    test_scaling.py::test_multiple_jobs_submission:
+      dimensions:
+        - regions: {{ regions }}
+          instances: {{ instances }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm", "sge"]
+  multiple_nics:
+    test_multiple_nics.py::test_multiple_nics:
+      dimensions:
+        - regions: {{ regions }}
+          instances: {{ instances }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm", "sge"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -384,7 +384,10 @@ def add_custom_packages_configs(cluster_config, request, region):
         if request.config.getoption(extra_json_custom_option):
             cluster = extra_json.get("cluster", {})
             if extra_json_custom_option not in cluster:
-                cluster[extra_json_custom_option] = request.config.getoption(extra_json_custom_option)
+                extra_json_custom_option_value = request.config.getoption(extra_json_custom_option)
+                # Escape '%' char to avoid 'Invalid Interpolation Syntax' error
+                extra_json_custom_option_value = extra_json_custom_option_value.replace("%", "%%")
+                cluster[extra_json_custom_option] = extra_json_custom_option_value
                 if extra_json_custom_option == "custom_node_package":
                     # Do not skip install recipes so that custom node package can take effect
                     cluster["skip_install_recipes"] = "no"

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
@@ -1,0 +1,79 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import pytest
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+from utils import get_compute_nodes_instance_ids
+
+from tests.common.schedulers_common import get_scheduler_commands
+
+
+@pytest.mark.regions(["us-east-1"])
+@pytest.mark.instances(["p4d.24xlarge"])
+@pytest.mark.schedulers(["slurm"])
+@pytest.mark.usefixtures("os", "instance", "scheduler")
+def test_multiple_nics(scheduler, region, pcluster_config_reader, clusters_factory):
+    cluster_config = pcluster_config_reader()
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+
+    _test_master_node_nics(remote_command_executor, region)
+    _test_compute_node_nics(cluster, region, remote_command_executor, scheduler_commands)
+
+
+def _get_private_ip_addresses(instance_id, region, remote_command_executor):
+    result = remote_command_executor.run_remote_command(
+        "aws ec2 describe-instances --instance-id {0} --region {1} "
+        '--query "Reservations[0].Instances[0].NetworkInterfaces[*].PrivateIpAddresses[*].PrivateIpAddress" '
+        "--output text".format(instance_id, region)
+    )
+    return result.stdout.strip().split("\n")
+
+
+def _test_master_node_nics(remote_command_executor, region):
+    # On the master node we just check that all the private IPs have been assigned to NICs
+    master_instance_id = remote_command_executor.run_remote_command(
+        "curl http://169.254.169.254/latest/meta-data/instance-id"
+    ).stdout
+
+    master_ip_addresses = _get_private_ip_addresses(master_instance_id, region, remote_command_executor)
+    ip_a_result = remote_command_executor.run_remote_command("ip a").stdout
+
+    for ip_address in master_ip_addresses:
+        assert_that(ip_a_result).matches(".* inet {0}.*".format(ip_address))
+
+
+def _test_compute_node_nics(cluster, region, remote_command_executor, scheduler_commands):
+    compute_instance_id = get_compute_nodes_instance_ids(cluster.cfn_name, region)[0]
+    # Get compute node's IP addresses
+    compute_ip_addresses = _get_private_ip_addresses(compute_instance_id, region, remote_command_executor)
+    for ip_address in compute_ip_addresses:
+        _test_compute_node_nic(ip_address, remote_command_executor, scheduler_commands)
+
+
+def _test_compute_node_nic(ip_address, remote_command_executor, scheduler_commands):
+    # ping test from head node
+    result = remote_command_executor.run_remote_command("ping -c 5 {0}".format(ip_address))
+    assert_that(result.stdout).matches(".*5 packets transmitted, 5 received, 0% packet loss,.*")
+    # ssh test from head node
+    result = remote_command_executor.run_remote_command(
+        "ssh -o StrictHostKeyChecking=no -q {0} echo Hello".format(ip_address)
+    )
+    assert_that(result.stdout).matches("Hello")
+    # ping test from compute node
+    result = scheduler_commands.submit_command("ping -I {0} -c 5 amazon.com > /shared/ping_{0}.out".format(ip_address))
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)
+    result = remote_command_executor.run_remote_command("cat /shared/ping_{0}.out".format(ip_address))
+    assert_that(result.stdout).matches(".*5 packets transmitted, 5 received, 0% packet loss,.*")

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.ini
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.ini
@@ -1,0 +1,20 @@
+[aws]
+aws_region_name =  {{ region }}
+
+[global]
+cluster_template = default
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+initial_queue_size = 1
+maintain_initial_size = true
+vpc_settings = parallelcluster-vpc
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}


### PR DESCRIPTION
Add support for P4d instance type.

This commit introduces support for the new P4d instance type which comes with the following peculiarities:
- Multiple Network Interfaces
- Support for EFA GDR

This change introduces the changes in configuration, mappings and templates to support multiple Network Interfaces and to enable efa gdr support on compute nodes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
