### PR TITLE
awsbatch: download AmazonLinux image from ECR rather than Docker Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ CHANGELOG
 - Remove CloudFormation DescribeStacks API call from AWS Batch Docker entrypoint. This removes the possibility of job
   failures due to CloudFormation throttling.
 
+**CHANGES**
+
+- Pull Amazon Linux Docker images from ECR when building docker image for `awsbatch` scheduler. This only applies to
+  images built for `x86` architecture.
+
+**BUG FIXES**
+
 2.10.0
 ------
 

--- a/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2
 
 ENV USER root
 

--- a/cli/src/pcluster/resources/batch/docker/buildspec.yml
+++ b/cli/src/pcluster/resources/batch/docker/buildspec.yml
@@ -1,13 +1,9 @@
 version: 0.2
 
 phases:
-  install:
-    runtime-versions:
-      docker: 18
   pre_build:
     commands:
-      - echo Logging in to Amazon ECR...
-      - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+      - sh ./pull-alinux-image.sh
   build:
     commands:
       - echo Build started on `date`

--- a/cli/src/pcluster/resources/batch/docker/pull-alinux-image.sh
+++ b/cli/src/pcluster/resources/batch/docker/pull-alinux-image.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+pull_docker_image_from_ecr() {
+    echo "Pulling amazonlinux:2 image from ECR"
+    aws ecr get-login-password --region "${ALINUX_ECR_REGISTRY_REGION}" | docker login --username AWS --password-stdin "${ALINUX_ECR_REGISTRY}" || return 1
+    docker pull "${ALINUX_ECR_REGISTRY}/amazonlinux:2" || return 1
+    docker tag "${ALINUX_ECR_REGISTRY}/amazonlinux:2" amazonlinux:2
+}
+
+if [ "${IMAGE}" = "alinux" ] || [ "${IMAGE}" = "alinux2" ]; then
+  if [ "${ARCHITECTURE}" = "x86_64" ]; then
+    if pull_docker_image_from_ecr; then
+      echo "Successfully pulled Amazon Linux image from ECR"
+    else
+      echo "Failed when pulling amazonlinux:2 image from ECR. Falling back to Docker Hub"
+      docker pull amazonlinux:2
+    fi
+  else
+    docker pull amazonlinux:2
+  fi
+fi

--- a/cli/src/pcluster/resources/batch/docker/upload-docker-images.sh
+++ b/cli/src/pcluster/resources/batch/docker/upload-docker-images.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
-set -eu
+set -euxo pipefail
+
+DOMAIN_SUFFIX=""
+if [[ ${AWS_REGION} == cn-* ]]; then
+    DOMAIN_SUFFIX=".cn"
+fi
 
 push_docker_image() {
     local image=$1
     echo "Uploading image ${image}"
-    S3_SUFFIX=""
-    if [[ ${AWS_REGION} == cn-* ]]; then
-        S3_SUFFIX=".cn"
-    fi
-    docker tag "${IMAGE_REPO_NAME}:${image}" "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com${S3_SUFFIX}/${IMAGE_REPO_NAME}:${image}"
-    docker push "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com${S3_SUFFIX}/${IMAGE_REPO_NAME}:${image}"
+    docker tag "${IMAGE_REPO_NAME}:${image}" "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com${DOMAIN_SUFFIX}/${IMAGE_REPO_NAME}:${image}"
+    docker push "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com${DOMAIN_SUFFIX}/${IMAGE_REPO_NAME}:${image}"
 }
+
+aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com${DOMAIN_SUFFIX}"
 
 if [ -z "${IMAGE}" ]; then
     for file in $(find `pwd` -type f -name Dockerfile); do

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -1,4 +1,23 @@
 {
+  "Mappings": {
+    "AmazonLinuxECR": {
+      "aws": {
+        "registry": "137112412989.dkr.ecr.us-east-1.amazonaws.com",
+        "region": "us-east-1",
+        "account": "137112412989"
+      },
+      "aws-us-gov": {
+        "registry": "045324592363.dkr.ecr.us-gov-east-1.amazonaws.com",
+        "region": "us-gov-east-1",
+        "account": "045324592363"
+      },
+      "aws-cn": {
+        "registry": "141808717104.dkr.ecr.cn-north-1.amazonaws.com.cn",
+        "region": "cn-north-1",
+        "account": "141808717104"
+      }
+    }
+  },
   "Parameters": {
     "MinvCpus": {
       "Description": "Min vCPU's for ComputeEnvironment",
@@ -656,9 +675,39 @@
               }
             },
             {
+              "Name": "ARCHITECTURE",
+              "Value": {
+                "Ref": "Architecture"
+              }
+            },
+            {
               "Name": "NOTIFICATION_URL",
               "Value": {
                 "Ref": "DockerBuildWaitHandle"
+              }
+            },
+            {
+              "Name": "ALINUX_ECR_REGISTRY",
+              "Value": {
+                "Fn::FindInMap": [
+                  "AmazonLinuxECR",
+                  {
+                    "Ref": "AWS::Partition"
+                  },
+                  "registry"
+                ]
+              }
+            },
+            {
+              "Name": "ALINUX_ECR_REGISTRY_REGION",
+              "Value": {
+                "Fn::FindInMap": [
+                  "AmazonLinuxECR",
+                  {
+                    "Ref": "AWS::Partition"
+                  },
+                  "region"
+                ]
               }
             }
           ],
@@ -754,6 +803,39 @@
                 "Fn::Sub": "arn:${AWS::Partition}:s3:::${ResourcesS3Bucket}/${ArtifactS3RootDirectory}/*"
               },
               "Sid": "S3GetObjectPolicy"
+            },
+            {
+              "Action": [
+                "ecr:BatchGetImage",
+                "ecr:GetDownloadUrlForLayer"
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Sub": [
+                  "arn:${AWS::Partition}:ecr:${alinux_ecr_region}:${alinux_ecr_registry_account}:repository/amazonlinux",
+                  {
+                    "alinux_ecr_region": {
+                      "Fn::FindInMap": [
+                        "AmazonLinuxECR",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        "region"
+                      ]
+                    },
+                    "alinux_ecr_registry_account": {
+                      "Fn::FindInMap": [
+                        "AmazonLinuxECR",
+                        {
+                          "Ref": "AWS::Partition"
+                        },
+                        "account"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "Sid": "AlinuxECRRepoPolicy"
             }
           ],
           "Version": "2012-10-17"

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -35,6 +35,7 @@ class Cluster:
         self.__cfn_resources = None
         self.__head_node_substack_cfn_resources = None
         self.__ebs_substack_cfn_resources = None
+        self.__awsbatch_substack_cfn_resources = None
 
     def __repr__(self):
         attrs = ", ".join(["{key}={value}".format(key=key, value=repr(value)) for key, value in self.__dict__.items()])
@@ -227,6 +228,18 @@ class Cluster:
                 self.cfn_resources.get("EBSCfnStack"), self.region
             )
         return self.__ebs_substack_cfn_resources
+
+    @property
+    def awsbatch_substack_cfn_resources(self):
+        """
+        Return the CloudFormation stack resources for the cluster's EBS substack.
+        Resources are retrieved only once and then cached.
+        """
+        if not self.__awsbatch_substack_cfn_resources:
+            self.__awsbatch_substack_cfn_resources = retrieve_cfn_resources(
+                self.cfn_resources.get("AWSBatchStack"), self.region
+            )
+        return self.__awsbatch_substack_cfn_resources
 
     def _reset_cached_properties(self):
         """Discard cached data."""


### PR DESCRIPTION
### Description of changes

* The change from `amazonlinux:latest` to `amazonlinux:2` is done to make sure we alway pull the latest for AL 2
* `docker: 18` removed from install/runtime-versions in CodeBuild buildspec because it is already available in the used container image and not needed anymore
* AL docker image is now pulled from ECR when the architecture is x86. ECR repos do not contain yet multi-arch images that support ARM. 
* Each partition is mapped to a single ECR repo hosted in a specific region. Currently there is no API to retrieve the registry id for AL images in the various regions, hence we keep this static mapping in the template for now.
* A new policy has been added to the CodeBuild role to allow access to the public ECR repo. This needs to be added to our docs.
* A fallback mechanism is put in place so that if the pull from ECR fails there is always a fallback to Docker Hub
* Integration tests have been extended to verify that the image is correctly pulled from ECR whenever possible

### Testing

I ran the following tests:
```
{%- import 'common.jinja2' as common -%}
test-suites:
  schedulers:
    test_awsbatch.py::test_awsbatch:
      dimensions:
        - regions: ["us-east-2"]
          instances: ["m6g.xlarge"]
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
        - regions: {{ common.REGIONS_COMMERCIAL }}
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
        - regions: {{ common.REGIONS_CHINA }}
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
        - regions: {{ common.REGIONS_GOVCLOUD }}
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
