### PR TITLE
Remove duplicated test

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -203,11 +203,6 @@ efa:
         # Torque is not supported by OpenMPI distributed with EFA
         # Slurm test is to verify EFA works correctly when using the SIT model in the config file
         schedulers: ["sge", "slurm"]
-        # P4d instances are currently not supported in SIT clusters
-      - regions: ["us-east-1"]
-        instances: ["p4d.24xlarge"]
-        oss: ["alinux", "ubuntu1804", "centos7"]
-        schedulers: ["slurm"]
 iam_policies:
   test_iam_policies.py::test_iam_policies:
     dimensions:


### PR DESCRIPTION
The test using p4d.24xlarge with slurm scheduler is already performed by the test_hit_efa test

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
