### PR TITLE
Support cluster creation without EC2 key pair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ CHANGELOG
 
 **CHANGES**
 
+- Make `key_name` parameter optional to support cluster configurations without a key pair. 
 - Remove support for Python 3.4
 
 **BUG FIXES**
 
 - Fix `enable_efa` parameter validation when using Centos8 and Slurm or ARM instances.
-- Fix `max_queue_size` checks during pcluster update to avoid terminating running nodes.
 
 2.10.1
 ------

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -769,7 +769,6 @@ CLUSTER_COMMON_PARAMS = [
     }),
     ("key_name", {
         "cfn_param_mapping": "KeyName",
-        "required": True,
         "validators": [ec2_key_pair_validator],
         "update_policy": UpdatePolicy.UNSUPPORTED
     }),

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -960,6 +960,12 @@ def cluster_validator(section_key, section_label, pcluster_config):
         if max_size < min_size:
             errors.append("max_queue_size must be greater than or equal to initial_queue_size")
 
+    if not section.get_param_value("key_name"):
+        warnings.append(
+            "If you do not specify a key pair, you can't connect to the instance unless you choose an AMI "
+            "that is configured to allow users another way to log in"
+        )
+
     return errors, warnings
 
 

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -717,12 +717,17 @@ def test_hit_cluster_param_from_file(
     [
         ("scheduler", None, None, "Configuration parameter 'scheduler' must have a value"),
         ("base_os", None, None, "Configuration parameter 'base_os' must have a value"),
-        ("key_name", None, None, "Configuration parameter 'key_name' must have a value"),
     ],
 )
 def test_sit_cluster_param_from_file_with_validation(mocker, param_key, param_value, expected_value, expected_message):
     utils.assert_param_from_file(
-        mocker, CLUSTER_SIT, param_key, param_value, expected_value, expected_message, do_validation=True
+        mocker,
+        CLUSTER_SIT,
+        param_key,
+        param_value,
+        expected_value,
+        expected_message,
+        do_validation=True,
     )
 
 

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -47,37 +47,46 @@ def boto3_stubber_path():
 
 
 @pytest.mark.parametrize(
-    "section_dict, expected_message",
+    "section_dict, expected_message, expected_warning",
     [
         # traditional scheduler
-        ({"scheduler": "sge", "initial_queue_size": 1, "max_queue_size": 2, "maintain_initial_size": True}, None),
+        ({"scheduler": "sge", "initial_queue_size": 1, "max_queue_size": 2, "maintain_initial_size": True}, None, None),
         (
             {"scheduler": "sge", "initial_queue_size": 3, "max_queue_size": 2, "maintain_initial_size": True},
             "initial_queue_size must be fewer than or equal to max_queue_size",
+            None,
         ),
         (
             {"scheduler": "sge", "initial_queue_size": 3, "max_queue_size": 2, "maintain_initial_size": False},
             "initial_queue_size must be fewer than or equal to max_queue_size",
+            None,
         ),
         # awsbatch
-        ({"scheduler": "awsbatch", "min_vcpus": 1, "desired_vcpus": 2, "max_vcpus": 3}, None),
+        ({"scheduler": "awsbatch", "min_vcpus": 1, "desired_vcpus": 2, "max_vcpus": 3}, None, None),
         (
             {"scheduler": "awsbatch", "min_vcpus": 3, "desired_vcpus": 2, "max_vcpus": 3},
             "desired_vcpus must be greater than or equal to min_vcpus",
+            None,
         ),
         (
             {"scheduler": "awsbatch", "min_vcpus": 1, "desired_vcpus": 4, "max_vcpus": 3},
             "desired_vcpus must be fewer than or equal to max_vcpus",
+            None,
         ),
         (
             {"scheduler": "awsbatch", "min_vcpus": 4, "desired_vcpus": 4, "max_vcpus": 3},
             "max_vcpus must be greater than or equal to min_vcpus",
+            None,
         ),
+        # key pair not provided
+        ({"scheduler": "awsbatch"}, None, "If you do not specify a key pair"),
     ],
 )
-def test_cluster_validator(mocker, section_dict, expected_message):
+def test_cluster_validator(mocker, capsys, section_dict, expected_message, expected_warning):
     config_parser_dict = {"cluster default": section_dict}
-    utils.assert_param_validator(mocker, config_parser_dict, expected_message)
+    utils.assert_param_validator(
+        mocker, config_parser_dict, expected_message, capsys, expected_warning=expected_warning
+    )
 
 
 @pytest.mark.parametrize(

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -4,7 +4,8 @@
   "Parameters": {
     "KeyName": {
       "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instances using the default cluster user.",
-      "Type": "AWS::EC2::KeyPair::KeyName"
+      "Type": "String",
+      "Default": "NONE"
     },
     "MasterInstanceType": {
       "Description": "Head node EC2 instance type",

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -129,6 +129,18 @@
         },
         "NONE"
       ]
+    },
+    "UseEC2Key": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Ref": "KeyName"
+            },
+            "NONE"
+          ]
+        }
+      ]
     }
   },
   "Resources": {
@@ -430,7 +442,15 @@
             }
           ],
           "Ec2KeyPair": {
-            "Ref": "KeyName"
+            "Fn::If": [
+              "UseEC2Key",
+              {
+                "Ref": "KeyName"
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
           },
           "SecurityGroupIds": {
             "Ref": "SecurityGroups"

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -106,6 +106,10 @@ Conditions:
   CreateIAMLambdaRole: !Equals
     - !Ref 'IAMLambdaRoleName'
     - NONE
+  UseEc2Key: !Not
+    - !Equals
+      - !Ref 'KeyName'
+      - NONE
 Resources:
 {%- for queue, queue_config in queues.items() %}
   {%- for compute_resource in queue_config.compute_resource_settings.values() %}
@@ -139,7 +143,10 @@ Resources:
           {%- endfor %}
         Placement:
           GroupName: {% if queue_config.placement_group == "DYNAMIC" %}!Ref 'PlacementGroup{{ queue | sha1 | truncate(16, True, "") | capitalize }}'{% elif queue_config.placement_group %}{{ queue_config.placement_group }}{% else %}!Ref 'AWS::NoValue'{% endif %}
-        KeyName: !Ref 'KeyName'
+        KeyName: !If
+          - UseEc2Key
+          - !Ref 'KeyName'
+          - !Ref 'AWS::NoValue'
         IamInstanceProfile:
           Name: !Ref 'IamInstanceProfile'
   {%- if queue_config.compute_type == "spot" %}

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -113,6 +113,10 @@ Conditions:
     - !Equals
       - !Ref 'EFA'
       - NONE
+  UseEc2Key: !Not
+    - !Equals
+      - !Ref 'KeyName'
+      - NONE
   DisableComputeHyperthreading: !Not
     - !Or
       - !Equals
@@ -280,7 +284,10 @@ Resources:
               SubnetId: !Ref 'ComputeSubnetId'
             - !Ref 'AWS::NoValue'
         InstanceType: !Ref 'ComputeInstanceType'
-        KeyName: !Ref 'KeyName'
+        KeyName: !If
+          - UseEc2Key
+          - !Ref 'KeyName'
+          - !Ref 'AWS::NoValue'
         IamInstanceProfile:
           Name: !Ref 'IamInstanceProfile'
         InstanceMarketOptions: !If

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -248,6 +248,10 @@ Conditions:
         - !Ref 'MasterNetworkInterfacesCount'
         - '3'
     - !Condition 'UseNIC2'
+  UseEc2Key: !Not
+    - !Equals
+      - !Ref 'KeyName'
+      - NONE
 Resources:
   MasterServer:
     Type: AWS::EC2::Instance
@@ -328,7 +332,10 @@ Resources:
             Ebs:
               VolumeSize: !Ref 'RootVolumeSize'
               VolumeType: gp2
-        KeyName: !Ref 'KeyName'
+        KeyName: !If
+          - UseEc2Key
+          - !Ref 'KeyName'
+          - !Ref 'AWS::NoValue'
         TagSpecifications:
           - ResourceType: instance
             Tags:


### PR DESCRIPTION
This commit introduces the support for a cluster configuration where no EC2 key pair
is used. Such configuration is possible only if  different authentication methods are
setup in the provided AMI, so we raise a warning when this condition is detected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
