### PR TITLE
Fix updating queue_size parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 CHANGELOG
 =========
 
+2.x.x
+------
+
+**ENHANCEMENTS**
+
+-
+
+**CHANGES**
+
+-
+
+**BUG FIXES**
+
+- Fix update behavior of initial_queue_size and max_queue_size parameters with new update policies
+
 2.10.1
 ------
 

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -1057,14 +1057,14 @@ CLUSTER_SIT = {
             ("initial_queue_size", {
                 "type": QueueSizeCfnParam,
                 "default": 0,
-                "cfn_param_mapping": "DesiredSize",  # TODO verify the update case
-                "update_policy": UpdatePolicy.SUPPORTED
+                "cfn_param_mapping": "DesiredSize",
+                "update_policy": UpdatePolicy.INITIAL_QUEUE_SIZE
             }),
             ("max_queue_size", {
                 "type": QueueSizeCfnParam,
                 "default": 10,
                 "cfn_param_mapping": "MaxSize",
-                "update_policy": UpdatePolicy.SUPPORTED
+                "update_policy": UpdatePolicy.MAX_QUEUE_SIZE
             }),
             ("maintain_initial_size", {
                 "type": MaintainInitialSizeCfnParam,

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -192,6 +192,25 @@ UpdatePolicy.MIN_COUNT = UpdatePolicy(
     condition_checker=_check_min_count,
 )
 
+# Check resize of initial_queue_size
+UpdatePolicy.INITIAL_QUEUE_SIZE = UpdatePolicy(
+    level=1,
+    fail_reason="Changing initial_queue_size may cause existing nodes to be terminated hence requires "
+    "the compute fleet to be stopped first",
+    action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
+    condition_checker=lambda change, patch: not utils.cluster_has_running_capacity(patch.stack_name),
+)
+
+# Check resize of max_queue_size
+UpdatePolicy.MAX_QUEUE_SIZE = UpdatePolicy(
+    level=1,
+    fail_reason="Decreasing max_queue_size may cause existing nodes to be terminated hence requires "
+    "the compute fleet to be stopped first",
+    action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
+    condition_checker=lambda change, patch: change.new_value >= change.old_value
+    or not utils.cluster_has_running_capacity(patch.stack_name),
+)
+
 # Checks that the value of the parameter has not been decreased
 UpdatePolicy.INCREASE_ONLY = UpdatePolicy(
     level=2,

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -73,8 +73,8 @@ def test_config_patch(mocker):
     [
         ("vpc", "default", "master_subnet_id", "subnet-12345678", "subnet-1234567a", UpdatePolicy.UNSUPPORTED),
         ("vpc", "default", "additional_sg", "sg-12345678", "sg-1234567a", UpdatePolicy.SUPPORTED),
-        ("cluster", "default", "initial_queue_size", 0, 1, UpdatePolicy.SUPPORTED),
-        ("cluster", "default", "max_queue_size", 0, 1, UpdatePolicy.SUPPORTED),
+        ("cluster", "default", "initial_queue_size", 0, 1, UpdatePolicy.INITIAL_QUEUE_SIZE),
+        ("cluster", "default", "max_queue_size", 0, 1, UpdatePolicy.MAX_QUEUE_SIZE),
         ("cluster", "default", "maintain_initial_size", 0, 1, UpdatePolicy.SUPPORTED),
         ("cluster", "default", "compute_instance_type", "t2.micro", "c4.xlarge", UpdatePolicy.COMPUTE_FLEET_STOP),
     ],

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -61,3 +61,50 @@ def test_min_count_policy(mocker, is_fleet_stopped, old_min_max, new_min_max, ex
 
     assert_that(UpdatePolicy.MIN_COUNT.condition_checker(change_mock, patch_mock)).is_equal_to(expected_result)
     cluster_has_running_capacity_mock.assert_called_with("stack_name")
+
+
+@pytest.mark.parametrize(
+    "is_fleet_stopped, old_value, new_value, expected_result",
+    [
+        (False, 3, 1, False),
+        (False, 1, 3, False),
+        (True, 3, 1, True),
+        (True, 1, 3, True),
+    ],
+)
+def test_initial_queue_size_policy(mocker, is_fleet_stopped, old_value, new_value, expected_result):
+    cluster_has_running_capacity_mock = mocker.patch(
+        "pcluster.utils.cluster_has_running_capacity", return_value=not is_fleet_stopped
+    )
+    patch_mock = mocker.MagicMock()
+    patch_mock.stack_name = "stack_name"
+    change_mock = mocker.MagicMock()
+    change_mock.new_value = new_value
+    change_mock.old_value = old_value
+
+    assert_that(UpdatePolicy.INITIAL_QUEUE_SIZE.condition_checker(change_mock, patch_mock)).is_equal_to(expected_result)
+    cluster_has_running_capacity_mock.assert_called_with("stack_name")
+
+
+@pytest.mark.parametrize(
+    "is_fleet_stopped, old_value, new_value, expected_result",
+    [
+        (False, 3, 1, False),
+        (False, 1, 3, True),
+        (True, 3, 1, True),
+        (True, 1, 3, True),
+    ],
+)
+def test_max_queue_size_policy(mocker, is_fleet_stopped, old_value, new_value, expected_result):
+    cluster_has_running_capacity_mock = mocker.patch(
+        "pcluster.utils.cluster_has_running_capacity", return_value=not is_fleet_stopped
+    )
+    patch_mock = mocker.MagicMock()
+    patch_mock.stack_name = "stack_name"
+    change_mock = mocker.MagicMock()
+    change_mock.new_value = new_value
+    change_mock.old_value = old_value
+
+    assert_that(UpdatePolicy.MAX_QUEUE_SIZE.condition_checker(change_mock, patch_mock)).is_equal_to(expected_result)
+    if new_value < old_value:
+        cluster_has_running_capacity_mock.assert_called_with("stack_name")


### PR DESCRIPTION
* Updates to initial_queue_size and max_queue_size parameters can potentially terminate existing cluster instances, and therefore should not have update policy of UpdatePolicy.SUPPORTED
* Implement new update policies for these parameters that recommends stopping the cluster first
* Implement new unit tests

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
