### PR TITLE
3.0: Refactor storage classes hierarchy and make it independent by schema

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -16,7 +16,7 @@
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import core
 
-from pcluster.models.cluster import Cluster, Fsx, HeadNode
+from pcluster.models.cluster import Cluster, HeadNode, SharedFsx
 
 
 class HeadNodeConstruct(core.Construct):
@@ -182,7 +182,7 @@ class FsxConstruct(core.Construct):
     """Create the resources related to the FSX."""
 
     # https://cdkworkshop.com/30-python/40-hit-counter/100-api.html
-    def __init__(self, scope: core.Construct, id: str, fsx: Fsx, **kwargs):
+    def __init__(self, scope: core.Construct, id: str, fsx: SharedFsx, **kwargs):
         super().__init__(scope, id)
         self.fsx = fsx
         # TODO add all the other required info other than fsx object and generate template

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -29,11 +29,11 @@ def test_cluster_schema_slurm(test_datadir, config_file_name):
     # Load cluster model from Yaml file
     input_yaml = load_yaml(test_datadir / config_file_name)
     print(input_yaml)
-    cluster_config = ClusterSchema().load(input_yaml)
-    print(cluster_config)
+    cluster = ClusterSchema().load(input_yaml)
+    print(cluster)
 
     # Re-create Yaml file from model and compare content
-    output_json = ClusterSchema().dump(cluster_config)
+    output_json = ClusterSchema().dump(cluster)
     assert_that(json.dumps(input_yaml, sort_keys=True)).is_equal_to(json.dumps(output_json, sort_keys=True))
 
     # Print output yaml
@@ -68,9 +68,9 @@ def test_image_schema(os, custom_ami, failure_message):
         with pytest.raises(ValidationError, match=failure_message):
             ImageSchema().load(image_schema)
     else:
-        image_config = ImageSchema().load(image_schema)
-        assert_that(image_config.os).is_equal_to(os)
-        assert_that(image_config.custom_ami).is_equal_to(custom_ami)
+        image = ImageSchema().load(image_schema)
+        assert_that(image.os).is_equal_to(os)
+        assert_that(image.custom_ami).is_equal_to(custom_ami)
 
 
 DUMMY_REQUIRED_QUEUE = [
@@ -96,19 +96,19 @@ FAKE_QUEUE_LIST = [
 
 
 @pytest.mark.parametrize(
-    "scheduler, queues_config, failure_message",
+    "scheduler, queues, failure_message",
     [
         (None, None, "Missing data for required field"),
         # (None, DUMMY_REQUIRED_QUEUE, None), What is the purpose?
         ("slurm", DUMMY_REQUIRED_QUEUE, None),
     ],
 )
-def test_scheduling_schema(scheduler, queues_config, failure_message):
+def test_scheduling_schema(scheduler, queues, failure_message):
     scheduling_schema = {}
     if scheduler:
         scheduling_schema["Scheduler"] = scheduler
-    if queues_config:
-        scheduling_schema["Queues"] = queues_config
+    if queues:
+        scheduling_schema["Queues"] = queues
 
     if failure_message:
         with pytest.raises(ValidationError, match=failure_message):

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -96,8 +96,7 @@ Scheduling:
           - InstanceType: c4.xlarge
 SharedStorage:
   - MountDir: /my/mount/point
-    StorageType: EBS
-    Settings:
+    EBS:
       VolumeType: String  # gp2 | gp3 | io1 | io2 | sc1 | st1 | standard
       Iops: Integer
       Size: Integer
@@ -109,8 +108,7 @@ SharedStorage:
         Type: String  # 0|1
         NumberOfVolumes: Integer  # [2-5]
   - MountDir: /my/mount/point2
-    StorageType: EFS
-    Settings:
+    EFS:
       Encrypted: Boolean  # true
       KmsKeyId: String  # id-xxx
       PerformanceMode: String  # generalPurpose | maxIO
@@ -118,8 +116,7 @@ SharedStorage:
       ProvisionedThroughput: String  # 1024
       FileSystemId: String  # fs-xxxx
   - MountDir: /my/mount/point3
-    StorageType: FSxLustre
-    Settings:
+    FSxLustre:
       StorageCapacity: Integer  # 3600
       DeploymentType: String  # PERSISTENT_1 | SCRATCH_1 | SCRATCH_2
       ImportedFileChunkSize: Integer  # 1024

--- a/cli/tests/pcluster/validators/test_ebs.py
+++ b/cli/tests/pcluster/validators/test_ebs.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 import pytest
 
-from pcluster.schemas.cluster_schema import EbsSchema
+from pcluster.schemas.cluster_schema import SharedStorageSchema
 from pcluster.validators.common import ConfigValidationError
 
 
@@ -33,8 +33,8 @@ from pcluster.validators.common import ConfigValidationError
 )
 def test_ebs_volume_throughput_validator(section_dict, expected_error):
     with pytest.raises(ConfigValidationError, match=expected_error):
-        ebs_config = EbsSchema().load(section_dict)
-        ebs_config.validate(raise_on_error=True)
+        ebs = SharedStorageSchema().load({"MountDir": "/my/mount/point", "EBS": section_dict})
+        ebs.validate(raise_on_error=True)
 
 
 @pytest.mark.parametrize(
@@ -77,8 +77,8 @@ def test_ebs_volume_throughput_validator(section_dict, expected_error):
 )
 def test_ebs_validators(section_dict, expected_error):
     with pytest.raises(ConfigValidationError, match=expected_error):
-        ebs_config = EbsSchema().load(section_dict)
-        ebs_config.validate(raise_on_error=True)
+        ebs = SharedStorageSchema().load({"MountDir": "/my/mount/point", "EBS": section_dict})
+        ebs.validate(raise_on_error=True)
 
 
 @pytest.mark.parametrize(
@@ -102,8 +102,8 @@ def test_ebs_validators(section_dict, expected_error):
 )
 def test_ebs_volume_type_size_validator(section_dict, expected_error):
     with pytest.raises(ConfigValidationError, match=expected_error):
-        ebs_config = EbsSchema().load(section_dict)
-        ebs_config.validate(raise_on_error=True)
+        ebs = SharedStorageSchema().load({"MountDir": "/my/mount/point", "EBS": section_dict})
+        ebs.validate(raise_on_error=True)
 
 
 @pytest.mark.parametrize(
@@ -146,5 +146,5 @@ def test_ebs_volume_type_size_validator(section_dict, expected_error):
 )
 def test_ebs_volume_iops_validator(section_dict, expected_error):
     with pytest.raises(ConfigValidationError, match=expected_error):
-        ebs_config = EbsSchema().load(section_dict)
-        ebs_config.validate(raise_on_error=True)
+        ebs = SharedStorageSchema().load({"MountDir": "/my/mount/point", "EBS": section_dict})
+        ebs.validate(raise_on_error=True)

--- a/cli/tests/pcluster/validators/test_fsx.py
+++ b/cli/tests/pcluster/validators/test_fsx.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 import pytest
 
-from pcluster.schemas.cluster_schema import FsxSchema
+from pcluster.schemas.cluster_schema import SharedStorageSchema
 from pcluster.validators.common import ConfigValidationError
 
 
@@ -59,5 +59,5 @@ from pcluster.validators.common import ConfigValidationError
 )
 def test_fsx_storage_capacity_validator(section_dict, expected_error):
     with pytest.raises(ConfigValidationError, match=expected_error):
-        fsx_config = FsxSchema().load(section_dict)
-        fsx_config.validate(raise_on_error=True)
+        fsx = SharedStorageSchema().load({"MountDir": "/my/mount/point", "FSxLustre": section_dict})
+        fsx.validate(raise_on_error=True)


### PR DESCRIPTION
Before this patch we had a 1:1 conversion between schema and model layers but some Schema classes don't make sense in the model.

For example we don't need `SharedStorage` class containing EBS or EFS or FSx because EBS, EFS and FSx _are_ shared storage items.

## New classes hierarchy

* `Ebs` representing a generic ebs volume (to be used for root volume or shared ebs)
* `SharedStorage` representing a generic shared storage that can be of different types and just have the `mount_dir` as attribute.
* `SharedEfs`, `SharedFsx` and `SharedEbs` are inheriting from `SharedStorage` and adding specific attributes.
* `SharedEbs` inherits from both `SharedStorage` and `Ebs`.
* Defined `SharedStorage.Type` enum.

## Schema changes

* In the `SharedStorageSchema` we're now instantiating a specific `SharedStorage` according to the type found in the config file rather than creating a `SharedStorage` class that was totally useless from the model point of view.
  As an example we're collapsing the `SharedStorage` and `EFS` information into a single object.
* Clearly when dumping the `SharedStorage` we need to restore the fields with a `pre_dump` action.
* For this reason the Efs|Ebs|Fsx Schemas don't need to generate any object. It will be done by the `SharedStorageSchema`.

