### PR TITLE
Continue polling FSx backup when state is PENDING

### DIFF
--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -24,7 +24,7 @@ from time_utils import minutes, seconds
 
 from tests.common.schedulers_common import get_scheduler_commands
 
-BACKUP_NOT_YET_AVAILABLE_STATES = {"CREATING", "TRANSFERRING"}
+BACKUP_NOT_YET_AVAILABLE_STATES = {"CREATING", "TRANSFERRING", "PENDING"}
 # Maximum number of minutes to wait past when an file system's automatic backup is scheduled to start creating.
 # If after this many minutes past the scheduled time backup creation has not started, the test will fail.
 MAX_MINUTES_TO_WAIT_FOR_AUTOMATIC_BACKUP_START = 5


### PR DESCRIPTION
Previously we were only continuing to poll when the state was one of
CREATING or TRANSFERRING. According to the boto3 docs, we should also
handle the PENDING state as well.

Signed-off-by: Tim Lane <tilne@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
