### PR TITLE
Restore default values in cfn template for ComputeInstanceType

### DIFF
--- a/cli/tests/pcluster/config/test_source_consistency.py
+++ b/cli/tests/pcluster/config/test_source_consistency.py
@@ -88,6 +88,10 @@ def test_defaults_consistency():
     # metadata is generated dynamically based on user's configuration.
     ignored_params += ["ClusterConfigMetadata"]
 
+    # ComputeInstanceType parameter is expected to differ from the default value in the CFN template because
+    # it is dynamically generated based on the AWS region
+    ignored_params += ["ComputeInstanceType"]
+
     cfn_params = [section_cfn_params.value for section_cfn_params in DefaultCfnParams]
     default_cfn_values = utils.merge_dicts(*cfn_params)
 

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -14,6 +14,7 @@
     "ComputeInstanceType": {
       "Description": "ComputeFleet EC2 instance type",
       "Type": "String",
+      "Default": "NONE",
       "ConstraintDescription": "Must be a valid EC2 instance type, with support for HVM."
     },
     "MinSize": {


### PR DESCRIPTION
Compute instance type parameter is not rendered if scheduler is Slurm. This caused the error `Parameters: [ComputeInstanceType] must have values` in CloudFormation because a value was still expected.
With this commit we set "NONE" as default to prevent this value being silently used as if set by the user.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
