### PR TITLE
Remove one region for awsbatch test in commercial

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -338,7 +338,7 @@ test-suites:
           schedulers: ["torque"]
     test_awsbatch.py::test_awsbatch:
       dimensions:
-        - regions: ["eu-north-1", "ap-south-1", "us-gov-west-1", "cn-north-1"]
+        - regions: ["eu-north-1", "us-gov-west-1", "cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]


### PR DESCRIPTION
Remove one of the two regions for the awsbatch test in commercial

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
