### PR TITLE
Remove explicit call to set/unset credentials in CfnStacksFactory.create_stack

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -631,6 +631,7 @@ def vpc_stack(vpc_stacks, region):
     retry_on_exception=lambda exception: not isinstance(exception, KeyboardInterrupt),
 )
 def _create_vpc_stack(request, template, region, cfn_stacks_factory):
+    set_credentials(region, request.config.getoption("credential"))
     if request.config.getoption("vpc_stack"):
         logging.info("Using stack {0} in region {1}".format(request.config.getoption("vpc_stack"), region))
         stack = CfnStack(name=request.config.getoption("vpc_stack"), region=region, template=template.to_json())

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -232,6 +232,10 @@ def set_credentials(region, credential_arg):
     :param region: region of the bucket
     :param credential_arg: credential list
     """
+    if os.environ.get("AWS_CREDENTIALS_SET", "false") == "true":
+        logging.info(f"AWS_CREDENTIALS are already set for region: {region}")
+        return
+
     if credential_arg:
         # credentials = dict { region1: (endpoint1, arn1, external_id1),
         #                      region2: (endpoint2, arn2, external_id2),
@@ -252,6 +256,8 @@ def set_credentials(region, credential_arg):
                 credential_endpoint, credential_arn, credential_external_id, region
             )
 
+            logging.info(f"Setting AWS_CREDENTIALS for region: {region}")
+
             # Set credential for all boto3 client
             boto3.setup_default_session(
                 aws_access_key_id=aws_credentials["AccessKeyId"],
@@ -263,6 +269,7 @@ def set_credentials(region, credential_arg):
             os.environ["AWS_ACCESS_KEY_ID"] = aws_credentials["AccessKeyId"]
             os.environ["AWS_SECRET_ACCESS_KEY"] = aws_credentials["SecretAccessKey"]
             os.environ["AWS_SESSION_TOKEN"] = aws_credentials["SessionToken"]
+            os.environ["AWS_CREDENTIALS_SET"] = "true"
 
 
 def _retrieve_sts_credential(credential_endpoint, credential_arn, credential_external_id, region):
@@ -283,6 +290,7 @@ def _retrieve_sts_credential(credential_endpoint, credential_arn, credential_ext
 def unset_credentials():
     """Unset credentials"""
     # Unset credential for all boto3 client
+    logging.info("Unsetting AWS_CREDENTIALS")
     boto3.setup_default_session()
     # Unset credential for cli command e.g. pcluster create
     if "AWS_ACCESS_KEY_ID" in os.environ:
@@ -291,6 +299,8 @@ def unset_credentials():
         del os.environ["AWS_SECRET_ACCESS_KEY"]
     if "AWS_SESSION_TOKEN" in os.environ:
         del os.environ["AWS_SESSION_TOKEN"]
+    if "AWS_CREDENTIALS_SET" in os.environ:
+        del os.environ["AWS_CREDENTIALS_SET"]
 
 
 def set_logger_formatter(formatter):


### PR DESCRIPTION
set/unset credentials are called by the fixture setup_sts_credentials which has the autouse property set to true

The set credentials is moved to the _create_vpc_stack method
A check to avoid credentials being set twice is implemented

What the change solve? Avoid to setting credentials when they are already set

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
