### PR TITLE
Enable rollback data generation for arbitrary S3 files

### DIFF
--- a/util/common.py
+++ b/util/common.py
@@ -73,10 +73,13 @@ def generate_rollback_data(regions, dest_bucket, files, sts_credentials):
         rollback_data[bucket_name] = {"region": region, "files": {}}
         doc_manager = S3DocumentManager(region, sts_credentials.get(region))
         for file_type in files:
+            s3_path = FILE_TO_S3_PATH.get(file_type, file_type)
             version = doc_manager.get_current_version(
-                dest_bucket.format(region=region), FILE_TO_S3_PATH[file_type], raise_on_object_not_found=False
+                dest_bucket.format(region=region),
+                s3_path,
+                raise_on_object_not_found=False,
             )
-            rollback_data[bucket_name]["files"][FILE_TO_S3_PATH[file_type]] = version
+            rollback_data[bucket_name]["files"][s3_path] = version
 
     logging.info("Rollback data:\n%s", json.dumps(rollback_data, indent=2))
     rollback_file_name = "rollback-data.json"


### PR DESCRIPTION
Previously generating rollback data was only supported by the modified
code for S3 keys related to the config files used to allow list certain
features/instance types. This enables the same code to be used for
generating rollback data for other S3 files. The motivation for this is
to enable the code to be used to generate rollback data for dependencies
to be hosted in S3.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
