### PR TITLE
Add integration test update for iops and throughput

### DIFF
--- a/tests/integration-tests/tests/update/test_update/test_update_sit/pcluster.config.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_sit/pcluster.config.ini
@@ -43,7 +43,9 @@ compute_subnet_id = {{ private_subnet_id }}
 
 [ebs custom]
 shared_dir = shared
+volume_type = gp3
 #volume_iops = None #Initially not set
+#volume_throughput = NONE # Initially not set
 
 [scaling custom]
 #scaledown_idletime = None #Initially not set

--- a/tests/integration-tests/tests/update/test_update/test_update_sit/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_sit/pcluster.config.update.ini
@@ -43,7 +43,9 @@ compute_subnet_id = {{ private_subnet_id }}
 
 [ebs custom]
 shared_dir = shared
-volume_iops = 140
+volume_type = gp3
+volume_iops = 3200
+volume_throughput = 130
 
 [scaling custom]
 #scaledown_idletime = None #Initially not set


### PR DESCRIPTION
Fix the test_update_sit get_instance to be able to be tests on us-east-1
Add test for updating the value of iops and throughput

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
