### PR TITLE
Enable EFA tests for c6gn.16xlarge

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -207,6 +207,10 @@ efa:
         instances: ["p4d.24xlarge"]
         oss: ["alinux2", "ubuntu1604", "centos8"]
         schedulers: ["slurm"]
+      - regions: ["us-west-2"]
+        instances: ["c6gn.16xlarge"]
+        oss: ["alinux2", "ubuntu1604"]
+        schedulers: ["slurm"]
   test_efa.py::test_sit_efa:
     dimensions:
       - regions: ["us-east-1"]

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -29,7 +29,7 @@ from tests.common.utils import fetch_instance_slots
 # Slurm test is to verify EFA works correctly when using the SIT model in the config file
 @pytest.mark.schedulers(["sge", "slurm"])
 @pytest.mark.usefixtures("os")
-def test_sit_efa(region, scheduler, instance, pcluster_config_reader, clusters_factory, test_datadir):
+def test_sit_efa(region, scheduler, instance, pcluster_config_reader, clusters_factory, test_datadir, architecture):
     """
     Test all EFA Features.
 
@@ -46,7 +46,8 @@ def test_sit_efa(region, scheduler, instance, pcluster_config_reader, clusters_f
     _test_mpi(remote_command_executor, slots_per_instance, scheduler)
     logging.info("Running on Instances: {0}".format(get_compute_nodes_instance_ids(cluster.cfn_name, region)))
     _test_osu_benchmarks("openmpi", remote_command_executor, scheduler_commands, test_datadir, slots_per_instance)
-    _test_osu_benchmarks("intelmpi", remote_command_executor, scheduler_commands, test_datadir, slots_per_instance)
+    if architecture == "x86_64":
+        _test_osu_benchmarks("intelmpi", remote_command_executor, scheduler_commands, test_datadir, slots_per_instance)
     _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor)
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)
@@ -57,7 +58,7 @@ def test_sit_efa(region, scheduler, instance, pcluster_config_reader, clusters_f
 @pytest.mark.oss(["alinux2"])
 @pytest.mark.schedulers(["slurm"])
 @pytest.mark.usefixtures("os")
-def test_hit_efa(region, scheduler, instance, pcluster_config_reader, clusters_factory, test_datadir):
+def test_hit_efa(region, scheduler, instance, pcluster_config_reader, clusters_factory, test_datadir, architecture):
     """
     Test all EFA Features.
 
@@ -82,14 +83,15 @@ def test_hit_efa(region, scheduler, instance, pcluster_config_reader, clusters_f
         slots_per_instance,
         partition="efa-enabled",
     )
-    _test_osu_benchmarks(
-        "intelmpi",
-        remote_command_executor,
-        scheduler_commands,
-        test_datadir,
-        slots_per_instance,
-        partition="efa-enabled",
-    )
+    if architecture == "x86_64":
+        _test_osu_benchmarks(
+            "intelmpi",
+            remote_command_executor,
+            scheduler_commands,
+            test_datadir,
+            slots_per_instance,
+            partition="efa-enabled",
+        )
     _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor, partition="efa-enabled")
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)


### PR DESCRIPTION
```
     580 total
      41 tests_outputs/1608298108.8449411.out/us-east-1/collected_tests.txt
      33 tests_outputs/1608298108.8449411.out/us-west-2/collected_tests.txt
      32 tests_outputs/1608298108.8449411.out/us-east-2/collected_tests.txt
      30 tests_outputs/1608298108.8449411.out/eu-west-1/collected_tests.txt
      30 tests_outputs/1608298108.8449411.out/ap-east-1/collected_tests.txt
      28 tests_outputs/1608298108.8449411.out/ca-central-1/collected_tests.txt
      28 tests_outputs/1608298108.8449411.out/ap-northeast-1/collected_tests.txt
      26 tests_outputs/1608298108.8449411.out/eu-north-1/collected_tests.txt
      26 tests_outputs/1608298108.8449411.out/ap-south-1/collected_tests.txt
      24 tests_outputs/1608298108.8449411.out/us-west-1/collected_tests.txt
      24 tests_outputs/1608298108.8449411.out/ap-southeast-2/collected_tests.txt
      24 tests_outputs/1608298108.8449411.out/ap-southeast-1/collected_tests.txt
      23 tests_outputs/1608298108.8449411.out/sa-east-1/collected_tests.txt
      23 tests_outputs/1608298108.8449411.out/eu-west-2/collected_tests.txt
      22 tests_outputs/1608298108.8449411.out/eu-west-3/collected_tests.txt
      22 tests_outputs/1608298108.8449411.out/ap-northeast-2/collected_tests.txt
      20 tests_outputs/1608298108.8449411.out/cn-north-1/collected_tests.txt
      20 tests_outputs/1608298108.8449411.out/af-south-1/collected_tests.txt
      19 tests_outputs/1608298108.8449411.out/eu-south-1/collected_tests.txt
      18 tests_outputs/1608298108.8449411.out/us-gov-west-1/collected_tests.txt
      18 tests_outputs/1608298108.8449411.out/us-gov-east-1/collected_tests.txt
      18 tests_outputs/1608298108.8449411.out/cn-northwest-1/collected_tests.txt
      16 tests_outputs/1608298108.8449411.out/eu-central-1/collected_tests.txt
      15 tests_outputs/1608298108.8449411.out/me-south-1/collected_tests.txt
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
