### PR TITLE
Skip instance type info retrieval for compute nodes with awsbatch

### DIFF
--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -678,7 +678,10 @@ class DisableHyperThreadingCfnParam(BoolCfnParam):
                 master_instance_type
             )
 
-            if self.pcluster_config.cluster_model.name == "SIT":
+            if (
+                self.pcluster_config.cluster_model.name == "SIT"
+                and cluster_config.get_param_value("scheduler") != "awsbatch"
+            ):
                 # compute_instance_type parameter is valid only in SIT clusters
                 compute_instance_type = cluster_config.get_param_value("compute_instance_type")
                 compute_cores, disable_compute_ht_via_cpu_options = self._get_cfn_params_for_instance_type(
@@ -1081,10 +1084,11 @@ class NetworkInterfacesCountCfnParam(CommaSeparatedCfnParam):
     def refresh(self):
         """Compute the number of network interfaces for master and compute nodes."""
         cluster_section = self.pcluster_config.get_section("cluster")
+        scheduler = cluster_section.get_param_value("scheduler")
         self.value = [
             str(get_instance_network_interfaces(cluster_section.get_param_value("master_instance_type"))),
             str(get_instance_network_interfaces(cluster_section.get_param_value("compute_instance_type")))
-            if self.pcluster_config.cluster_model.name == "SIT"
+            if self.pcluster_config.cluster_model.name == "SIT" and scheduler != "awsbatch"
             else "1",
         ]
 

--- a/cli/pcluster/utils.py
+++ b/cli/pcluster/utils.py
@@ -762,7 +762,7 @@ def check_if_latest_version():
         latest = json.loads(urllib.request.urlopen("https://pypi.python.org/pypi/aws-parallelcluster/json").read())[
             "info"
         ]["version"]
-        if get_installed_version() < latest:
+        if packaging.version.parse(get_installed_version()) < packaging.version.parse(latest):
             print("Info: There is a newer version %s of AWS ParallelCluster available." % latest)
     except Exception:
         pass


### PR DESCRIPTION
When scheduler is `awsbatch` we don't need to populate disable hyperthreading and network card info for compute nodes. Also compute nodes in Batch can assume the 'optimal' or an instance family value which can't be used in `describe_instance_types` calls.

This PR also addresses an issue with ParallelCluster version check in the CLI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
