### PR TITLE
Add simple retry mechanism to build_docker_image

### DIFF
--- a/cli/src/pcluster/resources/batch/docker/build-docker-images.sh
+++ b/cli/src/pcluster/resources/batch/docker/build-docker-images.sh
@@ -3,12 +3,23 @@ set -eu
 
 build_docker_image() {
     local image=$1
+    local retries=5
     echo "Building image ${image}"
     if [ ! -f "${image}/Dockerfile" ]; then
         echo "Dockerfile not found for image ${image}. Exiting..."
         exit 1
     fi
-    docker build -f "${image}/Dockerfile" -t "${IMAGE_REPO_NAME}:${image}" .
+
+    n=0
+    until [ $n -gt ${retries} ]
+    do
+      # Try building the image max ${retries} times. If the command succeeds it breaks the loop
+      echo "Docker build - trial #${n}"
+      docker build -f "${image}/Dockerfile" -t "${IMAGE_REPO_NAME}:${image}" . && break
+      echo "docker build failed."
+      n=$((n+1))
+      sleep ${RANDOM:0:1}
+    done
 }
 
 if [ -z "${IMAGE}" ]; then


### PR DESCRIPTION
This commit makes the docker build command being retried 5 times to deal with possible service issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
