### PR TITLE
Add a simple caching mechanism for functions

### DIFF
--- a/cli/pcluster/cache.py
+++ b/cli/pcluster/cache.py
@@ -1,0 +1,48 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+
+class Cache:
+    """Simple utility class providing a cache mechanism for expensive functions."""
+
+    cache = {}
+
+    @staticmethod
+    def enabled():
+        """Tell if the cache is enabled."""
+        return not os.environ.get("PCLUSTER_CACHE_DISABLED")
+
+    @staticmethod
+    def clear():
+        """Clear the content of cache."""
+        Cache.cache.clear()
+
+    @staticmethod
+    def cached(function):
+        """
+        Decorate a function to make it use a results cache based on passed arguments.
+
+        Note: all arguments must be hashable for this function to work properly.
+        """
+
+        def wrapper(*args, **kwargs):
+            cache_key = "{0}_{1}".format(str(args), str(kwargs))
+
+            if cache_key in Cache.cache and Cache.enabled():
+                return Cache.cache[cache_key]
+            else:
+                rv = function(*args, **kwargs)
+                if Cache.enabled():
+                    Cache.cache[cache_key] = rv
+                return rv
+
+        return wrapper

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -11,6 +11,9 @@
 # fmt: off
 from __future__ import absolute_import, print_function  # isort:skip
 from future import standard_library  # isort:skip
+
+from pcluster.cache import Cache
+
 standard_library.install_aliases()
 # fmt: on
 
@@ -1041,6 +1044,7 @@ def cluster_has_running_capacity(stack_name):
     return cluster_has_running_capacity.cached_result
 
 
+@Cache.cached
 def get_instance_type(instance_type):
     ec2_client = boto3.client("ec2")
     try:

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -17,6 +17,8 @@ from jinja2 import Environment, FileSystemLoader
 def clear_env():
     if "AWS_DEFAULT_REGION" in os.environ:
         del os.environ["AWS_DEFAULT_REGION"]
+    # Disable functions cache for tests
+    os.environ["PCLUSTER_CACHE_DISABLED"] = "yes"
 
 
 @pytest.fixture

--- a/cli/tests/pcluster/test_cache.py
+++ b/cli/tests/pcluster/test_cache.py
@@ -1,0 +1,63 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module provides unit tests for the functions in the pcluster.commands module."""
+import os
+
+import pytest
+from botocore.exceptions import UnStubbedResponseError
+
+from pcluster.utils import get_instance_type
+from tests.common import MockedBoto3Request
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    return "pcluster.utils.boto3"
+
+
+def test_cache(boto3_stubber):
+    mocked_requests = [
+        MockedBoto3Request(
+            method="describe_instance_types",
+            response={
+                "InstanceTypes": [
+                    {
+                        "InstanceType": "t2.micro",
+                        "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48, "DefaultThreadsPerCore": 2},
+                        "NetworkInfo": {"EfaSupported": True},
+                    }
+                ]
+            },
+            expected_params={"InstanceTypes": ["t2.micro"]},
+        )
+    ]
+
+    # First cache is disabled
+    os.environ["PCLUSTER_CACHE_DISABLED"] = "yes"
+    boto3_stubber("ec2", mocked_requests)
+
+    # First call must be stubbed
+    get_instance_type("t2.micro")
+
+    # Second call must fail for missing stubber
+    with pytest.raises(UnStubbedResponseError):
+        get_instance_type("t2.micro")
+
+    # Now cache is re-enabled
+    del os.environ["PCLUSTER_CACHE_DISABLED"]
+
+    # First call must be stubbed
+    boto3_stubber("ec2", mocked_requests)
+    get_instance_type("t2.micro")
+
+    # Second call must be from cache
+    get_instance_type("t2.micro")


### PR DESCRIPTION
This commit introduces a very simple caching mechanism based on a decorator that can be used to wrap functions that we want to cache.
The goal is to reduce the number of (duplicated) boto3 calls for actions like `describe_instance_types` that can be called multiple times for the same instance type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
