### PR TITLE
Remove awsbatch access test if scheduler is not awsbatch

### DIFF
--- a/tests/integration-tests/tests/iam_policies/test_iam_policies.py
+++ b/tests/integration-tests/tests/iam_policies/test_iam_policies.py
@@ -31,7 +31,9 @@ def test_iam_policies(region, scheduler, pcluster_config_reader, clusters_factor
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     _test_s3_access(remote_command_executor, region)
-    _test_batch_access(remote_command_executor, region)
+
+    if scheduler == "awsbatch":
+        _test_batch_access(remote_command_executor, region)
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)
 


### PR DESCRIPTION
What does the change solve? The change allows to run the iam policies test on the regions where AWS Batch is not present

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
