### PR TITLE
Change FSx deployment_type for FSx test in GovCloud

### DIFF
--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.ini
@@ -38,8 +38,8 @@ shared_dir = {{ mount_dir }}
 storage_capacity = {{ storage_capacity }}
 import_path = s3://{{ bucket_name }}
 export_path = s3://{{ bucket_name }}/export_dir
-{% if region.startswith("cn-") %}
-# the only deployment_type supported in China regions is PERSISTENT_1
+{% if region.startswith(("cn-", "us-gov-")) %}
+# the default deployment_type SCRATCH_1 is not supported in China and GovCloud
 deployment_type = PERSISTENT_1
 per_unit_storage_throughput = 200
 {% endif %}


### PR DESCRIPTION
The default deployment_type SCRATCH_1 is not supported in China and GovCloud

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
