### PR TITLE
Fix torque test when checking for scheduler configuration

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_torque.py
+++ b/tests/integration-tests/tests/schedulers/test_torque.py
@@ -192,7 +192,9 @@ def _test_dynamic_cluster_limits(remote_command_executor, max_queue_size, max_sl
 
     # Make sure cluster is scaled to 0 when this test starts
     assert_that(torque_commands.compute_nodes_count()).is_equal_to(0)
-
+    # sleeping for 1 second to give time to sqswatcher to reconfigure the master with np = max_nodes * node_slots
+    # operation that is performed right after sqswatcher removes the compute nodes from the scheduler
+    time.sleep(1)
     _assert_scheduler_configuration(remote_command_executor, torque_commands, max_slots, max_queue_size)
 
     # Submit a job to scale up to 1 node


### PR DESCRIPTION
Add 1 second sleep to give time to sqswatcher to reconfigure the master with np = max_nodes * node_slots
This operation is performed right after sqswatcher removes the compute nodes from the scheduler

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
