### PR TITLE
Upgrade EFA installer to version 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,13 @@ CHANGELOG
 
 **CHANGES**
 
-- Upgrade EFA installer to version 1.11.0.
-  - EFA configuration: ``efa-config-1.6`` (from efa-config-1.5)
-  - EFA profile: ``efa-profile-1.2`` (from efa-profile-1.1)
+- Upgrade EFA installer to version 1.11.1.
+  - EFA configuration: ``efa-config-1.7`` (from efa-config-1.5)
+  - EFA profile: ``efa-profile-1.3`` (from efa-profile-1.1)
   - EFA kernel module: ``efa-1.10.2`` (no change)
   - RDMA core: ``rdma-core-31.2amzn`` (from rdma-core-31.amzn0)
   - Libfabric: ``libfabric-1.11.1amzn1.0`` (from libfabric-1.11.1amzn1.1)
-  - Open MPI: ``openmpi40-aws-4.0.5`` (no change)
+  - Open MPI: ``openmpi40-aws-4.1.0`` (from openmpi40-aws-4.0.5)
 - Upgrade Intel MPI to version U8.
 - Upgrade NICE DCV to version 2020.2-9662.
 - Set default systemd runlevel to multi-user.target on all OSes during ParallelCluster official AMI creation.


### PR DESCRIPTION
Changelog
```
  - EFA configuration: ``efa-config-1.7`` (from efa-config-1.5)
  - EFA profile: ``efa-profile-1.3`` (from efa-profile-1.1)
  - EFA kernel module: ``efa-1.10.2`` (no change)
  - RDMA core: ``rdma-core-31.2amzn`` (from rdma-core-31.amzn0)
  - Libfabric: ``libfabric-1.11.1amzn1.0`` (from libfabric-1.11.1amzn1.1)
  - Open MPI: ``openmpi40-aws-4.1.0`` (from openmpi40-aws-4.0.5)
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
