### PR TITLE
3.0: Move architecture and hyperthreading related validators

### DIFF
--- a/cli/src/pcluster/config/cfn_param_types.py
+++ b/cli/src/pcluster/config/cfn_param_types.py
@@ -797,6 +797,7 @@ class BaseOSCfnParam(CfnParam):
     We need this class in order to initialize the private architecture param.
     """
 
+    # FIXME moved
     @staticmethod
     def get_instance_type_architecture(instance_type):
         """Compute cluster's 'Architecture' CFN parameter based on its head node instance type."""
@@ -813,6 +814,7 @@ class BaseOSCfnParam(CfnParam):
         #       compute instance types.
         return head_node_supported_architectures[0]
 
+    # FIXME moved
     def refresh(self):
         """Initialize the private architecture param."""
         if self.value:

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -55,13 +55,11 @@ from pcluster.config.json_param_types import (
 from pcluster.config.param_types import Visibility
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import (
-    architecture_os_validator,
     base_os_validator,
     cluster_validator,
     compute_instance_type_validator,
     compute_resource_validator,
     dcv_enabled_validator,
-    disable_hyperthreading_architecture_validator,
     duplicate_shared_dir_validator,
     ebs_settings_validator,
     ec2_ami_validator,
@@ -74,7 +72,6 @@ from pcluster.config.validators import (
     ec2_volume_validator,
     ec2_vpc_id_validator,
     efa_gdr_validator,
-    efa_os_arch_validator,
     efa_validator,
     efs_id_validator,
     efs_validator,
@@ -82,7 +79,6 @@ from pcluster.config.validators import (
     fsx_lustre_auto_import_validator,
     fsx_lustre_backup_validator,
     head_node_instance_type_validator,
-    instances_architecture_compatibility_validator,
     intel_hpc_architecture_validator,
     intel_hpc_os_validator,
     kms_key_validator,
@@ -624,7 +620,7 @@ COMPUTE_RESOURCE = {
     "params": OrderedDict([
         ("instance_type", {
             "type": JsonParam,
-            "validators": [ec2_instance_type_validator, instances_architecture_compatibility_validator],
+            "validators": [ec2_instance_type_validator],
             "required": True,
             "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP
         }),
@@ -715,7 +711,6 @@ QUEUE = {
         }),
         ("enable_efa", {
             "type": BooleanJsonParam,
-            "validators": [efa_os_arch_validator],
             "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP,
         }),
         ("enable_efa_gdr", {
@@ -784,7 +779,7 @@ CLUSTER_COMMON_PARAMS = [
         "type": BaseOSCfnParam,
         "cfn_param_mapping": "BaseOS",
         "allowed_values": ["alinux", "alinux2", "ubuntu1604", "ubuntu1804", "centos7", "centos8"],
-        "validators": [base_os_validator, architecture_os_validator],
+        "validators": [base_os_validator],
         "required": True,
         "update_policy": UpdatePolicy.UNSUPPORTED
     }),
@@ -831,7 +826,7 @@ CLUSTER_COMMON_PARAMS = [
     ("enable_efa", {
         "allowed_values": ["compute"],
         "cfn_param_mapping": "EFA",
-        "validators": [efa_validator, efa_os_arch_validator],
+        "validators": [efa_validator],
         "update_policy": UpdatePolicy.UNSUPPORTED
     }),
     ("enable_efa_gdr", {
@@ -1026,7 +1021,7 @@ CLUSTER_SIT = {
             ("compute_instance_type", {
                 "type": ComputeInstanceTypeCfnParam,
                 "cfn_param_mapping": "ComputeInstanceType",
-                "validators": [compute_instance_type_validator, instances_architecture_compatibility_validator],
+                "validators": [compute_instance_type_validator],
                 "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP
             }),
             ("initial_queue_size", {
@@ -1090,7 +1085,6 @@ CLUSTER_SIT = {
                 "type": DisableHyperThreadingCfnParam,
                 "default": False,
                 "cfn_param_mapping": "Cores",
-                "validators": [disable_hyperthreading_architecture_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
         ]
@@ -1121,7 +1115,6 @@ CLUSTER_HIT = {
             ("disable_hyperthreading", {
                 "type": DisableHyperThreadingCfnParam,
                 "cfn_param_mapping": "Cores",
-                "validators": [disable_hyperthreading_architecture_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("disable_cluster_dns", {

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -62,7 +62,6 @@ from pcluster.config.validators import (
     compute_resource_validator,
     dcv_enabled_validator,
     disable_hyperthreading_architecture_validator,
-    disable_hyperthreading_validator,
     duplicate_shared_dir_validator,
     ebs_settings_validator,
     ec2_ami_validator,
@@ -79,7 +78,6 @@ from pcluster.config.validators import (
     efa_validator,
     efs_id_validator,
     efs_validator,
-    extra_json_validator,
     fsx_architecture_os_validator,
     fsx_lustre_auto_import_validator,
     fsx_lustre_backup_validator,
@@ -881,7 +879,6 @@ CLUSTER_COMMON_PARAMS = [
     ("extra_json", {
         "type": ExtraJsonCfnParam,
         "cfn_param_mapping": "ExtraJson",
-        "validators": [extra_json_validator],
         "update_policy": UpdatePolicy(
             UpdatePolicy.UNSUPPORTED,
             fail_reason=UpdatePolicy.FAIL_REASONS["extra_json_update"],
@@ -1093,7 +1090,7 @@ CLUSTER_SIT = {
                 "type": DisableHyperThreadingCfnParam,
                 "default": False,
                 "cfn_param_mapping": "Cores",
-                "validators": [disable_hyperthreading_validator, disable_hyperthreading_architecture_validator],
+                "validators": [disable_hyperthreading_architecture_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
         ]
@@ -1124,7 +1121,7 @@ CLUSTER_HIT = {
             ("disable_hyperthreading", {
                 "type": DisableHyperThreadingCfnParam,
                 "cfn_param_mapping": "Cores",
-                "validators": [disable_hyperthreading_validator, disable_hyperthreading_architecture_validator],
+                "validators": [disable_hyperthreading_architecture_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("disable_cluster_dns", {

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -213,20 +213,6 @@ def fsx_architecture_os_validator(section_key, section_label, pcluster_config):
     return errors, warnings
 
 
-def disable_hyperthreading_validator(param_key, param_value, pcluster_config):
-    errors = []
-    warnings = []
-
-    if param_value:
-        # Check to see if cfn_scheduler_slots is set
-        cluster_section = pcluster_config.get_section("cluster")
-        extra_json = cluster_section.get_param_value("extra_json")
-        if extra_json and extra_json.get("cluster") and extra_json.get("cluster").get("cfn_scheduler_slots"):
-            errors.append("cfn_scheduler_slots cannot be set in addition to disable_hyperthreading = true")
-
-    return errors, warnings
-
-
 def disable_hyperthreading_architecture_validator(param_key, param_value, pcluster_config):
     errors = []
     warnings = []
@@ -239,19 +225,6 @@ def disable_hyperthreading_architecture_validator(param_key, param_value, pclust
             "disable_hyperthreading is only supported on instance types that support these architectures: {0}".format(
                 ", ".join(supported_architectures)
             )
-        )
-
-    return errors, warnings
-
-
-def extra_json_validator(param_key, param_value, pcluster_config):
-    errors = []
-    warnings = []
-
-    if param_value and param_value.get("cluster") and param_value.get("cluster").get("cfn_scheduler_slots"):
-        warnings.append(
-            "It is highly recommended to use the disable_hyperthreading parameter in order to control the "
-            "hyper-threading configuration in the cluster rather than using cfn_scheduler_slots in extra_json"
         )
 
     return errors, warnings

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -59,6 +59,7 @@ class Resource(ABC):
     def validate(self, raise_on_error=False):
         """Execute registered validators, ordered by priority (high prio --> executed first)."""
         # order validators by priority
+        self._validation_failures.clear()
         self.__validators = sorted(self.__validators, key=operator.attrgetter("priority"), reverse=True)
 
         # execute validators and add results in validation_failures array
@@ -415,7 +416,7 @@ class HeadNode(Resource):
         self.storage = storage
         self.dcv = dcv
         self.efa = efa
-        self._add_validator(InstanceTypeValidator, priority=1, instance_type=self.instance_type)
+        self._add_validator(InstanceTypeValidator, instance_type=self.instance_type)
 
 
 class BaseComputeResource(Resource):

--- a/cli/src/pcluster/models/cluster_awsbatch.py
+++ b/cli/src/pcluster/models/cluster_awsbatch.py
@@ -12,7 +12,6 @@
 # This module contains all the classes representing the Resources objects.
 # These objects are obtained from the configuration file through a conversion based on the Schema classes.
 #
-
 from typing import List
 
 from pcluster.models.cluster import (

--- a/cli/src/pcluster/models/cluster_slurm.py
+++ b/cli/src/pcluster/models/cluster_slurm.py
@@ -12,7 +12,6 @@
 # This module contains all the classes representing the Resources objects.
 # These objects are obtained from the configuration file through a conversion based on the Schema classes.
 #
-
 from typing import List
 
 from pcluster.models.cluster import (

--- a/cli/src/pcluster/models/param.py
+++ b/cli/src/pcluster/models/param.py
@@ -14,6 +14,7 @@
 # By extending build-in classes, we can add custom attributes while keep all the behaviors of the super class.
 #
 
+
 # Mark all values. This is useful for distinguishing values implied vs specified by a user.
 class Param:
     """Custom class to wrap a value and add more attributes."""

--- a/cli/src/pcluster/models/param.py
+++ b/cli/src/pcluster/models/param.py
@@ -15,12 +15,15 @@
 #
 
 
-# Mark all values. This is useful for distinguishing values implied vs specified by a user.
 class Param:
     """Custom class to wrap a value and add more attributes."""
 
     def __init__(self, value, default=None, valid: bool = True):
-        """Create MarkedValue object and add attributes."""
+        """
+        Initialize param by adding internal attributes.
+
+        Implied attribute is useful for distinguishing values implied vs specified by a user.
+        """
         if value is None and default is not None:
             self.value = default
             self.implied = True
@@ -28,3 +31,16 @@ class Param:
             self.value = value
             self.implied = False
         self.valid = valid
+
+
+class DynamicParam:
+    """Class to manage dynamic params that must be calculated at usage time."""
+
+    def __init__(self, value_calculator):
+        """Initialize dynamic param by saving the function to be used to retrieve the value."""
+        self.__value_calculator = value_calculator
+
+    @property
+    def value(self):
+        """Calculate and return the value."""
+        return self.__value_calculator()

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -346,6 +346,7 @@ class HeadNodeSchema(BaseSchema):
     """Represent the schema of the HeadNode."""
 
     instance_type = fields.Str(required=True)
+    simultaneous_multithreading = fields.Bool()
     networking = fields.Nested(HeadNodeNetworkingSchema, required=True)
     ssh = fields.Nested(SshSchema, required=True)
     image = fields.Nested(ImageSchema)

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -754,33 +754,6 @@ def test_intel_hpc_os_validator(mocker, section_dict, expected_message):
 
 
 @pytest.mark.parametrize(
-    "section_dict, expected_message",
-    [
-        (
-            {"disable_hyperthreading": True, "extra_json": '{"cluster": {"cfn_scheduler_slots": "vcpus"}}'},
-            "cfn_scheduler_slots cannot be set in addition to disable_hyperthreading = true",
-        ),
-        (
-            {"disable_hyperthreading": True, "extra_json": '{"cluster": {"cfn_scheduler_slots": "cores"}}'},
-            "cfn_scheduler_slots cannot be set in addition to disable_hyperthreading = true",
-        ),
-        (
-            {"disable_hyperthreading": True, "extra_json": '{"cluster": {"cfn_scheduler_slots": 3}}'},
-            "cfn_scheduler_slots cannot be set in addition to disable_hyperthreading = true",
-        ),
-        ({"disable_hyperthreading": True, "extra_json": '{"cluster": {"other_param": "fake_value"}}'}, None),
-        ({"disable_hyperthreading": True}, None),
-        ({"disable_hyperthreading": False, "extra_json": '{"cluster": {"cfn_scheduler_slots": "vcpus"}}'}, None),
-        ({"disable_hyperthreading": False, "extra_json": '{"cluster": {"cfn_scheduler_slots": "cores"}}'}, None),
-        ({"disable_hyperthreading": False, "extra_json": '{"cluster": {"cfn_scheduler_slots": 3}}'}, None),
-    ],
-)
-def test_disable_hyperthreading_validator(mocker, section_dict, expected_message):
-    config_parser_dict = {"cluster default": section_dict}
-    utils.assert_param_validator(mocker, config_parser_dict, expected_message)
-
-
-@pytest.mark.parametrize(
     "section_dict, expected_error, expected_warning",
     [
         ({"enable_efa": "NONE"}, "invalid value", None),
@@ -1851,31 +1824,6 @@ def test_duplicate_shared_dir_validator(
     }
 
     utils.assert_param_validator(mocker, config_parser_dict, expected_error=expected_message)
-
-
-@pytest.mark.parametrize(
-    "extra_json, expected_message",
-    [
-        (
-            {"extra_json": {"cluster": {"cfn_scheduler_slots": "1"}}},
-            "It is highly recommended to use the disable_hyperthreading parameter in order to control the "
-            "hyper-threading configuration in the cluster rather than using cfn_scheduler_slots in extra_json",
-        ),
-        (
-            {"extra_json": {"cluster": {"cfn_scheduler_slots": "vcpus"}}},
-            "It is highly recommended to use the disable_hyperthreading parameter in order to control the "
-            "hyper-threading configuration in the cluster rather than using cfn_scheduler_slots in extra_json",
-        ),
-        (
-            {"extra_json": {"cluster": {"cfn_scheduler_slots": "cores"}}},
-            "It is highly recommended to use the disable_hyperthreading parameter in order to control the "
-            "hyper-threading configuration in the cluster rather than using cfn_scheduler_slots in extra_json",
-        ),
-    ],
-)
-def test_extra_json_validator(mocker, capsys, extra_json, expected_message):
-    config_parser_dict = {"cluster default": extra_json}
-    utils.assert_param_validator(mocker, config_parser_dict, capsys=capsys, expected_warning=expected_message)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -109,7 +109,7 @@ def get_mock_pcluster_config_patches(scheduler, extra_patches=None):
     patches = {
         "pcluster.config.validators.get_supported_instance_types": head_node_instances,
         "pcluster.config.validators.get_supported_compute_instance_types": compute_instances,
-        "pcluster.config.validators.get_supported_architectures_for_instance_type": architectures,
+        "pcluster.utils.get_supported_architectures_for_instance_type": architectures,
         "pcluster.config.cfn_param_types.get_availability_zone_of_subnet": "mocked_avail_zone",
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type": architectures,
         "pcluster.config.cfn_param_types.InstanceTypeInfo.init_from_instance_type": InstanceTypeInfo(

--- a/cli/tests/pcluster/configure/test_pcluster_configure.py
+++ b/cli/tests/pcluster/configure/test_pcluster_configure.py
@@ -298,7 +298,7 @@ def _mock_parallel_cluster_config(mocker):
     # NOTE: the following shouldn't be needed given that easyconfig doesn't validate the config file,
     #       but it's being included in case that changes in the future.
     mocker.patch(
-        "pcluster.config.validators.get_supported_architectures_for_instance_type",
+        "pcluster.utils.get_supported_architectures_for_instance_type",
         side_effect=lambda instance: ["arm64"] if instance == "m6g.xlarge" else ["x86_64"],
     )
 

--- a/cli/tests/pcluster/models/cluster_dummy_model.py
+++ b/cli/tests/pcluster/models/cluster_dummy_model.py
@@ -1,0 +1,33 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pcluster.models.cluster import HeadNode, HeadNodeNetworking, Image, QueueNetworking, Ssh
+from pcluster.models.cluster_slurm import SlurmCluster, SlurmComputeResource, SlurmQueue, SlurmScheduling
+
+
+def dummy_head_node():
+    """Generate dummy head node."""
+    image = Image(os="fakeos")
+    head_node_networking = HeadNodeNetworking(subnet_id="test")
+    ssh = Ssh(key_name="test")
+    return HeadNode(instance_type="fake", networking=head_node_networking, ssh=ssh, image=image)
+
+
+def dummy_cluster():
+    """Generate dummy cluster."""
+    image = Image(os="fakeos")
+    head_node = dummy_head_node()
+    compute_resources = [SlurmComputeResource(instance_type="test")]
+    queue_networking = QueueNetworking(subnet_ids=["test"])
+    queues = [SlurmQueue(name="test", networking=queue_networking, compute_resources=compute_resources)]
+    scheduling = SlurmScheduling(queues=queues)
+    return SlurmCluster(image=image, head_node=head_node, scheduling=scheduling)

--- a/cli/tests/pcluster/models/imagebuilder_dummy_model.py
+++ b/cli/tests/pcluster/models/imagebuilder_dummy_model.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pcluster.models.imagebuilder import Build, DevSettings
+from pcluster.models.imagebuilder import Image as ImageBuilderImage
+from pcluster.models.imagebuilder import ImageBuilder
+
+
+def dummy_imagebuilder(is_official_ami_build):
+    """Generate dummy imagebuilder configuration."""
+    image = ImageBuilderImage(name="Pcluster")
+    if is_official_ami_build:
+        build = Build(
+            instance_type="c5.xlarge", parent_image="arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x"
+        )
+        dev_settings = DevSettings(update_os_and_reboot=True)
+    else:
+        build = Build(instance_type="g4dn.xlarge", parent_image="ami-0185634c5a8a37250")
+        dev_settings = DevSettings()
+    return ImageBuilder(image=image, build=build, dev_settings=dev_settings)

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -15,7 +15,7 @@ HeadNode:
       - sg-23456789
     Proxy:
       HttpProxyAddress: String  # https://proxy-address:port
-  #SimultaneousMultithreading: Boolean  # true
+  SimultaneousMultithreading: false
   Ssh:
     KeyName: String  # ec2-key-name
     AllowedIps: 1.2.3.4/32  # 1.2.3.4/32

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -15,7 +15,7 @@ HeadNode:
       - sg-3
     Proxy:
       HttpProxyAddress: String  # https://proxy-address:port
-  #SimultaneousMultithreading: Boolean  # true
+  SimultaneousMultithreading: Boolean  # true
   Ssh:
     KeyName: String  # ec2-key-name
     AllowedIps: String  # 1.2.3.4/32

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -1,0 +1,48 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import yaml
+from aws_cdk import core
+
+from common.utils import load_yaml_dict
+from pcluster.models.cluster import HeadNode
+from pcluster.templates.cdk_builder import CDKTemplateBuilder
+from pcluster.templates.cluster_stack import HeadNodeConstruct
+from tests.pcluster.models.cluster_dummy_model import dummy_cluster, dummy_head_node
+
+
+def test_cluster_builder():
+    generated_template = CDKTemplateBuilder().build(cluster=dummy_cluster())
+    print(yaml.dump(generated_template))
+    # TODO assert content of the template by matching expected template
+
+
+def test_head_node_construct(tmpdir):
+    # TODO verify if it's really useful
+
+    class DummyStack(core.Stack):
+        """Simple Stack to test a specific construct."""
+
+        def __init__(self, scope: core.Construct, construct_id: str, head_node: HeadNode, **kwargs) -> None:
+            super().__init__(scope, construct_id, **kwargs)
+
+            HeadNodeConstruct(self, "HeadNode", head_node)
+
+    output_file = "cluster"
+    app = core.App(outdir=str(tmpdir))
+    DummyStack(app, output_file, head_node=dummy_head_node())
+    app.synth()
+    generated_template = load_yaml_dict(os.path.join(tmpdir, f"{output_file}.template.json"))
+
+    print(yaml.dump(generated_template))
+    # TODO assert content of the template by matching expected template


### PR DESCRIPTION
# DynamicParam
* Defined new `DynamicParam` class to cope with parameters that are not defined in the config and   must be evaluated at runtime (e.g. `architecture`).
* We might use properties for them but if a validator requires the property it will evaluate it  when calling `_add_validator`. With the `DynamicParam` the value will be evaluated when needed.
* Added tests for `dynamic_property_behaviour`.

# Disable Hyperthreading
* Renamed to `SimultaneousMultithreading` (Hyperthreading is Intel's proprietary)
* Added attribute to Head node and enabled in schema tests
* Moved `disable_hyperthreading_architecture_validator` to `SimultaneousMultithreadingArchitectureValidator`
  and moved tests

# Architecture
* Defined new DynamicParam for architecture attribute.
* Moved `architecture_os_validator` to `ArchitectureOsValidator` and moved tests.
* Moved `efa_os_arch_validator` to `EfaOsArchitectureValidator`. It will be executed only if efa is defined
  in the class.
* Moved `instances_architecture_compatibility_validator` and splitted into two different validators:
  `InstanceArchitectureCompatibilityValidator` and `AwsbatchInstancesArchitectureCompatibilityValidator`,
  splitted the tests too.

# Extra json and cfn_scheduler_slots
* Removed `extra_json` and `cfn_scheduler_slots` validators
* Extra json parameter and the possibility to configure `cfn_scheduler_slots` is deprecated. It was already deprecated for Slurm.

# Other changes
+ Fixed `FsxNetworkingValidator` by adding `Param` type hint.
+ Split image builder and cluster stack generation tests and move dummy model classes into new tests modules.
+ Reset validators failures when calling validate function
+ Changed mock in old tests because some methods are no longer included in the validators module.
+ Other minor cleanup changes.