### PR TITLE
Change validator to unblock io2 Block Express Volume

### DIFF
--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -76,7 +76,7 @@ EFA_UNSUPPORTED_ARCHITECTURES_OSES = {
 EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS = {
     "standard": (1, 1024),
     "io1": (4, 16 * 1024),
-    "io2": (4, 16 * 1024),
+    "io2": (4, 64 * 1024),
     "gp2": (1, 16 * 1024),
     "gp3": (1, 16 * 1024),
     "st1": (500, 16 * 1024),
@@ -85,7 +85,7 @@ EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS = {
 
 EBS_VOLUME_IOPS_BOUNDS = {
     "io1": (100, 64000),
-    "io2": (100, 64000),
+    "io2": (100, 256000),
     "gp3": (3000, 16000),
 }
 
@@ -1360,7 +1360,7 @@ def ebs_volume_iops_validator(section_key, section_label, pcluster_config):
     section = pcluster_config.get_section(section_key, section_label)
     volume_size = section.get_param_value("volume_size")
     volume_type = section.get_param_value("volume_type")
-    volume_type_to_iops_ratio = {"io1": 50, "io2": 500, "gp3": 500}
+    volume_type_to_iops_ratio = {"io1": 50, "io2": 1000, "gp3": 500}
     volume_iops = section.get_param_value("volume_iops")
 
     if volume_type in EBS_VOLUME_IOPS_BOUNDS:

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -698,14 +698,14 @@ def test_efs_validator(mocker, section_dict, expected_message):
         ({"volume_type": "io2", "volume_size": 20, "volume_iops": 120}, None),
         (
             {"volume_type": "io2", "volume_size": 20, "volume_iops": 90},
-            "IOPS rate must be between 100 and 64000 when provisioning io2 volumes.",
+            "IOPS rate must be between 100 and 256000 when provisioning io2 volumes.",
         ),
         (
-            {"volume_type": "io2", "volume_size": 20, "volume_iops": 64001},
-            "IOPS rate must be between 100 and 64000 when provisioning io2 volumes.",
+            {"volume_type": "io2", "volume_size": 20, "volume_iops": 256001},
+            "IOPS rate must be between 100 and 256000 when provisioning io2 volumes.",
         ),
         (
-            {"volume_type": "io2", "volume_size": 20, "volume_iops": 10001},
+            {"volume_type": "io2", "volume_size": 20, "volume_iops": 20001},
             "IOPS to volume size ratio of .* is too high",
         ),
         ({"volume_type": "gp3", "volume_size": 20, "volume_iops": 3000}, None),
@@ -2449,7 +2449,7 @@ def test_fsx_ignored_parameters_validator(mocker, section_dict, expected_error):
         ({"volume_type": "io1", "volume_size": 16385}, "The size of io1 volumes can not exceed 16384 GiB"),
         ({"volume_type": "io2", "volume_size": 15}, None),
         ({"volume_type": "io2", "volume_size": 3}, "The size of io2 volumes must be at least 4 GiB"),
-        ({"volume_type": "io2", "volume_size": 16385}, "The size of io2 volumes can not exceed 16384 GiB"),
+        ({"volume_type": "io2", "volume_size": 65537}, "The size of io2 volumes can not exceed 65536 GiB"),
         ({"volume_type": "gp2", "volume_size": 15}, None),
         ({"volume_type": "gp2", "volume_size": 0}, "The size of gp2 volumes must be at least 1 GiB"),
         ({"volume_type": "gp2", "volume_size": 16385}, "The size of gp2 volumes can not exceed 16384 GiB"),
@@ -2493,14 +2493,14 @@ def test_ebs_allowed_values_all_have_volume_size_bounds():
         ({"volume_type": "io2", "volume_size": 20, "volume_iops": 120}, None),
         (
             {"volume_type": "io2", "volume_size": 20, "volume_iops": 90},
-            "IOPS rate must be between 100 and 64000 when provisioning io2 volumes.",
+            "IOPS rate must be between 100 and 256000 when provisioning io2 volumes.",
         ),
         (
-            {"volume_type": "io2", "volume_size": 20, "volume_iops": 64001},
-            "IOPS rate must be between 100 and 64000 when provisioning io2 volumes.",
+            {"volume_type": "io2", "volume_size": 20, "volume_iops": 256001},
+            "IOPS rate must be between 100 and 256000 when provisioning io2 volumes.",
         ),
         (
-            {"volume_type": "io2", "volume_size": 20, "volume_iops": 10001},
+            {"volume_type": "io2", "volume_size": 20, "volume_iops": 20001},
             "IOPS to volume size ratio of .* is too high",
         ),
         ({"volume_type": "gp3", "volume_size": 20, "volume_iops": 3000}, None),


### PR DESCRIPTION
Modify the iops and size range ro unblock user create io2 Block Express volume
According to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html#io2-block-express,
people can now opt in to the io2 Block Express volumes preview in some region. After opt in, all io2 volumes created in the account in the opted-in Regions will be io2 Block Express volumes.
io2 Block Express volume rise range: 4 GiB - 64 TiB
max iops: 256,000
max throughput: 4,000 MiB/s
Provisioned IOPS up to 256,000, with an IOPS:GiB ratio of 1,000:1. Maximum IOPS can be provisioned with volumes 256 GiB in size and larger (1,000 IOPS x 256 GiB = 256,000 IOPS). 

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
