### PR TITLE
3.0: Split, move, clean up FSx validators (lustre and architecture related are not touched)

### DIFF
--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -81,13 +81,8 @@ from pcluster.config.validators import (
     efs_validator,
     extra_json_validator,
     fsx_architecture_os_validator,
-    fsx_id_validator,
-    fsx_ignored_parameters_validator,
-    fsx_imported_file_chunk_size_validator,
     fsx_lustre_auto_import_validator,
     fsx_lustre_backup_validator,
-    fsx_storage_capacity_validator,
-    fsx_validator,
     head_node_instance_type_validator,
     instances_architecture_compatibility_validator,
     intel_hpc_architecture_validator,
@@ -479,7 +474,6 @@ FSX = {
     "type": CfnSection,
     "key": "fsx",
     "default_label": "default",
-    "validators": [fsx_validator, fsx_storage_capacity_validator, fsx_ignored_parameters_validator],
     "cfn_param_mapping": "FSXOptions",  # All the parameters in the section are converted into a single CFN parameter
     "params": OrderedDict(  # Use OrderedDict because the parameters must respect the order in the CFN parameter
         [
@@ -490,7 +484,6 @@ FSX = {
             }),
             ("fsx_fs_id", {
                 "allowed_values": ALLOWED_VALUES["fsx_fs_id"],
-                "validators": [fsx_id_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("storage_capacity", {
@@ -503,7 +496,6 @@ FSX = {
             }),
             ("imported_file_chunk_size", {
                 "type": IntCfnParam,
-                "validators": [fsx_imported_file_chunk_size_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("export_path", {

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -29,7 +29,13 @@ from pcluster.validators.ebs_validators import (
     EbsVolumeTypeSizeValidator,
 )
 from pcluster.validators.ec2_validators import InstanceTypeValidator
-from pcluster.validators.fsx_validators import FsxValidator
+from pcluster.validators.fsx_validators import (
+    FsxBackupOptionsValidator,
+    FsxPersistentOptionsValidator,
+    FsxS3Validator,
+    FsxStorageCapacityValidator,
+    FsxStorageTypeOptionsValidator,
+)
 from pcluster.validators.s3_validators import UrlValidator
 
 
@@ -250,7 +256,46 @@ class SharedFsx(SharedStorage):
         self.auto_import_policy = Param(auto_import_policy)
         self.drive_cache_type = Param(drive_cache_type)
         self.storage_type = Param(storage_type)
-        self._add_validator(FsxValidator, fsx_config=self)
+        self._add_validator(
+            FsxS3Validator,
+            import_path=self.import_path,
+            imported_file_chunk_size=self.imported_file_chunk_size,
+            export_path=self.export_path,
+            auto_import_policy=self.auto_import_policy,
+        )
+        self._add_validator(
+            FsxPersistentOptionsValidator,
+            deployment_type=self.deployment_type,
+            kms_key_id=self.kms_key_id,
+            per_unit_storage_throughput=self.per_unit_storage_throughput,
+        )
+        self._add_validator(
+            FsxBackupOptionsValidator,
+            automatic_backup_retention_days=self.automatic_backup_retention_days,
+            daily_automatic_backup_start_time=self.daily_automatic_backup_start_time,
+            copy_tags_to_backups=self.copy_tags_to_backups,
+            deployment_type=self.deployment_type,
+            imported_file_chunk_size=self.imported_file_chunk_size,
+            import_path=self.import_path,
+            export_path=self.export_path,
+            auto_import_policy=self.auto_import_policy,
+        )
+        self._add_validator(
+            FsxStorageTypeOptionsValidator,
+            storage_type=self.storage_type,
+            deployment_type=self.deployment_type,
+            per_unit_storage_throughput=self.per_unit_storage_throughput,
+            drive_cache_type=self.drive_cache_type,
+        )
+        self._add_validator(
+            FsxStorageCapacityValidator,
+            storage_capacity=self.storage_capacity,
+            deployment_type=self.deployment_type,
+            storage_type=self.storage_type,
+            per_unit_storage_throughput=self.per_unit_storage_throughput,
+            file_system_id=self.file_system_id,
+            backup_id=self.backup_id,
+        )
         # TODO decide whether we should split FsxValidator into smaller ones
 
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -179,12 +179,11 @@ class FsxSchema(BaseSchema):
     @validates_schema
     def validate_fsx_ignored_parameters(self, data, **kwargs):
         """Return errors for parameters in the FSx config section that would be ignored."""
-        # If file_system_id is specified, all parameters besides shared_dir are ignored.
-        relevant_when_using_existing_fsx = ["file_system_id", "shared_dir"]
+        # If file_system_id is specified, all parameters are ignored.
         messages = []
         if data.get("file_system_id") is not None:
             for key in data:
-                if key is not None and key not in relevant_when_using_existing_fsx:
+                if key is not None and key != "file_system_id":
                     messages.append(FSX_MESSAGES["errors"]["ignored_param_with_fsx_fs_id"].format(fsx_param=key))
             if messages:
                 raise ValidationError(message=messages)

--- a/cli/src/pcluster/validators/common.py
+++ b/cli/src/pcluster/validators/common.py
@@ -68,7 +68,8 @@ class Validator(ABC):
             if isinstance(param, Param):
                 if not param.valid:
                     return self._failures
-        return self.validate(*arg, **kwargs)
+        self.validate(*arg, **kwargs)
+        return self._failures
 
     @abstractmethod
     def validate(self, *args, **kwargs):

--- a/cli/src/pcluster/validators/ebs_validators.py
+++ b/cli/src/pcluster/validators/ebs_validators.py
@@ -121,7 +121,7 @@ class EbsVolumeIopsValidator(Validator):
                     FailureLevel.ERROR,
                     [volume_iops],
                 )
-            if (
+            elif (
                 volume_iops_value
                 and volume_iops_value > volume_size_value * EBS_VOLUME_TYPE_TO_IOPS_RATIO[volume_type_value]
             ):

--- a/cli/src/pcluster/validators/fsx_validators.py
+++ b/cli/src/pcluster/validators/fsx_validators.py
@@ -12,83 +12,64 @@ from pcluster.constants import FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT
 from pcluster.validators.common import FailureLevel, Validator
 
 
-class FsxValidator(Validator):
-    """FSX validator."""
+class FsxS3Validator(Validator):
+    """FSX S3 validator."""
 
-    def validate(self, fsx_config):
-        """Validate FSX config."""
-        import_path = fsx_config.import_path.value
-        imported_file_chunk_size = fsx_config.imported_file_chunk_size.value
-        export_path = fsx_config.export_path.value
-        auto_import_policy = fsx_config.auto_import_policy.value
-        deployment_type = fsx_config.deployment_type.value
-        kms_key_id = fsx_config.kms_key_id.value
-        per_unit_storage_throughput = fsx_config.per_unit_storage_throughput.value
-        daily_automatic_backup_start_time = fsx_config.daily_automatic_backup_start_time.value
-        automatic_backup_retention_days = fsx_config.automatic_backup_retention_days.value
-        copy_tags_to_backups = fsx_config.copy_tags_to_backups.value
-        storage_type = fsx_config.storage_type.value
-        drive_cache_type = fsx_config.drive_cache_type.value
-
-        self._validate_s3_options(import_path, imported_file_chunk_size, export_path, auto_import_policy)
-        self._validate_persistent_options(deployment_type, kms_key_id, per_unit_storage_throughput)
-        self._validate_backup_options(
-            automatic_backup_retention_days,
-            daily_automatic_backup_start_time,
-            copy_tags_to_backups,
-            deployment_type,
-            imported_file_chunk_size,
-            import_path,
-            export_path,
-            auto_import_policy,
-        ),
-        self._validate_storage_type_options(
-            storage_type, deployment_type, per_unit_storage_throughput, drive_cache_type
-        )
-
-        self._validate_fsx_storage_capacity(fsx_config)
-        self._validate_fsx_ignored_parameters(fsx_config)
-        return self._failures
-
-    def _validate_s3_options(self, import_path, imported_file_chunk_size, export_path, auto_import_policy):
+    def validate(self, import_path, imported_file_chunk_size, export_path, auto_import_policy):
         """Verify compatibility of given S3 options for FSX."""
-        if imported_file_chunk_size and not import_path:
+        if imported_file_chunk_size.value and not import_path.value:
             self._add_failure(
                 "When specifying imported file chunk size, the import path option must be specified",
                 FailureLevel.CRITICAL,
+                [imported_file_chunk_size, import_path],
             )
 
-        if export_path and not import_path:
+        if export_path.value and not import_path.value:
             self._add_failure(
                 "When specifying export path, the import path option must be specified",
                 FailureLevel.CRITICAL,
+                [export_path, import_path],
             )
 
-        if auto_import_policy and not import_path:
+        if auto_import_policy.value and not import_path.value:
             self._add_failure(
                 "When specifying auto import policy, the import path option must be specified",
                 FailureLevel.CRITICAL,
+                [auto_import_policy, import_path],
             )
 
-    def _validate_persistent_options(self, deployment_type, kms_key_id, per_unit_storage_throughput):
-        if deployment_type == "PERSISTENT_1":
-            if not per_unit_storage_throughput:
+
+class FsxPersistentOptionsValidator(Validator):
+    """FSX persistent options validator."""
+
+    def validate(self, deployment_type, kms_key_id, per_unit_storage_throughput):
+        """Verify compatibility of given persistent options for FSX."""
+        if deployment_type.value == "PERSISTENT_1":
+            if not per_unit_storage_throughput.value:
                 self._add_failure(
-                    "'per_unit_storage_throughput' must be specified when 'deployment_type = PERSISTENT_1'",
+                    "per unit storage throughput must be specified when deployment type is `PERSISTENT_1'",
                     FailureLevel.CRITICAL,
+                    [deployment_type, per_unit_storage_throughput],
                 )
         else:
-            if kms_key_id:
+            if kms_key_id.value:
                 self._add_failure(
-                    "'kms_key_id' can only be used when 'deployment_type = PERSISTENT_1'", FailureLevel.CRITICAL
-                )
-            if per_unit_storage_throughput:
-                self._add_failure(
-                    "'per_unit_storage_throughput' can only be used when 'deployment_type = PERSISTENT_1'",
+                    "kms key id can only be used when deployment type is `PERSISTENT_1'",
                     FailureLevel.CRITICAL,
+                    [deployment_type, kms_key_id],
+                )
+            if per_unit_storage_throughput.value:
+                self._add_failure(
+                    "per unit storage throughput can only be used when deployment type is `PERSISTENT_1'",
+                    FailureLevel.CRITICAL,
+                    [deployment_type, per_unit_storage_throughput],
                 )
 
-    def _validate_backup_options(
+
+class FsxBackupOptionsValidator(Validator):
+    """FSX backup options validator."""
+
+    def validate(
         self,
         automatic_backup_retention_days,
         daily_automatic_backup_start_time,
@@ -99,89 +80,117 @@ class FsxValidator(Validator):
         export_path,
         auto_import_policy,
     ):
-        if not automatic_backup_retention_days and daily_automatic_backup_start_time:
+        """Verify compatibility of given backup options for FSX."""
+        if not automatic_backup_retention_days.value and daily_automatic_backup_start_time.value:
             self._add_failure(
-                "When specifying 'daily_automatic_backup_start_time', "
-                "the 'automatic_backup_retention_days' option must be specified",
+                "When specifying daily automatic backup start time,"
+                "the automatic backup retention days option must be specified",
                 FailureLevel.CRITICAL,
+                [automatic_backup_retention_days, daily_automatic_backup_start_time],
             )
-        if not automatic_backup_retention_days and copy_tags_to_backups is not None:
+        if not automatic_backup_retention_days.value and copy_tags_to_backups.value is not None:
             self._add_failure(
-                "When specifying 'copy_tags_to_backups', "
-                "the 'automatic_backup_retention_days' option must be specified",
+                "When specifying copy tags to backups, " "the automatic backup retention days option must be specified",
                 FailureLevel.CRITICAL,
+                [automatic_backup_retention_days, copy_tags_to_backups],
             )
-        if deployment_type != "PERSISTENT_1" and automatic_backup_retention_days:
+        if deployment_type.value != "PERSISTENT_1" and automatic_backup_retention_days.value:
             self._add_failure(
-                "FSx automatic backup features can be used only with 'PERSISTENT_1' file systems", FailureLevel.CRITICAL
+                "FSx automatic backup features can be used only with 'PERSISTENT_1' file systems",
+                FailureLevel.CRITICAL,
+                [deployment_type, automatic_backup_retention_days],
             )
         if (
-            imported_file_chunk_size or import_path or export_path or auto_import_policy
-        ) and automatic_backup_retention_days:
-            self._add_failure("Backups cannot be created on S3-linked file systems", FailureLevel.CRITICAL)
+            imported_file_chunk_size.value or import_path.value or export_path.value or auto_import_policy.value
+        ) and automatic_backup_retention_days.value:
+            self._add_failure(
+                "Backups cannot be created on S3-linked file systems",
+                FailureLevel.CRITICAL,
+                [automatic_backup_retention_days],
+            )
 
-    def _validate_storage_type_options(
-        self, storage_type, deployment_type, per_unit_storage_throughput, drive_cache_type
-    ):
-        if storage_type == "HDD":
-            if deployment_type != "PERSISTENT_1":
+
+class FsxStorageTypeOptionsValidator(Validator):
+    """FSX storage type options validator."""
+
+    def validate(self, storage_type, deployment_type, per_unit_storage_throughput, drive_cache_type):
+        """Verify compatibility of given storage type options for FSX."""
+        if storage_type.value == "HDD":
+            if deployment_type.value != "PERSISTENT_1":
                 self._add_failure(
-                    "For HDD filesystems, 'deployment_type' must be 'PERSISTENT_1'", FailureLevel.CRITICAL
+                    "For HDD filesystems, deployment type must be 'PERSISTENT_1'",
+                    FailureLevel.CRITICAL,
+                    [storage_type, deployment_type],
                 )
-            if per_unit_storage_throughput not in FSX_HDD_THROUGHPUT:
+            if per_unit_storage_throughput.value not in FSX_HDD_THROUGHPUT:
                 self._add_failure(
-                    "For HDD filesystems, 'per_unit_storage_throughput' can only have the following values: {0}".format(
+                    "For HDD filesystems, per unit storage throughput can only have the following values: {0}".format(
                         FSX_HDD_THROUGHPUT
                     ),
                     FailureLevel.CRITICAL,
+                    [storage_type, per_unit_storage_throughput],
                 )
         else:  # SSD or None
-            if drive_cache_type is not None:
+            if drive_cache_type.value:
                 self._add_failure(
-                    "'drive_cache_type' features can be used only with HDD filesystems", FailureLevel.CRITICAL
+                    "drive cache type features can be used only with HDD filesystems",
+                    FailureLevel.CRITICAL,
+                    [storage_type, drive_cache_type],
                 )
-            if per_unit_storage_throughput and per_unit_storage_throughput not in FSX_SSD_THROUGHPUT:
+            if per_unit_storage_throughput.value and per_unit_storage_throughput.value not in FSX_SSD_THROUGHPUT:
                 self._add_failure(
-                    "For SSD filesystems, 'per_unit_storage_throughput' can only have the following values: {0}".format(
+                    "For SSD filesystems, per unit storage throughput can only have the following values: {0}".format(
                         FSX_SSD_THROUGHPUT
                     ),
                     FailureLevel.CRITICAL,
+                    [storage_type, per_unit_storage_throughput],
                 )
 
-    def _validate_fsx_storage_capacity(self, fsx_config):
-        storage_capacity = fsx_config.storage_capacity.value
-        deployment_type = fsx_config.deployment_type.value
-        storage_type = fsx_config.storage_type.value
-        per_unit_storage_throughput = fsx_config.per_unit_storage_throughput.value
-        if fsx_config.file_system_id.value or fsx_config.backup_id.value:
+
+class FsxStorageCapacityValidator(Validator):
+    """FSX storage capacity validator."""
+
+    def validate(
+        self, storage_capacity, deployment_type, storage_type, per_unit_storage_throughput, file_system_id, backup_id
+    ):
+        """Verify compatibility of given storage capacity options for FSX."""
+        if file_system_id.value or backup_id.value:
             # if file_system_id is provided, don't validate storage_capacity
             # if backup_id is provided, validation for storage_capacity will be done in fsx_lustre_backup_validator.
             return
-        if not storage_capacity:
+        if not storage_capacity.value:
             # if file_system_id is not provided, storage_capacity must be provided
             self._add_failure(
-                "When specifying 'fsx' section, the 'StorageCapacity' option must be specified", FailureLevel.CRITICAL
+                "When specifying 'fsx' section, the 'StorageCapacity' option must be specified",
+                FailureLevel.CRITICAL,
+                [storage_capacity],
             )
-        elif deployment_type == "SCRATCH_1":
-            if not (storage_capacity == 1200 or storage_capacity == 2400 or storage_capacity % 3600 == 0):
+        elif deployment_type.value == "SCRATCH_1":
+            if not (
+                storage_capacity.value == 1200 or storage_capacity.value == 2400 or storage_capacity.value % 3600 == 0
+            ):
                 self._add_failure(
                     "Capacity for FSx SCRATCH_1 filesystem is 1,200 GB, 2,400 GB or increments of 3,600 GB",
                     FailureLevel.CRITICAL,
+                    [storage_capacity, deployment_type],
                 )
-        elif deployment_type == "PERSISTENT_1" and storage_type == "HDD":
-            if per_unit_storage_throughput == 12 and not (storage_capacity % 6000 == 0):
+        elif deployment_type.value == "PERSISTENT_1" and storage_type.value == "HDD":
+            if per_unit_storage_throughput.value == 12 and not (storage_capacity.value % 6000 == 0):
                 self._add_failure(
                     "Capacity for FSx PERSISTENT HDD 12 MB/s/TiB file systems is increments of 6,000 GiB",
                     FailureLevel.CRITICAL,
+                    [storage_capacity, deployment_type, storage_type, per_unit_storage_throughput],
                 )
-            elif per_unit_storage_throughput == 40 and not (storage_capacity % 1800 == 0):
+            elif per_unit_storage_throughput.value == 40 and not (storage_capacity.value % 1800 == 0):
                 self._add_failure(
                     "Capacity for FSx PERSISTENT HDD 40 MB/s/TiB file systems is increments of 1,800 GiB",
                     FailureLevel.CRITICAL,
+                    [storage_capacity, deployment_type, storage_type, per_unit_storage_throughput],
                 )
-        elif deployment_type in ["SCRATCH_2", "PERSISTENT_1"]:
-            if not (storage_capacity == 1200 or storage_capacity % 2400 == 0):
+        elif deployment_type.value in ["SCRATCH_2", "PERSISTENT_1"]:
+            if not (storage_capacity.value == 1200 or storage_capacity.value % 2400 == 0):
                 self._add_failure(
                     "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
                     FailureLevel.CRITICAL,
+                    [storage_capacity, deployment_type],
                 )

--- a/cli/tests/pcluster/validators/test_fsx.py
+++ b/cli/tests/pcluster/validators/test_fsx.py
@@ -10,54 +10,362 @@
 # limitations under the License.
 import pytest
 
-from pcluster.schemas.cluster_schema import SharedStorageSchema
-from pcluster.validators.common import ConfigValidationError
+from pcluster.models.param import Param
+from pcluster.validators.fsx_validators import (
+    FsxBackupOptionsValidator,
+    FsxPersistentOptionsValidator,
+    FsxS3Validator,
+    FsxStorageCapacityValidator,
+    FsxStorageTypeOptionsValidator,
+)
+from tests.pcluster.validators.utils import assert_failure_messages
 
 
 @pytest.mark.parametrize(
-    "section_dict, expected_error",
+    "import_path, imported_file_chunk_size, export_path, auto_import_policy, expected_message",
     [
         (
-            {"StorageCapacity": 1, "DeploymentType": "SCRATCH_1"},
-            "Capacity for FSx SCRATCH_1 filesystem is 1,200 GB, 2,400 GB or increments of 3,600 GB",
+            "s3://test",
+            1024,
+            None,
+            None,
+            None,
         ),
         (
-            {"StorageCapacity": 3600, "DeploymentType": "SCRATCH_2"},
-            "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+            None,
+            1024,
+            None,
+            None,
+            "When specifying imported file chunk size, the import path option must be specified",
         ),
         (
-            {"StorageCapacity": 3600, "DeploymentType": "PERSISTENT_1", "PerUnitStorageThroughput": 50},
-            "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+            "s3://test",
+            None,
+            "s3://test",
+            None,
+            None,
         ),
         (
-            {"StorageCapacity": 3601, "DeploymentType": "PERSISTENT_1", "PerUnitStorageThroughput": 50},
-            "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
-        ),
-        (
-            {"DeploymentType": "SCRATCH_1"},
-            "When specifying 'fsx' section, the 'StorageCapacity' option must be specified",
-        ),
-        (
-            {
-                "StorageType": "HDD",
-                "DeploymentType": "PERSISTENT_1",
-                "StorageCapacity": 1801,
-                "PerUnitStorageThroughput": 40,
-            },
-            "Capacity for FSx PERSISTENT HDD 40 MB/s/TiB file systems is increments of 1,800 GiB",
-        ),
-        (
-            {
-                "StorageType": "HDD",
-                "DeploymentType": "PERSISTENT_1",
-                "StorageCapacity": 6001,
-                "PerUnitStorageThroughput": 12,
-            },
-            "Capacity for FSx PERSISTENT HDD 12 MB/s/TiB file systems is increments of 6,000 GiB",
+            None,
+            None,
+            "s3://test",
+            None,
+            "When specifying export path, the import path option must be specified",
         ),
     ],
 )
-def test_fsx_storage_capacity_validator(section_dict, expected_error):
-    with pytest.raises(ConfigValidationError, match=expected_error):
-        fsx = SharedStorageSchema().load({"MountDir": "/my/mount/point", "FSxLustre": section_dict})
-        fsx.validate(raise_on_error=True)
+def test_fsx_s3_validator(import_path, imported_file_chunk_size, export_path, auto_import_policy, expected_message):
+    actual_failures = FsxS3Validator()(
+        Param(import_path), Param(imported_file_chunk_size), Param(export_path), Param(auto_import_policy)
+    )
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "deployment_type, kms_key_id, per_unit_storage_throughput, expected_message",
+    [
+        (
+            "PERSISTENT_1",
+            "9e8a129be-0e46-459d-865b-3a5bf974a22k",
+            50,
+            None,
+        ),
+        (
+            "PERSISTENT_1",
+            None,
+            200,
+            None,
+        ),
+        (
+            "SCRATCH_2",
+            "9e8a129be-0e46-459d-865b-3a5bf974a22k",
+            None,
+            "kms key id can only be used when deployment type is `PERSISTENT_1'",
+        ),
+        (
+            "SCRATCH_1",
+            None,
+            200,
+            "per unit storage throughput can only be used when deployment type is `PERSISTENT_1'",
+        ),
+        (
+            "PERSISTENT_1",
+            None,
+            None,
+            "per unit storage throughput must be specified when deployment type is `PERSISTENT_1'",
+        ),
+    ],
+)
+def test_fsx_persistent_options_validator(deployment_type, kms_key_id, per_unit_storage_throughput, expected_message):
+    actual_failures = FsxPersistentOptionsValidator()(
+        Param(deployment_type), Param(kms_key_id), Param(per_unit_storage_throughput)
+    )
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "automatic_backup_retention_days, daily_automatic_backup_start_time, copy_tags_to_backups, deployment_type,"
+    "imported_file_chunk_size, import_path, export_path, auto_import_policy, expected_message",
+    [
+        (
+            2,
+            None,
+            None,
+            "SCRATCH_1",
+            None,
+            None,
+            None,
+            None,
+            "FSx automatic backup features can be used only with 'PERSISTENT_1' file systems",
+        ),
+        (
+            None,
+            "03:00",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "When specifying daily automatic backup start time,"
+            "the automatic backup retention days option must be specified",
+        ),
+        (
+            None,
+            None,
+            True,
+            "PERSISTENT_1",
+            None,
+            None,
+            None,
+            None,
+            "When specifying copy tags to backups, the automatic backup retention days option must be specified",
+        ),
+        (
+            None,
+            None,
+            False,
+            "PERSISTENT_1",
+            None,
+            None,
+            None,
+            None,
+            "When specifying copy tags to backups, the automatic backup retention days option must be specified",
+        ),
+        (
+            None,
+            "03:00",
+            True,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "When specifying daily automatic backup start time,"
+            "the automatic backup retention days option must be specified",
+        ),
+        (
+            2,
+            None,
+            None,
+            "PERSISTENT_1",
+            1024,
+            "s3://test",
+            "s3://test",
+            None,
+            "Backups cannot be created on S3-linked file systems",
+        ),
+        (
+            2,
+            None,
+            None,
+            "PERSISTENT_1",
+            1200,
+            "s3://test",
+            "s3://test",
+            None,
+            "Backups cannot be created on S3-linked file systems",
+        ),
+    ],
+)
+def test_fsx_backup_options_validator(
+    automatic_backup_retention_days,
+    daily_automatic_backup_start_time,
+    copy_tags_to_backups,
+    deployment_type,
+    imported_file_chunk_size,
+    import_path,
+    export_path,
+    auto_import_policy,
+    expected_message,
+):
+    actual_failures = FsxBackupOptionsValidator()(
+        Param(automatic_backup_retention_days),
+        Param(daily_automatic_backup_start_time),
+        Param(copy_tags_to_backups),
+        Param(deployment_type),
+        Param(imported_file_chunk_size),
+        Param(import_path),
+        Param(export_path),
+        Param(auto_import_policy),
+    )
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "storage_type, deployment_type, per_unit_storage_throughput, drive_cache_type, expected_message",
+    [
+        (
+            "HDD",
+            "SCRATCH_1",
+            12,
+            "READ",
+            "For HDD filesystems, deployment type must be 'PERSISTENT_1'",
+        ),
+        (
+            "HDD",
+            "PERSISTENT_1",
+            50,
+            "READ",
+            r"For HDD filesystems, per unit storage throughput can only have the following values: \[12, 40\]",
+        ),
+        (
+            "SSD",
+            "PERSISTENT_1",
+            12,
+            None,
+            r"For SSD filesystems, per unit storage throughput can only have the following values: \[50, 100, 200\]",
+        ),
+        (
+            "SSD",
+            "PERSISTENT_1",
+            50,
+            None,
+            None,
+        ),
+        (
+            None,
+            "PERSISTENT_1",
+            50,
+            "READ",
+            "drive cache type features can be used only with HDD filesystems",
+        ),
+    ],
+)
+def test_fsx_storage_type_options_validator(
+    storage_type, deployment_type, per_unit_storage_throughput, drive_cache_type, expected_message
+):
+    actual_failures = FsxStorageTypeOptionsValidator()(
+        Param(storage_type), Param(deployment_type), Param(per_unit_storage_throughput), Param(drive_cache_type)
+    )
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "storage_capacity, deployment_type, storage_type, per_unit_storage_throughput,"
+    " file_system_id, backup_id, expected_message",
+    [
+        (
+            1,
+            "SCRATCH_1",
+            None,
+            None,
+            None,
+            None,
+            "Capacity for FSx SCRATCH_1 filesystem is 1,200 GB, 2,400 GB or increments of 3,600 GB",
+        ),
+        (
+            3600,
+            "SCRATCH_2",
+            None,
+            None,
+            None,
+            None,
+            "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+        ),
+        (
+            3600,
+            "PERSISTENT_1",
+            None,
+            50,
+            None,
+            None,
+            "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+        ),
+        (
+            3601,
+            "PERSISTENT_1",
+            None,
+            50,
+            None,
+            None,
+            "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+        ),
+        (
+            None,
+            "SCRATCH_1",
+            None,
+            None,
+            None,
+            None,
+            "When specifying 'fsx' section, the 'StorageCapacity' option must be specified",
+        ),
+        (
+            1801,
+            "PERSISTENT_1",
+            "HDD",
+            40,
+            None,
+            None,
+            "Capacity for FSx PERSISTENT HDD 40 MB/s/TiB file systems is increments of 1,800 GiB",
+        ),
+        (
+            6001,
+            "PERSISTENT_1",
+            "HDD",
+            12,
+            None,
+            None,
+            "Capacity for FSx PERSISTENT HDD 12 MB/s/TiB file systems is increments of 6,000 GiB",
+        ),
+        (1200, "SCRATCH_1", None, None, None, None, None),
+        (2400, "SCRATCH_1", None, None, None, None, None),
+        (3600, "SCRATCH_1", None, None, None, None, None),
+        (
+            1800,
+            "PERSISTENT_1",
+            "HDD",
+            40,
+            None,
+            None,
+            None,
+        ),
+        (
+            6000,
+            "PERSISTENT_1",
+            "HDD",
+            12,
+            None,
+            None,
+            None,
+        ),
+    ],
+)
+def test_fsx_storage_capacity_validator(
+    storage_capacity,
+    deployment_type,
+    storage_type,
+    per_unit_storage_throughput,
+    file_system_id,
+    backup_id,
+    expected_message,
+):
+    actual_failures = FsxStorageCapacityValidator()(
+        Param(storage_capacity),
+        Param(deployment_type),
+        Param(storage_type),
+        Param(per_unit_storage_throughput),
+        Param(file_system_id),
+        Param(backup_id),
+    )
+    assert_failure_messages(actual_failures, expected_message)


### PR DESCRIPTION
## Split FsxValidator in fsx_validators.py
The original approach was to have to a central method to orchestrate all validations of FSx section. We decided to change the approach to split the validator into smaller ones to be consistent with other validators and facilitate unit testing.

## Remove moved FSx validators from mappings.py
Starting from #2405, we decided to delete the migrated validators in the old code. This commit will delete `fsx_id_validator`, `fsx_ignored_parameters_validator`, `fsx_imported_file_chunk_size_validator`, `fsx_storage_capacity_validator`, `fsx_validator` in mappings.py

## Move unit tests

## Minor changes
1. Prevent validation of iops/volume_size ratio if validation of absolute iops value fails.
2. In the base Validator class, return the `_failures` explicitly so that the return of `_failures` at the end of each `validate()` is not required

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
