### PR TITLE
integ-tests: FSx Storage Capacity/File Chunk Size/Maintenance Start Time

### DIFF
--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.ini
@@ -30,10 +30,10 @@ use_public_ips = false
 [fsx fsx]
 shared_dir = {{ mount_dir }}
 storage_capacity = {{ storage_capacity }}
-imported_file_chunk_size = 1024
+imported_file_chunk_size = {{ imported_file_chunk_size }}
 import_path = s3://{{ bucket_name }}
 export_path = s3://{{ bucket_name }}/export_dir
-weekly_maintenance_start_time = 1:00:00
+weekly_maintenance_start_time = {{ weekly_maintenance_start_time }}
 deployment_type = {{ deployment_type }}
 {% if per_unit_storage_throughput %}
 per_unit_storage_throughput = {{ per_unit_storage_throughput }}


### PR DESCRIPTION
* Ensure FSx File Chunk Size/Maintenance Start Time retrieved from cluster are same as config file setting
* Ensure deviation of FSx storage capacity is less than 0.2 between the storage size in cluster and config file

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
