### PR TITLE
Remove duplicated test and enable p4d.xlarge test with sge

### DIFF
--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -1033,17 +1033,6 @@ def compute_instance_type_validator(param_key, param_value, pcluster_config):
     else:
         errors, warnings = ec2_instance_type_validator(param_key, param_value, pcluster_config)
 
-        if scheduler != "slurm":
-            # Multiple NICs instance types are currently supported only with Slurm clusters
-            instance_nics = InstanceTypeInfo.init_from_instance_type(param_value).max_network_interface_count()
-            if instance_nics > 1:
-                warnings.append(
-                    "Some services needed to support clusters with instance type '{0}' with multiple "
-                    "network interfaces and job scheduler '{1}' may not yet be generally available. "
-                    "Please refer to https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-launch-template.html "
-                    "for more information.".format(param_value, scheduler)
-                )
-
     return errors, warnings
 
 

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -203,11 +203,10 @@ efa:
         # Torque is not supported by OpenMPI distributed with EFA
         # Slurm test is to verify EFA works correctly when using the SIT model in the config file
         schedulers: ["sge", "slurm"]
-        # P4d instances are currently not supported in SIT clusters
-      - regions: ["us-east-1"]
+      - regions: ["us-west-2"]
         instances: ["p4d.24xlarge"]
         oss: ["alinux", "ubuntu1804", "centos7"]
-        schedulers: ["slurm"]
+        schedulers: ["sge"]
 iam_policies:
   test_iam_policies.py::test_iam_policies:
     dimensions:


### PR DESCRIPTION
The test using p4d.24xlarge with slurm scheduler is already performed by the test_hit_efa test
Change test_sit_efa to use sge and move it to us-west-2
Remove warning when using p4d.24xlarge with scheduler != slurm 

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
