### PR TITLE
Update sanity check message for P4d with SIT clusters

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -1022,9 +1022,11 @@ def compute_instance_type_validator(param_key, param_value, pcluster_config):
             # Multiple NICs instance types are currently supported only with Slurm clusters
             instance_nics = get_instance_network_interfaces(param_value)
             if instance_nics > 1:
-                errors.append(
-                    "The instance type '{0}' has {1} Network Interfaces. Instances with multiple network interfaces "
-                    "are currently not supported with '{2}' scheduler".format(param_value, instance_nics, scheduler)
+                warnings.append(
+                    "Some services needed to support clusters with instance type '{0}' with multiple "
+                    "network interfaces and job scheduler '{1}' may not yet be generally available. "
+                    "Please refer to https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-launch-template.html "
+                    "for more information.".format(param_value, scheduler)
                 )
 
     return errors, warnings


### PR DESCRIPTION
Updated message and behaviour changed from error to warning.

INFO: When creating a SIT cluster with this issue we get a really not clear output:

```
Beginning cluster creation for cluster: test-mnics-sit-3
WARNING: The configuration parameter 'scheduler' generated the following warnings:
The job scheduler you are using (sge) is scheduled to be deprecated in future releases of ParallelCluster. More information is available here: https://github.com/aws/aws-parallelcluster/wiki/Deprecation-of-SGE-and-Torque-in-ParallelCluster
WARNING: The configuration parameter 'compute_instance_type' generated the following warnings:
Some services needed to support clusters with instance type 'p4d.24xlarge' with multiple network interfaces and job scheduler 'sge' may not yet be generally available. Please refer to https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-launch-template.html for more information.
Info: There is a newer version 2.9.1 of AWS ParallelCluster available.
Creating stack named: parallelcluster-test-mnics-sit-3
Status: parallelcluster-test-mnics-sit-3 - ROLLBACK_IN_PROGRESS
Cluster creation failed.  Failed events:
  - AWS::CloudFormation::Stack ComputeFleetSubstack Embedded stack arn:aws:cloudformation:us-west-2:366244450692:stack/parallelcluster-test-mnics-sit-3-ComputeFleetSubstack-ZGKHUW9S02GY/206bf280-250d-11eb-85a0-0605c8f6c87b was not successfully created: The following resource(s) failed to create: [ComputeFleet].
Stack [parallelcluster-test-mnics-sit-3-ComputeFleetSubstack-ZGKHUW9S02GY] does not exist
Deleting artifacts under parallelcluster-ndf4ai8kpk1azvky/parallelcluster-test-mnics-sit-3-zbj5jjzkmfzod3hj
Deleting bucket parallelcluster-ndf4ai8kpk1azvky
```
Only by digging in the substack events we have the clear error:

```
Incompatible launch template: Auto Scaling does not support multiple network interfaces. (Service: AmazonAutoScaling; Status Code: 400; Error Code: InvalidQueryParameter; Request ID: 957dcfaa-4f59-448a-b8c0-d496e2bd9dfc; Proxy: null)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
