### PR TITLE
Remove old CentOS6 references

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -229,7 +229,6 @@ cloudwatch_logging suite defined above will produce the following parametrizatio
 ```
 cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[ap-east-1-c5.xlarge-alinux-slurm]
 cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[ap-east-1-c5.xlarge-alinux2-slurm]
-cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[ap-east-1-c5.xlarge-centos6-slurm]
 cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[ap-east-1-c5.xlarge-centos7-slurm]
 cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[ap-east-1-c5.xlarge-ubuntu1604-slurm]
 cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[ap-east-1-c5.xlarge-ubuntu1804-slurm]

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -52,8 +52,8 @@ OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
 OS_TO_PCLUSTER_AMI_NAME_OWNER_MAP = {
     "alinux": {"name": "amzn-hvm-x86_64-*", "owners": ["amazon"]},
     "alinux2": {"name": "amzn2-hvm-*-*", "owners": ["amazon"]},
-    "centos6": {"name": "centos6-hvm-x86_64-*", "owners": ["amazon"]},
     "centos7": {"name": "centos7-hvm-x86_64-*", "owners": ["amazon"]},
+    "centos8": {"name": "centos8-hvm-x86_64-*", "owners": ["amazon"]},
     "ubuntu1604": {"name": "ubuntu-1604-lts-hvm-x86_64-*", "owners": ["amazon"]},
     "ubuntu1804": {"name": "ubuntu-1804-lts-hvm-*-*", "owners": ["amazon"]},
 }

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -54,8 +54,6 @@ MAX_MINUTES_TO_WAIT_FOR_BACKUP_COMPLETION = 7
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["slurm"])
 @pytest.mark.usefixtures("instance")
-# FSx is not supported on CentOS 6
-@pytest.mark.skip_oss(["centos6"])
 def test_fsx_lustre_configuration_options(
     deployment_type,
     per_unit_storage_throughput,

--- a/tests/integration-tests/tests/tags/test_tag_propagation.py
+++ b/tests/integration-tests/tests/tags/test_tag_propagation.py
@@ -190,8 +190,8 @@ def get_root_volume_id(instance_id, region, os):
     logging.info("Getting root volume for instance %s", instance_id)
     os_to_root_volume_device = {
         # These are taken from the main CFN template
-        "centos6": "/dev/sda1",
         "centos7": "/dev/sda1",
+        "centos8": "/dev/sda1",
         "alinux": "/dev/xvda",
         "alinux2": "/dev/xvda",
         "ubuntu1604": "/dev/sda1",


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
