### PR TITLE
Enable FSx Lustre tests in GovCloud

### DIFF
--- a/cloudformation/raid-substack.cfn.json
+++ b/cloudformation/raid-substack.cfn.json
@@ -858,7 +858,7 @@
       "Description": "Availability Zone the cluster will launch into. THIS IS REQUIRED",
       "Type": "AWS::EC2::AvailabilityZone::Name"
     },
-    "RAIDOptions":{
+    "RAIDOptions": {
       "Description": "Comma separated list of RAID related options, 9 parameters in total, [0 shared_dir,1 raid_type,2 num_of_vols,3 vol_type,4 vol_size,5 vol_IOPS,6 encrypted, 7 ebs_kms_key, 8 volume_throughput]",
       "Type": "CommaDelimitedList"
     }

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -389,6 +389,10 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux"]
         schedulers: ["slurm"]
+      - regions: ["us-gov-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
   test_fsx_lustre.py::test_fsx_lustre_configuration_options:
     dimensions:
       - regions: ["us-east-2"]

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
@@ -38,8 +38,8 @@ shared_dir = {{ mount_dir }}
 storage_capacity = {{ storage_capacity }}
 import_path = s3://{{ bucket_name }}
 export_path = s3://{{ bucket_name }}/export_dir
-{% if region.startswith("cn-") %}
-# the only deployment_type supported in China regions is PERSISTENT_1
+{% if region.startswith(("cn-", "us-gov-")) %}
+# SCRATCH_1 not available in China/GovCloud regions
 deployment_type = PERSISTENT_1
 per_unit_storage_throughput = 200
 {% endif %}


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2020/12/amazon-fsx-available-govcloud-regions/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
