### PR TITLE
Fix integ_test: dynamic placememnt group

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -495,6 +495,8 @@ AVAILABILITY_ZONE_OVERRIDES = {
     "eu-west-1": ["euw1-az1", "euw1-az2"],
     # io2 EBS volumes not available in cac1-az4
     "ca-central-1": ["cac1-az1", "cac1-az2"],
+    # instance can only be launch in placement group in eun1-az2
+    "eu-north-1": ["eun1-az2"],
 }
 
 


### PR DESCRIPTION
Change the az for the test because instance can only be launch in placement group in `eun1-az2` in `eu-north-1`

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
