### PR TITLE
3.0: Encapsulate Params metadata in Resource classes

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -12,12 +12,11 @@
 # This module contains all the classes representing the Resources objects.
 # These objects are obtained from the configuration file through a conversion based on the Schema classes.
 #
-
 from enum import Enum
 from typing import List
 
 from pcluster.constants import CIDR_ALL_IPS, EBS_VOLUME_TYPE_IOPS_DEFAULT
-from pcluster.models.common import BaseTag, Param, Resource
+from pcluster.models.common import BaseTag, Resource
 from pcluster.utils import (
     error,
     get_availability_zone_of_subnet,
@@ -78,12 +77,12 @@ class Ebs(Resource):
         throughput: int = None,
     ):
         super().__init__()
-        self.volume_type = Param(volume_type, default="gp2")
-        self.iops = Param(iops, default=EBS_VOLUME_TYPE_IOPS_DEFAULT.get(self.volume_type.value))
-        self.size = Param(size, default=20)
-        self.encrypted = Param(encrypted, default=False)
-        self.kms_key_id = Param(kms_key_id)
-        self.throughput = Param(throughput, default=125 if self.volume_type.value == "gp3" else None)
+        self.volume_type = Resource.init_param(volume_type, default="gp2")
+        self.iops = Resource.init_param(iops, default=EBS_VOLUME_TYPE_IOPS_DEFAULT.get(self.volume_type))
+        self.size = Resource.init_param(size, default=20)
+        self.encrypted = Resource.init_param(encrypted, default=False)
+        self.kms_key_id = Resource.init_param(kms_key_id)
+        self.throughput = Resource.init_param(throughput, default=125 if self.volume_type == "gp3" else None)
 
     def _register_validators(self):
         self._add_validator(
@@ -113,8 +112,8 @@ class Raid(Resource):
 
     def __init__(self, raid_type: int = None, number_of_volumes=None):
         super().__init__()
-        self.raid_type = Param(raid_type)
-        self.number_of_volumes = Param(number_of_volumes, default=2)
+        self.raid_type = Resource.init_param(raid_type)
+        self.number_of_volumes = Resource.init_param(number_of_volumes, default=2)
 
 
 class EphemeralVolume(Resource):
@@ -122,8 +121,8 @@ class EphemeralVolume(Resource):
 
     def __init__(self, encrypted: bool = None, mount_dir: str = None):
         super().__init__()
-        self.encrypted = Param(encrypted, default=False)
-        self.mount_dir = Param(mount_dir, default="/scratch")
+        self.encrypted = Resource.init_param(encrypted, default=False)
+        self.mount_dir = Resource.init_param(mount_dir, default="/scratch")
 
 
 class Storage(Resource):
@@ -131,7 +130,7 @@ class Storage(Resource):
 
     def __init__(self, root_volume: Ebs = None, ephemeral_volume: EphemeralVolume = None):
         super().__init__()
-        self.root_volume = Param(root_volume)
+        self.root_volume = Resource.init_param(root_volume)
         self.ephemeral_volume = ephemeral_volume
 
 
@@ -147,7 +146,7 @@ class SharedStorage(Resource):
 
     def __init__(self, mount_dir: str, shared_storage_type: Type):
         super().__init__()
-        self.mount_dir = Param(mount_dir)
+        self.mount_dir = Resource.init_param(mount_dir)
         self.shared_storage_type = shared_storage_type
 
 
@@ -169,8 +168,8 @@ class SharedEbs(SharedStorage, Ebs):
     ):
         SharedStorage.__init__(self, mount_dir=mount_dir, shared_storage_type=SharedStorage.Type.EBS)
         Ebs.__init__(self, volume_type, iops, size, encrypted, kms_key_id, throughput)
-        self.snapshot_id = Param(snapshot_id)
-        self.volume_id = Param(volume_id)
+        self.snapshot_id = Resource.init_param(snapshot_id)
+        self.volume_id = Resource.init_param(volume_id)
         self.raid = raid
 
 
@@ -188,12 +187,12 @@ class SharedEfs(SharedStorage):
         file_system_id: str = None,
     ):
         super().__init__(mount_dir=mount_dir, shared_storage_type=SharedStorage.Type.EFS)
-        self.encrypted = Param(encrypted, default=False)
-        self.kms_key_id = Param(kms_key_id)
-        self.performance_mode = Param(performance_mode, default="generalPurpose")
-        self.throughput_mode = Param(throughput_mode, default="bursting")
-        self.provisioned_throughput = Param(provisioned_throughput)
-        self.file_system_id = Param(file_system_id)
+        self.encrypted = Resource.init_param(encrypted, default=False)
+        self.kms_key_id = Resource.init_param(kms_key_id)
+        self.performance_mode = Resource.init_param(performance_mode, default="generalPurpose")
+        self.throughput_mode = Resource.init_param(throughput_mode, default="bursting")
+        self.provisioned_throughput = Resource.init_param(provisioned_throughput)
+        self.file_system_id = Resource.init_param(file_system_id)
 
 
 class SharedFsx(SharedStorage):
@@ -220,23 +219,23 @@ class SharedFsx(SharedStorage):
         storage_type: str = None,
     ):
         super().__init__(mount_dir=mount_dir, shared_storage_type=SharedStorage.Type.FSX)
-        self.storage_capacity = Param(storage_capacity)
-        self.storage_type = Param(storage_type)
-        self.deployment_type = Param(deployment_type)
-        self.export_path = Param(export_path)
-        self.import_path = Param(import_path)
-        self.imported_file_chunk_size = Param(imported_file_chunk_size)
-        self.weekly_maintenance_start_time = Param(weekly_maintenance_start_time)
-        self.automatic_backup_retention_days = Param(automatic_backup_retention_days)
-        self.copy_tags_to_backups = Param(copy_tags_to_backups)
-        self.daily_automatic_backup_start_time = Param(daily_automatic_backup_start_time)
-        self.per_unit_storage_throughput = Param(per_unit_storage_throughput)
-        self.backup_id = Param(backup_id)
-        self.kms_key_id = Param(kms_key_id)
-        self.file_system_id = Param(file_system_id)
-        self.auto_import_policy = Param(auto_import_policy)
-        self.drive_cache_type = Param(drive_cache_type)
-        self.storage_type = Param(storage_type)
+        self.storage_capacity = Resource.init_param(storage_capacity)
+        self.storage_type = Resource.init_param(storage_type)
+        self.deployment_type = Resource.init_param(deployment_type)
+        self.export_path = Resource.init_param(export_path)
+        self.import_path = Resource.init_param(import_path)
+        self.imported_file_chunk_size = Resource.init_param(imported_file_chunk_size)
+        self.weekly_maintenance_start_time = Resource.init_param(weekly_maintenance_start_time)
+        self.automatic_backup_retention_days = Resource.init_param(automatic_backup_retention_days)
+        self.copy_tags_to_backups = Resource.init_param(copy_tags_to_backups)
+        self.daily_automatic_backup_start_time = Resource.init_param(daily_automatic_backup_start_time)
+        self.per_unit_storage_throughput = Resource.init_param(per_unit_storage_throughput)
+        self.backup_id = Resource.init_param(backup_id)
+        self.kms_key_id = Resource.init_param(kms_key_id)
+        self.file_system_id = Resource.init_param(file_system_id)
+        self.auto_import_policy = Resource.init_param(auto_import_policy)
+        self.drive_cache_type = Resource.init_param(drive_cache_type)
+        self.storage_type = Resource.init_param(storage_type)
 
     def _register_validators(self):
         self._add_validator(
@@ -304,9 +303,9 @@ class _BaseNetworking(Resource):
         proxy: Proxy = None,
     ):
         super().__init__()
-        self.assign_public_ip = Param(assign_public_ip)
-        self.security_groups = Param(security_groups)
-        self.additional_security_groups = Param(additional_security_groups)
+        self.assign_public_ip = Resource.init_param(assign_public_ip)
+        self.security_groups = Resource.init_param(security_groups)
+        self.additional_security_groups = Resource.init_param(additional_security_groups)
         self.proxy = proxy
 
     def _register_validators(self):
@@ -319,8 +318,8 @@ class HeadNodeNetworking(_BaseNetworking):
 
     def __init__(self, subnet_id: str, elastic_ip: str = None, **kwargs):
         super().__init__(**kwargs)
-        self.subnet_id = Param(subnet_id)
-        self.elastic_ip = Param(elastic_ip)
+        self.subnet_id = Resource.init_param(subnet_id)
+        self.elastic_ip = Resource.init_param(elastic_ip)
 
     @property
     def availability_zone(self):
@@ -333,8 +332,8 @@ class PlacementGroup(Resource):
 
     def __init__(self, enabled: bool = None, id: str = None):
         super().__init__()
-        self.enabled = Param(enabled, default=False)
-        self.id = Param(id)
+        self.enabled = Resource.init_param(enabled, default=False)
+        self.id = Resource.init_param(id)
 
     def _register_validators(self):
         self._add_validator(PlacementGroupIdValidator, placement_group_id=self.id)
@@ -345,7 +344,7 @@ class QueueNetworking(_BaseNetworking):
 
     def __init__(self, subnet_ids: List[str], placement_group: PlacementGroup = None, **kwargs):
         super().__init__(**kwargs)
-        self.subnet_ids = Param(subnet_ids)
+        self.subnet_ids = Resource.init_param(subnet_ids)
         self.placement_group = placement_group
 
 
@@ -354,8 +353,8 @@ class Ssh(Resource):
 
     def __init__(self, key_name: str, allowed_ips: str = None):
         super().__init__()
-        self.key_name = Param(key_name)
-        self.allowed_ips = Param(allowed_ips, default=CIDR_ALL_IPS)
+        self.key_name = Resource.init_param(key_name)
+        self.allowed_ips = Resource.init_param(allowed_ips, default=CIDR_ALL_IPS)
 
     def _register_validators(self):
         self._add_validator(KeyPairValidator, key_name=self.key_name)
@@ -366,9 +365,9 @@ class Dcv(Resource):
 
     def __init__(self, enabled: bool, port: int = None, allowed_ips: str = None):
         super().__init__()
-        self.enabled = Param(enabled)
-        self.port = Param(port, default=8843)
-        self.allowed_ips = Param(allowed_ips, default=CIDR_ALL_IPS)
+        self.enabled = Resource.init_param(enabled)
+        self.port = Resource.init_param(port, default=8843)
+        self.allowed_ips = Resource.init_param(allowed_ips, default=CIDR_ALL_IPS)
 
 
 class Efa(Resource):
@@ -376,8 +375,8 @@ class Efa(Resource):
 
     def __init__(self, enabled: bool = None, gdr_support: bool = None):
         super().__init__()
-        self.enabled = Param(enabled, default=True)
-        self.gdr_support = Param(gdr_support, default=False)
+        self.enabled = Resource.init_param(enabled, default=True)
+        self.gdr_support = Resource.init_param(gdr_support, default=False)
 
 
 # ---------------------- Nodes ---------------------- #
@@ -388,8 +387,8 @@ class Image(Resource):
 
     def __init__(self, os: str, custom_ami: str = None):
         super().__init__()
-        self.os = Param(os)
-        self.custom_ami = Param(custom_ami)
+        self.os = Resource.init_param(os)
+        self.custom_ami = Resource.init_param(custom_ami)
 
 
 class HeadNode(Resource):
@@ -406,8 +405,8 @@ class HeadNode(Resource):
         efa: Efa = None,
     ):
         super().__init__()
-        self.instance_type = Param(instance_type)
-        self.simultaneous_multithreading = Param(simultaneous_multithreading, default=True)
+        self.instance_type = Resource.init_param(instance_type)
+        self.simultaneous_multithreading = Resource.init_param(simultaneous_multithreading, default=True)
         self.networking = networking
         self.ssh = ssh
         self.storage = storage
@@ -420,9 +419,9 @@ class HeadNode(Resource):
     @property
     def architecture(self):
         """Compute cluster's architecture based on its head node instance type."""
-        supported_architectures = get_supported_architectures_for_instance_type(self.instance_type.value)
+        supported_architectures = get_supported_architectures_for_instance_type(self.instance_type)
         if not supported_architectures:
-            error(f"Unable to get architectures supported by instance type {self.instance_type.value}")
+            error(f"Unable to get architectures supported by instance type {self.instance_type}")
         # If the instance type supports multiple architectures, choose the first one.
         # TODO: this is currently not an issue because none of the instance types we support more than one of the
         #       architectures we support. If this were ever to change (e.g., we start supporting i386) then we would
@@ -440,8 +439,8 @@ class BaseComputeResource(Resource):
         simultaneous_multithreading: bool = None,
     ):
         super().__init__()
-        self.allocation_strategy = Param(allocation_strategy, default="BEST_FIT")
-        self.simultaneous_multithreading = Param(simultaneous_multithreading, default=True)
+        self.allocation_strategy = Resource.init_param(allocation_strategy, default="BEST_FIT")
+        self.simultaneous_multithreading = Resource.init_param(simultaneous_multithreading, default=True)
 
 
 class BaseQueue(Resource):
@@ -455,10 +454,10 @@ class BaseQueue(Resource):
         compute_type: str = None,
     ):
         super().__init__()
-        self.name = Param(name)
+        self.name = Resource.init_param(name)
         self.networking = networking
         self.storage = storage
-        self.compute_type = Param(compute_type, default="ONDEMAND")
+        self.compute_type = Resource.init_param(compute_type, default="ONDEMAND")
 
     def _register_validators(self):
         self._add_validator(QueueNameValidator, name=self.name)
@@ -469,7 +468,7 @@ class CommonSchedulingSettings(Resource):
 
     def __init__(self, scaledown_idletime: int):
         super().__init__()
-        self.scaledown_idletime = Param(scaledown_idletime)
+        self.scaledown_idletime = Resource.init_param(scaledown_idletime)
 
 
 class CustomAction(Resource):
@@ -477,10 +476,10 @@ class CustomAction(Resource):
 
     def __init__(self, script: str, args: List[str] = None, event: str = None, run_as: str = None):
         super().__init__()
-        self.script = Param(script)
+        self.script = Resource.init_param(script)
         self.args = args
-        self.event = Param(event)
-        self.run_as = Param(run_as)
+        self.event = Resource.init_param(event)
+        self.run_as = Resource.init_param(run_as)
 
     def _register_validators(self):
         self._add_validator(UrlValidator, url=self.script)
@@ -500,10 +499,10 @@ class CloudWatchLogs(Resource):
         kms_key_id: str = None,
     ):
         super().__init__()
-        self.enabled = Param(enabled, default=True)
-        self.retention_in_days = Param(retention_in_days, default=14)
-        self.log_group_id = Param(log_group_id)
-        self.kms_key_id = Param(kms_key_id)
+        self.enabled = Resource.init_param(enabled, default=True)
+        self.retention_in_days = Resource.init_param(retention_in_days, default=14)
+        self.log_group_id = Resource.init_param(log_group_id)
+        self.kms_key_id = Resource.init_param(kms_key_id)
 
 
 class CloudWatchDashboards(Resource):
@@ -514,7 +513,7 @@ class CloudWatchDashboards(Resource):
         enabled: bool = None,
     ):
         super().__init__()
-        self.enabled = Param(enabled, default=True)
+        self.enabled = Resource.init_param(enabled, default=True)
 
 
 class Logs(Resource):
@@ -549,7 +548,7 @@ class Monitoring(Resource):
         dashboards: Dashboards = None,
     ):
         super().__init__()
-        self.detailed_monitoring = Param(detailed_monitoring, default=False)
+        self.detailed_monitoring = Resource.init_param(detailed_monitoring, default=False)
         self.logs = logs
         self.dashboards = dashboards
 
@@ -581,9 +580,9 @@ class Roles(Resource):
         custom_lambda_resources: str = None,
     ):
         super().__init__()
-        self.head_node = Param(head_node, default="AUTO")
-        self.compute_node = Param(compute_node, default="AUTO")
-        self.custom_lambda_resources = Param(custom_lambda_resources, default="AUTO")
+        self.head_node = Resource.init_param(head_node, default="AUTO")
+        self.compute_node = Resource.init_param(compute_node, default="AUTO")
+        self.custom_lambda_resources = Resource.init_param(custom_lambda_resources, default="AUTO")
 
 
 class S3Access(Resource):
@@ -595,8 +594,8 @@ class S3Access(Resource):
         type: str = None,
     ):
         super().__init__()
-        self.bucket_name = Param(bucket_name)
-        self.type = Param(type, default="READ_ONLY")
+        self.bucket_name = Resource.init_param(bucket_name)
+        self.type = Resource.init_param(type, default="READ_ONLY")
 
 
 class AdditionalIamPolicy(Resource):
@@ -608,8 +607,8 @@ class AdditionalIamPolicy(Resource):
         scope: str = None,
     ):
         super().__init__()
-        self.policy = Param(policy)
-        self.scope = Param(scope, default="CLUSTER")
+        self.policy = Resource.init_param(policy)
+        self.scope = Resource.init_param(scope, default="CLUSTER")
 
     def _register_validators(self):
         self._add_validator(AdditionalIamPolicyValidator, policy=self.policy)
@@ -638,7 +637,7 @@ class IntelSelectSolutions(Resource):
         install_intel_software: bool = None,
     ):
         super().__init__()
-        self.install_intel_software = Param(install_intel_software, default=False)
+        self.install_intel_software = Resource.init_param(install_intel_software, default=False)
 
 
 class AdditionalPackages(Resource):

--- a/cli/src/pcluster/models/cluster_awsbatch.py
+++ b/cli/src/pcluster/models/cluster_awsbatch.py
@@ -20,10 +20,9 @@ from pcluster.models.cluster import (
     BaseQueue,
     CommonSchedulingSettings,
     QueueNetworking,
-    Resource,
     Storage,
 )
-from pcluster.models.common import Param
+from pcluster.models.common import Resource
 from pcluster.validators.awsbatch_validators import (
     AwsbatchComputeInstanceTypeValidator,
     AwsbatchInstancesArchitectureCompatibilityValidator,
@@ -47,9 +46,9 @@ class AwsbatchComputeResource(BaseComputeResource):
     ):
         super().__init__(allocation_strategy, simultaneous_multithreading)
         self.instance_type = instance_type
-        self.max_vcpus = Param(max_vcpus, default=10)
-        self.min_vcpus = Param(min_vcpus, default=0)
-        self.desired_vcpus = Param(desired_vcpus, default=0)
+        self.max_vcpus = Resource.init_param(max_vcpus, default=10)
+        self.min_vcpus = Resource.init_param(min_vcpus, default=0)
+        self.desired_vcpus = Resource.init_param(desired_vcpus, default=0)
         self.spot_bid_percentage = spot_bid_percentage
 
     def _register_validators(self):

--- a/cli/src/pcluster/models/cluster_slurm.py
+++ b/cli/src/pcluster/models/cluster_slurm.py
@@ -24,7 +24,6 @@ from pcluster.models.cluster import (
     Resource,
     Storage,
 )
-from pcluster.models.common import Param
 from pcluster.validators.cluster_validators import (
     DuplicateInstanceTypeValidator,
     EfaOsArchitectureValidator,
@@ -51,10 +50,10 @@ class SlurmComputeResource(BaseComputeResource):
         efa: Efa = None,
     ):
         super().__init__(allocation_strategy, simultaneous_multithreading)
-        self.instance_type = Param(instance_type)
-        self.max_count = Param(max_count, default=10)
-        self.min_count = Param(min_count, default=0)
-        self.spot_price = Param(spot_price)
+        self.instance_type = Resource.init_param(instance_type)
+        self.max_count = Resource.init_param(max_count, default=10)
+        self.min_count = Resource.init_param(min_count, default=0)
+        self.spot_price = Resource.init_param(spot_price)
         self.efa = efa
 
     def _register_validators(self):
@@ -160,8 +159,8 @@ class SlurmCluster(BaseCluster):
             {
                 subnet_id
                 for queue in self.scheduling.queues
-                if queue.networking.subnet_ids and queue.networking.subnet_ids.value
-                for subnet_id in queue.networking.subnet_ids.value
+                if queue.networking.subnet_ids and queue.networking.subnet_ids
+                for subnet_id in queue.networking.subnet_ids
                 if queue.networking.subnet_ids
             }
         )
@@ -173,7 +172,7 @@ class SlurmCluster(BaseCluster):
             {
                 security_group
                 for queue in self.scheduling.queues
-                if queue.networking.security_groups and queue.networking.security_groups.value
-                for security_group in queue.networking.security_groups.value
+                if queue.networking.security_groups and queue.networking.security_groups
+                for security_group in queue.networking.security_groups
             }
         )

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -32,7 +32,7 @@ class HeadNodeConstruct(core.Construct):
         self.head_node = head_node
 
         # TODO: use attributes from head_node instead of using these static variables.
-        master_instance_type = self.head_node.instance_type.value
+        master_instance_type = self.head_node.instance_type
         master_core_count = "-1,true"
         # compute_core_count = "-1"
         key_name = "keyname"
@@ -237,30 +237,30 @@ class ClusterStack(core.Stack):
 
     def _add_fsx_storage(self, id: str, shared_fsx: SharedFsx):
         """Add specific Cfn Resources to map the FSX storage."""
-        fsx_id = shared_fsx.file_system_id.value
+        fsx_id = shared_fsx.file_system_id
 
-        if not fsx_id and shared_fsx.mount_dir.value:
+        if not fsx_id and shared_fsx.mount_dir:
             fsx_resource = fsx.CfnFileSystem(
                 scope=self,
-                storage_capacity=shared_fsx.storage_capacity.value,
+                storage_capacity=shared_fsx.storage_capacity,
                 lustre_configuration=fsx.CfnFileSystem.LustreConfigurationProperty(
-                    deployment_type=shared_fsx.deployment_type.value,
-                    imported_file_chunk_size=shared_fsx.imported_file_chunk_size.value,
-                    export_path=shared_fsx.export_path.value,
-                    import_path=shared_fsx.import_path.value,
-                    weekly_maintenance_start_time=shared_fsx.weekly_maintenance_start_time.value,
-                    automatic_backup_retention_days=shared_fsx.automatic_backup_retention_days.value,
-                    copy_tags_to_backups=shared_fsx.copy_tags_to_backups.value,
-                    daily_automatic_backup_start_time=shared_fsx.daily_automatic_backup_start_time.value,
-                    per_unit_storage_throughput=shared_fsx.per_unit_storage_throughput.value,
-                    auto_import_policy=shared_fsx.auto_import_policy.value,
-                    drive_cache_type=shared_fsx.drive_cache_type.value,
+                    deployment_type=shared_fsx.deployment_type,
+                    imported_file_chunk_size=shared_fsx.imported_file_chunk_size,
+                    export_path=shared_fsx.export_path,
+                    import_path=shared_fsx.import_path,
+                    weekly_maintenance_start_time=shared_fsx.weekly_maintenance_start_time,
+                    automatic_backup_retention_days=shared_fsx.automatic_backup_retention_days,
+                    copy_tags_to_backups=shared_fsx.copy_tags_to_backups,
+                    daily_automatic_backup_start_time=shared_fsx.daily_automatic_backup_start_time,
+                    per_unit_storage_throughput=shared_fsx.per_unit_storage_throughput,
+                    auto_import_policy=shared_fsx.auto_import_policy,
+                    drive_cache_type=shared_fsx.drive_cache_type,
                 ),
-                backup_id=shared_fsx.backup_id.value,
-                kms_key_id=shared_fsx.kms_key_id.value,
+                backup_id=shared_fsx.backup_id,
+                kms_key_id=shared_fsx.kms_key_id,
                 id=id,
                 file_system_type="LUSTRE",
-                storage_type=shared_fsx.drive_cache_type.value,
+                storage_type=shared_fsx.drive_cache_type,
                 subnet_ids=self._cluster.compute_subnet_ids,
                 security_group_ids=self._cluster.compute_security_groups,
             )
@@ -271,16 +271,16 @@ class ClusterStack(core.Stack):
     def _add_efs_storage(self, id: str, shared_efs: SharedEfs):
         """Add specific Cfn Resources to map the EFS storage."""
         # EFS FileSystem
-        efs_id = shared_efs.file_system_id.value
+        efs_id = shared_efs.file_system_id
         if not efs_id and shared_efs.mount_dir:
             efs_resource = efs.CfnFileSystem(
                 scope=self,
                 id=id,
-                encrypted=shared_efs.encrypted.value,
-                kms_key_id=shared_efs.kms_key_id.value,
-                performance_mode=shared_efs.performance_mode.value,
-                provisioned_throughput_in_mibps=shared_efs.provisioned_throughput.value,
-                throughput_mode=shared_efs.throughput_mode.value,
+                encrypted=shared_efs.encrypted,
+                kms_key_id=shared_efs.kms_key_id,
+                performance_mode=shared_efs.performance_mode,
+                provisioned_throughput_in_mibps=shared_efs.provisioned_throughput,
+                throughput_mode=shared_efs.throughput_mode,
             )
             efs_id = efs_resource.ref
 
@@ -296,8 +296,8 @@ class ClusterStack(core.Stack):
         self._add_efs_mount_target(
             id,
             efs_id,
-            self._cluster.head_node.networking.security_groups.value,
-            self._cluster.head_node.networking.subnet_id.value,
+            self._cluster.head_node.networking.security_groups,
+            self._cluster.head_node.networking.subnet_id,
             checked_availability_zones,
         )
         return efs_id
@@ -322,21 +322,21 @@ class ClusterStack(core.Stack):
 
     def _add_ebs_volume(self, id: str, shared_ebs: SharedEbs):
         """Add specific Cfn Resources to map the EBS storage."""
-        ebs_id = shared_ebs.volume_id.value
+        ebs_id = shared_ebs.volume_id
         if not ebs_id and shared_ebs.mount_dir:
             ebs_resource = ec2.CfnVolume(
                 scope=self,
                 id=id,
                 availability_zone=AWSApi.instance().ec2.get_availability_zone_of_subnet(
-                    self._cluster.head_node.networking.subnet_id.value
+                    self._cluster.head_node.networking.subnet_id
                 ),
-                encrypted=shared_ebs.encrypted.value,
-                iops=shared_ebs.iops.value,
-                throughput=shared_ebs.throughput.value,
-                kms_key_id=shared_ebs.kms_key_id.value,
-                size=shared_ebs.size.value,
-                snapshot_id=shared_ebs.snapshot_id.value,
-                volume_type=shared_ebs.volume_type.value,
+                encrypted=shared_ebs.encrypted,
+                iops=shared_ebs.iops,
+                throughput=shared_ebs.throughput,
+                kms_key_id=shared_ebs.kms_key_id,
+                size=shared_ebs.size,
+                snapshot_id=shared_ebs.snapshot_id,
+                volume_type=shared_ebs.volume_type,
             )
             ebs_id = ebs_resource.ref
 

--- a/cli/src/pcluster/validators/ebs_validators.py
+++ b/cli/src/pcluster/validators/ebs_validators.py
@@ -15,7 +15,7 @@ from pcluster.config.validators import (
     EBS_VOLUME_TYPE_TO_IOPS_RATIO,
     EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS,
 )
-from pcluster.models.common import FailureLevel, Param, Validator
+from pcluster.models.common import FailureLevel, Validator
 from pcluster.utils import get_ebs_snapshot_info, get_partition
 
 
@@ -31,20 +31,18 @@ class EbsVolumeTypeSizeValidator(Validator):
     The volume sizes of st1 and sc1 range from 500 GiB - 16 TiB(16384 GiB)
     """
 
-    def _validate(self, volume_type: Param, volume_size: Param):
-        if volume_type.value in EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS:
-            min_size, max_size = EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS.get(volume_type.value)
-            if volume_size.value > max_size:
+    def _validate(self, volume_type: str, volume_size: int):
+        if volume_type in EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS:
+            min_size, max_size = EBS_VOLUME_TYPE_TO_VOLUME_SIZE_BOUNDS.get(volume_type)
+            if volume_size > max_size:
                 self._add_failure(
-                    "The size of {0} volumes can not exceed {1} GiB".format(volume_type.value, max_size),
+                    "The size of {0} volumes can not exceed {1} GiB".format(volume_type, max_size),
                     FailureLevel.ERROR,
-                    [volume_size],
                 )
-            elif volume_size.value < min_size:
+            elif volume_size < min_size:
                 self._add_failure(
-                    "The size of {0} volumes must be at least {1} GiB".format(volume_type.value, min_size),
+                    "The size of {0} volumes must be at least {1} GiB".format(volume_type, min_size),
                     FailureLevel.ERROR,
-                    [volume_size],
                 )
 
 
@@ -55,17 +53,16 @@ class EbsVolumeThroughputValidator(Validator):
     Validate gp3 throughput.
     """
 
-    def _validate(self, volume_type: Param, volume_throughput: Param):
-        if volume_type.value == "gp3":
+    def _validate(self, volume_type, volume_throughput):
+        if volume_type == "gp3":
             min_throughput, max_throughput = 125, 1000
-            if volume_throughput.value < min_throughput or volume_throughput.value > max_throughput:
+            if volume_throughput < min_throughput or volume_throughput > max_throughput:
                 self._add_failure(
                     "Throughput must be between {min_throughput} MB/s and {max_throughput} MB/s when provisioning "
                     "{volume_type} volumes.".format(
-                        min_throughput=min_throughput, max_throughput=max_throughput, volume_type=volume_type.value
+                        min_throughput=min_throughput, max_throughput=max_throughput, volume_type=volume_type
                     ),
                     FailureLevel.ERROR,
-                    [volume_throughput],
                 )
 
 
@@ -76,19 +73,15 @@ class EbsVolumeThroughputIopsValidator(Validator):
     Validate gp3 throughput.
     """
 
-    def _validate(self, volume_type: Param, volume_iops: Param, volume_throughput: Param):
+    def _validate(self, volume_type, volume_iops, volume_throughput):
         volume_throughput_to_iops_ratio = 0.25
-        if volume_type.value == "gp3":
-            if (
-                volume_throughput.value
-                and volume_throughput.value > volume_iops.value * volume_throughput_to_iops_ratio
-            ):
+        if volume_type == "gp3":
+            if volume_throughput and volume_throughput > volume_iops * volume_throughput_to_iops_ratio:
                 self._add_failure(
                     "Throughput to IOPS ratio of {0} is too high; maximum is 0.25.".format(
-                        float(volume_throughput.value) / float(volume_iops.value)
+                        float(volume_throughput) / float(volume_iops)
                     ),
                     FailureLevel.ERROR,
-                    [volume_throughput],
                 )
 
 
@@ -99,27 +92,21 @@ class EbsVolumeIopsValidator(Validator):
     Validate IOPS value in respect of volume type.
     """
 
-    def _validate(self, volume_type: Param, volume_size: Param, volume_iops: Param):
-        if volume_type.value in EBS_VOLUME_IOPS_BOUNDS:
-            min_iops, max_iops = EBS_VOLUME_IOPS_BOUNDS.get(volume_type.value)
-            if volume_iops.value and (volume_iops.value < min_iops or volume_iops.value > max_iops):
+    def _validate(self, volume_type, volume_size, volume_iops):
+        if volume_type in EBS_VOLUME_IOPS_BOUNDS:
+            min_iops, max_iops = EBS_VOLUME_IOPS_BOUNDS.get(volume_type)
+            if volume_iops and (volume_iops < min_iops or volume_iops > max_iops):
                 self._add_failure(
-                    f"IOPS rate must be between {min_iops} and {max_iops}"
-                    f" when provisioning {volume_type.value} volumes.",
+                    f"IOPS rate must be between {min_iops} and {max_iops}" f" when provisioning {volume_type} volumes.",
                     FailureLevel.ERROR,
-                    [volume_iops],
                 )
-            elif (
-                volume_iops.value
-                and volume_iops.value > volume_size.value * EBS_VOLUME_TYPE_TO_IOPS_RATIO[volume_type.value]
-            ):
+            elif volume_iops and volume_iops > volume_size * EBS_VOLUME_TYPE_TO_IOPS_RATIO[volume_type]:
                 self._add_failure(
                     "IOPS to volume size ratio of {0} is too high; maximum is {1}.".format(
-                        float(volume_iops.value) / float(volume_size.value),
-                        EBS_VOLUME_TYPE_TO_IOPS_RATIO[volume_type.value],
+                        float(volume_iops) / float(volume_size),
+                        EBS_VOLUME_TYPE_TO_IOPS_RATIO[volume_type],
                     ),
                     FailureLevel.ERROR,
-                    [volume_iops],
                 )
 
 
@@ -132,25 +119,22 @@ class EbsVolumeSizeSnapshotValidator(Validator):
     - If users specify the volume size, the volume must be not smaller than the volume size of the EBS snapshot.
     """
 
-    def _validate(self, snapshot_id: Param, volume_size: Param):
-        if snapshot_id.value:
+    def _validate(self, snapshot_id: int, volume_size: int):
+        if snapshot_id:
             try:
-                snapshot_response_dict = get_ebs_snapshot_info(snapshot_id.value, raise_exceptions=True)
+                snapshot_response_dict = get_ebs_snapshot_info(snapshot_id, raise_exceptions=True)
 
                 # validate that the input volume size is larger than the volume size of the EBS snapshot
                 snapshot_volume_size = snapshot_response_dict.get("VolumeSize")
                 if snapshot_volume_size is None:
-                    self._add_failure(
-                        f"Unable to get volume size for snapshot {snapshot_id.value}", FailureLevel.ERROR, [snapshot_id]
-                    )
-                elif volume_size.value < snapshot_volume_size:
+                    self._add_failure(f"Unable to get volume size for snapshot {snapshot_id}", FailureLevel.ERROR)
+                elif volume_size < snapshot_volume_size:
                     self._add_failure(
                         f"The EBS volume size must not be smaller than {snapshot_volume_size}, "
                         "because it is the size of the provided snapshot {snapshot_id}",
                         FailureLevel.ERROR,
-                        [volume_size],
                     )
-                elif volume_size.value > snapshot_volume_size:
+                elif volume_size > snapshot_volume_size:
                     self._add_failure(
                         "The specified volume size is larger than snapshot size. In order to use the full capacity "
                         "of the volume, you'll need to manually resize the partition according to this doc: "
@@ -158,17 +142,15 @@ class EbsVolumeSizeSnapshotValidator(Validator):
                             partition_url="docs.amazonaws.cn" if get_partition() == "aws-cn" else "docs.aws.amazon.com"
                         ),
                         FailureLevel.WARNING,
-                        [volume_size],
                     )
 
                 # validate that the state of ebs snapshot
                 if snapshot_response_dict.get("State") != "completed":
                     self._add_failure(
                         "Snapshot {0} is in state '{1}' not 'completed'".format(
-                            snapshot_id.value, snapshot_response_dict.get("State")
+                            snapshot_id, snapshot_response_dict.get("State")
                         ),
                         FailureLevel.WARNING,
-                        [snapshot_id],
                     )
             except Exception as exception:
                 if isinstance(exception, ClientError) and exception.response.get("Error").get("Code") in [
@@ -177,21 +159,19 @@ class EbsVolumeSizeSnapshotValidator(Validator):
                 ]:
                     self._add_failure(
                         "The snapshot {0} does not appear to exist: {1}".format(
-                            snapshot_id.value, exception.response.get("Error").get("Message")
+                            snapshot_id, exception.response.get("Error").get("Message")
                         ),
                         FailureLevel.ERROR,
-                        [snapshot_id],
                     )
                 else:
                     self._add_failure(
                         "Issue getting info for snapshot {0}: {1}".format(
-                            snapshot_id.value,
+                            snapshot_id,
                             exception.response.get("Error").get("Message")
                             if isinstance(exception, ClientError)
                             else exception,
                         ),
                         FailureLevel.ERROR,
-                        [snapshot_id],
                     )
 
 
@@ -202,10 +182,9 @@ class EBSVolumeKmsKeyIdValidator(Validator):
     Validate KmsKeyId value based on encrypted value.
     """
 
-    def _validate(self, volume_kms_key_id: Param, volume_encrypted: Param):
-        if volume_kms_key_id.value and not volume_encrypted.value:
+    def _validate(self, volume_kms_key_id, volume_encrypted):
+        if volume_kms_key_id and not volume_encrypted:
             self._add_failure(
-                "Kms Key Id {0} is specified, the encrypted state must be True.".format(volume_kms_key_id.value),
+                "Kms Key Id {0} is specified, the encrypted state must be True.".format(volume_kms_key_id),
                 FailureLevel.ERROR,
-                [volume_encrypted],
             )

--- a/cli/src/pcluster/validators/fsx_validators.py
+++ b/cli/src/pcluster/validators/fsx_validators.py
@@ -13,7 +13,7 @@ from botocore.exceptions import ClientError
 
 from pcluster.config.validators import get_bucket_name_from_s3_url
 from pcluster.constants import FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT
-from pcluster.models.common import FailureLevel, Param, Validator
+from pcluster.models.common import FailureLevel, Validator
 from pcluster.utils import get_region
 
 
@@ -25,27 +25,28 @@ class FsxS3Validator(Validator):
     """
 
     def _validate(
-        self, import_path: Param, imported_file_chunk_size: Param, export_path: Param, auto_import_policy: Param
+        self,
+        import_path,
+        imported_file_chunk_size,
+        export_path,
+        auto_import_policy,
     ):
-        if imported_file_chunk_size.value and not import_path.value:
+        if imported_file_chunk_size and not import_path:
             self._add_failure(
                 "When specifying imported file chunk size, the import path option must be specified",
                 FailureLevel.ERROR,
-                [imported_file_chunk_size, import_path],
             )
 
-        if export_path.value and not import_path.value:
+        if export_path and not import_path:
             self._add_failure(
                 "When specifying export path, the import path option must be specified",
                 FailureLevel.ERROR,
-                [export_path, import_path],
             )
 
-        if auto_import_policy.value and not import_path.value:
+        if auto_import_policy and not import_path:
             self._add_failure(
                 "When specifying auto import policy, the import path option must be specified",
                 FailureLevel.ERROR,
-                [auto_import_policy, import_path],
             )
 
 
@@ -56,26 +57,23 @@ class FsxPersistentOptionsValidator(Validator):
     Verify compatibility of given persistent options for FSX.
     """
 
-    def _validate(self, deployment_type: Param, kms_key_id: Param, per_unit_storage_throughput: Param):
-        if deployment_type.value == "PERSISTENT_1":
-            if not per_unit_storage_throughput.value:
+    def _validate(self, deployment_type, kms_key_id, per_unit_storage_throughput):
+        if deployment_type == "PERSISTENT_1":
+            if not per_unit_storage_throughput:
                 self._add_failure(
                     "per unit storage throughput must be specified when deployment type is `PERSISTENT_1'",
                     FailureLevel.ERROR,
-                    [deployment_type, per_unit_storage_throughput],
                 )
         else:
-            if kms_key_id.value:
+            if kms_key_id:
                 self._add_failure(
                     "kms key id can only be used when deployment type is `PERSISTENT_1'",
                     FailureLevel.ERROR,
-                    [deployment_type, kms_key_id],
                 )
-            if per_unit_storage_throughput.value:
+            if per_unit_storage_throughput:
                 self._add_failure(
                     "per unit storage throughput can only be used when deployment type is `PERSISTENT_1'",
                     FailureLevel.ERROR,
-                    [deployment_type, per_unit_storage_throughput],
                 )
 
 
@@ -84,41 +82,37 @@ class FsxBackupOptionsValidator(Validator):
 
     def _validate(
         self,
-        automatic_backup_retention_days: Param,
-        daily_automatic_backup_start_time: Param,
-        copy_tags_to_backups: Param,
-        deployment_type: Param,
-        imported_file_chunk_size: Param,
-        import_path: Param,
-        export_path: Param,
-        auto_import_policy: Param,
+        automatic_backup_retention_days,
+        daily_automatic_backup_start_time,
+        copy_tags_to_backups,
+        deployment_type,
+        imported_file_chunk_size,
+        import_path,
+        export_path,
+        auto_import_policy,
     ):
-        if not automatic_backup_retention_days.value and daily_automatic_backup_start_time.value:
+        if not automatic_backup_retention_days and daily_automatic_backup_start_time:
             self._add_failure(
                 "When specifying daily automatic backup start time,"
                 "the automatic backup retention days option must be specified",
                 FailureLevel.ERROR,
-                [automatic_backup_retention_days, daily_automatic_backup_start_time],
             )
-        if not automatic_backup_retention_days.value and copy_tags_to_backups.value is not None:
+        if not automatic_backup_retention_days and copy_tags_to_backups is not None:
             self._add_failure(
                 "When specifying copy tags to backups, " "the automatic backup retention days option must be specified",
                 FailureLevel.ERROR,
-                [automatic_backup_retention_days, copy_tags_to_backups],
             )
-        if deployment_type.value != "PERSISTENT_1" and automatic_backup_retention_days.value:
+        if deployment_type != "PERSISTENT_1" and automatic_backup_retention_days:
             self._add_failure(
                 "FSx automatic backup features can be used only with 'PERSISTENT_1' file systems",
                 FailureLevel.ERROR,
-                [deployment_type, automatic_backup_retention_days],
             )
         if (
-            imported_file_chunk_size.value or import_path.value or export_path.value or auto_import_policy.value
-        ) and automatic_backup_retention_days.value:
+            imported_file_chunk_size or import_path or export_path or auto_import_policy
+        ) and automatic_backup_retention_days:
             self._add_failure(
                 "Backups cannot be created on S3-linked file systems",
                 FailureLevel.ERROR,
-                [automatic_backup_retention_days],
             )
 
 
@@ -126,37 +120,37 @@ class FsxStorageTypeOptionsValidator(Validator):
     """FSX storage type options validator."""
 
     def _validate(
-        self, storage_type: Param, deployment_type: Param, per_unit_storage_throughput: Param, drive_cache_type: Param
+        self,
+        storage_type,
+        deployment_type,
+        per_unit_storage_throughput,
+        drive_cache_type,
     ):
-        if storage_type.value == "HDD":
-            if deployment_type.value != "PERSISTENT_1":
+        if storage_type == "HDD":
+            if deployment_type != "PERSISTENT_1":
                 self._add_failure(
                     "For HDD filesystems, deployment type must be 'PERSISTENT_1'",
                     FailureLevel.ERROR,
-                    [storage_type, deployment_type],
                 )
-            if per_unit_storage_throughput.value not in FSX_HDD_THROUGHPUT:
+            if per_unit_storage_throughput not in FSX_HDD_THROUGHPUT:
                 self._add_failure(
                     "For HDD filesystems, per unit storage throughput can only have the following values: {0}".format(
                         FSX_HDD_THROUGHPUT
                     ),
                     FailureLevel.ERROR,
-                    [storage_type, per_unit_storage_throughput],
                 )
         else:  # SSD or None
-            if drive_cache_type.value:
+            if drive_cache_type:
                 self._add_failure(
                     "drive cache type features can be used only with HDD filesystems",
                     FailureLevel.ERROR,
-                    [storage_type, drive_cache_type],
                 )
-            if per_unit_storage_throughput.value and per_unit_storage_throughput.value not in FSX_SSD_THROUGHPUT:
+            if per_unit_storage_throughput and per_unit_storage_throughput not in FSX_SSD_THROUGHPUT:
                 self._add_failure(
                     "For SSD filesystems, per unit storage throughput can only have the following values: {0}".format(
                         FSX_SSD_THROUGHPUT
                     ),
                     FailureLevel.ERROR,
-                    [storage_type, per_unit_storage_throughput],
                 )
 
 
@@ -165,88 +159,78 @@ class FsxStorageCapacityValidator(Validator):
 
     def _validate(
         self,
-        storage_capacity: Param,
-        deployment_type: Param,
-        storage_type: Param,
-        per_unit_storage_throughput: Param,
-        file_system_id: Param,
-        backup_id: Param,
+        storage_capacity,
+        deployment_type,
+        storage_type,
+        per_unit_storage_throughput,
+        file_system_id,
+        backup_id,
     ):
-        if file_system_id.value or backup_id.value:
+        if file_system_id or backup_id:
             # if file_system_id is provided, don't validate storage_capacity
             # if backup_id is provided, validation for storage_capacity will be done in fsx_lustre_backup_validator.
             return
-        if not storage_capacity.value:
+        if not storage_capacity:
             # if file_system_id is not provided, storage_capacity must be provided
             self._add_failure(
                 "When specifying 'fsx' section, the 'StorageCapacity' option must be specified",
                 FailureLevel.ERROR,
-                [storage_capacity],
             )
-        elif deployment_type.value == "SCRATCH_1":
-            if not (
-                storage_capacity.value == 1200 or storage_capacity.value == 2400 or storage_capacity.value % 3600 == 0
-            ):
+        elif deployment_type == "SCRATCH_1":
+            if not (storage_capacity == 1200 or storage_capacity == 2400 or storage_capacity % 3600 == 0):
                 self._add_failure(
                     "Capacity for FSx SCRATCH_1 filesystem is 1,200 GB, 2,400 GB or increments of 3,600 GB",
                     FailureLevel.ERROR,
-                    [storage_capacity, deployment_type],
                 )
-        elif deployment_type.value == "PERSISTENT_1" and storage_type.value == "HDD":
-            if per_unit_storage_throughput.value == 12 and not storage_capacity.value % 6000 == 0:
+        elif deployment_type == "PERSISTENT_1" and storage_type == "HDD":
+            if per_unit_storage_throughput == 12 and not storage_capacity % 6000 == 0:
                 self._add_failure(
                     "Capacity for FSx PERSISTENT HDD 12 MB/s/TiB file systems is increments of 6,000 GiB",
                     FailureLevel.ERROR,
-                    [storage_capacity, deployment_type, storage_type, per_unit_storage_throughput],
                 )
-            elif per_unit_storage_throughput.value == 40 and not storage_capacity.value % 1800 == 0:
+            elif per_unit_storage_throughput == 40 and not storage_capacity % 1800 == 0:
                 self._add_failure(
                     "Capacity for FSx PERSISTENT HDD 40 MB/s/TiB file systems is increments of 1,800 GiB",
                     FailureLevel.ERROR,
-                    [storage_capacity, deployment_type, storage_type, per_unit_storage_throughput],
                 )
-        elif deployment_type.value in ["SCRATCH_2", "PERSISTENT_1"]:
-            if not (storage_capacity.value == 1200 or storage_capacity.value % 2400 == 0):
+        elif deployment_type in ["SCRATCH_2", "PERSISTENT_1"]:
+            if not (storage_capacity == 1200 or storage_capacity % 2400 == 0):
                 self._add_failure(
                     "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
                     FailureLevel.ERROR,
-                    [storage_capacity, deployment_type],
                 )
 
 
 class FsxBackupIdValidator(Validator):
     """Backup id validator."""
 
-    def _validate(self, backup_id: Param):
-        if backup_id.value:
+    def _validate(self, backup_id):
+        if backup_id:
             try:
-                boto3.client("fsx").describe_backups(BackupIds=[backup_id.value]).get("Backups")[0]
+                boto3.client("fsx").describe_backups(BackupIds=[backup_id]).get("Backups")[0]
             except ClientError as e:
                 self._add_failure(
                     "Failed to retrieve backup with Id '{0}': {1}".format(
-                        backup_id.value, e.response.get("Error").get("Message")
+                        backup_id, e.response.get("Error").get("Message")
                     ),
                     FailureLevel.ERROR,
-                    [backup_id],
                 )
 
 
 class FsxAutoImportValidator(Validator):
     """Auto import validator."""
 
-    def _validate(self, auto_import_policy: Param, import_path: Param):
-        bucket = get_bucket_name_from_s3_url(import_path.value)
+    def _validate(self, auto_import_policy, import_path):
+        bucket = get_bucket_name_from_s3_url(import_path)
 
-        if auto_import_policy.value is not None:
+        if auto_import_policy is not None:
             try:
                 s3_bucket_region = boto3.client("s3").get_bucket_location(Bucket=bucket).get("LocationConstraint")
                 # Buckets in Region us-east-1 have a LocationConstraint of null
                 if s3_bucket_region is None:
                     s3_bucket_region = "us-east-1"
                 if s3_bucket_region != get_region():
-                    self._add_failure(
-                        "AutoImport is not supported for cross-region buckets.", FailureLevel.ERROR, [import_path]
-                    )
+                    self._add_failure("AutoImport is not supported for cross-region buckets.", FailureLevel.ERROR)
             except ClientError as client_error:
                 if client_error.response.get("Error").get("Code") == "NoSuchBucket":
                     self._add_failure(
@@ -254,7 +238,6 @@ class FsxAutoImportValidator(Validator):
                             bucket, client_error.response.get("Error").get("Message")
                         ),
                         FailureLevel.ERROR,
-                        [import_path],
                     )
                 elif client_error.response.get("Error").get("Code") == "AccessDenied":
                     self._add_failure(
@@ -262,7 +245,6 @@ class FsxAutoImportValidator(Validator):
                             bucket, client_error.response.get("Error").get("Message")
                         ),
                         FailureLevel.ERROR,
-                        [import_path],
                     )
                 else:
                     self._add_failure(
@@ -270,5 +252,4 @@ class FsxAutoImportValidator(Validator):
                             bucket, client_error.response.get("Error").get("Message")
                         ),
                         FailureLevel.ERROR,
-                        [import_path],
                     )

--- a/cli/src/pcluster/validators/s3_validators.py
+++ b/cli/src/pcluster/validators/s3_validators.py
@@ -6,7 +6,7 @@ from urllib.request import urlopen
 from botocore.exceptions import ClientError
 
 from common.boto3.s3 import S3Client
-from pcluster.models.common import FailureLevel, Param, Validator
+from pcluster.models.common import FailureLevel, Validator
 
 
 class UrlValidator(Validator):
@@ -16,37 +16,35 @@ class UrlValidator(Validator):
     Validate given url with s3, https or file prefix.
     """
 
-    def _validate(self, url: Param):
-        scheme = urlparse(url.value).scheme
+    def _validate(self, url):
+        scheme = urlparse(url).scheme
         if scheme in ["https", "s3", "file"]:
             if scheme == "s3":
-                self._validate_s3_uri(url.value)
+                self._validate_s3_uri(url)
             if scheme == "https":
                 try:
-                    urlopen(url.value)
+                    urlopen(url)
                 except HTTPError as e:
                     self._add_failure(
                         "The url '{0}' cause HTTPError, the error code is '{1}', the error reason is '{2}'".format(
-                            url.value, e.code, e.reason
+                            url, e.code, e.reason
                         ),
                         FailureLevel.WARNING,
                     )
                 except URLError as e:
                     self._add_failure(
-                        "The url '{0}' causes URLError, the error reason is '{1}'".format(url.value, e.reason),
+                        "The url '{0}' causes URLError, the error reason is '{1}'".format(url, e.reason),
                         FailureLevel.WARNING,
                     )
                 except ValueError:
                     self._add_failure(
-                        "The value '{0}' is not a valid URL".format(url.value),
+                        "The value '{0}' is not a valid URL".format(url),
                         FailureLevel.ERROR,
-                        [url],
                     )
         else:
             self._add_failure(
-                f"The value '{url.value}' is not a valid URL, choose URL with 'https', 's3' or 'file' prefix.",
+                f"The value '{url}' is not a valid URL, choose URL with 'https', 's3' or 'file' prefix.",
                 FailureLevel.ERROR,
-                [url],
             )
 
     def _validate_s3_uri(self, s3_url):

--- a/cli/tests/pcluster/models/test_cluster_model.py
+++ b/cli/tests/pcluster/models/test_cluster_model.py
@@ -14,28 +14,28 @@ from typing import List
 from assertpy import assert_that
 
 from pcluster.models.cluster import Resource
-from pcluster.models.common import FailureLevel, Param, Validator
+from pcluster.models.common import FailureLevel, Validator
 
 
 class FakeInfoValidator(Validator):
     """Dummy validator of info level."""
 
-    def _validate(self, param: Param):
-        self._add_failure(f"Wrong value {param.value}.", FailureLevel.INFO)
+    def _validate(self, param):
+        self._add_failure(f"Wrong value {param}.", FailureLevel.INFO)
 
 
 class FakeErrorValidator(Validator):
     """Dummy validator of error level."""
 
-    def _validate(self, param: Param):
-        self._add_failure(f"Error {param.value}.", FailureLevel.ERROR)
+    def _validate(self, param):
+        self._add_failure(f"Error {param}.", FailureLevel.ERROR)
 
 
 class FakeComplexValidator(Validator):
     """Dummy validator requiring multiple parameters as input."""
 
-    def _validate(self, fake_attribute: Param, other_attribute: Param):
-        self._add_failure(f"Combination {fake_attribute.value} - {other_attribute.value}.", FailureLevel.WARNING)
+    def _validate(self, fake_attribute, other_attribute):
+        self._add_failure(f"Combination {fake_attribute} - {other_attribute}.", FailureLevel.WARNING)
 
 
 class FakePropertyValidator(Validator):
@@ -59,8 +59,8 @@ def test_resource_validate():
 
         def __init__(self):
             super().__init__()
-            self.fake_attribute = Param("fake-value")
-            self.other_attribute = Param("other-value")
+            self.fake_attribute = "fake-value"
+            self.other_attribute = "other-value"
 
         def _register_validators(self):
             self._add_validator(FakeErrorValidator, priority=10, param=self.fake_attribute)
@@ -125,7 +125,7 @@ def test_nested_resource_validate():
 
         def __init__(self, fake_value):
             super().__init__()
-            self.fake_attribute = Param(fake_value)
+            self.fake_attribute = fake_value
 
         def _register_validators(self):
             self._add_validator(FakeErrorValidator, param=self.fake_attribute)
@@ -136,7 +136,7 @@ def test_nested_resource_validate():
         def __init__(self, nested_resource: FakeNestedResource, list_of_resources: List[FakeNestedResource]):
             super().__init__()
             self.fake_resource = nested_resource
-            self.other_attribute = Param("other-value")
+            self.other_attribute = "other-value"
             self.list_of_resources = list_of_resources
 
         def _register_validators(self):

--- a/cli/tests/pcluster/models/test_common.py
+++ b/cli/tests/pcluster/models/test_common.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from assertpy import assert_that
+
+from pcluster.models.common import Resource
+
+
+@pytest.mark.parametrize(
+    "value, default, expected_value, expected_implied",
+    [
+        ("abc", "default_value", "abc", False),
+        (None, "default_value", "default_value", True),
+        (5, 10, 5, False),
+        (None, 10, 10, True),
+    ],
+)
+def test_resource_params(value, default, expected_value, expected_implied):
+    class TestBaseBaseResource(Resource):
+        def __init__(self):
+            super().__init__()
+
+    class TestBaseResource(TestBaseBaseResource):
+        def __init__(self):
+            super().__init__()
+
+    class TestResource(TestBaseResource):
+        def __init__(self):
+            super().__init__()
+            self.test_attr = Resource.init_param(value=value, default=default)
+
+    test_resource = TestResource()
+    assert_that(test_resource.test_attr).is_equal_to(expected_value)
+    assert_that(test_resource.is_implied("test_attr")).is_equal_to(expected_implied)
+
+    param = test_resource.get_param("test_attr")
+    assert_that(param).is_not_none()
+    assert_that(param.value).is_equal_to(expected_value)
+    assert_that(param.default).is_equal_to(default)
+
+    test_resource.test_attr = "new_value"
+    assert_that(test_resource.is_implied("test_attr")).is_false()
+
+    param = test_resource.get_param("test_attr")
+    assert_that(param).is_not_none()
+    assert_that(param.value).is_equal_to("new_value")
+    assert_that(param.default).is_equal_to(default)

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -69,8 +69,8 @@ def test_image_schema(os, custom_ami, failure_message):
             ImageSchema().load(image_schema)
     else:
         image = ImageSchema().load(image_schema)
-        assert_that(image.os.value).is_equal_to(os)
-        assert_that(image.custom_ami.value).is_equal_to(custom_ami)
+        assert_that(image.os).is_equal_to(os)
+        assert_that(image.custom_ami).is_equal_to(custom_ami)
 
 
 DUMMY_REQUIRED_QUEUE = [

--- a/cli/tests/pcluster/validators/test_awsbatch_validators.py
+++ b/cli/tests/pcluster/validators/test_awsbatch_validators.py
@@ -11,7 +11,6 @@
 import pytest
 from assertpy import assert_that
 
-from pcluster.models.common import Param
 from pcluster.utils import InstanceTypeInfo
 from pcluster.validators.awsbatch_validators import (
     AwsbatchComputeInstanceTypeValidator,
@@ -58,7 +57,7 @@ def test_compute_instance_type_validator(mocker, instance_type, max_vcpus, expec
             }
         ),
     )
-    actual_failures = AwsbatchComputeInstanceTypeValidator().execute(Param(instance_type), Param(max_vcpus))
+    actual_failures = AwsbatchComputeInstanceTypeValidator().execute(instance_type, max_vcpus)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -87,9 +86,7 @@ def test_compute_instance_type_validator(mocker, instance_type, max_vcpus, expec
     ],
 )
 def test_awsbatch_compute_resource_size_validator(min_vcpus, desired_vcpus, max_vcpus, expected_message):
-    actual_failures = AwsbatchComputeResourceSizeValidator().execute(
-        Param(min_vcpus), Param(desired_vcpus), Param(max_vcpus)
-    )
+    actual_failures = AwsbatchComputeResourceSizeValidator().execute(min_vcpus, desired_vcpus, max_vcpus)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -128,7 +125,7 @@ def test_awsbatch_instances_architecture_compatibility_validator(
     instance_types = compute_instance_types.split(",")
 
     actual_failures = AwsbatchInstancesArchitectureCompatibilityValidator().execute(
-        Param(compute_instance_types), head_node_architecture
+        compute_instance_types, head_node_architecture
     )
     assert_failure_messages(actual_failures, expected_message)
     if expected_message:

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 import pytest
 
-from pcluster.models.common import Param
 from pcluster.utils import InstanceTypeInfo
 from pcluster.validators.cluster_validators import (
     FSX_MESSAGES,
@@ -56,7 +55,7 @@ def boto3_stubber_path():
     ],
 )
 def test_scheduler_os_validator(os, scheduler, expected_message):
-    actual_failures = SchedulerOsValidator().execute(Param(os), Param(scheduler))
+    actual_failures = SchedulerOsValidator().execute(os, scheduler)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -69,7 +68,7 @@ def test_scheduler_os_validator(os, scheduler, expected_message):
     ],
 )
 def test_compute_resource_size_validator(min_count, max_count, expected_message):
-    actual_failures = ComputeResourceSizeValidator().execute(Param(min_count), Param(max_count))
+    actual_failures = ComputeResourceSizeValidator().execute(min_count, max_count)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -87,7 +86,7 @@ def test_compute_resource_size_validator(min_count, max_count, expected_message)
     ],
 )
 def test_duplicate_instance_type_validator(instance_type_list, expected_message):
-    instance_type_param_list = [Param(instance_type) for instance_type in instance_type_list]
+    instance_type_param_list = [instance_type for instance_type in instance_type_list]
     actual_failures = DuplicateInstanceTypeValidator().execute(instance_type_param_list)
     assert_failure_messages(actual_failures, expected_message)
 
@@ -122,7 +121,7 @@ def test_efa_validator(mocker, boto3_stubber, instance_type, efa_enabled, gdr_su
             ),
         )
 
-    actual_failures = EfaValidator().execute(Param(instance_type), Param(efa_enabled), Param(gdr_support))
+    actual_failures = EfaValidator().execute(instance_type, efa_enabled, gdr_support)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -138,9 +137,7 @@ def test_efa_validator(mocker, boto3_stubber, instance_type, efa_enabled, gdr_su
     ],
 )
 def test_efa_placement_group_validator(efa_enabled, placement_group_id, placement_group_enabled, expected_message):
-    actual_failures = EfaPlacementGroupValidator().execute(
-        Param(efa_enabled), Param(placement_group_id), Param(placement_group_enabled)
-    )
+    actual_failures = EfaPlacementGroupValidator().execute(efa_enabled, placement_group_id, placement_group_enabled)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -255,9 +252,7 @@ def test_efa_security_group_validator(
 
         boto3_stubber("ec2", mocked_requests)
 
-    actual_failures = EfaSecurityGroupValidator().execute(
-        Param(efa_enabled), Param(security_groups), Param(additional_security_groups)
-    )
+    actual_failures = EfaSecurityGroupValidator().execute(efa_enabled, security_groups, additional_security_groups)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -281,7 +276,7 @@ def test_simultaneous_multithreading_architecture_validator(
     simultaneous_multithreading, architecture, expected_message
 ):
     actual_failures = SimultaneousMultithreadingArchitectureValidator().execute(
-        Param(simultaneous_multithreading), architecture
+        simultaneous_multithreading, architecture
     )
     assert_failure_messages(actual_failures, expected_message)
 
@@ -304,7 +299,7 @@ def test_simultaneous_multithreading_architecture_validator(
     ],
 )
 def test_efa_os_architecture_validator(efa_enabled, os, architecture, expected_message):
-    actual_failures = EfaOsArchitectureValidator().execute(Param(efa_enabled), Param(os), architecture)
+    actual_failures = EfaOsArchitectureValidator().execute(efa_enabled, os, architecture)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -329,7 +324,7 @@ def test_efa_os_architecture_validator(efa_enabled, os, architecture, expected_m
 )
 def test_architecture_os_validator(os, architecture, expected_message):
     """Verify that the correct set of OSes is supported for each supported architecture."""
-    actual_failures = ArchitectureOsValidator().execute(Param(os), architecture)
+    actual_failures = ArchitectureOsValidator().execute(os, architecture)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -360,7 +355,7 @@ def test_instance_architecture_compatibility_validator(
         return_value=[compute_architecture],
     )
     actual_failures = InstanceArchitectureCompatibilityValidator().execute(
-        Param(compute_instance_type), head_node_architecture
+        compute_instance_type, head_node_architecture
     )
     assert_failure_messages(actual_failures, expected_message)
 
@@ -379,7 +374,7 @@ def test_instance_architecture_compatibility_validator(
     ],
 )
 def test_queue_name_validator(name, expected_message):
-    actual_failures = QueueNameValidator().execute(Param(name))
+    actual_failures = QueueNameValidator().execute(name)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -574,7 +569,7 @@ def test_fsx_network_validator(boto3_stubber, fsx_vpc, ip_permissions, network_i
 
     boto3_stubber("ec2", ec2_mocked_requests)
 
-    actual_failures = FsxNetworkingValidator().execute(Param("fs-0ff8da96d57f3b4e3"), Param("subnet-12345678"))
+    actual_failures = FsxNetworkingValidator().execute("fs-0ff8da96d57f3b4e3", "subnet-12345678")
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -623,7 +618,7 @@ def test_fsx_network_validator(boto3_stubber, fsx_vpc, ip_permissions, network_i
     ],
 )
 def test_fsx_architecture_os_validator(architecture, os, expected_message):
-    actual_failures = FsxArchitectureOsValidator().execute(architecture, Param(os))
+    actual_failures = FsxArchitectureOsValidator().execute(architecture, os)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -653,7 +648,7 @@ def test_fsx_architecture_os_validator(architecture, os, expected_message):
     ],
 )
 def test_duplicate_mount_dir_validator(mount_dir_list, expected_message):
-    mount_dir_param_list = [Param(mount_dir) for mount_dir in mount_dir_list]
+    mount_dir_param_list = [mount_dir for mount_dir in mount_dir_list]
     actual_failures = DuplicateMountDirValidator().execute(mount_dir_param_list)
     assert_failure_messages(actual_failures, expected_message)
 
@@ -697,11 +692,11 @@ def test_number_of_storage_validator(storage_type, max_number, storage_count, ex
 )
 def test_dcv_validator(dcv_enabled, os, instance_type, allowed_ips, port, expected_message):
     actual_failures = DcvValidator().execute(
-        Param(instance_type),
-        Param(dcv_enabled),
-        Param(allowed_ips),
-        Param(port),
-        Param(os),
+        instance_type,
+        dcv_enabled,
+        allowed_ips,
+        port,
+        os,
         "x86_64" if instance_type.startswith("t2") else "arm64",
     )
     assert_failure_messages(actual_failures, expected_message)
@@ -718,5 +713,5 @@ def test_dcv_validator(dcv_enabled, os, instance_type, allowed_ips, port, expect
     ],
 )
 def test_tags_validator(key, expected_message):
-    actual_failures = TagKeyValidator().execute(Param(key))
+    actual_failures = TagKeyValidator().execute(key)
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/test_ebs_validators.py
+++ b/cli/tests/pcluster/validators/test_ebs_validators.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 import pytest
 
-from pcluster.models.common import Param
 from pcluster.validators.ebs_validators import (
     EbsVolumeIopsValidator,
     EBSVolumeKmsKeyIdValidator,
@@ -33,7 +32,7 @@ from tests.pcluster.validators.utils import assert_failure_messages
     ],
 )
 def test_ebs_volume_throughput_validator(volume_type, volume_throughput, expected_message):
-    actual_failures = EbsVolumeThroughputValidator().execute(Param(volume_type), Param(volume_throughput))
+    actual_failures = EbsVolumeThroughputValidator().execute(volume_type, volume_throughput)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -48,9 +47,7 @@ def test_ebs_volume_throughput_validator(volume_type, volume_throughput, expecte
     ],
 )
 def test_ebs_volume_throughput_iops_validator(volume_type, volume_iops, volume_throughput, expected_message):
-    actual_failures = EbsVolumeThroughputIopsValidator().execute(
-        Param(volume_type), Param(volume_iops), Param(volume_throughput)
-    )
+    actual_failures = EbsVolumeThroughputIopsValidator().execute(volume_type, volume_iops, volume_throughput)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -72,7 +69,7 @@ def test_ebs_volume_throughput_iops_validator(volume_type, volume_iops, volume_t
     ],
 )
 def test_ebs_volume_iops_validators(volume_type, volume_size, volume_iops, expected_message):
-    actual_failures = EbsVolumeIopsValidator().execute(Param(volume_type), Param(volume_size), Param(volume_iops))
+    actual_failures = EbsVolumeIopsValidator().execute(volume_type, volume_size, volume_iops)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -103,7 +100,7 @@ def test_ebs_volume_iops_validators(volume_type, volume_size, volume_iops, expec
     ],
 )
 def test_ebs_volume_type_size_validator(volume_type, volume_size, expected_message):
-    actual_failures = EbsVolumeTypeSizeValidator().execute(Param(volume_type), Param(volume_size))
+    actual_failures = EbsVolumeTypeSizeValidator().execute(volume_type, volume_size)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -200,7 +197,7 @@ def test_ebs_volume_size_snapshot_validator(
         return_value="aws-cn" if partition == "aws-cn" else "aws-us-gov",
     )
 
-    actual_failures = EbsVolumeSizeSnapshotValidator().execute(Param(snapshot_id), Param(volume_size))
+    actual_failures = EbsVolumeSizeSnapshotValidator().execute(snapshot_id, volume_size)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -222,7 +219,5 @@ def test_ebs_volume_size_snapshot_validator(
     ],
 )
 def test_ebs_volume_kms_key_id_validator(kms_key_id, encrypted, expected_message):
-    actual_failures = EBSVolumeKmsKeyIdValidator().execute(
-        volume_kms_key_id=Param(kms_key_id), volume_encrypted=Param(encrypted)
-    )
+    actual_failures = EBSVolumeKmsKeyIdValidator().execute(volume_kms_key_id=kms_key_id, volume_encrypted=encrypted)
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -11,7 +11,6 @@
 
 import pytest
 
-from pcluster.models.common import Param
 from pcluster.validators.ec2_validators import (
     BaseAMIValidator,
     InstanceTypeBaseAMICompatibleValidator,
@@ -31,7 +30,7 @@ def test_instance_type_validator(mocker, instance_type, expected_message):
         return_value=["t2.micro", "c4.xlarge"],
     )
 
-    actual_failures = InstanceTypeValidator().execute(Param(instance_type))
+    actual_failures = InstanceTypeValidator().execute(instance_type)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -42,7 +41,7 @@ def test_instance_type_validator(mocker, instance_type, expected_message):
 def test_base_ami_validator(mocker, image_id, expected_message, response):
     mocker.patch("pcluster.validators.ec2_validators.Ec2Client.__init__", return_value=None)
     mocker.patch("pcluster.validators.ec2_validators.Ec2Client.describe_ami_id_offering", return_value=response)
-    actual_failures = BaseAMIValidator().execute(Param(image_id))
+    actual_failures = BaseAMIValidator().execute(image_id)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -105,6 +104,6 @@ def test_instance_type_base_ami_compatible_validator(
     mocker.patch("pcluster.utils.get_info_for_amis", return_value=ami_response)
     mocker.patch("pcluster.utils.get_supported_architectures_for_instance_type", return_value=instance_architecture)
     actual_failures = InstanceTypeBaseAMICompatibleValidator().execute(
-        instance_type=Param(instance_type), parent_image=Param(parent_image)
+        instance_type=instance_type, parent_image=parent_image
     )
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/test_fsx_validators.py
+++ b/cli/tests/pcluster/validators/test_fsx_validators.py
@@ -12,7 +12,6 @@ import os
 
 import pytest
 
-from pcluster.models.common import Param
 from pcluster.validators.fsx_validators import (
     FsxAutoImportValidator,
     FsxBackupIdValidator,
@@ -66,7 +65,10 @@ def boto3_stubber_path():
 )
 def test_fsx_s3_validator(import_path, imported_file_chunk_size, export_path, auto_import_policy, expected_message):
     actual_failures = FsxS3Validator().execute(
-        Param(import_path), Param(imported_file_chunk_size), Param(export_path), Param(auto_import_policy)
+        import_path,
+        imported_file_chunk_size,
+        export_path,
+        auto_import_policy,
     )
     assert_failure_messages(actual_failures, expected_message)
 
@@ -107,9 +109,7 @@ def test_fsx_s3_validator(import_path, imported_file_chunk_size, export_path, au
     ],
 )
 def test_fsx_persistent_options_validator(deployment_type, kms_key_id, per_unit_storage_throughput, expected_message):
-    actual_failures = FsxPersistentOptionsValidator().execute(
-        Param(deployment_type), Param(kms_key_id), Param(per_unit_storage_throughput)
-    )
+    actual_failures = FsxPersistentOptionsValidator().execute(deployment_type, kms_key_id, per_unit_storage_throughput)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -210,14 +210,14 @@ def test_fsx_backup_options_validator(
     expected_message,
 ):
     actual_failures = FsxBackupOptionsValidator().execute(
-        Param(automatic_backup_retention_days),
-        Param(daily_automatic_backup_start_time),
-        Param(copy_tags_to_backups),
-        Param(deployment_type),
-        Param(imported_file_chunk_size),
-        Param(import_path),
-        Param(export_path),
-        Param(auto_import_policy),
+        automatic_backup_retention_days,
+        daily_automatic_backup_start_time,
+        copy_tags_to_backups,
+        deployment_type,
+        imported_file_chunk_size,
+        import_path,
+        export_path,
+        auto_import_policy,
     )
     assert_failure_messages(actual_failures, expected_message)
 
@@ -266,7 +266,10 @@ def test_fsx_storage_type_options_validator(
     storage_type, deployment_type, per_unit_storage_throughput, drive_cache_type, expected_message
 ):
     actual_failures = FsxStorageTypeOptionsValidator().execute(
-        Param(storage_type), Param(deployment_type), Param(per_unit_storage_throughput), Param(drive_cache_type)
+        storage_type,
+        deployment_type,
+        per_unit_storage_throughput,
+        drive_cache_type,
     )
     assert_failure_messages(actual_failures, expected_message)
 
@@ -371,12 +374,12 @@ def test_fsx_storage_capacity_validator(
     expected_message,
 ):
     actual_failures = FsxStorageCapacityValidator().execute(
-        Param(storage_capacity),
-        Param(deployment_type),
-        Param(storage_type),
-        Param(per_unit_storage_throughput),
-        Param(file_system_id),
-        Param(backup_id),
+        storage_capacity,
+        deployment_type,
+        storage_type,
+        per_unit_storage_throughput,
+        file_system_id,
+        backup_id,
     )
     assert_failure_messages(actual_failures, expected_message)
 
@@ -416,7 +419,7 @@ def test_fsx_backup_id_validator(boto3_stubber, backup_id, expected_message):
         )
     ]
     boto3_stubber("fsx", fsx_mocked_requests)
-    actual_failures = FsxBackupIdValidator().execute(Param(backup_id))
+    actual_failures = FsxBackupIdValidator().execute(backup_id)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -475,5 +478,5 @@ def test_auto_import_policy_validator(
 
     boto3_stubber("s3", mocked_requests)
 
-    actual_failures = FsxAutoImportValidator().execute(Param(auto_import_policy), Param(import_path))
+    actual_failures = FsxAutoImportValidator().execute(auto_import_policy, import_path)
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/test_s3_validators.py
+++ b/cli/tests/pcluster/validators/test_s3_validators.py
@@ -1,6 +1,5 @@
 import pytest
 
-from pcluster.models.common import Param
 from pcluster.validators.s3_validators import UrlValidator
 from tests.pcluster.validators.utils import assert_failure_messages
 
@@ -27,5 +26,5 @@ def test_url_validator(mocker, url, response, expected_message):
     )
     mocker.patch("pcluster.validators.s3_validators.urlopen", return_value=None)
 
-    actual_failures = UrlValidator().execute(url=Param(url))
+    actual_failures = UrlValidator().execute(url=url)
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/utils.py
+++ b/cli/tests/pcluster/validators/utils.py
@@ -21,9 +21,9 @@ def assert_failure_messages(actual_failures, expected_messages):
         for expected_message in expected_messages:
             # Either check the regex of expected_message match actual failure or check the whole strings are equal.
             # This is to deal with strings having regex symbols (e.g. "[") inside
-            assert_that(
-                any(re.search(expected_message, actual_failure.message) for actual_failure in actual_failures)
-                or any(expected_message == actual_failure.message for actual_failure in actual_failures)
-            ).is_true()
+            res = any(re.search(expected_message, actual_failure.message) for actual_failure in actual_failures) or any(
+                expected_message == actual_failure.message for actual_failure in actual_failures
+            )
+            assert_that(res).is_true()
     else:
         assert_that(actual_failures).is_empty()


### PR DESCRIPTION
This commit replaces the usage of Param instances in resource attributes with a new internal logic inside the base resource class.
With this change resource attributes can be accessed directly instead of through the `value` property, while the related configuration information can always be retrieved through the new `get_param` method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
