### PR TITLE
3.0: Move compute resource and instance type validators

### DIFF
--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -55,13 +55,11 @@ from pcluster.config.json_param_types import (
 from pcluster.config.param_types import Visibility
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import (
-    compute_instance_type_validator,
     dcv_enabled_validator,
     duplicate_shared_dir_validator,
     ebs_settings_validator,
     ec2_ami_validator,
     ec2_iam_policies_validator,
-    ec2_instance_type_validator,
     ec2_key_pair_validator,
     ec2_placement_group_validator,
     ec2_security_group_validator,
@@ -584,7 +582,6 @@ COMPUTE_RESOURCE = {
     "params": OrderedDict([
         ("instance_type", {
             "type": JsonParam,
-            "validators": [ec2_instance_type_validator],
             "required": True,
             "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP
         }),
@@ -723,7 +720,7 @@ CLUSTER_COMMON_PARAMS = [
     ("master_instance_type", {
         "type": HeadNodeInstanceTypeCfnParam,
         "cfn_param_mapping": "MasterInstanceType",
-        "validators": [head_node_instance_type_validator, ec2_instance_type_validator],
+        "validators": [head_node_instance_type_validator],
         "update_policy": UpdatePolicy.UNSUPPORTED,
     }),
     ("master_root_volume_size", {
@@ -976,7 +973,6 @@ CLUSTER_SIT = {
             ("compute_instance_type", {
                 "type": ComputeInstanceTypeCfnParam,
                 "cfn_param_mapping": "ComputeInstanceType",
-                "validators": [compute_instance_type_validator],
                 "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP
             }),
             ("initial_queue_size", {

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -56,7 +56,6 @@ from pcluster.config.param_types import Visibility
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import (
     compute_instance_type_validator,
-    compute_resource_validator,
     dcv_enabled_validator,
     duplicate_shared_dir_validator,
     ebs_settings_validator,
@@ -581,7 +580,6 @@ COMPUTE_RESOURCE = {
     "type": JsonSection,
     "key": "compute_resource",
     "default_label": "default",
-    "validators": [compute_resource_validator],
     "max_resources": 3,
     "params": OrderedDict([
         ("instance_type", {

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -983,35 +983,6 @@ def settings_validator(param_key, param_value, pcluster_config):
     return errors, []
 
 
-def compute_resource_validator(section_key, section_label, pcluster_config):
-    errors = []
-    section = pcluster_config.get_section(section_key, section_label)
-
-    min_count = section.get_param_value("min_count")
-    max_count = section.get_param_value("max_count")
-    initial_count = section.get_param_value("initial_count")
-
-    if min_count < 0:
-        errors.append("Parameter 'min_count' must be 0 or greater than 0")
-
-    if max_count < 1:
-        errors.append("Parameter 'max_count' must be 1 or greater than 1")
-
-    if section.get_param_value("max_count") < min_count:
-        errors.append("Parameter 'max_count' must be greater than or equal to min_count")
-
-    if initial_count < min_count:
-        errors.append("Parameter 'initial_count' must be greater than or equal to 'min_count'")
-
-    if initial_count > max_count:
-        errors.append("Parameter 'initial_count' must be lower than or equal to 'max_count'")
-
-    if section.get_param_value("spot_price") < 0:
-        errors.append("Parameter 'spot_price' must be 0 or greater than 0")
-
-    return errors, []
-
-
 def _get_efa_enabled_instance_types(errors):
     instance_types = []
 

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -20,7 +20,6 @@ from botocore.exceptions import ClientError, ParamValidationError
 from pcluster.constants import CIDR_ALL_IPS
 from pcluster.dcv.utils import get_supported_dcv_os
 from pcluster.utils import (
-    InstanceTypeInfo,
     ellipsize,
     get_base_additional_iam_policies,
     get_efs_mount_target_id,

--- a/cli/src/pcluster/configure/easyconfig.py
+++ b/cli/src/pcluster/configure/easyconfig.py
@@ -38,7 +38,6 @@ from pcluster.utils import (
     get_region,
     get_supported_az_for_multi_instance_types,
     get_supported_az_for_one_instance_type,
-    get_supported_compute_instance_types,
     get_supported_instance_types,
     get_supported_os_for_scheduler,
     get_supported_schedulers,
@@ -382,7 +381,7 @@ class ClusterConfigureHelper:
                 default_compute_instance_type = get_default_instance_type()
             self.compute_instance_type = prompt(
                 "Compute instance type",
-                lambda x: x in get_supported_compute_instance_types(self.scheduler),
+                lambda x: x in get_supported_instance_types(),
                 default_value=default_compute_instance_type,
             )
         # Cache availability zones offering the selected instance type(s) for later use

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -376,7 +376,24 @@ class HeadNode(Resource):
         self.storage = storage
         self.dcv = dcv
         self.efa = efa
+        # Dynamic params, not present in config
+        self.architecture = DynamicParam(value_calculator=self._fetch_architecture)
+        # Validators
         self._add_validator(InstanceTypeValidator, instance_type=self.instance_type)
+
+    def _fetch_architecture(self):
+        """Compute cluster's architecture based on its head node instance type."""
+        head_node_instance_type = self.instance_type.value
+        # TODO verify if it's referred to an old instance type
+        head_node_supported_architectures = get_supported_architectures_for_instance_type(head_node_instance_type)
+        if not head_node_supported_architectures:
+            error(f"Unable to get architectures supported by instance type {head_node_instance_type}")
+        # If the instance type supports multiple architectures, choose the first one.
+        # TODO: this is currently not an issue because none of the instance types we support more than one of the
+        #       architectures we support. If this were ever to change (e.g., we start supporting i386) then we would
+        #       probably need to choose based on the subset of the architectures supported by both the head node and
+        #       compute instance types.
+        return head_node_supported_architectures[0]
 
 
 class BaseComputeResource(Resource):
@@ -583,14 +600,12 @@ class BaseCluster(Resource):
         self.iam = iam
         self.custom_actions = custom_actions
         self.cores = None
-        # Dynamic params, not present in config
-        self.architecture = DynamicParam(value_calculator=self._fetch_architecture)
         # Validators
         self._add_validator(
             ArchitectureOsValidator,
             priority=10,
             os=self.image.os,
-            architecture=self.architecture,
+            architecture=self.head_node.architecture,
         )
         if self.head_node.efa:
             self._add_validator(
@@ -598,13 +613,13 @@ class BaseCluster(Resource):
                 priority=9,
                 efa_enabled=self.head_node.efa.enabled,
                 os=self.image.os,
-                architecture=self.architecture,
+                architecture=self.head_node.architecture,
             )
         self._add_validator(
             SimultaneousMultithreadingArchitectureValidator,
             priority=8,
             simultaneous_multithreading=self.head_node.simultaneous_multithreading,
-            architecture=self.architecture,
+            architecture=self.head_node.architecture,
         )
         if self.shared_storage:
             for storage in self.shared_storage:
@@ -614,29 +629,3 @@ class BaseCluster(Resource):
                         fs_system_id=storage.file_system_id,
                         head_node_subnet_id=self.head_node.networking.subnet_id,
                     )
-
-    def _fetch_architecture(self):
-        """Compute cluster's architecture based on its head node instance type."""
-        head_node_instance_type = self.head_node.instance_type.value
-        # TODO verify if it's referred to an old instance type
-        head_node_supported_architectures = get_supported_architectures_for_instance_type(head_node_instance_type)
-        if not head_node_supported_architectures:
-            error(f"Unable to get architectures supported by instance type {head_node_instance_type}")
-        # If the instance type supports multiple architectures, choose the first one.
-        # TODO: this is currently not an issue because none of the instance types we support more than one of the
-        #       architectures we support. If this were ever to change (e.g., we start supporting i386) then we would
-        #       probably need to choose based on the subset of the architectures supported by both the head node and
-        #       compute instance types.
-        return head_node_supported_architectures[0]
-
-    @property
-    def cores(self):
-        """Return the number of cores. Example derived attribute, not present in the config file."""
-        if self._cores is None:
-            # FIXME boto3 call to retrieve the value
-            self._cores = "1"
-        return self._cores
-
-    @cores.setter
-    def cores(self, value):
-        self._cores = value

--- a/cli/src/pcluster/models/cluster_awsbatch.py
+++ b/cli/src/pcluster/models/cluster_awsbatch.py
@@ -32,7 +32,10 @@ from pcluster.models.cluster import (
     Tag,
 )
 from pcluster.models.common import Param
-from pcluster.validators.awsbatch_validators import AwsbatchInstancesArchitectureCompatibilityValidator
+from pcluster.validators.awsbatch_validators import (
+    AwsbatchComputeInstanceTypeValidator,
+    AwsbatchInstancesArchitectureCompatibilityValidator,
+)
 from pcluster.validators.cluster_validators import EfaOsArchitectureValidator
 
 
@@ -56,6 +59,9 @@ class AwsbatchComputeResource(BaseComputeResource):
         self.min_vcpus = Param(min_vcpus, default=0)
         self.desired_vcpus = Param(desired_vcpus, default=0)
         self.spot_bid_percentage = spot_bid_percentage
+        self._add_validator(
+            AwsbatchComputeInstanceTypeValidator, instance_types=self.instance_type, max_vcpus=max_vcpus
+        )
 
 
 class AwsbatchQueue(BaseQueue):

--- a/cli/src/pcluster/models/cluster_awsbatch.py
+++ b/cli/src/pcluster/models/cluster_awsbatch.py
@@ -111,12 +111,12 @@ class AwsbatchCluster(BaseCluster):
                 self._add_validator(
                     AwsbatchInstancesArchitectureCompatibilityValidator,
                     instance_types=compute_resource.instance_type,
-                    architecture=self.architecture,
+                    architecture=self.head_node.architecture,
                 )
                 if compute_resource.efa:
                     self._add_validator(
                         EfaOsArchitectureValidator,
                         efa_enabled=compute_resource.efa.enabled,
                         os=self.image.os,
-                        architecture=self.architecture,
+                        architecture=self.head_node.architecture,
                     )

--- a/cli/src/pcluster/models/cluster_slurm.py
+++ b/cli/src/pcluster/models/cluster_slurm.py
@@ -36,6 +36,7 @@ from pcluster.validators.cluster_validators import (
     EfaOsArchitectureValidator,
     InstanceArchitectureCompatibilityValidator,
 )
+from pcluster.validators.ec2_validators import InstanceTypeValidator
 
 
 class SlurmComputeResource(BaseComputeResource):
@@ -56,6 +57,7 @@ class SlurmComputeResource(BaseComputeResource):
         self.max_count = Param(max_count, default=10)
         self.min_count = Param(min_count, default=0)
         self.spot_price = Param(spot_price)
+        self._add_validator(InstanceTypeValidator, instance_type=self.instance_type)
 
 
 class SlurmQueue(BaseQueue):

--- a/cli/src/pcluster/models/cluster_slurm.py
+++ b/cli/src/pcluster/models/cluster_slurm.py
@@ -115,7 +115,7 @@ class SlurmCluster(BaseCluster):
                 self._add_validator(
                     InstanceArchitectureCompatibilityValidator,
                     instance_type=compute_resource.instance_type,
-                    architecture=self.architecture,
+                    architecture=self.head_node.architecture,
                 )
                 if compute_resource.efa:
                     self._add_validator(
@@ -123,5 +123,5 @@ class SlurmCluster(BaseCluster):
                         priority=9,
                         efa_enabled=compute_resource.efa.enabled,
                         os=self.image.os,
-                        architecture=self.architecture,
+                        architecture=self.head_node.architecture,
                     )

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -366,9 +366,9 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
     """Represent the schema of the Slurm ComputeResource."""
 
     instance_type = fields.Str(required=True)
-    max_count = fields.Int()
-    min_count = fields.Int()
-    spot_price = fields.Float()
+    max_count = fields.Int(validate=validate.Range(min=1))
+    min_count = fields.Int(validate=validate.Range(min=0))
+    spot_price = fields.Float(validate=validate.Range(min=0))
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -380,9 +380,9 @@ class AwsbatchComputeResourceSchema(_ComputeResourceSchema):
     """Represent the schema of the Batch ComputeResource."""
 
     instance_type = fields.Str(required=True)  # TODO it is a comma separated list
-    max_vcpus = fields.Int(data_key="MaxvCpus")
-    min_vcpus = fields.Int(data_key="MinvCpus")
-    desired_vcpus = fields.Int(data_key="DesiredvCpus")
+    max_vcpus = fields.Int(data_key="MaxvCpus", validate=validate.Range(min=1))
+    min_vcpus = fields.Int(data_key="MinvCpus", validate=validate.Range(min=0))
+    desired_vcpus = fields.Int(data_key="DesiredvCpus", validate=validate.Range(min=0))
     spot_bid_percentage = fields.Float(validate=validate.Range(min=0, max=1, min_inclusive=False))
 
     @post_load

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -14,7 +14,7 @@
 # These classes are created by following marshmallow syntax.
 #
 
-from marshmallow import Schema, fields, post_dump, post_load, pre_dump, pre_load, validate
+from marshmallow import Schema, fields, post_dump, post_load, pre_dump, validate
 
 from pcluster.constants import SUPPORTED_ARCHITECTURES
 from pcluster.models.cluster import Tag
@@ -62,15 +62,6 @@ class BaseSchema(Schema):
             # If the schema is to be loaded partially, do not check existence constrain.
             return True
         return len([data.get(field_name) for field_name in field_list if data.get(field_name)]) == 1
-
-    @pre_load
-    def evaluate_dynamic_defaults(self, raw_data, **kwargs):
-        """Evaluate dynamic default, it's just an example to be removed."""
-        # FIXME to be removed, it's a test
-        for fieldname, field in self.fields.items():
-            if fieldname not in raw_data and callable(field.metadata.get("dynamic_default")):
-                raw_data[fieldname] = field.metadata.get("dynamic_default")(raw_data)
-        return raw_data
 
     @pre_dump
     def remove_implied_values(self, data, **kwargs):

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -482,16 +482,6 @@ def get_supported_batch_instance_types():
     return supported_batch_types
 
 
-def get_supported_compute_instance_types(scheduler):
-    """
-    Get supported instance types (and families in awsbatch case).
-
-    :param scheduler: the scheduler for which we want to know the supported compute instance types or families
-    :return: the list of supported instance types and families
-    """
-    return get_supported_batch_instance_types() if scheduler == "awsbatch" else get_supported_instance_types()
-
-
 def get_supported_az_for_one_instance_type(instance_type):
     """
     Return a tuple of availability zones that have the instance_types.

--- a/cli/src/pcluster/validators/awsbatch_validators.py
+++ b/cli/src/pcluster/validators/awsbatch_validators.py
@@ -20,10 +20,13 @@ from pcluster.utils import (
 
 
 class AwsbatchComputeResourceSizeValidator(Validator):
-    """Awsbatch compute resource size validator."""
+    """
+    Awsbatch compute resource size validator.
+
+    Validate min, desired and max vcpus combination.
+    """
 
     def _validate(self, min_vcpus: Param, desired_vcpus: Param, max_vcpus: Param):
-        """Validate min, desired and max vcpus combination."""
         if desired_vcpus.value < min_vcpus.value:
             self._add_failure(
                 "The number of desired vcpus must be greater than or equal to min vcpus",
@@ -92,14 +95,14 @@ class AwsbatchComputeInstanceTypeValidator(Validator):
 
 
 class AwsbatchInstancesArchitectureCompatibilityValidator(Validator):
-    """Validate instance type and architecture combination."""
+    """
+    Validate instance type and architecture combination.
+
+    Verify that head node and compute instance types imply compatible architectures.
+    With AWS Batch, compute instance type can contain a CSV list.
+    """
 
     def _validate(self, instance_types: Param, architecture: DynamicParam):
-        """
-        Verify that head node and compute instance types imply compatible architectures.
-
-        When awsbatch is used as the scheduler, compute_instance_type can contain a CSV list.
-        """
         head_node_architecture = architecture.value
         for instance_type in instance_types.value.split(","):
             # When awsbatch is used as the scheduler instance families can be used.

--- a/cli/src/pcluster/validators/awsbatch_validators.py
+++ b/cli/src/pcluster/validators/awsbatch_validators.py
@@ -13,8 +13,8 @@ from pcluster.models.common import DynamicParam, FailureLevel, Param, Validator
 from pcluster.utils import get_supported_architectures_for_instance_type, is_instance_type_format
 
 
-class AwsbatchComputeResourceValidator(Validator):
-    """Awsbatch compute resource validator."""
+class AwsbatchComputeResourceSizeValidator(Validator):
+    """Awsbatch compute resource size validator."""
 
     def _validate(self, min_vcpus: Param, desired_vcpus: Param, max_vcpus: Param):
         """Validate min, desired and max vcpus combination."""

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -21,10 +21,13 @@ EFA_UNSUPPORTED_ARCHITECTURES_OSES = {
 
 
 class ComputeResourceSizeValidator(Validator):
-    """Slurm compute resource size validator."""
+    """
+    Slurm compute resource size validator.
+
+    Validate min count and max count combinations.
+    """
 
     def _validate(self, min_count: Param, max_count: Param):
-        """Validate min count and max count combinations."""
         if max_count.value < min_count.value:
             self._add_failure(
                 "Max count must be greater than or equal to min count", FailureLevel.ERROR, [min_count, max_count]
@@ -32,10 +35,13 @@ class ComputeResourceSizeValidator(Validator):
 
 
 class FsxNetworkingValidator(Validator):
-    """FSx and networking validator."""
+    """
+    FSx networking validator.
+
+    Validate file system mount point according to the head node subnet.
+    """
 
     def _validate(self, file_system_id: Param, head_node_subnet_id: Param):
-        """Validate FSx and networking config."""
         try:
             ec2 = boto3.client("ec2")
 
@@ -123,7 +129,8 @@ class FsxNetworkingValidator(Validator):
 
         return in_out_access
 
-    def _check_sg_rules_for_port(self, rule, port_to_check):
+    @staticmethod
+    def _check_sg_rules_for_port(rule, port_to_check):
         """
         Verify if the security group rule accepts connections on the given port.
 
@@ -147,10 +154,13 @@ class FsxNetworkingValidator(Validator):
 
 
 class SimultaneousMultithreadingArchitectureValidator(Validator):
-    """Simultaneous Multithreading architecture validator."""
+    """
+    Simultaneous Multithreading architecture validator.
+
+    Validate Simultaneous Multithreading and architecture combination.
+    """
 
     def _validate(self, simultaneous_multithreading: Param, architecture: DynamicParam):
-        """Validate Simultaneous Multithreading and architecture combination."""
         supported_architectures = ["x86_64"]
         if simultaneous_multithreading.value and architecture.value not in supported_architectures:
             self._add_failure(
@@ -165,7 +175,6 @@ class EfaOsArchitectureValidator(Validator):
     """OS and architecture combination validator if EFA is enabled."""
 
     def _validate(self, efa_enabled: Param, os: Param, architecture: DynamicParam):
-        """Check os and architecture combination whan efa is enabled."""
         if efa_enabled.value and os.value in EFA_UNSUPPORTED_ARCHITECTURES_OSES.get(architecture.value):
             self._add_failure(
                 "EFA currently not supported on {0} for {1} architecture".format(os.value, architecture.value),
@@ -175,10 +184,13 @@ class EfaOsArchitectureValidator(Validator):
 
 
 class ArchitectureOsValidator(Validator):
-    """Validate OS and architecture combination."""
+    """
+    Validate OS and architecture combination.
+
+    ARM AMIs are only available for a subset of the supported OSes.
+    """
 
     def _validate(self, os: Param, architecture: DynamicParam):
-        """ARM AMIs are only available for  a subset of the supported OSes."""
         allowed_oses = get_supported_os_for_architecture(architecture.value)
         if os.value not in allowed_oses:
             self._add_failure(
@@ -191,10 +203,13 @@ class ArchitectureOsValidator(Validator):
 
 
 class InstanceArchitectureCompatibilityValidator(Validator):
-    """Validate instance type and architecture combination."""
+    """
+    Validate instance type and architecture combination.
+
+    Verify that head node and compute instance types imply compatible architectures.
+    """
 
     def _validate(self, instance_type: Param, architecture: DynamicParam):
-        """Verify that head node and compute instance types imply compatible architectures."""
         head_node_architecture = architecture.value
         compute_architectures = get_supported_architectures_for_instance_type(instance_type.value)
         if head_node_architecture not in compute_architectures:

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -20,8 +20,8 @@ EFA_UNSUPPORTED_ARCHITECTURES_OSES = {
 }
 
 
-class ComputeResourceValidator(Validator):
-    """Slurm compute resource validator."""
+class ComputeResourceSizeValidator(Validator):
+    """Slurm compute resource size validator."""
 
     def _validate(self, min_count: Param, max_count: Param):
         """Validate min count and max count combinations."""

--- a/cli/src/pcluster/validators/ebs_validators.py
+++ b/cli/src/pcluster/validators/ebs_validators.py
@@ -20,19 +20,18 @@ from pcluster.utils import get_ebs_snapshot_info, get_partition
 
 
 class EbsVolumeTypeSizeValidator(Validator):
-    """EBS volume type and size validator."""
+    """EBS volume type and size validator.
+
+    Validate that the EBS volume size matches the chosen volume type.
+
+    The default value of volume_size for EBS volumes is 20 GiB.
+    The volume size of standard ranges from 1 GiB - 1 TiB(1024 GiB)
+    The volume size of gp2 and gp3 ranges from 1 GiB - 16 TiB(16384 GiB)
+    The volume size of io1 and io2 ranges from 4 GiB - 16 TiB(16384 GiB)
+    The volume sizes of st1 and sc1 range from 500 GiB - 16 TiB(16384 GiB)
+    """
 
     def _validate(self, volume_type: Param, volume_size: Param):
-        """Validate given instance type."""
-        """
-        Validate that the EBS volume size matches the chosen volume type.
-
-        The default value of volume_size for EBS volumes is 20 GiB.
-        The volume size of standard ranges from 1 GiB - 1 TiB(1024 GiB)
-        The volume size of gp2 and gp3 ranges from 1 GiB - 16 TiB(16384 GiB)
-        The volume size of io1 and io2 ranges from 4 GiB - 16 TiB(16384 GiB)
-        The volume sizes of st1 and sc1 range from 500 GiB - 16 TiB(16384 GiB)
-        """
         if volume_type.value in EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS:
             min_size, max_size = EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS.get(volume_type.value)
             if volume_size.value > max_size:
@@ -50,10 +49,13 @@ class EbsVolumeTypeSizeValidator(Validator):
 
 
 class EbsVolumeThroughputValidator(Validator):
-    """EBS volume throughput validator."""
+    """
+    EBS volume throughput validator.
+
+    Validate gp3 throughput.
+    """
 
     def _validate(self, volume_type: Param, volume_throughput: Param):
-        """Validate gp3 throughput."""
         if volume_type.value == "gp3":
             min_throughput, max_throughput = 125, 1000
             if volume_throughput.value < min_throughput or volume_throughput.value > max_throughput:
@@ -68,10 +70,13 @@ class EbsVolumeThroughputValidator(Validator):
 
 
 class EbsVolumeThroughputIopsValidator(Validator):
-    """EBS volume throughput to iops ratio validator."""
+    """
+    EBS volume throughput to iops ratio validator.
+
+    Validate gp3 throughput.
+    """
 
     def _validate(self, volume_type: Param, volume_iops: Param, volume_throughput: Param):
-        """Validate gp3 throughput."""
         volume_throughput_to_iops_ratio = 0.25
         if volume_type.value == "gp3":
             if (
@@ -88,10 +93,13 @@ class EbsVolumeThroughputIopsValidator(Validator):
 
 
 class EbsVolumeIopsValidator(Validator):
-    """EBS volume IOPS validator."""
+    """
+    EBS volume IOPS validator.
+
+    Validate IOPS value in respect of volume type.
+    """
 
     def _validate(self, volume_type: Param, volume_size: Param, volume_iops: Param):
-        """Validate IOPS value in respect of volume type."""
         if volume_type.value in EBS_VOLUME_IOPS_BOUNDS:
             min_iops, max_iops = EBS_VOLUME_IOPS_BOUNDS.get(volume_type.value)
             if volume_iops.value and (volume_iops.value < min_iops or volume_iops.value > max_iops):
@@ -116,15 +124,15 @@ class EbsVolumeIopsValidator(Validator):
 
 
 class EbsVolumeSizeSnapshotValidator(Validator):
-    """EBS volume size snapshot validator."""
+    """
+    EBS volume size snapshot validator.
+
+    Validate the following cases:
+    - The EBS snapshot is in "completed" state if it is specified.
+    - If users specify the volume size, the volume must be not smaller than the volume size of the EBS snapshot.
+    """
 
     def _validate(self, snapshot_id: Param, volume_size: Param):
-        """
-        Validate the following cases.
-
-        The EBS snapshot is in "completed" state if it is specified
-        If users specify the volume size, the volume must be not smaller than the volume size of the EBS snapshot
-        """
         if snapshot_id.value:
             try:
                 snapshot_response_dict = get_ebs_snapshot_info(snapshot_id.value, raise_exceptions=True)
@@ -188,10 +196,13 @@ class EbsVolumeSizeSnapshotValidator(Validator):
 
 
 class EBSVolumeKmsKeyIdValidator(Validator):
-    """EBS volume KmsKeyId validator."""
+    """
+    EBS volume KmsKeyId validator.
+
+    Validate KmsKeyId value based on encrypted value.
+    """
 
     def _validate(self, volume_kms_key_id: Param, volume_encrypted: Param):
-        """Validate KmsKeyId value based on  encrypted value."""
         if volume_kms_key_id.value and not volume_encrypted.value:
             self._add_failure(
                 "Kms Key Id {0} is specified, the encrypted state must be True.".format(volume_kms_key_id.value),

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -14,20 +14,26 @@ from pcluster.models.common import FailureLevel, Param, Validator
 
 
 class BaseAMIValidator(Validator):
-    """Base AMI validator."""
+    """
+    Base AMI validator.
+
+    Validate given ami id or image arn.
+    """
 
     def _validate(self, image: Param):
-        """Validate given ami id or image arn."""
         ami_id = utils.get_ami_id(image.value)
         if not Ec2Client().describe_ami_id_offering(ami_id=ami_id):
             self._add_failure(f"The ami id '{ami_id}' is not supported.", FailureLevel.ERROR, [image])
 
 
 class InstanceTypeValidator(Validator):
-    """EC2 Instance type validator."""
+    """
+    EC2 Instance type validator.
+
+    Verify the given instance type is a supported one.
+    """
 
     def _validate(self, instance_type: Param):
-        """Validate given instance type."""
         if instance_type.value not in Ec2Client().describe_instance_type_offerings():
             self._add_failure(
                 f"The instance type '{instance_type.value}' is not supported.",
@@ -37,10 +43,9 @@ class InstanceTypeValidator(Validator):
 
 
 class InstanceTypeBaseAMICompatibleValidator(Validator):
-    """EC2 Instance type and base ami compatible validator."""
+    """EC2 Instance type and base ami compatibility validator."""
 
     def _validate(self, instance_type: Param, parent_image: Param):
-        """Validate given instance type and ami id are compatible."""
         ami_id = utils.get_ami_id(parent_image.value)
         ami_architecture = utils.get_info_for_amis([ami_id])[0].get("Architecture")
         instance_architecture = utils.get_supported_architectures_for_instance_type(instance_type.value)

--- a/cli/src/pcluster/validators/fsx_validators.py
+++ b/cli/src/pcluster/validators/fsx_validators.py
@@ -14,12 +14,15 @@ from pcluster.models.common import FailureLevel, Param, Validator
 
 
 class FsxS3Validator(Validator):
-    """FSX S3 validator."""
+    """
+    FSX S3 validator.
+
+    Verify compatibility of given S3 options for FSX.
+    """
 
     def _validate(
         self, import_path: Param, imported_file_chunk_size: Param, export_path: Param, auto_import_policy: Param
     ):
-        """Verify compatibility of given S3 options for FSX."""
         if imported_file_chunk_size.value and not import_path.value:
             self._add_failure(
                 "When specifying imported file chunk size, the import path option must be specified",
@@ -43,10 +46,13 @@ class FsxS3Validator(Validator):
 
 
 class FsxPersistentOptionsValidator(Validator):
-    """FSX persistent options validator."""
+    """
+    FSX persistent options validator.
+
+    Verify compatibility of given persistent options for FSX.
+    """
 
     def _validate(self, deployment_type: Param, kms_key_id: Param, per_unit_storage_throughput: Param):
-        """Verify compatibility of given persistent options for FSX."""
         if deployment_type.value == "PERSISTENT_1":
             if not per_unit_storage_throughput.value:
                 self._add_failure(
@@ -83,7 +89,6 @@ class FsxBackupOptionsValidator(Validator):
         export_path: Param,
         auto_import_policy: Param,
     ):
-        """Verify compatibility of given backup options for FSX."""
         if not automatic_backup_retention_days.value and daily_automatic_backup_start_time.value:
             self._add_failure(
                 "When specifying daily automatic backup start time,"
@@ -119,7 +124,6 @@ class FsxStorageTypeOptionsValidator(Validator):
     def _validate(
         self, storage_type: Param, deployment_type: Param, per_unit_storage_throughput: Param, drive_cache_type: Param
     ):
-        """Verify compatibility of given storage type options for FSX."""
         if storage_type.value == "HDD":
             if deployment_type.value != "PERSISTENT_1":
                 self._add_failure(
@@ -164,7 +168,6 @@ class FsxStorageCapacityValidator(Validator):
         file_system_id: Param,
         backup_id: Param,
     ):
-        """Verify compatibility of given storage capacity options for FSX."""
         if file_system_id.value or backup_id.value:
             # if file_system_id is provided, don't validate storage_capacity
             # if backup_id is provided, validation for storage_capacity will be done in fsx_lustre_backup_validator.

--- a/cli/src/pcluster/validators/s3_validators.py
+++ b/cli/src/pcluster/validators/s3_validators.py
@@ -10,10 +10,13 @@ from pcluster.models.common import FailureLevel, Param, Validator
 
 
 class UrlValidator(Validator):
-    """Url Validator."""
+    """
+    Url Validator.
+
+    Validate given url with s3, https or file prefix.
+    """
 
     def _validate(self, url: Param):
-        """Validate given url with s3, https or file prefix."""
         scheme = urlparse(url.value).scheme
         if scheme in ["https", "s3", "file"]:
             if scheme == "s3":

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -37,46 +37,10 @@ def boto3_stubber_path():
     return "pcluster.config.validators.boto3"
 
 
-# FIXME Moved
-@pytest.mark.parametrize(
-    "instance_type, expected_message", [("t2.micro", None), ("c4.xlarge", None), ("c5.xlarge", "is not supported")]
-)
-def test_ec2_instance_type_validator(mocker, instance_type, expected_message):
-    config_parser_dict = {"cluster default": {"compute_instance_type": instance_type}}
-    utils.assert_param_validator(mocker, config_parser_dict, expected_message)
-
-
 @pytest.mark.parametrize("instance_type, expected_message", [("t2.micro", None), ("c4.xlarge", None)])
 def test_head_node_instance_type_validator(mocker, instance_type, expected_message):
     config_parser_dict = {"cluster default": {"master_instance_type": instance_type}}
     utils.assert_param_validator(mocker, config_parser_dict, expected_message)
-
-
-@pytest.mark.parametrize(
-    "scheduler, instance_type, expected_message, expected_warnings",
-    [
-        ("sge", "t2.micro", None, None),
-        ("sge", "c4.xlarge", None, None),
-        ("sge", "c5.xlarge", "is not supported", None),
-        # NOTE: compute_instance_type_validator calls ec2_instance_type_validator only if the scheduler is not awsbatch
-        ("awsbatch", "t2.micro", None, None),
-        ("awsbatch", "c4.xlarge", "is not supported", None),
-        ("awsbatch", "t2", None, None),  # t2 family
-        ("awsbatch", "optimal", None, None),
-        ("sge", "p4d.24xlarge", None, "has 4 Network Interfaces."),
-        ("slurm", "p4d.24xlarge", None, None),
-    ],
-)
-def test_compute_instance_type_validator(mocker, scheduler, instance_type, expected_message, expected_warnings):
-    config_parser_dict = {"cluster default": {"scheduler": scheduler, "compute_instance_type": instance_type}}
-    extra_patches = {
-        "pcluster.config.validators.InstanceTypeInfo.max_network_interface_count": 4
-        if instance_type == "p4d.24xlarge"
-        else 1,
-    }
-    utils.assert_param_validator(
-        mocker, config_parser_dict, expected_message, expected_warnings, extra_patches=extra_patches
-    )
 
 
 def test_ec2_key_pair_validator(mocker, boto3_stubber):
@@ -941,7 +905,7 @@ def test_dcv_enabled_validator(
 
     architectures = ["x86_64"] if instance_type.startswith("t2") else ["arm64"]
     extra_patches = {
-        "pcluster.config.validators.get_supported_instance_types": ["t2.nano", "t2.micro", "t2.medium", "m6g.xlarge"],
+        "pcluster.utils.get_supported_instance_types": ["t2.nano", "t2.micro", "t2.medium", "m6g.xlarge"],
         "pcluster.utils.get_supported_architectures_for_instance_type": architectures,
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type": architectures,
         "pcluster.utils.get_supported_os_for_architecture": [base_os],

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -105,10 +105,8 @@ def get_mock_pcluster_config_patches(scheduler, extra_patches=None):
     """Return mocks for a set of functions that should be mocked by default because they access the network."""
     architectures = ["x86_64"]
     head_node_instances = ["t2.micro", "t2.large", "c4.xlarge", "p4d.24xlarge"]
-    compute_instances = ["t2.micro", "t2.large", "t2", "optimal"] if scheduler == "awsbatch" else head_node_instances
     patches = {
-        "pcluster.config.validators.get_supported_instance_types": head_node_instances,
-        "pcluster.config.validators.get_supported_compute_instance_types": compute_instances,
+        "pcluster.utils.get_supported_instance_types": head_node_instances,
         "pcluster.utils.get_supported_architectures_for_instance_type": architectures,
         "pcluster.config.cfn_param_types.get_availability_zone_of_subnet": "mocked_avail_zone",
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type": architectures,
@@ -132,6 +130,7 @@ def mock_pcluster_config(mocker, scheduler=None, extra_patches=None, patch_funcs
     mocker.patch.object(PclusterConfig, "_PclusterConfig__test_configuration")
 
 
+# TODO moved
 def mock_instance_type_info(mocker, instance_type="t2.micro"):
     mocker.patch(
         "pcluster.utils.InstanceTypeInfo.init_from_instance_type",

--- a/cli/tests/pcluster/configure/test_pcluster_configure.py
+++ b/cli/tests/pcluster/configure/test_pcluster_configure.py
@@ -287,9 +287,7 @@ def _mock_parallel_cluster_config(mocker):
         "p4d.24xlarge",
     ]
     mocker.patch("pcluster.configure.easyconfig.get_supported_instance_types", return_value=supported_instance_types)
-    mocker.patch(
-        "pcluster.configure.easyconfig.get_supported_compute_instance_types", return_value=supported_instance_types
-    )
+    mocker.patch("pcluster.configure.easyconfig.get_supported_instance_types", return_value=supported_instance_types)
     mocker.patch("pcluster.config.cfn_param_types.get_availability_zone_of_subnet", return_value="mocked_avail_zone")
     mocker.patch(
         "pcluster.config.cfn_param_types.get_supported_architectures_for_instance_type",

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -104,40 +104,50 @@ def test_compute_type_validator(compute_type, expected_message):
 
 
 @pytest.mark.parametrize(
-    "spot_price, expected_message",
+    "section_dict, expected_message",
     [
-        ("", "Not a valid number"),
-        ("NONE", "Not a valid number"),
-        ("wrong_value", "Not a valid number"),
-        (0.09, None),
-        (0, None),
-        (0.1, None),
-        (1, None),
-        (100, None),
-        (100.0, None),
-        (100.1, None),
-        (101, None),
+        ({"MinCount": -1}, "Must be greater than or equal"),
+        ({"MinCount": 0}, None),
+        ({"MaxCount": 0}, "Must be greater than or equal"),
+        ({"MaxCount": 1}, None),
+        ({"SpotPrice": ""}, "Not a valid number"),
+        ({"SpotPrice": "NONE"}, "Not a valid number"),
+        ({"SpotPrice": "wrong_value"}, "Not a valid number"),
+        ({"SpotPrice": -1.1}, "Must be greater than or equal"),
+        ({"SpotPrice": 0}, None),
+        ({"SpotPrice": 0.09}, None),
+        ({"SpotPrice": 0}, None),
+        ({"SpotPrice": 0.1}, None),
+        ({"SpotPrice": 1}, None),
+        ({"SpotPrice": 100}, None),
+        ({"SpotPrice": 100.0}, None),
+        ({"SpotPrice": 100.1}, None),
+        ({"SpotPrice": 101}, None),
     ],
 )
-def test_spot_price_validator(spot_price, expected_message):
-    _validate_and_assert_error(SlurmComputeResourceSchema(), {"SpotPrice": spot_price}, expected_message)
+def test_slurm_compute_resource_validator(section_dict, expected_message):
+    _validate_and_assert_error(SlurmComputeResourceSchema(), section_dict, expected_message)
 
 
 @pytest.mark.parametrize(
-    "spot_bid_percentage, expected_message",
+    "section_dict, expected_message",
     [
-        ("", "Not a valid number"),
-        ("NONE", "Not a valid number"),
-        ("wrong_value", "Not a valid number"),
-        (0.01, None),
-        (0.22, None),
-        (1.01, "Must be.*less than or equal to 1"),
+        ({"MinvCpus": -1}, "Must be greater than or equal"),
+        ({"MinvCpus": 0}, None),
+        ({"DesiredvCpus": -1}, "Must be greater than or equal"),
+        ({"DesiredvCpus": 0}, None),
+        ({"MaxvCpus": 0}, "Must be greater than or equal"),
+        ({"MaxvCpus": 1}, None),
+        ({"SpotBidPercentage": ""}, "Not a valid number"),
+        ({"SpotBidPercentage": "NONE"}, "Not a valid number"),
+        ({"SpotBidPercentage": "wrong_value"}, "Not a valid number"),
+        ({"SpotBidPercentage": 0.01}, None),
+        ({"SpotBidPercentage": 0.22}, None),
+        ({"SpotBidPercentage": 1.01}, "Must be.*less than or equal to 1"),
     ],
 )
-def test_spot_bid_percentage_validator(spot_bid_percentage, expected_message):
-    _validate_and_assert_error(
-        AwsbatchComputeResourceSchema(), {"SpotBidPercentage": spot_bid_percentage}, expected_message
-    )
+def test_awsbatch_compute_resource_validator(section_dict, expected_message):
+    _validate_and_assert_error(AwsbatchComputeResourceSchema(), section_dict, expected_message)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -702,20 +702,6 @@ def test_validate_pcluster_version_based_on_ami_name(mocker, ami_name, error_exp
         utils.validate_pcluster_version_based_on_ami_name(ami_name)
 
 
-@pytest.mark.parametrize("scheduler", ["slurm", "sge", "torque", "awsbatch"])
-def test_get_supported_compute_instance_types(mocker, scheduler):
-    """Verify that the correct function to get supported instance types is called based on the scheduler used."""
-    batch_function_patch = mocker.patch("pcluster.utils.get_supported_batch_instance_types")
-    traditional_scheduler_function_patch = mocker.patch("pcluster.utils.get_supported_instance_types")
-    utils.get_supported_compute_instance_types(scheduler)
-    if scheduler == "awsbatch":
-        assert_that(batch_function_patch.call_count).is_equal_to(1)
-        traditional_scheduler_function_patch.assert_not_called()
-    else:
-        assert_that(traditional_scheduler_function_patch.call_count).is_equal_to(1)
-        batch_function_patch.assert_not_called()
-
-
 @pytest.mark.parametrize(
     "raise_error_api_function, raise_error_parsing_function, types_parsed_from_emsg_are_known",
     product([True, False], repeat=3),

--- a/cli/tests/pcluster/validators/test_awsbatch_validators.py
+++ b/cli/tests/pcluster/validators/test_awsbatch_validators.py
@@ -13,7 +13,7 @@ from assertpy import assert_that
 
 from pcluster.models.common import DynamicParam, Param
 from pcluster.validators.awsbatch_validators import (
-    AwsbatchComputeResourceValidator,
+    AwsbatchComputeResourceSizeValidator,
     AwsbatchInstancesArchitectureCompatibilityValidator,
 )
 
@@ -44,8 +44,8 @@ from .utils import assert_failure_messages
         ),
     ],
 )
-def test_cluster_validator(min_vcpus, desired_vcpus, max_vcpus, expected_message):
-    actual_failures = AwsbatchComputeResourceValidator().execute(
+def test_awsbatch_compute_resource_size_validator(min_vcpus, desired_vcpus, max_vcpus, expected_message):
+    actual_failures = AwsbatchComputeResourceSizeValidator().execute(
         Param(min_vcpus), Param(desired_vcpus), Param(max_vcpus)
     )
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -13,7 +13,7 @@ import pytest
 from pcluster.models.common import DynamicParam, Param
 from pcluster.validators.cluster_validators import (
     ArchitectureOsValidator,
-    ComputeResourceValidator,
+    ComputeResourceSizeValidator,
     EfaOsArchitectureValidator,
     FsxNetworkingValidator,
     InstanceArchitectureCompatibilityValidator,
@@ -36,8 +36,8 @@ def boto3_stubber_path():
         (2, 1, "Max count must be greater than or equal to min count"),
     ],
 )
-def test_compute_resource_validator(min_count, max_count, expected_message):
-    actual_failures = ComputeResourceValidator().execute(Param(min_count), Param(max_count))
+def test_compute_resource_size_validator(min_count, max_count, expected_message):
+    actual_failures = ComputeResourceSizeValidator().execute(Param(min_count), Param(max_count))
     assert_failure_messages(actual_failures, expected_message)
 
 

--- a/cli/tests/pcluster/validators/utils.py
+++ b/cli/tests/pcluster/validators/utils.py
@@ -12,6 +12,8 @@ import re
 
 from assertpy import assert_that
 
+from pcluster.utils import InstanceTypeInfo
+
 
 def assert_failure_messages(actual_failures, expected_messages):
     """Check failure messages."""
@@ -24,3 +26,16 @@ def assert_failure_messages(actual_failures, expected_messages):
             ).is_true()
     else:
         assert_that(actual_failures).is_empty()
+
+
+def mock_instance_type_info(mocker, instance_type):
+    mocker.patch(
+        "pcluster.validators.awsbatch_validators.InstanceTypeInfo.init_from_instance_type",
+        return_value=InstanceTypeInfo(
+            {
+                "InstanceType": instance_type,
+                "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2},
+                "NetworkInfo": {"EfaSupported": False},
+            }
+        ),
+    )


### PR DESCRIPTION
## slurm compute resource validator
* The checks for min values have been moved into Schema Ranges validators.
* initial_count has been deprecated so related checks have been removed.
* The combination between min/max/desired is already checked in the (Awsbatch)ComputeResourceValidator
* Defined DUMMY_COMPUTE_RESOURCE for the parameters required by the schema.

## instance type validators
* `ec2_instance_type_validator` was already moved and already used for slurm model
* `compute_instance_type_validator` moved to `AwsbatchComputeInstanceTypeValidator`. Now the code is AWS Batch specific.
* Removed from mappings
* Moved tests

I deleted the `get_supported_compute_instance_types` utility method.
In the new `AwsbatchComputeInstanceTypeValidator` we can use `get_supported_batch_instance_types` and in easyconfig.py we're in the no-awsbatch case so we can use `get_supported_instance_types`. Removed related tests.

## Other changes:
* Rename `*ComputeResourceValidator` to `*ComputeResourceSizeValidator`
* Add instance type validator for Slurm compute instances
* Move validators doc from private method to class definition
* Move architecture attribute in the head node
* Remove draft code
