### PR TITLE
Support user-provided S3 bucket to host cluster artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ CHANGELOG
 - Enable support for AWS Batch scheduler in GovCloud regions.
 - Add support for P4d instance type 
 - Add ``-r/-region`` arg to ``pcluster configure``. If this arg is provided, configuration will skip region selection.
+- Add `cluster_resource_bucket` parameter under `cluster` section of cluster config to allow using user-provided bucket 
+  for hosting S3 resources used by cluster
 
 **CHANGES**
 

--- a/cli/awsbatch/awsbsub.py
+++ b/cli/awsbatch/awsbsub.py
@@ -537,7 +537,7 @@ def main():
 
         # generate an internal unique job-id
         job_key = _generate_unique_job_key(job_name)
-        job_s3_folder = "batch/{0}/".format(job_key)
+        job_s3_folder = "{prefix}/batch/{job_key}/".format(prefix=config.artifact_directory, job_key=job_key)
         # upload script, if needed, and get related command
         command = _upload_and_get_command(boto3_factory, args, job_s3_folder, job_name, config, log)
         # parse and validate depends_on parameter

--- a/cli/awsbatch/common.py
+++ b/cli/awsbatch/common.py
@@ -253,6 +253,7 @@ class AWSBatchCliConfig(object):
                 # or the region from the [main] section
                 self.region = config.get(cluster_section, "region")
                 self.s3_bucket = config.get(cluster_section, "s3_bucket")
+                self.artifact_directory = config.get(cluster_section, "artifact_directory")
                 self.compute_environment = config.get(cluster_section, "compute_environment")
                 self.job_queue = config.get(cluster_section, "job_queue")
                 self.job_definition = config.get(cluster_section, "job_definition")
@@ -306,6 +307,8 @@ class AWSBatchCliConfig(object):
                     output_value = output.get("OutputValue")
                     if output_key == "ResourcesS3Bucket":
                         self.s3_bucket = output_value
+                    elif output_key == "ArtifactS3RootDirectory":
+                        self.artifact_directory = output_value
                     elif output_key == "BatchComputeEnvironmentArn":
                         self.compute_environment = output_value
                     elif output_key == "BatchJobQueueArn":

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -95,6 +95,7 @@ from pcluster.config.validators import (
     queue_settings_validator,
     queue_validator,
     raid_volume_iops_validator,
+    s3_bucket_uri_validator,
     s3_bucket_validator,
     scheduler_validator,
     shared_dir_validator,
@@ -495,11 +496,11 @@ FSX = {
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("export_path", {
-                "validators": [s3_bucket_validator],
+                "validators": [s3_bucket_uri_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("import_path", {
-                "validators": [s3_bucket_validator],
+                "validators": [s3_bucket_uri_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("weekly_maintenance_start_time", {
@@ -993,6 +994,11 @@ CLUSTER_COMMON_PARAMS = [
         # This param is managed automatically
         "update_policy": UpdatePolicy.IGNORED,
         "visibility": Visibility.PRIVATE,
+    }),
+    ("cluster_resource_bucket", {
+        "cfn_param_mapping": "ResourcesS3Bucket",
+        "validators": [s3_bucket_validator],
+        "update_policy": UpdatePolicy.IGNORED,
     }),
 ]
 

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -144,6 +144,7 @@ DEFAULT_CLUSTER_SIT_DICT = {
     "cluster_config_metadata": {"sections": {}},
     "architecture": "x86_64",
     "network_interfaces_count": ["1", "1"],
+    "cluster_resource_bucket": None,
 }
 
 DEFAULT_CLUSTER_HIT_DICT = {
@@ -192,6 +193,7 @@ DEFAULT_CLUSTER_HIT_DICT = {
     "cluster_config_metadata": {"sections": {}},
     "architecture": "x86_64",
     "network_interfaces_count": ["1", "1"],
+    "cluster_resource_bucket": None,  # cluster_resource_bucket no default, but this is here to make testing easier
 }
 
 DEFAULT_CW_LOG_DICT = {"enable": True, "retention_days": 14}
@@ -224,11 +226,11 @@ class DefaultDict(Enum):
 # ------------------ Default CFN parameters ------------------ #
 
 # number of CFN parameters created by the PclusterConfig object.
-CFN_SIT_CONFIG_NUM_OF_PARAMS = 60
+CFN_SIT_CONFIG_NUM_OF_PARAMS = 61
 CFN_HIT_CONFIG_NUM_OF_PARAMS = 52
 
 # CFN parameters created by the pcluster CLI
-CFN_CLI_RESERVED_PARAMS = ["ResourcesS3Bucket"]
+CFN_CLI_RESERVED_PARAMS = ["ArtifactS3RootDirectory", "RemoveBucketOnDeletion"]
 
 
 DEFAULT_SCALING_CFN_PARAMS = {"ScaleDownIdleTime": "10"}
@@ -303,7 +305,9 @@ DEFAULT_CLUSTER_SIT_CFN_PARAMS = {
     "NumberOfEBSVol": "1",
     "Cores": "NONE,NONE,NONE,NONE",
     "IntelHPCPlatform": "false",
-    # "ResourcesS3Bucket": "NONE",  # parameter added by the CLI
+    "ResourcesS3Bucket": "NONE",  # parameter added by the CLI
+    # "ArtifactS3RootDirectory": "NONE",  # parameter added by the CLI
+    # "RemoveBucketOnDeletion": "NONE",  # parameter added by the CLI
     # scaling
     "ScaleDownIdleTime": "10",
     # vpc
@@ -370,7 +374,9 @@ DEFAULT_CLUSTER_HIT_CFN_PARAMS = {
     "NumberOfEBSVol": "1",
     "Cores": "NONE,NONE,NONE,NONE",
     "IntelHPCPlatform": "false",
-    # "ResourcesS3Bucket": "NONE",  # parameter added by the CLI
+    "ResourcesS3Bucket": "NONE",  # parameter added by the CLI
+    # "ArtifactS3RootDirectory": "NONE",  # parameter added by the CLI
+    # "RemoveBucketOnDeletion": "NONE",  # parameter added by the CLI
     # scaling
     "ScaleDownIdleTime": "10",
     # vpc

--- a/cli/tests/pcluster/config/test_pcluster_config.py
+++ b/cli/tests/pcluster/config/test_pcluster_config.py
@@ -70,7 +70,11 @@ def test_get_latest_alinux_ami_id(mocker, boto3_stubber, path, boto3_response, e
     [
         (
             # ResourceS3Bucket available
-            {"Scheduler": "slurm", "ResourcesS3Bucket": "valid_bucket"},
+            {
+                "Scheduler": "slurm",
+                "ResourcesS3Bucket": "valid_bucket",
+                "ArtifactS3RootDirectory": "valid_dir",
+            },
             "2.9.0",
             {"test_key": "test_value"},
         ),

--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -89,9 +89,9 @@ def test_defaults_consistency():
     """Verifies that the defaults values for the CFN parameters used in the tests are the same in the CFN template."""
     template_num_of_params = _get_pcluster_cfn_num_of_params()
 
-    # verify that the number of parameters in the template is lower than the limit of 60 parameters
+    # verify that the number of parameters in the template is lower than the limit of 200 parameters
     # https://docs.aws.amazon.com/en_us/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
-    assert_that(template_num_of_params).is_less_than_or_equal_to(61)
+    assert_that(template_num_of_params).is_less_than_or_equal_to(200)
 
     # verify number of parameters used for tests with number of parameters in CFN template
     total_number_of_params = CFN_SIT_CONFIG_NUM_OF_PARAMS + len(CFN_CLI_RESERVED_PARAMS)

--- a/cli/tests/pcluster/utils/test_pcluster_utils.py
+++ b/cli/tests/pcluster/utils/test_pcluster_utils.py
@@ -354,8 +354,8 @@ def _generate_stack_event():
 @pytest.mark.parametrize(
     "bucket_prefix", ["test", "test-", "prefix-63-characters-long--------------------------------to-cut"]
 )
-def test_generate_random_bucket_name(bucket_prefix):
-    bucket_name = utils.generate_random_bucket_name(bucket_prefix)
+def test_generate_random_name_with_prefix(bucket_prefix):
+    bucket_name = utils.generate_random_name_with_prefix(bucket_prefix)
     max_bucket_name_length = 63
     random_suffix_length = 17  # 16 digits + 1 separator
 

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -304,7 +304,15 @@
       "Default": "NONE"
     },
     "ResourcesS3Bucket": {
-      "Description": "S3 bucket where resources needed by the stack are located. The bucket gets deleted on stack deletion.",
+      "Description": "S3 bucket where resources needed by the stack are located. The bucket gets deleted on stack deletion if it is not user-provided.",
+      "Type": "String"
+    },
+    "ArtifactS3RootDirectory": {
+      "Description": "Root directory in S3 bucket where cluster artifacts are stored, i.e. cluster artifacts would be under {ResourcesS3Bucket}/{ArtifactS3RootDirectory}.",
+      "Type": "String"
+    },
+    "RemoveBucketOnDeletion": {
+      "Description": "Parameter to control if bucket is removed on cluster deletion. pcluster created buckets are alway removed, user provided buckets are kept.",
       "Type": "String"
     },
     "RAIDOptions": {
@@ -776,6 +784,14 @@
           "Ref": "Architecture"
         },
         "arm64"
+      ]
+    },
+    "UseProvidedResourcesS3Bucket": {
+      "Fn::Equals": [
+        {
+          "Ref": "RemoveBucketOnDeletion"
+        },
+        "False"
       ]
     }
   },
@@ -1645,7 +1661,7 @@
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/batch/*"
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/${ArtifactS3RootDirectory}/batch/*"
                 }
               ]
             },
@@ -1737,13 +1753,24 @@
             {
               "Sid": "ResourcesS3Bucket",
               "Effect": "Allow",
-              "Action": "s3:*",
+              "Action": {
+                "Fn::If": [
+                  "UseProvidedResourcesS3Bucket",
+                  [
+                    "s3:ListBucket",
+                    "s3:ListBucketVersions",
+                    "s3:GetObject*",
+                    "s3:PutObject*"
+                  ],
+                  "s3:*"
+                ]
+              },
               "Resource": [
                 {
                   "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}"
                 },
                 {
-                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/*"
+                  "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/${ArtifactS3RootDirectory}/*"
                 }
               ]
             },
@@ -2284,6 +2311,9 @@
           "ResourcesS3Bucket": {
             "Ref": "ResourcesS3Bucket"
           },
+          "ArtifactS3RootDirectory": {
+            "Ref": "ArtifactS3RootDirectory"
+          },
           "SharedDir": {
             "Ref": "SharedDir"
           },
@@ -2401,20 +2431,31 @@
                   "Sid": "CloudWatchLogsPolicy"
                 },
                 {
-                  "Action": [
-                    "s3:DeleteBucket",
-                    "s3:DeleteObject",
-                    "s3:DeleteObjectVersion",
-                    "s3:ListBucket",
-                    "s3:ListBucketVersions"
-                  ],
+                  "Action": {
+                    "Fn::If": [
+                      "UseProvidedResourcesS3Bucket",
+                      [
+                        "s3:DeleteObject",
+                        "s3:DeleteObjectVersion",
+                        "s3:ListBucket",
+                        "s3:ListBucketVersions"
+                      ],
+                      [
+                        "s3:DeleteBucket",
+                        "s3:DeleteObject",
+                        "s3:DeleteObjectVersion",
+                        "s3:ListBucket",
+                        "s3:ListBucketVersions"
+                      ]
+                    ]
+                  },
                   "Effect": "Allow",
                   "Resource": [
                     {
                       "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}"
                     },
                     {
-                      "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/*"
+                      "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/${ArtifactS3RootDirectory}/*"
                     }
                   ],
                   "Sid": "S3BucketPolicy"
@@ -2472,7 +2513,13 @@
         "ResourcesS3Bucket": {
           "Ref": "ResourcesS3Bucket"
         },
-        "Action": "DELETE_S3_BUCKET",
+        "ArtifactS3RootDirectory": {
+          "Ref": "ArtifactS3RootDirectory"
+        },
+        "RemoveBucketOnDeletion": {
+          "Ref": "RemoveBucketOnDeletion"
+        },
+        "Action": "DELETE_S3_ARTIFACTS",
         "ServiceToken": {
           "Fn::GetAtt": [
             "CleanupResourcesFunction",
@@ -2528,7 +2575,9 @@
           "S3Bucket": {
             "Ref": "ResourcesS3Bucket"
           },
-          "S3Key": "custom_resources_code/artifacts.zip"
+          "S3Key": {
+            "Fn::Sub": "${ArtifactS3RootDirectory}/custom_resources_code/artifacts.zip"
+          }
         },
         "Handler": "cleanup_resources.handler",
         "MemorySize": 128,
@@ -3059,6 +3108,9 @@
           },
           "ResourcesS3Bucket": {
             "Ref": "ResourcesS3Bucket"
+          },
+          "ArtifactS3RootDirectory": {
+            "Ref": "ArtifactS3RootDirectory"
           },
           "DependsOnCustomResources": {
             "Fn::If": [
@@ -3895,11 +3947,14 @@
           },
           "ResourcesS3Bucket": {
             "Ref": "ResourcesS3Bucket"
+          },
+          "ArtifactS3RootDirectory": {
+            "Ref": "ArtifactS3RootDirectory"
           }
         },
         "TemplateURL": {
           "Fn::Sub": [
-            "https://${ResourcesS3Bucket}.s3.${AWS::Region}.${s3_url}/templates/compute-fleet-hit-substack.rendered.cfn.yaml",
+            "https://${ResourcesS3Bucket}.s3.${AWS::Region}.${s3_url}/${ArtifactS3RootDirectory}/templates/compute-fleet-hit-substack.rendered.cfn.yaml",
             {
               "s3_url": {
                 "Fn::FindInMap": [
@@ -4000,7 +4055,7 @@
         },
         "TemplateURL": {
           "Fn::Sub": [
-            "https://${ResourcesS3Bucket}.s3.${AWS::Region}.${s3_url}/templates/cw-dashboard-substack.rendered.cfn.yaml",
+            "https://${ResourcesS3Bucket}.s3.${AWS::Region}.${s3_url}/${ArtifactS3RootDirectory}/templates/cw-dashboard-substack.rendered.cfn.yaml",
             {
               "s3_url": {
                 "Fn::FindInMap": [
@@ -4090,6 +4145,12 @@
       "Description": "S3 user bucket where AWS ParallelCluster resources are stored",
       "Value": {
         "Ref": "ResourcesS3Bucket"
+      }
+    },
+    "ArtifactS3RootDirectory": {
+      "Description": "Root directory in S3 bucket where cluster artifacts are stored",
+      "Value": {
+        "Ref": "ArtifactS3RootDirectory"
       }
     },
     "BatchComputeEnvironmentArn": {

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -49,6 +49,10 @@
       "Description": "S3 Bucket where resources needed by this stack are located.",
       "Type": "String"
     },
+    "ArtifactS3RootDirectory": {
+      "Description": "Root directory in S3 bucket where cluster artifacts are stored, i.e. cluster artifacts would be under {ResourcesS3Bucket}/{ArtifactS3RootDirectory}.",
+      "Type": "String"
+    },
     "SharedDir": {
       "Description": "The path/mountpoint for the shared drive",
       "Type": "String"
@@ -181,7 +185,7 @@
                   "Action": "s3:PutObject",
                   "Resource": [
                     {
-                      "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/batch/*"
+                      "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/${ArtifactS3RootDirectory}/batch/*"
                     }
                   ]
                 }
@@ -284,7 +288,7 @@
                       "Fn::Sub": "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/parallelcluster-*/*"
                     },
                     {
-                      "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/batch/*"
+                      "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/${ArtifactS3RootDirectory}/batch/*"
                     },
                     {
                       "Fn::GetAtt": [
@@ -669,7 +673,7 @@
         },
         "Source": {
           "Location": {
-            "Fn::Sub": "${ResourcesS3Bucket}/docker/artifacts.zip"
+            "Fn::Sub": "${ResourcesS3Bucket}/${ArtifactS3RootDirectory}/docker/artifacts.zip"
           },
           "Type": "S3"
         },
@@ -731,7 +735,7 @@
               ],
               "Effect": "Allow",
               "Resource": {
-                "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/*"
+                "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/${ArtifactS3RootDirectory}/*"
               },
               "Sid": "S3GetObjectPolicy"
             }
@@ -794,7 +798,9 @@
           "S3Bucket": {
             "Ref": "ResourcesS3Bucket"
           },
-          "S3Key": "custom_resources_code/artifacts.zip"
+          "S3Key": {
+            "Fn::Sub": "${ArtifactS3RootDirectory}/custom_resources_code/artifacts.zip"
+          }
         },
         "Handler": "manage_docker_images.handler",
         "MemorySize": 128,
@@ -942,7 +948,9 @@
           "S3Bucket": {
             "Ref": "ResourcesS3Bucket"
           },
-          "S3Key": "custom_resources_code/artifacts.zip"
+          "S3Key": {
+            "Fn::Sub": "${ArtifactS3RootDirectory}/custom_resources_code/artifacts.zip"
+          }
         },
         "Handler": "send_build_notification.handler",
         "MemorySize": 128,
@@ -1046,6 +1054,12 @@
       "Description": "S3 user bucket where resources are stored",
       "Value": {
         "Ref": "ResourcesS3Bucket"
+      }
+    },
+    "ArtifactS3RootDirectory": {
+      "Description": "Root directory in S3 bucket where cluster artifacts are stored",
+      "Value": {
+        "Ref": "ArtifactS3RootDirectory"
       }
     },
     "MNPJobDefinitionArn": {

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -84,6 +84,8 @@ Parameters:
     Type: String
   ResourcesS3Bucket:
     Type: String
+  ArtifactS3RootDirectory:
+    Type: String
 Conditions:
   UseProxy: !Not
     - !Equals
@@ -526,7 +528,7 @@ Resources:
               - !Ref 'AWS::StackId'
       Code:
         S3Bucket: !Ref 'ResourcesS3Bucket'
-        S3Key: custom_resources_code/artifacts.zip
+        S3Key: !Sub '${ArtifactS3RootDirectory}/custom_resources_code/artifacts.zip'
       Handler: cleanup_resources.handler
       MemorySize: 128
       Role: !GetAtt 'CleanupRoute53FunctionExecutionRole.Arn'
@@ -577,7 +579,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: !Ref 'ResourcesS3Bucket'
-        S3Key: custom_resources_code/artifacts.zip
+        S3Key: !Sub '${ArtifactS3RootDirectory}/custom_resources_code/artifacts.zip'
       Handler: wait_for_update.handler
       MemorySize: 128
       Role: !GetAtt 'UpdateWaiterFunctionExecutionRole.Arn'

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -106,6 +106,8 @@ Parameters:
     Type: String
   ResourcesS3Bucket:
     Type: String
+  ArtifactS3RootDirectory:
+    Type: String
   DependsOnCustomResources:
     Type: String
     Description: This is needed to set a conditional dependency on the TerminateComputeFleetCustomResource
@@ -595,7 +597,7 @@ Resources:
                       "enable_intel_hpc_platform": "${IntelHPCPlatform}",
                       "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}",
                       "cluster_s3_bucket": "${ResourcesS3Bucket}",
-                      "cluster_config_s3_key": "configs/cluster-config.json",
+                      "cluster_config_s3_key": "${ArtifactS3RootDirectory}/configs/cluster-config.json",
                       "cluster_config_version": "${HITConfigVersion}"
                     },
                     "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"


### PR DESCRIPTION
* Add new parameter `cluster_artifact_bucket` under `cluster` section of cluster config to allow user to pass in a bucket to be used to host cluster artifacts
* In case a bucket is provided, artifacts are cleaned up on cluster deletion but bucket is not deleted
* If no bucket is provided, cluster will follow current behavior and create 1 bucket per cluster, with name `parallelcluster-{random_string}`. This bucket will be cleaned up on cluster deletion
* All artifacts are now uploaded to `{bucket_name}/{artifact_directory}`, where `artifact_directory` has name `{stack_name}-{random_string}`
* Add validator for `cluster_artifact_bucket`. Bucket must have versioning enabled.
* Amend unit tests

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
