### PR TITLE
Fix integ_test ebs encrypted with KMS: add policy for chronicle and s…

### DIFF
--- a/tests/integration-tests/resources/batch_instance_policy.json
+++ b/tests/integration-tests/resources/batch_instance_policy.json
@@ -112,6 +112,16 @@
       ],
       "Effect": "Allow",
       "Sid": "CWLogs"
+    },
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:{{ partition }}:s3:::aws-parallelcluster-jenkins-*"
+      ],
+      "Effect": "Allow",
+      "Sid": "Chronicle"
     }
   ]
 }

--- a/tests/integration-tests/resources/traditional_instance_policy.json
+++ b/tests/integration-tests/resources/traditional_instance_policy.json
@@ -168,6 +168,16 @@
       ],
       "Effect": "Allow",
       "Sid": "Route53"
+    },
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:{{ partition }}:s3:::aws-parallelcluster-jenkins-*"
+      ],
+      "Effect": "Allow",
+      "Sid": "Chronicle"
     }
   ]
 }

--- a/tests/integration-tests/tests/storage/kms_key_factory.py
+++ b/tests/integration-tests/tests/storage/kms_key_factory.py
@@ -48,11 +48,11 @@ class KMSKeyFactory:
         :param region: Create different roles on different regions, since we need to attach different policies
         """
         random_string = "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
-        iam_role_name = "Integration_test_ParallelClusterInstanceRole_{0}_{1}".format(self.region, random_string)
+        iam_role_name = "Integ_test_InstanceRole_{0}_{1}".format(self.region, random_string)
 
-        iam_policy_name_batch = "".join("Integ_test_ParallelClusterInstancePolicy_batch" + random_string)
+        iam_policy_name_batch = "".join("Integ_test_InstancePolicy_batch" + random_string)
         logging.info("iam policy for awsbatch is {0}".format(iam_policy_name_batch))
-        iam_policy_name_traditional = "".join("Integ_test_ParallelClusterInstancePolicy" + random_string)
+        iam_policy_name_traditional = "".join("Integ_test_InstancePolicy" + random_string)
         logging.info("iam_policy for traditional scheduler is {0}".format(iam_policy_name_traditional))
 
         self.iam_client = boto3.client("iam", region_name=region)
@@ -130,7 +130,7 @@ class KMSKeyFactory:
         # create KMS key
         self.kms_client = boto3.client("kms", region_name=region)
         random_string = "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
-        key_alias = "alias/Integration_test_KMS_key_{0}_{1}".format(self.region, random_string)
+        key_alias = "alias/Integ_test_KMS_{0}_{1}".format(self.region, random_string)
 
         # If the key already existed, use the existing key
         for alias in self.kms_client.list_aliases().get("Aliases"):


### PR DESCRIPTION
…horter role name

Difine shorter role name and policy name to fix the problem that in some region, the length of role name created in the KMS key exceed its max lenghth 64.
Add permission to instance policy in the test to enable download Chronicle from Jenkins bucket.

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
