### PR TITLE
Improve messages from delete command when cluster does not exist

### DIFF
--- a/cli/pcluster/cli_commands/delete.py
+++ b/cli/pcluster/cli_commands/delete.py
@@ -34,7 +34,7 @@ def delete(args):
                     args.cluster_name
                 )
             )
-        utils.warn("Cluster {0} has already been deleted.".format(args.cluster_name))
+        utils.warn("Cluster {0} has already been deleted or does not exist.".format(args.cluster_name))
         _terminate_cluster_nodes(stack_name)
         sys.exit(0)
     elif args.keep_logs:
@@ -130,9 +130,7 @@ def _delete_cluster(cluster_name, nowait):
 
 def _terminate_cluster_nodes(stack_name):
     try:
-        LOGGER.debug("Compute fleet clean-up: STARTED")
-        # FIXME: improve messaging when cluster does not exist
-        LOGGER.info("\nChecking if there are any running compute fleet nodes that require termination")
+        LOGGER.info("\nChecking if there are running compute nodes that require termination...")
         ec2 = boto3.client("ec2", config=Config(retries={"max_attempts": 10}))
 
         for instance_ids in _describe_instance_ids_iterator(stack_name):
@@ -140,7 +138,7 @@ def _terminate_cluster_nodes(stack_name):
             if instance_ids:
                 ec2.terminate_instances(InstanceIds=instance_ids)
 
-        LOGGER.debug("Compute fleet clean-up: COMPLETED")
+        LOGGER.info("Compute fleet cleaned up.")
     except Exception as e:
         LOGGER.error("Failed when checking for running EC2 instances with error: %s", e)
 

--- a/cli/tests/pcluster/cli_commands/test_pcluster_delete.py
+++ b/cli/tests/pcluster/cli_commands/test_pcluster_delete.py
@@ -59,7 +59,9 @@ def test_delete(
 
     assert_that(warn_mock.call_count).is_equal_to(warn_call_count)
     if warn_call_count > 0:
-        warn_mock.assert_called_with("Cluster {0} has already been deleted.".format(args.cluster_name))
+        warn_mock.assert_called_with(
+            "Cluster {0} has already been deleted or does not exist.".format(args.cluster_name)
+        )
 
     assert_that(persist_cloudwatch_log_groups_mock.called).is_equal_to(persist_called)
     if persist_called:


### PR DESCRIPTION
Before:
```
Deleting: test
WARNING: Cluster test has already been deleted.

Checking if there are any running compute fleet nodes that require termination
```

After:
```
Deleting: test
WARNING: Cluster test has already been deleted or does not exist.

Checking if there are running compute nodes that require termination...
Compute fleet cleaned up.
```

