### PR TITLE
Mandate the presence of vpc_settings, vpc_id, master_subnet_id in the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ CHANGELOG
 
 **BUG FIXES**
 
+- Mandate the presence of `vpc_settings`, `vpc_id`, `master_subnet_id` in the config file to avoid unhandled exceptions.
+
 2.10.0
 ------
 

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -240,68 +240,70 @@ VPC = {
     "key": "vpc",
     "default_label": "default",
     "autocreate": True,
-    "params": {
-        "vpc_id": {
+    "params": OrderedDict([
+        ("vpc_id", {
             "cfn_param_mapping": "VPCId",
+            "required": True,
             "allowed_values": ALLOWED_VALUES["vpc_id"],
             "validators": [ec2_vpc_id_validator],
             "update_policy": UpdatePolicy.UNSUPPORTED
-        },
-        "master_subnet_id": {
+        }),
+        ("master_subnet_id", {
             "cfn_param_mapping": "MasterSubnetId",
+            "required": True,
             "allowed_values": ALLOWED_VALUES["subnet_id"],
             "validators": [ec2_subnet_id_validator],
             "update_policy": UpdatePolicy.UNSUPPORTED
-        },
-        "ssh_from": {
+        }),
+        ("ssh_from", {
             "default": CIDR_ALL_IPS,
             "allowed_values": ALLOWED_VALUES["cidr"],
             "cfn_param_mapping": "AccessFrom",
             "update_policy": UpdatePolicy.SUPPORTED
-        },
-        "additional_sg": {
+        }),
+        ("additional_sg", {
             "cfn_param_mapping": "AdditionalSG",
             "allowed_values": ALLOWED_VALUES["security_group_id"],
             "validators": [ec2_security_group_validator],
             "update_policy": UpdatePolicy.SUPPORTED
-        },
-        "compute_subnet_id": {
+        }),
+        ("compute_subnet_id", {
             "cfn_param_mapping": "ComputeSubnetId",
             "allowed_values": ALLOWED_VALUES["subnet_id"],
             "validators": [ec2_subnet_id_validator],
             "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP
-        },
-        "compute_subnet_cidr": {
+        }),
+        ("compute_subnet_cidr", {
             "cfn_param_mapping": "ComputeSubnetCidr",
             "allowed_values": ALLOWED_VALUES["cidr"],
             "update_policy": UpdatePolicy.UNSUPPORTED
-        },
-        "use_public_ips": {
+        }),
+        ("use_public_ips", {
             "type": BoolCfnParam,
             "default": True,
             "cfn_param_mapping": "UsePublicIps",
             "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP
-        },
-        "vpc_security_group_id": {
+        }),
+        ("vpc_security_group_id", {
             "cfn_param_mapping": "VPCSecurityGroupId",
             "allowed_values": ALLOWED_VALUES["security_group_id"],
             "validators": [ec2_security_group_validator],
             "update_policy": UpdatePolicy.SUPPORTED
-        },
-        "master_availability_zone": {
+        }),
+        ("master_availability_zone", {
             # NOTE: this is not exposed as a configuration parameter
             "type": HeadNodeAvailabilityZoneCfnParam,
             "cfn_param_mapping": "AvailabilityZone",
             "update_policy": UpdatePolicy.IGNORED,
             "visibility": Visibility.PRIVATE
-        },
-        "compute_availability_zone": {
+        }),
+        ("compute_availability_zone", {
             # NOTE: this is not exposed as a configuration parameter
             "type": ComputeAvailabilityZoneCfnParam,
             "update_policy": UpdatePolicy.IGNORED,
             "visibility": Visibility.PRIVATE
-        }
-    },
+        })
+    ]),
 }
 
 EBS = {
@@ -922,6 +924,7 @@ CLUSTER_COMMON_PARAMS = [
     }),
     ("vpc_settings", {
         "type": SettingsCfnParam,
+        "required": True,
         "referred_section": VPC,
         "update_policy": UpdatePolicy.UNSUPPORTED,
     }),

--- a/cli/src/pcluster/models/hit/hit_cluster_model.py
+++ b/cli/src/pcluster/models/hit/hit_cluster_model.py
@@ -42,7 +42,7 @@ class HITClusterModel(ClusterModel):
         cluster_section = pcluster_config.get_section("cluster")
         vpc_section = pcluster_config.get_section("vpc")
 
-        if not cluster_section or cluster_section.get_param_value("scheduler") == "awsbatch" or not vpc_section:
+        if cluster_section.get_param_value("scheduler") == "awsbatch":
             return
 
         head_node_instance_type = cluster_section.get_param_value("master_instance_type")

--- a/cli/src/pcluster/models/sit/sit_cluster_model.py
+++ b/cli/src/pcluster/models/sit/sit_cluster_model.py
@@ -60,10 +60,8 @@ class SITClusterModel(ClusterModel):
         vpc_section = pcluster_config.get_section("vpc")
 
         if (
-            not cluster_section
-            or cluster_section.get_param_value("scheduler") == "awsbatch"
+            cluster_section.get_param_value("scheduler") == "awsbatch"
             or cluster_section.get_param_value("cluster_type") == "spot"
-            or not vpc_section
         ):
             return
 


### PR DESCRIPTION
These parameters have been essential to create a cluster/AMI. Before this commit, the code does not check the existence of the parameters, causing unhandled exceptions if a config file does not have any of the parameters.

This commit adds `OrderedDict` to VPC section in `mappings.py` to make the code compatible with Python <= 3.5

This PR is verified by the following integration tests:
```
  cli_commands:
    test_cli_commands.py::test_sit_cli_commands:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
  configure:
    test_pcluster_configure.py::test_pcluster_configure:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm", "sge"]
  networking:
    test_cluster_networking.py::test_cluster_in_private_subnet:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
    test_networking.py::test_public_network_topology:
      dimensions:
        - regions: ["eu-central-1"]
    test_networking.py::test_public_private_network_topology:
      dimensions:
        - regions: ["eu-central-1"]
    test_multi_cidr.py::test_multi_cidr:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm", "awsbatch"]
    test_security_groups.py::test_additional_sg_and_ssh_from:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_security_groups.py::test_overwrite_sg:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
  update:
    test_update.py::test_update_awsbatch:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_update.py::test_update_sit:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["sge"]
```

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
