### PR TITLE
3.0: Register validators right before resource validation

### DIFF
--- a/cli/src/pcluster/models/cluster_awsbatch.py
+++ b/cli/src/pcluster/models/cluster_awsbatch.py
@@ -59,8 +59,10 @@ class AwsbatchComputeResource(BaseComputeResource):
         self.min_vcpus = Param(min_vcpus, default=0)
         self.desired_vcpus = Param(desired_vcpus, default=0)
         self.spot_bid_percentage = spot_bid_percentage
+
+    def _register_validators(self):
         self._add_validator(
-            AwsbatchComputeInstanceTypeValidator, instance_types=self.instance_type, max_vcpus=max_vcpus
+            AwsbatchComputeInstanceTypeValidator, instance_types=self.instance_type, max_vcpus=self.max_vcpus
         )
 
 
@@ -106,6 +108,7 @@ class AwsbatchCluster(BaseCluster):
         super().__init__(image, head_node, shared_storage, monitoring, tags, iam, custom_actions)
         self.scheduling = scheduling
 
+    def _register_validators(self):
         for queue in self.scheduling.queues:
             for compute_resource in queue.compute_resources:
                 self._add_validator(

--- a/cli/src/pcluster/models/cluster_slurm.py
+++ b/cli/src/pcluster/models/cluster_slurm.py
@@ -110,6 +110,7 @@ class SlurmCluster(BaseCluster):
         super().__init__(image, head_node, shared_storage, monitoring, tags, iam, custom_actions)
         self.scheduling = scheduling
 
+    def _register_validators(self):
         for queue in self.scheduling.queues:
             for compute_resource in queue.compute_resources:
                 self._add_validator(

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -37,6 +37,8 @@ class Volume(Resource):
         self.encrypted = Param(encrypted, default=False)
         self.kms_key_id = Param(kms_key_id)
         # TODO: add validator
+
+    def _register_validators(self):
         self._add_validator(
             EBSVolumeKmsKeyIdValidator, volume_kms_key_id=self.kms_key_id, volume_encrypted=self.encrypted
         )
@@ -102,7 +104,8 @@ class Build(Resource):
         self.subnet_id = Param(subnet_id)
         self.security_group_ids = security_group_ids
         self.components = components
-        # TODO: add validator
+
+    def _register_validators(self):
         self._add_validator(BaseAMIValidator, priority=15, parent_image=self.parent_image)
         self._add_validator(InstanceTypeValidator, priority=15, instance_type=self.instance_type)
         self._add_validator(
@@ -148,7 +151,8 @@ class DevSettings(Resource):
         self.aws_batch_cli_url = Param(aws_batch_cli_url)
         self.distribution_configuration_arn = Param(distribution_configuration_arn)
         self.terminate_instance_on_failure = Param(terminate_instance_on_failure, default=True)
-        # TODO: add validator
+
+    def _register_validators(self):
         self._add_validator(UrlValidator, url=self.node_url)
         self._add_validator(UrlValidator, url=self.aws_batch_cli_url)
 
@@ -170,6 +174,8 @@ class ImageBuilder(Resource):
         self.build = build
         self.dev_settings = dev_settings
         self._set_default()
+
+    def _register_validators(self):
         self._add_validator(
             EbsVolumeTypeSizeValidator, priority=10, volume_type=Param("gp2"), volume_size=self.image.root_volume.size
         )

--- a/cli/src/pcluster/validators/awsbatch_validators.py
+++ b/cli/src/pcluster/validators/awsbatch_validators.py
@@ -9,7 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pcluster.models.common import DynamicParam, FailureLevel, Param, Validator
+from pcluster.models.common import FailureLevel, Param, Validator
 from pcluster.utils import (
     InstanceTypeInfo,
     get_region,
@@ -102,8 +102,7 @@ class AwsbatchInstancesArchitectureCompatibilityValidator(Validator):
     With AWS Batch, compute instance type can contain a CSV list.
     """
 
-    def _validate(self, instance_types: Param, architecture: DynamicParam):
-        head_node_architecture = architecture.value
+    def _validate(self, instance_types: Param, architecture: str):
         for instance_type in instance_types.value.split(","):
             # When awsbatch is used as the scheduler instance families can be used.
             # Don't attempt to validate architectures for instance families, as it would require
@@ -116,11 +115,11 @@ class AwsbatchInstancesArchitectureCompatibilityValidator(Validator):
                 )
                 continue
             compute_architectures = get_supported_architectures_for_instance_type(instance_type)
-            if head_node_architecture not in compute_architectures:
+            if architecture not in compute_architectures:
                 self._add_failure(
                     "The specified compute instance type ({0}) supports the architectures {1}, none of which are "
                     "compatible with the architecture supported by the head node instance type ({2}).".format(
-                        instance_type, compute_architectures, head_node_architecture
+                        instance_type, compute_architectures, architecture
                     ),
                     FailureLevel.ERROR,
                     [instance_types],

--- a/cli/tests/pcluster/validators/test_awsbatch_validators.py
+++ b/cli/tests/pcluster/validators/test_awsbatch_validators.py
@@ -11,7 +11,7 @@
 import pytest
 from assertpy import assert_that
 
-from pcluster.models.common import DynamicParam, Param
+from pcluster.models.common import Param
 from pcluster.validators.awsbatch_validators import (
     AwsbatchComputeInstanceTypeValidator,
     AwsbatchComputeResourceSizeValidator,
@@ -105,7 +105,7 @@ def test_awsbatch_instances_architecture_compatibility_validator(
     instance_types = compute_instance_types.split(",")
 
     actual_failures = AwsbatchInstancesArchitectureCompatibilityValidator().execute(
-        Param(compute_instance_types), DynamicParam(lambda: head_node_architecture)
+        Param(compute_instance_types), head_node_architecture
     )
     assert_failure_messages(actual_failures, expected_message)
     if expected_message:

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 import pytest
 
-from pcluster.models.common import DynamicParam, Param
+from pcluster.models.common import Param
 from pcluster.validators.cluster_validators import (
     ArchitectureOsValidator,
     ComputeResourceSizeValidator,
@@ -61,7 +61,7 @@ def test_simultaneous_multithreading_architecture_validator(
     simultaneous_multithreading, architecture, expected_message
 ):
     actual_failures = SimultaneousMultithreadingArchitectureValidator().execute(
-        Param(simultaneous_multithreading), DynamicParam(lambda: architecture)
+        Param(simultaneous_multithreading), architecture
     )
     assert_failure_messages(actual_failures, expected_message)
 
@@ -84,9 +84,7 @@ def test_simultaneous_multithreading_architecture_validator(
     ],
 )
 def test_efa_os_architecture_validator(efa_enabled, os, architecture, expected_message):
-    actual_failures = EfaOsArchitectureValidator().execute(
-        Param(efa_enabled), Param(os), DynamicParam(lambda: architecture)
-    )
+    actual_failures = EfaOsArchitectureValidator().execute(Param(efa_enabled), Param(os), architecture)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -111,7 +109,7 @@ def test_efa_os_architecture_validator(efa_enabled, os, architecture, expected_m
 )
 def test_architecture_os_validator(os, architecture, expected_message):
     """Verify that the correct set of OSes is supported for each supported architecture."""
-    actual_failures = ArchitectureOsValidator().execute(Param(os), DynamicParam(lambda: architecture))
+    actual_failures = ArchitectureOsValidator().execute(Param(os), architecture)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -142,7 +140,7 @@ def test_instance_architecture_compatibility_validator(
         return_value=[compute_architecture],
     )
     actual_failures = InstanceArchitectureCompatibilityValidator().execute(
-        Param(compute_instance_type), DynamicParam(lambda: head_node_architecture)
+        Param(compute_instance_type), head_node_architecture
     )
     assert_failure_messages(actual_failures, expected_message)
 
@@ -417,6 +415,6 @@ def test_dcv_validator(dcv_enabled, os, instance_type, allowed_ips, port, expect
         Param(allowed_ips),
         Param(port),
         Param(os),
-        DynamicParam(lambda: "x86_64" if instance_type.startswith("t2") else "arm64"),
+        "x86_64" if instance_type.startswith("t2") else "arm64",
     )
     assert_failure_messages(actual_failures, expected_message)


### PR DESCRIPTION
The previous approach of registering the validators in the initialization of the Resource wasn't considering the possibility to change the model attributes.
The registered validators were validating only the attributes present at init time.

With the new approach the validator are registered just before calling the validation so we'll have the validators associated to the current status of the model.
For this reason we don't need anymore the Dynamic param because we don't need to pass a reference to the validator but we can simply pass the property with the value in that specific moment.

By removing the DynamicParam concept we're simplifying the tests and the usage of the model.
