### PR TITLE
Add support for me-south-1, af-south-1 and eu-south-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ CHANGELOG
 
 **ENHANCEMENTS**
 
+- Add support for me-south-1 region (Bahrein), af-south-1 region (Cape Town) and eu-south-1 region (Milan)
+  - At the time of this version launch:
+    - AWS Lustre and ARM instance type are not supported in me-south-1, af-south-1 and eu-south-1  
+    - AWS Batch is not supported in af-south-1
+    - EBS io2 is not supported in af-south-1 and eu-south-1 
 - Remove CloudFormation DescribeStacks API call from AWS Batch Docker entrypoint. This removes the possibility of job
   failures due to CloudFormation throttling.
 - Add support for io2 EBS volume type.

--- a/tests/integration-tests/configs/common.jinja2
+++ b/tests/integration-tests/configs/common.jinja2
@@ -1,4 +1,4 @@
-{%- set REGIONS_COMMERCIAL = ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "eu-north-1"] -%}
+{%- set REGIONS_COMMERCIAL = ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "eu-north-1", "me-south-1", "af-south-1", "eu-south-1"] -%}
 {%- set REGIONS_CHINA = ["cn-north-1", "cn-northwest-1"] -%}
 {%- set REGIONS_GOVCLOUD = ["us-gov-west-1", "us-gov-east-1"] -%}
 {%- set REGIONS_ALL = REGIONS_COMMERCIAL + REGIONS_CHINA + REGIONS_GOVCLOUD -%}

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -1,7 +1,7 @@
 cfn-init:
   test_cfn_init.py::test_replace_compute_on_failure:
     dimensions:
-      - regions: ["eu-central-1"]
+      - regions: ["af-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_ONE_PER_DISTRO }}
         schedulers: ["slurm", "sge"]
@@ -77,7 +77,7 @@ configure:
 create:
   test_create.py::test_create_wrong_os:
     dimensions:
-      - regions: ["eu-central-1"]
+      - regions: ["af-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"]  # os must be different from centos7 to test os validation logic when wrong os is provided
         schedulers: ["slurm"]
@@ -101,7 +101,7 @@ createami:
         oss: ["alinux2"]
   test_createami.py::test_createami_post_install:
     dimensions:
-      - regions: ["ap-southeast-2"]
+      - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7", "ubuntu1804"]
       - regions: ["eu-west-1"]
@@ -109,7 +109,7 @@ createami:
         oss: ["alinux2"]
   test_createami.py::test_createami_wrong_os:
     dimensions:
-      - regions: ["eu-central-1"]
+      - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux"]  # os must be different from alinux2 to test os validation logic when wrong os is provided
   test_createami.py::test_createami_wrong_pcluster_version:
@@ -229,7 +229,7 @@ intel_hpc:
 networking:
   test_cluster_networking.py::test_cluster_in_private_subnet:
     dimensions:
-      - regions: ["us-west-2"]
+      - regions: ["me-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm"]
@@ -239,10 +239,10 @@ networking:
         schedulers: ["sge"]
   test_networking.py::test_public_network_topology:
     dimensions:
-      - regions: ["eu-central-1", "us-gov-east-1", "cn-northwest-1"]
+      - regions: ["af-south-1", "us-gov-east-1", "cn-northwest-1"]
   test_networking.py::test_public_private_network_topology:
     dimensions:
-      - regions: ["eu-central-1", "us-gov-east-1", "cn-northwest-1"]
+      - regions: ["af-south-1", "us-gov-east-1", "cn-northwest-1"]
   test_multi_cidr.py::test_multi_cidr:
     dimensions:
       - regions: ["ap-northeast-2"]
@@ -305,7 +305,7 @@ scaling:
 schedulers:
   test_sge.py::test_sge:
     dimensions:
-      - regions: ["eu-central-1"]
+      - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["sge"]
@@ -356,7 +356,7 @@ schedulers:
 spot:
   test_spot.py::test_spot_default:
     dimensions:
-      - regions: ["us-west-2"]
+      - regions: ["me-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["sge", "slurm"]
@@ -499,13 +499,13 @@ tags:
 update:
   test_update.py::test_update_awsbatch:
     dimensions:
-      - regions: ["eu-west-1"]
+      - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
   test_update.py::test_update_hit:
     dimensions:
-      - regions: ["eu-west-1"]
+      - regions: ["me-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]


### PR DESCRIPTION
New regions are me-south-1 (Bahrein), af-south-1 (Cape Town) and eu-south-1 (Milan)
Distribute the integration tests to use these new regions

* AWS Lustre and ARM instance type are not yet supported in me-south-1, af-south-1 and eu-south-1
* AWS Batch is not yet supported in af-south-1
* EBS io2 is not yet supported in af-south-1 and eu-south-1

Test redistribution before
```
37 us-east-1
34 us-west-2
30 eu-central-1
29 us-east-2
29 eu-west-1
26 ap-south-1
25 ap-northeast-1
24 ap-southeast-2
24 ap-southeast-1
23 eu-west-2
22 eu-west-3
22 ca-central-1
22 ap-northeast-2
21 us-west-1
20 eu-north-1
18 ap-east-1
17 sa-east-1
```

Test redistribution after
```
37 us-east-1
31 us-west-2
29 us-east-2
26 ap-south-1
25 ap-northeast-1
24 ap-southeast-1
23 eu-west-2
22 eu-west-3
22 eu-west-1
22 eu-south-1
22 ca-central-1
22 ap-southeast-2
22 ap-northeast-2
21 us-west-1
21 me-south-1
21 af-south-1
20 eu-north-1
18 ap-east-1
17 sa-east-1
14 eu-central-1
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
