### PR TITLE
Fix test renaming

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -26,12 +26,6 @@ test-suites:
           schedulers: ["{{ scheduler }}"]
         {%- endfor %}
   scaling:
-    test_scaling.py::test_hit_scaling:
-      dimensions:
-        - regions: ["us-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_ONE_PER_DISTRO }}
-          schedulers: ["slurm"]
     test_scaling.py::test_nodewatcher_terminates_failing_node:
       dimensions:
         - regions: ["sa-east-1"]


### PR DESCRIPTION
Regression introduced in https://github.com/aws/aws-parallelcluster/commit/2b1ccc5e96a8a68f0ba155dd999bf973a396db33
where test_hit_scaling was renamed in test_slurm_scaling

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
