### PR TITLE
Fix createami test to not fail when custom_node is not specified

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -49,6 +49,7 @@ def test_createami(region, os, instance, request, pcluster_config_reader, vpc_st
     # Custom Node
     # inject PARALLELCLUSTER_NODE_URL into packer environment
     custom_node = request.config.getoption("createami_custom_node_package")
+    env = None
     if custom_node:
         env = environ.copy()
         env["PARALLELCLUSTER_NODE_URL"] = custom_node


### PR DESCRIPTION
if `custom_node` is not specified, the `env` variable was referenced before assignment.
