### PR TITLE
Check S3 bucket owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ CHANGELOG
 **CHANGES**
 
 - Make `key_name` parameter optional to support cluster configurations without a key pair. 
-- Remove support for Python 3.4
+- Remove support for Python 3.4 
 
 **BUG FIXES**
 
 - Fix `enable_efa` parameter validation when using Centos8 and Slurm or ARM instances.
+
+**ENHANCEMENTS**
+
+- Check bucket owner when accessing public ParallelCluster artifacts to prevent S3 buckets sniping
 
 2.10.1
 ------


### PR DESCRIPTION
Check bucket owner when retrieving ParallelCluster public artifacts from S3 to prevent bucket sniping attacks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
