### PR TITLE
3.0: Add support for DevSettings for cluster and uniform namings with imagebuilder

### DIFF
--- a/cli/src/common/utils.py
+++ b/cli/src/common/utils.py
@@ -25,6 +25,7 @@ def load_yaml_dict(config_file):
     """Read the content of a yaml file."""
     with open(config_file) as conf_file:
         yaml_content = yaml.load(conf_file, Loader=yaml.SafeLoader)
+    # TODO prevent yaml.load from converting 1:00:00 to int 3600
 
     # TODO use from cfn_flip import load_yaml
     return yaml_content

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -16,7 +16,7 @@ from enum import Enum
 from typing import List
 
 from pcluster.constants import CIDR_ALL_IPS, EBS_VOLUME_TYPE_IOPS_DEFAULT
-from pcluster.models.common import BaseTag, Resource
+from pcluster.models.common import BaseDevSettings, BaseTag, Resource
 from pcluster.utils import (
     error,
     get_availability_zone_of_subnet,
@@ -651,6 +651,18 @@ class AdditionalPackages(Resource):
         self.intel_select_solutions = intel_select_solutions
 
 
+class ClusterDevSettings(BaseDevSettings):
+    """Represent the dev settings configuration."""
+
+    def __init__(self, cluster_template: str = None, **kwargs):
+        super().__init__(**kwargs)
+        self.cluster_template = Resource.init_param(cluster_template)
+
+    def _register_validators(self):
+        super()._register_validators()
+        self._add_validator(UrlValidator, url=self.cluster_template)
+
+
 # ---------------------- Root resource ---------------------- #
 
 
@@ -669,6 +681,7 @@ class BaseCluster(Resource):
         custom_actions: CustomAction = None,
         cluster_s3_bucket: str = None,
         additional_resources: str = None,
+        dev_settings: ClusterDevSettings = None,
     ):
         super().__init__()
         self.image = image
@@ -681,6 +694,7 @@ class BaseCluster(Resource):
         self.custom_actions = custom_actions
         self.cluster_s3_bucket = cluster_s3_bucket
         self.additional_resources = additional_resources
+        self.dev_settings = dev_settings
 
     def _register_validators(self):
         self._add_validator(

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -16,14 +16,13 @@
 from typing import List
 
 from pcluster import utils
-from pcluster.models.common import BaseTag, Resource
+from pcluster.models.common import BaseDevSettings, BaseTag, Resource
 from pcluster.validators.ebs_validators import EBSVolumeKmsKeyIdValidator, EbsVolumeTypeSizeValidator
 from pcluster.validators.ec2_validators import (
     BaseAMIValidator,
     InstanceTypeBaseAMICompatibleValidator,
     InstanceTypeValidator,
 )
-from pcluster.validators.s3_validators import UrlValidator
 
 # ---------------------- Image ---------------------- #
 
@@ -119,44 +118,22 @@ class Build(Resource):
 # ---------------------- Dev Settings ---------------------- #
 
 
-class ChefCookbook(Resource):
-    """Represent the chef cookbook configuration for the ImageBuilder."""
-
-    def __init__(self, url: str, json: str):
-        super().__init__()
-        self.url = Resource.init_param(url)
-        self.json = Resource.init_param(json)
-        # TODO: add validator
-
-    def _register_validators(self):
-        self._add_validator(UrlValidator, url=self.url)
-
-
-class DevSettings(Resource):
+class ImagebuilderDevSettings(BaseDevSettings):
     """Represent the dev settings configuration for the ImageBuilder."""
 
     def __init__(
         self,
         update_os_and_reboot: bool = None,
         disable_pcluster_component: bool = None,
-        chef_cookbook: ChefCookbook = None,
-        node_url: str = None,
-        aws_batch_cli_url: str = None,
         distribution_configuration_arn: str = None,
         terminate_instance_on_failure: bool = None,
+        **kwargs
     ):
-        super().__init__()
+        super().__init__(**kwargs)
         self.update_os_and_reboot = Resource.init_param(update_os_and_reboot, default=False)
         self.disable_pcluster_component = Resource.init_param(disable_pcluster_component, default=False)
-        self.chef_cookbook = chef_cookbook
-        self.node_url = Resource.init_param(node_url)
-        self.aws_batch_cli_url = Resource.init_param(aws_batch_cli_url)
         self.distribution_configuration_arn = Resource.init_param(distribution_configuration_arn)
         self.terminate_instance_on_failure = Resource.init_param(terminate_instance_on_failure, default=True)
-
-    def _register_validators(self):
-        self._add_validator(UrlValidator, url=self.node_url)
-        self._add_validator(UrlValidator, url=self.aws_batch_cli_url)
 
 
 # ---------------------- ImageBuilder ---------------------- #
@@ -169,7 +146,7 @@ class ImageBuilder(Resource):
         self,
         image: Image,
         build: Build,
-        dev_settings: DevSettings = None,
+        dev_settings: ImagebuilderDevSettings = None,
     ):
         super().__init__()
         self.image = image

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -37,12 +37,12 @@ class ImageBuilderStack(core.Stack):
         # TODO: use attributes from imagebuilder config instead of using these static variables.
         core.CfnParameter(self, "EnableNvidia", type="String", default="false", description="EnableNvidia")
         core.CfnParameter(self, "EnableDCV", type="String", default="false", description="EnableDCV")
-        default_node_url = dev_settings.node_url if dev_settings and dev_settings.node_url else ""
+        default_node_package = dev_settings.node_package if dev_settings and dev_settings.node_package else ""
         core.CfnParameter(
             self,
             "CustomNodePackage",
             type="String",
-            default=default_node_url,
+            default=default_node_package,
             description="CustomNodePackage",
         )
         core.CfnParameter(

--- a/cli/src/pcluster/validators/awsbatch_validators.py
+++ b/cli/src/pcluster/validators/awsbatch_validators.py
@@ -9,7 +9,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pcluster.models.common import FailureLevel, Validator
 from pcluster.utils import (
     InstanceTypeInfo,
     get_region,
@@ -17,6 +16,7 @@ from pcluster.utils import (
     get_supported_batch_instance_types,
     is_instance_type_format,
 )
+from pcluster.validators.common import FailureLevel, Validator
 
 
 class AwsbatchRegionValidator(Validator):

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -15,7 +15,6 @@ from botocore.exceptions import ClientError
 
 from pcluster.constants import CIDR_ALL_IPS
 from pcluster.dcv.utils import get_supported_dcv_os
-from pcluster.models.common import FailureLevel, Validator
 from pcluster.utils import (
     InstanceTypeInfo,
     get_efs_mount_target_id,
@@ -23,6 +22,7 @@ from pcluster.utils import (
     get_supported_os_for_architecture,
     get_supported_os_for_scheduler,
 )
+from pcluster.validators.common import FailureLevel, Validator
 
 QUEUE_NAME_MAX_LENGTH = 30
 QUEUE_NAME_REGEX = r"^[a-z][a-z0-9\-]*$"

--- a/cli/src/pcluster/validators/common.py
+++ b/cli/src/pcluster/validators/common.py
@@ -1,0 +1,68 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This module contains all the classes representing the Resources objects.
+# These objects are obtained from the configuration file through a conversion based on the Schema classes.
+#
+
+from abc import ABC, abstractmethod
+from enum import Enum
+
+
+class FailureLevel(Enum):
+    """Validation failure level."""
+
+    ERROR = 40
+    WARNING = 30
+    INFO = 20
+
+
+class ValidationResult:
+    """Represent the result of the validation."""
+
+    def __init__(self, message: str, level: FailureLevel):
+        self.message = message
+        self.level = level
+
+
+class ConfigValidationError(Exception):
+    """Configuration file validation error."""
+
+    def __init__(self, validation_result: ValidationResult):
+        message = f"{validation_result.level.name}: {validation_result.message}"
+        super().__init__(message)
+
+
+class Validator(ABC):
+    """Abstract validator. The children must implement the validate method."""
+
+    def __init__(self, raise_on_error=False):
+        self._failures = []
+        self._raise_on_error = raise_on_error
+
+    def _fail(self, message, level):
+        raise ConfigValidationError
+
+    def _add_failure(self, message: str, level: FailureLevel):
+        result = ValidationResult(message, level)
+        if self._raise_on_error:
+            raise ConfigValidationError(result)
+        self._failures.append(result)
+
+    def execute(self, *arg, **kwargs):
+        """Entry point of all validators to verify all input params are valid."""
+        self._validate(*arg, **kwargs)
+        return self._failures
+
+    @abstractmethod
+    def _validate(self, *args, **kwargs):
+        """Must be implemented with specific validation logic."""
+        pass

--- a/cli/src/pcluster/validators/ebs_validators.py
+++ b/cli/src/pcluster/validators/ebs_validators.py
@@ -15,8 +15,8 @@ from pcluster.config.validators import (
     EBS_VOLUME_TYPE_TO_IOPS_RATIO,
     EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS,
 )
-from pcluster.models.common import FailureLevel, Validator
 from pcluster.utils import get_ebs_snapshot_info, get_partition
+from pcluster.validators.common import FailureLevel, Validator
 
 
 class EbsVolumeTypeSizeValidator(Validator):

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -12,8 +12,8 @@ from common.boto3.common import AWSClientError
 from common.boto3.ec2 import Ec2Client
 from common.boto3.iam import IamClient
 from pcluster import utils
-from pcluster.models.common import FailureLevel, Validator
 from pcluster.utils import policy_name_to_arn
+from pcluster.validators.common import FailureLevel, Validator
 
 
 class BaseAMIValidator(Validator):

--- a/cli/src/pcluster/validators/fsx_validators.py
+++ b/cli/src/pcluster/validators/fsx_validators.py
@@ -13,8 +13,8 @@ from botocore.exceptions import ClientError
 
 from pcluster.config.validators import get_bucket_name_from_s3_url
 from pcluster.constants import FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT
-from pcluster.models.common import FailureLevel, Validator
 from pcluster.utils import get_region
+from pcluster.validators.common import FailureLevel, Validator
 
 
 class FsxS3Validator(Validator):

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -13,7 +13,7 @@ from typing import List
 import boto3
 from botocore.exceptions import ClientError
 
-from pcluster.models.common import FailureLevel, Validator
+from pcluster.validators.common import FailureLevel, Validator
 
 
 class SecurityGroupsValidator(Validator):

--- a/cli/src/pcluster/validators/s3_validators.py
+++ b/cli/src/pcluster/validators/s3_validators.py
@@ -6,7 +6,7 @@ from urllib.request import urlopen
 from botocore.exceptions import ClientError
 
 from common.boto3.s3 import S3Client
-from pcluster.models.common import FailureLevel, Validator
+from pcluster.validators.common import FailureLevel, Validator
 
 
 class UrlValidator(Validator):

--- a/cli/tests/pcluster/models/imagebuilder_dummy_model.py
+++ b/cli/tests/pcluster/models/imagebuilder_dummy_model.py
@@ -9,9 +9,9 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pcluster.models.imagebuilder import Build, DevSettings
+from pcluster.models.imagebuilder import Build
 from pcluster.models.imagebuilder import Image as ImageBuilderImage
-from pcluster.models.imagebuilder import ImageBuilder
+from pcluster.models.imagebuilder import ImageBuilder, ImagebuilderDevSettings
 
 
 def dummy_imagebuilder(is_official_ami_build):
@@ -21,8 +21,8 @@ def dummy_imagebuilder(is_official_ami_build):
         build = Build(
             instance_type="c5.xlarge", parent_image="arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x"
         )
-        dev_settings = DevSettings(update_os_and_reboot=True)
+        dev_settings = ImagebuilderDevSettings(update_os_and_reboot=True)
     else:
         build = Build(instance_type="g4dn.xlarge", parent_image="ami-0185634c5a8a37250")
-        dev_settings = DevSettings()
+        dev_settings = ImagebuilderDevSettings()
     return ImageBuilder(image=image, build=build, dev_settings=dev_settings)

--- a/cli/tests/pcluster/models/test_cluster_model.py
+++ b/cli/tests/pcluster/models/test_cluster_model.py
@@ -14,7 +14,7 @@ from typing import List
 from assertpy import assert_that
 
 from pcluster.models.cluster import Resource
-from pcluster.models.common import FailureLevel, Validator
+from pcluster.validators.common import FailureLevel, Validator
 
 
 class FakeInfoValidator(Validator):

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.simple.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.simple.yaml
@@ -144,3 +144,11 @@ CustomActions:
     RunAs: String
 ClusterS3Bucket: String
 AdditionalResources: String  # https://template.url
+DevSettings:
+  ClusterTemplate: file:///tests/aws-parallelcluster-template-3.0.tgz
+  Cookbook:
+    ChefCookbook: file:///tests/aws-parallelcluster-cookbook-3.0.tgz
+    ExtraChefAttributes: |
+      {"cluster": {"cfn_scheduler_slots": "cores"}}
+  AwsBatchCliPackage: s3://test/aws-parallelcluster-batch-3.0.tgz
+  NodePackage: s3://test/aws-parallelcluster-node-3.0.tgz

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
@@ -37,11 +37,11 @@ Build:
 DevSettings:
   UpdateOsAndReboot: True
   DisablePclusterComponent: False
-  ChefCookbook:
-    Url: file:///tests/aws-parallelcluster-cookbook-3.0.tgz
-    Json: |
+  Cookbook:
+    ChefCookbook: file:///tests/aws-parallelcluster-cookbook-3.0.tgz
+    ExtraChefAttributes: |
       {"cluster": {"cfn_scheduler_slots": "cores"}}
-  NodeUrl: s3://test/aws-parallelcluster-node-3.0.tgz
-  AWSBatchCliUrl: s3://test/aws-parallelcluster-batch-3.0.tgz
+  NodePackage: s3://test/aws-parallelcluster-node-3.0.tgz
+  AwsBatchCliPackage: s3://test/aws-parallelcluster-batch-3.0.tgz
   DistributionConfigurationArn: arn:aws:imagebuilder:us-east-1:aws:distributionconfiguration/amazon-cloudwatch-agent-linux/1.0.0
   TerminateInstanceOnFailure: True


### PR DESCRIPTION
To import validators inside `models/common.oy`, this commit also separate the module into `models/common.py`, `models/param.py`, `validators/common.py` to avoid circular import.

Fix an infinite reference (`restore_child` in cluster_schema.py) crashing Python when debug. The code ran finely without debug. However, when debugging, the original code would fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
