### PR TITLE
Disable createami tests on Ubuntu1804 in release-2.10

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -87,10 +87,14 @@ createami:
     dimensions:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux", "alinux2", "ubuntu1604", "ubuntu1804"] # temporary disable FPGA AMI since there is not enough free space on root partition
+        # Ubuntu18.04 disabled due to SGE package missing
+        # see https://github.com/aws/aws-parallelcluster-cookbook/commit/db8c63d900c7837157519ae7eef462ac3af627a5
+        oss: ["alinux", "alinux2", "ubuntu1604"] # temporary disable FPGA AMI since there is not enough free space on root partition
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1604", "ubuntu1804"]
+        # Ubuntu18.04 disabled due to SGE package missing
+        # see https://github.com/aws/aws-parallelcluster-cookbook/commit/db8c63d900c7837157519ae7eef462ac3af627a5
+        oss: ["ubuntu1604"]
       - regions: ["cn-northwest-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]


### PR DESCRIPTION
Ubuntu18.04 createmi test is failing due to the missing SGE source package.
The issue has been fixed by [db8c63d900c7837157519ae7eef462ac3af627a5](https://github.com/aws/aws-parallelcluster-cookbook/commit/db8c63d900c7837157519ae7eef462ac3af627a5
)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
