### PR TITLE
integ-tests: fix test_pcluster_configure

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -612,7 +612,7 @@ def vpc_stacks(cfn_stacks_factory, request):
             availability_zone=availability_zones[0],
             default_gateway=Gateways.NAT_GATEWAY,
         )
-        # cidr="192.168.96.0/19" used by test_networking
+        # cidr="192.168.96.0/19" used by test_networking and test_pcluster_configure
         private_subnet_different_cidr = SubnetConfig(
             name="PrivateAdditionalCidr",
             cidr="192.168.128.0/17",  # 32766 IPs

--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -300,7 +300,7 @@ def subnet_in_use1_az3(vpc_stack):
     )
     assert_that(offerings).is_empty()
     subnet_id = ec2_client.create_subnet(
-        AvailabilityZoneId="use1-az3", CidrBlock="192.168.16.0/20", VpcId=vpc_stack.cfn_outputs["VpcId"]
+        AvailabilityZoneId="use1-az3", CidrBlock="192.168.112.0/20", VpcId=vpc_stack.cfn_outputs["VpcId"]
     )["Subnet"]["SubnetId"]
     yield subnet_id
     ec2_client.delete_subnet(SubnetId=subnet_id)


### PR DESCRIPTION
broken by: #2339

the test_pcluster_configure is assuming that a portion of the VPC created for all tests is free.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
