### PR TITLE
integ-test: fix weekly maintenance time start time format

### DIFF
--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -78,7 +78,7 @@ def test_fsx_lustre_configuration_options(
     bucket_name = s3_bucket_factory()
     bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
     bucket.upload_file(str(test_datadir / "s3_test_file"), "s3_test_file")
-    weekly_maintenance_start_time = (datetime.datetime.utcnow() + datetime.timedelta(minutes=60)).strftime("%w:%H:%M")
+    weekly_maintenance_start_time = (datetime.datetime.utcnow() + datetime.timedelta(minutes=60)).strftime("%u:%H:%M")
     cluster_config = pcluster_config_reader(
         bucket_name=bucket_name,
         mount_dir=mount_dir,


### PR DESCRIPTION
Failed test uses datatime.strftime() to generate the weekly_maintenance_start_time
%w - day of the week as a decimal, Sunday=0
%u - weekday as a number (1 to 7), Monday=1. Warning: In Sun Solaris Sunday=1
The weekly_maintenance_start_time accepts regex ^[1-7]:([0:1]\\d|2[0-3]):([0-5]\\d)$, so change format %w to %u

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
