### PR TITLE
Fix update policy for max_queue_size parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
 **BUG FIXES**
 
 - Fix `enable_efa` parameter validation when using Centos8 and Slurm or ARM instances.
-
+- Fix `max_queue_size` checks during pcluster update to avoid terminating running nodes.
 
 2.10.1
 ------

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -1064,7 +1064,7 @@ CLUSTER_SIT = {
                 "type": QueueSizeCfnParam,
                 "default": 10,
                 "cfn_param_mapping": "MaxSize",
-                "update_policy": UpdatePolicy.SUPPORTED
+                "update_policy": UpdatePolicy.MAX_QUEUE_SIZE
             }),
             ("maintain_initial_size", {
                 "type": MaintainInitialSizeCfnParam,

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -174,6 +174,14 @@ UpdatePolicy.AWSBATCH_CE_MAX_RESIZE = UpdatePolicy(
     <= patch.target_config.get_section("cluster").get_param_value("max_vcpus"),
 )
 
+UpdatePolicy.MAX_QUEUE_SIZE = UpdatePolicy(
+    level=1,
+    fail_reason="Shrinking the queue size requires the compute fleet to be stopped first",
+    action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
+    condition_checker=lambda change, patch: not utils.cluster_has_running_capacity(patch.stack_name)
+    or change.new_value >= change.old_value,
+)
+
 # Checks resize of max_count
 UpdatePolicy.MAX_COUNT = UpdatePolicy(
     level=1,

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -74,7 +74,7 @@ def test_config_patch(mocker):
         ("vpc", "default", "master_subnet_id", "subnet-12345678", "subnet-1234567a", UpdatePolicy.UNSUPPORTED),
         ("vpc", "default", "additional_sg", "sg-12345678", "sg-1234567a", UpdatePolicy.SUPPORTED),
         ("cluster", "default", "initial_queue_size", 0, 1, UpdatePolicy.SUPPORTED),
-        ("cluster", "default", "max_queue_size", 0, 1, UpdatePolicy.SUPPORTED),
+        ("cluster", "default", "max_queue_size", 0, 1, UpdatePolicy.MAX_QUEUE_SIZE),
         ("cluster", "default", "maintain_initial_size", 0, 1, UpdatePolicy.SUPPORTED),
         ("cluster", "default", "compute_instance_type", "t2.micro", "c4.xlarge", UpdatePolicy.COMPUTE_FLEET_STOP),
     ],

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -18,7 +18,7 @@ from pcluster.config.update_policy import UpdatePolicy
     "is_fleet_stopped, old_max, new_max, expected_result",
     [(True, 10, 11, True), (True, 10, 9, True), (False, 10, 9, False), (False, 10, 11, True)],
 )
-def test_max_count_policy(mocker, is_fleet_stopped, old_max, new_max, expected_result):
+def test_max_queue_size_policies(mocker, is_fleet_stopped, old_max, new_max, expected_result):
     cluster_has_running_capacity_mock = mocker.patch(
         "pcluster.utils.cluster_has_running_capacity", return_value=not is_fleet_stopped
     )
@@ -29,6 +29,7 @@ def test_max_count_policy(mocker, is_fleet_stopped, old_max, new_max, expected_r
     change_mock.old_value = old_max
 
     assert_that(UpdatePolicy.MAX_COUNT.condition_checker(change_mock, patch_mock)).is_equal_to(expected_result)
+    assert_that(UpdatePolicy.MAX_QUEUE_SIZE.condition_checker(change_mock, patch_mock)).is_equal_to(expected_result)
     cluster_has_running_capacity_mock.assert_called_with("stack_name")
 
 


### PR DESCRIPTION
When the value of the max_queue_size parameter is updated we must check that no running nodes will be shut down.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
