### PR TITLE
3.0: Migrate compute resource validator and other refactorings

### DIFF
--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -55,7 +55,6 @@ from pcluster.config.json_param_types import (
 from pcluster.config.param_types import Visibility
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import (
-    base_os_validator,
     cluster_validator,
     compute_instance_type_validator,
     compute_resource_validator,
@@ -779,7 +778,6 @@ CLUSTER_COMMON_PARAMS = [
         "type": BaseOSCfnParam,
         "cfn_param_mapping": "BaseOS",
         "allowed_values": ["alinux", "alinux2", "ubuntu1604", "ubuntu1804", "centos7", "centos8"],
-        "validators": [base_os_validator],
         "required": True,
         "update_policy": UpdatePolicy.UNSUPPORTED
     }),

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -55,7 +55,6 @@ from pcluster.config.json_param_types import (
 from pcluster.config.param_types import Visibility
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import (
-    cluster_validator,
     compute_instance_type_validator,
     compute_resource_validator,
     dcv_enabled_validator,
@@ -1001,7 +1000,7 @@ CLUSTER_SIT = {
     "key": "cluster",
     "default_label": "default",
     "cluster_model": "SIT",
-    "validators": [cluster_validator] + CLUSTER_COMMON_VALIDATORS,
+    "validators": CLUSTER_COMMON_VALIDATORS,
     "params": OrderedDict(
         CLUSTER_COMMON_PARAMS + [
             ("placement_group", {

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -902,19 +902,6 @@ def intel_hpc_architecture_validator(param_key, param_value, pcluster_config):
     return errors, warnings
 
 
-def base_os_validator(param_key, param_value, pcluster_config):
-    warnings = []
-
-    eol_2020 = ["alinux"]
-    if param_value in eol_2020:
-        warnings.append(
-            "The operating system you are using ({0}) will reach end-of-life in late 2020. It will be deprecated in "
-            "future releases of ParallelCluster".format(param_value)
-        )
-
-    return [], warnings
-
-
 def tags_validator(param_key, param_value, pcluster_config):
     errors = []
 

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -778,40 +778,6 @@ def scheduler_validator(param_key, param_value, pcluster_config):
     return errors, warnings
 
 
-def cluster_validator(section_key, section_label, pcluster_config):
-    errors = []
-    warnings = []
-
-    section = pcluster_config.get_section(section_key, section_label)
-    if section.get_param_value("scheduler") == "awsbatch":
-        min_size = section.get_param_value("min_vcpus")
-        desired_size = section.get_param_value("desired_vcpus")
-        max_size = section.get_param_value("max_vcpus")
-
-        if desired_size < min_size:
-            errors.append("desired_vcpus must be greater than or equal to min_vcpus")
-
-        if desired_size > max_size:
-            errors.append("desired_vcpus must be fewer than or equal to max_vcpus")
-
-        if max_size < min_size:
-            errors.append("max_vcpus must be greater than or equal to min_vcpus")
-    else:
-        min_size = (
-            section.get_param_value("initial_queue_size") if section.get_param_value("maintain_initial_size") else 0
-        )
-        desired_size = section.get_param_value("initial_queue_size")
-        max_size = section.get_param_value("max_queue_size")
-
-        if desired_size > max_size:
-            errors.append("initial_queue_size must be fewer than or equal to max_queue_size")
-
-        if max_size < min_size:
-            errors.append("max_queue_size must be greater than or equal to initial_queue_size")
-
-    return errors, warnings
-
-
 def compute_instance_type_validator(param_key, param_value, pcluster_config):
     """Validate compute instance type, calling ec2_instance_type_validator if the scheduler is not awsbatch."""
     errors = []

--- a/cli/src/pcluster/models/cluster_awsbatch.py
+++ b/cli/src/pcluster/models/cluster_awsbatch.py
@@ -32,10 +32,8 @@ from pcluster.models.cluster import (
     Tag,
 )
 from pcluster.models.common import Param
-from pcluster.validators.cluster_validators import (
-    AwsbatchInstancesArchitectureCompatibilityValidator,
-    EfaOsArchitectureValidator,
-)
+from pcluster.validators.awsbatch_validators import AwsbatchInstancesArchitectureCompatibilityValidator
+from pcluster.validators.cluster_validators import EfaOsArchitectureValidator
 
 
 class AwsbatchComputeResource(BaseComputeResource):

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -58,7 +58,6 @@ class DynamicParam:
 class FailureLevel(Enum):
     """Validation failure level."""
 
-    CRITICAL = 50
     ERROR = 40
     WARNING = 30
     INFO = 20

--- a/cli/src/pcluster/validators/awsbatch_validators.py
+++ b/cli/src/pcluster/validators/awsbatch_validators.py
@@ -1,0 +1,45 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pcluster.models.common import DynamicParam, FailureLevel, Param, Validator
+from pcluster.utils import get_supported_architectures_for_instance_type, is_instance_type_format
+
+
+class AwsbatchInstancesArchitectureCompatibilityValidator(Validator):
+    """Validate instance type and architecture combination."""
+
+    def _validate(self, instance_types: Param, architecture: DynamicParam):
+        """
+        Verify that head node and compute instance types imply compatible architectures.
+
+        When awsbatch is used as the scheduler, compute_instance_type can contain a CSV list.
+        """
+        head_node_architecture = architecture.value
+        for instance_type in instance_types.value.split(","):
+            # When awsbatch is used as the scheduler instance families can be used.
+            # Don't attempt to validate architectures for instance families, as it would require
+            # guessing a valid instance type from within the family.
+            if not is_instance_type_format(instance_type) and instance_type != "optimal":
+                self._add_failure(
+                    "Not validating architecture compatibility for compute instance type {0} because it does not have "
+                    "the expected format".format(instance_type),
+                    FailureLevel.INFO,
+                )
+                continue
+            compute_architectures = get_supported_architectures_for_instance_type(instance_type)
+            if head_node_architecture not in compute_architectures:
+                self._add_failure(
+                    "The specified compute instance type ({0}) supports the architectures {1}, none of which are "
+                    "compatible with the architecture supported by the head node instance type ({2}).".format(
+                        instance_type, compute_architectures, head_node_architecture
+                    ),
+                    FailureLevel.ERROR,
+                )

--- a/cli/src/pcluster/validators/awsbatch_validators.py
+++ b/cli/src/pcluster/validators/awsbatch_validators.py
@@ -67,4 +67,5 @@ class AwsbatchInstancesArchitectureCompatibilityValidator(Validator):
                         instance_type, compute_architectures, head_node_architecture
                     ),
                     FailureLevel.ERROR,
+                    [instance_types],
                 )

--- a/cli/src/pcluster/validators/awsbatch_validators.py
+++ b/cli/src/pcluster/validators/awsbatch_validators.py
@@ -13,6 +13,31 @@ from pcluster.models.common import DynamicParam, FailureLevel, Param, Validator
 from pcluster.utils import get_supported_architectures_for_instance_type, is_instance_type_format
 
 
+class AwsbatchComputeResourceValidator(Validator):
+    """Awsbatch compute resource validator."""
+
+    def _validate(self, min_vcpus: Param, desired_vcpus: Param, max_vcpus: Param):
+        """Validate min, desired and max vcpus combination."""
+        if desired_vcpus.value < min_vcpus.value:
+            self._add_failure(
+                "The number of desired vcpus must be greater than or equal to min vcpus",
+                FailureLevel.ERROR,
+                [min_vcpus, desired_vcpus],
+            )
+
+        if desired_vcpus.value > max_vcpus.value:
+            self._add_failure(
+                "The number of desired vcpus must be fewer than or equal to max vcpus",
+                FailureLevel.ERROR,
+                [max_vcpus, desired_vcpus],
+            )
+
+        if max_vcpus.value < min_vcpus.value:
+            self._add_failure(
+                "Max vcpus must be greater than or equal to min vcpus", FailureLevel.ERROR, [max_vcpus, min_vcpus]
+            )
+
+
 class AwsbatchInstancesArchitectureCompatibilityValidator(Validator):
     """Validate instance type and architecture combination."""
 

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -51,7 +51,7 @@ class FsxNetworkingValidator(Validator):
                 self._add_failure(
                     "Currently only support using FSx file system that is in the same VPC as the stack. "
                     "The file system provided is in {0}".format(file_system.get("VpcId")),
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [file_system_id],
                 )
 
@@ -61,7 +61,7 @@ class FsxNetworkingValidator(Validator):
                 self._add_failure(
                     "Unable to validate FSx security groups. The given FSx file system '{0}' doesn't have "
                     "Elastic Network Interfaces attached to it.".format(file_system_id.value),
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [file_system_id],
                 )
             else:
@@ -82,11 +82,11 @@ class FsxNetworkingValidator(Validator):
                         "The current security group settings on file system '{0}' does not satisfy mounting requirement"
                         ". The file system must be associated to a security group that allows inbound and outbound "
                         "TCP traffic through port 988.".format(file_system_id.value),
-                        FailureLevel.CRITICAL,
+                        FailureLevel.ERROR,
                         [file_system_id],
                     )
         except ClientError as e:
-            self._add_failure(e.response.get("Error").get("Message"), FailureLevel.CRITICAL)
+            self._add_failure(e.response.get("Error").get("Message"), FailureLevel.ERROR)
 
     def _check_in_out_access(self, security_groups_ids, port):
         """
@@ -157,7 +157,7 @@ class SimultaneousMultithreadingArchitectureValidator(Validator):
                 "Simultaneous Multithreading is only supported on instance types that support "
                 "these architectures: {0}".format(", ".join(supported_architectures)),
                 FailureLevel.ERROR,
-                [simultaneous_multithreading]
+                [simultaneous_multithreading],
             )
 
 
@@ -170,7 +170,7 @@ class EfaOsArchitectureValidator(Validator):
             self._add_failure(
                 "EFA currently not supported on {0} for {1} architecture".format(os.value, architecture.value),
                 FailureLevel.ERROR,
-                [efa_enabled]
+                [efa_enabled],
             )
 
 

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -52,6 +52,7 @@ class FsxNetworkingValidator(Validator):
                     "Currently only support using FSx file system that is in the same VPC as the stack. "
                     "The file system provided is in {0}".format(file_system.get("VpcId")),
                     FailureLevel.CRITICAL,
+                    [file_system_id],
                 )
 
             # If there is an existing mt in the az, need to check the inbound and outbound rules of the security groups
@@ -61,6 +62,7 @@ class FsxNetworkingValidator(Validator):
                     "Unable to validate FSx security groups. The given FSx file system '{0}' doesn't have "
                     "Elastic Network Interfaces attached to it.".format(file_system_id.value),
                     FailureLevel.CRITICAL,
+                    [file_system_id],
                 )
             else:
                 network_interface_responses = ec2.describe_network_interfaces(
@@ -81,6 +83,7 @@ class FsxNetworkingValidator(Validator):
                         ". The file system must be associated to a security group that allows inbound and outbound "
                         "TCP traffic through port 988.".format(file_system_id.value),
                         FailureLevel.CRITICAL,
+                        [file_system_id],
                     )
         except ClientError as e:
             self._add_failure(e.response.get("Error").get("Message"), FailureLevel.CRITICAL)
@@ -154,6 +157,7 @@ class SimultaneousMultithreadingArchitectureValidator(Validator):
                 "Simultaneous Multithreading is only supported on instance types that support "
                 "these architectures: {0}".format(", ".join(supported_architectures)),
                 FailureLevel.ERROR,
+                [simultaneous_multithreading]
             )
 
 
@@ -166,6 +170,7 @@ class EfaOsArchitectureValidator(Validator):
             self._add_failure(
                 "EFA currently not supported on {0} for {1} architecture".format(os.value, architecture.value),
                 FailureLevel.ERROR,
+                [efa_enabled]
             )
 
 
@@ -181,6 +186,7 @@ class ArchitectureOsValidator(Validator):
                     architecture.value, allowed_oses
                 ),
                 FailureLevel.ERROR,
+                [os],
             )
 
 
@@ -198,4 +204,5 @@ class InstanceArchitectureCompatibilityValidator(Validator):
                     instance_type.value, compute_architectures, head_node_architecture
                 ),
                 FailureLevel.ERROR,
+                [instance_type],
             )

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -20,6 +20,17 @@ EFA_UNSUPPORTED_ARCHITECTURES_OSES = {
 }
 
 
+class ComputeResourceValidator(Validator):
+    """Slurm compute resource validator."""
+
+    def _validate(self, min_count: Param, max_count: Param):
+        """Validate min count and max count combinations."""
+        if max_count.value < min_count.value:
+            self._add_failure(
+                "Max count must be greater than or equal to min count", FailureLevel.ERROR, [min_count, max_count]
+            )
+
+
 class FsxNetworkingValidator(Validator):
     """FSx and networking validator."""
 

--- a/cli/src/pcluster/validators/ebs_validators.py
+++ b/cli/src/pcluster/validators/ebs_validators.py
@@ -196,4 +196,5 @@ class EBSVolumeKmsKeyIdValidator(Validator):
             self._add_failure(
                 "Kms Key Id {0} is specified, the encrypted state must be True.".format(volume_kms_key_id.value),
                 FailureLevel.ERROR,
+                [volume_encrypted],
             )

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -20,7 +20,7 @@ class BaseAMIValidator(Validator):
         """Validate given ami id or image arn."""
         ami_id = utils.get_ami_id(image.value)
         if not Ec2Client().describe_ami_id_offering(ami_id=ami_id):
-            self._add_failure(f"The ami id '{ami_id}' is not supported.", FailureLevel.CRITICAL)
+            self._add_failure(f"The ami id '{ami_id}' is not supported.", FailureLevel.CRITICAL, [image])
 
 
 class InstanceTypeValidator(Validator):
@@ -29,7 +29,11 @@ class InstanceTypeValidator(Validator):
     def _validate(self, instance_type: Param):
         """Validate given instance type."""
         if instance_type.value not in Ec2Client().describe_instance_type_offerings():
-            self._add_failure(f"The instance type '{instance_type.value}' is not supported.", FailureLevel.CRITICAL)
+            self._add_failure(
+                f"The instance type '{instance_type.value}' is not supported.",
+                FailureLevel.CRITICAL,
+                [instance_type],
+            )
 
 
 class InstanceTypeBaseAMICompatibleValidator(Validator):
@@ -47,4 +51,5 @@ class InstanceTypeBaseAMICompatibleValidator(Validator):
                     ami_id, ami_architecture, instance_type.value, instance_architecture
                 ),
                 FailureLevel.CRITICAL,
+                [instance_type, parent_image],
             )

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -20,7 +20,7 @@ class BaseAMIValidator(Validator):
         """Validate given ami id or image arn."""
         ami_id = utils.get_ami_id(image.value)
         if not Ec2Client().describe_ami_id_offering(ami_id=ami_id):
-            self._add_failure(f"The ami id '{ami_id}' is not supported.", FailureLevel.CRITICAL, [image])
+            self._add_failure(f"The ami id '{ami_id}' is not supported.", FailureLevel.ERROR, [image])
 
 
 class InstanceTypeValidator(Validator):
@@ -31,7 +31,7 @@ class InstanceTypeValidator(Validator):
         if instance_type.value not in Ec2Client().describe_instance_type_offerings():
             self._add_failure(
                 f"The instance type '{instance_type.value}' is not supported.",
-                FailureLevel.CRITICAL,
+                FailureLevel.ERROR,
                 [instance_type],
             )
 
@@ -50,6 +50,6 @@ class InstanceTypeBaseAMICompatibleValidator(Validator):
                 "chosen ({3}). Use either a different AMI or a different instance type.".format(
                     ami_id, ami_architecture, instance_type.value, instance_architecture
                 ),
-                FailureLevel.CRITICAL,
+                FailureLevel.ERROR,
                 [instance_type, parent_image],
             )

--- a/cli/src/pcluster/validators/fsx_validators.py
+++ b/cli/src/pcluster/validators/fsx_validators.py
@@ -23,21 +23,21 @@ class FsxS3Validator(Validator):
         if imported_file_chunk_size.value and not import_path.value:
             self._add_failure(
                 "When specifying imported file chunk size, the import path option must be specified",
-                FailureLevel.CRITICAL,
+                FailureLevel.ERROR,
                 [imported_file_chunk_size, import_path],
             )
 
         if export_path.value and not import_path.value:
             self._add_failure(
                 "When specifying export path, the import path option must be specified",
-                FailureLevel.CRITICAL,
+                FailureLevel.ERROR,
                 [export_path, import_path],
             )
 
         if auto_import_policy.value and not import_path.value:
             self._add_failure(
                 "When specifying auto import policy, the import path option must be specified",
-                FailureLevel.CRITICAL,
+                FailureLevel.ERROR,
                 [auto_import_policy, import_path],
             )
 
@@ -51,20 +51,20 @@ class FsxPersistentOptionsValidator(Validator):
             if not per_unit_storage_throughput.value:
                 self._add_failure(
                     "per unit storage throughput must be specified when deployment type is `PERSISTENT_1'",
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [deployment_type, per_unit_storage_throughput],
                 )
         else:
             if kms_key_id.value:
                 self._add_failure(
                     "kms key id can only be used when deployment type is `PERSISTENT_1'",
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [deployment_type, kms_key_id],
                 )
             if per_unit_storage_throughput.value:
                 self._add_failure(
                     "per unit storage throughput can only be used when deployment type is `PERSISTENT_1'",
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [deployment_type, per_unit_storage_throughput],
                 )
 
@@ -88,19 +88,19 @@ class FsxBackupOptionsValidator(Validator):
             self._add_failure(
                 "When specifying daily automatic backup start time,"
                 "the automatic backup retention days option must be specified",
-                FailureLevel.CRITICAL,
+                FailureLevel.ERROR,
                 [automatic_backup_retention_days, daily_automatic_backup_start_time],
             )
         if not automatic_backup_retention_days.value and copy_tags_to_backups.value is not None:
             self._add_failure(
                 "When specifying copy tags to backups, " "the automatic backup retention days option must be specified",
-                FailureLevel.CRITICAL,
+                FailureLevel.ERROR,
                 [automatic_backup_retention_days, copy_tags_to_backups],
             )
         if deployment_type.value != "PERSISTENT_1" and automatic_backup_retention_days.value:
             self._add_failure(
                 "FSx automatic backup features can be used only with 'PERSISTENT_1' file systems",
-                FailureLevel.CRITICAL,
+                FailureLevel.ERROR,
                 [deployment_type, automatic_backup_retention_days],
             )
         if (
@@ -108,7 +108,7 @@ class FsxBackupOptionsValidator(Validator):
         ) and automatic_backup_retention_days.value:
             self._add_failure(
                 "Backups cannot be created on S3-linked file systems",
-                FailureLevel.CRITICAL,
+                FailureLevel.ERROR,
                 [automatic_backup_retention_days],
             )
 
@@ -124,7 +124,7 @@ class FsxStorageTypeOptionsValidator(Validator):
             if deployment_type.value != "PERSISTENT_1":
                 self._add_failure(
                     "For HDD filesystems, deployment type must be 'PERSISTENT_1'",
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [storage_type, deployment_type],
                 )
             if per_unit_storage_throughput.value not in FSX_HDD_THROUGHPUT:
@@ -132,14 +132,14 @@ class FsxStorageTypeOptionsValidator(Validator):
                     "For HDD filesystems, per unit storage throughput can only have the following values: {0}".format(
                         FSX_HDD_THROUGHPUT
                     ),
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [storage_type, per_unit_storage_throughput],
                 )
         else:  # SSD or None
             if drive_cache_type.value:
                 self._add_failure(
                     "drive cache type features can be used only with HDD filesystems",
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [storage_type, drive_cache_type],
                 )
             if per_unit_storage_throughput.value and per_unit_storage_throughput.value not in FSX_SSD_THROUGHPUT:
@@ -147,7 +147,7 @@ class FsxStorageTypeOptionsValidator(Validator):
                     "For SSD filesystems, per unit storage throughput can only have the following values: {0}".format(
                         FSX_SSD_THROUGHPUT
                     ),
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [storage_type, per_unit_storage_throughput],
                 )
 
@@ -173,7 +173,7 @@ class FsxStorageCapacityValidator(Validator):
             # if file_system_id is not provided, storage_capacity must be provided
             self._add_failure(
                 "When specifying 'fsx' section, the 'StorageCapacity' option must be specified",
-                FailureLevel.CRITICAL,
+                FailureLevel.ERROR,
                 [storage_capacity],
             )
         elif deployment_type.value == "SCRATCH_1":
@@ -182,26 +182,26 @@ class FsxStorageCapacityValidator(Validator):
             ):
                 self._add_failure(
                     "Capacity for FSx SCRATCH_1 filesystem is 1,200 GB, 2,400 GB or increments of 3,600 GB",
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [storage_capacity, deployment_type],
                 )
         elif deployment_type.value == "PERSISTENT_1" and storage_type.value == "HDD":
             if per_unit_storage_throughput.value == 12 and not (storage_capacity.value % 6000 == 0):
                 self._add_failure(
                     "Capacity for FSx PERSISTENT HDD 12 MB/s/TiB file systems is increments of 6,000 GiB",
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [storage_capacity, deployment_type, storage_type, per_unit_storage_throughput],
                 )
             elif per_unit_storage_throughput.value == 40 and not (storage_capacity.value % 1800 == 0):
                 self._add_failure(
                     "Capacity for FSx PERSISTENT HDD 40 MB/s/TiB file systems is increments of 1,800 GiB",
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [storage_capacity, deployment_type, storage_type, per_unit_storage_throughput],
                 )
         elif deployment_type.value in ["SCRATCH_2", "PERSISTENT_1"]:
             if not (storage_capacity.value == 1200 or storage_capacity.value % 2400 == 0):
                 self._add_failure(
                     "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
-                    FailureLevel.CRITICAL,
+                    FailureLevel.ERROR,
                     [storage_capacity, deployment_type],
                 )

--- a/cli/src/pcluster/validators/fsx_validators.py
+++ b/cli/src/pcluster/validators/fsx_validators.py
@@ -8,14 +8,17 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+
 from pcluster.constants import FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT
-from pcluster.models.common import FailureLevel, Validator
+from pcluster.models.common import FailureLevel, Param, Validator
 
 
 class FsxS3Validator(Validator):
     """FSX S3 validator."""
 
-    def _validate(self, import_path, imported_file_chunk_size, export_path, auto_import_policy):
+    def _validate(
+        self, import_path: Param, imported_file_chunk_size: Param, export_path: Param, auto_import_policy: Param
+    ):
         """Verify compatibility of given S3 options for FSX."""
         if imported_file_chunk_size.value and not import_path.value:
             self._add_failure(
@@ -42,7 +45,7 @@ class FsxS3Validator(Validator):
 class FsxPersistentOptionsValidator(Validator):
     """FSX persistent options validator."""
 
-    def _validate(self, deployment_type, kms_key_id, per_unit_storage_throughput):
+    def _validate(self, deployment_type: Param, kms_key_id: Param, per_unit_storage_throughput: Param):
         """Verify compatibility of given persistent options for FSX."""
         if deployment_type.value == "PERSISTENT_1":
             if not per_unit_storage_throughput.value:
@@ -71,14 +74,14 @@ class FsxBackupOptionsValidator(Validator):
 
     def _validate(
         self,
-        automatic_backup_retention_days,
-        daily_automatic_backup_start_time,
-        copy_tags_to_backups,
-        deployment_type,
-        imported_file_chunk_size,
-        import_path,
-        export_path,
-        auto_import_policy,
+        automatic_backup_retention_days: Param,
+        daily_automatic_backup_start_time: Param,
+        copy_tags_to_backups: Param,
+        deployment_type: Param,
+        imported_file_chunk_size: Param,
+        import_path: Param,
+        export_path: Param,
+        auto_import_policy: Param,
     ):
         """Verify compatibility of given backup options for FSX."""
         if not automatic_backup_retention_days.value and daily_automatic_backup_start_time.value:
@@ -113,7 +116,9 @@ class FsxBackupOptionsValidator(Validator):
 class FsxStorageTypeOptionsValidator(Validator):
     """FSX storage type options validator."""
 
-    def _validate(self, storage_type, deployment_type, per_unit_storage_throughput, drive_cache_type):
+    def _validate(
+        self, storage_type: Param, deployment_type: Param, per_unit_storage_throughput: Param, drive_cache_type: Param
+    ):
         """Verify compatibility of given storage type options for FSX."""
         if storage_type.value == "HDD":
             if deployment_type.value != "PERSISTENT_1":
@@ -151,7 +156,13 @@ class FsxStorageCapacityValidator(Validator):
     """FSX storage capacity validator."""
 
     def _validate(
-        self, storage_capacity, deployment_type, storage_type, per_unit_storage_throughput, file_system_id, backup_id
+        self,
+        storage_capacity: Param,
+        deployment_type: Param,
+        storage_type: Param,
+        per_unit_storage_throughput: Param,
+        file_system_id: Param,
+        backup_id: Param,
     ):
         """Verify compatibility of given storage capacity options for FSX."""
         if file_system_id.value or backup_id.value:

--- a/cli/src/pcluster/validators/s3_validators.py
+++ b/cli/src/pcluster/validators/s3_validators.py
@@ -37,11 +37,13 @@ class UrlValidator(Validator):
                     self._add_failure(
                         "The value '{0}' is not a valid URL".format(url.value),
                         FailureLevel.ERROR,
+                        [url],
                     )
         else:
             self._add_failure(
                 f"The value '{url.value}' is not a valid URL, choose URL with 'https', 's3' or 'file' prefix.",
                 FailureLevel.ERROR,
+                [url],
             )
 
     def _validate_s3_uri(self, s3_url):

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -1077,22 +1077,6 @@ def test_maintain_initial_size_validator(mocker, section_dict, expected_message)
 
 
 @pytest.mark.parametrize(
-    "base_os, expected_warning",
-    [
-        ("alinux2", None),
-        ("centos7", None),
-        ("centos8", None),
-        ("ubuntu1604", None),
-        ("ubuntu1804", None),
-        ("alinux", "alinux.*will reach end-of-life in late 2020"),
-    ],
-)
-def test_base_os_validator(mocker, capsys, base_os, expected_warning):
-    config_parser_dict = {"cluster default": {"base_os": base_os}}
-    utils.assert_param_validator(mocker, config_parser_dict, capsys=capsys, expected_warning=expected_warning)
-
-
-@pytest.mark.parametrize(
     "cluster_section_dict, expected_message",
     [
         # SIT cluster, perfectly fine

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -38,40 +38,6 @@ def boto3_stubber_path():
     return "pcluster.config.validators.boto3"
 
 
-@pytest.mark.parametrize(
-    "section_dict, expected_message",
-    [
-        # traditional scheduler
-        ({"scheduler": "sge", "initial_queue_size": 1, "max_queue_size": 2, "maintain_initial_size": True}, None),
-        (
-            {"scheduler": "sge", "initial_queue_size": 3, "max_queue_size": 2, "maintain_initial_size": True},
-            "initial_queue_size must be fewer than or equal to max_queue_size",
-        ),
-        (
-            {"scheduler": "sge", "initial_queue_size": 3, "max_queue_size": 2, "maintain_initial_size": False},
-            "initial_queue_size must be fewer than or equal to max_queue_size",
-        ),
-        # awsbatch
-        ({"scheduler": "awsbatch", "min_vcpus": 1, "desired_vcpus": 2, "max_vcpus": 3}, None),
-        (
-            {"scheduler": "awsbatch", "min_vcpus": 3, "desired_vcpus": 2, "max_vcpus": 3},
-            "desired_vcpus must be greater than or equal to min_vcpus",
-        ),
-        (
-            {"scheduler": "awsbatch", "min_vcpus": 1, "desired_vcpus": 4, "max_vcpus": 3},
-            "desired_vcpus must be fewer than or equal to max_vcpus",
-        ),
-        (
-            {"scheduler": "awsbatch", "min_vcpus": 4, "desired_vcpus": 4, "max_vcpus": 3},
-            "max_vcpus must be greater than or equal to min_vcpus",
-        ),
-    ],
-)
-def test_cluster_validator(mocker, section_dict, expected_message):
-    config_parser_dict = {"cluster default": section_dict}
-    utils.assert_param_validator(mocker, config_parser_dict, expected_message)
-
-
 # FIXME Moved
 @pytest.mark.parametrize(
     "instance_type, expected_message", [("t2.micro", None), ("c4.xlarge", None), ("c5.xlarge", "is not supported")]

--- a/cli/tests/pcluster/models/test_cluster_model.py
+++ b/cli/tests/pcluster/models/test_cluster_model.py
@@ -22,11 +22,11 @@ class FakeInfoValidator(Validator):
         self._add_failure(f"Wrong value {param.value}.", FailureLevel.INFO)
 
 
-class FakeCriticalValidator(Validator):
-    """Dummy validator of critical level."""
+class FakeErrorValidator(Validator):
+    """Dummy validator of error level."""
 
     def _validate(self, param: Param):
-        self._add_failure(f"Critical error {param.value}.", FailureLevel.CRITICAL)
+        self._add_failure(f"Error {param.value}.", FailureLevel.ERROR)
 
 
 class FakeComplexValidator(Validator):
@@ -52,7 +52,7 @@ def test_resource_validate():
             super().__init__()
             self.fake_attribute = Param("fake-value")
             self.other_attribute = Param("other-value")
-            self._add_validator(FakeCriticalValidator, priority=10, param=self.fake_attribute)
+            self._add_validator(FakeErrorValidator, priority=10, param=self.fake_attribute)
             self._add_validator(FakeInfoValidator, priority=2, param=self.other_attribute)
             self._add_validator(
                 FakeComplexValidator,
@@ -65,7 +65,7 @@ def test_resource_validate():
     validation_failures = fake_resource.validate()
 
     # Verify high prio is the first of the list
-    _assert_validation_result(validation_failures[0], FailureLevel.CRITICAL, "Critical error fake-value.")
+    _assert_validation_result(validation_failures[0], FailureLevel.ERROR, "Error fake-value.")
     _assert_validation_result(validation_failures[1], FailureLevel.WARNING, "Combination fake-value - other-value.")
     _assert_validation_result(validation_failures[2], FailureLevel.INFO, "Wrong value other-value.")
 

--- a/cli/tests/pcluster/validators/test_awsbatch_validators.py
+++ b/cli/tests/pcluster/validators/test_awsbatch_validators.py
@@ -1,0 +1,65 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from assertpy import assert_that
+
+from pcluster.models.common import DynamicParam, Param
+from pcluster.validators.awsbatch_validators import AwsbatchInstancesArchitectureCompatibilityValidator
+
+from .utils import assert_failure_messages
+
+
+@pytest.mark.parametrize(
+    "head_node_architecture, compute_architecture, compute_instance_types, expected_message",
+    [
+        ("x86_64", "x86_64", "optimal", None),
+        # Function to get supported architectures shouldn't be called because compute instance types arg
+        # are instance families.
+        ("x86_64", None, "m6g", "Not validating architecture"),
+        ("x86_64", None, "c5", "Not validating architecture"),
+        # The validator must handle the case where compute instance type is a CSV list
+        ("arm64", "arm64", "m6g.xlarge,r6g.xlarge", None),
+        (
+            "x86_64",
+            "arm64",
+            "m6g.xlarge,r6g.xlarge",
+            "none of which are compatible with the architecture supported by the head node instance type",
+        ),
+    ],
+)
+def test_awsbatch_instances_architecture_compatibility_validator(
+    mocker, head_node_architecture, compute_architecture, compute_instance_types, expected_message
+):
+    def _internal_is_instance_type(itype):
+        return "." in itype or itype == "optimal"
+
+    supported_architectures_patch = mocker.patch(
+        "pcluster.validators.awsbatch_validators.get_supported_architectures_for_instance_type",
+        return_value=[compute_architecture],
+    )
+    is_instance_type_patch = mocker.patch(
+        "pcluster.validators.awsbatch_validators.is_instance_type_format", side_effect=_internal_is_instance_type
+    )
+
+    instance_types = compute_instance_types.split(",")
+
+    actual_failures = AwsbatchInstancesArchitectureCompatibilityValidator().execute(
+        Param(compute_instance_types), DynamicParam(lambda: head_node_architecture)
+    )
+    assert_failure_messages(actual_failures, expected_message)
+    if expected_message:
+        assert_that(len(actual_failures)).is_equal_to(len(instance_types))
+
+    non_instance_families = [
+        instance_type for instance_type in instance_types if _internal_is_instance_type(instance_type)
+    ]
+    assert_that(supported_architectures_patch.call_count).is_equal_to(len(non_instance_families))
+    assert_that(is_instance_type_patch.call_count).is_equal_to(len(instance_types))

--- a/cli/tests/pcluster/validators/test_awsbatch_validators.py
+++ b/cli/tests/pcluster/validators/test_awsbatch_validators.py
@@ -12,9 +12,43 @@ import pytest
 from assertpy import assert_that
 
 from pcluster.models.common import DynamicParam, Param
-from pcluster.validators.awsbatch_validators import AwsbatchInstancesArchitectureCompatibilityValidator
+from pcluster.validators.awsbatch_validators import (
+    AwsbatchComputeResourceValidator,
+    AwsbatchInstancesArchitectureCompatibilityValidator,
+)
 
 from .utils import assert_failure_messages
+
+
+@pytest.mark.parametrize(
+    "min_vcpus, desired_vcpus, max_vcpus, expected_message",
+    [
+        (1, 2, 3, None),
+        (
+            3,
+            2,
+            3,
+            "desired vcpus must be greater than or equal to min vcpus",
+        ),
+        (
+            1,
+            4,
+            3,
+            "desired vcpus must be fewer than or equal to max vcpus",
+        ),
+        (
+            4,
+            4,
+            3,
+            "Max vcpus must be greater than or equal to min vcpus",
+        ),
+    ],
+)
+def test_cluster_validator(min_vcpus, desired_vcpus, max_vcpus, expected_message):
+    actual_failures = AwsbatchComputeResourceValidator().execute(
+        Param(min_vcpus), Param(desired_vcpus), Param(max_vcpus)
+    )
+    assert_failure_messages(actual_failures, expected_message)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -13,6 +13,7 @@ import pytest
 from pcluster.models.common import DynamicParam, Param
 from pcluster.validators.cluster_validators import (
     ArchitectureOsValidator,
+    ComputeResourceValidator,
     EfaOsArchitectureValidator,
     FsxNetworkingValidator,
     InstanceArchitectureCompatibilityValidator,
@@ -25,6 +26,19 @@ from tests.pcluster.validators.utils import assert_failure_messages
 @pytest.fixture()
 def boto3_stubber_path():
     return "pcluster.validators.cluster_validators.boto3"
+
+
+@pytest.mark.parametrize(
+    "min_count, max_count, expected_message",
+    [
+        (1, 2, None),
+        (1, 1, None),
+        (2, 1, "Max count must be greater than or equal to min count"),
+    ],
+)
+def test_compute_resource_validator(min_count, max_count, expected_message):
+    actual_failures = ComputeResourceValidator().execute(Param(min_count), Param(max_count))
+    assert_failure_messages(actual_failures, expected_message)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -9,12 +9,10 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
-from assertpy import assert_that
 
 from pcluster.models.common import DynamicParam, Param
 from pcluster.validators.cluster_validators import (
     ArchitectureOsValidator,
-    AwsbatchInstancesArchitectureCompatibilityValidator,
     EfaOsArchitectureValidator,
     FsxNetworkingValidator,
     InstanceArchitectureCompatibilityValidator,
@@ -322,51 +320,3 @@ def test_instance_architecture_compatibility_validator(
         Param(compute_instance_type), DynamicParam(lambda: head_node_architecture)
     )
     assert_failure_messages(actual_failures, expected_message)
-
-
-@pytest.mark.parametrize(
-    "head_node_architecture, compute_architecture, compute_instance_types, expected_message",
-    [
-        ("x86_64", "x86_64", "optimal", None),
-        # Function to get supported architectures shouldn't be called because compute instance types arg
-        # are instance families.
-        ("x86_64", None, "m6g", "Not validating architecture"),
-        ("x86_64", None, "c5", "Not validating architecture"),
-        # The validator must handle the case where compute instance type is a CSV list
-        ("arm64", "arm64", "m6g.xlarge,r6g.xlarge", None),
-        (
-            "x86_64",
-            "arm64",
-            "m6g.xlarge,r6g.xlarge",
-            "none of which are compatible with the architecture supported by the head node instance type",
-        ),
-    ],
-)
-def test_awsbatch_instances_architecture_compatibility_validator(
-    mocker, head_node_architecture, compute_architecture, compute_instance_types, expected_message
-):
-    def _internal_is_instance_type(itype):
-        return "." in itype or itype == "optimal"
-
-    supported_architectures_patch = mocker.patch(
-        "pcluster.validators.cluster_validators.get_supported_architectures_for_instance_type",
-        return_value=[compute_architecture],
-    )
-    is_instance_type_patch = mocker.patch(
-        "pcluster.validators.cluster_validators.is_instance_type_format", side_effect=_internal_is_instance_type
-    )
-
-    instance_types = compute_instance_types.split(",")
-
-    actual_failures = AwsbatchInstancesArchitectureCompatibilityValidator().execute(
-        Param(compute_instance_types), DynamicParam(lambda: head_node_architecture)
-    )
-    assert_failure_messages(actual_failures, expected_message)
-    if expected_message:
-        assert_that(len(actual_failures)).is_equal_to(len(instance_types))
-
-    non_instance_families = [
-        instance_type for instance_type in instance_types if _internal_is_instance_type(instance_type)
-    ]
-    assert_that(supported_architectures_patch.call_count).is_equal_to(len(non_instance_families))
-    assert_that(is_instance_type_patch.call_count).is_equal_to(len(instance_types))


### PR DESCRIPTION
## Move compute resource size validators

* initial_queue_size has been deprecated
* min_size and max_size have been renamed to MinCount and MaxCount
* We had a single validator for both awsbatch and slurm, now we have two different validators associated to the different ComputeResources
* migrated and updated related tests

## Other changes
* Add missing type hints for Fsx validators 
* Remove os validator. It was used to alert the users when using alinux but it will be deprecated within the next version.
* Move AWS Batch validators and tests in separate modules
* Remove useless CRITICAL FailureLevel
* Add missing information about the failed parameters in validators
* Align validators code by using .value everywhere