### PR TITLE
Remove Support for Python 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
         os: [ubuntu-latest]
         name:
           - Python 2.7 Tests
-          - Python 3.4 Tests
           - Python 3.5 Tests
           - Python 3.6 Tests
           - Python 3.7 Tests
@@ -25,10 +24,6 @@ jobs:
             python: 2.7
             toxdir: cli
             toxenv: py27-nocov
-          - name: Python 3.4 Tests
-            python: 3.4
-            toxdir: cli
-            toxenv: py34-nocov
           - name: Python 3.5 Tests
             python: 3.5
             toxdir: cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 2.10.2
 ------
 
+**CHANGES**
+
+- Remove support for Python 3.4
+
 **BUG FIXES**
 
 - Fix `enable_efa` parameter validation when using Centos8 and Slurm or ARM instances.

--- a/cli/requirements34.txt
+++ b/cli/requirements34.txt
@@ -1,8 +1,0 @@
-boto3>=1.16.14
-future>=0.18.2
-tabulate==0.8.5
-ipaddress>=1.0.22
-enum34>=1.1.6
-configparser>=3.5.0
-PyYAML==5.2
-jinja2==2.10.1

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -32,10 +32,8 @@ REQUIRES = [
     "jinja2==2.10.1" if sys.version_info.major == 3 and sys.version_info.minor <= 4 else "jinja2>=2.11.0",
 ]
 
-if sys.version_info < (3, 4):
-    REQUIRES.append("enum34>=1.1.6")
-
 if sys.version_info[0] == 2:
+    REQUIRES.append("enum34>=1.1.6")
     REQUIRES.append("configparser>=3.5.0,<=3.8.1")
 
 setup(
@@ -48,7 +46,7 @@ setup(
     license="Apache License 2.0",
     package_dir={"": "src"},
     packages=find_packages("src"),
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=REQUIRES,
     entry_points={
         "console_scripts": [
@@ -73,7 +71,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
* Remove support for Python 3.4, which reached EOL March 18th 2019
* Remove Python 3.4 CI tests and requirements.txt

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
