### PR TITLE
Change yes/no to true/false in integ test config schema

### DIFF
--- a/tests/integration-tests/framework/tests_configuration/config_schema.yaml
+++ b/tests/integration-tests/framework/tests_configuration/config_schema.yaml
@@ -16,41 +16,41 @@ type: map
 mapping:
   test-suites:
     type: map
-    required:  yes
+    required:  true
     mapping:
       regex;(.+):
         type: map
-        required: yes
+        required: true
         mapping:
           regex;(.+\.py::.+):
             type: map
-            required: yes
+            required: true
             mapping:
               dimensions:
                 type: seq
-                required: yes
+                required: true
                 sequence:
                   - type: map
-                    required: yes
+                    required: true
                     mapping:
                       regions:
                         type: seq
-                        required: yes
+                        required: true
                         sequence:
                           - type: str
                       instances:
                         type: seq
-                        required: no
+                        required: false
                         sequence:
                           - type: str
                       oss:
                         type: seq
-                        required: no
+                        required: false
                         allowempty: False
                         sequence:
                           - type: str
                       schedulers:
                         type: seq
-                        required: no
+                        required: false
                         sequence:
                           - type: str


### PR DESCRIPTION
This was required due to the release of pykwalify v1.8.0, which uses
ruamel.yaml as the parser. This parser apparently does not support the
use of yes/no for boolean values.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
