### PR TITLE
Set use_public_ips to true in EFA tests

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.ini
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.ini
@@ -39,4 +39,4 @@ max_count = {{ max_queue_size }}
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
-use_public_ips = false
+use_public_ips = true

--- a/tests/integration-tests/tests/efa/test_efa/test_sit_efa/pcluster.config.ini
+++ b/tests/integration-tests/tests/efa/test_efa/test_sit_efa/pcluster.config.ini
@@ -24,4 +24,4 @@ placement_group = DYNAMIC
 vpc_id = {{ vpc_id }}
 master_subnet_id = {{ public_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
-use_public_ips = false
+use_public_ips = true


### PR DESCRIPTION
When P4d instances are used as head node, the parameter use_public_ips must be set to true in order for the public IP to be assigned to the instance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
