### PR TITLE
Allow skipping tests when cluster creation fails

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -16,6 +16,7 @@ import time
 
 import boto3
 import configparser
+from pytest import skip
 from retrying import retry
 from utils import retrieve_cfn_outputs, retrieve_cfn_resources, retry_if_subprocess_error, run_command
 
@@ -272,6 +273,8 @@ class ClustersFactory:
             logging.error(error)
             if raise_on_error:
                 raise Exception(error)
+            else:
+                skip(error)
         elif "WARNING" in result.stdout:
             error = "Cluster creation for {0} generated a warning: {1}".format(name, result.stdout)
             logging.warning(error)

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
@@ -23,7 +23,7 @@ from tests.common.schedulers_common import get_scheduler_commands
 @pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_multiple_nics(scheduler, region, pcluster_config_reader, clusters_factory):
     cluster_config = pcluster_config_reader()
-    cluster = clusters_factory(cluster_config)
+    cluster = clusters_factory(cluster_config, raise_on_error=False)
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
 


### PR DESCRIPTION
Sometimes integration tests results are "polluted" by cluster creation failures, raising false alarms on the specific features that should have been the target of the tests.
With this commit we allow tests to be skipped, instead of making them fail, when the cluster creation is not part of the real test we want to perform. The reason of the skip will be logged for deeper analysis.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
