### PR TITLE
integ-tests:test existing FSx

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -414,6 +414,12 @@ storage:
         # FSx is only supported on ARM instances for Ubuntu 18.04, Amazon Linux 2 and CentOS 8
         oss: ["alinux2", "ubuntu1804", "centos8"]
         schedulers: ["sge"]
+  test_fsx_lustre.py::test_existing_fsx:
+    dimensions:
+      - regions: ["us-west-2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["centos7"]
+        schedulers: ["slurm"]
   test_efs.py::test_efs_compute_az:
     dimensions:
       - regions: ["us-west-1"]

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_existing_fsx/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_existing_fsx/pcluster.config.ini
@@ -1,0 +1,28 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = {{ scheduler }}
+master_instance_type = {{ instance }}
+compute_instance_type = {{ instance }}
+initial_queue_size = 1
+maintain_initial_size = true
+fsx_settings = fsx
+s3_read_resource = arn:aws:s3:::{{ bucket_name }}/*
+
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false
+
+[fsx fsx]
+shared_dir = {{ mount_dir }}
+fsx_fs_id = {{fsx_fs_id}}

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_existing_fsx/s3_test_file
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_existing_fsx/s3_test_file
@@ -1,0 +1,1 @@
+Downloaded by FSx Lustre


### PR DESCRIPTION
* This test is to test using existing FSx file system in pcluster create
* If using an existing file system, it must be associated to a security group that allows inbound TCP traffic to port 988. Setting the source to 0.0.0.0/0 on a security group rule provides client access from all the IP ranges within your VPC security group for the protocol and port range for that rule. 
For more information: https://docs.aws.amazon.com/parallelcluster/latest/ug/fsx-section.html

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
