### PR TITLE
Fail gracefully when checking invalid bucket name

### DIFF
--- a/cli/pcluster/config/validators.py
+++ b/cli/pcluster/config/validators.py
@@ -15,7 +15,7 @@ import urllib.request
 from urllib.parse import urlparse
 
 import boto3
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ParamValidationError
 
 from pcluster.constants import CIDR_ALL_IPS, FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT
 from pcluster.dcv.utils import get_supported_dcv_os
@@ -750,6 +750,10 @@ def s3_bucket_validator(param_key, param_value, pcluster_config):
             )
     except ClientError as client_error:
         _process_generic_s3_bucket_error(client_error, param_value, warnings, errors)
+    except ParamValidationError as validation_error:
+        errors.append(
+            "Error validating parameter '{0}'. Failed with exception: {1}".format(param_key, str(validation_error))
+        )
 
     return errors, warnings
 


### PR DESCRIPTION
Fix to avoid printing stacktrace  when an empty or invalid value is set for `cluster_resource_bucket` parameter.

NOTE: unit tests are still to be implemented for this validator; this will require a bit of mocking, better to be handled as a separate commit.

Manual tests performed:

pcluster create / update with following values:

`cluster_resource_bucket = `
`cluster_resource_bucket = abc#_1!`

Example of output before the patch:
```
Unexpected error of type ParamValidationError: Parameter validation failed:
Invalid bucket name "abc"!": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:s3:[a-z\-0-9]+:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$"
Traceback (most recent call last):
  File "/home/pcluster-dev/lib/python3.7/site-packages/pcluster/cli.py", line 467, in main
    args.func(args)
  File "/home/pcluster-dev/lib/python3.7/site-packages/pcluster/cli.py", line 38, in create
    pcluster.create(args)
  File "/home/pcluster-dev/lib/python3.7/site-packages/pcluster/commands.py", line 209, in create
    pcluster_config.validate()
  File "/home/pcluster-dev/lib/python3.7/site-packages/pcluster/config/pcluster_config.py", line 492, in validate
    section.validate()
  File "/home/pcluster-dev/lib/python3.7/site-packages/pcluster/config/param_types.py", line 537, in validate
    param.validate()
  File "/home/pcluster-dev/lib/python3.7/site-packages/pcluster/config/param_types.py", line 158, in validate
    errors, warnings = validation_func(self.key, self.value, self.pcluster_config)
  File "/home/pcluster-dev/lib/python3.7/site-packages/pcluster/config/validators.py", line 741, in s3_bucket_validator
    s3_client.head_bucket(Bucket=param_value)
  File "/home/pcluster-dev/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/pcluster-dev/lib/python3.7/site-packages/botocore/client.py", line 649, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/home/pcluster-dev/lib/python3.7/site-packages/botocore/client.py", line 695, in _convert_to_request_dict
    api_params, operation_model, context)
  File "/home/pcluster-dev/lib/python3.7/site-packages/botocore/client.py", line 727, in _emit_api_params
    params=api_params, model=operation_model, context=context)
  File "/home/pcluster-dev/lib/python3.7/site-packages/botocore/hooks.py", line 356, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
  File "/home/pcluster-dev/lib/python3.7/site-packages/botocore/hooks.py", line 228, in emit
    return self._emit(event_name, kwargs)
  File "/home/pcluster-dev/lib/python3.7/site-packages/botocore/hooks.py", line 211, in _emit
    response = handler(**kwargs)
  File "/home/pcluster-dev/lib/python3.7/site-packages/botocore/handlers.py", line 210, in validate_bucket_name
    raise ParamValidationError(report=error_msg)
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid bucket name "abc"!": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:s3:[a-z\-0-9]+:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$"
```

Example of output after the patch:
```
ERROR: The configuration parameter 'cluster_resource_bucket' generated the following errors:
Error validating parameter 'cluster_resource_bucket'. Failed with exception: Parameter validation failed:
Invalid bucket name "abc"!": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:s3:[a-z\-0-9]+:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$"

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
