### PR TITLE
Fix assert_job_submitted with awsbatch tests

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -135,7 +135,7 @@ class AWSBatchCommands(SchedulerCommands):
 
     def assert_job_submitted(self, awsbsub_output):  # noqa: D102
         __tracebackhide__ = True
-        match = re.match(r"Job ([a-z0-9\-]{36}) \(.+\) has been submitted.", awsbsub_output)
+        match = re.search(r"Job ([a-z0-9\-]{36}) \(.+\) has been submitted.", awsbsub_output)
         assert_that(match).is_not_none()
         return match.group(1)
 


### PR DESCRIPTION
A new warning about Python 2.7 deprecation makes our match fail. This commit fixes this issue, while the upgrade of Python at global level should be considered in further patches.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
