### PR TITLE
Enable EFA on all supported OSs but Centos8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
 - Remove CloudFormation DescribeStacks API call from AWS Batch Docker entrypoint. This removes the possibility of job
   failures due to CloudFormation throttling.
 - Add support for io2 EBS volume type.
+- Install EFA kernel module also on ARM instances with `alinux2` and `ubuntu1804`
 
 **CHANGES**
 
@@ -21,7 +22,13 @@ CHANGELOG
 - Use inclusive language in user facing messages and internal naming convention.
 - Change the default of instance types from the hardcoded `t2.micro` to the free tier instance type 
   (`t2.micro` or `t3.micro` dependent on region). In regions without free tier, the default is `t3.micro`.
-
+- Upgrade EFA installer to version 1.11.0
+  - EFA configuration: ``efa-config-1.6`` (from efa-config-1.5)
+  - EFA profile: ``efa-profile-1.2`` (from efa-profile-1.1)
+  - EFA kernel module: ``efa-1.10.2`` (no change)
+  - RDMA core: ``rdma-core-31.2amzn`` (from rdma-core-31.amzn0)
+  - Libfabric: ``libfabric-1.11.1amzn1.0`` (from libfabric-1.11.1amzn1.1)
+  - Open MPI: ``openmpi40-aws-4.0.5`` (no change)
 
 **BUG FIXES**
 

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -77,6 +77,7 @@ from pcluster.config.validators import (
     ec2_volume_validator,
     ec2_vpc_id_validator,
     efa_gdr_validator,
+    efa_os_arch_validator,
     efa_validator,
     efs_id_validator,
     efs_validator,
@@ -718,6 +719,7 @@ QUEUE = {
         }),
         ("enable_efa", {
             "type": BooleanJsonParam,
+            "validators": [efa_os_arch_validator],
             "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP,
         }),
         ("enable_efa_gdr", {
@@ -833,7 +835,7 @@ CLUSTER_COMMON_PARAMS = [
     ("enable_efa", {
         "allowed_values": ["compute"],
         "cfn_param_mapping": "EFA",
-        "validators": [efa_validator],
+        "validators": [efa_validator, efa_os_arch_validator],
         "update_policy": UpdatePolicy.UNSUPPORTED
     }),
     ("enable_efa_gdr", {

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -68,6 +68,11 @@ FSX_SUPPORTED_ARCHITECTURES_OSES = {
 
 FSX_PARAM_WITH_DEFAULT = {"drive_cache_type": "NONE"}
 
+EFA_UNSUPPORTED_ARCHITECTURES_OSES = {
+    "x86_64": [],
+    "arm64": ["centos8"],
+}
+
 EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS = {
     "standard": (1, 1024),
     "io1": (4, 16 * 1024),
@@ -1537,5 +1542,19 @@ def duplicate_shared_dir_validator(section_key, section_label, pcluster_config):
             # if there are multiple EBS sections configured, provide an error message
             elif len(list_of_ebs_sections) > 1:
                 errors.append("'shared_dir' can not be specified in cluster section when using multiple EBS volumes")
+
+    return errors, warnings
+
+
+def efa_os_arch_validator(param_key, param_value, pcluster_config):
+    errors = []
+    warnings = []
+
+    cluster_section = pcluster_config.get_section("cluster")
+    architecture = cluster_section.get_param_value("architecture")
+    base_os = cluster_section.get_param_value("base_os")
+
+    if base_os in EFA_UNSUPPORTED_ARCHITECTURES_OSES.get(architecture):
+        errors.append("EFA currently not supported on {0} for {1} architecture".format(base_os, architecture))
 
     return errors, warnings

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -29,6 +29,7 @@ from pcluster.config.validators import (
     compute_resource_validator,
     disable_hyperthreading_architecture_validator,
     efa_gdr_validator,
+    efa_os_arch_validator,
     fsx_ignored_parameters_validator,
     instances_architecture_compatibility_validator,
     intel_hpc_architecture_validator,
@@ -2677,3 +2678,38 @@ def test_duplicate_shared_dir_validator(
 def test_extra_json_validator(mocker, capsys, extra_json, expected_message):
     config_parser_dict = {"cluster default": extra_json}
     utils.assert_param_validator(mocker, config_parser_dict, capsys=capsys, expected_warning=expected_message)
+
+
+@pytest.mark.parametrize(
+    "cluster_dict, architecture, expected_error",
+    [
+        ({"base_os": "alinux2", "enable_efa": "compute"}, "x86_64", None),
+        ({"base_os": "alinux2", "enable_efa": "compute"}, "arm64", None),
+        ({"base_os": "centos8", "enable_efa": "compute"}, "x86_64", None),
+        (
+            {"base_os": "centos8", "enable_efa": "compute"},
+            "arm64",
+            "EFA currently not supported on centos8 for arm64 architecture",
+        ),
+        ({"base_os": "ubuntu1804", "enable_efa": "compute"}, "x86_64", None),
+        ({"base_os": "ubuntu1804", "enable_efa": "compute"}, "arm64", None),
+    ],
+)
+def test_efa_os_arch_validator(mocker, cluster_dict, architecture, expected_error):
+    mocker.patch(
+        "pcluster.config.cfn_param_types.BaseOSCfnParam.get_instance_type_architecture", return_value=architecture
+    )
+
+    config_parser_dict = {"cluster default": cluster_dict}
+    config_parser = configparser.ConfigParser()
+    config_parser.read_dict(config_parser_dict)
+
+    pcluster_config = utils.init_pcluster_config_from_configparser(config_parser, False, auto_refresh=False)
+    pcluster_config.get_section("cluster").get_param("architecture").value = architecture
+    enable_efa_value = pcluster_config.get_section("cluster").get_param_value("enable_efa")
+
+    errors, warnings = efa_os_arch_validator("enable_efa", enable_efa_value, pcluster_config)
+    if expected_error:
+        assert_that(errors[0]).matches(expected_error)
+    else:
+        assert_that(errors).is_empty()


### PR DESCRIPTION
The new EFA installer provides the EFA kmod for all supported OSs except for Centos8. This commit adds a validator to prevent EFA from being enabled on ARM architectures with Centos8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
