### PR TITLE
3.0: Migrate validators: volume id, intel, S3

### DIFF
--- a/cli/src/common/boto3/common.py
+++ b/cli/src/common/boto3/common.py
@@ -13,7 +13,7 @@ import functools
 from abc import ABC
 
 import boto3
-from botocore.exceptions import BotoCoreError, ClientError
+from botocore.exceptions import BotoCoreError, ClientError, ParamValidationError
 
 
 class AWSClientError(Exception):
@@ -37,6 +37,11 @@ class AWSExceptionHandler:
                 return func(*args, **kwargs)
             except (BotoCoreError, ClientError) as e:
                 raise AWSClientError(func.__name__, e.response["Error"]["Message"])
+            except ParamValidationError as validation_error:
+                raise AWSClientError(
+                    func.__name__,
+                    "Error validating parameter. Failed with exception: {0}".format(str(validation_error)),
+                )
 
         return wrapper
 

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -57,14 +57,9 @@ from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import (
     ec2_ami_validator,
     ec2_subnet_id_validator,
-    ec2_volume_validator,
     ec2_vpc_id_validator,
     head_node_instance_type_validator,
-    intel_hpc_architecture_validator,
-    intel_hpc_os_validator,
     kms_key_validator,
-    s3_bucket_uri_validator,
-    s3_bucket_validator,
     shared_dir_validator,
 )
 from pcluster.constants import CIDR_ALL_IPS, FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT, SUPPORTED_ARCHITECTURES
@@ -312,7 +307,6 @@ EBS = {
         }),
         ("ebs_volume_id", {
             "cfn_param_mapping": "EBSVolumeId",
-            "validators": [ec2_volume_validator],
             "update_policy": UpdatePolicy.UNSUPPORTED
         }),
         ("volume_throughput", {
@@ -444,11 +438,9 @@ FSX = {
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("export_path", {
-                "validators": [s3_bucket_uri_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("import_path", {
-                "validators": [s3_bucket_uri_validator],
                 "update_policy": UpdatePolicy.UNSUPPORTED
             }),
             ("weekly_maintenance_start_time", {
@@ -817,7 +809,6 @@ CLUSTER_COMMON_PARAMS = [
         "default": False,
         "type": BoolCfnParam,
         "cfn_param_mapping": "IntelHPCPlatform",
-        "validators": [intel_hpc_os_validator, intel_hpc_architecture_validator],
         "update_policy": UpdatePolicy.UNSUPPORTED,
     }),
     # Settings
@@ -903,7 +894,6 @@ CLUSTER_COMMON_PARAMS = [
     }),
     ("cluster_resource_bucket", {
         "cfn_param_mapping": "ResourcesS3Bucket",
-        "validators": [s3_bucket_validator],
         "update_policy": UpdatePolicy.READ_ONLY_RESOURCE_BUCKET,
     }),
     ("iam_lambda_role", {

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -551,6 +551,32 @@ class DcvValidator(Validator):
                 )
 
 
+class IntelHpcOsValidator(Validator):
+    """Intel HPC OS validator."""
+
+    def _validate(self, os: str):
+        allowed_oses = ["centos7", "centos8"]
+        if os not in allowed_oses:
+            self._add_failure(
+                "When enabling intel software, the operating system is required to be set "
+                "to one of the following values : {0}".format(allowed_oses),
+                FailureLevel.ERROR,
+            )
+
+
+class IntelHpcArchitectureValidator(Validator):
+    """Intel HPC architecture validator."""
+
+    def _validate(self, architecture: str):
+        allowed_architectures = ["x86_64"]
+        if architecture not in allowed_architectures:
+            self._add_failure(
+                "When enabling intel software, it is required to use head node and compute instance "
+                "types and an AMI that support these architectures: {0}".format(allowed_architectures),
+                FailureLevel.ERROR,
+            )
+
+
 # --------------- Other validators --------------- #
 
 

--- a/cli/src/pcluster/validators/fsx_validators.py
+++ b/cli/src/pcluster/validators/fsx_validators.py
@@ -11,10 +11,10 @@
 import boto3
 from botocore.exceptions import ClientError
 
-from pcluster.config.validators import get_bucket_name_from_s3_url
 from pcluster.constants import FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT
 from pcluster.utils import get_region
 from pcluster.validators.common import FailureLevel, Validator
+from pcluster.validators.utils import get_bucket_name_from_s3_url
 
 
 class FsxS3Validator(Validator):

--- a/cli/src/pcluster/validators/utils.py
+++ b/cli/src/pcluster/validators/utils.py
@@ -8,20 +8,11 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import List
-
-import boto3
-from botocore.exceptions import ClientError
-
-from pcluster.validators.common import FailureLevel, Validator
+#
+# This module contains all the classes representing the Resources objects.
+# These objects are obtained from the configuration file through a conversion based on the Schema classes.
+#
 
 
-class SecurityGroupsValidator(Validator):
-    """SubnetId validator."""
-
-    def _validate(self, security_group_ids: List[str]):
-        for sg_id in security_group_ids:
-            try:
-                boto3.client("ec2").describe_security_groups(GroupIds=[sg_id])
-            except ClientError as e:
-                self._add_failure(e.response.get("Error").get("Message"), FailureLevel.ERROR)
+def get_bucket_name_from_s3_url(import_path):
+    return import_path.split("/")[2]

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -26,6 +26,8 @@ from pcluster.validators.cluster_validators import (
     FsxArchitectureOsValidator,
     FsxNetworkingValidator,
     InstanceArchitectureCompatibilityValidator,
+    IntelHpcArchitectureValidator,
+    IntelHpcOsValidator,
     NumberOfStorageValidator,
     QueueNameValidator,
     SchedulerOsValidator,
@@ -699,6 +701,40 @@ def test_dcv_validator(dcv_enabled, os, instance_type, allowed_ips, port, expect
         os,
         "x86_64" if instance_type.startswith("t2") else "arm64",
     )
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "architecture, expected_message",
+    [
+        ("x86_64", []),
+        ("arm64", ["instance types and an AMI that support these architectures"]),
+        # TODO migrate the parametrizations below to unit test for the whole model
+        # (False, "x86_64", []),
+        # (False, "arm64", []),
+    ],
+)
+def test_intel_hpc_architecture_validator(architecture, expected_message):
+    actual_failures = IntelHpcArchitectureValidator().execute(architecture)
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "os, expected_message",
+    [
+        ("centos7", None),
+        ("centos8", None),
+        ("alinux", "the operating system is required to be set"),
+        ("alinux2", "the operating system is required to be set"),
+        ("ubuntu1604", "the operating system is required to be set"),
+        ("ubuntu1804", "the operating system is required to be set"),
+        # TODO migrate the parametrization below to unit test for the whole model
+        # intel hpc disabled, you can use any os
+        # ({"enable_intel_hpc_platform": "false", "base_os": "alinux"}, None),
+    ],
+)
+def test_intel_hpc_os_validator(os, expected_message):
+    actual_failures = IntelHpcOsValidator().execute(os)
     assert_failure_messages(actual_failures, expected_message)
 
 

--- a/cli/tests/pcluster/validators/test_s3_validators.py
+++ b/cli/tests/pcluster/validators/test_s3_validators.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pcluster.validators.s3_validators import UrlValidator
+from pcluster.validators.s3_validators import S3BucketUriValidator, UrlValidator
 from tests.pcluster.validators.utils import assert_failure_messages
 
 
@@ -27,4 +27,24 @@ def test_url_validator(mocker, url, response, expected_message):
     mocker.patch("pcluster.validators.s3_validators.urlopen")
 
     actual_failures = UrlValidator().execute(url=url)
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "url, expected_message",
+    [
+        ("s3://test/test1/test2", None),
+        (
+            "http://test/test.json",
+            "is not a valid S3 URI",
+        ),
+    ],
+)
+def test_s3_bucket_uri_validator(mocker, url, expected_message):
+    mocker.patch("pcluster.validators.s3_validators.S3Client.__init__", return_value=None)
+    mocker.patch(
+        "pcluster.validators.s3_validators.S3Client.head_bucket",
+        return_value=True,
+    )
+    actual_failures = S3BucketUriValidator().execute(url=url)
     assert_failure_messages(actual_failures, expected_message)


### PR DESCRIPTION
Migrate SharedEBSVolumeIdValidator, IntelHpcArchitectureValidator, IntelHpcOsValidator, S3BucketUriValidator, S3BucketValidator

Fix a bug in SecurityGroupsValidator, this bug shows that our unit test coverage is low

Remove old url validators (already moved by yuleiwan)

Split BaseCluster._register_validators to pass code-linters check for complex code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
