### PR TITLE
Remove extra comma from dna.json in compute fleet substack

### DIFF
--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -455,7 +455,7 @@ Resources:
                         "cfn_cluster_user": "${OSUser}",
                         "enable_intel_hpc_platform": "${IntelHPCPlatform}",
                         "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}",
-                        "enable_efa_gdr": "${EFAGDR}",
+                        "enable_efa_gdr": "${EFAGDR}"
                       },
                       "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
                     }


### PR DESCRIPTION
It was causing issues when parsing the dna.json at compute node startup:
```
FATAL: Could not parse the provided JSON file (/etc/chef/dna.json): parse error: invalid object key (must be a string)
           "enable_efa_gdr": "NONE",   },   "run_list": "recipe[aws-pa
                     (right here) ------^
```