### PR TITLE
3.0: Migrate a bunch of validators and add recursive validation

### DIFF
--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -72,7 +72,6 @@ from pcluster.config.validators import (
     s3_bucket_uri_validator,
     s3_bucket_validator,
     shared_dir_validator,
-    tags_validator,
 )
 from pcluster.constants import CIDR_ALL_IPS, FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT, SUPPORTED_ARCHITECTURES
 
@@ -820,7 +819,6 @@ CLUSTER_COMMON_PARAMS = [
     ("tags", {
         # There is no cfn_param_mapping because it's not converted to a CFN Input parameter
         "type": TagsParam,
-        "validators": [tags_validator],
         "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP,
     }),
     ("custom_chef_cookbook", {

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -73,7 +73,6 @@ from pcluster.config.validators import (
     queue_validator,
     s3_bucket_uri_validator,
     s3_bucket_validator,
-    scheduler_validator,
     shared_dir_validator,
     tags_validator,
 )
@@ -697,7 +696,6 @@ CLUSTER_COMMON_PARAMS = [
     }),
     ("scheduler", {
         "cfn_param_mapping": "Scheduler",
-        "validators": [scheduler_validator],
         "required": True,
         "update_policy": UpdatePolicy.UNSUPPORTED
     }),

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -67,7 +67,6 @@ from pcluster.config.validators import (
     intel_hpc_architecture_validator,
     intel_hpc_os_validator,
     kms_key_validator,
-    maintain_initial_size_validator,
     queue_settings_validator,
     queue_validator,
     s3_bucket_uri_validator,
@@ -968,7 +967,6 @@ CLUSTER_SIT = {
                 "type": MaintainInitialSizeCfnParam,
                 "default": False,
                 "cfn_param_mapping": "MinSize",
-                "validators": [maintain_initial_size_validator],
                 "update_policy": UpdatePolicy.SUPPORTED
             }),
             ("min_vcpus", {

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -64,7 +64,6 @@ from pcluster.config.validators import (
     efa_gdr_validator,
     efa_validator,
     efs_id_validator,
-    efs_validator,
     head_node_instance_type_validator,
     intel_hpc_architecture_validator,
     intel_hpc_os_validator,
@@ -341,7 +340,6 @@ EFS = {
     "key": "efs",
     "type": EFSCfnSection,
     "default_label": "default",
-    "validators": [efs_validator],
     "cfn_param_mapping": "EFSOptions",  # All the parameters in the section are converted into a single CFN parameter
     "params": OrderedDict(  # Use OrderedDict because the parameters must respect the order in the CFN parameter
         [

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -63,7 +63,6 @@ from pcluster.config.validators import (
     ec2_vpc_id_validator,
     efa_gdr_validator,
     efa_validator,
-    efs_id_validator,
     head_node_instance_type_validator,
     intel_hpc_architecture_validator,
     intel_hpc_os_validator,
@@ -347,7 +346,6 @@ EFS = {
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("efs_fs_id", {
-                "validators": [efs_id_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("performance_mode", {

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -67,7 +67,6 @@ from pcluster.config.validators import (
     intel_hpc_architecture_validator,
     intel_hpc_os_validator,
     kms_key_validator,
-    queue_settings_validator,
     queue_validator,
     s3_bucket_uri_validator,
     s3_bucket_validator,
@@ -1030,7 +1029,6 @@ CLUSTER_HIT = {
             ("queue_settings", {
                 "type": SettingsJsonParam,
                 "referred_section": QUEUE,
-                "validators": [queue_settings_validator],
                 "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP,
             }),
             ("disable_hyperthreading", {

--- a/cli/src/pcluster/config/param_types.py
+++ b/cli/src/pcluster/config/param_types.py
@@ -19,7 +19,6 @@ from enum import Enum
 from configparser import NoSectionError
 
 from pcluster.config.update_policy import UpdatePolicy
-from pcluster.config.validators import settings_validator
 from pcluster.utils import get_file_section_name
 
 LOGGER = logging.getLogger(__name__)
@@ -261,7 +260,6 @@ class SettingsParam(Param):
         self.referred_section_definition = param_definition.get("referred_section")
         self.referred_section_key = self.referred_section_definition.get("key")
         self.referred_section_type = self.referred_section_definition.get("type")
-        param_definition.get("validators", []).append(settings_validator)
         super(SettingsParam, self).__init__(
             section_key, section_label, param_key, param_definition, pcluster_config, owner_section
         )

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -464,21 +464,6 @@ def intel_hpc_os_validator(param_key, param_value, pcluster_config):
     return errors, warnings
 
 
-def maintain_initial_size_validator(param_key, param_value, pcluster_config):
-    errors = []
-    cluster_section = pcluster_config.get_section("cluster")
-    scheduler = cluster_section.get_param_value("scheduler")
-    initial_queue_size = cluster_section.get_param_value("initial_queue_size")
-
-    if param_value:
-        if scheduler == "awsbatch":
-            errors.append("maintain_initial_size is not supported when using awsbatch as scheduler")
-        elif initial_queue_size == 0:
-            errors.append("maintain_initial_size cannot be set to true if initial_queue_size is 0")
-
-    return errors, []
-
-
 def intel_hpc_architecture_validator(param_key, param_value, pcluster_config):
     errors = []
     warnings = []

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -537,25 +537,6 @@ def ec2_volume_validator(param_key, param_value, pcluster_config):
     return errors, warnings
 
 
-def efs_validator(section_key, section_label, pcluster_config):
-    errors = []
-    warnings = []
-
-    section = pcluster_config.get_section(section_key, section_label)
-    throughput_mode = section.get_param_value("throughput_mode")
-    provisioned_throughput = section.get_param_value("provisioned_throughput")
-
-    if throughput_mode != "provisioned" and provisioned_throughput:
-        errors.append("When specifying 'provisioned_throughput', the 'throughput_mode' must be set to 'provisioned'")
-
-    if throughput_mode == "provisioned" and not provisioned_throughput:
-        errors.append(
-            "When specifying 'throughput_mode' to 'provisioned', the 'provisioned_throughput' option must be specified"
-        )
-
-    return errors, warnings
-
-
 def scheduler_validator(param_key, param_value, pcluster_config):
     errors = []
     warnings = []

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -480,19 +480,6 @@ def intel_hpc_architecture_validator(param_key, param_value, pcluster_config):
     return errors, warnings
 
 
-def tags_validator(param_key, param_value, pcluster_config):
-    errors = []
-
-    for key in param_value.keys():
-        if key == "Version":
-            errors.append(
-                "The key 'Version' used in your 'tags' configuration parameter is a reserved one, please change it."
-            )
-            break
-
-    return errors, []
-
-
 def queue_settings_validator(param_key, param_value, pcluster_config):
     errors = []
     cluster_section = pcluster_config.get_section("cluster")

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -49,10 +49,6 @@ EBS_VOLUME_TYPE_TO_IOPS_RATIO = {"io1": 50, "io2": 1000, "gp3": 500}
 HEAD_NODE_UNSUPPORTED_INSTANCE_TYPES = []
 HEAD_NODE_UNSUPPORTED_MESSAGE = "The instance type '{0}' is not supported as head node."
 
-# Constants for section labels
-LABELS_MAX_LENGTH = 64
-LABELS_REGEX = r"^[A-Za-z0-9\-_]+$"
-
 
 def _get_sts_endpoint():
     """Get regionalized STS endpoint."""
@@ -480,27 +476,6 @@ def intel_hpc_architecture_validator(param_key, param_value, pcluster_config):
     return errors, warnings
 
 
-def queue_settings_validator(param_key, param_value, pcluster_config):
-    errors = []
-    cluster_section = pcluster_config.get_section("cluster")
-    scheduler = cluster_section.get_param_value("scheduler")
-
-    if scheduler != "slurm":
-        errors.append("queue_settings is supported only with slurm scheduler")
-
-    for label in param_value.split(","):
-        if re.search("[A-Z]", label) or re.match("^default$", label) or "_" in label:
-            errors.append(
-                (
-                    "Invalid queue name '{0}'. Queue section names can be at most 30 chars long, must begin with"
-                    " a letter and only contain lowercase letters, digits and hyphens. It is forbidden to use"
-                    " 'default' as a queue section name."
-                ).format(label)
-            )
-
-    return errors, []
-
-
 def queue_validator(section_key, section_label, pcluster_config):
     errors = []
     warnings = []
@@ -560,26 +535,6 @@ def queue_validator(section_key, section_label, pcluster_config):
         errors.append("The parameter 'enable_efa_gdr' can be used only in combination with 'enable_efa'")
 
     return errors, warnings
-
-
-def settings_validator(param_key, param_value, pcluster_config):
-    errors = []
-    if param_value:
-        for label in param_value.split(","):
-            label = label.strip()
-            match = re.match(LABELS_REGEX, label)
-            if not match:
-                errors.append(
-                    "Invalid label '{0}' in param '{1}'. Section labels can only contain alphanumeric characters, "
-                    "dashes or underscores.".format(ellipsize(label, 20), param_key)
-                )
-            else:
-                if len(label) > LABELS_MAX_LENGTH:
-                    errors.append(
-                        "Invalid label '{0}' in param '{1}'. The maximum length allowed for section labels is "
-                        "{2} characters".format(ellipsize(label, 20), param_key, LABELS_MAX_LENGTH)
-                    )
-    return errors, []
 
 
 def _get_efa_enabled_instance_types(errors):

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -22,7 +22,6 @@ from pcluster.utils import (
     get_efs_mount_target_id,
     get_file_section_name,
     get_region,
-    get_supported_os_for_scheduler,
     paginate_boto3,
     validate_pcluster_version_based_on_ami_name,
 )
@@ -533,29 +532,6 @@ def ec2_volume_validator(param_key, param_value, pcluster_config):
             errors.append("Volume {0} does not exist".format(param_value))
         else:
             errors.append(e.response.get("Error").get("Message"))
-
-    return errors, warnings
-
-
-def scheduler_validator(param_key, param_value, pcluster_config):
-    errors = []
-    warnings = []
-
-    if param_value == "awsbatch":
-        if pcluster_config.region in ["ap-northeast-3"]:
-            errors.append("'awsbatch' scheduler is not supported in the '{0}' region".format(pcluster_config.region))
-
-    supported_os = get_supported_os_for_scheduler(param_value)
-    if pcluster_config.get_section("cluster").get_param_value("base_os") not in supported_os:
-        errors.append("'{0}' scheduler supports the following Operating Systems: {1}".format(param_value, supported_os))
-
-    will_be_deprecated = ["sge", "torque"]
-    wiki_url = "https://github.com/aws/aws-parallelcluster/wiki/Deprecation-of-SGE-and-Torque-in-ParallelCluster"
-    if param_value in will_be_deprecated:
-        warnings.append(
-            "The job scheduler you are using ({0}) is scheduled to be deprecated in future releases of "
-            "ParallelCluster. More information is available here: {1}".format(param_value, wiki_url)
-        )
 
     return errors, warnings
 

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -17,7 +17,7 @@ from enum import Enum
 from typing import List
 
 from pcluster.constants import CIDR_ALL_IPS, EBS_VOLUME_TYPE_IOPS_DEFAULT
-from pcluster.models.common import Param, Resource, Tag
+from pcluster.models.common import BaseTag, Param, Resource
 from pcluster.utils import (
     error,
     get_availability_zone_of_subnet,
@@ -34,6 +34,7 @@ from pcluster.validators.cluster_validators import (
     FsxNetworkingValidator,
     NumberOfStorageValidator,
     SimultaneousMultithreadingArchitectureValidator,
+    TagKeyValidator,
 )
 from pcluster.validators.ebs_validators import (
     EbsVolumeIopsValidator,
@@ -539,6 +540,20 @@ class Monitoring(Resource):
 
 
 # ---------------------- Others ---------------------- #
+
+
+class Tag(BaseTag):
+    """Represent the Tag configuration."""
+
+    def __init__(
+        self,
+        key: str = None,
+        value: str = None,
+    ):
+        super().__init__(key, value)
+
+    def _register_validators(self):
+        self._add_validator(TagKeyValidator, key=self.key)
 
 
 class Roles(Resource):

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -18,7 +18,7 @@ from typing import List
 
 from pcluster.constants import CIDR_ALL_IPS, EBS_VOLUME_TYPE_IOPS_DEFAULT
 from pcluster.models.common import Param, Resource, Tag
-from pcluster.utils import error, get_supported_architectures_for_instance_type
+from pcluster.utils import error, get_region, get_supported_architectures_for_instance_type
 from pcluster.validators.cluster_validators import (
     ArchitectureOsValidator,
     DcvValidator,
@@ -707,3 +707,8 @@ class BaseCluster(Resource):
                 os=self.image.os,
                 architecture=self.head_node.architecture,
             )
+
+    @property
+    def region(self):
+        """Retrieve region from environment."""
+        return get_region()

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -33,6 +33,7 @@ from pcluster.validators.cluster_validators import (
     FsxArchitectureOsValidator,
     FsxNetworkingValidator,
     NumberOfStorageValidator,
+    QueueNameValidator,
     SimultaneousMultithreadingArchitectureValidator,
     TagKeyValidator,
 )
@@ -447,6 +448,9 @@ class BaseQueue(Resource):
         self.networking = networking
         self.storage = storage
         self.compute_type = Param(compute_type, default="ONDEMAND")
+
+    def _register_validators(self):
+        self._add_validator(QueueNameValidator, name=self.name)
 
 
 class CommonSchedulingSettings(Resource):

--- a/cli/src/pcluster/models/cluster_awsbatch.py
+++ b/cli/src/pcluster/models/cluster_awsbatch.py
@@ -28,8 +28,9 @@ from pcluster.models.common import Param
 from pcluster.validators.awsbatch_validators import (
     AwsbatchComputeInstanceTypeValidator,
     AwsbatchInstancesArchitectureCompatibilityValidator,
+    AwsbatchRegionValidator,
 )
-from pcluster.validators.cluster_validators import EfaOsArchitectureValidator
+from pcluster.validators.cluster_validators import EfaOsArchitectureValidator, SchedulerOsValidator
 
 
 class AwsbatchComputeResource(BaseComputeResource):
@@ -92,6 +93,9 @@ class AwsbatchCluster(BaseCluster):
         self.scheduling = scheduling
 
     def _register_validators(self):
+        self._add_validator(AwsbatchRegionValidator, region=self.region)
+        self._add_validator(SchedulerOsValidator, scheduler=self.scheduling.scheduler, os=self.image.os)
+
         for queue in self.scheduling.queues:
             for compute_resource in queue.compute_resources:
                 self._add_validator(

--- a/cli/src/pcluster/models/cluster_slurm.py
+++ b/cli/src/pcluster/models/cluster_slurm.py
@@ -28,6 +28,7 @@ from pcluster.models.common import Param
 from pcluster.validators.cluster_validators import (
     EfaOsArchitectureValidator,
     InstanceArchitectureCompatibilityValidator,
+    SchedulerOsValidator,
 )
 from pcluster.validators.ec2_validators import InstanceTypeValidator
 
@@ -94,6 +95,8 @@ class SlurmCluster(BaseCluster):
         self.scheduling = scheduling
 
     def _register_validators(self):
+        self._add_validator(SchedulerOsValidator, scheduler=self.scheduling.scheduler, os=self.image.os)
+
         for queue in self.scheduling.queues:
             for compute_resource in queue.compute_resources:
                 self._add_validator(

--- a/cli/src/pcluster/models/cluster_slurm.py
+++ b/cli/src/pcluster/models/cluster_slurm.py
@@ -51,6 +51,8 @@ class SlurmComputeResource(BaseComputeResource):
         self.max_count = Param(max_count, default=10)
         self.min_count = Param(min_count, default=0)
         self.spot_price = Param(spot_price)
+
+    def _register_validators(self):
         self._add_validator(InstanceTypeValidator, instance_type=self.instance_type)
 
 

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -18,7 +18,6 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List
 
-
 # ----------------- Params ----------------- #
 
 

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List
 
+
 # ----------------- Params ----------------- #
 
 
@@ -172,7 +173,7 @@ class Resource(ABC):
 # ------------ Common resources between ImageBuilder an Cluster models ----------- #
 
 
-class Tag(Resource):
+class BaseTag(Resource):
     """Represent the Tag configuration."""
 
     def __init__(

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -127,6 +127,8 @@ class ChefCookbook(Resource):
         self.url = Param(url)
         self.json = Param(json)
         # TODO: add validator
+
+    def _register_validators(self):
         self._add_validator(UrlValidator, url=self.url)
 
 

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -16,7 +16,7 @@
 from typing import List
 
 from pcluster import utils
-from pcluster.models.common import Param, Resource, Tag
+from pcluster.models.common import BaseTag, Param, Resource
 from pcluster.validators.ebs_validators import EBSVolumeKmsKeyIdValidator, EbsVolumeTypeSizeValidator
 from pcluster.validators.ec2_validators import (
     BaseAMIValidator,
@@ -51,7 +51,7 @@ class Image(Resource):
         self,
         name: str,
         description: str = None,
-        tags: List[Tag] = None,
+        tags: List[BaseTag] = None,
         root_volume: Volume = None,
     ):
         super().__init__()
@@ -65,7 +65,7 @@ class Image(Resource):
     def _set_default(self):
         if self.tags is None:
             self.tags = []
-        default_tag = Tag("PclusterVersion", utils.get_installed_version())
+        default_tag = BaseTag("PclusterVersion", utils.get_installed_version())
         default_tag.implied = True
         self.tags.append(default_tag)
 
@@ -92,7 +92,7 @@ class Build(Resource):
         parent_image: str,
         instance_role: str = None,  # TODO: auto generate if not assigned
         subnet_id: str = None,  # TODO: auto generate if not assigned
-        tags: List[Tag] = None,
+        tags: List[BaseTag] = None,
         security_group_ids: List[str] = None,
         components: List[Component] = None,
     ):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -438,7 +438,7 @@ class SlurmQueueSchema(_QueueSchema):
 class AwsbatchQueueSchema(_QueueSchema):
     """Represent the schema of a Batch Queue."""
 
-    compute_resources = fields.Nested(AwsbatchComputeResourceSchema, many=True)
+    compute_resources = fields.Nested(AwsbatchComputeResourceSchema, many=True, validate=validate.Length(equal=1))
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -483,7 +483,7 @@ class AwsbatchSchema(BaseSchema):
     """Represent the schema of the Awsbatch section."""
 
     settings = fields.Nested(AwsbatchSettingsSchema)
-    queues = fields.Nested(AwsbatchQueueSchema, many=True, required=True)
+    queues = fields.Nested(AwsbatchQueueSchema, many=True, required=True, validate=validate.Length(equal=1))
 
 
 class SchedulingSchema(BaseSchema):

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -17,7 +17,7 @@
 from marshmallow import Schema, fields, post_dump, post_load, pre_dump, validate
 
 from pcluster.constants import SUPPORTED_ARCHITECTURES
-from pcluster.models.cluster import Tag
+from pcluster.models.cluster import BaseTag
 from pcluster.models.common import Param
 
 ALLOWED_VALUES = {
@@ -110,4 +110,4 @@ class TagSchema(BaseSchema):
     @post_load
     def make_resource(self, data, **kwargs):
         """Generate resource."""
-        return Tag(**data)
+        return BaseTag(**data)

--- a/cli/src/pcluster/validators/awsbatch_validators.py
+++ b/cli/src/pcluster/validators/awsbatch_validators.py
@@ -19,6 +19,19 @@ from pcluster.utils import (
 )
 
 
+class AwsbatchRegionValidator(Validator):
+    """
+    AWS Batch region validator.
+
+    Validate if the region is supported by AWS Batch.
+    """
+
+    def _validate(self, region: str):
+        # TODO use dryrun
+        if region in ["ap-northeast-3"]:
+            self._add_failure(f"AWS Batch scheduler is not supported in the '{region}' region", FailureLevel.ERROR)
+
+
 class AwsbatchComputeResourceSizeValidator(Validator):
     """
     Awsbatch compute resource size validator.

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -415,3 +415,18 @@ class DcvValidator(Validator):
                     "It is recommended to restrict access.",
                     FailureLevel.WARNING,
                 )
+
+
+# --------------- Other validators --------------- #
+
+
+class TagKeyValidator(Validator):
+    """
+    Tag key validator.
+
+    Validate the tag key is not a reserved one.
+    """
+
+    def _validate(self, key: Param):
+        if key.value == "Version":
+            self._add_failure("The tag key 'Version' is a reserved one.", FailureLevel.ERROR, [key])

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -331,7 +331,7 @@ class NumberOfStorageValidator(Validator):
     Validate the number of storage specified is lower than maximum supported.
     """
 
-    def _validate(self, storage_type, max_number, storage_count):
+    def _validate(self, storage_type: str, max_number: int, storage_count: int):
         if storage_count > max_number:
             self._add_failure(
                 "Invalid number of shared storage of {0} type specified. "

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -17,7 +17,11 @@ from botocore.exceptions import ClientError
 from pcluster.constants import CIDR_ALL_IPS
 from pcluster.dcv.utils import get_supported_dcv_os
 from pcluster.models.common import FailureLevel, Param, Validator
-from pcluster.utils import get_supported_architectures_for_instance_type, get_supported_os_for_architecture
+from pcluster.utils import (
+    get_supported_architectures_for_instance_type,
+    get_supported_os_for_architecture,
+    get_supported_os_for_scheduler,
+)
 
 EFA_UNSUPPORTED_ARCHITECTURES_OSES = {
     "x86_64": [],
@@ -42,6 +46,23 @@ FSX_MESSAGES = {
         "fsx_fs_id.",
     }
 }
+
+
+class SchedulerOsValidator(Validator):
+    """
+    scheduler - os validator.
+
+    Validate os and scheduler combination.
+    """
+
+    def _validate(self, os: Param, scheduler: Param):
+        supported_os = get_supported_os_for_scheduler(scheduler.value)
+        if os.value not in supported_os:
+            self._add_failure(
+                f"{scheduler.value} scheduler supports the following Operating Systems: {supported_os}",
+                FailureLevel.ERROR,
+                [os],
+            )
 
 
 class ComputeResourceSizeValidator(Validator):

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -655,24 +655,6 @@ def test_efa_validator_with_vpc_security_group(
 
 
 @pytest.mark.parametrize(
-    "section_dict, expected_message",
-    [
-        (
-            {"initial_queue_size": "0", "maintain_initial_size": True},
-            "maintain_initial_size cannot be set to true if initial_queue_size is 0",
-        ),
-        (
-            {"scheduler": "awsbatch", "maintain_initial_size": True},
-            "maintain_initial_size is not supported when using awsbatch as scheduler",
-        ),
-    ],
-)
-def test_maintain_initial_size_validator(mocker, section_dict, expected_message):
-    config_parser_dict = {"cluster default": section_dict}
-    utils.assert_param_validator(mocker, config_parser_dict, expected_message)
-
-
-@pytest.mark.parametrize(
     "cluster_section_dict, expected_message",
     [
         # SIT cluster, perfectly fine

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -9,7 +9,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import datetime
-import os
 import re
 
 import configparser
@@ -159,68 +158,6 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
         "ebs default": {"shared_dir": "test", "ebs_volume_id": "vol-12345678"},
     }
     utils.assert_param_validator(mocker, config_parser_dict)
-
-
-@pytest.mark.parametrize(
-    "region, base_os, scheduler, expected_message",
-    [
-        # verify awsbatch supported regions
-        ("ap-northeast-3", "alinux", "awsbatch", "scheduler is not supported in the .* region"),
-        ("us-gov-east-1", "alinux", "awsbatch", None),
-        ("us-gov-west-1", "alinux", "awsbatch", None),
-        ("eu-west-1", "alinux", "awsbatch", None),
-        ("us-east-1", "alinux", "awsbatch", None),
-        ("eu-north-1", "alinux", "awsbatch", None),
-        ("cn-north-1", "alinux", "awsbatch", None),
-        ("cn-northwest-1", "alinux", "awsbatch", None),
-        ("cn-northwest-1", "alinux2", "awsbatch", None),
-        # verify traditional schedulers are supported in all the regions
-        ("cn-northwest-1", "alinux", "sge", None),
-        ("ap-northeast-3", "alinux", "sge", None),
-        ("cn-northwest-1", "alinux", "slurm", None),
-        ("ap-northeast-3", "alinux", "slurm", None),
-        ("cn-northwest-1", "alinux", "torque", None),
-        ("ap-northeast-3", "alinux", "torque", None),
-        # verify awsbatch supported OSes
-        ("eu-west-1", "centos7", "awsbatch", "scheduler supports the following Operating Systems"),
-        ("eu-west-1", "centos8", "awsbatch", "scheduler supports the following Operating Systems"),
-        ("eu-west-1", "ubuntu1604", "awsbatch", "scheduler supports the following Operating Systems"),
-        ("eu-west-1", "ubuntu1804", "awsbatch", "scheduler supports the following Operating Systems"),
-        ("eu-west-1", "alinux", "awsbatch", None),
-        ("eu-west-1", "alinux2", "awsbatch", None),
-        # verify sge supports all the OSes
-        ("eu-west-1", "centos7", "sge", None),
-        ("eu-west-1", "centos8", "sge", None),
-        ("eu-west-1", "ubuntu1604", "sge", None),
-        ("eu-west-1", "ubuntu1804", "sge", None),
-        ("eu-west-1", "alinux", "sge", None),
-        ("eu-west-1", "alinux2", "sge", None),
-        # verify slurm supports all the OSes
-        ("eu-west-1", "centos7", "slurm", None),
-        ("eu-west-1", "centos8", "slurm", None),
-        ("eu-west-1", "ubuntu1604", "slurm", None),
-        ("eu-west-1", "ubuntu1804", "slurm", None),
-        ("eu-west-1", "alinux", "slurm", None),
-        ("eu-west-1", "alinux2", "slurm", None),
-        # verify torque supports all the OSes
-        ("eu-west-1", "centos7", "torque", None),
-        ("eu-west-1", "centos8", "torque", None),
-        ("eu-west-1", "ubuntu1604", "torque", None),
-        ("eu-west-1", "ubuntu1804", "torque", None),
-        ("eu-west-1", "alinux", "torque", None),
-        ("eu-west-1", "alinux2", "torque", None),
-    ],
-)
-def test_scheduler_validator(mocker, capsys, region, base_os, scheduler, expected_message):
-    # we need to set the region in the environment because it takes precedence respect of the config file
-    os.environ["AWS_DEFAULT_REGION"] = region
-    config_parser_dict = {"cluster default": {"base_os": base_os, "scheduler": scheduler}}
-    # Deprecation warning should be printed for sge and torque
-    expected_warning = None
-    wiki_url = "https://github.com/aws/aws-parallelcluster/wiki/Deprecation-of-SGE-and-Torque-in-ParallelCluster"
-    if scheduler in ["sge", "torque"]:
-        expected_warning = ".{0}. is scheduled to be deprecated.*{1}".format(scheduler, wiki_url)
-    utils.assert_param_validator(mocker, config_parser_dict, expected_message, capsys, expected_warning)
 
 
 def test_placement_group_validator(mocker, boto3_stubber):

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -103,21 +103,6 @@ def test_ec2_ami_validator(mocker, boto3_stubber, image_architecture, bad_ami_me
     utils.assert_param_validator(mocker, config_parser_dict, expected_message)
 
 
-@pytest.mark.parametrize(
-    "section_dict, expected_message",
-    [
-        ({"tags": {"key": "value", "key2": "value2"}}, None),
-        (
-            {"tags": {"key": "value", "Version": "value2"}},
-            r"Version.*reserved",
-        ),
-    ],
-)
-def test_tags_validator(mocker, capsys, section_dict, expected_message):
-    config_parser_dict = {"cluster default": section_dict}
-    utils.assert_param_validator(mocker, config_parser_dict, expected_error=expected_message)
-
-
 def test_ec2_volume_validator(mocker, boto3_stubber):
     describe_volumes_response = {
         "Volumes": [

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -68,7 +68,7 @@ Scheduling:
           Proxy:
             HttpProxyAddress: String  # https://proxy-address:port
         ComputeResources:  # this maps to a Batch compute environment (initially we support only 1)
-          - InstanceType: optimal
+          - InstanceType: optimal,c4.xlarge,c5.large
             MinvCpus: 0  # 0
             DesiredvCpus: 10
             MaxvCpus: 20
@@ -78,15 +78,6 @@ Scheduling:
               Enabled: true  # true
               GdrSupport: true  # false
             #AllocationStrategy: String
-          - InstanceType: c4.xlarge,c5.large
-          - InstanceType: c5,c4
-      - Name: queue2
-        Networking:
-          SubnetIds:
-            - subnet-12345678
-        ComputeResources:
-          - InstanceType: c5.xlarge
-          - InstanceType: c4.xlarge
 SharedStorage:
   - MountDir: /my/mount/point
     EBS:

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -151,6 +151,18 @@ def test_awsbatch_compute_resource_validator(section_dict, expected_message):
 
 
 @pytest.mark.parametrize(
+    "section_dict, expected_message",
+    [
+        ({"ComputeResources": []}, "Length must be 1"),
+        ({"ComputeResources": [{"InstanceType": "c5.xlarge"}]}, None),
+        ({"ComputeResources": [{"InstanceType": "c5.xlarge"}, {"InstanceType": "c4.xlarge"}]}, "Length must be 1"),
+    ],
+)
+def test_awsbatch_queue_validator(section_dict, expected_message):
+    _validate_and_assert_error(AwsbatchQueueSchema(), section_dict, expected_message)
+
+
+@pytest.mark.parametrize(
     "custom_ami, expected_message",
     [
         ("", "does not match expected pattern"),

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -403,26 +403,11 @@ def test_efs_throughput_mode_provisioned_throughput_validator(section_dict, expe
         ({"ImportedFileChunkSize": "NONE"}, "Not a valid integer"),
         ({"ImportedFileChunkSize": "wrong_value"}, "Not a valid integer"),
         ({"ImportedFileChunkSize": 3}, None),
-        (
-            {"ImportedFileChunkSize": 0},
-            "has a minimum size of 1 MiB, and max size of 512,000 MiB",
-        ),
-        (
-            {"ImportedFileChunkSize": 1},
-            None,
-        ),
-        (
-            {"ImportedFileChunkSize": 10},
-            None,
-        ),
-        (
-            {"ImportedFileChunkSize": 512000},
-            None,
-        ),
-        (
-            {"ImportedFileChunkSize": 512001},
-            "has a minimum size of 1 MiB, and max size of 512,000 MiB",
-        ),
+        ({"ImportedFileChunkSize": 0}, "has a minimum size of 1 MiB, and max size of 512,000 MiB"),
+        ({"ImportedFileChunkSize": 1}, None),
+        ({"ImportedFileChunkSize": 10}, None),
+        ({"ImportedFileChunkSize": 512000}, None),
+        ({"ImportedFileChunkSize": 512001}, "has a minimum size of 1 MiB, and max size of 512,000 MiB"),
         # TODO add regex for export path
         ({"ExportPath": ""}, None),
         ({"ExportPath": "fake_value"}, None),
@@ -455,14 +440,8 @@ def test_efs_throughput_mode_provisioned_throughput_validator(section_dict, expe
         ({"DailyAutomaticBackupStartTime": ""}, "does not match expected pattern"),
         ({"DailyAutomaticBackupStartTime": "01:00"}, None),
         ({"DailyAutomaticBackupStartTime": "23:00"}, None),
-        (
-            {"DailyAutomaticBackupStartTime": "25:00"},
-            "does not match expected pattern",
-        ),
-        (
-            {"DailyAutomaticBackupStartTime": "2300"},
-            "does not match expected pattern",
-        ),
+        ({"DailyAutomaticBackupStartTime": "25:00"}, "does not match expected pattern"),
+        ({"DailyAutomaticBackupStartTime": "2300"}, "does not match expected pattern"),
         ({"AutomaticBackupRetentionDays": ""}, "Not a valid integer"),
         ({"AutomaticBackupRetentionDays": 0}, None),
         ({"AutomaticBackupRetentionDays": 35}, None),
@@ -472,28 +451,16 @@ def test_efs_throughput_mode_provisioned_throughput_validator(section_dict, expe
         ({"CopyTagsToBackups": True}, None),
         ({"CopyTagsToBackups": False}, None),
         ({"BackupId": ""}, "does not match expected pattern"),
-        (
-            {"BackupId": "back-0a1b2c3d4e5f6a7b8"},
-            "does not match expected pattern",
-        ),
-        (
-            {"BackupId": "backup-0A1B2C3d4e5f6a7b8"},
-            "does not match expected pattern",
-        ),
+        ({"BackupId": "back-0a1b2c3d4e5f6a7b8"}, "does not match expected pattern"),
+        ({"BackupId": "backup-0A1B2C3d4e5f6a7b8"}, "does not match expected pattern"),
         ({"BackupId": "backup-0a1b2c3d4e5f6a7b8"}, None),
         ({"AutoImportPolicy": "NEW"}, None),
         ({"AutoImportPolicy": "NEW_CHANGED"}, None),
         ({"StorageType": "SSD"}, None),
         ({"StorageType": "HDD"}, None),
-        (
-            {"StorageType": "INVALID_VALUE"},
-            "Must be one of",
-        ),
+        ({"StorageType": "INVALID_VALUE"}, "Must be one of"),
         ({"DriveCacheType": "READ"}, None),
-        (
-            {"DriveCacheType": "INVALID_VALUE"},
-            "Must be one of",
-        ),
+        ({"DriveCacheType": "INVALID_VALUE"}, "Must be one of"),
         ({"invalid_key": "fake_value"}, "Unknown field"),
     ],
 )

--- a/cli/tests/pcluster/validators/test_awsbatch_validators.py
+++ b/cli/tests/pcluster/validators/test_awsbatch_validators.py
@@ -16,9 +16,22 @@ from pcluster.validators.awsbatch_validators import (
     AwsbatchComputeInstanceTypeValidator,
     AwsbatchComputeResourceSizeValidator,
     AwsbatchInstancesArchitectureCompatibilityValidator,
+    AwsbatchRegionValidator,
 )
 
 from .utils import assert_failure_messages, mock_instance_type_info
+
+
+@pytest.mark.parametrize(
+    "region, expected_message",
+    [
+        ("eu-west-1", None),
+        ("ap-northeast-3", "AWS Batch scheduler is not supported in the .* region"),
+    ],
+)
+def test_awsbatch_region_validator(region, expected_message):
+    actual_failures = AwsbatchRegionValidator().execute(region)
+    assert_failure_messages(actual_failures, expected_message)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -25,6 +25,7 @@ from pcluster.validators.cluster_validators import (
     NumberOfStorageValidator,
     SchedulerOsValidator,
     SimultaneousMultithreadingArchitectureValidator,
+    TagKeyValidator,
 )
 from tests.common import MockedBoto3Request
 from tests.pcluster.validators.utils import assert_failure_messages
@@ -488,4 +489,19 @@ def test_dcv_validator(dcv_enabled, os, instance_type, allowed_ips, port, expect
         Param(os),
         "x86_64" if instance_type.startswith("t2") else "arm64",
     )
+    assert_failure_messages(actual_failures, expected_message)
+
+
+# -------------- Other validators -------------- #
+
+
+@pytest.mark.parametrize(
+    "key, expected_message",
+    [
+        ("key1", None),
+        ("Version", "The tag key 'Version' is a reserved one"),
+    ],
+)
+def test_tags_validator(key, expected_message):
+    actual_failures = TagKeyValidator().execute(Param(key))
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -23,6 +23,7 @@ from pcluster.validators.cluster_validators import (
     FsxNetworkingValidator,
     InstanceArchitectureCompatibilityValidator,
     NumberOfStorageValidator,
+    QueueNameValidator,
     SchedulerOsValidator,
     SimultaneousMultithreadingArchitectureValidator,
     TagKeyValidator,
@@ -165,6 +166,24 @@ def test_instance_architecture_compatibility_validator(
     actual_failures = InstanceArchitectureCompatibilityValidator().execute(
         Param(compute_instance_type), head_node_architecture
     )
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "name, expected_message",
+    [
+        ("default", "forbidden"),
+        ("1queue", "must begin with a letter"),
+        ("queue_1", "only contain lowercase letters, digits and hyphens"),
+        ("aQUEUEa", "only contain lowercase letters, digits and hyphens"),
+        ("queue1!2", "only contain lowercase letters, digits and hyphens"),
+        ("my-default-queue2", None),
+        ("queue-123456789abcdefghijklmnop", "can be at most 30 chars long"),
+        ("queue-123456789abcdefghijklmno", None),
+    ],
+)
+def test_queue_name_validator(name, expected_message):
+    actual_failures = QueueNameValidator().execute(Param(name))
     assert_failure_messages(actual_failures, expected_message)
 
 

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -23,6 +23,7 @@ from pcluster.validators.cluster_validators import (
     FsxNetworkingValidator,
     InstanceArchitectureCompatibilityValidator,
     NumberOfStorageValidator,
+    SchedulerOsValidator,
     SimultaneousMultithreadingArchitectureValidator,
 )
 from tests.common import MockedBoto3Request
@@ -32,6 +33,24 @@ from tests.pcluster.validators.utils import assert_failure_messages
 @pytest.fixture()
 def boto3_stubber_path():
     return "pcluster.validators.cluster_validators.boto3"
+
+
+@pytest.mark.parametrize(
+    "os, scheduler, expected_message",
+    [
+        ("centos7", "slurm", None),
+        ("centos8", "slurm", None),
+        ("ubuntu1804", "slurm", None),
+        ("alinux2", "slurm", None),
+        ("centos7", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("centos8", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("ubuntu1804", "awsbatch", "scheduler supports the following Operating Systems"),
+        ("alinux2", "awsbatch", None),
+    ],
+)
+def test_scheduler_os_validator(os, scheduler, expected_message):
+    actual_failures = SchedulerOsValidator().execute(Param(os), Param(scheduler))
+    assert_failure_messages(actual_failures, expected_message)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Migrate scheduler validator
* The region check has been moved in a specific validator: AwsbatchRegionValidator
* The scheduler - os combination check is now in the SchedulerOsValidator
* Splitted tests and remove alinux and ubuntu1604 checks.
* Removed from mappings.
* Removed sge and torque deprecation check.

## Migrate queue name validator and remove settings validator
Check for length and format.
In the new configuration file format there are no settings parameters and label to be checked.


## Remove already migrated efs validator 
This test is done in the schema

## Remove maintain initial size validator
Both initial_count and maintain_initial_size parameter have been deprecated.
It's still possible to configure the initial static capacity (min_count) to be
launched with the cluster.

## Migrate EFS id validator
* Added availability zone attribute to head node networking
* There were no existing tests, still TODO

## Migrate tag validator
* Define a new Tag class in the cluster model to differentiate
  behaviour from the BaseTag class used in the imagebuilder model.
* Migrate tests

## Add recursive call for nested resources validators
All the failures of the nested children will be collected by the parent resource.
Add new tests for the model.


## Other changes
* Limit number of queues and compute resources for AWS Batch
* Add missing register validator calls 