### PR TITLE
Fix integration test kms key: add region name

### DIFF
--- a/tests/integration-tests/tests/storage/kms_key_factory.py
+++ b/tests/integration-tests/tests/storage/kms_key_factory.py
@@ -30,7 +30,9 @@ class KMSKeyFactory:
         """
         self.region = region
         self.account_id = (
-            boto3.client("sts", endpoint_url=_get_sts_endpoint(region)).get_caller_identity().get("Account")
+            boto3.client("sts", endpoint_url=_get_sts_endpoint(region), region_name=region)
+            .get_caller_identity()
+            .get("Account")
         )
 
         if self.kms_key_id:


### PR DESCRIPTION
Add region_name parameter to boto3 call on get account id

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
