### PR TITLE
Add new test runner parameter `--createami-custom-node-url`

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -39,7 +39,8 @@ python -m test_runner --help
 usage: test_runner.py [-h] --key-name KEY_NAME --key-path KEY_PATH [-n PARALLELISM] [--sequential] [--credential CREDENTIAL] [--retry-on-failures] [--tests-root-dir TESTS_ROOT_DIR] [-c TESTS_CONFIG]
                       [-i [INSTANCES [INSTANCES ...]]] [-o [OSS [OSS ...]]] [-s [SCHEDULERS [SCHEDULERS ...]]] [-r [REGIONS [REGIONS ...]]] [-f FEATURES [FEATURES ...]] [--show-output]
                       [--reports {html,junitxml,json,cw} [{html,junitxml,json,cw} ...]] [--cw-region CW_REGION] [--cw-namespace CW_NAMESPACE] [--cw-timestamp-day-start] [--output-dir OUTPUT_DIR]
-                      [--custom-node-url CUSTOM_NODE_URL] [--custom-cookbook-url CUSTOM_COOKBOOK_URL] [--createami-custom-cookbook-url CREATEAMI_CUSTOM_COOKBOOK_URL] [--custom-template-url CUSTOM_TEMPLATE_URL]
+                      [--custom-node-url CUSTOM_NODE_URL] [--custom-cookbook-url CUSTOM_COOKBOOK_URL] [--createami-custom-cookbook-url CREATEAMI_CUSTOM_COOKBOOK_URL] 
+                      [--createami-custom-node-url CREATEAMI_CUSTOM_NODE_URL] [--custom-template-url CUSTOM_TEMPLATE_URL]
                       [--custom-hit-template-url CUSTOM_HIT_TEMPLATE_URL] [--custom-awsbatchcli-url CUSTOM_AWSBATCHCLI_URL] [--custom-ami CUSTOM_AMI] [--pre-install PRE_INSTALL] [--post-install POST_INSTALL]
                       [--benchmarks] [--benchmarks-target-capacity BENCHMARKS_TARGET_CAPACITY] [--benchmarks-max-time BENCHMARKS_MAX_TIME] [--vpc-stack VPC_STACK] [--cluster CLUSTER] [--no-delete]
                       [--keep-logs-on-cluster-failure] [--keep-logs-on-test-failure] [--stackname-suffix STACKNAME_SUFFIX] [--dry-run]
@@ -98,6 +99,8 @@ Custom packages and templates:
                         URL to a custom cookbook package. (default: None)
   --createami-custom-cookbook-url CREATEAMI_CUSTOM_COOKBOOK_URL
                         URL to a custom cookbook package for the createami command. (default: None)
+  --createami-custom-node-url CREATEAMI_CUSTOM_NODE_URL
+                        URL to a custom node package for the createami command. (default: None)
   --custom-template-url CUSTOM_TEMPLATE_URL
                         URL to a custom cfn template. (default: None)
   --custom-hit-template-url CUSTOM_HIT_TEMPLATE_URL

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -70,6 +70,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--createami-custom-chef-cookbook", help="url to a custom cookbook package for the createami command"
     )
+    parser.addoption("--createami-custom-node-package", help="url to a custom node package for the createami command")
     parser.addoption("--custom-awsbatch-template-url", help="url to a custom awsbatch template")
     parser.addoption("--template-url", help="url to a custom cfn template")
     parser.addoption("--hit-template-url", help="url to a custom HIT cfn template")

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -53,6 +53,7 @@ TEST_DEFAULTS = {
     "custom_node_url": None,
     "custom_cookbook_url": None,
     "createami_custom_cookbook_url": None,
+    "createami_custom_node_url": None,
     "custom_template_url": None,
     "custom_awsbatchcli_url": None,
     "custom_hit_template_url": None,
@@ -210,6 +211,12 @@ def _init_argparser():
         "--createami-custom-cookbook-url",
         help="URL to a custom cookbook package for the createami command.",
         default=TEST_DEFAULTS.get("createami_custom_cookbook_url"),
+        type=_is_url,
+    )
+    custom_group.add_argument(
+        "--createami-custom-node-url",
+        help="URL to a custom node package for the createami command.",
+        default=TEST_DEFAULTS.get("createami_custom_node_url"),
         type=_is_url,
     )
     custom_group.add_argument(
@@ -425,6 +432,9 @@ def _set_custom_packages_args(args, pytest_args):  # noqa: C901
 
     if args.createami_custom_cookbook_url:
         pytest_args.extend(["--createami-custom-chef-cookbook", args.createami_custom_cookbook_url])
+
+    if args.createami_custom_node_url:
+        pytest_args.extend(["--createami-custom-node-package", args.createami_custom_node_url])
 
     if args.custom_template_url:
         pytest_args.extend(["--template-url", args.custom_template_url])


### PR DESCRIPTION
The new parameter allows to specify a custom node for the createami test.
This new parameter permits to specify a custom node URL, that is needed when version bump is done and node package is not yet present in PyPi.

Linked to https://github.com/aws/aws-parallelcluster-cookbook/pull/817

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
