### PR TITLE
Remove createami test from china partition

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -102,10 +102,7 @@ createami:
         oss: ["alinux", "alinux2", "ubuntu1604", "ubuntu1804"] # temporary disable FPGA AMI since there is not enough free space on root partition
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1604", "ubuntu1804"]
-      - regions: ["cn-northwest-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["ubuntu1604", "ubuntu1804", "alinux2"]
   test_createami.py::test_createami_post_install:
     dimensions:
       - regions: ["ap-southeast-2"]


### PR DESCRIPTION
Create ami is repeatedly failing in China because of a timeout error when downloading
python package from https://www.python.org/ftp/python/3.6.9/

We can skip the test because we are executing the same recipes at AMI build.

