### PR TITLE
awsbatch: set head node IP in the JobDefinition environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ CHANGELOG
 2.10.1
 ------
 
+**ENHANCEMENTS**
+
+- Remove CloudFormation DescribeStacks API call from AWS Batch Docker entrypoint. This removes the possibility of job
+  failures due to CloudFormation throttling.
+
 2.10.0
 ------
 

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2345,6 +2345,12 @@
           },
           "Architecture": {
             "Ref": "Architecture"
+          },
+          "MasterPrivateIP": {
+            "Fn::GetAtt": [
+              "MasterServerSubstack",
+              "Outputs.MasterPrivateIP"
+            ]
           }
         },
         "TemplateURL": {

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -95,6 +95,10 @@
         "x86_64",
         "arm64"
       ]
+    },
+    "MasterPrivateIP": {
+      "Description": "Private IP of the head node",
+      "Type": "String"
     }
   },
   "Conditions": {
@@ -525,6 +529,12 @@
               "Value": {
                 "Ref": "RAIDSharedDir"
               }
+            },
+            {
+              "Name": "PCLUSTER_MASTER_IP",
+              "Value": {
+                "Ref": "MasterPrivateIP"
+              }
             }
           ]
         }
@@ -588,6 +598,12 @@
                     "Name": "PCLUSTER_RAID_SHARED_DIR",
                     "Value": {
                       "Ref": "RAIDSharedDir"
+                    }
+                  },
+                  {
+                    "Name": "PCLUSTER_MASTER_IP",
+                    "Value": {
+                      "Ref": "MasterPrivateIP"
                     }
                   }
                 ]


### PR DESCRIPTION
This removes the need of calling CloudFormation API at every docker container launch, which was being throttled and causing job failures.
In order to do so a dependency on the head node substack has been introduced for the AWS Batch substack. This makes the cluster creation slower by around 40% when awsbatch is selected as the scheduler.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
