### PR TITLE
Add sleep action after sit cluster update

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -598,6 +598,9 @@ def _check_update_compute(
     cluster.config_file = str(updated_config_file)
     cluster.update()
 
+    logging.info("Sleeping for 180 seconds in case instance type properties cache is not updated yet in jobwatcher")
+    time.sleep(180)
+
     # Check cfn_scheduler_slots changed by changing compute instance type
     _check_compute_node_slots(
         cluster,


### PR DESCRIPTION
Sleep 180 seconds in case instance type properties cache is not updated yet in jobwatcher

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
