### PR TITLE
inte-tests: fix test_networking

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -595,7 +595,7 @@ def vpc_stacks(cfn_stacks_factory, request):
                 availability_zones = random.sample(az_list, k=2)
 
         # Subnets visual representation:
-        # http://www.davidc.net/sites/default/subnets/subnets.html?network=192.168.0.0&mask=16&division=7.70
+        # https://www.davidc.net/sites/default/subnets/subnets.html?network=192.168.0.0&mask=16&division=9.720
         public_subnet = SubnetConfig(
             name="Public",
             cidr="192.168.32.0/19",  # 8190 IPs
@@ -606,12 +606,13 @@ def vpc_stacks(cfn_stacks_factory, request):
         )
         private_subnet = SubnetConfig(
             name="Private",
-            cidr="192.168.64.0/18",  # 16382 IPs
+            cidr="192.168.64.0/19",  # 8190 IPs
             map_public_ip_on_launch=False,
             has_nat_gateway=False,
             availability_zone=availability_zones[0],
             default_gateway=Gateways.NAT_GATEWAY,
         )
+        # cidr="192.168.96.0/19" used by test_networking
         private_subnet_different_cidr = SubnetConfig(
             name="PrivateAdditionalCidr",
             cidr="192.168.128.0/17",  # 32766 IPs

--- a/tests/integration-tests/tests/networking/test_networking.py
+++ b/tests/integration-tests/tests/networking/test_networking.py
@@ -48,7 +48,7 @@ def networking_stack_factory(request):
 def test_public_network_topology(region, vpc_stack, networking_stack_factory, random_az_selector):
     ec2_client = boto3.client("ec2", region_name=region)
     vpc_id = vpc_stack.cfn_outputs["VpcId"]
-    public_subnet_cidr = "192.168.3.0/24"
+    public_subnet_cidr = "192.168.96.0/24"
     availability_zone = random_az_selector(region, default_value="")
     internet_gateway_id = vpc_stack.cfn_resources["InternetGateway"]
 
@@ -71,8 +71,8 @@ def test_public_network_topology(region, vpc_stack, networking_stack_factory, ra
 def test_public_private_network_topology(region, vpc_stack, networking_stack_factory, random_az_selector):
     ec2_client = boto3.client("ec2", region_name=region)
     vpc_id = vpc_stack.cfn_outputs["VpcId"]
-    public_subnet_cidr = "192.168.5.0/24"
-    private_subnet_cidr = "192.168.4.0/24"
+    public_subnet_cidr = "192.168.98.0/24"
+    private_subnet_cidr = "192.168.97.0/24"
     availability_zone = random_az_selector(region, default_value="")
     internet_gateway_id = vpc_stack.cfn_resources["InternetGateway"]
 


### PR DESCRIPTION
broken by: https://github.com/aws/aws-parallelcluster/pull/2339

the test_networking is assuming that a portion of the VPC created for all tests is free.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
