### PR TITLE
3.0: Add support for AdditionalPackages, ClusterS3Bucket, AdditionalResources

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -580,6 +580,28 @@ class Iam(Resource):
         self.additional_iam_policies = additional_iam_policies
 
 
+class IntelSelectSolutions(Resource):
+    """Represent the Intel select solution configuration."""
+
+    def __init__(
+        self,
+        install_intel_software: bool = None,
+    ):
+        super().__init__()
+        self.install_intel_software = Param(install_intel_software, default=False)
+
+
+class AdditionalPackages(Resource):
+    """Represent the additional packages configuration."""
+
+    def __init__(
+        self,
+        intel_select_solutions: IntelSelectSolutions = None,
+    ):
+        super().__init__()
+        self.intel_select_solutions = intel_select_solutions
+
+
 # ---------------------- Root resource ---------------------- #
 
 
@@ -592,18 +614,24 @@ class BaseCluster(Resource):
         head_node: HeadNode,
         shared_storage: List[SharedStorage] = None,
         monitoring: Monitoring = None,
+        additional_packages: AdditionalPackages = None,
         tags: List[Tag] = None,
         iam: Iam = None,
         custom_actions: CustomAction = None,
+        cluster_s3_bucket: str = None,
+        additional_resources: str = None,
     ):
         super().__init__()
         self.image = image
         self.head_node = head_node
         self.shared_storage = shared_storage
         self.monitoring = monitoring
+        self.additional_packages = additional_packages
         self.tags = tags
         self.iam = iam
         self.custom_actions = custom_actions
+        self.cluster_s3_bucket = cluster_s3_bucket
+        self.additional_resources = additional_resources
 
     def _register_validators(self):
         self._add_validator(

--- a/cli/src/pcluster/models/cluster_awsbatch.py
+++ b/cli/src/pcluster/models/cluster_awsbatch.py
@@ -19,17 +19,10 @@ from pcluster.models.cluster import (
     BaseComputeResource,
     BaseQueue,
     CommonSchedulingSettings,
-    CustomAction,
     Efa,
-    HeadNode,
-    Iam,
-    Image,
-    Monitoring,
     QueueNetworking,
     Resource,
-    SharedStorage,
     Storage,
-    Tag,
 )
 from pcluster.models.common import Param
 from pcluster.validators.awsbatch_validators import (
@@ -94,18 +87,8 @@ class AwsbatchScheduling(Resource):
 class AwsbatchCluster(BaseCluster):
     """Represent the full Awsbatch Cluster configuration."""
 
-    def __init__(
-        self,
-        image: Image,
-        head_node: HeadNode,
-        scheduling: AwsbatchScheduling,
-        shared_storage: List[SharedStorage] = None,
-        monitoring: Monitoring = None,
-        tags: List[Tag] = None,
-        iam: Iam = None,
-        custom_actions: CustomAction = None,
-    ):
-        super().__init__(image, head_node, shared_storage, monitoring, tags, iam, custom_actions)
+    def __init__(self, scheduling: AwsbatchScheduling, **kwargs):
+        super().__init__(**kwargs)
         self.scheduling = scheduling
 
     def _register_validators(self):

--- a/cli/src/pcluster/models/cluster_slurm.py
+++ b/cli/src/pcluster/models/cluster_slurm.py
@@ -19,17 +19,10 @@ from pcluster.models.cluster import (
     BaseComputeResource,
     BaseQueue,
     CommonSchedulingSettings,
-    CustomAction,
     Efa,
-    HeadNode,
-    Iam,
-    Image,
-    Monitoring,
     QueueNetworking,
     Resource,
-    SharedStorage,
     Storage,
-    Tag,
 )
 from pcluster.models.common import Param
 from pcluster.validators.cluster_validators import (
@@ -96,18 +89,8 @@ class SlurmScheduling(Resource):
 class SlurmCluster(BaseCluster):
     """Represent the full Slurm Cluster configuration."""
 
-    def __init__(
-        self,
-        image: Image,
-        head_node: HeadNode,
-        scheduling: SlurmScheduling,
-        shared_storage: List[SharedStorage] = None,
-        monitoring: Monitoring = None,
-        tags: List[Tag] = None,
-        iam: Iam = None,
-        custom_actions: CustomAction = None,
-    ):
-        super().__init__(image, head_node, shared_storage, monitoring, tags, iam, custom_actions)
+    def __init__(self, scheduling: SlurmScheduling, **kwargs):
+        super().__init__(**kwargs)
         self.scheduling = scheduling
 
     def _register_validators(self):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -20,6 +20,7 @@ from pcluster.config.validators import FSX_MESSAGES
 from pcluster.constants import FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT
 from pcluster.models.cluster import (
     AdditionalIamPolicy,
+    AdditionalPackages,
     CloudWatchDashboards,
     CloudWatchLogs,
     CommonSchedulingSettings,
@@ -33,6 +34,7 @@ from pcluster.models.cluster import (
     HeadNodeNetworking,
     Iam,
     Image,
+    IntelSelectSolutions,
     Logs,
     Monitoring,
     PlacementGroup,
@@ -624,6 +626,28 @@ class IamSchema(BaseSchema):
         return Iam(**data)
 
 
+class IntelSelectSolutionsSchema(BaseSchema):
+    """Represent the schema of additional packages."""
+
+    install_intel_software = fields.Bool()
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return IntelSelectSolutions(**data)
+
+
+class AdditionalPackagesSchema(BaseSchema):
+    """Represent the schema of additional packages."""
+
+    intel_select_solutions = fields.Nested(IntelSelectSolutionsSchema)
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return AdditionalPackages(**data)
+
+
 # ---------------------- Root Schema ---------------------- #
 
 
@@ -636,9 +660,12 @@ class ClusterSchema(BaseSchema):
     shared_storage = fields.Nested(SharedStorageSchema, many=True)
 
     monitoring = fields.Nested(MonitoringSchema)
+    additional_packages = fields.Nested(AdditionalPackagesSchema)
     tags = fields.Nested(TagSchema, many=True)
     custom_actions = fields.Nested(CustomActionSchema, many=True)
     iam = fields.Nested(IamSchema, data_key="IAM")
+    cluster_s3_bucket = fields.Str()
+    additional_resources = fields.Str()
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -168,7 +168,6 @@ CustomActions:
       - String  # HEAD | COMPUTE
     Event: String  # NODE_START | NODE_CONFIGURED
     RunAs: String
-ClusterS3ResourceBucket: String
 Tags:
   - Key: String
     Value: String

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.simple.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.simple.yaml
@@ -127,6 +127,9 @@ Monitoring:
   Dashboards:
     CloudWatch:
       Enabled: true  # true
+AdditionalPackages:
+  IntelSelectSolutions:
+    InstallIntelSoftware: false
 Tags:
   - Key: String
     Value: String
@@ -139,3 +142,5 @@ CustomActions:
       - stirng2
     Event: NODE_START
     RunAs: String
+ClusterS3Bucket: String
+AdditionalResources: String  # https://template.url


### PR DESCRIPTION
1. Add support for AdditionalPackages, ClusterS3Bucket and AdditionalResources
2. Aggregate arguments that are only used in BaseCluster in to `kwargs`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
