### PR TITLE
Add closed issue message github action

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -1,0 +1,17 @@
+name: Closed Issue Message
+on:
+  issues:
+    types: [closed]
+jobs:
+  auto_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/closed-issue-message@v1
+        with:
+          # These inputs are both required
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          message: |
+            ### ⚠️COMMENT VISIBILITY WARNING⚠️
+            Comments on closed issues are hard for our team to see.
+            If you need more assistance, please either tag a team member or open a new issue that references this one.
+            If you wish to keep having a conversation with other community members under this issue feel free to do so.


### PR DESCRIPTION
Add a Github Action to set a default message to be commented on all issues when they get closed in order to warn users that comments on closed issues are hard for our team to see.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
