### PR TITLE
Use inclusive language for user facing messages and internal naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
 
 - Pull Amazon Linux Docker images from ECR when building docker image for `awsbatch` scheduler. This only applies to
   images built for `x86` architecture.
+- Use inclusive language in user facing messages and internal naming convention.
 
 **BUG FIXES**
 
@@ -24,7 +25,7 @@ CHANGELOG
 
 - Add support for CentOS 8 in all Commercial regions.
 - Add support for P4d instance type as compute node.
-- Add the possibilty to enable NVIDIA GPUDirect RDMA support on EFA by using the new `enable_efa_gdr` configuration
+- Add the possibility to enable NVIDIA GPUDirect RDMA support on EFA by using the new `enable_efa_gdr` configuration
   parameter.
 - Enable support for NICE DCV in GovCloud regions.
 - Enable support for AWS Batch scheduler in GovCloud regions.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ In the latter case, just select the configuration you prefer.
 ```
 Automate Subnet creation? (y/n) [y]: y
 Allowed values for Network Configuration:
-1. Master in a public subnet and compute fleet in a private subnet
-2. Master and compute fleet in the same public subnet
+1. Head node in a public subnet and compute fleet in a private subnet
+2. Head node and compute fleet in the same public subnet
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Automate VPC creation? (y/n) [n]:
 
 Enter ``n`` if you already have a VPC suitable for the cluster. Otherwise you can let ``pcluster configure``
 create a VPC for you. The same choice is given for the subnet: you can select a valid subnet ID for
-both the master and compute nodes, or you can let ``pcluster configure`` set up everything for you.
+both the head node and compute nodes, or you can let ``pcluster configure`` set up everything for you.
 The same choice is given for the subnet configuration: you can select a valid subnet ID for both
-the master and compute nodes, or you can let pcluster configure set up everything for you.
+the head node and compute nodes, or you can let pcluster configure set up everything for you.
 In the latter case, just select the configuration you prefer.
 
 ```

--- a/cli/README
+++ b/cli/README
@@ -17,11 +17,11 @@ You can build higher level workflows, such as a Genomics portal that automates t
         update              Updates a running cluster.
         delete              Deletes a cluster.
         start               Starts the compute fleet that has been stopped.
-        stop                Stops the compute fleet, but leave the master server running for debugging/development.
+        stop                Stops the compute fleet, but leave the head node running for debugging/development.
         status              Pulls the current status of the cluster.
         list                Displays a list of stacks associated with AWS ParallelCluster.
         instances           Displays a list of all instances in a cluster.
-        ssh                 Connects to the master server using SSH.
+        ssh                 Connects to the head node using SSH.
         configure           Starts the AWS ParallelCluster configuration.
         version             Displays version of AWS ParallelCluster.
         createami           (Linux/macOS) Creates a custom AMI to use with AWS ParallelCluster.

--- a/cli/src/awsbatch/awsbsub.py
+++ b/cli/src/awsbatch/awsbsub.py
@@ -566,7 +566,7 @@ def main():
             retry_attempts=args.retry_attempts,
             timeout=args.timeout,
             env=[
-                ("MASTER_IP", config.master_ip),  # TODO remove
+                ("MASTER_IP", config.head_node_ip),  # TODO remove
                 ("PCLUSTER_JOB_S3_URL", "s3://{0}/{1}".format(config.s3_bucket, job_s3_folder)),
             ],
         )

--- a/cli/src/awsbatch/common.py
+++ b/cli/src/awsbatch/common.py
@@ -178,7 +178,7 @@ class AWSBatchCliConfig(object):
             log.debug("compute_environment = %s", self.compute_environment)
             log.debug("job_queue = %s", self.job_queue)
             log.debug("job_definition = %s", self.job_definition)
-            log.debug("master_ip = %s", self.master_ip)
+            log.debug("master_ip = %s", self.head_node_ip)
             log.info(self)
         except AttributeError as e:
             fail(
@@ -261,7 +261,7 @@ class AWSBatchCliConfig(object):
                     self.job_definition_mnp = config.get(cluster_section, "job_definition_mnp")
                 except NoOptionError:
                     pass
-                self.master_ip = config.get(cluster_section, "master_ip")
+                self.head_node_ip = config.get(cluster_section, "master_ip")
 
                 # get proxy
                 self.proxy = config.get(cluster_section, "proxy")
@@ -316,7 +316,7 @@ class AWSBatchCliConfig(object):
                     elif output_key == "BatchJobDefinitionArn":
                         self.job_definition = output_value
                     elif output_key == "MasterPrivateIP":
-                        self.master_ip = output_value
+                        self.head_node_ip = output_value
                     elif output_key == "BatchJobDefinitionMnpArn":
                         self.job_definition_mnp = output_value
 

--- a/cli/src/awsbatch/examples/awsbatch-cli.cfg
+++ b/cli/src/awsbatch/examples/awsbatch-cli.cfg
@@ -37,7 +37,7 @@ job_definition = arn:aws:batch:<region>:<account-id>:job-definition/parallelclus
 job_definition_mnp = arn:aws:batch:<region>:<account-id>:job-definition/parallelcluster-<cluster-name>-mnp:1
 # HTTP(S) proxy server, typically http://x.x.x.x:8080, used for internal boto3 calls
 proxy = NONE
-# Private Master IP, used internally in the job submission phase.
+# Private head node IP, used internally in the job submission phase.
 master_ip = x.x.x.x
 # Environment blacklist variables
 # Comma separated list of environment variable names to not export when submitting a job with "--env all" parameter

--- a/cli/src/pcluster/cli.py
+++ b/cli/src/pcluster/cli.py
@@ -272,9 +272,9 @@ Examples::
     # stop command subparser
     pstop = subparsers.add_parser(
         "stop",
-        help="Stops the compute fleet, leaving the master server running.",
+        help="Stops the compute fleet, leaving the head node running.",
         epilog="This command sets the Auto Scaling Group parameters to min/max/desired = 0/0/0 and "
-        "terminates the compute fleet. The master will remain running. To terminate "
+        "terminates the compute fleet. The head node will remain running. To terminate "
         "all EC2 resources and avoid EC2 charges, consider deleting the cluster.",
     )
     pstop.add_argument("cluster_name", help="Stops the compute fleet of the cluster name provided here.")
@@ -331,7 +331,7 @@ Variables substituted::
     )
     pssh = subparsers.add_parser(
         "ssh",
-        help="Connects to the master instance using SSH.",
+        help="Connects to the head node instance using SSH.",
         description="Run ssh command with the cluster username and IP address pre-populated. "
         "Arbitrary arguments are appended to the end of the ssh command. "
         "This command can be customized in the aliases "
@@ -429,7 +429,7 @@ Variables substituted::
     dcv_subparsers.required = True
     dcv_subparsers.dest = "subcommand"
     pdcv_connect = dcv_subparsers.add_parser(
-        "connect", help="Permits to connect to the master node through an interactive session by using NICE DCV."
+        "connect", help="Permits to connect to the head node through an interactive session by using NICE DCV."
     )
     _addarg_region(pdcv_connect)
     pdcv_connect.add_argument("cluster_name", help="Name of the cluster to connect to")

--- a/cli/src/pcluster/cluster_model.py
+++ b/cli/src/pcluster/cluster_model.py
@@ -133,11 +133,11 @@ class ClusterModel(ABC):
     def public_ips_in_compute_subnet(self, pcluster_config, network_interfaces_count):
         """Tell if public IPs will be used in compute subnet."""
         vpc_section = pcluster_config.get_section("vpc")
-        master_subnet_id = vpc_section.get_param_value("master_subnet_id")
+        head_node_subnet_id = vpc_section.get_param_value("master_subnet_id")
         compute_subnet_id = vpc_section.get_param_value("compute_subnet_id")
         use_public_ips = vpc_section.get_param_value("use_public_ips") and (
-            # For single NIC instances we check only if subnet is the same of master node
-            (not compute_subnet_id or compute_subnet_id == master_subnet_id)
+            # For single NIC instances we check only if subnet is the same of head node
+            (not compute_subnet_id or compute_subnet_id == head_node_subnet_id)
             # For multiple NICs instances we check also if subnet is different
             # to warn users about the current lack of support for public IPs
             or (network_interfaces_count > 1)

--- a/cli/src/pcluster/commands.py
+++ b/cli/src/pcluster/commands.py
@@ -429,7 +429,7 @@ def _poll_head_node_state(stack_name):
     try:
         instances = utils.describe_cluster_instances(stack_name, node_type=utils.NodeType.head_node)
         if not instances:
-            LOGGER.error("Cannot retrieve master node status. Exiting...")
+            LOGGER.error("Cannot retrieve head node status. Exiting...")
             sys.exit(1)
         head_node_id = instances[0].get("InstanceId")
         state = instances[0].get("State").get("Name")

--- a/cli/src/pcluster/commands.py
+++ b/cli/src/pcluster/commands.py
@@ -424,33 +424,33 @@ def list_stacks(args):
         sys.exit(0)
 
 
-def _poll_master_server_state(stack_name):
+def _poll_head_node_state(stack_name):
     ec2 = boto3.client("ec2")
     try:
-        instances = utils.describe_cluster_instances(stack_name, node_type=utils.NodeType.master)
+        instances = utils.describe_cluster_instances(stack_name, node_type=utils.NodeType.head_node)
         if not instances:
             LOGGER.error("Cannot retrieve master node status. Exiting...")
             sys.exit(1)
-        master_id = instances[0].get("InstanceId")
+        head_node_id = instances[0].get("InstanceId")
         state = instances[0].get("State").get("Name")
         sys.stdout.write("\rMasterServer: %s" % state.upper())
         sys.stdout.flush()
         while state not in ["running", "stopped", "terminated", "shutting-down"]:
             time.sleep(5)
             state = (
-                ec2.describe_instance_status(InstanceIds=[master_id])
+                ec2.describe_instance_status(InstanceIds=[head_node_id])
                 .get("InstanceStatuses")[0]
                 .get("InstanceState")
                 .get("Name")
             )
-            master_status = "\r\033[KMasterServer: %s" % state.upper()
-            sys.stdout.write(master_status)
+            head_node_status = "\r\033[KMasterServer: %s" % state.upper()
+            sys.stdout.write(head_node_status)
             sys.stdout.flush()
         if state in ["terminated", "shutting-down"]:
             LOGGER.info("State: %s is irrecoverable. Cluster needs to be re-created.", state)
             sys.exit(1)
-        master_status = "\rMasterServer: %s\n" % state.upper()
-        sys.stdout.write(master_status)
+        head_node_status = "\rMasterServer: %s\n" % state.upper()
+        sys.stdout.write(head_node_status)
         sys.stdout.flush()
     except ClientError as e:
         LOGGER.critical(e.response.get("Error").get("Message"))
@@ -475,9 +475,9 @@ def instances(args):
     scheduler = utils.get_cfn_param(cfn_stack.get("Parameters"), "Scheduler")
 
     instances = []
-    master_server = utils.describe_cluster_instances(stack_name, node_type=utils.NodeType.master)
-    if master_server:
-        instances.append(("MasterServer", master_server[0].get("InstanceId")))
+    head_node_server = utils.describe_cluster_instances(stack_name, node_type=utils.NodeType.head_node)
+    if head_node_server:
+        instances.append(("MasterServer", head_node_server[0].get("InstanceId")))
 
     if scheduler != "awsbatch":
         instances.extend(_get_compute_instances(stack_name))
@@ -491,7 +491,7 @@ def instances(args):
 
 def ssh(args, extra_args):  # noqa: C901 FIXME!!!
     """
-    Execute an SSH command to the master instance, according to the [aliases] section if there.
+    Execute an SSH command to the head node instance, according to the [aliases] section if there.
 
     :param args: pcluster CLI args
     :param extra_args: pcluster CLI extra_args
@@ -504,7 +504,7 @@ def ssh(args, extra_args):  # noqa: C901 FIXME!!!
         ssh_command = "ssh {CFN_USER}@{MASTER_IP} {ARGS}"
 
     try:
-        master_ip, username = utils.get_master_ip_and_username(args.cluster_name)
+        head_node_ip, username = utils.get_head_node_ip_and_username(args.cluster_name)
         try:
             from shlex import quote as cmd_quote
         except ImportError:
@@ -512,7 +512,7 @@ def ssh(args, extra_args):  # noqa: C901 FIXME!!!
 
         # build command
         cmd = ssh_command.format(
-            CFN_USER=username, MASTER_IP=master_ip, ARGS=" ".join(cmd_quote(str(arg)) for arg in extra_args)
+            CFN_USER=username, MASTER_IP=head_node_ip, ARGS=" ".join(cmd_quote(str(arg)) for arg in extra_args)
         )
 
         # run command
@@ -558,7 +558,7 @@ def status(args):  # noqa: C901 FIXME!!!
             sys.stdout.write("\rStatus: %s\n" % stack.get("StackStatus"))
             sys.stdout.flush()
             if stack.get("StackStatus") in ["CREATE_COMPLETE", "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE"]:
-                state = _poll_master_server_state(stack_name)
+                state = _poll_head_node_state(stack_name)
                 if state == "running":
                     _print_stack_outputs(stack)
                 _print_compute_fleet_status(args.cluster_name, stack)

--- a/cli/src/pcluster/config/cfn_param_types.py
+++ b/cli/src/pcluster/config/cfn_param_types.py
@@ -590,7 +590,7 @@ class HeadNodeAvailabilityZoneCfnParam(AvailabilityZoneCfnParam):
     """
 
     def from_file(self, config_parser):
-        """Initialize the Availability zone of the cluster by checking the Master Subnet."""
+        """Initialize the Availability zone of the cluster by checking the head node Subnet."""
         self._init_az(config_parser, "master_subnet_id")
 
         return self
@@ -667,7 +667,7 @@ class DisableHyperThreadingCfnParam(BoolCfnParam):
         """
         Define the Cores CFN parameter if disable_hyperthreading = true.
 
-        :return: string (cores_master,cores_compute,master_supports_cpu_options,compute_supports_cpu_options)
+        :return: string (head_node_cores,compute_cores,head_node_supports_cpu_options,compute_supports_cpu_options)
         """
         cfn_params = {self.definition.get("cfn_param_mapping"): "NONE,NONE,NONE,NONE"}
         cluster_config = self.pcluster_config.get_section(self.section_key)
@@ -798,7 +798,7 @@ class BaseOSCfnParam(CfnParam):
 
     @staticmethod
     def get_instance_type_architecture(instance_type):
-        """Compute cluster's 'Architecture' CFN parameter based on its master server instance type."""
+        """Compute cluster's 'Architecture' CFN parameter based on its head node instance type."""
         if not instance_type:
             error("Cannot infer architecture without master instance type")
         head_node_supported_architectures = get_supported_architectures_for_instance_type(instance_type)
@@ -808,7 +808,7 @@ class BaseOSCfnParam(CfnParam):
         # If the instance type supports multiple architectures, choose the first one.
         # TODO: this is currently not an issue because none of the instance types we support more than one of the
         #       architectures we support. If this were ever to change (e.g., we start supporting i386) then we would
-        #       probably need to choose based on the subset of the architecutres supported by both the master and
+        #       probably need to choose based on the subset of the architecutres supported by both the head node and
         #       compute instance types.
         return head_node_supported_architectures[0]
 
@@ -1077,11 +1077,11 @@ class NetworkInterfacesCountCfnParam(CommaSeparatedCfnParam):
     Class to manage NetworkInterfacesCount Cfn param.
 
     The internal value is a list of two items, which respectively indicate the number of network interfaces to activate
-    on master and compute nodes.
+    on head node and compute nodes.
     """
 
     def refresh(self):
-        """Compute the number of network interfaces for master and compute nodes."""
+        """Compute the number of network interfaces for head node and compute nodes."""
         cluster_section = self.pcluster_config.get_section("cluster")
         scheduler = cluster_section.get_param_value("scheduler")
         self.value = [
@@ -1235,7 +1235,7 @@ class EFSCfnSection(CfnSection):
             compute_mt_valid = bool(compute_mount_target_id)
 
         cfn_items.append("Valid" if head_node_mt_valid else "NONE")
-        # Do not create additional compute mount target if compute and master subnet in the same AZ
+        # Do not create additional compute mount target if compute and head node subnet in the same AZ
         cfn_items.append("Valid" if compute_mt_valid or (head_node_avail_zone == compute_avail_zone) else "NONE")
         cfn_params[cfn_converter] = ",".join(cfn_items)
 

--- a/cli/src/pcluster/config/cfn_param_types.py
+++ b/cli/src/pcluster/config/cfn_param_types.py
@@ -581,7 +581,7 @@ class AvailabilityZoneCfnParam(CfnParam):
         pass
 
 
-class MasterAvailabilityZoneCfnParam(AvailabilityZoneCfnParam):
+class HeadNodeAvailabilityZoneCfnParam(AvailabilityZoneCfnParam):
     """
     Class to manage master_availability_zone internal attribute.
 
@@ -596,9 +596,9 @@ class MasterAvailabilityZoneCfnParam(AvailabilityZoneCfnParam):
         return self
 
     def from_cfn_params(self, cfn_params):
-        """Initialize the Availability zone by checking the Compute Subnet from cfn."""
-        master_subnet_id = get_cfn_param(cfn_params, "MasterSubnetId")
-        self.value = get_availability_zone_of_subnet(master_subnet_id)
+        """Initialize the Availability zone by checking the head node subnet from cfn."""
+        head_node_subnet_id = get_cfn_param(cfn_params, "MasterSubnetId")
+        self.value = get_availability_zone_of_subnet(head_node_subnet_id)
         return self
 
 
@@ -672,9 +672,9 @@ class DisableHyperThreadingCfnParam(BoolCfnParam):
         cfn_params = {self.definition.get("cfn_param_mapping"): "NONE,NONE,NONE,NONE"}
         cluster_config = self.pcluster_config.get_section(self.section_key)
         if self.value:
-            master_instance_type = cluster_config.get_param_value("master_instance_type")
-            master_cores, disable_master_ht_via_cpu_options = self._get_cfn_params_for_instance_type(
-                master_instance_type
+            head_node_instance_type = cluster_config.get_param_value("master_instance_type")
+            head_node_cores, disable_head_node_ht_via_cpu_options = self._get_cfn_params_for_instance_type(
+                head_node_instance_type
             )
 
             if (
@@ -692,7 +692,7 @@ class DisableHyperThreadingCfnParam(BoolCfnParam):
                 disable_compute_ht_via_cpu_options = False
 
             for node_label, cores, instance_type in [
-                ("master", master_cores, master_instance_type),
+                ("master", head_node_cores, head_node_instance_type),
                 ("compute", compute_cores, compute_instance_type),
             ]:
                 if isinstance(cores, int) and cores < 0:
@@ -703,9 +703,9 @@ class DisableHyperThreadingCfnParam(BoolCfnParam):
             cfn_params.update(
                 {
                     self.definition.get("cfn_param_mapping"): "{0},{1},{2},{3}".format(
-                        master_cores,
+                        head_node_cores,
                         compute_cores,
-                        str(disable_master_ht_via_cpu_options).lower(),
+                        str(disable_head_node_ht_via_cpu_options).lower(),
                         str(disable_compute_ht_via_cpu_options).lower(),
                     )
                 }
@@ -801,22 +801,22 @@ class BaseOSCfnParam(CfnParam):
         """Compute cluster's 'Architecture' CFN parameter based on its master server instance type."""
         if not instance_type:
             error("Cannot infer architecture without master instance type")
-        master_inst_supported_architectures = get_supported_architectures_for_instance_type(instance_type)
+        head_node_supported_architectures = get_supported_architectures_for_instance_type(instance_type)
 
-        if not master_inst_supported_architectures:
+        if not head_node_supported_architectures:
             error("Unable to get architectures supported by instance type {0}.".format(instance_type))
         # If the instance type supports multiple architectures, choose the first one.
         # TODO: this is currently not an issue because none of the instance types we support more than one of the
         #       architectures we support. If this were ever to change (e.g., we start supporting i386) then we would
         #       probably need to choose based on the subset of the architecutres supported by both the master and
         #       compute instance types.
-        return master_inst_supported_architectures[0]
+        return head_node_supported_architectures[0]
 
     def refresh(self):
         """Initialize the private architecture param."""
         if self.value:
-            master_inst_type = self.owner_section.get_param_value("master_instance_type")
-            architecture = self.get_instance_type_architecture(master_inst_type)
+            head_node_instance_type = self.owner_section.get_param_value("master_instance_type")
+            architecture = self.get_instance_type_architecture(head_node_instance_type)
             self.owner_section.get_param("architecture").value = architecture
 
 
@@ -1215,28 +1215,28 @@ class EFSCfnSection(CfnSection):
                 cfn_items.append(param.get_cfn_value())
 
         if cfn_items[0] == "NONE":
-            master_mt_valid = False
+            head_node_mt_valid = False
             compute_mt_valid = False
-            master_avail_zone = "fake_az1"
+            head_node_avail_zone = "fake_az1"
             compute_avail_zone = "fake_az2"
             # empty dict or first item is NONE --> set all values to NONE
             cfn_items = ["NONE"] * len(self.definition.get("params"))
         else:
             # add another CFN param that will identify if create or not a Mount Target for the given EFS FS Id
-            master_avail_zone = self.pcluster_config.get_master_availability_zone()
-            master_mount_target_id = get_efs_mount_target_id(
-                efs_fs_id=self.get_param_value("efs_fs_id"), avail_zone=master_avail_zone
+            head_node_avail_zone = self.pcluster_config.get_head_node_availability_zone()
+            head_node_mount_target_id = get_efs_mount_target_id(
+                efs_fs_id=self.get_param_value("efs_fs_id"), avail_zone=head_node_avail_zone
             )
             compute_avail_zone = self.pcluster_config.get_compute_availability_zone()
             compute_mount_target_id = get_efs_mount_target_id(
                 efs_fs_id=self.get_param_value("efs_fs_id"), avail_zone=compute_avail_zone
             )
-            master_mt_valid = bool(master_mount_target_id)
+            head_node_mt_valid = bool(head_node_mount_target_id)
             compute_mt_valid = bool(compute_mount_target_id)
 
-        cfn_items.append("Valid" if master_mt_valid else "NONE")
+        cfn_items.append("Valid" if head_node_mt_valid else "NONE")
         # Do not create additional compute mount target if compute and master subnet in the same AZ
-        cfn_items.append("Valid" if compute_mt_valid or (master_avail_zone == compute_avail_zone) else "NONE")
+        cfn_items.append("Valid" if compute_mt_valid or (head_node_avail_zone == compute_avail_zone) else "NONE")
         cfn_params[cfn_converter] = ",".join(cfn_items)
 
         return storage_params

--- a/cli/src/pcluster/config/cfn_param_types.py
+++ b/cli/src/pcluster/config/cfn_param_types.py
@@ -800,7 +800,7 @@ class BaseOSCfnParam(CfnParam):
     def get_instance_type_architecture(instance_type):
         """Compute cluster's 'Architecture' CFN parameter based on its head node instance type."""
         if not instance_type:
-            error("Cannot infer architecture without master instance type")
+            error("Cannot infer architecture without head node instance type")
         head_node_supported_architectures = get_supported_architectures_for_instance_type(instance_type)
 
         if not head_node_supported_architectures:

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -768,7 +768,7 @@ CLUSTER_COMMON_PARAMS = [
         "required": True,
         "update_policy": UpdatePolicy.UNSUPPORTED
     }),
-    # Master
+    # Head node
     ("master_instance_type", {
         "default": "t2.micro",
         "cfn_param_mapping": "MasterInstanceType",

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -26,9 +26,9 @@ from pcluster.config.cfn_param_types import (
     EFSCfnSection,
     ExtraJsonCfnParam,
     FloatCfnParam,
+    HeadNodeAvailabilityZoneCfnParam,
     IntCfnParam,
     MaintainInitialSizeCfnParam,
-    MasterAvailabilityZoneCfnParam,
     NetworkInterfacesCountCfnParam,
     QueueSizeCfnParam,
     SettingsCfnParam,
@@ -288,7 +288,7 @@ VPC = {
         },
         "master_availability_zone": {
             # NOTE: this is not exposed as a configuration parameter
-            "type": MasterAvailabilityZoneCfnParam,
+            "type": HeadNodeAvailabilityZoneCfnParam,
             "cfn_param_mapping": "AvailabilityZone",
             "update_policy": UpdatePolicy.IGNORED,
             "visibility": Visibility.PRIVATE

--- a/cli/src/pcluster/config/pcluster_config.py
+++ b/cli/src/pcluster/config/pcluster_config.py
@@ -494,8 +494,8 @@ class PclusterConfig(object):
         # test provided configuration
         self.__test_configuration()
 
-    def get_master_availability_zone(self):
-        """Get the Availability zone of the Master Subnet."""
+    def get_head_node_availability_zone(self):
+        """Get the Availability zone of the Head Node Subnet."""
         return self.get_section("vpc").get_param_value("master_availability_zone")
 
     def get_compute_availability_zone(self):

--- a/cli/src/pcluster/config/resource_map.py
+++ b/cli/src/pcluster/config/resource_map.py
@@ -22,7 +22,7 @@ class ResourceMap(object):
         """
         Represents a set of available resources for a single resource type.
 
-        For instance, this class can represent the available EBS volume resources that can be attached to a master node.
+        For instance, this class can represent the available EBS volume resources that can be attached to a head node.
         """
 
         def __init__(self, resources):

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -210,12 +210,12 @@ UpdatePolicy.COMPUTE_FLEET_STOP = UpdatePolicy(
     condition_checker=lambda change, patch: not utils.cluster_has_running_capacity(patch.stack_name),
 )
 
-# Update supported only with master node down
-UpdatePolicy.MASTER_STOP = UpdatePolicy(
+# Update supported only with head node down
+UpdatePolicy.HEAD_NODE_STOP = UpdatePolicy(
     level=20,
     fail_reason="To perform this update action, the master node must be in a stopped state",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
-    condition_checker=lambda change, patch: utils.get_master_server_state(patch.stack_name) == "stopped",
+    condition_checker=lambda change, patch: utils.get_head_node_state(patch.stack_name) == "stopped",
 )
 
 # Expected Behavior:

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -213,7 +213,7 @@ UpdatePolicy.COMPUTE_FLEET_STOP = UpdatePolicy(
 # Update supported only with head node down
 UpdatePolicy.HEAD_NODE_STOP = UpdatePolicy(
     level=20,
-    fail_reason="To perform this update action, the master node must be in a stopped state",
+    fail_reason="To perform this update action, the head node must be in a stopped state",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
     condition_checker=lambda change, patch: utils.get_head_node_state(patch.stack_name) == "stopped",
 )

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -387,7 +387,7 @@ def dcv_enabled_validator(param_key, param_value, pcluster_config):
         if re.search(r"(micro)|(nano)", head_node_instance_type):
             warnings.append(
                 "The packages required for desktop virtualization in the selected instance type '{0}' "
-                "may cause instability of the master instance. If you want to use NICE DCV it is recommended "
+                "may cause instability of the head node instance. If you want to use NICE DCV it is recommended "
                 "to use an instance type with at least 1.7 GB of memory.".format(head_node_instance_type)
             )
 
@@ -625,7 +625,7 @@ def ec2_ami_validator(param_key, param_value, pcluster_config):
         if cluster_section.get_param_value("architecture") != ami_architecture:
             errors.append(
                 "AMI {0}'s architecture ({1}) is incompatible with the architecture supported by the instance type "
-                "chosen for the master server ({2}). Use either a different AMI or a different instance type.".format(
+                "chosen for the head node ({2}). Use either a different AMI or a different instance type.".format(
                     param_value, ami_architecture, cluster_section.get_param_value("architecture")
                 )
             )
@@ -1075,7 +1075,7 @@ def intel_hpc_architecture_validator(param_key, param_value, pcluster_config):
     architecture = pcluster_config.get_section("cluster").get_param_value("architecture")
     if param_value and architecture not in allowed_architectures:
         errors.append(
-            "When using enable_intel_hpc_platform = {0} it is required to use master and compute instance "
+            "When using enable_intel_hpc_platform = {0} it is required to use head node and compute instance "
             "types and an AMI that support these architectures: {1}".format(param_value, allowed_architectures)
         )
 

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -952,7 +952,7 @@ def cluster_validator(section_key, section_label, pcluster_config):
 
 
 def instances_architecture_compatibility_validator(param_key, param_value, pcluster_config):
-    """Verify that master and compute instance types imply compatible architectures."""
+    """Verify that head node and compute instance types imply compatible architectures."""
     errors = []
     warnings = []
 

--- a/cli/src/pcluster/configure/easyconfig.py
+++ b/cli/src/pcluster/configure/easyconfig.py
@@ -266,13 +266,13 @@ def _filter_subnets_offering_instance_type(subnet_list, instance_type):
 
 def _ask_for_subnets(subnet_list, vpc_section, qualified_head_node_subnets, qualified_compute_subnets):
     head_node_subnet_id = _prompt_for_subnet(
-        vpc_section.get_param_value("master_subnet_id"), subnet_list, qualified_head_node_subnets, "Master Subnet ID"
+        vpc_section.get_param_value("master_subnet_id"), subnet_list, qualified_head_node_subnets, "head node Subnet ID"
     )
     compute_subnet_id = _prompt_for_subnet(
         vpc_section.get_param_value("compute_subnet_id") or head_node_subnet_id,
         subnet_list,
         qualified_compute_subnets,
-        "Compute Subnet ID",
+        "compute Subnet ID",
     )
 
     vpc_parameters = {"master_subnet_id": head_node_subnet_id}
@@ -294,8 +294,8 @@ def _choose_network_configuration(cluster_config):
         # Automate subnet creation only allows subnets to reside in a single az.
         # But user can bypass it by using manual subnets creation during configure or modify the config file directly.
         print(
-            "Error: There is no single availability zone offering master and compute in current region.\n"
-            "To create your cluster, make sure you have a subnet for master node in {0}"
+            "Error: There is no single availability zone offering head node and compute in current region.\n"
+            "To create your cluster, make sure you have a subnet for head node in {0}"
             ", and a subnet for compute nodes in {1}. Then run pcluster configure again"
             "and avoid using Automate VPC/Subnet creation.".format(azs_for_head_node_type, azs_for_compute_type)
         )
@@ -368,7 +368,7 @@ class ClusterConfigureHelper:
     def prompt_instance_types(self):
         """Ask for head_node_instance_type and compute_instance_type (if necessary)."""
         self.head_node_instance_type = prompt(
-            "Master instance type",
+            "Head node instance type",
             lambda x: _is_instance_type_supported_for_head_node(x) and x in get_supported_instance_types(),
             default_value=self.cluster_section.get_param_value("master_instance_type"),
         )

--- a/cli/src/pcluster/configure/easyconfig.py
+++ b/cli/src/pcluster/configure/easyconfig.py
@@ -419,7 +419,7 @@ class ClusterConfigureHelper:
 
     def cache_qualified_az(self):
         """
-        Call API once for both master and compute instance type.
+        Call API once for both head node and compute instance type.
 
         Cache is done inside get get_supported_az_for_instance_types.
         """

--- a/cli/src/pcluster/configure/networking.py
+++ b/cli/src/pcluster/configure/networking.py
@@ -92,7 +92,7 @@ class PublicNetworkConfig(BaseNetworkConfig):
 
     def __init__(self, availability_zones=None):
         super(PublicNetworkConfig, self).__init__(
-            config_type="Master and compute fleet in the same public subnet",
+            config_type="Head node and compute fleet in the same public subnet",
             template_name="public",
             stack_name_prefix="pub",
             availability_zones=availability_zones,
@@ -119,7 +119,7 @@ class PublicPrivateNetworkConfig(BaseNetworkConfig):
 
     def __init__(self, availability_zones=None):
         super(PublicPrivateNetworkConfig, self).__init__(
-            config_type="Master in a public subnet and compute fleet in a private subnet",
+            config_type="Head node in a public subnet and compute fleet in a private subnet",
             template_name="public-private",
             stack_name_prefix="pubpriv",
             availability_zones=availability_zones,

--- a/cli/src/pcluster/configure/networking.py
+++ b/cli/src/pcluster/configure/networking.py
@@ -88,7 +88,7 @@ class BaseNetworkConfig(ABC):
 
 
 class PublicNetworkConfig(BaseNetworkConfig):
-    """The public configuration that creates one public subnet with master and compute fleet."""
+    """The public configuration that creates one public subnet with head node and compute fleet."""
 
     def __init__(self, availability_zones=None):
         super(PublicNetworkConfig, self).__init__(
@@ -115,7 +115,7 @@ class PublicNetworkConfig(BaseNetworkConfig):
 
 
 class PublicPrivateNetworkConfig(BaseNetworkConfig):
-    """The publicprivate configuration that creates one public subnet for master and one private subnet for compute."""
+    """The public private config that creates one public subnet for head node and one private subnet for compute."""
 
     def __init__(self, availability_zones=None):
         super(PublicPrivateNetworkConfig, self).__init__(

--- a/cli/src/pcluster/configure/networking.py
+++ b/cli/src/pcluster/configure/networking.py
@@ -33,7 +33,7 @@ from pcluster.utils import (
 DEFAULT_AWS_REGION_NAME = "us-east-1"
 LOGGER = logging.getLogger(__name__)
 TIMESTAMP = "-{:%Y%m%d%H%M%S}".format(datetime.datetime.utcnow())
-MASTER_SUBNET_IPS = 250
+HEAD_NODE_SUBNET_IPS = 250
 
 if sys.version_info >= (3, 4):
     ABC = abc.ABC
@@ -106,7 +106,7 @@ class PublicNetworkConfig(BaseNetworkConfig):
 
     def _create(self, vpc_id, vpc_cidr, subnet_cidrs, internet_gateway_id, compute_subnet_size):
         public_cidr = get_subnet_cidr(
-            vpc_cidr=vpc_cidr, occupied_cidr=subnet_cidrs, min_subnet_size=compute_subnet_size + MASTER_SUBNET_IPS
+            vpc_cidr=vpc_cidr, occupied_cidr=subnet_cidrs, min_subnet_size=compute_subnet_size + HEAD_NODE_SUBNET_IPS
         )
         _validate_cidr(public_cidr)
         parameters = self.get_cfn_parameters(vpc_id, internet_gateway_id, public_cidr)
@@ -133,7 +133,7 @@ class PublicPrivateNetworkConfig(BaseNetworkConfig):
         return parameters
 
     def _create(self, vpc_id, vpc_cidr, subnet_cidrs, internet_gateway_id, compute_subnet_size):  # noqa D102
-        public_cidr = evaluate_cidr(vpc_cidr=vpc_cidr, occupied_cidrs=subnet_cidrs, target_size=MASTER_SUBNET_IPS)
+        public_cidr = evaluate_cidr(vpc_cidr=vpc_cidr, occupied_cidrs=subnet_cidrs, target_size=HEAD_NODE_SUBNET_IPS)
         _validate_cidr(public_cidr)
         subnet_cidrs.append(public_cidr)
         private_cidr = get_subnet_cidr(

--- a/cli/src/pcluster/dcv/connect.py
+++ b/cli/src/pcluster/dcv/connect.py
@@ -59,7 +59,7 @@ def dcv_connect(args):
         error(
             "Something went wrong during DCV connection.\n{0}"
             "Please check the logs in the /var/log/parallelcluster/ folder "
-            "of the master instance and submit an issue {1}\n".format(e, PCLUSTER_ISSUES_LINK)
+            "of the head node and submit an issue {1}\n".format(e, PCLUSTER_ISSUES_LINK)
         )
 
     if args.show_url:
@@ -93,7 +93,7 @@ def _retrieve_dcv_session_url(ssh_cmd, cluster_name, head_node_ip):
             error(
                 "Something went wrong during DCV connection. Please manually execute the command:\n{0}\n"
                 "If the problem persists, please check the logs in the /var/log/parallelcluster/ folder "
-                "of the master instance and submit an issue {1}".format(ssh_cmd, PCLUSTER_ISSUES_LINK)
+                "of the head node and submit an issue {1}".format(ssh_cmd, PCLUSTER_ISSUES_LINK)
             )
 
     except sub.CalledProcessError as e:

--- a/cli/src/pcluster/dcv/connect.py
+++ b/cli/src/pcluster/dcv/connect.py
@@ -40,7 +40,7 @@ def dcv_connect(args):
     # Parse configuration file to read the AWS section
     PclusterConfig.init_aws()  # FIXME it always searches for the default configuration file
 
-    # Prepare ssh command to execute in the master instance
+    # Prepare ssh command to execute in the head node instance
     stack = get_stack(get_stack_name(args.cluster_name))
     shared_dir = get_cfn_param(stack.get("Parameters"), "SharedDir")
     head_node_ip, username = get_head_node_ip_and_username(args.cluster_name)
@@ -74,7 +74,7 @@ def dcv_connect(args):
 
 
 def _retrieve_dcv_session_url(ssh_cmd, cluster_name, head_node_ip):
-    """Connect by ssh to the master instance, prepare DCV session and return the DCV session URL."""
+    """Connect by ssh to the head node instance, prepare DCV session and return the DCV session URL."""
     try:
         LOGGER.debug("SSH command: {0}".format(ssh_cmd))
         output = _check_command_output(ssh_cmd)

--- a/cli/src/pcluster/examples/config
+++ b/cli/src/pcluster/examples/config
@@ -23,7 +23,7 @@ key_name = mykey
 # Override path to cloudformation in S3
 # (defaults to https://s3.amazonaws.com/<aws_region_name>-aws-parallelcluster/templates/aws-parallelcluster-<version>.cfn.json)
 #template_url = https://s3.amazonaws.com/<aws_region_name>-aws-parallelcluster/templates/aws-parallelcluster-<version>.cfn.json
-# EC2 instance type for master node
+# EC2 instance type for head node
 # (defaults to t2.micro)
 #master_instance_type = t2.micro
 # EC2 instance type for compute nodes
@@ -94,7 +94,7 @@ key_name = mykey
 # Encrypted ephemeral drives. In-memory keys, non-recoverable.
 # (defaults to false)
 #encrypted_ephemeral = false
-# MasterServer root volume size in GB. (AMI must support growroot)
+# Head node root volume size in GB. (AMI must support growroot)
 # (defaults to 25)
 #master_root_volume_size = 25
 # ComputeFleet root volume size in GB. (AMI must support growroot)
@@ -137,7 +137,7 @@ vpc_settings = public
 [vpc public]
 # ID of the VPC you want to provision cluster into.
 vpc_id = vpc-12345678
-# ID of the Subnet you want to provision the Master server into
+# ID of the Subnet you want to provision the head node into
 master_subnet_id = subnet-12345678
 # SSH from CIDR
 # This is only used when AWS ParallelCluster creates the security group
@@ -153,7 +153,7 @@ master_subnet_id = subnet-12345678
 #[vpc private-new]
 # ID of the VPC you want to provision cluster into.
 #vpc_id = vpc-12345678
-# ID of the Subnet you want to provision the Master server into
+# ID of the Subnet you want to provision the head node into
 #master_subnet_id = subnet-12345678
 # CIDR for new backend subnet i.e. 10.0.100.0/24
 #compute_subnet_cidr = 10.0.100.0/24
@@ -161,7 +161,7 @@ master_subnet_id = subnet-12345678
 #[vpc private-existing]
 # ID of the VPC you want to provision cluster into.
 #vpc_id = vpc-12345678
-# ID of the Subnet you want to provision the Master server into
+# ID of the Subnet you want to provision the head node into
 #master_subnet_id = subnet-12345678
 # CIDR for new backend subnet i.e. 10.0.100.0/24
 #compute_subnet_id = subnet-23456789
@@ -184,7 +184,7 @@ master_subnet_id = subnet-12345678
 # Use encrypted volume (should not be used with snapshots)
 # (defaults to false)
 #encrypted = false
-# Existing EBS volume to be attached to the MasterServer
+# Existing EBS volume to be attached to the head node
 # (defaults to NONE)
 #ebs_volume_id = NONE
 

--- a/cli/src/pcluster/models/hit/hit_cluster_model.py
+++ b/cli/src/pcluster/models/hit/hit_cluster_model.py
@@ -45,51 +45,52 @@ class HITClusterModel(ClusterModel):
         if not cluster_section or cluster_section.get_param_value("scheduler") == "awsbatch" or not vpc_section:
             return
 
-        master_instance_type = cluster_section.get_param_value("master_instance_type")
+        head_node_instance_type = cluster_section.get_param_value("master_instance_type")
 
         # Retrieve network parameters
         compute_subnet = vpc_section.get_param_value("compute_subnet_id")
-        master_subnet = vpc_section.get_param_value("master_subnet_id")
+        head_node_subnet = vpc_section.get_param_value("master_subnet_id")
         vpc_security_group = vpc_section.get_param_value("vpc_security_group_id")
         if not compute_subnet:
-            compute_subnet = master_subnet
+            compute_subnet = head_node_subnet
         security_groups_ids = []
         if vpc_security_group:
             security_groups_ids.append(vpc_security_group)
 
         # Initialize CpuOptions
         disable_hyperthreading = cluster_section.get_param_value("disable_hyperthreading")
-        master_instance_type_info = InstanceTypeInfo.init_from_instance_type(master_instance_type)
+        head_node_instance_type_info = InstanceTypeInfo.init_from_instance_type(head_node_instance_type)
 
         # Set vcpus according to queue's disable_hyperthreading and instance features
-        master_vcpus = master_instance_type_info.vcpus_count()
+        head_node_vcpus = head_node_instance_type_info.vcpus_count()
 
-        master_threads_per_core = master_instance_type_info.default_threads_per_core()
-        master_cpu_options = (
-            {"CoreCount": master_vcpus // master_threads_per_core, "ThreadsPerCore": 1}
-            if disable_hyperthreading and disable_ht_via_cpu_options(master_instance_type, master_threads_per_core)
+        head_node_threads_per_core = head_node_instance_type_info.default_threads_per_core()
+        head_node_cpu_options = (
+            {"CoreCount": head_node_vcpus // head_node_threads_per_core, "ThreadsPerCore": 1}
+            if disable_hyperthreading
+            and disable_ht_via_cpu_options(head_node_instance_type, head_node_threads_per_core)
             else {}
         )
         try:
             latest_alinux_ami_id = self._get_latest_alinux_ami_id()
 
-            master_network_interfaces = self.build_launch_network_interfaces(
+            head_node_network_interfaces = self.build_launch_network_interfaces(
                 network_interfaces_count=int(cluster_section.get_param_value("network_interfaces_count")[0]),
-                use_efa=False,  # EFA is not supported on master node
+                use_efa=False,  # EFA is not supported on head node
                 security_group_ids=security_groups_ids,
-                subnet=master_subnet,
+                subnet=head_node_subnet,
                 use_public_ips=vpc_section.get_param_value("use_public_ips"),
             )
 
-            # Test Master Instance Configuration
+            # Test Head Node Instance Configuration
             self._ec2_run_instance(
                 pcluster_config,
-                InstanceType=master_instance_type,
+                InstanceType=head_node_instance_type,
                 MinCount=1,
                 MaxCount=1,
                 ImageId=latest_alinux_ami_id,
-                CpuOptions=master_cpu_options,
-                NetworkInterfaces=master_network_interfaces,
+                CpuOptions=head_node_cpu_options,
+                NetworkInterfaces=head_node_network_interfaces,
                 DryRun=True,
             )
 

--- a/cli/src/pcluster/models/sit/sit_cluster_model.py
+++ b/cli/src/pcluster/models/sit/sit_cluster_model.py
@@ -67,30 +67,31 @@ class SITClusterModel(ClusterModel):
         ):
             return
 
-        master_instance_type = cluster_section.get_param_value("master_instance_type")
+        head_node_instance_type = cluster_section.get_param_value("master_instance_type")
         compute_instance_type = cluster_section.get_param_value("compute_instance_type")
 
         # Retrieve network parameters
         compute_subnet = vpc_section.get_param_value("compute_subnet_id")
-        master_subnet = vpc_section.get_param_value("master_subnet_id")
+        head_node_subnet = vpc_section.get_param_value("master_subnet_id")
         vpc_security_group = vpc_section.get_param_value("vpc_security_group_id")
         if not compute_subnet:
-            compute_subnet = master_subnet
+            compute_subnet = head_node_subnet
         security_groups_ids = []
         if vpc_security_group:
             security_groups_ids.append(vpc_security_group)
 
         # Initialize CpuOptions
         disable_hyperthreading = cluster_section.get_param_value("disable_hyperthreading")
-        master_instance_type_info = InstanceTypeInfo.init_from_instance_type(master_instance_type)
-        master_vcpus = master_instance_type_info.vcpus_count()
-        master_threads_per_core = master_instance_type_info.default_threads_per_core()
+        head_node_instance_type_info = InstanceTypeInfo.init_from_instance_type(head_node_instance_type)
+        head_node_vcpus = head_node_instance_type_info.vcpus_count()
+        head_node_threads_per_core = head_node_instance_type_info.default_threads_per_core()
         compute_instance_type_info = InstanceTypeInfo.init_from_instance_type(compute_instance_type)
         compute_vcpus = compute_instance_type_info.vcpus_count()
         compute_threads_per_core = compute_instance_type_info.default_threads_per_core()
-        master_cpu_options = (
-            {"CoreCount": master_vcpus // master_threads_per_core, "ThreadsPerCore": 1}
-            if disable_hyperthreading and disable_ht_via_cpu_options(master_instance_type, master_threads_per_core)
+        head_node_cpu_options = (
+            {"CoreCount": head_node_vcpus // head_node_threads_per_core, "ThreadsPerCore": 1}
+            if disable_hyperthreading
+            and disable_ht_via_cpu_options(head_node_instance_type, head_node_threads_per_core)
             else {}
         )
         compute_cpu_options = (
@@ -102,7 +103,7 @@ class SITClusterModel(ClusterModel):
         # Initialize Placement Group Logic
         placement_group = cluster_section.get_param_value("placement_group")
         placement = cluster_section.get_param_value("placement")
-        master_placement_group = (
+        head_node_placement_group = (
             {"GroupName": placement_group}
             if placement_group not in [None, "NONE", "DYNAMIC"] and placement == "cluster"
             else {}
@@ -114,24 +115,24 @@ class SITClusterModel(ClusterModel):
         try:
             latest_alinux_ami_id = self._get_latest_alinux_ami_id()
 
-            master_network_interfaces = self.build_launch_network_interfaces(
+            head_node_network_interfaces = self.build_launch_network_interfaces(
                 network_interfaces_count=int(cluster_section.get_param_value("network_interfaces_count")[0]),
                 use_efa=False,  # EFA is not supported on master node
                 security_group_ids=security_groups_ids,
-                subnet=master_subnet,
+                subnet=head_node_subnet,
                 use_public_ips=vpc_section.get_param_value("use_public_ips"),
             )
 
-            # Test Master Instance Configuration
+            # Test head node configuration
             self._ec2_run_instance(
                 pcluster_config,
-                InstanceType=master_instance_type,
+                InstanceType=head_node_instance_type,
                 MinCount=1,
                 MaxCount=1,
                 ImageId=latest_alinux_ami_id,
-                CpuOptions=master_cpu_options,
-                NetworkInterfaces=master_network_interfaces,
-                Placement=master_placement_group,
+                CpuOptions=head_node_cpu_options,
+                NetworkInterfaces=head_node_network_interfaces,
+                Placement=head_node_placement_group,
                 DryRun=True,
             )
 

--- a/cli/src/pcluster/models/sit/sit_cluster_model.py
+++ b/cli/src/pcluster/models/sit/sit_cluster_model.py
@@ -117,7 +117,7 @@ class SITClusterModel(ClusterModel):
 
             head_node_network_interfaces = self.build_launch_network_interfaces(
                 network_interfaces_count=int(cluster_section.get_param_value("network_interfaces_count")[0]),
-                use_efa=False,  # EFA is not supported on master node
+                use_efa=False,  # EFA is not supported on head node
                 security_group_ids=security_groups_ids,
                 subnet=head_node_subnet,
                 use_public_ips=vpc_section.get_param_value("use_public_ips"),
@@ -138,7 +138,7 @@ class SITClusterModel(ClusterModel):
 
             compute_network_interfaces_count = int(cluster_section.get_param_value("network_interfaces_count")[1])
             enable_efa = "compute" == cluster_section.get_param_value("enable_efa")
-            # TODO: check if master == compute subnet condition is to take into account
+            # TODO: check if head node == compute subnet condition is to take into account
             use_public_ips = self.public_ips_in_compute_subnet(pcluster_config, compute_network_interfaces_count)
 
             network_interfaces = self.build_launch_network_interfaces(

--- a/cli/src/pcluster/resources/batch/docker/scripts/mount_nfs.sh
+++ b/cli/src/pcluster/resources/batch/docker/scripts/mount_nfs.sh
@@ -13,7 +13,7 @@
 # ANY KIND, express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-# Usage: mount_filesystem.sh master_ip shared_dir
+# Usage: mount_filesystem.sh head_node_ip shared_dir
 
 error_exit_usage() {
     echo "Error executing script: $1"
@@ -28,20 +28,20 @@ error_exit() {
 
 usage() {
     cat <<ENDUSAGE
-This script mounts the shared dir from master instance on the nodes in the batch job.
+This script mounts the shared dir from head node instance on the nodes in the batch job.
 The shared directory will be created if it does not exist.
 
 USAGE:
-mount_nfs <master_ip> <shared_dir>
-master_ip: ip address of the main node
-shared_dir: directory from master to be shared. If directory doesn't exist on compute, will be created
+mount_nfs <head_node_ip> <shared_dir>
+head_node_ip: ip address of the main node
+shared_dir: directory from head node to be shared. If directory doesn't exist on compute, will be created
 ENDUSAGE
 }
 
 # Check that the arguments are valid
 check_arguments_valid(){
-    if [ -z "${master_ip}" ]; then
-        error_exit_usage "Master IP is a required argument"
+    if [ -z "${head_node_ip}" ]; then
+        error_exit_usage "Head Node IP is a required argument"
     fi
 
     if [ -z "${shared_dir}" ]; then
@@ -58,22 +58,22 @@ mount_nfs() {
     fi
 
     mkdir -p ${shared_dir}
-    error_message=$(mount -t nfs -o hard,intr,noatime,_netdev "${master_ip}":"${shared_dir}" "${shared_dir}" 2>&1)
+    error_message=$(mount -t nfs -o hard,intr,noatime,_netdev "${head_node_ip}":"${shared_dir}" "${shared_dir}" 2>&1)
     if [[ $? -ne 0 ]]; then
-        error_exit "Failed to mount nfs volume from ${master_ip}:${shared_dir} with error_message: ${error_message}"
+        error_exit "Failed to mount nfs volume from ${head_node_ip}:${shared_dir} with error_message: ${error_message}"
     fi
 
     # Check that the filesystem is mounted as appropriate
-    mount_line=$(mount | grep "${master_ip}:${shared_dir}")
+    mount_line=$(mount | grep "${head_node_ip}:${shared_dir}")
     if [[ -z "${mount_line}" ]]; then
-        error_exit "mount succeeded but nfs volume from ${master_ip}:${shared_dir} was not mounted as expected"
+        error_exit "mount succeeded but nfs volume from ${head_node_ip}:${shared_dir} was not mounted as expected"
     fi
 }
 
 
 # main function
 main() {
-    master_ip=${1}
+    head_node_ip=${1}
     shared_dir=${2}
     if [[ "${shared_dir:0:1}" != '/' ]]; then
       shared_dir="/${shared_dir}"

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -857,7 +857,7 @@ def _get_head_node_ip(stack_name):
         ip_address = head_node.get("PrivateIpAddress")
     state = head_node.get("State").get("Name")
     if state != "running" or ip_address is None:
-        error("Head node: {0}\nCannot get ip address.".format(state.upper()))
+        error("MasterServer: {0}\nCannot get ip address.".format(state.upper()))
     return ip_address
 
 

--- a/cli/tests/pcluster/config/test_json_param_types.py
+++ b/cli/tests/pcluster/config/test_json_param_types.py
@@ -147,7 +147,7 @@ def test_config_to_json(capsys, boto3_stubber, test_datadir, pcluster_config_rea
     expected_json_params = _prepare_json_config(queues, test_datadir)
 
     # Mock expected boto3 calls
-    _mock_boto3(boto3_stubber, expected_json_params, master_instance_type="c4.xlarge")
+    _mock_boto3(boto3_stubber, expected_json_params, head_node_instance_type="c4.xlarge")
 
     # Load config from created config file
     dst_config_file = pcluster_config_reader(dst_config_file, queue_settings=queue_settings)
@@ -179,7 +179,7 @@ def test_config_from_json(mocker, boto3_stubber, test_datadir, pcluster_config_r
     expected_json_params = _prepare_json_config(queues, test_datadir)
 
     # Mock expected boto3 calls
-    _mock_boto3(boto3_stubber, expected_json_params, master_instance_type="t2.micro")
+    _mock_boto3(boto3_stubber, expected_json_params, head_node_instance_type="t2.micro")
 
     pcluster_config = get_mocked_pcluster_config(mocker, auto_refresh=False)
     cluster_section = CfnSection(CLUSTER_HIT, pcluster_config, section_label="default")
@@ -244,14 +244,14 @@ def _prepare_json_config(queues, test_datadir):
     return expected_json_params
 
 
-def _mock_boto3(boto3_stubber, expected_json_params, master_instance_type=None):
+def _mock_boto3(boto3_stubber, expected_json_params, head_node_instance_type=None):
     """Mock the boto3 client based on the expected json configuration."""
     expected_json_queue_settings = expected_json_params["cluster"].get("queue_settings", {})
     mocked_requests = []
     instance_types = []
-    # One describe_instance_type for the Master node
-    if master_instance_type:
-        instance_types.append(master_instance_type)
+    # One describe_instance_type for the Head node
+    if head_node_instance_type:
+        instance_types.append(head_node_instance_type)
 
     # One describe_instance_type per compute resource
     for _, queue in expected_json_queue_settings.items():

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -265,7 +265,7 @@ def test_hit_cluster_section_from_file(mocker, config_parser_dict, expected_dict
         ("placement", "wrong_value", None, "has an invalid value"),
         ("placement", "NONE", None, "has an invalid value"),
         ("placement", "cluster", "cluster", None),
-        # Master
+        # Head node
         # TODO add regex for master_instance_type
         ("master_instance_type", None, "t2.micro", None),
         ("master_instance_type", "", "", None),
@@ -541,7 +541,7 @@ def test_sit_cluster_param_from_file(
         ("shared_dir", "/test//test2", None, "has an invalid value"),
         ("shared_dir", "/test\\test2", None, "has an invalid value"),
         ("shared_dir", "NONE", "NONE", None),  # NONE is evaluated as a valid path
-        # Master
+        # Head node
         # TODO add regex for master_instance_type
         ("master_instance_type", None, "t2.micro", None),
         ("master_instance_type", "", "", None),

--- a/cli/tests/pcluster/config/test_section_efs.py
+++ b/cli/tests/pcluster/config/test_section_efs.py
@@ -164,7 +164,8 @@ def test_efs_param_from_file(mocker, param_key, param_value, expected_value, exp
 def test_efs_section_to_cfn(mocker, section_dict, expected_cfn_params):
     mocker.patch("pcluster.config.cfn_param_types.get_efs_mount_target_id", return_value="valid_mount_target_id")
     mocker.patch(
-        "pcluster.config.pcluster_config.PclusterConfig.get_master_availability_zone", return_value="mocked_avail_zone"
+        "pcluster.config.pcluster_config.PclusterConfig.get_head_node_availability_zone",
+        return_value="mocked_avail_zone",
     )
     utils.assert_section_to_cfn(mocker, EFS, section_dict, expected_cfn_params)
 

--- a/cli/tests/pcluster/config/test_section_efs/test_efs_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_efs/test_efs_from_file_to_cfn/pcluster.config.ini
@@ -13,7 +13,7 @@ scheduler = slurm
 base_os = alinux2
 
 [vpc default]
-# EFS conversion requires master subnet id to check mount-target avail zone
+# EFS conversion requires head node subnet id to check mount-target avail zone
 master_subnet_id = subnet-12345678
 compute_subnet_id = subnet-23456789
 

--- a/cli/tests/pcluster/config/test_section_fsx/test_fsx_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_fsx/test_fsx_from_file_to_cfn/pcluster.config.ini
@@ -13,7 +13,7 @@ scheduler = slurm
 base_os = alinux2
 
 [vpc default]
-# FSX conversion requires master subnet id to check mount-target
+# FSX conversion requires head node subnet id to check mount-target
 master_subnet_id = subnet-12345678
 
 [fsx test1]

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -2211,7 +2211,7 @@ def test_disable_hyperthreading_architecture_validator(mocker, disable_hyperthre
 
 
 @pytest.mark.parametrize(
-    "master_architecture, compute_architecture, compute_instance_type, expected_message",
+    "head_node_architecture, compute_architecture, compute_instance_type, expected_message",
     [
         # Single compute_instance_type
         ("x86_64", "x86_64", "c5.xlarge", []),
@@ -2244,7 +2244,7 @@ def test_disable_hyperthreading_architecture_validator(mocker, disable_hyperthre
     ],
 )
 def test_instances_architecture_compatibility_validator(
-    mocker, caplog, master_architecture, compute_architecture, compute_instance_type, expected_message
+    mocker, caplog, head_node_architecture, compute_architecture, compute_instance_type, expected_message
 ):
     def internal_is_instance_type(itype):
         return "." in itype or itype == "optimal"
@@ -2258,7 +2258,7 @@ def test_instances_architecture_compatibility_validator(
     logger_patch = mocker.patch.object(LOGFILE_LOGGER, "debug")
     run_architecture_validator_test(
         mocker,
-        {"cluster": {"architecture": master_architecture}},
+        {"cluster": {"architecture": head_node_architecture}},
         "cluster",
         "architecture",
         "compute_instance_type",

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -147,12 +147,12 @@ def test_ec2_key_pair_validator(mocker, boto3_stubber):
         (
             "arm64",
             None,
-            "incompatible with the architecture supported by the instance type chosen for the master server",
+            "incompatible with the architecture supported by the instance type chosen for the head node",
         ),
         (
             "arm64",
             "Unable to get information for AMI",
-            "incompatible with the architecture supported by the instance type chosen for the master server",
+            "incompatible with the architecture supported by the instance type chosen for the head node",
         ),
     ],
 )

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -103,10 +103,10 @@ def assert_param_from_file(
 def get_mock_pcluster_config_patches(scheduler, extra_patches=None):
     """Return mocks for a set of functions that should be mocked by default because they access the network."""
     architectures = ["x86_64"]
-    master_instances = ["t2.micro", "t2.large", "c4.xlarge", "p4d.24xlarge"]
-    compute_instances = ["t2.micro", "t2.large", "t2", "optimal"] if scheduler == "awsbatch" else master_instances
+    head_node_instances = ["t2.micro", "t2.large", "c4.xlarge", "p4d.24xlarge"]
+    compute_instances = ["t2.micro", "t2.large", "t2", "optimal"] if scheduler == "awsbatch" else head_node_instances
     patches = {
-        "pcluster.config.validators.get_supported_instance_types": master_instances,
+        "pcluster.config.validators.get_supported_instance_types": head_node_instances,
         "pcluster.config.validators.get_supported_compute_instance_types": compute_instances,
         "pcluster.config.validators.get_supported_architectures_for_instance_type": architectures,
         "pcluster.config.cfn_param_types.get_availability_zone_of_subnet": "mocked_avail_zone",

--- a/cli/tests/pcluster/configure/test_pcluster_configure.py
+++ b/cli/tests/pcluster/configure/test_pcluster_configure.py
@@ -345,15 +345,15 @@ class ComposeInput:
         self.input_list = [] if aws_region_name is None else [aws_region_name]
         self.input_list.extend([key, scheduler])
 
-    def add_first_flow(self, op_sys, min_size, max_size, master_instance, compute_instance):
+    def add_first_flow(self, op_sys, min_size, max_size, head_node_instance, compute_instance):
         if self.is_not_aws_batch:
             self.input_list.append(op_sys)
-        self.input_list.extend([min_size, max_size, master_instance])
+        self.input_list.extend([min_size, max_size, head_node_instance])
         if self.is_not_aws_batch:
             self.input_list.append(compute_instance)
 
-    def add_no_automation_no_empty_vpc(self, vpc_id, master_id, compute_id):
-        self.input_list.extend(["n", vpc_id, "n", master_id, compute_id])
+    def add_no_automation_no_empty_vpc(self, vpc_id, head_node_id, compute_id):
+        self.input_list.extend(["n", vpc_id, "n", head_node_id, compute_id])
 
     def add_sub_automation(self, vpc_id, network_configuration, vpc_has_subnets=True):
         self.input_list.extend(["n", vpc_id])
@@ -416,7 +416,7 @@ def _run_input_test_with_config(
     output,
     capsys,
     with_input=False,
-    master_instance="c5.xlarge",
+    head_node_instance="c5.xlarge",
     compute_instance="g3.8xlarge",
 ):
     if with_input:
@@ -425,16 +425,16 @@ def _run_input_test_with_config(
             op_sys="ubuntu1604",
             min_size="7",
             max_size="18",
-            master_instance=master_instance,
+            head_node_instance=head_node_instance,
             compute_instance=compute_instance,
         )
         input_composer.add_no_automation_no_empty_vpc(
-            vpc_id="vpc-34567891", master_id="subnet-34567891", compute_id="subnet-45678912"
+            vpc_id="vpc-34567891", head_node_id="subnet-34567891", compute_id="subnet-45678912"
         )
     else:
         input_composer = ComposeInput(aws_region_name="", key="", scheduler="")
-        input_composer.add_first_flow(op_sys="", min_size="", max_size="", master_instance="", compute_instance="")
-        input_composer.add_no_automation_no_empty_vpc(vpc_id="", master_id="", compute_id="")
+        input_composer.add_first_flow(op_sys="", min_size="", max_size="", head_node_instance="", compute_instance="")
+        input_composer.add_no_automation_no_empty_vpc(vpc_id="", head_node_id="", compute_id="")
 
     input_composer.mock_input(mocker)
 
@@ -447,10 +447,10 @@ def test_no_automation_no_awsbatch_no_errors(mocker, capsys, test_datadir):
     MockHandler(mocker)
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="torque")
     input_composer.add_first_flow(
-        op_sys="alinux", min_size="13", max_size="14", master_instance="t2.nano", compute_instance="t2.micro"
+        op_sys="alinux", min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance="t2.micro"
     )
     input_composer.add_no_automation_no_empty_vpc(
-        vpc_id="vpc-12345678", master_id="subnet-12345678", compute_id="subnet-23456789"
+        vpc_id="vpc-12345678", head_node_id="subnet-12345678", compute_id="subnet-23456789"
     )
     input_composer.mock_input(mocker)
 
@@ -483,10 +483,10 @@ def test_with_region_arg_with_config_file(mocker, capsys, test_datadir):
 
     input_composer = ComposeInput(aws_region_name=None, key="key1", scheduler="torque")
     input_composer.add_first_flow(
-        op_sys="alinux", min_size="13", max_size="14", master_instance="t2.nano", compute_instance="t2.micro"
+        op_sys="alinux", min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance="t2.micro"
     )
     input_composer.add_no_automation_no_empty_vpc(
-        vpc_id="vpc-12345678", master_id="subnet-12345678", compute_id="subnet-23456789"
+        vpc_id="vpc-12345678", head_node_id="subnet-12345678", compute_id="subnet-23456789"
     )
     input_composer.mock_input(mocker)
     os.environ["AWS_DEFAULT_REGION"] = "env_region_name_to_be_overwritten"
@@ -524,7 +524,7 @@ def test_unexisting_instance_type(mocker, capsys, test_datadir):
         output,
         capsys,
         with_input=True,
-        master_instance="m6g.xlarge",
+        head_node_instance="m6g.xlarge",
         compute_instance="m6g.xlarge",
     )
 
@@ -533,7 +533,7 @@ def test_no_available_no_input_no_automation_no_errors_with_config_file(mocker, 
     """
     Testing easy config with user hitting return on all prompts.
 
-    Mocking the case where parameters: aws_region_name, key_name, vpc_id, compute_subnet_id, master_subnet_id.
+    Mocking the case where parameters: aws_region_name, key_name, vpc_id, compute_subnet_id, head_node_subnet_id.
     Are not found in available list under new partition/region/vpc configuration.
     After running easy config, the old original_config_file should be the same as pcluster.config.ini
     """
@@ -565,7 +565,7 @@ def test_with_input_no_automation_no_errors_with_config_file(mocker, capsys, tes
         output,
         capsys,
         with_input=True,
-        master_instance="m6g.xlarge",
+        head_node_instance="m6g.xlarge",
         compute_instance="m6g.xlarge",
     )
 
@@ -577,10 +577,10 @@ def test_no_automation_yes_awsbatch_no_errors(mocker, capsys, test_datadir):
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="awsbatch")
     input_composer.add_first_flow(
-        op_sys=None, min_size="13", max_size="14", master_instance="t2.nano", compute_instance=None
+        op_sys=None, min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance=None
     )
     input_composer.add_no_automation_no_empty_vpc(
-        vpc_id="vpc-12345678", master_id="subnet-12345678", compute_id="subnet-23456789"
+        vpc_id="vpc-12345678", head_node_id="subnet-12345678", compute_id="subnet-23456789"
     )
     input_composer.mock_input(mocker)
 
@@ -595,7 +595,7 @@ def test_subnet_automation_no_awsbatch_no_errors_empty_vpc(mocker, capsys, test_
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="sge")
     input_composer.add_first_flow(
-        op_sys="centos7", min_size="13", max_size="14", master_instance="t2.nano", compute_instance="t2.micro"
+        op_sys="centos7", min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance="t2.micro"
     )
     input_composer.add_sub_automation(
         vpc_id="vpc-23456789", network_configuration=PUBLIC_PRIVATE_CONFIGURATION, vpc_has_subnets=False
@@ -613,7 +613,7 @@ def test_subnet_automation_no_awsbatch_no_errors(mocker, capsys, test_datadir):
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="sge")
     input_composer.add_first_flow(
-        op_sys="centos7", min_size="13", max_size="14", master_instance="t2.nano", compute_instance="t2.micro"
+        op_sys="centos7", min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance="t2.micro"
     )
     input_composer.add_sub_automation(
         vpc_id="vpc-12345678", network_configuration=PUBLIC_PRIVATE_CONFIGURATION, vpc_has_subnets=True
@@ -632,7 +632,7 @@ def test_subnet_automation_no_awsbatch_no_errors_with_config_file(mocker, capsys
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="sge")
     input_composer.add_first_flow(
-        op_sys="centos7", min_size="13", max_size="14", master_instance="t2.nano", compute_instance="t2.micro"
+        op_sys="centos7", min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance="t2.micro"
     )
     input_composer.add_sub_automation(
         vpc_id="vpc-12345678", network_configuration=PUBLIC_PRIVATE_CONFIGURATION, vpc_has_subnets=True
@@ -650,7 +650,7 @@ def test_vpc_automation_no_awsbatch_no_errors(mocker, capsys, test_datadir):
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="sge")
     input_composer.add_first_flow(
-        op_sys="centos7", min_size="13", max_size="14", master_instance="t2.nano", compute_instance="t2.micro"
+        op_sys="centos7", min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance="t2.micro"
     )
     input_composer.add_vpc_sub_automation(network_configuration=PUBLIC_PRIVATE_CONFIGURATION)
     input_composer.mock_input(mocker)
@@ -666,7 +666,7 @@ def test_vpc_automation_yes_awsbatch_no_errors(mocker, capsys, test_datadir):
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="awsbatch")
     input_composer.add_first_flow(
-        op_sys=None, min_size="13", max_size="14", master_instance="t2.nano", compute_instance=None
+        op_sys=None, min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance=None
     )
     input_composer.add_vpc_sub_automation(network_configuration=PUBLIC_PRIVATE_CONFIGURATION)
     input_composer.mock_input(mocker)
@@ -685,7 +685,7 @@ def test_vpc_automation_invalid_vpc_block(mocker, capsys, test_datadir):
 
         input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="awsbatch")
         input_composer.add_first_flow(
-            op_sys=None, min_size="13", max_size="14", master_instance="t2.nano", compute_instance=None
+            op_sys=None, min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance=None
         )
         input_composer.add_vpc_sub_automation(network_configuration=PUBLIC_PRIVATE_CONFIGURATION)
         input_composer.mock_input(mocker)
@@ -702,7 +702,7 @@ def test_subnet_automation_yes_awsbatch_invalid_vpc(mocker, capsys, test_datadir
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="awsbatch")
     input_composer.add_first_flow(
-        op_sys=None, min_size="13", max_size="14", master_instance="t2.nano", compute_instance=None
+        op_sys=None, min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance=None
     )
     input_composer.add_sub_automation(vpc_id="vpc-12345678", network_configuration=PUBLIC_PRIVATE_CONFIGURATION)
     input_composer.mock_input(mocker)
@@ -718,7 +718,7 @@ def test_vpc_automation_no_vpc_in_region(mocker, capsys, test_datadir):
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="slurm")
     input_composer.add_first_flow(
-        op_sys="centos7", min_size="13", max_size="14", master_instance="t2.nano", compute_instance="t2.micro"
+        op_sys="centos7", min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance="t2.micro"
     )
     input_composer.add_vpc_sub_automation_empty_region(network_configuration=PUBLIC_PRIVATE_CONFIGURATION)
     input_composer.mock_input(mocker)
@@ -734,7 +734,7 @@ def test_vpc_automation_no_vpc_in_region_public(mocker, capsys, test_datadir):
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="slurm")
     input_composer.add_first_flow(
-        op_sys="centos7", min_size="13", max_size="14", master_instance="t2.nano", compute_instance="t2.micro"
+        op_sys="centos7", min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance="t2.micro"
     )
     input_composer.add_vpc_sub_automation_empty_region(network_configuration="2")
     input_composer.mock_input(mocker)
@@ -761,7 +761,7 @@ def test_bad_config_file(mocker, capsys, test_datadir):
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="sge")
     input_composer.add_first_flow(
-        op_sys="centos7", min_size="13", max_size="14", master_instance="t2.nano", compute_instance="t2.micro"
+        op_sys="centos7", min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance="t2.micro"
     )
     input_composer.add_sub_automation(
         vpc_id="vpc-12345678", network_configuration=PUBLIC_PRIVATE_CONFIGURATION, vpc_has_subnets=True
@@ -778,18 +778,18 @@ def general_wrapper_for_prompt_testing(
     op_sys="centos7",
     min_size="0",
     max_size="10",
-    master_instance="t2.nano",
+    head_node_instance="t2.nano",
     compute_instance="t2.micro",
     key="key1",
     vpc_id="vpc-12345678",
-    master_id="subnet-12345678",
+    head_node_id="subnet-12345678",
     compute_id="subnet-23456789",
 ):
     path = os.path.join(tempfile.gettempdir(), "test_pcluster_configure")
     MockHandler(mocker)
     input_composer = ComposeInput(aws_region_name=region, key=key, scheduler=scheduler)
-    input_composer.add_first_flow(op_sys, min_size, max_size, master_instance, compute_instance)
-    input_composer.add_no_automation_no_empty_vpc(vpc_id, master_id, compute_id)
+    input_composer.add_first_flow(op_sys, min_size, max_size, head_node_instance, compute_instance)
+    input_composer.add_no_automation_no_empty_vpc(vpc_id, head_node_id, compute_id)
     input_composer.mock_input(mocker)
 
     _run_configuration(mocker, path)
@@ -808,7 +808,7 @@ def test_vpc_automation_with_no_single_qualified_az(mocker, capsys, test_datadir
 
     input_composer = ComposeInput(aws_region_name="eu-west-1", key="key1", scheduler="sge")
     input_composer.add_first_flow(
-        op_sys="centos7", min_size="13", max_size="14", master_instance="t2.nano", compute_instance="t2.micro"
+        op_sys="centos7", min_size="13", max_size="14", head_node_instance="t2.nano", compute_instance="t2.micro"
     )
     input_composer.add_vpc_sub_automation(network_configuration=PUBLIC_PRIVATE_CONFIGURATION)
     input_composer.mock_input(mocker)
@@ -878,30 +878,30 @@ def test_invalid_vpc(mocker, vpc_id):
 
 
 @pytest.mark.parametrize(
-    "vpc_id, master_id, compute_id",
+    "vpc_id, head_node_id, compute_id",
     [
         ("vpc-12345678", "subnet-34567891", "subnet-45678912"),
         ("vpc-23456789", "subnet-34567891", "subnet-45678912"),
         ("vpc-34567891", "subnet-12345678", "subnet-23456789"),
     ],
 )
-def test_invalid_subnet(mocker, vpc_id, master_id, compute_id):
+def test_invalid_subnet(mocker, vpc_id, head_node_id, compute_id):
     with pytest.raises(StopIteration):
 
         assert_that(
-            general_wrapper_for_prompt_testing(mocker, vpc_id=vpc_id, master_id=master_id, compute_id=compute_id)
+            general_wrapper_for_prompt_testing(mocker, vpc_id=vpc_id, head_node_id=head_node_id, compute_id=compute_id)
         ).is_true()
 
 
 @pytest.mark.parametrize(
-    "vpc_id, master_id, compute_id",
+    "vpc_id, head_node_id, compute_id",
     [("vpc-12345678", "subnet-12345678", "subnet-23456789"), ("vpc-34567891", "subnet-45678912", "subnet-45678912")],
 )
-def test_valid_subnet(mocker, vpc_id, master_id, compute_id):
+def test_valid_subnet(mocker, vpc_id, head_node_id, compute_id):
     # valid subnets
 
     assert_that(
-        general_wrapper_for_prompt_testing(mocker, vpc_id=vpc_id, master_id=master_id, compute_id=compute_id)
+        general_wrapper_for_prompt_testing(mocker, vpc_id=vpc_id, head_node_id=head_node_id, compute_id=compute_id)
     ).is_true()
 
 
@@ -917,7 +917,7 @@ def test_hit_config_file(mocker, capsys, test_datadir):
 
 def test_invalid_p4d_head_node_type(mocker):
     with pytest.raises(StopIteration):
-        assert_that(general_wrapper_for_prompt_testing(mocker, master_instance="p4d.24xlarge")).is_true()
+        assert_that(general_wrapper_for_prompt_testing(mocker, head_node_instance="p4d.24xlarge")).is_true()
 
 
 def test_valid_p4d_compute_node_type(mocker):

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_bad_config_file/output.txt
@@ -51,7 +51,7 @@ Allowed values for VPC ID:
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Allowed values for Network Configuration:
-1. Master in a public subnet and compute fleet in a private subnet
-2. Master and compute fleet in the same public subnet
+1. Head node in a public subnet and compute fleet in a private subnet
+2. Head node and compute fleet in the same public subnet
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
@@ -46,12 +46,12 @@ Allowed values for VPC ID:
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Note:  2 subnet(s) is/are not listed, because the instance type is not in their availability zone(s)
-Allowed values for Master Subnet ID:
+Allowed values for head node Subnet ID:
   #  id               name      size  availability_zone
 ---  ---------------  ------  ------  -------------------
   1  subnet-45678912            4096  eu-west-1a
 Note:  2 subnet(s) is/are not listed, because the instance type is not in their availability zone(s)
-Allowed values for Compute Subnet ID:
+Allowed values for compute Subnet ID:
   #  id               name      size  availability_zone
 ---  ---------------  ------  ------  -------------------
   1  subnet-45678912            4096  eu-west-1a

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
@@ -45,12 +45,12 @@ Allowed values for VPC ID:
   2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
-Allowed values for Master Subnet ID:
+Allowed values for head node Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
   2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
-Allowed values for Compute Subnet ID:
+Allowed values for compute Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/output.txt
@@ -38,12 +38,12 @@ Allowed values for VPC ID:
   2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
-Allowed values for Master Subnet ID:
+Allowed values for head node Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
   2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
-Allowed values for Compute Subnet ID:
+Allowed values for compute Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_available_no_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_available_no_input_no_automation_no_errors_with_config_file/output.txt
@@ -28,12 +28,12 @@ Allowed values for VPC ID:
   2  vpc-bcdefghi  ParallelClusterVPC-20190624105051                    0
   3  vpc-cdefghij  default                                              3
   4  vpc-abdbabcb  ParallelClusterVPC-20190626095403                    1
-Allowed values for Master Subnet ID:
+Allowed values for head node Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-77777777  ParallelClusterPublicSubnet      256  cn-north-1a
   2  subnet-66666666  ParallelClusterPrivateSubnet    4096  cn-north-1a
-Allowed values for Compute Subnet ID:
+Allowed values for compute Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-77777777  ParallelClusterPublicSubnet      256  cn-north-1a

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_input_no_automation_no_errors_with_config_file/output.txt
@@ -45,12 +45,12 @@ Allowed values for VPC ID:
   2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
-Allowed values for Master Subnet ID:
+Allowed values for head node Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
   2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
-Allowed values for Compute Subnet ID:
+Allowed values for compute Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_region_env_overwrite_region_config/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_region_env_overwrite_region_config/output.txt
@@ -45,12 +45,12 @@ Allowed values for VPC ID:
   2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
-Allowed values for Master Subnet ID:
+Allowed values for head node Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
   2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
-Allowed values for Compute Subnet ID:
+Allowed values for compute Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
@@ -46,7 +46,7 @@ Allowed values for VPC ID:
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Allowed values for Network Configuration:
-1. Master in a public subnet and compute fleet in a private subnet
-2. Master and compute fleet in the same public subnet
+1. Head node in a public subnet and compute fleet in a private subnet
+2. Head node and compute fleet in the same public subnet
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
@@ -47,7 +47,7 @@ Allowed values for VPC ID:
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 There are no qualified subnets. Starting automatic creation of subnets...
 Allowed values for Network Configuration:
-1. Master in a public subnet and compute fleet in a private subnet
-2. Master and compute fleet in the same public subnet
+1. Head node in a public subnet and compute fleet in a private subnet
+2. Head node and compute fleet in the same public subnet
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_with_config_file/output.txt
@@ -46,7 +46,7 @@ Allowed values for VPC ID:
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Allowed values for Network Configuration:
-1. Master in a public subnet and compute fleet in a private subnet
-2. Master and compute fleet in the same public subnet
+1. Head node in a public subnet and compute fleet in a private subnet
+2. Head node and compute fleet in the same public subnet
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_unexisting_instance_type/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_unexisting_instance_type/output.txt
@@ -45,13 +45,13 @@ Allowed values for VPC ID:
   2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
-Allowed values for Master Subnet ID:
+Allowed values for head node Subnet ID:
   #  id               name      size  availability_zone
 ---  ---------------  ------  ------  -------------------
   1  subnet-34567891            4096  eu-west-1b
   2  subnet-45678912            4096  eu-west-1a
   3  subnet-56789123            4096  eu-west-1c
-Allowed values for Compute Subnet ID:
+Allowed values for compute Subnet ID:
   #  id               name      size  availability_zone
 ---  ---------------  ------  ------  -------------------
   1  subnet-34567891            4096  eu-west-1b

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
@@ -39,8 +39,8 @@ Allowed values for Operating System:
 5. ubuntu1604
 6. ubuntu1804
 Allowed values for Network Configuration:
-1. Master in a public subnet and compute fleet in a private subnet
-2. Master and compute fleet in the same public subnet
+1. Head node in a public subnet and compute fleet in a private subnet
+2. Head node and compute fleet in the same public subnet
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
@@ -40,8 +40,8 @@ Allowed values for Operating System:
 6. ubuntu1804
 There are no VPC for the given region. Starting automatic creation of VPC and subnets...
 Allowed values for Network Configuration:
-1. Master in a public subnet and compute fleet in a private subnet
-2. Master and compute fleet in the same public subnet
+1. Head node in a public subnet and compute fleet in a private subnet
+2. Head node and compute fleet in the same public subnet
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
@@ -40,8 +40,8 @@ Allowed values for Operating System:
 6. ubuntu1804
 There are no VPC for the given region. Starting automatic creation of VPC and subnets...
 Allowed values for Network Configuration:
-1. Master in a public subnet and compute fleet in a private subnet
-2. Master and compute fleet in the same public subnet
+1. Head node in a public subnet and compute fleet in a private subnet
+2. Head node and compute fleet in the same public subnet
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 Configuration file written to {{ CONFIG_FILE }}
 You can edit your configuration file or simply run 'pcluster create -c {{ CONFIG_FILE }} cluster-name' to create your cluster

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/output.txt
@@ -45,13 +45,13 @@ Allowed values for VPC ID:
   2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
-Allowed values for Master Subnet ID:
+Allowed values for head node Subnet ID:
   #  id               name      size  availability_zone
 ---  ---------------  ------  ------  -------------------
   1  subnet-34567891            4096  eu-west-1b
   2  subnet-45678912            4096  eu-west-1a
   3  subnet-56789123            4096  eu-west-1c
-Allowed values for Compute Subnet ID:
+Allowed values for compute Subnet ID:
   #  id               name      size  availability_zone
 ---  ---------------  ------  ------  -------------------
   1  subnet-34567891            4096  eu-west-1b

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_region_arg_with_config_file/output.txt
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_region_arg_with_config_file/output.txt
@@ -28,12 +28,12 @@ Allowed values for VPC ID:
   2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
-Allowed values for Master Subnet ID:
+Allowed values for head node Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
   2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
-Allowed values for Compute Subnet ID:
+Allowed values for compute Subnet ID:
   #  id               name                            size  availability_zone
 ---  ---------------  ----------------------------  ------  -------------------
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -527,9 +527,9 @@ def test_get_supported_architectures_for_instance_type(mocker, instance_type, su
 @pytest.mark.parametrize(
     "node_type, expected_fallback, expected_response, expected_instances",
     [
-        (utils.NodeType.master, False, {"Reservations": [{"Groups": [], "Instances": [{}]}]}, 1),
-        (utils.NodeType.master, True, {"Reservations": [{"Groups": [], "Instances": [{}]}]}, 1),
-        (utils.NodeType.master, True, {"Reservations": []}, 0),
+        (utils.NodeType.head_node, False, {"Reservations": [{"Groups": [], "Instances": [{}]}]}, 1),
+        (utils.NodeType.head_node, True, {"Reservations": [{"Groups": [], "Instances": [{}]}]}, 1),
+        (utils.NodeType.head_node, True, {"Reservations": []}, 0),
         (utils.NodeType.compute, False, {"Reservations": [{"Groups": [], "Instances": [{}, {}, {}]}]}, 3),
         (utils.NodeType.compute, True, {"Reservations": [{"Groups": [], "Instances": [{}, {}]}]}, 2),
         (utils.NodeType.compute, True, {"Reservations": []}, 0),
@@ -570,7 +570,7 @@ def test_describe_cluster_instances(boto3_stubber, node_type, expected_fallback,
 
 
 @pytest.mark.parametrize(
-    "master_instance, expected_ip, error",
+    "head_node_instance, expected_ip, error",
     [
         (
             {
@@ -594,17 +594,17 @@ def test_describe_cluster_instances(boto3_stubber, node_type, expected_fallback,
     ],
     ids=["public_ip", "private_ip", "stopped"],
 )
-def test_get_master_server_ips(mocker, master_instance, expected_ip, error):
+def test_get_head_node_ips(mocker, head_node_instance, expected_ip, error):
     describe_cluster_instances_mock = mocker.patch(
-        "pcluster.utils.describe_cluster_instances", return_value=[master_instance]
+        "pcluster.utils.describe_cluster_instances", return_value=[head_node_instance]
     )
 
     if error:
         with pytest.raises(SystemExit, match=error):
-            utils._get_master_server_ip("stack-name")
+            utils._get_head_node_ip("stack-name")
     else:
-        assert_that(utils._get_master_server_ip("stack-name")).is_equal_to(expected_ip)
-        describe_cluster_instances_mock.assert_called_with("stack-name", node_type=utils.NodeType.master)
+        assert_that(utils._get_head_node_ip("stack-name")).is_equal_to(expected_ip)
+        describe_cluster_instances_mock.assert_called_with("stack-name", node_type=utils.NodeType.head_node)
 
 
 @pytest.mark.parametrize(

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -7,7 +7,7 @@
       "Type": "AWS::EC2::KeyPair::KeyName"
     },
     "MasterInstanceType": {
-      "Description": "MasterServer EC2 instance type",
+      "Description": "Head node EC2 instance type",
       "Type": "String",
       "Default": "t2.micro",
       "ConstraintDescription": "Must be a valid EC2 instance type, with support for HVM."
@@ -72,7 +72,7 @@
       "AllowedPattern": "^(NONE|standard|io1|io2|gp2|st1|sc1)((,|, )(NONE|standard|io1|io2|gp2|st1|sc1)){4}$"
     },
     "MasterSubnetId": {
-      "Description": "ID of the Subnet you want to provision the Master server into",
+      "Description": "ID of the Subnet you want to provision the head node into",
       "Type": "AWS::EC2::Subnet::Id"
     },
     "AvailabilityZone": {
@@ -265,7 +265,7 @@
       "Default": "NONE,NONE,NONE,NONE,NONE"
     },
     "MasterRootVolumeSize": {
-      "Description": "Size of MasterServer EBS root volume in GB",
+      "Description": "Size of head node EBS root volume in GB",
       "Type": "Number",
       "Default": "25",
       "MinValue": "25"
@@ -337,7 +337,7 @@
       "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },
     "Cores": {
-      "Description": "Comma seperated string of [master cores], [compute cores], [master instance type supports disabling hyperthreading via CPU options], [compute instance type supports disabling hyperthreading via CPU options].",
+      "Description": "Comma seperated string of [head node cores], [compute cores], [head node instance type supports disabling hyperthreading via CPU options], [compute instance type supports disabling hyperthreading via CPU options].",
       "Type": "CommaDelimitedList",
       "Default": "NONE,NONE,NONE,NONE"
     },
@@ -370,7 +370,7 @@
       "Default": "true,14"
     },
     "NetworkInterfacesCount": {
-      "Description": "Comma separated string of [master network interfaces], [compute network interfaces].",
+      "Description": "Comma separated string of [head node network interfaces], [compute network interfaces].",
       "Type": "CommaDelimitedList",
       "Default": "1,1"
     }
@@ -1935,7 +1935,7 @@
     "MasterSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "Enable access to the Master host",
+        "GroupDescription": "Enable access to the head node",
         "VpcId": {
           "Ref": "VPCId"
         },
@@ -2084,7 +2084,7 @@
     "MasterENI": {
       "Type": "AWS::EC2::NetworkInterface",
       "Properties": {
-        "Description": "AWS ParallelCluster Master Server",
+        "Description": "AWS ParallelCluster head node interface",
         "SubnetId": {
           "Ref": "MasterSubnetId"
         },
@@ -4093,7 +4093,7 @@
   },
   "Outputs": {
     "ClusterUser": {
-      "Description": "Username to login to Master host",
+      "Description": "Username to login to head node",
       "Value": {
         "Fn::FindInMap": [
           "OSFeatures",
@@ -4105,7 +4105,7 @@
       }
     },
     "MasterPrivateIP": {
-      "Description": "Private IP Address of the Master host",
+      "Description": "Private IP Address of the head node",
       "Value": {
         "Fn::GetAtt": [
           "MasterServerSubstack",
@@ -4114,7 +4114,7 @@
       }
     },
     "MasterPublicIP": {
-      "Description": "Public IP Address of the Master host",
+      "Description": "Public IP Address of the head node",
       "Value": {
         "Fn::GetAtt": [
           "MasterServerSubstack",

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -332,7 +332,7 @@
       "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },
     "EFSOptions": {
-      "Description": "Comma separated list of EFS related options, 9 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,exists_valid_master_mt,exists_valid_compute_mt]",
+      "Description": "Comma separated list of EFS related options, 9 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,exists_valid_head_node_mt,exists_valid_compute_mt]",
       "Type": "String",
       "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },

--- a/cloudformation/cw-dashboard-substack.cfn.yaml
+++ b/cloudformation/cw-dashboard-substack.cfn.yaml
@@ -53,10 +53,10 @@ Parameters:
     Type: String
   {#- Head Node parameters #}
   MasterInstanceId:
-    Description: ID of the Master instance
+    Description: ID of the head node instance
     Type: AWS::EC2::Instance::Id
   MasterPrivateIP:
-    Description: Private IP of the Master instance
+    Description: Private IP of the head node instance
     Type: String
   {#- EBS parameters #}
   EBSVolumesIds:

--- a/cloudformation/efs-substack.cfn.json
+++ b/cloudformation/efs-substack.cfn.json
@@ -247,7 +247,7 @@
       "Type": "CommaDelimitedList"
     },
     "MasterSubnetId": {
-      "Description": "Master subnet id for master mount target",
+      "Description": "Head node subnet id for head node mount target",
       "Type": "String"
     }
   },

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -696,7 +696,7 @@ Resources:
               command: chef-client --local-mode --config /etc/chef/client.rb --log_level
                 info --logfile /var/log/chef-client.log --force-formatter --no-color
                 --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist
-                aws-parallelcluster::update_master
+                aws-parallelcluster::update_head_node
               cwd: /etc/chef
   UpdateWaiterCustomResource:
     Type: AWS::CloudFormation::CustomResource

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -707,17 +707,17 @@ Resources:
     Condition: HasUpdateWaiterFunction
 Outputs:
   MasterInstanceID:
-    Description: ID of the Master instance
+    Description: ID of the head node instance
     Value: !Ref 'MasterServer'
   MasterPrivateIP:
-    Description: Private IP Address of the Master host
+    Description: Private IP Address of the head node
     Value: !GetAtt 'MasterServer.PrivateIp'
   MasterPublicIP:
-    Description: Public IP Address of the Master host
+    Description: Public IP Address of the head node
     Value: !GetAtt 'MasterServer.PublicIp'
     Condition: HasMasterPublicIp
   MasterPrivateDnsName:
-    Description: Private DNS name of the Master host
+    Description: Private DNS name of the head node
     Value: !GetAtt 'MasterServer.PrivateDnsName'
 Metadata:
   DependsOnCustomResources: !Ref 'DependsOnCustomResources'

--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -706,7 +706,7 @@ included the CloudFormation stack outputs.
 
 ### Execute Remote Commands
 
-To execute remote commands or scripts on the Master instance of the cluster under test, the `RemoteCommandExecutor`
+To execute remote commands or scripts on the head node of the cluster under test, the `RemoteCommandExecutor`
 class can be used. It simply requires a valid `Cluster` object to be initialized and it offers some utility
 methods to execute remote commands and scripts as shown in the example below:
 

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -160,7 +160,7 @@ class Cluster:
         return self.config.get("aws", "aws_region_name", fallback="us-east-1")
 
     @property
-    def master_ip(self):
+    def head_node_ip(self):
         """Return the public ip of the cluster master node."""
         if "MasterPublicIP" in self.cfn_outputs:
             return self.cfn_outputs["MasterPublicIP"]

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -161,7 +161,7 @@ class Cluster:
 
     @property
     def head_node_ip(self):
-        """Return the public ip of the cluster master node."""
+        """Return the public ip of the cluster head node."""
         if "MasterPublicIP" in self.cfn_outputs:
             return self.cfn_outputs["MasterPublicIP"]
         else:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -561,7 +561,7 @@ def vpc_stacks(cfn_stacks_factory, request):
 
     for region in regions:
         # Creating private_subnet_different_cidr in a different AZ for test_efs
-        # To-do: isolate this logic and create a compute subnet in different AZ than master in test_efs
+        # To-do: isolate this logic and create a compute subnet in different AZ than head node in test_efs
 
         # if region has a non-empty list in AVAILABILITY_ZONE_OVERRIDES, select a subset of those AZs
         credential = request.config.getoption("credential")

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -25,7 +25,7 @@ class RemoteCommandExecutionError(Exception):
 
 
 class RemoteCommandExecutor:
-    """Execute remote commands on the cluster master node."""
+    """Execute remote commands on the cluster head node."""
 
     def __init__(self, cluster, username=None):
         if not username:
@@ -57,7 +57,7 @@ class RemoteCommandExecutor:
         timeout=None,
     ):
         """
-        Execute remote command on the cluster master node.
+        Execute remote command on the cluster head node.
 
         :param command: command to execute.
         :param log_error: log errors.
@@ -95,9 +95,9 @@ class RemoteCommandExecutor:
         self, script_file, args=None, log_error=True, additional_files=None, hide=False, timeout=None, run_as_root=False
     ):
         """
-        Execute a script remotely on the cluster master node.
+        Execute a script remotely on the cluster head node.
 
-        Script is copied to the master home dir before being executed.
+        Script is copied to the head node home dir before being executed.
         :param script_file: local path to the script to execute remotely.
         :param args: args to pass to the script when invoked.
         :param log_error: log errors.

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -31,12 +31,12 @@ class RemoteCommandExecutor:
         if not username:
             username = get_username_for_os(cluster.os)
         self.__connection = Connection(
-            host=cluster.master_ip,
+            host=cluster.head_node_ip,
             user=username,
             forward_agent=False,
             connect_kwargs={"key_filename": [cluster.ssh_key]},
         )
-        self.__user_at_hostname = "{0}@{1}".format(username, cluster.master_ip)
+        self.__user_at_hostname = "{0}@{1}".format(username, cluster.head_node_ip)
 
     def __del__(self):
         try:

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init.py
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init.py
@@ -72,7 +72,7 @@ def test_install_args_quotes(region, pcluster_config_reader, clusters_factory, s
     init_config_file = pcluster_config_reader(bucket_name=bucket_name)
     cluster = clusters_factory(init_config_file)
 
-    # Check master and compute node status
+    # Check head node and compute node status
     _assert_server_status(cluster)
 
 

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -29,9 +29,9 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_SHARED_DIR = "/shared"
 DEFAULT_RETENTION_DAYS = 14
 NODE_CONFIG_PATH = "/etc/chef/dna.json"
-MASTER_NODE_ROLE_NAME = "MasterServer"
+HEAD_NODE_ROLE_NAME = "MasterServer"
 COMPUTE_NODE_ROLE_NAME = "ComputeFleet"
-NODE_ROLE_NAMES = {MASTER_NODE_ROLE_NAME, COMPUTE_NODE_ROLE_NAME}
+NODE_ROLE_NAMES = {HEAD_NODE_ROLE_NAME, COMPUTE_NODE_ROLE_NAME}
 
 
 def _get_log_group_name_for_cluster(cluster_name):
@@ -95,8 +95,8 @@ class CloudWatchLoggingClusterState:
         self.shared_dir = self._get_shared_dir(shared_dir)
         self.remote_command_executor = RemoteCommandExecutor(self.cluster)
         self.scheduler_commands = get_scheduler_commands(self.scheduler, self.remote_command_executor)
-        self._relevant_logs = {MASTER_NODE_ROLE_NAME: [], COMPUTE_NODE_ROLE_NAME: []}
-        self._cluster_log_state = {MASTER_NODE_ROLE_NAME: {}, COMPUTE_NODE_ROLE_NAME: {}}
+        self._relevant_logs = {HEAD_NODE_ROLE_NAME: [], COMPUTE_NODE_ROLE_NAME: []}
+        self._cluster_log_state = {HEAD_NODE_ROLE_NAME: {}, COMPUTE_NODE_ROLE_NAME: {}}
         self._set_cluster_log_state()
 
     @property
@@ -115,7 +115,7 @@ class CloudWatchLoggingClusterState:
     def get_logs_state(self):
         """Get the state of the log files applicable to each of the cluster's EC2 instances."""
         desired_keys = ["hostname", "instance_id", "node_role", "agent_status", "logs"]
-        states = [{key: self._cluster_log_state.get(MASTER_NODE_ROLE_NAME).get(key) for key in desired_keys}]
+        states = [{key: self._cluster_log_state.get(HEAD_NODE_ROLE_NAME).get(key) for key in desired_keys}]
         states.extend(
             [
                 {key: host_dict[key] for key in desired_keys}
@@ -145,11 +145,11 @@ class CloudWatchLoggingClusterState:
         no_digits = base_os.rstrip(string.digits)
         return translations.get(no_digits, no_digits)
 
-    def _set_master_instance(self, instance):
-        """Set the master instance field in self.cluster_log_state."""
-        self._cluster_log_state.get(MASTER_NODE_ROLE_NAME).update(
+    def _set_head_node_instance(self, instance):
+        """Set the head node instance field in self.cluster_log_state."""
+        self._cluster_log_state.get(HEAD_NODE_ROLE_NAME).update(
             {
-                "node_role": MASTER_NODE_ROLE_NAME,
+                "node_role": HEAD_NODE_ROLE_NAME,
                 "hostname": instance.get("PrivateDnsName"),
                 "instance_id": instance.get("InstanceId"),
             }
@@ -157,7 +157,7 @@ class CloudWatchLoggingClusterState:
 
     def _add_compute_instance(self, instance):
         """Update the cluster's log state by adding a compute node."""
-        compute_hostname = self._run_command_on_master(
+        compute_hostname = self._run_command_on_head_node(
             "ssh -o StrictHostKeyChecking=no -q {} hostname -f".format(instance.get("PrivateDnsName"))
         )
         self._cluster_log_state[COMPUTE_NODE_ROLE_NAME][compute_hostname] = {
@@ -173,24 +173,24 @@ class CloudWatchLoggingClusterState:
             if tags.get("ClusterName", "") != self.cluster.name:
                 continue
             elif tags.get("Name", "") == "Master":
-                self._set_master_instance(instance)
+                self._set_head_node_instance(instance)
             else:
                 self._add_compute_instance(instance)
         LOGGER.debug("After getting initial cluster state:\n{0}".format(self._dump_cluster_log_state()))
 
-    def _read_log_configs_from_master(self):
+    def _read_log_configs_from_head_node(self):
         """Read the log configs file at /usr/local/etc/cloudwatch_log_files.json."""
         read_cmd = "cat /usr/local/etc/cloudwatch_log_files.json"
-        config = json.loads(self._run_command_on_master(read_cmd))
+        config = json.loads(self._run_command_on_head_node(read_cmd))
         return config.get("log_configs")
 
-    def _read_master_node_config(self):
-        """Read the node configuration JSON file at NODE_CONFIG_PATH on the master node."""
+    def _read_head_node_config(self):
+        """Read the node configuration JSON file at NODE_CONFIG_PATH on the head node."""
         read_cmd = "cat {0}".format(NODE_CONFIG_PATH)
-        master_node_config = json.loads(self._run_command_on_master(read_cmd)).get("cfncluster", {})
-        assert_that(master_node_config).is_not_empty()
-        LOGGER.info("DNA config read from master node: {0}".format(_dump_json(master_node_config)))
-        return master_node_config
+        head_node_config = json.loads(self._run_command_on_head_node(read_cmd)).get("cfncluster", {})
+        assert_that(head_node_config).is_not_empty()
+        LOGGER.info("DNA config read from head node: {0}".format(_dump_json(head_node_config)))
+        return head_node_config
 
     def _read_compute_node_config(self):
         """Read the node configuration JSON file at NODE_CONFIG_PATH on a compute node."""
@@ -209,7 +209,7 @@ class CloudWatchLoggingClusterState:
     def _read_node_configs(self):
         """Return a dict mapping node role names to the config at NODE_CONFIG_PATH."""
         return {
-            MASTER_NODE_ROLE_NAME: self._read_master_node_config(),
+            HEAD_NODE_ROLE_NAME: self._read_head_node_config(),
             COMPUTE_NODE_ROLE_NAME: self._read_compute_node_config(),
         }
 
@@ -273,7 +273,7 @@ class CloudWatchLoggingClusterState:
         """Populate self._relevant_logs with the entries of logs."""
         # When the scheduler is AWS Batch, only keep log that whose config's node_role value is MasterServer, since
         # Batch doesn't have compute nodes in the traditional sense.
-        desired_node_roles = {MASTER_NODE_ROLE_NAME} if self.scheduler == "awsbatch" else NODE_ROLE_NAMES
+        desired_node_roles = {HEAD_NODE_ROLE_NAME} if self.scheduler == "awsbatch" else NODE_ROLE_NAMES
         for log in logs:
             for node_role in set(log.get("node_roles")) & desired_node_roles:
                 self._relevant_logs[node_role].append(self._clean_log_config(log))
@@ -286,8 +286,8 @@ class CloudWatchLoggingClusterState:
 
     def _create_log_entries_for_nodes(self):
         """Create an entry for each relevant log in self._cluster_log_state."""
-        self._cluster_log_state[MASTER_NODE_ROLE_NAME]["logs"] = {
-            log.get("file_path"): log for log in self._relevant_logs.get(MASTER_NODE_ROLE_NAME)
+        self._cluster_log_state[HEAD_NODE_ROLE_NAME]["logs"] = {
+            log.get("file_path"): log for log in self._relevant_logs.get(HEAD_NODE_ROLE_NAME)
         }
         for _hostname, compute_instance_dict in self._cluster_log_state.get(COMPUTE_NODE_ROLE_NAME).items():
             compute_instance_dict["logs"] = {
@@ -296,19 +296,19 @@ class CloudWatchLoggingClusterState:
 
     def _get_relevant_logs(self):
         """Get subset of all log configs that apply to this cluster's scheduler/os combo."""
-        logs = self._read_log_configs_from_master()
+        logs = self._read_log_configs_from_head_node()
         self._filter_logs(logs)
         self._create_log_entries_for_nodes()
         LOGGER.debug("After populating relevant logs:\n{0}".format(self._dump_cluster_log_state()))
 
-    def _run_command_on_master(self, cmd):
+    def _run_command_on_head_node(self, cmd):
         """Run cmd on cluster's MasterServer."""
         return self.remote_command_executor.run_remote_command(cmd, timeout=60).stdout.strip()
 
     def _run_command_on_computes(self, cmd, assert_success=True):
         """Run cmd on all computes in the cluster."""
         # Create directory in self.shared_dir to direct outputs to
-        out_dir = Path(self._run_command_on_master("mktemp -d -p {shared_dir}".format(shared_dir=self.shared_dir)))
+        out_dir = Path(self._run_command_on_head_node("mktemp -d -p {shared_dir}".format(shared_dir=self.shared_dir)))
         redirect = " > {out_dir}/$(hostname -f) ".format(out_dir=out_dir)
         remote_cmd = cmd.format(redirect=redirect)
 
@@ -321,17 +321,17 @@ class CloudWatchLoggingClusterState:
 
         # Read the output and map it to the hostname
         outputs = {}
-        result_files = self._run_command_on_master("ls {0}".format(out_dir))
+        result_files = self._run_command_on_head_node("ls {0}".format(out_dir))
         for hostname in result_files.split():
-            outputs[hostname] = self._run_command_on_master("sudo cat {0}".format(out_dir / hostname))
-        self._run_command_on_master("rm -rf {0}".format(out_dir))
+            outputs[hostname] = self._run_command_on_head_node("sudo cat {0}".format(out_dir / hostname))
+        self._run_command_on_head_node("rm -rf {0}".format(out_dir))
         return outputs
 
-    def _populate_master_log_existence(self):
+    def _populate_head_node_log_existence(self):
         """Figure out which of the relevant logs for the MasterServer don't exist."""
-        for log_path, log_dict in self._cluster_log_state.get(MASTER_NODE_ROLE_NAME).get("logs").items():
+        for log_path, log_dict in self._cluster_log_state.get(HEAD_NODE_ROLE_NAME).get("logs").items():
             cmd = "[ -f {path} ] && echo exists || echo does not exist".format(path=log_path)
-            output = self._run_command_on_master(cmd)
+            output = self._run_command_on_head_node(cmd)
             log_dict["exists"] = output == "exists"
 
     def _populate_compute_log_existence(self):
@@ -354,16 +354,16 @@ class CloudWatchLoggingClusterState:
 
     def _populate_log_existence(self):
         """Figure out which of the relevant logs for each node type don't exist."""
-        self._populate_master_log_existence()
+        self._populate_head_node_log_existence()
         self._populate_compute_log_existence()
         LOGGER.debug("After populating log existence:\n{0}".format(self._dump_cluster_log_state()))
 
-    def _populate_master_log_emptiness_and_tail(self):
+    def _populate_head_node_log_emptiness_and_tail(self):
         """Figure out which of the relevant logs for the MasterServer are empty."""
-        for log_path, log_dict in self._cluster_log_state.get(MASTER_NODE_ROLE_NAME).get("logs").items():
+        for log_path, log_dict in self._cluster_log_state.get(HEAD_NODE_ROLE_NAME).get("logs").items():
             if not log_dict.get("exists"):
                 continue
-            output = self._run_command_on_master("sudo tail -n 1 {path}".format(path=log_path))
+            output = self._run_command_on_head_node("sudo tail -n 1 {path}".format(path=log_path))
             log_dict["is_empty"] = output == ""
             log_dict["tail"] = output
 
@@ -392,15 +392,15 @@ class CloudWatchLoggingClusterState:
 
     def _populate_log_emptiness_and_tail(self):
         """Figure out which of the relevant logs for each node type are empty."""
-        self._populate_master_log_emptiness_and_tail()
+        self._populate_head_node_log_emptiness_and_tail()
         self._populate_compute_log_emptiness_and_tail()
         LOGGER.debug("After populating log emptiness and tails:\n{0}".format(self._dump_cluster_log_state()))
 
-    def _populate_master_agent_status(self):
+    def _populate_head_node_agent_status(self):
         """Get the cloudwatch agent's status for the MasterServer."""
         status_cmd = "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status"
-        status = json.loads(self._run_command_on_master(status_cmd))
-        self._cluster_log_state[MASTER_NODE_ROLE_NAME]["agent_status"] = status.get("status")
+        status = json.loads(self._run_command_on_head_node(status_cmd))
+        self._cluster_log_state[HEAD_NODE_ROLE_NAME]["agent_status"] = status.get("status")
 
     def _populate_compute_agent_status(self):
         """Get the cloudwatch agent's status for all the compute nodes in the cluster."""
@@ -414,7 +414,7 @@ class CloudWatchLoggingClusterState:
 
     def _populate_agent_status(self):
         """Get the cloudwatch agent's status for all the nodes in the cluster."""
-        self._populate_master_agent_status()
+        self._populate_head_node_agent_status()
         self._populate_compute_agent_status()
         LOGGER.debug("After populating agent statuses:\n{0}".format(self._dump_cluster_log_state()))
 

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -541,7 +541,7 @@ class TorqueCommands(SchedulerCommands):
 
     @retry(retry_on_result=lambda result: "offline" not in result, wait_fixed=seconds(5), stop_max_delay=minutes(5))
     def wait_for_locked_node(self):  # noqa: D102
-        # discard the first node since that is the master server
+        # discard the first node since that is the head node
         return self._remote_command_executor.run_remote_command(r'pbsnodes | grep -e "\sstate = " | tail -n +2').stdout
 
     def get_node_cores(self):

--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -220,17 +220,17 @@ def orchestrate_pcluster_configure_stages(
         {"prompt": r"Operating System \[alinux2\]: ", "response": os, "skip_for_batch": True},
         {"prompt": fr"Minimum cluster size \({compute_units}\) \[0\]: ", "response": "1"},
         {"prompt": fr"Maximum cluster size \({compute_units}\) \[10\]: ", "response": ""},
-        {"prompt": r"Master instance type \[t2\.micro\]: ", "response": instance},
+        {"prompt": r"Head node instance type \[t2\.micro\]: ", "response": instance},
         {"prompt": r"Compute instance type \[t2\.micro\]: ", "response": instance, "skip_for_batch": True},
         {"prompt": r"Automate VPC creation\? \(y/n\) \[n\]: ", "response": "n"},
         {"prompt": r"VPC ID \[vpc-.+\]: ", "response": vpc_id},
         {"prompt": r"Automate Subnet creation\? \(y/n\) \[y\]: ", "response": "n"},
         {
-            "prompt": fr"{omitted_note}Master Subnet ID \[subnet-.+\]: ",
+            "prompt": fr"{omitted_note}head node Subnet ID \[subnet-.+\]: ",
             "response": headnode_subnet_id,
         },
         {
-            "prompt": fr"{omitted_note}Compute Subnet ID \[{default_compute_subnet}\]: ",
+            "prompt": fr"{omitted_note}compute Subnet ID \[{default_compute_subnet}\]: ",
             "response": compute_subnet_id,
         },
     ]

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -76,7 +76,7 @@ def _assert_head_node_is_running(region, cluster):
     logging.info("Asserting the head node is running")
     head_node_state = (
         boto3.client("ec2", region_name=region)
-        .describe_instances(Filters=[{"Name": "ip-address", "Values": [cluster.master_ip]}])
+        .describe_instances(Filters=[{"Name": "ip-address", "Values": [cluster.head_node_ip]}])
         .get("Reservations")[0]
         .get("Instances")[0]
         .get("State")

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -119,13 +119,13 @@ def _test_dcv_configuration(
 
     # add ssh key to jenkins user known hosts file to avoid ssh keychecking prompt
     host_keys_file = operating_system.path.expanduser("~/.ssh/known_hosts")
-    add_keys_to_known_hosts(cluster.master_ip, host_keys_file)
+    add_keys_to_known_hosts(cluster.head_node_ip, host_keys_file)
 
     try:
         result = run_command(["pcluster", "dcv", "connect", cluster.name, "--show-url"], env=env)
     finally:
         # remove ssh key from jenkins user known hosts file
-        remove_keys_from_known_hosts(cluster.master_ip, host_keys_file, env=env)
+        remove_keys_from_known_hosts(cluster.head_node_ip, host_keys_file, env=env)
 
     assert_that(result.stdout).matches(
         r"Please use the following one-time URL in your browser within 30 seconds:\n"

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
@@ -85,8 +85,8 @@ def _test_disable_hyperthreading_settings(
     expected_cpus_per_instance = slots_per_instance // 2 if hyperthreading_disabled else slots_per_instance
     expected_threads_per_core = 1 if hyperthreading_disabled else 2
 
-    # Test disable hyperthreading on Master
-    logging.info("Test Disable Hyperthreading on Master")
+    # Test disable hyperthreading on head node
+    logging.info("Test Disable Hyperthreading on head node")
     result = remote_command_executor.run_remote_command("lscpu")
     if partition:
         # If partition is supplied, assume this is HIT setting where ht settings are at the queue level

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
@@ -90,7 +90,7 @@ def _test_disable_hyperthreading_settings(
     result = remote_command_executor.run_remote_command("lscpu")
     if partition:
         # If partition is supplied, assume this is HIT setting where ht settings are at the queue level
-        # In this case, ht is not disabled on master
+        # In this case, ht is not disabled on head node
         assert_that(result.stdout).matches(r"Thread\(s\) per core:\s+{0}".format(2))
         _assert_active_cpus(result.stdout, slots_per_instance)
     else:

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -115,7 +115,7 @@ def _test_efa_installation(scheduler_commands, remote_command_executor, efa_inst
     else:
         assert_that(result.stdout).does_not_contain("1d0f:efa0")
 
-    # Check EFA interface not present on master
+    # Check EFA interface not present on head node
     result = remote_command_executor.run_remote_command("lspci -n")
     assert_that(result.stdout).does_not_contain("1d0f:efa0")
 

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
@@ -35,7 +35,7 @@ def test_intel_hpc(region, scheduler, instance, os, pcluster_config_reader, clus
 
 
 def _test_intel_clck(remote_command_executor, scheduler_commands, test_datadir, os):
-    # Install Intel Cluster Checker CLCK Master
+    # Install Intel Cluster Checker CLCK on head node
     logging.info("Installing Intel Cluster Checker")
     remote_command_executor.run_remote_script(str(test_datadir / "install_clck.sh"), hide=False)
 

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
@@ -27,7 +27,7 @@ def test_multiple_nics(scheduler, region, pcluster_config_reader, clusters_facto
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
 
-    _test_master_node_nics(remote_command_executor, region)
+    _test_head_node_nics(remote_command_executor, region)
     _test_compute_node_nics(cluster, region, remote_command_executor, scheduler_commands)
 
 
@@ -40,16 +40,16 @@ def _get_private_ip_addresses(instance_id, region, remote_command_executor):
     return result.stdout.strip().split("\n")
 
 
-def _test_master_node_nics(remote_command_executor, region):
-    # On the master node we just check that all the private IPs have been assigned to NICs
-    master_instance_id = remote_command_executor.run_remote_command(
+def _test_head_node_nics(remote_command_executor, region):
+    # On the head node we just check that all the private IPs have been assigned to NICs
+    head_node_instance_id = remote_command_executor.run_remote_command(
         "curl http://169.254.169.254/latest/meta-data/instance-id"
     ).stdout
 
-    master_ip_addresses = _get_private_ip_addresses(master_instance_id, region, remote_command_executor)
+    head_node_ip_addresses = _get_private_ip_addresses(head_node_instance_id, region, remote_command_executor)
     ip_a_result = remote_command_executor.run_remote_command("ip a").stdout
 
-    for ip_address in master_ip_addresses:
+    for ip_address in head_node_ip_addresses:
         assert_that(ip_a_result).matches(".* inet {0}.*".format(ip_address))
 
 

--- a/tests/integration-tests/tests/runtime_bake/test_runtime_bake.py
+++ b/tests/integration-tests/tests/runtime_bake/test_runtime_bake.py
@@ -40,7 +40,7 @@ def test_runtime_bake(scheduler, os, region, pcluster_config_reader, clusters_fa
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     # Verify no chef.io endpoint is called in cloud-init-output log to download chef installer or chef packages"""
-    # on master
+    # on head node
     remote_command_executor.run_remote_script(str(test_datadir / "verify_chef_download.sh"))
     # on compute
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)

--- a/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/cluster-check.sh
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/cluster-check.sh
@@ -19,7 +19,7 @@
 # minutes, one of which (hopefully) requires scaling (note that
 # scaling is currently not tested on Torque, because it's too big of a
 # pain to determine how many slots per node are on a Torque compute
-# node from the master node).
+# node from the head node).
 #
 
 # Usage:

--- a/tests/integration-tests/tests/schedulers/test_torque.py
+++ b/tests/integration-tests/tests/schedulers/test_torque.py
@@ -192,7 +192,7 @@ def _test_dynamic_cluster_limits(remote_command_executor, max_queue_size, max_sl
 
     # Make sure cluster is scaled to 0 when this test starts
     assert_that(torque_commands.compute_nodes_count()).is_equal_to(0)
-    # sleeping for 1 second to give time to sqswatcher to reconfigure the master with np = max_nodes * node_slots
+    # sleeping for 1 second to give time to sqswatcher to reconfigure the head node with np = max_nodes * node_slots
     # operation that is performed right after sqswatcher removes the compute nodes from the scheduler
     time.sleep(1)
     _assert_scheduler_configuration(remote_command_executor, torque_commands, max_slots, max_queue_size)

--- a/tests/integration-tests/tests/storage/snapshots_factory.py
+++ b/tests/integration-tests/tests/storage/snapshots_factory.py
@@ -18,7 +18,7 @@ from fabric import Connection
 from retrying import retry
 from utils import random_alphanumeric
 
-SnapshotConfig = namedtuple("ClusterConfig", ["ssh_key", "key_name", "vpc_id", "master_subnet_id"])
+SnapshotConfig = namedtuple("ClusterConfig", ["ssh_key", "key_name", "vpc_id", "head_node_subnet_id"])
 
 
 class EBSSnapshotsFactory:
@@ -84,7 +84,7 @@ class EBSSnapshotsFactory:
 
         self.security_group_id = self._get_security_group_id()
 
-        subnet = self.ec2.Subnet(self.config.master_subnet_id)
+        subnet = self.ec2.Subnet(self.config.head_node_subnet_id)
 
         # Create a new volume and attach to the instance
         self.volume = self._create_volume(subnet)

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -13,13 +13,13 @@ from utils import random_alphanumeric
 
 
 def verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands):
-    master_file = random_alphanumeric()
+    head_node_file = random_alphanumeric()
     compute_file = random_alphanumeric()
     remote_command_executor.run_remote_command(
-        "touch {mount_dir}/{master_file}".format(mount_dir=mount_dir, master_file=master_file)
+        "touch {mount_dir}/{head_node_file}".format(mount_dir=mount_dir, head_node_file=head_node_file)
     )
-    job_command = "cat {mount_dir}/{master_file} && touch {mount_dir}/{compute_file}".format(
-        mount_dir=mount_dir, master_file=master_file, compute_file=compute_file
+    job_command = "cat {mount_dir}/{head_node_file} && touch {mount_dir}/{compute_file}".format(
+        mount_dir=mount_dir, head_node_file=head_node_file, compute_file=compute_file
     )
 
     result = scheduler_commands.submit_command(job_command)

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -223,11 +223,11 @@ def _test_efs_correctly_mounted(remote_command_executor, mount_dir):
 
 def _assert_subnet_az_relations(region, vpc_stack, expected_in_same_az):
     vpc = get_vpc_snakecase_value(vpc_stack)
-    master_subnet_id = vpc["public_subnet_id"]
+    head_node_subnet_id = vpc["public_subnet_id"]
     compute_subnet_id = vpc["private_subnet_id"] if expected_in_same_az else vpc["private_additional_cidr_subnet_id"]
-    master_subnet_az = boto3.resource("ec2", region_name=region).Subnet(master_subnet_id).availability_zone
+    head_node_subnet_az = boto3.resource("ec2", region_name=region).Subnet(head_node_subnet_id).availability_zone
     compute_subnet_az = boto3.resource("ec2", region_name=region).Subnet(compute_subnet_id).availability_zone
     if expected_in_same_az:
-        assert_that(master_subnet_az).is_equal_to(compute_subnet_az)
+        assert_that(head_node_subnet_az).is_equal_to(compute_subnet_az)
     else:
-        assert_that(master_subnet_az).is_not_equal_to(compute_subnet_az)
+        assert_that(head_node_subnet_az).is_not_equal_to(compute_subnet_az)

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -35,7 +35,7 @@ from tests.storage.storage_common import verify_directory_correctly_shared
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_efs_compute_az(region, scheduler, pcluster_config_reader, clusters_factory, vpc_stack):
     """
-    Test when compute subnet is in a different AZ from master subnet.
+    Test when compute subnet is in a different AZ from head node subnet.
 
     A compute mount target should be created and the efs correctly mounted on compute.
     """
@@ -57,7 +57,7 @@ def test_efs_compute_az(region, scheduler, pcluster_config_reader, clusters_fact
 @pytest.mark.usefixtures("region", "os", "instance")
 def test_efs_same_az(region, scheduler, pcluster_config_reader, clusters_factory, vpc_stack):
     """
-    Test when compute subnet is in the same AZ as master subnet.
+    Test when compute subnet is in the same AZ as head node subnet.
 
     No compute mount point needed and the efs correctly mounted on compute.
     """

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.ini
@@ -23,7 +23,7 @@ efs_settings = efs
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
-# This compute subnet would be in a different AZ than master for regions defined in AVAILABILITY_ZONE_OVERRIDES
+# This compute subnet would be in a different AZ than head node for regions defined in AVAILABILITY_ZONE_OVERRIDES
 # See conftest for details
 compute_subnet_id = {{ private_additional_cidr_subnet_id }}
 

--- a/util/cfn-stacks-generators/generate-efs-substack.py
+++ b/util/cfn-stacks-generators/generate-efs-substack.py
@@ -7,7 +7,7 @@ def main(args):
     t = Template()
 
     # [0 shared_dir, 1 efs_fs_id, 2 performance_mode, 3 efs_kms_key_id,
-    # 4 provisioned_throughput, 5 encrypted, 6 throughput_mode, 7 exists_valid_master_mt, 8 exists_valid_compute_mt]
+    # 4 provisioned_throughput, 5 encrypted, 6 throughput_mode, 7 exists_valid_head_node_mt, 8 exists_valid_compute_mt]
     efs_options = t.add_parameter(
         Parameter(
             "EFSOptions",
@@ -18,7 +18,7 @@ def main(args):
     compute_security_group = t.add_parameter(
         Parameter("ComputeSecurityGroup", Type="String", Description="Security Group for Mount Target")
     )
-    master_subnet_id = t.add_parameter(
+    head_node_subnet_id = t.add_parameter(
         Parameter("MasterSubnetId", Type="String", Description="Master subnet id for master mount target")
     )
     compute_subnet_id = t.add_parameter(
@@ -33,7 +33,7 @@ def main(args):
         "CreateEFS",
         And(Not(Equals(Select(str(0), Ref(efs_options)), "NONE")), Equals(Select(str(1), Ref(efs_options)), "NONE")),
     )
-    create_master_mt = t.add_condition(
+    create_head_node_mt = t.add_condition(
         "CreateMasterMT",
         And(Not(Equals(Select(str(0), Ref(efs_options)), "NONE")), Equals(Select(str(7), Ref(efs_options)), "NONE")),
     )
@@ -43,10 +43,10 @@ def main(args):
     )
     # Need to create compute mount target if:
     # user is providing a compute subnet and
-    # there is no existing MT in compute subnet's AZ(includes case where master AZ == compute AZ).
+    # there is no existing MT in compute subnet's AZ(includes case where head node AZ == compute AZ).
     #
-    # If user is not providing a compute subnet, either we are using the master subnet as compute subnet,
-    # or we will be creating a compute subnet that is in the same AZ as master subnet,
+    # If user is not providing a compute subnet, either we are using the head node subnet as compute subnet,
+    # or we will be creating a compute subnet that is in the same AZ as head node subnet,
     # see ComputeSubnet resource in the main stack.
     # In both cases no compute MT is needed.
     create_compute_mt = t.add_condition(
@@ -82,8 +82,8 @@ def main(args):
             "MasterSubnetEFSMT",
             FileSystemId=If(create_efs, Ref(fs), Select(str(1), Ref(efs_options))),
             SecurityGroups=[Ref(compute_security_group)],
-            SubnetId=Ref(master_subnet_id),
-            Condition=create_master_mt,
+            SubnetId=Ref(head_node_subnet_id),
+            Condition=create_head_node_mt,
         )
     )
 

--- a/util/cfn-stacks-generators/generate-efs-substack.py
+++ b/util/cfn-stacks-generators/generate-efs-substack.py
@@ -19,7 +19,7 @@ def main(args):
         Parameter("ComputeSecurityGroup", Type="String", Description="Security Group for Mount Target")
     )
     head_node_subnet_id = t.add_parameter(
-        Parameter("MasterSubnetId", Type="String", Description="Master subnet id for master mount target")
+        Parameter("MasterSubnetId", Type="String", Description="Head node subnet id for head node mount target")
     )
     compute_subnet_id = t.add_parameter(
         Parameter(


### PR DESCRIPTION
Note: this patch is required by https://github.com/aws/aws-parallelcluster-cookbook/pull/825 because of the update recipe renaming.

Patch verified with the following 44 tests:

```
test-suites:
  cfn-init:
    test_cfn_init.py::test_install_args_quotes:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  cli_commands:
    test_cli_commands.py::test_hit_cli_commands:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
    test_cli_commands.py::test_sit_cli_commands:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
  cloudwatch_logging:
    test_cloudwatch_logging.py::test_cloudwatch_logging:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  configure:
    test_pcluster_configure.py::test_pcluster_configure:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm", "sge"]
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
      dimensions:
        - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  dashboard:
    test_dashboard.py::test_dashboard:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
        # DCV on GPU enabled instance
        - regions: ["eu-west-1"]
          instances: ["g3.8xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_dcv.py::test_dcv_with_remote_access:
      dimensions:
        - regions: ["ap-southeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos8"]
          schedulers: ["sge"]
  disable_hyperthreading:
    test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
      dimensions:
        # Manually disabled HT
        - regions: ["us-west-1"]
          instances: ["m4.xlarge"]
          oss: ["ubuntu1604"]
          schedulers: ["slurm"]
        # HT disabled via CpuOptions
        - regions: ["us-west-1"]
          instances: ["c5.xlarge"]
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  efa:
    test_efa.py::test_hit_efa:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5n.18xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
  iam_policies:
    test_iam_policies.py::test_iam_policies:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
  networking:
    test_cluster_networking.py::test_cluster_in_private_subnet:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_networking.py::test_public_network_topology:
      dimensions:
        - regions: ["eu-central-1"]
    test_networking.py::test_public_private_network_topology:
      dimensions:
        - regions: ["eu-central-1"]
    test_security_groups.py::test_additional_sg_and_ssh_from:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  scaling:
    test_scaling.py::test_hit_scaling:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm"]
  schedulers:
    test_sge.py::test_sge:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos8"]
          schedulers: ["sge"]
    test_torque.py::test_torque:
      dimensions:
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: {{ common.OSS_COMMERCIAL_ARM }}
          schedulers: ["torque"]
    test_awsbatch.py::test_awsbatch:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_slurm.py::test_slurm:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux"]
          schedulers: ["slurm"]
  storage:
    test_fsx_lustre.py::test_fsx_lustre:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_efs.py::test_efs_same_az:
      dimensions:
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
    test_ebs.py::test_ebs_multiple:
      dimensions:
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  tags:
    test_tag_propagation.py::test_tag_propagation:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm", "awsbatch"]
  update:
    test_update.py::test_update_awsbatch:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_update.py::test_update_hit:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
    test_update.py::test_update_sit:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
  resource_bucket:
    test_resource_bucket.py::test_resource_bucket:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```
