### PR TITLE
Fix pcluster update with "cluster_resource_bucket"

### DIFF
--- a/cli/pcluster/config/cfn_param_types.py
+++ b/cli/pcluster/config/cfn_param_types.py
@@ -1278,3 +1278,26 @@ class VolumeSizeParam(IntCfnParam):
             else:
                 default_volume_size = 20
             self.value = default_volume_size
+
+
+class ClusterResourceBucketCfnParam(CfnParam):
+    """Class to manage cluster_resource_bucket parameter."""
+
+    def from_cfn_params(self, cfn_params):
+        """
+        Initialize parameter value by parsing CFN input parameters.
+
+        :param cfn_params: list of all the CFN parameters, used if "cfn_param_mapping" is specified in the definition
+        """
+        cfn_converter = self.definition.get("cfn_param_mapping", None)
+        if cfn_params:
+            cfn_value = get_cfn_param(cfn_params, cfn_converter) if cfn_converter else "NONE"
+            self.value = (
+                None
+                if get_cfn_param(cfn_params, "RemoveBucketOnDeletion") == "True"
+                else self.get_value_from_string(cfn_value)
+            )
+            # When the value of "RemoveBucketOnDeletion" is "True",
+            # the "cluster_resource_bucket" is not created by the user.
+
+        return self

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -20,6 +20,7 @@ from pcluster.config.cfn_param_types import (
     CfnSection,
     ClusterCfnSection,
     ClusterConfigMetadataCfnParam,
+    ClusterResourceBucketCfnParam,
     ComputeAvailabilityZoneCfnParam,
     DisableHyperThreadingCfnParam,
     EBSSettingsCfnParam,
@@ -996,9 +997,10 @@ CLUSTER_COMMON_PARAMS = [
         "visibility": Visibility.PRIVATE,
     }),
     ("cluster_resource_bucket", {
+        "type": ClusterResourceBucketCfnParam,
         "cfn_param_mapping": "ResourcesS3Bucket",
         "validators": [s3_bucket_validator],
-        "update_policy": UpdatePolicy.IGNORED,
+        "update_policy": UpdatePolicy.UNSUPPORTED,
     }),
 ]
 


### PR DESCRIPTION
Before this PR, when user does not specify bucket when create, but specifies bucket=[bucket we generate] when updating. In this case we will falsely detect that the bucket value has changed, when in reality it doesn’t.

After this PR,  we give user more visibility on what’s going on instead of just ignoring that parameter. When user provide the S3 bucket through "cluster_resource_bucket", the pcluster update will detect the bucket name, if user doesn't provide the bucket name, the pcluster update will not show the bucket name.

The following cases are tested:

-  Creation and update with same config: [cluster] not provide "cluster_resource_bucket"  --->The creation and update succeed.
- Creation and update with same config: [cluster] "cluster_resource_bucket"= "bucket1" --->The creation and update succeed.

- Creation with [cluster] not provide "cluster_resource_bucket", Update with [cluster] "cluster_resource_bucket"= "bucket1" ---> Creation succeed, update failed with:
```
#    parameter                old value    new value
---  -----------------------  -----------  ---------------
     [cluster default]
01*  cluster_resource_bucket  -            bucket1
```

- Creation with [cluster] "cluster_resource_bucket"= "bucket1" , Update with [cluster] "cluster_resource_bucket"= "bucket2"---> Creation succeed, update failed with:

```
#    parameter                old value       new value
---  -----------------------  --------------  ---------------
     [cluster default]
01*  cluster_resource_bucket  bucket1           bucket2
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
