### PR TITLE
3.0: Initialize the imagebuilder configuration and cdk

### DIFF
--- a/cli/src/common/boto3/ec2.py
+++ b/cli/src/common/boto3/ec2.py
@@ -27,3 +27,14 @@ class Ec2Client(Boto3Client):
             offering.get("InstanceType")
             for offering in self._paginate_results(self._client.describe_instance_type_offerings)
         ]
+
+    @AWSExceptionHandler.handle_client_exception
+    def describe_ami_id_offering(self, ami_id):
+        """Return a boolean to determine ami id is valid or not."""
+        return self._paginate_results(
+            self._client.describe_images(
+                ImageIds=[
+                    ami_id,
+                ]
+            )
+        )

--- a/cli/src/common/utils.py
+++ b/cli/src/common/utils.py
@@ -8,7 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
 from urllib.request import urlopen
 
 import yaml
@@ -20,10 +20,15 @@ def download_file(url):
     return response.read().decode("utf-8")
 
 
-def load_yaml(config_file):
+def load_yaml_dict(config_file):
     """Read the content of a yaml file."""
     with open(config_file) as conf_file:
         yaml_content = yaml.load(conf_file, Loader=yaml.SafeLoader)
 
     # TODO use from cfn_flip import load_yaml
     return yaml_content
+
+
+def load_yaml(source_dir, file_name):
+    """Get string data from yaml file."""
+    return yaml.dump(load_yaml_dict(os.path.join(source_dir, file_name)))

--- a/cli/src/pcluster/managers/imagebuilder_manager.py
+++ b/cli/src/pcluster/managers/imagebuilder_manager.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This module defines the classes to manage the "live" objects in EC2 or CFN.
+#
+
+from pcluster.models.imagebuilder import ImageBuilder
+
+
+class ImageBuilderManager:
+    """Represent the ImageBuilder Manager."""
+
+    def __init__(self, imagebuild: ImageBuilder = None):
+        self.imagebuild = imagebuild

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -1,0 +1,167 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This module contains all the classes representing the Resources objects.
+# These objects are obtained from the configuration file through a conversion based on the Schema classes.
+#
+
+from typing import List
+
+from pcluster import utils
+from pcluster.config.extended_builtin_class import MarkedBool
+from pcluster.models.cluster import Resource, Tag
+from pcluster.validators.ec2_validators import BaseAMIValidator
+
+# ---------------------- Image ---------------------- #
+
+
+class Volume(Resource):
+    """Represent the volume configuration for the ImageBuilder."""
+
+    def __init__(self, size: int = None, encrypted: bool = None, kms_key_id: str = None):
+        super().__init__()
+        self.size = size
+        self.encrypted = encrypted
+        self.kms_key_id = kms_key_id
+        self._set_defaults()
+        # TODO: add validator
+
+    def _set_defaults(self):
+        if self.encrypted is None:
+            self.encrypted = MarkedBool(False)
+
+
+class Image(Resource):
+    """Represent the image configuration for the ImageBuilder."""
+
+    def __init__(
+        self,
+        name: str,
+        description: str = None,
+        tags: List[Tag] = None,
+        root_volume: Volume = None,
+    ):
+        super().__init__()
+        self.name = name
+        self.description = description
+        self.tags = tags
+        self.root_volume = root_volume
+        self._set_default()
+        # TODO: add validator
+
+    def _set_default(self):
+        if self.tags is None:
+            self.tags = []
+        default_tag = Tag("PclusterVersion", utils.get_installed_version())
+        default_tag.implied = True
+        self.tags.append(default_tag)
+
+
+# ---------------------- Build ---------------------- #
+
+
+class Component(Resource):
+    """Represent the components configuration for the ImageBuilder."""
+
+    def __init__(self, type: str = None, value: str = None):
+        super().__init__()
+        self.type = type
+        self.value = value
+        # TODO: add validator
+
+
+class Build(Resource):
+    """Represent the build configuration for the ImageBuilder."""
+
+    def __init__(
+        self,
+        instance_type: str,
+        parent_image: str,
+        instance_role: str = None,  # TODO: auto generate if not assigned
+        subnet_id: str = None,  # TODO: auto generate if not assigned
+        tags: List[Tag] = None,
+        security_group_ids: List[str] = None,
+        components: List[Component] = None,
+    ):
+        super().__init__()
+        self.instance_type = instance_type
+        self.parent_image = parent_image
+        self.instance_role = instance_role
+        self.tags = tags
+        self.subnet_id = subnet_id
+        self.security_group_ids = security_group_ids
+        self.components = components
+        # TODO: add validator
+
+
+# ---------------------- Dev Settings ---------------------- #
+
+
+class ChefCookbook(Resource):
+    """Represent the chef cookbook configuration for the ImageBuilder."""
+
+    def __init__(self, url: str, json: str):
+        super().__init__()
+        self.url = url
+        self.json = json
+        # TODO: add validator
+
+
+class DevSettings(Resource):
+    """Represent the dev settings configuration for the ImageBuilder."""
+
+    def __init__(
+        self,
+        update_os_and_reboot: bool = None,
+        disable_pcluster_component: bool = None,
+        chef_cookbook: ChefCookbook = None,
+        node_url: str = None,
+        aws_batch_cli_url: str = None,
+        distribution_configuration_arn: str = None,
+        terminate_instance_on_failure: bool = None,
+    ):
+        super().__init__()
+        self.update_os_and_reboot = update_os_and_reboot
+        self.disable_pcluster_component = disable_pcluster_component
+        self.chef_cookbook = chef_cookbook
+        self.node_url = node_url
+        self.aws_batch_cli_url = aws_batch_cli_url
+        self.distribution_configuration_arn = distribution_configuration_arn
+        self.terminate_instance_on_failure = terminate_instance_on_failure
+        self._set_default()
+        # TODO: add validator
+
+    def _set_default(self):
+        if self.update_os_and_reboot is None:
+            self.update_os_and_reboot = MarkedBool(False)
+        if self.disable_pcluster_component is None:
+            self.disable_pcluster_component = MarkedBool(False)
+        if self.terminate_instance_on_failure is None:
+            self.terminate_instance_on_failure = MarkedBool(True)
+
+
+# ---------------------- ImageBuilder ---------------------- #
+
+
+class ImageBuilder(Resource):
+    """Represent the configuration of an ImageBuilder."""
+
+    def __init__(
+        self,
+        image: Image,
+        build: Build,
+        dev_settings: DevSettings = None,
+    ):
+        super().__init__()
+        self.image = image
+        self.build = build
+        self.dev_settings = dev_settings
+        self._add_validator(BaseAMIValidator, ami_id=self.build.parent_image)

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -125,12 +125,14 @@ class BaseSchema(Schema):
         for key, value in vars(data).copy().items():
             if _is_implied(value):
                 delattr(data, key)
+            if isinstance(value, list):
+                value[:] = [v for v in value if not _is_implied(v)]
         return data
 
     @post_dump
     def remove_none_values(self, data, **kwargs):
         """Remove None values before creating the Yaml format."""
-        return {key: value for key, value in data.items() if value is not None}
+        return {key: value for key, value in data.items() if value is not None and value != []}
 
 
 def _is_implied(value):

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -1,0 +1,128 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This module contains all the classes representing the Schema of the configuration file.
+# These classes are created by following marshmallow syntax.
+#
+from marshmallow import fields, post_load
+
+from pcluster.models.imagebuilder import Build, ChefCookbook, Component, DevSettings, Image, ImageBuilder, Volume
+from pcluster.schemas.cluster_schema import BaseSchema, TagSchema
+
+# ---------------------- Image Schema---------------------- #
+
+
+class VolumeSchema(BaseSchema):
+    """Represent the schema of the ImageBuilder Volume."""
+
+    size = fields.Int(data_key="Size")
+    encrypted = fields.Bool(data_key="Encrypted")
+    kms_key_id = fields.Str()
+
+    @post_load()
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return Volume(**data)
+
+
+class ImageSchema(BaseSchema):
+    """Represent the schema of the ImageBuilder Image."""
+
+    name = fields.Str(data_key="Name", required=True)
+    description = fields.Str(data_key="Description")
+    tags = fields.List(fields.Nested(TagSchema), data_key="Tags")
+    root_volume = fields.Nested(VolumeSchema)
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return Image(**data)
+
+
+# ---------------------- Build Schema---------------------- #
+
+
+class ComponentSchema(BaseSchema):
+    """Represent the schema of the ImageBuilder component."""
+
+    type = fields.Str(data_key="Type")
+    value = fields.Str(data_key="Value")
+
+    @post_load()
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return Component(**data)
+
+
+class BuildSchema(BaseSchema):
+    """Represent the schema of the ImageBuilder Build."""
+
+    instance_role = fields.Str()
+    instance_type = fields.Str(required=True)
+    components = fields.List(fields.Nested(ComponentSchema), data_key="Components")
+    parent_image = fields.Str(required=True)
+    tags = fields.List(fields.Nested(TagSchema), data_key="Tags")
+    security_group_ids = fields.List(fields.Str)
+    subnet_id = fields.Str()
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return Build(**data)
+
+
+# ---------------------- Dev Settings Schema ---------------------- #
+
+
+class ChefCookbookSchema(BaseSchema):
+    """Represent the schema of the ImageBuilder chef cookbook."""
+
+    url = fields.Str(data_key="Url")
+    json = fields.Str(data_key="Json")
+
+    @post_load()
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return ChefCookbook(**data)
+
+
+class DevSettingsSchema(BaseSchema):
+    """Represent the schema of the ImageBuilder Dev Setting."""
+
+    update_os_and_reboot = fields.Bool()
+    disable_pcluster_component = fields.Bool()
+    chef_cookbook = fields.Nested(ChefCookbookSchema)
+    node_url = fields.Str()
+    aws_batch_cli_url = fields.Str(data_key="AWSBatchCliUrl")
+    distribution_configuration_arn = fields.Str()
+    terminate_instance_on_failure = fields.Bool()
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return DevSettings(**data)
+
+
+# ---------------------- ImageBuilder Schema ---------------------- #
+
+
+class ImageBuilderSchema(BaseSchema):
+    """Represent the schema of the ImageBuilder."""
+
+    image = fields.Nested(ImageSchema, data_key="Image", required=True)
+    build = fields.Nested(BuildSchema, data_key="Build", required=True)
+    dev_settings = fields.Nested(DevSettingsSchema)
+
+    @post_load()
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return ImageBuilder(**data)

--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -12,15 +12,16 @@
 #
 # This module contains all the classes required to convert a Cluster into a CFN template by using CDK.
 #
-
 import os
 import tempfile
 
 from aws_cdk import core
 
-from common.utils import load_yaml
+from common.utils import load_yaml_dict
 from pcluster.models.cluster import Cluster
+from pcluster.models.imagebuilder import ImageBuilder
 from pcluster.templates.cluster_stack import ClusterStack
+from pcluster.templates.imagebuilder_stack import ImageBuilderStack
 
 
 class CDKTemplateBuilder:
@@ -33,6 +34,17 @@ class CDKTemplateBuilder:
             app = core.App(outdir=str(tempdir))
             ClusterStack(app, output_file, cluster=cluster)
             app.synth()
-            generated_template = load_yaml(os.path.join(tempdir, f"{output_file}.template.json"))
+            generated_template = load_yaml_dict(os.path.join(tempdir, f"{output_file}.template.json"))
+
+        return generated_template
+
+    def build_ami(self, imagebuild: ImageBuilder):
+        """Build template for the given imagebuilder and return as output in Yaml format."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            output_file = "imagebuilder"
+            app = core.App(outdir=str(tempdir))
+            ImageBuilderStack(app, output_file, imagebuild)
+            app.synth()
+            generated_template = load_yaml_dict(os.path.join(tempdir, f"{output_file}.template.json"))
 
         return generated_template

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -1,0 +1,186 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This module contains all the classes required to convert a ImageBuilder into a CFN template by using CDK.
+#
+
+import os
+
+from aws_cdk import aws_iam as iam
+from aws_cdk import aws_imagebuilder as imagebuilder
+from aws_cdk import aws_ssm as ssm
+from aws_cdk import core
+
+import pcluster.utils as utils
+from common.utils import load_yaml
+from pcluster.models.imagebuilder import ImageBuilder
+
+
+class ImageBuilderStack(core.Stack):
+    """Create the Stack for imagebuilder."""
+
+    def __init__(self, scope: core.Construct, construct_id: str, imagebuild: ImageBuilder, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+        image = imagebuild.image
+        build = imagebuild.build
+        dev_settings = imagebuild.dev_settings
+
+        # TODO: use attributes from imagebuilder config instead of using these static variables.
+        core.CfnParameter(self, "EnableNvidia", type="String", default="false", description="EnableNvidia")
+        core.CfnParameter(self, "EnableDCV", type="String", default="false", description="EnableDCV")
+        default_node_url = dev_settings.node_url if dev_settings and dev_settings.node_url else ""
+        core.CfnParameter(
+            self,
+            "CustomNodePackage",
+            type="String",
+            default=default_node_url,
+            description="CustomNodePackage",
+        )
+        core.CfnParameter(
+            self,
+            "UpdateAndReboot",
+            type="String",
+            default=str.lower(str(bool(dev_settings.update_os_and_reboot))),
+            description="UpdateAndReboot",
+        )
+        ami_info = utils.get_info_for_amis([build.parent_image])
+        architecture = ami_info[0].get("Architecture")
+        if build.instance_type:
+            instance_types = [build.instance_type]
+        else:
+            instance_types = ["p2.xlarge", "c5.xlarge"] if architecture == "x86_64" else ["m6g.xlarge"]
+
+        # Setup ImageBuilder Resources
+        resources_prefix = utils.generate_random_prefix()
+
+        # InstanceRole
+        managed_policy_arns = [
+            core.Fn.sub("arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"),
+            core.Fn.sub("arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder"),
+        ]
+        if build.instance_role:
+            managed_policy_arns.extend([build.instance_role])
+
+        instancerole = iam.CfnRole(
+            self,
+            id="InstanceRole",
+            managed_policy_arns=managed_policy_arns,
+            assume_role_policy_document={
+                "Statement": {
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ec2.amazonaws.com"},
+                },
+                "Version": "2012-10-17",
+            },
+            path="/executionServiceEC2Role/",
+        )
+        instancerole.add_metadata("Comment", "Role to be used by instance during image build.")
+
+        # InstanceProfile
+        iam.CfnInstanceProfile(
+            self, id="InstanceProfile", path="/executionServiceEC2Role/", roles=[core.Fn.ref("InstanceRole")]
+        )
+
+        # InfrastructureConfiguration
+        imagebuilder.CfnInfrastructureConfiguration(
+            self,
+            id="PClusterImageInfrastructureConfiguration",
+            name="-".join(["PCluster-Image-Infrastructure-Configuration", resources_prefix]),
+            instance_profile_name=core.Fn.ref("InstanceProfile"),
+            terminate_instance_on_failure=bool(dev_settings.terminate_instance_on_failure),
+            instance_types=instance_types,
+        )
+
+        # Define ami build instance ebs
+        increase_volume_size = 15
+        if image.root_volume:
+            ebs = imagebuilder.CfnImageRecipe.EbsInstanceBlockDeviceSpecificationProperty(
+                volume_size=image.root_volume.size
+                or ami_info[0].get("BlockDeviceMappings")[0].get("Ebs").get("VolumeSize") + increase_volume_size,
+                volume_type="gp2",
+            )
+        else:
+            ebs = imagebuilder.CfnImageRecipe.EbsInstanceBlockDeviceSpecificationProperty(
+                volume_size=ami_info[0].get("BlockDeviceMappings")[0].get("Ebs").get("VolumeSize")
+                + increase_volume_size,
+                volume_type="gp2",
+            )
+
+        imagebuilder_cloudformation_dir = os.path.join(utils.get_cloudformation_directory(), "imagebuilder")
+        # Components
+        components = []
+        if dev_settings and dev_settings.update_os_and_reboot:
+            imagebuilder.CfnComponent(
+                self,
+                id="UpdateAndRebootComponent",
+                name="-".join(["UpdateAndReboot", resources_prefix]),
+                version="0.0.1",
+                description="Update OS and Reboot",
+                change_description="First version",
+                platform="Linux",
+                data=core.Fn.sub(load_yaml(imagebuilder_cloudformation_dir, "update_and_reboot.yaml")),
+            )
+            components.append(
+                imagebuilder.CfnImageRecipe.ComponentConfigurationProperty(
+                    component_arn=core.Fn.ref("UpdateAndRebootComponent")
+                )
+            )
+
+        imagebuilder.CfnComponent(
+            self,
+            id="PClusterComponent",
+            name="-".join(["PCluster", resources_prefix]),
+            version="0.0.1",
+            description="Bake PCluster AMI",
+            change_description="First version",
+            platform="Linux",
+            data=core.Fn.sub(load_yaml(imagebuilder_cloudformation_dir, "pcluster_install.yaml")),
+        )
+
+        components.append(
+            imagebuilder.CfnImageRecipe.ComponentConfigurationProperty(component_arn=core.Fn.ref("PClusterComponent"))
+        )
+
+        # ImageRecipe
+        imagebuilder.CfnImageRecipe(
+            self,
+            id="PClusterImageRecipe",
+            name="-".join(["PCluster", utils.get_installed_version().replace(".", "-"), resources_prefix]),
+            version="0.0.1",
+            parent_image=core.Fn.sub(build.parent_image),
+            components=components,
+            block_device_mappings=[
+                imagebuilder.CfnImageRecipe.InstanceBlockDeviceMappingProperty(
+                    device_name="/dev/xvda",
+                    ebs=ebs,
+                )
+            ],
+        )
+
+        # Image
+        imagebuilder.CfnImage(
+            self,
+            id="PClusterImage",
+            image_recipe_arn=core.Fn.ref("PClusterImageRecipe"),
+            infrastructure_configuration_arn=core.Fn.ref("PClusterImageInfrastructureConfiguration"),
+        )
+
+        # AWS Systems Manager
+        ssm.CfnParameter(
+            self,
+            id="PClusterParameter",
+            description="Image Id for PCluster",
+            name="-".join(["/Test/Images/PCluster", resources_prefix]),
+            type="String",
+            value=core.Fn.get_att("PClusterImage", "ImageId").to_string(),
+        )

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -141,9 +141,24 @@ def generate_random_name_with_prefix(name_prefix):
 
     Example: <name_prefix>-4htvo26lchkqeho1
     """
-    random_string = "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(16))
+    random_string = generate_random_prefix()
     output_name = "-".join([name_prefix.lower()[: 63 - len(random_string) - 1], random_string])
     return output_name
+
+
+def generate_random_prefix():
+    """
+    Generate a random prefix that is 16 characters long.
+
+    Example: 4htvo26lchkqeho1
+    """
+    return "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(16))
+
+
+def get_cloudformation_directory():
+    """Get cloudforamtion directory."""
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(current_dir, "..", "..", "..", "cloudformation")
 
 
 def create_s3_bucket(bucket_name, region):

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -13,6 +13,16 @@ from common.boto3.ec2 import Ec2Client
 from pcluster.validators.common import FailureLevel, Validator
 
 
+class BaseAMIValidator(Validator):
+    """Base AMI validator."""
+
+    def __call__(self, ami_id: str):
+        """Validate given ami id."""
+        if not Ec2Client().describe_ami_id_offering(ami_id=ami_id):
+            self._add_failure(f"The ami id '{ami_id}' is not supported.", FailureLevel.CRITICAL)
+        return self._failures
+
+
 class InstanceTypeValidator(Validator):
     """EC2 Instance type validator."""
 

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -16,7 +16,7 @@ import yaml
 from assertpy import assert_that
 from marshmallow.validate import ValidationError
 
-from common.utils import load_yaml
+from common.utils import load_yaml_dict
 from pcluster.schemas.cluster_schema import ClusterSchema, ImageSchema, SchedulingSchema
 
 
@@ -27,7 +27,7 @@ def test_cluster_schema_slurm(test_datadir, config_file_name):
     # TODO use yaml render_module: https://marshmallow.readthedocs.io/en/3.0/api_reference.html#marshmallow.Schema.Meta
 
     # Load cluster model from Yaml file
-    input_yaml = load_yaml(test_datadir / config_file_name)
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
     print(input_yaml)
     cluster = ClusterSchema().load(input_yaml)
     print(cluster)

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema.py
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema.py
@@ -1,0 +1,27 @@
+import json
+
+import pytest
+import yaml
+from assertpy import assert_that
+
+from common.utils import load_yaml_dict
+from pcluster.schemas.imagebuilder_schema import ImageBuilderSchema
+
+
+@pytest.mark.parametrize("config_file_name", ["imagebuilder_schema_required.yaml", "imagebuilder_schema_dev.yaml"])
+def test_imagebuilder_schema(test_datadir, config_file_name):
+    # Load imagebuilder model from Yaml file
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+    print(input_yaml)
+    imagebuilder_config = ImageBuilderSchema().load(input_yaml)
+    print(imagebuilder_config)
+
+    # Re-create Yaml file from model and compare content
+    output_json = ImageBuilderSchema().dump(imagebuilder_config)
+
+    # Assert imagebuilder config file can be convert to imagebuilder config
+    assert_that(json.dumps(input_yaml, sort_keys=True)).is_equal_to(json.dumps(output_json, sort_keys=True))
+
+    # Print output yaml
+    output_yaml = yaml.dump(output_json)
+    print(output_yaml)

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
@@ -1,0 +1,47 @@
+Image:
+  Name: Pcluster
+  Description: Build for Pcluster 3.0
+  Tags:
+    - Key: Name
+      Value: ParallelCluster-3.0-AMI
+    - Key: Version
+      Value: verion-3.0
+  RootVolume:
+    Size: 25
+    Encrypted: True
+    KmsKeyId: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
+
+Build:
+  InstanceRole: TestRole
+  InstanceType: c5.xlarge
+  Components:
+    - Type: arn
+      Value: arn:aws:imagebuilder:us-east-1:aws:component/amazon-cloudwatch-agent-linux/1.0.0
+    - Type: yaml
+      Value: s3://test/mysql_component.yml
+    - Type: yaml
+      Value: s3://test/keras_component.yml
+    - Type: bash
+      Value: s3://test/post_install.sh
+  ParentImage: arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x
+  Tags:
+    - Key: Name
+      Value: ParallelCluster-3.0-Build
+    - Key: Date
+      Value: 2022.1.1
+  SecurityGroupIds:
+    - sg-990022199901
+    - sg-889920129301
+  SubnetId: subnet-0d03dc52
+
+DevSettings:
+  UpdateOsAndReboot: True
+  DisablePclusterComponent: False
+  ChefCookbook:
+    Url: s3://test/aws-parallelcluster-cookbook-3.0.tgz
+    Json: |
+      { "cluster" : {"cfn_scheduler_slots": "cores"}}
+  NodeUrl: s3://test/aws-parallelcluster-node-3.0.tgz
+  AWSBatchCliUrl: s3://test/aws-parallelcluster-batch-3.0.tgz
+  DistributionConfigurationArn: arn:aws:imagebuilder:us-east-1:aws:distributionconfiguration/amazon-cloudwatch-agent-linux/1.0.0
+  TerminateInstanceOnFailure: True

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_required.yaml
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_required.yaml
@@ -1,0 +1,6 @@
+Image:
+  Name: Pcluster
+
+Build:
+  InstanceType: c5.xlarge
+  ParentImage: ami-0185634c5a8a37250

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -367,6 +367,11 @@ def test_generate_random_name_with_prefix(bucket_prefix):
     assert_that(len(bucket_name)).is_between(3, max_bucket_name_length)
 
 
+def test_generate_random_prefix():
+    prefix = utils.generate_random_prefix()
+    assert_that(len(prefix)).is_equal_to(16)
+
+
 @pytest.mark.parametrize(
     "region,create_error_message,configure_error_message",
     [

--- a/cli/tests/pcluster/validators/test_ec2.py
+++ b/cli/tests/pcluster/validators/test_ec2.py
@@ -11,7 +11,7 @@
 
 import pytest
 
-from pcluster.validators.ec2_validators import InstanceTypeValidator
+from pcluster.validators.ec2_validators import BaseAMIValidator, InstanceTypeValidator
 from tests.pcluster.validators.utils import assert_failure_messages
 
 
@@ -27,4 +27,15 @@ def test_instance_type_validator(mocker, instance_type, expected_message):
     )
 
     actual_failures = InstanceTypeValidator()(instance_type)
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "image_id, expected_message, response",
+    [("ami-0185634c5a8a37250", None, True), ("ami-000000000000", "is not supported", False)],
+)
+def test_base_ami_validator(mocker, image_id, expected_message, response):
+    mocker.patch("pcluster.validators.ec2_validators.Ec2Client.__init__", return_value=None)
+    mocker.patch("pcluster.validators.ec2_validators.Ec2Client.describe_ami_id_offering", return_value=response)
+    actual_failures = BaseAMIValidator()(image_id)
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -9,3 +9,6 @@ recordclass
 marshmallow
 aws-cdk.core
 aws-cdk.aws-ec2
+aws-cdk.aws-imagebuilder
+aws-cdk.aws-iam
+aws-cdk.aws-ssm

--- a/cloudformation/imagebuilder/pcluster_install.yaml
+++ b/cloudformation/imagebuilder/pcluster_install.yaml
@@ -1,0 +1,249 @@
+name: PCluster
+description: Bake PCluster AMI
+schemaVersion: 1.0
+
+phases:
+  - name: build
+    steps:
+      - name: Exit
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo 1
+
+      # Check input base AMI OS and get OS information, the output should be like centos.7 | centos.8 | amzn.2018.03 | amzn.2 | ubuntu.18.04 | ubuntu.16.04
+      - name: OperatingSystemRelease
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              FILE=/etc/os-release
+              if [ -e ${!FILE} ]; then
+                . ${!FILE}
+                echo "${!ID}${!VERSION_ID:+.${!VERSION_ID}}"
+              else
+                echo "The file '${!FILE}' does not exist. Failing build."
+                exit {{ build.Exit.outputs.stdout }}
+              fi
+
+      # Get uniformed OS name
+      - name: OperatingSystemName
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              RELEASE='{{ build.OperatingSystemRelease.outputs.stdout }}'
+
+              if [ `echo "${!RELEASE}" | grep -w '^amzn\.2'` ]; then
+                OS='alinux2'
+              elif [ `echo "${!RELEASE}" | grep '^amzn'` ]; then
+                OS='alinux'
+              elif [ `echo "${!RELEASE}" | grep '^centos\.7'` ]; then
+                OS='centos7'
+              elif [ `echo "${!RELEASE}" | grep '^centos\.8'` ]; then
+                OS='centos8'
+              elif [ `echo "${!RELEASE}" | grep '^ubuntu\.18'` ]; then
+                OS='ubuntu1804'
+              elif [ `echo "${!RELEASE}" | grep '^ubuntu\.16'` ]; then
+                OS='ubuntu1604'
+              else
+                echo "Operating System '${!RELEASE}' is not supported. Failing build."
+                exit {{ build.Exit.outputs.stdout }}
+              fi
+
+              echo ${!OS}
+
+      # Get platform name
+      - name: PlatformName
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+               set -x
+               OS='{{ build.OperatingSystemName.outputs.stdout }}'
+
+               if [ `echo "${!OS}" | grep -E '^(alinux|centos)'` ]; then
+                 PLATFORM='RHEL'
+               elif [ `echo "${!OS}" | grep -E '^ubuntu'` ]; then
+                 PLATFORM='DEBIAN'
+               fi
+
+               echo ${!PLATFORM}
+
+      # Get input base AMI Architecture
+      - name: OperatingSystemArchitecture
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              ARCH=$(uname -m)
+              case ${!ARCH} in
+                'x86_64')
+                  echo 'x86_64'
+                  ;;
+                'aarch64')
+                  echo 'arm64'
+                  ;;
+                *)
+                  echo "The '${!ARCH}' architecture is not supported. Failing build."
+                  exit {{ build.Exit.outputs.stdout }}
+                  ;;
+              esac
+
+      - name: OperationSystemPrerequisite
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              OS='{{ build.OperatingSystemName.outputs.stdout }}'
+              PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+
+              if [[ ${!OS} =~ ^centos[7-8]$ ]]; then
+                  if [[ ${!OS} == centos7 ]]; then
+                    yum -y install epel-release
+                  else
+                    dnf -y install epel-release
+                  fi
+                  /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config
+                  /bin/sed -r -i -e 's/GRUB_CMDLINE_LINUX="(.*)"/GRUB_CMDLINE_LINUX="\\1 rd.driver.blacklist=nouveau nouveau.modeset=0"/' /etc/default/grub
+                  grub2-mkconfig -o /boot/grub2/grub.cfg
+              elif [[ ${!OS} =~ ^ubuntu1(6|8)04$ ]]; then
+                  apt-cache search build-essential
+                  apt-get clean
+                  apt-get update
+              fi
+
+      - name: InstallDevelopmentAndJq
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              OS='{{ build.OperatingSystemName.outputs.stdout }}'
+              PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+
+              if [[ ${!PLATFORM} == RHEL ]]; then
+                if [[ ${!OS} == centos8 ]]; then
+                  dnf -y groupinstall development && sudo dnf -y install curl wget jq
+                else
+                  yum -y groupinstall development && sudo yum -y install curl wget jq
+                fi
+              elif [[ ${!PLATFORM} == DEBIAN ]]; then
+                apt-get -y install build-essential curl wget jq
+              fi
+
+      - name: DownloadCookbook
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              CookbookVersion="aws-parallelcluster-cookbook-2.10.1"
+              cookbook_url=https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/cookbooks/${!CookbookVersion}.tgz
+              echo "${!cookbook_url}"
+              chef_version="15.11.8"
+              berkshelf_version="7.0.10"
+              curl --retry 3 -L https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.amazonaws.com/archives/cinc/cinc-install.sh | bash -s -- -v ${!chef_version}
+              /opt/cinc/embedded/bin/gem install --no-document berkshelf:${!berkshelf_version}
+
+              mkdir -p /etc/chef && sudo chown -R root:root /etc/chef
+              curl --retry 3 -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+              curl --retry 3 -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${!cookbook_url}.date
+              curl --retry 3 -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.md5 ${!cookbook_url}.md5
+
+              mkdir /tmp/cookbooks
+              cd /tmp/cookbooks
+              tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz
+
+              export HOME="/tmp"
+              for d in `ls /tmp/cookbooks`; do
+                cd /tmp/cookbooks/$d
+                LANG=en_US.UTF-8 sudo /opt/cinc/embedded/bin/berks vendor /etc/chef/cookbooks --delete || (echo 'Vendoring cookbook failed.' && exit {{ build.Exit.outputs.stdout }})
+              done;
+
+      - name: CreatingChefClientFile
+        action: CreateFile
+        inputs:
+          - path: /etc/chef/client.rb
+            content: |
+              cookbook_path ['/etc/chef/cookbooks']
+            overwrite: true
+
+      - name: CreatingJsonFile
+        action: CreateFile
+        inputs:
+          - path: /tmp/dna.json
+            content: |
+              {
+                "cfncluster" : {
+                  "cfn_region": "${AWS::Region}",
+                  "nvidia" : {
+                    "enabled" : "${EnableNvidia}"
+                  },
+                  "is_official_ami_build": "${UpdateAndReboot}",
+                  "custom_node_package" : "${CustomNodePackage}",
+                  "cfn_base_os" : "{{ build.OperatingSystemName.outputs.stdout }}"
+                }
+              }
+            overwrite: true
+
+      - name: InstallPClusterPackages
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              chef-client --local-mode --config /etc/chef/client.rb --log_level info --logfile /var/log/chef-client.log --force-formatter --no-color --chef-zero-port 8889 --json-attributes /tmp/dna.json --override-runlist aws-parallelcluster::default
+
+      - name: Bootstrap
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              OS='{{ build.OperatingSystemName.outputs.stdout }}'
+
+              if [[ ${!OS} =~ ^(centos[7-8]|ubuntu1(6|8)04)$ ]]; then
+                bucket="s3.amazonaws.com"
+                [[ ${AWS::Region} =~ ^cn- ]] && bucket="s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
+                curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz https://${!bucket}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+                if [[ ${!OS} == centos8 ]]; then
+                  dnf install -y python3-pip
+                  pip3 install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
+                elif [[ ${!OS} == centos7 ]]; then
+                  which pip2
+                  if [ $? -eq 0 ]; then
+                    pip2 install /tmp/aws-cfn-bootstrap-latest.tar.gz
+                  else
+                    pip install /tmp/aws-cfn-bootstrap-latest.tar.gz
+                  fi
+                elif [[ ${!OS} =~ ^ubuntu1(6|8)04$ ]]; then
+                  pip install /tmp/aws-cfn-bootstrap-latest.tar.gz
+                fi
+              fi
+
+              echo aws-parallelcluster-cookbook-2.10.1 | sudo tee /opt/parallelcluster/.bootstrapped
+
+              if [[ ${!OS} =~ ^centos[7-8]$ ]]; then
+                sed -i -e "s/\s*Defaults\s\s*requiretty//# Defaults  requiretty/" /etc/sudoers
+              fi
+
+      - name: CleanUp
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              /usr/local/sbin/ami_cleanup.sh
+
+
+
+  - name: validate
+    steps:
+      - name: PClusterValidate
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              echo "I am validate"

--- a/cloudformation/imagebuilder/update_and_reboot.yaml
+++ b/cloudformation/imagebuilder/update_and_reboot.yaml
@@ -1,0 +1,131 @@
+name: UpdateAndReboot
+description: Update OS and Reboot
+schemaVersion: 1.0
+
+phases:
+  - name: build
+    steps:
+      - name: Exit
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo 1
+
+      # Check input base AMI OS and get OS information, the output should be like centos.7 | centos.8 | amzn.2018.03 | amzn.2 | ubuntu.18.04 | ubuntu.16.04
+      - name: OperatingSystemRelease
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              FILE=/etc/os-release
+              if [ -e ${!FILE} ]; then
+                . ${!FILE}
+                echo "${!ID}${!VERSION_ID:+.${!VERSION_ID}}"
+              else
+                echo "The file '${!FILE}' does not exist. Failing build."
+                exit {{ build.Exit.outputs.stdout }}
+              fi
+
+      # Get uniformed OS name
+      - name: OperatingSystemName
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              RELEASE='{{ build.OperatingSystemRelease.outputs.stdout }}'
+
+              if [ `echo "${!RELEASE}" | grep -w '^amzn\.2'` ]; then
+                OS='alinux2'
+              elif [ `echo "${!RELEASE}" | grep '^amzn'` ]; then
+                OS='alinux'
+              elif [ `echo "${!RELEASE}" | grep '^centos\.7'` ]; then
+                OS='centos7'
+              elif [ `echo "${!RELEASE}" | grep '^centos\.8'` ]; then
+                OS='centos8'
+              elif [ `echo "${!RELEASE}" | grep '^ubuntu\.18'` ]; then
+                OS='ubuntu1804'
+              elif [ `echo "${!RELEASE}" | grep '^ubuntu\.16'` ]; then
+                OS='ubuntu1604'
+              else
+                echo "Operating System '${!RELEASE}' is not supported. Failing build."
+                exit {{ build.Exit.outputs.stdout }}
+              fi
+
+              echo ${!OS}
+
+      # Get platform name
+      - name: PlatformName
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+               set -x
+               OS='{{ build.OperatingSystemName.outputs.stdout }}'
+
+               if [ `echo "${!OS}" | grep -E '^(alinux|centos)'` ]; then
+                 PLATFORM='RHEL'
+               elif [ `echo "${!OS}" | grep -E '^ubuntu'` ]; then
+                 PLATFORM='DEBIAN'
+               fi
+
+               echo ${!PLATFORM}
+
+      # Check if input base AMI has supported OS
+      - name: IsOperatingSystemSupported
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              RELEASE='{{ build.OperatingSystemRelease.outputs.stdout }}'
+              if [ `echo "${!RELEASE}" | grep -Ev '^(amzn|centos|ubuntu)'` ]; then
+                echo "This component does not support '${!RELEASE}'. Failing build."
+                exit {{ build.Exit.outputs.stdout }}
+              fi
+
+              # This component only supports aarch64 CPUs on Amazon Linux 2, Ubuntu1804 and Centos8
+              ARCH=$(uname -m)
+              if [[ `echo ${!ARCH}` == 'aarch64' ]]; then
+                if [ `echo "${!RELEASE}" | grep -Ev '^(amzn\.2|centos\.8|ubuntu\.18\.04)'` ]; then
+                  echo "This component does not support '${!RELEASE}' on ARM64 CPUs. Failing build."
+                  exit {{ build.Exit.outputs.stdout }}
+                fi
+              fi
+
+      - name: UpdateOS
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+
+              OS='{{ build.OperatingSystemName.outputs.stdout }}'
+              PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+
+              if [[ ${!PLATFORM} == RHEL ]]; then
+                if [[ ${!OS} == centos8 ]]; then
+                  dnf -y update
+                else
+                  yum -y update && package-cleanup -y --oldkernels --count=1
+                fi
+              elif [[ ${!PLATFORM} == DEBIAN ]]; then
+                while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done
+                flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)\/?'$/\1/")/daily_lock systemctl stop apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service
+                DEBIAN_FRONTEND=noninteractive
+                apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --with-new-pkgs upgrade && apt-get autoremove -y
+              fi
+
+      - name: RebootStep
+        action: Reboot
+        onFailure: Abort
+        maxAttempts: 2
+        inputs:
+            delaySeconds: 10
+
+  - name: validate
+    steps:
+      - name: UpdateValidate
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              echo "Check the OS has been updated"


### PR DESCRIPTION
## Commits
* Add imagebuilder schema and config based on 3.0 new create ami configuration
* Add imagebuilder cdk to get parameter from imagebuilder config
* Add official ami build component and custom ami build component

## Folders
#### imagebuilder_schema
`cli/src/pcluster/schemas/imagebuilder_schema.py`: contains three main sections schema(`image_schema`, `build_schema` and `dev_settings_schema`). For each section contains attributes and nested schema.
#### imagebuilder_config
`cli/src/pcluster/config/imagebuilder_config.py`: contains three main configs corresponding to three main schema sections. Give an example for parent AMI validation in this layer.
#### cdk_build
`cli/src/pcluster/templates/cdk_builder.py`: use cdk with imagebuilder object to retrieve the parameters defined by imagebuilder configuration to generate cloudformation template
#### imagebuilder components
`cloudformation/imagebuilder`: define official ami build component and custom ami build component. All the AMI with different OSes use the same component. Use condition `RebootAndUpdate` in dev setting  to choose the update_and_reboot  component for cdk template generation

## Tests
add basic test for imagebuilder_schema and imagebuilder cdk_builder

## Current Block Issues
* Data property in imagebuilder component with literal string isn't parsed correctly. Create an issue for cdk repo to track this issue: https://github.com/aws/aws-cdk/issues/12405 (resolved)
* centos7/centos8 ami creation fails after rebooting, instance status check fails

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
