### PR TITLE
Reduce AWS Batch tests to avoid Docker hub throttling

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -382,7 +382,7 @@ storage:
         schedulers: ["slurm"]
       - regions: ["ap-northeast-1", "cn-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_BATCH }}
+        oss: ["alinux2"]
         schedulers: ["awsbatch"]
   test_raid.py::test_raid_fault_tolerance_mode:
     dimensions:
@@ -402,7 +402,7 @@ storage:
         schedulers: ["sge"]
       - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_BATCH }}
+        oss: ["alinux"]
         schedulers: ["awsbatch"]
   test_ebs.py::test_default_ebs:
     dimensions:


### PR DESCRIPTION
Removed one os from `test_efs_same_az` and from `test_raid_performance_mode`.

I think we can safely remove one os from these tests because the EFS and RAID recipes don't depend by the OS.
In any case we're already testing all the OSes with the other schedulers.


