### PR TITLE
 Make update behavior of cluster_resource_bucket consistent

### DIFF
--- a/cli/pcluster/cli_commands/update.py
+++ b/cli/pcluster/cli_commands/update.py
@@ -249,6 +249,8 @@ def _restore_cfn_only_params(cfn_boto3_client, args, cfn_params, stack_name, tar
 
     # Autofill S3 bucket related cfn param
     params = utils.get_stack(stack_name, cfn_boto3_client).get("Parameters")
+    # Update of cluster_resource_bucket/ResourcesS3Bucket is not supported
+    # We will always restore the value of this parameter from CFN stack
     cfn_params["ResourcesS3Bucket"] = utils.get_cfn_param(params, "ResourcesS3Bucket")
     cfn_params["ArtifactS3RootDirectory"] = utils.get_cfn_param(params, "ArtifactS3RootDirectory")
     cfn_params["RemoveBucketOnDeletion"] = utils.get_cfn_param(params, "RemoveBucketOnDeletion")

--- a/cli/pcluster/config/config_patch.py
+++ b/cli/pcluster/config/config_patch.py
@@ -232,7 +232,10 @@ class ConfigPatch(object):
 
                 if check_result != UpdatePolicy.CheckResult.SUCCEEDED:
                     patch_allowed = False
-
+                if change.update_policy == UpdatePolicy.READ_ONLY_RESOURCE_BUCKET and patch_allowed:
+                    # Special case for cluster_resource_bucket/ResourcesS3Bucket
+                    # Do not append diff if patch is allowed
+                    continue
                 rows.append(
                     [
                         section_name,

--- a/cli/pcluster/config/config_patch.py
+++ b/cli/pcluster/config/config_patch.py
@@ -225,17 +225,12 @@ class ConfigPatch(object):
         patch_allowed = True
 
         for change in self.changes:
-            if change.update_policy != UpdatePolicy.IGNORED:
+            check_result, reason, action_needed, print_change = change.update_policy.check(change, self)
+            if print_change:
                 section_name = get_file_section_name(change.section_key, change.section_label)
-
-                check_result, reason, action_needed = change.update_policy.check(change, self)
 
                 if check_result != UpdatePolicy.CheckResult.SUCCEEDED:
                     patch_allowed = False
-                if change.update_policy == UpdatePolicy.READ_ONLY_RESOURCE_BUCKET and patch_allowed:
-                    # Special case for cluster_resource_bucket/ResourcesS3Bucket
-                    # Do not append diff if patch is allowed
-                    continue
                 rows.append(
                     [
                         section_name,

--- a/cli/pcluster/config/config_patch.py
+++ b/cli/pcluster/config/config_patch.py
@@ -226,11 +226,12 @@ class ConfigPatch(object):
 
         for change in self.changes:
             check_result, reason, action_needed, print_change = change.update_policy.check(change, self)
+
+            if check_result != UpdatePolicy.CheckResult.SUCCEEDED:
+                patch_allowed = False
+
             if print_change:
                 section_name = get_file_section_name(change.section_key, change.section_label)
-
-                if check_result != UpdatePolicy.CheckResult.SUCCEEDED:
-                    patch_allowed = False
                 rows.append(
                     [
                         section_name,

--- a/cli/pcluster/config/mappings.py
+++ b/cli/pcluster/config/mappings.py
@@ -999,7 +999,7 @@ CLUSTER_COMMON_PARAMS = [
     ("cluster_resource_bucket", {
         "cfn_param_mapping": "ResourcesS3Bucket",
         "validators": [s3_bucket_validator],
-        "update_policy": UpdatePolicy.IGNORED,
+        "update_policy": UpdatePolicy.READ_ONLY_RESOURCE_BUCKET,
     }),
 ]
 

--- a/cli/pcluster/config/update_policy.py
+++ b/cli/pcluster/config/update_policy.py
@@ -141,20 +141,12 @@ def _check_generated_bucket(change, patch):
 
     # If bucket is generated (no cluster_resource_bucket specified when creating) and no change in config
     # Old value is retrieve from CFN's ResourcesS3Bucket param, and new value is from config(not specified)
-    # Diff based on config should be:
-    #
-    # old value                         new value
-    # ---------------------------------------------
-    # {ResourcesS3Bucket}               -
-    #
     # Actual ResourcesS3Bucket will not change when updating, so no actual change when update is applied
     # Since there is no change, user should not be informed of a change/diff
     # Print no diff and proceed with updating other parameters
-    if _is_bucket_pcluster_generated(patch.stack_name) and (not change.new_value or change.new_value == "NONE"):
-        return True
     # Else display diff
     # Inform user cluster_resource_bucket/ResourcesS3Bucket will not be updated even if force update
-    return False
+    return _is_bucket_pcluster_generated(patch.stack_name) and not change.new_value
 
 
 # Base policies

--- a/cli/tests/pcluster/config/test_config_patch/test_patch_check_cluster_resource_bucket/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_config_patch/test_patch_check_cluster_resource_bucket/pcluster.config.ini
@@ -1,0 +1,13 @@
+[global]
+cluster_template = some_cluster
+update_check = true
+sanity_check = false
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster some_cluster]
+ec2_iam_role = {{ ec2_iam_role }}
+{% if cluster_resource_bucket %}
+cluster_resource_bucket = {{ cluster_resource_bucket }}
+{% endif %}


### PR DESCRIPTION
* Changes to `cluster_resource_bucket` when running update will never be applied. i.e. value of cfn param `ResourcesS3Bucket` will never change when updating. This behavior is checked by integration test
* If user does not specify `cluster_resource_bucket` both when create and update(using default pcluster behaviors), do not block update or print diff
* Otherwise, block update if `cluster_resource_bucket` is changed and print message to inform user value of `cluster_resource_bucket` will not be changed even if force update
* Add unit test to check the above behavior

Update behavior after this patch:
* No `cluster_resource_bucket` when create, no `cluster_resource_bucket` when update:
```
Retrieving configuration from CloudFormation for cluster test-no-bucket...
Validating configuration file ...
No changes found in your cluster configuration.
Do you want to proceed with the update? - Y/N: 
```
* No `cluster_resource_bucket` when create, specifies different `cluster_resource_bucket` when update:
```
Retrieving configuration from CloudFormation for cluster no-s3...
Validating configuration file ...
Found Configuration Changes:

#    parameter                old value                       new value
---  -----------------------  ------------------------------  -----------------
     [cluster no-s3]
01*  cluster_resource_bucket  parallelcluster-nwh0pdfdbbi...  new-bucket-name

Validating configuration update...
The requested update cannot be performed. Line numbers with an asterisk indicate updates requiring additional actions. Please review the details below:

#01
'cluster_resource_bucket' parameter is a read_only parameter that cannot be updated. New value 'new-bucket-name' will be ignored and old value 'parallelcluster-nwh0pdfdbbi1pavp' will be used if you force the update.
How to fix:
Restore the value of parameter 'cluster_resource_bucket' to 'parallelcluster-nwh0pdfdbbi1pavp'
```
* Specifies `cluster_resource_bucket` when create, different `cluster_resource_bucket` when update:
```
Retrieving configuration from CloudFormation for cluster s3...
Validating configuration file ...
Found Configuration Changes:

#    parameter                old value          new value
---  -----------------------  -----------------  -----------
     [cluster s3]
01*  cluster_resource_bucket  old-bucket-name  -

Validating configuration update...
The requested update cannot be performed. Line numbers with an asterisk indicate updates requiring additional actions. Please review the details below:

#01
'cluster_resource_bucket' parameter is a read_only parameter that cannot be updated. New value 'None' will be ignored and old value 'old-bucket-name' will be used if you force the update.
How to fix:
Restore the value of parameter 'cluster_resource_bucket' to 'old-bucket-name'
```

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
