### PR TITLE
3.0: Migrate additional IAM policies and key pair validators

### DIFF
--- a/cli/src/common/boto3/ec2.py
+++ b/cli/src/common/boto3/ec2.py
@@ -38,3 +38,8 @@ class Ec2Client(Boto3Client):
                 ]
             )
         )
+
+    @AWSExceptionHandler.handle_client_exception
+    def describe_key_pair(self, key_name):
+        """Return the given key, if exists."""
+        return self._client.describe_key_pairs(KeyNames=[key_name])

--- a/cli/src/common/boto3/iam.py
+++ b/cli/src/common/boto3/iam.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common.boto3.common import AWSExceptionHandler, Boto3Client
+
+
+class IamClient(Boto3Client):
+    """Iam Boto3 client."""
+
+    def __init__(self):
+        super().__init__("iam")
+
+    @AWSExceptionHandler.handle_client_exception
+    def get_policy(self, iam_policy):
+        """Get policy information."""
+        self._client.get_policy(PolicyArn=iam_policy)

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -56,7 +56,6 @@ from pcluster.config.param_types import Visibility
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import (
     ec2_ami_validator,
-    ec2_iam_policies_validator,
     ec2_key_pair_validator,
     ec2_placement_group_validator,
     ec2_security_group_validator,
@@ -905,7 +904,6 @@ CLUSTER_COMMON_PARAMS = [
     ("additional_iam_policies", {
         "type": AdditionalIamPoliciesCfnParam,
         "cfn_param_mapping": "EC2IAMPolicies",
-        "validators": [ec2_iam_policies_validator],
         "update_policy": UpdatePolicy.SUPPORTED,
     }),
     # Derived parameters - present in CFN parameters but not in config file

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -56,7 +56,6 @@ from pcluster.config.param_types import Visibility
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import (
     ec2_ami_validator,
-    ec2_key_pair_validator,
     ec2_placement_group_validator,
     ec2_security_group_validator,
     ec2_subnet_id_validator,
@@ -701,7 +700,6 @@ CLUSTER_COMMON_PARAMS = [
     ("key_name", {
         "cfn_param_mapping": "KeyName",
         "required": True,
-        "validators": [ec2_key_pair_validator],
         "update_policy": UpdatePolicy.UNSUPPORTED
     }),
     ("scheduler", {

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -868,23 +868,5 @@ def fsx_lustre_backup_validator(param_key, param_value, pcluster_config):
     return errors, warnings
 
 
-def fsx_ignored_parameters_validator(section_key, section_label, pcluster_config):
-    """Return errors for parameters in the FSx config section that would be ignored."""
-    errors = []
-    warnings = []
-
-    fsx_section = pcluster_config.get_section(section_key, section_label)
-
-    # If fsx_fs_id is specified, all parameters besides shared_dir are ignored.
-    relevant_when_using_existing_fsx = ["fsx_fs_id", "shared_dir"]
-    if fsx_section.get_param_value("fsx_fs_id") is not None:
-        for fsx_param in fsx_section.params:
-            if fsx_param not in relevant_when_using_existing_fsx and FSX_PARAM_WITH_DEFAULT.get(
-                fsx_param, None
-            ) != fsx_section.get_param_value(fsx_param):
-                errors.append(FSX_MESSAGES["errors"]["ignored_param_with_fsx_fs_id"].format(fsx_param=fsx_param))
-    return errors, warnings
-
-
 def get_bucket_name_from_s3_url(import_path):
     return import_path.split("/")[2]

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -19,7 +19,6 @@ from botocore.exceptions import ClientError, ParamValidationError
 
 from pcluster.utils import (
     ellipsize,
-    get_base_additional_iam_policies,
     get_efs_mount_target_id,
     get_file_section_name,
     get_region,
@@ -322,21 +321,6 @@ def ec2_key_pair_validator(param_key, param_value, pcluster_config):
     warnings = []
     try:
         _describe_ec2_key_pair(param_value)
-    except ClientError as e:
-        errors.append(e.response.get("Error").get("Message"))
-
-    return errors, warnings
-
-
-def ec2_iam_policies_validator(param_key, param_value, pcluster_config):
-    errors = []
-    warnings = []
-    try:
-        if param_value:
-            for iam_policy in param_value:
-                if iam_policy not in get_base_additional_iam_policies():
-                    iam = boto3.client("iam")
-                    iam.get_policy(PolicyArn=iam_policy.strip())
     except ClientError as e:
         errors.append(e.response.get("Error").get("Message"))
 

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -316,17 +316,6 @@ def _validate_efa_sg(pcluster_config, errors):
             errors.append(e.response.get("Error").get("Message"))
 
 
-def ec2_key_pair_validator(param_key, param_value, pcluster_config):
-    errors = []
-    warnings = []
-    try:
-        _describe_ec2_key_pair(param_value)
-    except ClientError as e:
-        errors.append(e.response.get("Error").get("Message"))
-
-    return errors, warnings
-
-
 def head_node_instance_type_validator(param_key, param_value, pcluster_config):
     errors = []
     warnings = []
@@ -895,11 +884,6 @@ def fsx_ignored_parameters_validator(section_key, section_label, pcluster_config
             ) != fsx_section.get_param_value(fsx_param):
                 errors.append(FSX_MESSAGES["errors"]["ignored_param_with_fsx_fs_id"].format(fsx_param=fsx_param))
     return errors, warnings
-
-
-def _describe_ec2_key_pair(key_pair_name):
-    """Return information about the provided ec2 key pair."""
-    return boto3.client("ec2").describe_key_pairs(KeyNames=[key_pair_name])
 
 
 def get_bucket_name_from_s3_url(import_path):

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -34,7 +34,7 @@ from pcluster.validators.ebs_validators import (
     EbsVolumeThroughputValidator,
     EbsVolumeTypeSizeValidator,
 )
-from pcluster.validators.ec2_validators import InstanceTypeValidator
+from pcluster.validators.ec2_validators import AdditionalIamPolicyValidator, InstanceTypeValidator
 from pcluster.validators.fsx_validators import (
     FsxBackupOptionsValidator,
     FsxPersistentOptionsValidator,
@@ -563,6 +563,9 @@ class AdditionalIamPolicy(Resource):
         super().__init__()
         self.policy = Param(policy)
         self.scope = Param(scope, default="CLUSTER")
+
+    def _register_validators(self):
+        self._add_validator(AdditionalIamPolicyValidator, policy=self.policy)
 
 
 class Iam(Resource):

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -34,7 +34,7 @@ from pcluster.validators.ebs_validators import (
     EbsVolumeThroughputValidator,
     EbsVolumeTypeSizeValidator,
 )
-from pcluster.validators.ec2_validators import AdditionalIamPolicyValidator, InstanceTypeValidator
+from pcluster.validators.ec2_validators import AdditionalIamPolicyValidator, InstanceTypeValidator, KeyPairValidator
 from pcluster.validators.fsx_validators import (
     FsxBackupOptionsValidator,
     FsxPersistentOptionsValidator,
@@ -327,6 +327,9 @@ class Ssh(Resource):
         super().__init__()
         self.key_name = Param(key_name)
         self.allowed_ips = Param(allowed_ips, default=CIDR_ALL_IPS)
+
+    def _register_validators(self):
+        self._add_validator(KeyPairValidator, key_name=self.key_name)
 
 
 class Dcv(Resource):

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -1066,10 +1066,6 @@ def policy_name_to_arn(policy_name):
     return "arn:{0}:iam::aws:policy/{1}".format(get_partition(), policy_name)
 
 
-def get_base_additional_iam_policies():
-    return [policy_name_to_arn("CloudWatchAgentServerPolicy"), policy_name_to_arn("AWSBatchFullAccess")]
-
-
 def cluster_has_running_capacity(stack_name):
     if not hasattr(cluster_has_running_capacity, "cached_result"):
         stack = get_stack(stack_name)

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -80,3 +80,17 @@ class AdditionalIamPolicyValidator(Validator):  # TODO add test
     @staticmethod
     def _get_base_additional_iam_policies():
         return [policy_name_to_arn("CloudWatchAgentServerPolicy"), policy_name_to_arn("AWSBatchFullAccess")]
+
+
+class KeyPairValidator(Validator):  # TODO add test
+    """
+    EC2 key pair validator.
+
+    Verify the given key pair is correct.
+    """
+
+    def _validate(self, key_name: Param):
+        try:
+            Ec2Client().describe_key_pair(key_name)
+        except AWSClientError as e:
+            self._add_failure(str(e), FailureLevel.ERROR, [key_name])

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -42,24 +42,6 @@ def test_head_node_instance_type_validator(mocker, instance_type, expected_messa
     utils.assert_param_validator(mocker, config_parser_dict, expected_message)
 
 
-def test_ec2_key_pair_validator(mocker, boto3_stubber):
-    describe_key_pairs_response = {
-        "KeyPairs": [
-            {"KeyFingerprint": "12:bf:7c:56:6c:dd:4f:8c:24:45:75:f1:1b:16:54:89:82:09:a4:26", "KeyName": "key1"}
-        ]
-    }
-    mocked_requests = [
-        MockedBoto3Request(
-            method="describe_key_pairs", response=describe_key_pairs_response, expected_params={"KeyNames": ["key1"]}
-        )
-    ]
-    boto3_stubber("ec2", mocked_requests)
-
-    # TODO test with invalid key
-    config_parser_dict = {"cluster default": {"key_name": "key1"}}
-    utils.assert_param_validator(mocker, config_parser_dict)
-
-
 @pytest.mark.parametrize(
     "image_architecture, bad_ami_message, bad_architecture_message",
     [


### PR DESCRIPTION
* Migrate additional Iam policies validator
  * With the new model we can validate a single policy rather than a list.
  * There were no unit tests for it, still to do.
*  Migrate key pair validator
   * There was a unit test but it was useless, just testing the working case, still to do.
* Remove already migrated validator from validator module