### PR TITLE
Support P4d instances on integration tests

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -194,6 +194,10 @@ test-suites:
           instances: ["c5n.18xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]
+        - regions: ["us-east-1"]
+          instances: ["p4d.24xlarge"]
+          oss: ["alinux2", "ubuntu1604", "centos8"]
+          schedulers: ["slurm"]
     test_efa.py::test_sit_efa:
       dimensions:
         - regions: ["us-east-1"]
@@ -202,6 +206,11 @@ test-suites:
           # Torque is not supported by OpenMPI distributed with EFA
           # Slurm test is to verify EFA works correctly when using the SIT model in the config file
           schedulers: ["sge", "slurm"]
+          # P4d instances are currently not supported in SIT clusters
+        - regions: ["us-west-2"]
+          instances: ["p4d.24xlarge"]
+          oss: ["alinux", "ubuntu1804", "centos7"]
+          schedulers: ["slurm"]
   iam_policies:
     test_iam_policies.py::test_iam_policies:
       dimensions:
@@ -524,3 +533,14 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["centos7"]
           schedulers: ["sge"]
+  multiple_nics:
+    test_multiple_nics.py::test_multiple_nics:
+      dimensions:
+        - regions: ["us-west-2"]
+          instances: ["p4d.24xlarge"]
+          oss: ["alinux2", "ubuntu1604", "centos8"]
+          schedulers: ["slurm"]
+        - regions: ["us-east-1"]
+          instances: ["p4d.24xlarge"]
+          oss: ["alinux", "ubuntu1804", "centos7"]
+          schedulers: ["slurm"]

--- a/tests/integration-tests/configs/p4d.yaml
+++ b/tests/integration-tests/configs/p4d.yaml
@@ -1,5 +1,5 @@
 {%- import 'common.jinja2' as common -%}
-  {%- set regions = ["us-east-1"] -%}
+  {%- set regions = ["us-east-1", "us-west-2"] -%}
   {%- set instances = ["p4d.24xlarge"] -%}
 
 ---
@@ -11,7 +11,7 @@ test-suites:
           instances: {{ instances }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           # Torque is not supported by OpenMPI distributed with EFA
-          schedulers: ["sge", "slurm"]
+          schedulers: ["slurm"]
   dns:
     test_dns.py::test_hit_no_cluster_dns_mpi:
       dimensions:
@@ -31,11 +31,11 @@ test-suites:
         - regions: {{ regions }}
           instances: {{ instances }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
-          schedulers: ["slurm", "sge"]
+          schedulers: ["slurm"]
   multiple_nics:
     test_multiple_nics.py::test_multiple_nics:
       dimensions:
         - regions: {{ regions }}
           instances: {{ instances }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
-          schedulers: ["slurm", "sge"]
+          schedulers: ["slurm"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -462,11 +462,13 @@ AVAILABILITY_ZONE_OVERRIDES = {
     # c5.xlarge is not supported in use1-az3
     # FSx Lustre file system creation is currently not supported for use1-az3
     # m6g.xlarge is not supported in use1-az2 or use1-az3
-    "us-east-1": ["use1-az6", "use1-az1", "use1-az4", "use1-az5"],
+    # p4d.24xlarge is only available on use1-az6
+    "us-east-1": ["use1-az6"],
     # m6g.xlarge is not supported in use2-az1
     "us-east-2": ["use2-az2", "use2-az3"],
     # c4.xlarge is not supported in usw2-az4
-    "us-west-2": ["usw2-az2", "usw2-az1", "usw2-az3"],
+    # p4d.24xlarge is only available on uw2-az2
+    "us-west-2": ["usw2-az2"],
     # c5.xlarge is not supported in apse2-az3
     "ap-southeast-2": ["apse2-az1", "apse2-az2"],
     # m6g.xlarge is not supported in apne1-az2


### PR DESCRIPTION
This commit contains some (temporary) adaptations to allow P4d instances being used in integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
