### PR TITLE
Remove test awsbatch desired_vcpus

### DIFF
--- a/tests/integration-tests/tests/common/scaling_common.py
+++ b/tests/integration-tests/tests/common/scaling_common.py
@@ -183,18 +183,6 @@ def get_batch_ce_min_size(stack_name, region):
     )
 
 
-def get_batch_ce_desired_size(stack_name, region):
-    """Get min vcpus for Batch Compute Environment."""
-    client = boto3.client("batch", region_name=region)
-
-    return (
-        client.describe_compute_environments(computeEnvironments=[get_batch_ce(stack_name, region)])
-        .get("computeEnvironments")[0]
-        .get("computeResources")
-        .get("desiredvCpus")
-    )
-
-
 def test_maintain_initial_size(stack_name, region, maintain_initial_size, initial_size):
     min_size = get_min_asg_capacity(region, stack_name)
     if maintain_initial_size == "true":

--- a/tests/integration-tests/tests/schedulers/test_awsbatch.py
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch.py
@@ -15,7 +15,7 @@ import pytest
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 
-from tests.common.scaling_common import get_batch_ce_desired_size, get_batch_ce_max_size, get_batch_ce_min_size
+from tests.common.scaling_common import get_batch_ce_max_size, get_batch_ce_min_size
 from tests.common.schedulers_common import AWSBatchCommands
 
 
@@ -41,10 +41,8 @@ def test_awsbatch(pcluster_config_reader, clusters_factory, test_datadir, caplog
 
     min_vcpus = cluster.config.get("cluster awsbatch", "min_vcpus")
     max_vcpus = cluster.config.get("cluster awsbatch", "max_vcpus")
-    desired_vcpus = cluster.config.get("cluster awsbatch", "desired_vcpus")
     assert_that(get_batch_ce_min_size(cluster.cfn_name, region)).is_equal_to(int(min_vcpus))
     assert_that(get_batch_ce_max_size(cluster.cfn_name, region)).is_equal_to(int(max_vcpus))
-    assert_that(get_batch_ce_desired_size(cluster.cfn_name, region)).is_equal_to(int(desired_vcpus))
 
     timeout = 120 if region.startswith("cn-") else 60  # Longer timeout in china regions due to less reliable networking
     _test_simple_job_submission(remote_command_executor, test_datadir, timeout)


### PR DESCRIPTION
The desired_vcpus of awsbatch is the numbers of vcpus when the compute enviromment first launch, it will scale down quickly if no jobs running. Sometimes the instance will scaledown before the cluster is able to used. The default scale down time for auto scaling group is 300s. Since we do not have an option to set scaledown time for awsbatch in parallelclsuter, we do not want to test the initial desired_vcpus

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
