### PR TITLE
Temporarily disable alinux2 createami test in govcloud

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -102,7 +102,7 @@ createami:
         oss: ["alinux", "alinux2", "ubuntu1604", "ubuntu1804"] # temporary disable FPGA AMI since there is not enough free space on root partition
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1604", "ubuntu1804", "alinux2"]
+        oss: ["ubuntu1604", "ubuntu1804"] # alinux2 temporarily disabled due to incompatible device name
   test_createami.py::test_createami_post_install:
     dimensions:
       - regions: ["ap-southeast-2"]


### PR DESCRIPTION
The base ami for alinux2 in govcloud comes with a different device name (/dev/sda1 vs the expected /dev/xvda) and this makes the test fail. This commit disables this test while a valid solution will be studied.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
