### PR TITLE
Change second queue instance type from c4.xlarge to c5.large

### DIFF
--- a/tests/integration-tests/tests/scaling/test_scaling/test_hit_scaling/pcluster.config.ini
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_hit_scaling/pcluster.config.ini
@@ -20,14 +20,14 @@ compute_resource_settings = ondemand_i1,ondemand_i2
 compute_resource_settings = ondemand_i3,ondemand_i4
 
 [compute_resource ondemand_i1]
-instance_type = c4.xlarge
+instance_type = c5.large
 
 [compute_resource ondemand_i2]
 instance_type = {{ instance }}
 min_count = 2
 
 [compute_resource ondemand_i3]
-instance_type = c4.xlarge
+instance_type = c5.large
 
 [compute_resource ondemand_i4]
 instance_type = {{ instance }}


### PR DESCRIPTION
Reason for this change is that not all the regions support c4.xlarge.
C5 family support is broader

What does this change solve? It allows to run the test where C4 isn't present

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
