### PR TITLE
3.0: Add more business logics to imagebuilder cdk

### DIFF
--- a/cli/src/common/aws/aws_api.py
+++ b/cli/src/common/aws/aws_api.py
@@ -11,6 +11,7 @@
 
 from common.boto3.ec2 import Ec2Client
 from common.boto3.efs import EfsClient
+from common.boto3.imagebuilder import ImageBuilderClient
 from common.boto3.s3 import S3Client
 
 
@@ -30,6 +31,7 @@ class AWSApi:
         self.efs = EfsClient(ec2_client=self.ec2)
         # pylint: disable=C0103
         self.s3 = S3Client()
+        self.imagebuilder = ImageBuilderClient()
 
     @staticmethod
     def instance():

--- a/cli/src/common/imagebuilder_utils.py
+++ b/cli/src/common/imagebuilder_utils.py
@@ -14,7 +14,7 @@ from common.aws.aws_api import AWSApi
 
 ROOT_VOLUME_TYPE = "gp2"
 PCLUSTER_RESERVED_VOLUME_SIZE = 15
-InstanceRole = Enum("InstanceRole", ("ROLE", "INSTANCE_PROFILE", "DEFAULT"))
+InstanceRole = Enum("InstanceRole", ("ROLE", "INSTANCE_PROFILE"))
 
 
 def get_ami_id(parent_image):

--- a/cli/src/common/imagebuilder_utils.py
+++ b/cli/src/common/imagebuilder_utils.py
@@ -8,7 +8,13 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+from enum import Enum
+
 from common.aws.aws_api import AWSApi
+
+ROOT_VOLUME_TYPE = "gp2"
+PCLUSTER_RESERVED_VOLUME_SIZE = 15
+InstanceRole = Enum("InstanceRole", ("ROLE", "INSTANCE_PROFILE", "DEFAULT"))
 
 
 def get_ami_id(parent_image):

--- a/cli/src/common/imagebuilder_utils.py
+++ b/cli/src/common/imagebuilder_utils.py
@@ -8,13 +8,13 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from common.boto3.imagebuilder import ImageBuilderClient
+from common.aws.aws_api import AWSApi
 
 
 def get_ami_id(parent_image):
     """Get ami id from parent image, parent image could be image id or image arn."""
     if parent_image.startswith("arn"):
-        ami_id = ImageBuilderClient().get_image_id(parent_image)
+        ami_id = AWSApi.instance().imagebuilder.get_image_id(parent_image)
     else:
         ami_id = parent_image
     return ami_id
@@ -22,4 +22,4 @@ def get_ami_id(parent_image):
 
 def get_info_for_ami_from_arn(image_arn):
     """Get image resources returned by imagebuilder's get_image API for the given arn of AMI."""
-    return ImageBuilderClient().get_image_resources(image_arn)
+    return AWSApi.instance().imagebuilder.get_image_resources(image_arn)

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -15,16 +15,13 @@
 
 from typing import List
 
-from common import imagebuilder_utils
-from common.boto3.common import AWSClientError
-from common.boto3.ec2 import Ec2Client
+from common.imagebuilder_utils import ROOT_VOLUME_TYPE
 from pcluster import utils
 from pcluster.models.common import BaseDevSettings, BaseTag, Resource
 from pcluster.validators.ebs_validators import EBSVolumeKmsKeyIdValidator, EbsVolumeTypeSizeValidator
 from pcluster.validators.ec2_validators import InstanceTypeBaseAMICompatibleValidator
 from pcluster.validators.imagebuilder_validators import AMIVolumeSizeValidator
 
-PCLUSTER_RESERVED_VOLUME_SIZE = 15
 # ---------------------- Image ---------------------- #
 
 
@@ -150,34 +147,17 @@ class ImageBuilder(Resource):
         self.image = image
         self.build = build
         self.dev_settings = dev_settings
-        self._set_default()
 
     def _register_validators(self):
         self._add_validator(
-            EbsVolumeTypeSizeValidator, priority=10, volume_type="gp2", volume_size=self.image.root_volume.size
+            EbsVolumeTypeSizeValidator,
+            priority=10,
+            volume_type=ROOT_VOLUME_TYPE,
+            volume_size=self.image.root_volume.size,
         )
         self._add_validator(
             AMIVolumeSizeValidator,
             priority=9,
             volume_size=self.image.root_volume.size,
             image=self.build.parent_image,
-            pcluster_reserved_volume_size=PCLUSTER_RESERVED_VOLUME_SIZE,
         )
-
-    def _set_default(self):
-        # set default root volume
-        if self.image.root_volume is None or self.image.root_volume.size is None:
-            try:
-                ami_id = imagebuilder_utils.get_ami_id(self.build.parent_image)
-                ami_info = Ec2Client().describe_image(ami_id)
-                default_root_volume_size = (
-                    ami_info.get("BlockDeviceMappings")[0].get("Ebs").get("VolumeSize") + PCLUSTER_RESERVED_VOLUME_SIZE
-                )
-                if self.image.root_volume is None:
-                    default_root_volume = Volume(size=default_root_volume_size)
-                    default_root_volume.implied = True
-                    self.image.root_volume = default_root_volume
-                else:
-                    self.image.root_volume.size = Resource.init_param(value=None, default=default_root_volume_size)
-            except AWSClientError:
-                self.image.root_volume = Volume(size=PCLUSTER_RESERVED_VOLUME_SIZE)

--- a/cli/src/pcluster/models/imagebuilder_extra_attributes.py
+++ b/cli/src/pcluster/models/imagebuilder_extra_attributes.py
@@ -27,9 +27,13 @@ class ChefAttributes:
         self._set_extra_attributes(dev_settings)
 
     def _set_default(self, dev_settings: ImagebuilderDevSettings):
-        self.cfn_region = "${AWS::Region}"
+        self.cfn_region = "{{ build.AWSRegion.outputs.stdout }}"
         self.nvidia = {"enabled": "false"}
-        self.is_official_ami_build = str.lower(str(dev_settings.update_os_and_reboot)) if dev_settings else "false"
+        self.is_official_ami_build = (
+            str.lower(str(dev_settings.update_os_and_reboot))
+            if dev_settings and dev_settings.update_os_and_reboot
+            else "false"
+        )
         self.custom_node_package = dev_settings.node_package if dev_settings and dev_settings.node_package else ""
         self.cfn_base_os = "{{ build.OperatingSystemName.outputs.stdout }}"
 
@@ -46,5 +50,5 @@ class ChefAttributes:
         """Dump chef attribute json to string."""
         default_attributes_json = {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
         default_attributes_json.update(self._extra_attributes_json)
-        dna_json = {"cfncluster": default_attributes_json}
-        return json.dumps(dna_json)
+        attribute_json = {"cfncluster": default_attributes_json}
+        return json.dumps(attribute_json)

--- a/cli/src/pcluster/models/imagebuilder_extra_attributes.py
+++ b/cli/src/pcluster/models/imagebuilder_extra_attributes.py
@@ -1,0 +1,50 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+from pcluster.models.imagebuilder import ImagebuilderDevSettings
+
+
+class ChefAttributes:
+    """Attributes for Chef Client."""
+
+    def __init__(self, dev_settings: ImagebuilderDevSettings):
+        self.cfn_region = None
+        self.nvidia = None
+        self.is_official_ami_build = None
+        self.custom_node_package = None
+        self.cfn_base_os = None
+        self._extra_attributes_json = {}
+        self._set_default(dev_settings)
+        self._set_extra_attributes(dev_settings)
+
+    def _set_default(self, dev_settings: ImagebuilderDevSettings):
+        self.cfn_region = "${AWS::Region}"
+        self.nvidia = {"enabled": "false"}
+        self.is_official_ami_build = str.lower(str(dev_settings.update_os_and_reboot)) if dev_settings else "false"
+        self.custom_node_package = dev_settings.node_package if dev_settings and dev_settings.node_package else ""
+        self.cfn_base_os = "{{ build.OperatingSystemName.outputs.stdout }}"
+
+    def _set_extra_attributes(self, dev_settings: ImagebuilderDevSettings):
+        if dev_settings and dev_settings.cookbook and dev_settings.cookbook.extra_chef_attributes:
+            extra_attributes = json.loads(dev_settings.cookbook.extra_chef_attributes)
+            for key, value in extra_attributes.items():
+                if key in self.__dict__:
+                    self.__dict__.update({key: value})
+                else:
+                    self._extra_attributes_json.update({key: value})
+
+    def dump_json(self):
+        """Dump chef attribute json to string."""
+        default_attributes_json = {k: v for k, v in self.__dict__.items() if not k.startswith("_")}
+        default_attributes_json.update(self._extra_attributes_json)
+        dna_json = {"cfncluster": default_attributes_json}
+        return json.dumps(dna_json)

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -111,7 +111,7 @@ class ComponentSchema(BaseSchema):
 class BuildSchema(BaseSchema):
     """Represent the schema of the ImageBuilder Build."""
 
-    instance_role = fields.Str()
+    instance_role = fields.Str(validate=validate.Regexp("^arn:.*:(role|instance-profile)/"))
     instance_type = fields.Str(required=True)
     components = fields.List(fields.Nested(ComponentSchema))
     parent_image = fields.Str(required=True, validate=validate.Regexp("^ami|arn"))

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -57,18 +57,10 @@ class ImageBuilderStack(core.Stack):
         core.CfnParameter(self, "CfnParamCincInstaller", type="String", default="", description="CincInstaller")
         core.CfnParameter(
             self,
-            "CfnParamDnaJson",
+            "CfnParamAttributeJson",
             type="String",
             default=ChefAttributes(dev_settings).dump_json(),
             description="ChefAttributes",
-        )
-
-        core.CfnParameter(
-            self,
-            "UpdateAndReboot",
-            type="String",
-            default=str.lower(str(dev_settings.update_os_and_reboot)),
-            description="UpdateAndReboot",
         )
 
         # Setup ImageBuilder Resources
@@ -80,10 +72,8 @@ class ImageBuilderStack(core.Stack):
             instance_role_type = self._get_instance_role_type()
             if instance_role_type == InstanceRole.ROLE:
                 self._set_instance_profile(instance_role=build.instance_role)
-            elif instance_role_type == InstanceRole.INSTANCE_PROFILE:
-                instance_profile_name = build.instance_role
             else:
-                self._set_instance_profile()
+                instance_profile_name = build.instance_role
         else:
             self._set_default_instance_role()
             self._set_instance_profile()
@@ -165,9 +155,7 @@ class ImageBuilderStack(core.Stack):
         identifier = instance_role.split("/", 1)[0]
         if identifier.endswith("role"):
             return InstanceRole.ROLE
-        if identifier.endswith("instance-profile"):
-            return InstanceRole.INSTANCE_PROFILE
-        return InstanceRole.DEFAULT
+        return InstanceRole.INSTANCE_PROFILE
 
     def _set_default_instance_role(self):
         """Set default instance role in imagebuilder cfn template."""
@@ -222,6 +210,7 @@ class ImageBuilderStack(core.Stack):
                     description="CustomComponent",
                     change_description="First version",
                     platform="Linux",
+                    # TODO check the yaml url for https://, s3:// and file:///
                     uri=custom_component,
                 )
             else:
@@ -235,6 +224,7 @@ class ImageBuilderStack(core.Stack):
                     description="CustomComponent",
                     change_description="First version",
                     platform="Linux",
+                    # TODO implement _wrap_bash_to_component
                     data=self._wrap_bash_to_component(),
                 )
 

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -145,7 +145,7 @@ class ImageBuilderStack(core.Stack):
             components=components,
             block_device_mappings=[
                 imagebuilder.CfnImageRecipe.InstanceBlockDeviceMappingProperty(
-                    device_name="/dev/xvda",
+                    device_name=self._get_root_device_name(),
                     ebs=self._set_ebs_volume(),
                 )
             ],
@@ -269,3 +269,8 @@ class ImageBuilderStack(core.Stack):
             )
 
         return ebs
+
+    def _get_root_device_name(self):
+        ami_id = imagebuilder_utils.get_ami_id(self.imagebuild.build.parent_image)
+        ami_info = AWSApi.instance().ec2.describe_image(ami_id)
+        return ami_info.get("BlockDeviceMappings")[0].get("DeviceName")

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -12,17 +12,22 @@
 #
 # This module contains all the classes required to convert a ImageBuilder into a CFN template by using CDK.
 #
-
+import copy
 import os
 
+import yaml
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_imagebuilder as imagebuilder
-from aws_cdk import aws_ssm as ssm
 from aws_cdk import core
 
 import pcluster.utils as utils
+from common import imagebuilder_utils
+from common.aws.aws_api import AWSApi
+from common.imagebuilder_utils import PCLUSTER_RESERVED_VOLUME_SIZE, ROOT_VOLUME_TYPE, InstanceRole
 from common.utils import load_yaml
-from pcluster.models.imagebuilder import ImageBuilder
+from pcluster.models.imagebuilder import ImageBuilder, Volume
+from pcluster.models.imagebuilder_extra_attributes import ChefAttributes
+from pcluster.schemas.imagebuilder_schema import ImageBuilderSchema
 
 
 class ImageBuilderStack(core.Stack):
@@ -30,21 +35,34 @@ class ImageBuilderStack(core.Stack):
 
     def __init__(self, scope: core.Construct, construct_id: str, imagebuild: ImageBuilder, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
-        image = imagebuild.image
+        self.imagebuild = imagebuild
         build = imagebuild.build
         dev_settings = imagebuild.dev_settings
 
+        config_file = ImageBuilderSchema().dump(copy.deepcopy(self.imagebuild))
+        self.template_options.metadata = {"Config": yaml.dump(config_file)}
+
         # TODO: use attributes from imagebuilder config instead of using these static variables.
-        core.CfnParameter(self, "EnableNvidia", type="String", default="false", description="EnableNvidia")
-        core.CfnParameter(self, "EnableDCV", type="String", default="false", description="EnableDCV")
-        default_node_package = dev_settings.node_package if dev_settings and dev_settings.node_package else ""
+        custom_chef_cookbook = dev_settings.cookbook.chef_cookbook if dev_settings and dev_settings.cookbook else ""
         core.CfnParameter(
             self,
-            "CustomNodePackage",
+            "CfnParamCookbookVersion",
             type="String",
-            default=default_node_package,
-            description="CustomNodePackage",
+            default=utils.get_installed_version(),
+            description="CookbookVersion",
         )
+        core.CfnParameter(
+            self, "CfnParamChefCookbook", type="String", default=custom_chef_cookbook, description="ChefCookbook"
+        )
+        core.CfnParameter(self, "CfnParamCincInstaller", type="String", default="", description="CincInstaller")
+        core.CfnParameter(
+            self,
+            "CfnParamDnaJson",
+            type="String",
+            default=ChefAttributes(dev_settings).dump_json(),
+            description="ChefAttributes",
+        )
+
         core.CfnParameter(
             self,
             "UpdateAndReboot",
@@ -56,51 +74,28 @@ class ImageBuilderStack(core.Stack):
         # Setup ImageBuilder Resources
         resources_prefix = utils.generate_random_prefix()
 
-        # InstanceRole
-        managed_policy_arns = [
-            core.Fn.sub("arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"),
-            core.Fn.sub("arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder"),
-        ]
+        # InstanceRole and InstanceProfile
+        instance_profile_name = None
         if build.instance_role:
-            managed_policy_arns.extend([build.instance_role])
-
-        instancerole = iam.CfnRole(
-            self,
-            id="InstanceRole",
-            managed_policy_arns=managed_policy_arns,
-            assume_role_policy_document={
-                "Statement": {
-                    "Action": "sts:AssumeRole",
-                    "Effect": "Allow",
-                    "Principal": {"Service": "ec2.amazonaws.com"},
-                },
-                "Version": "2012-10-17",
-            },
-            path="/executionServiceEC2Role/",
-        )
-        instancerole.add_metadata("Comment", "Role to be used by instance during image build.")
-
-        # InstanceProfile
-        iam.CfnInstanceProfile(
-            self, id="InstanceProfile", path="/executionServiceEC2Role/", roles=[core.Fn.ref("InstanceRole")]
-        )
+            instance_role_type = self._get_instance_role_type()
+            if instance_role_type == InstanceRole.ROLE:
+                self._set_instance_profile(instance_role=build.instance_role)
+            elif instance_role_type == InstanceRole.INSTANCE_PROFILE:
+                instance_profile_name = build.instance_role
+            else:
+                self._set_instance_profile()
+        else:
+            self._set_default_instance_role()
+            self._set_instance_profile()
 
         # InfrastructureConfiguration
         imagebuilder.CfnInfrastructureConfiguration(
             self,
             id="PClusterImageInfrastructureConfiguration",
             name="-".join(["PCluster-Image-Infrastructure-Configuration", resources_prefix]),
-            instance_profile_name=core.Fn.ref("InstanceProfile"),
+            instance_profile_name=core.Fn.ref(instance_profile_name or "InstanceProfile"),
             terminate_instance_on_failure=dev_settings.terminate_instance_on_failure,
             instance_types=[build.instance_type],
-        )
-
-        # Define ami build instance ebs
-        ebs = imagebuilder.CfnImageRecipe.EbsInstanceBlockDeviceSpecificationProperty(
-            volume_size=image.root_volume.size,
-            volume_type="gp2",
-            encrypted=image.root_volume.encrypted,
-            kms_key_id=image.root_volume.kms_key_id,
         )
 
         imagebuilder_cloudformation_dir = os.path.join(utils.get_cloudformation_directory(), "imagebuilder")
@@ -137,6 +132,8 @@ class ImageBuilderStack(core.Stack):
         components.append(
             imagebuilder.CfnImageRecipe.ComponentConfigurationProperty(component_arn=core.Fn.ref("PClusterComponent"))
         )
+        if build.components:
+            self._set_custom_components(components)
 
         # ImageRecipe
         imagebuilder.CfnImageRecipe(
@@ -149,7 +146,7 @@ class ImageBuilderStack(core.Stack):
             block_device_mappings=[
                 imagebuilder.CfnImageRecipe.InstanceBlockDeviceMappingProperty(
                     device_name="/dev/xvda",
-                    ebs=ebs,
+                    ebs=self._set_ebs_volume(),
                 )
             ],
         )
@@ -162,12 +159,113 @@ class ImageBuilderStack(core.Stack):
             infrastructure_configuration_arn=core.Fn.ref("PClusterImageInfrastructureConfiguration"),
         )
 
-        # AWS Systems Manager
-        ssm.CfnParameter(
+    def _get_instance_role_type(self):
+        """Get instance role type based on instance_role in config."""
+        instance_role = self.imagebuild.build.instance_role
+        identifier = instance_role.split("/", 1)[0]
+        if identifier.endswith("role"):
+            return InstanceRole.ROLE
+        if identifier.endswith("instance-profile"):
+            return InstanceRole.INSTANCE_PROFILE
+        return InstanceRole.DEFAULT
+
+    def _set_default_instance_role(self):
+        """Set default instance role in imagebuilder cfn template."""
+        managed_policy_arns = [
+            core.Fn.sub("arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"),
+            core.Fn.sub("arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder"),
+        ]
+
+        instancerole = iam.CfnRole(
             self,
-            id="PClusterParameter",
-            description="Image Id for PCluster",
-            name="-".join(["/Test/Images/PCluster", resources_prefix]),
-            type="String",
-            value=core.Fn.get_att("PClusterImage", "ImageId").to_string(),
+            id="InstanceRole",
+            managed_policy_arns=managed_policy_arns,
+            assume_role_policy_document={
+                "Statement": {
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ec2.amazonaws.com"},
+                },
+                "Version": "2012-10-17",
+            },
+            path="/executionServiceEC2Role/",
         )
+
+        instancerole.add_metadata("Comment", "Role to be used by instance during image build.")
+
+    def _set_instance_profile(self, instance_role="InstanceRole"):
+        """Set default instance profile in imagebuilder cfn template."""
+        iam.CfnInstanceProfile(
+            self, id="InstanceProfile", path="/executionServiceEC2Role/", roles=[core.Fn.ref(instance_role)]
+        )
+
+    def _set_custom_components(self, components):
+        """Set custom component in imagebuilder cfn template."""
+        build = self.imagebuild.build
+        custom_components = build.components
+        initial_component_len = len(custom_components)
+        arn_components_len = 0
+        for custom_component in custom_components:
+            if custom_component.type.startswith("arn"):
+                components.append(
+                    imagebuilder.CfnImageRecipe.ComponentConfigurationProperty(component_arn=custom_component)
+                )
+                arn_components_len += 1
+            elif custom_component.type.startswith("yaml"):
+                imagebuilder.CfnComponent(
+                    self,
+                    id="CustomComponent" + str(len(components) - initial_component_len - arn_components_len),
+                    name="-".join(
+                        ["CustomComponent", str(len(components) - initial_component_len - arn_components_len)]
+                    ),
+                    version="0.0.1",
+                    description="CustomComponent",
+                    change_description="First version",
+                    platform="Linux",
+                    uri=custom_component,
+                )
+            else:
+                imagebuilder.CfnComponent(
+                    self,
+                    id="CustomComponent" + str(len(components) - initial_component_len - arn_components_len),
+                    name="-".join(
+                        ["CustomComponent", str(len(components) - initial_component_len - arn_components_len)]
+                    ),
+                    version="0.0.1",
+                    description="CustomComponent",
+                    change_description="First version",
+                    platform="Linux",
+                    data=self._wrap_bash_to_component(),
+                )
+
+    def _set_ebs_volume(self):
+        """Set ebs root volume in imagebuilder cfn template."""
+        image = self.imagebuild.image
+        build = self.imagebuild.build
+
+        if image.root_volume is None or image.root_volume.size is None:
+            ami_id = imagebuilder_utils.get_ami_id(build.parent_image)
+            ami_info = AWSApi.instance().ec2.describe_image(ami_id)
+            default_root_volume_size = (
+                ami_info.get("BlockDeviceMappings")[0].get("Ebs").get("VolumeSize") + PCLUSTER_RESERVED_VOLUME_SIZE
+            )
+            if image.root_volume is None:
+                default_root_volume = Volume(size=default_root_volume_size)
+            else:
+                default_root_volume = copy.deepcopy(image.root_volume)
+                default_root_volume.size = default_root_volume_size
+            ebs = imagebuilder.CfnImageRecipe.EbsInstanceBlockDeviceSpecificationProperty(
+                volume_size=default_root_volume.size,
+                volume_type=ROOT_VOLUME_TYPE,
+                encrypted=default_root_volume.encrypted,
+                kms_key_id=default_root_volume.kms_key_id,
+            )
+        else:
+            ebs = imagebuilder.CfnImageRecipe.EbsInstanceBlockDeviceSpecificationProperty(
+                volume_size=image.root_volume.size,
+                volume_type=ROOT_VOLUME_TYPE,
+                encrypted=image.root_volume.encrypted,
+                kms_key_id=image.root_volume.kms_key_id,
+            )
+
+        return ebs

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -9,8 +9,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 from common import imagebuilder_utils
+from common.aws.aws_api import AWSApi
 from common.boto3.common import AWSClientError
-from common.boto3.ec2 import Ec2Client
 from common.boto3.iam import IamClient
 from pcluster import utils
 from pcluster.utils import policy_name_to_arn
@@ -25,7 +25,7 @@ class InstanceTypeValidator(Validator):
     """
 
     def _validate(self, instance_type: str):
-        if instance_type not in Ec2Client().describe_instance_type_offerings():
+        if instance_type not in AWSApi.instance().ec2.describe_instance_type_offerings():
             self._add_failure(
                 f"The instance type '{instance_type}' is not supported.",
                 FailureLevel.ERROR,
@@ -53,14 +53,14 @@ class InstanceTypeBaseAMICompatibleValidator(Validator):
     def _validate_base_ami(self, image: str):
         try:
             ami_id = imagebuilder_utils.get_ami_id(image)
-            ami_info = Ec2Client().describe_image(ami_id=ami_id)
+            ami_info = AWSApi.instance().ec2.describe_image(ami_id=ami_id)
             return ami_id, ami_info
         except AWSClientError:
             self._add_failure(f"Invalid image '{image}'.", FailureLevel.ERROR)
             return None, None
 
     def _validate_instance_type(self, instance_type: str):
-        if instance_type not in Ec2Client().describe_instance_type_offerings():
+        if instance_type not in AWSApi.instance().ec2.describe_instance_type_offerings():
             self._add_failure(
                 f"The instance type '{instance_type}' is not supported.",
                 FailureLevel.ERROR,
@@ -97,7 +97,7 @@ class KeyPairValidator(Validator):  # TODO add test
 
     def _validate(self, key_name: str):
         try:
-            Ec2Client().describe_key_pair(key_name)
+            AWSApi.instance().ec2.describe_key_pair(key_name)
         except AWSClientError as e:
             self._add_failure(str(e), FailureLevel.ERROR)
 
@@ -108,6 +108,6 @@ class PlacementGroupIdValidator(Validator):  # TODO: add tests
     def _validate(self, placement_group_id: str):
         if placement_group_id:
             try:
-                Ec2Client().describe_placement_group(placement_group_id)
+                AWSApi.instance().ec2.describe_placement_group(placement_group_id)
             except AWSClientError as e:
                 self._add_failure(str(e), FailureLevel.ERROR)

--- a/cli/src/pcluster/validators/imagebuilder_validators.py
+++ b/cli/src/pcluster/validators/imagebuilder_validators.py
@@ -17,17 +17,14 @@ from pcluster.validators.common import FailureLevel, Validator
 class AMIVolumeSizeValidator(Validator):
     """AMI root volume size validator."""
 
-    def _validate(self, volume_size: int, image: str, pcluster_reserved_volume_size: int):
+    def _validate(self, volume_size: int, image: str):
         """Validate the volume size is larger than base ami volume size."""
         ami_id = imagebuilder_utils.get_ami_id(image)
         ami_info = AWSApi.instance().ec2.describe_image(ami_id)
-        base_ami_volume_size = ami_info.get("BlockDeviceMappings")[0].get("Ebs").get("VolumeSize")
-        min_volume_size = base_ami_volume_size + pcluster_reserved_volume_size
+        min_volume_size = ami_info.get("BlockDeviceMappings")[0].get("Ebs").get("VolumeSize")
         if volume_size < min_volume_size:
             self._add_failure(
-                "Root volume size {0} GB is less than the minimum required size {1} GB that equals base ami {2} GB "
-                "plus size 15 GB to allow PCluster software stack installation.".format(
-                    volume_size, min_volume_size, base_ami_volume_size
-                ),
+                "Root volume size {0} GB is less than the minimum required size {1} GB that equals parent ami "
+                "volume size.".format(volume_size, min_volume_size),
                 FailureLevel.ERROR,
             )

--- a/cli/src/pcluster/validators/imagebuilder_validators.py
+++ b/cli/src/pcluster/validators/imagebuilder_validators.py
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 from common import imagebuilder_utils
-from common.boto3.ec2 import Ec2Client
+from common.aws.aws_api import AWSApi
 from pcluster.validators.common import FailureLevel, Validator
 
 
@@ -20,7 +20,7 @@ class AMIVolumeSizeValidator(Validator):
     def _validate(self, volume_size: int, image: str, pcluster_reserved_volume_size: int):
         """Validate the volume size is larger than base ami volume size."""
         ami_id = imagebuilder_utils.get_ami_id(image)
-        ami_info = Ec2Client().describe_image(ami_id)
+        ami_info = AWSApi.instance().ec2.describe_image(ami_id)
         base_ami_volume_size = ami_info.get("BlockDeviceMappings")[0].get("Ebs").get("VolumeSize")
         min_volume_size = base_ami_volume_size + pcluster_reserved_volume_size
         if volume_size < min_volume_size:

--- a/cli/src/pcluster/validators/s3_validators.py
+++ b/cli/src/pcluster/validators/s3_validators.py
@@ -5,7 +5,6 @@ from urllib.request import urlopen
 
 from common.aws.aws_api import AWSApi
 from common.boto3.common import AWSClientError
-from common.boto3.s3 import S3Client
 from pcluster.validators.common import FailureLevel, Validator
 from pcluster.validators.utils import get_bucket_name_from_s3_url
 
@@ -55,7 +54,7 @@ class UrlValidator(Validator):
                 self._add_failure(f"s3 url '{url}' is invalid.", FailureLevel.ERROR)
             else:
                 bucket_name, object_name = match.group(1), match.group(2)
-                S3Client().head_object(bucket_name=bucket_name, object_name=object_name)
+                AWSApi.instance().s3.head_object(bucket_name=bucket_name, object_name=object_name)
 
         except AWSClientError:
             # Todo: Check that bucket is in s3_read_resource or s3_read_write_resource.
@@ -70,7 +69,7 @@ class S3BucketUriValidator(Validator):
         if urlparse(url).scheme == "s3":
             try:
                 bucket = get_bucket_name_from_s3_url(url)
-                S3Client().head_bucket(bucket_name=bucket)
+                AWSApi.instance().s3.head_bucket(bucket_name=bucket)
             except AWSClientError as e:
                 self._add_failure(str(e), FailureLevel.ERROR)
         else:

--- a/cli/tests/common/test_imagebuilder_utils.py
+++ b/cli/tests/common/test_imagebuilder_utils.py
@@ -12,6 +12,7 @@ import pytest
 from assertpy import assert_that
 
 from common import imagebuilder_utils
+from tests.pcluster.boto3.dummy_boto3 import DummyAWSApi
 
 
 @pytest.mark.parametrize(
@@ -19,15 +20,15 @@ from common import imagebuilder_utils
     [
         (
             "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x",
-            {"image": {"outputResources": {"amis": [{"image": "ami-0be2609ba883822ec"}]}}},
+            "ami-0be2609ba883822ec",
             "ami-0be2609ba883822ec",
         ),
         ("ami-00e87074e52e6c9f9", "{}", "ami-00e87074e52e6c9f9"),
     ],
 )
 def test_evaluate_ami_id(mocker, parent_image, response, ami_id):
-    mocker.patch("common.imagebuilder_utils.ImageBuilderClient.__init__", return_value=None)
-    mocker.patch("common.imagebuilder_utils.ImageBuilderClient.get_image_resources", return_value=response)
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
+    mocker.patch("common.boto3.imagebuilder.ImageBuilderClient.get_image_id", return_value=response)
     assert_that(imagebuilder_utils.get_ami_id(parent_image)).is_equal_to(ami_id)
 
 
@@ -46,6 +47,6 @@ def test_evaluate_ami_id(mocker, parent_image, response, ami_id):
 )
 def test_get_info_for_ami_from_arn(mocker, image_arn, response):
     """Verify get_info_for_ami_from_arn returns the expected response, and that errors cause nonzero exit."""
-    mocker.patch("common.imagebuilder_utils.ImageBuilderClient.__init__", return_value=None)
-    mocker.patch("common.imagebuilder_utils.ImageBuilderClient.get_image_resources", return_value=response)
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
+    mocker.patch("common.boto3.imagebuilder.ImageBuilderClient.get_image_resources", return_value=response)
     assert_that(imagebuilder_utils.get_info_for_ami_from_arn(image_arn)).is_equal_to(response)

--- a/cli/tests/pcluster/boto3/dummy_boto3.py
+++ b/cli/tests/pcluster/boto3/dummy_boto3.py
@@ -11,12 +11,16 @@
 from common.aws.aws_api import AWSApi
 from common.boto3.common import AWSClientError
 from common.boto3.ec2 import Ec2Client
+from common.boto3.imagebuilder import ImageBuilderClient
+from common.boto3.s3 import S3Client
 
 
 class DummyAWSApi(AWSApi):
     def __init__(self):
         self.ec2 = dummy_ec2_client()
         self.efs = dummy_efs_client()
+        self.s3 = dummy_s3_client()
+        self.imagebuilder = dummy_imagebuilder_client()
         # TODO: mock all clients
 
 
@@ -60,12 +64,34 @@ class DummyEfsClient(Ec2Client):
         return mt_id
 
 
+class DummyS3Client(S3Client):
+    def __init__(self):
+        """Override Parent constructor. No real boto3 client is created."""
+
+    pass
+
+
+class DummyImageBuilderClient(ImageBuilderClient):
+    def __init__(self):
+        """Override Parent constructor. No real boto3 client is created."""
+
+    pass
+
+
 def dummy_ec2_client():
     return DummyEc2Client()
 
 
 def dummy_efs_client():
     return DummyEfsClient()
+
+
+def dummy_s3_client():
+    return DummyS3Client()
+
+
+def dummy_imagebuilder_client():
+    return DummyImageBuilderClient()
 
 
 def mock_aws_api():

--- a/cli/tests/pcluster/models/imagebuilder_dummy_model.py
+++ b/cli/tests/pcluster/models/imagebuilder_dummy_model.py
@@ -9,10 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 from pcluster.models.common import BaseTag, Cookbook
-from pcluster.models.imagebuilder import Build, Component
-from pcluster.models.imagebuilder import Image
-from pcluster.models.imagebuilder import Image as ImageBuilderImage
-from pcluster.models.imagebuilder import ImageBuilder, ImagebuilderDevSettings, Volume
+from pcluster.models.imagebuilder import Build, Component, Image, ImageBuilder, ImagebuilderDevSettings, Volume
 
 CLASS_DICT = {
     "imagebuilder": ImageBuilder,
@@ -28,7 +25,7 @@ CLASS_DICT = {
 
 def dummy_imagebuilder(is_official_ami_build):
     """Generate dummy imagebuilder configuration."""
-    image = ImageBuilderImage(name="Pcluster")
+    image = Image(name="Pcluster")
     if is_official_ami_build:
         build = Build(
             instance_type="c5.xlarge", parent_image="arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x"

--- a/cli/tests/pcluster/models/test_imagebuilder_extra_attributes.py
+++ b/cli/tests/pcluster/models/test_imagebuilder_extra_attributes.py
@@ -25,15 +25,15 @@ from tests.pcluster.models.imagebuilder_dummy_model import imagebuilder_factory
                 "dev_settings": {
                     "cookbook": {
                         "chef_cookbook": "file:///test/aws-parallelcluster-cookbook-3.0.tgz",
-                        "extra_chef_attributes": '{"nvidia": { "enable" : "true" }, "dcv" :"false"}',
+                        "extra_chef_attributes": '{"nvidia": { "enabled" : "true" }, "dcv" :"false"}',
                     },
                     "node_package": "s3://test/aws-parallelcluster-node-3.0.tgz",
                 },
             },
             {
                 "cfncluster": {
-                    "cfn_region": "${AWS::Region}",
-                    "nvidia": {"enable": "true"},
+                    "cfn_region": "{{ build.AWSRegion.outputs.stdout }}",
+                    "nvidia": {"enabled": "true"},
                     "is_official_ami_build": "false",
                     "custom_node_package": "s3://test/aws-parallelcluster-node-3.0.tgz",
                     "cfn_base_os": "{{ build.OperatingSystemName.outputs.stdout }}",
@@ -46,15 +46,15 @@ from tests.pcluster.models.imagebuilder_dummy_model import imagebuilder_factory
                 "dev_settings": {
                     "cookbook": {
                         "chef_cookbook": "file:///test/aws-parallelcluster-cookbook-3.0.tgz",
-                        "extra_chef_attributes": '{"nvidia": { "enable" : "true" }, "dcv" :"false", '
+                        "extra_chef_attributes": '{"nvidia": { "enabled" : "true" }, "dcv" :"false", '
                         '"cluster":{"cfn_slots":"cores"}}',
                     },
                 },
             },
             {
                 "cfncluster": {
-                    "cfn_region": "${AWS::Region}",
-                    "nvidia": {"enable": "true"},
+                    "cfn_region": "{{ build.AWSRegion.outputs.stdout }}",
+                    "nvidia": {"enabled": "true"},
                     "is_official_ami_build": "false",
                     "custom_node_package": "",
                     "cfn_base_os": "{{ build.OperatingSystemName.outputs.stdout }}",

--- a/cli/tests/pcluster/models/test_imagebuilder_extra_attributes.py
+++ b/cli/tests/pcluster/models/test_imagebuilder_extra_attributes.py
@@ -1,0 +1,71 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.models.imagebuilder_extra_attributes import ChefAttributes
+from tests.pcluster.models.imagebuilder_dummy_model import imagebuilder_factory
+
+
+@pytest.mark.parametrize(
+    "resource, dna_json",
+    [
+        (
+            {
+                "dev_settings": {
+                    "cookbook": {
+                        "chef_cookbook": "file:///test/aws-parallelcluster-cookbook-3.0.tgz",
+                        "extra_chef_attributes": '{"nvidia": { "enable" : "true" }, "dcv" :"false"}',
+                    },
+                    "node_package": "s3://test/aws-parallelcluster-node-3.0.tgz",
+                },
+            },
+            {
+                "cfncluster": {
+                    "cfn_region": "${AWS::Region}",
+                    "nvidia": {"enable": "true"},
+                    "is_official_ami_build": "false",
+                    "custom_node_package": "s3://test/aws-parallelcluster-node-3.0.tgz",
+                    "cfn_base_os": "{{ build.OperatingSystemName.outputs.stdout }}",
+                    "dcv": "false",
+                }
+            },
+        ),
+        (
+            {
+                "dev_settings": {
+                    "cookbook": {
+                        "chef_cookbook": "file:///test/aws-parallelcluster-cookbook-3.0.tgz",
+                        "extra_chef_attributes": '{"nvidia": { "enable" : "true" }, "dcv" :"false", '
+                        '"cluster":{"cfn_slots":"cores"}}',
+                    },
+                },
+            },
+            {
+                "cfncluster": {
+                    "cfn_region": "${AWS::Region}",
+                    "nvidia": {"enable": "true"},
+                    "is_official_ami_build": "false",
+                    "custom_node_package": "",
+                    "cfn_base_os": "{{ build.OperatingSystemName.outputs.stdout }}",
+                    "dcv": "false",
+                    "cluster": {"cfn_slots": "cores"},
+                }
+            },
+        ),
+    ],
+)
+def test_chef_attributes(resource, dna_json):
+    dev_settings = imagebuilder_factory(resource).get("dev_settings")
+    chef_attributes = ChefAttributes(dev_settings).dump_json()
+    assert_that(chef_attributes).is_equal_to(json.dumps(dna_json))

--- a/cli/tests/pcluster/models/test_imagebuilder_model.py
+++ b/cli/tests/pcluster/models/test_imagebuilder_model.py
@@ -14,6 +14,7 @@ import pytest
 
 from common.boto3.common import AWSClientError
 from pcluster.validators.common import FailureLevel
+from tests.pcluster.boto3.dummy_boto3 import DummyAWSApi
 from tests.pcluster.models.imagebuilder_dummy_model import imagebuilder_factory
 from tests.pcluster.models.test_cluster_model import _assert_validation_result
 
@@ -143,20 +144,17 @@ def _test_imagebuilder(
 ):
     mocker.patch("common.imagebuilder_utils.get_ami_id", return_value="ami-0185634c5a8a37250")
     mocker.patch("pcluster.utils.get_supported_architectures_for_instance_type", return_value=supported_architecture)
-    mocker.patch("pcluster.validators.imagebuilder_validators.Ec2Client.__init__", return_value=None)
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
     mocker.patch(
-        "pcluster.validators.imagebuilder_validators.Ec2Client.describe_image",
+        "common.boto3.ec2.Ec2Client.describe_image",
         return_value=ami_response,
         side_effect=ami_side_effect,
     )
     mocker.patch(
-        "pcluster.validators.imagebuilder_validators.Ec2Client.describe_instance_type_offerings",
+        "common.boto3.ec2.Ec2Client.describe_instance_type_offerings",
         return_value=instance_response,
     )
-    mocker.patch("pcluster.validators.s3_validators.S3Client.__init__", return_value=None)
-    mocker.patch(
-        "pcluster.validators.s3_validators.S3Client.head_object", return_value=url_response, side_effect=url_side_effect
-    )
+    mocker.patch("common.boto3.s3.S3Client.head_object", return_value=url_response, side_effect=url_side_effect)
     mocker.patch("pcluster.validators.s3_validators.urlopen", side_effect=url_open_side_effect)
 
     imagebuilder = imagebuilder_factory(resource).get("imagebuilder")
@@ -188,14 +186,14 @@ def _test_build(
 ):
     mocker.patch("common.imagebuilder_utils.get_ami_id", return_value="ami-0185634c5a8a37250")
     mocker.patch("pcluster.utils.get_supported_architectures_for_instance_type", return_value=supported_architecture)
-    mocker.patch("pcluster.validators.imagebuilder_validators.Ec2Client.__init__", return_value=None)
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
     mocker.patch(
-        "pcluster.validators.imagebuilder_validators.Ec2Client.describe_image",
+        "common.boto3.ec2.Ec2Client.describe_image",
         return_value=ami_response,
         side_effect=ami_side_effect,
     )
     mocker.patch(
-        "pcluster.validators.imagebuilder_validators.Ec2Client.describe_instance_type_offerings",
+        "common.boto3.ec2.Ec2Client.describe_instance_type_offerings",
         return_value=instance_response,
     )
 
@@ -216,10 +214,8 @@ def _test_dev_settings(
     expected_failure_messages,
     expected_failure_levels,
 ):
-    mocker.patch("pcluster.validators.s3_validators.S3Client.__init__", return_value=None)
-    mocker.patch(
-        "pcluster.validators.s3_validators.S3Client.head_object", return_value=url_response, side_effect=url_side_effect
-    )
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
+    mocker.patch("common.boto3.s3.S3Client.head_object", return_value=url_response, side_effect=url_side_effect)
     mocker.patch("pcluster.validators.s3_validators.urlopen", side_effect=url_open_side_effect)
 
     dev_settings = imagebuilder_factory(resource).get("dev_settings")

--- a/cli/tests/pcluster/models/test_imagebuilder_model.py
+++ b/cli/tests/pcluster/models/test_imagebuilder_model.py
@@ -55,8 +55,8 @@ from tests.pcluster.models.test_cluster_model import _assert_validation_result
             None,
             [
                 "Kms Key Id key_id is specified, the encrypted state must be True.",
-                "Root volume size 25 GB is less than the minimum required size 65 GB that equals "
-                "base ami 50 GB plus size 15 GB to allow PCluster software stack installation.",
+                "Root volume size 25 GB is less than the minimum required size 50 GB that equals parent ami"
+                " volume size.",
             ],
             [FailureLevel.ERROR, FailureLevel.ERROR],
         )

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema.py
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema.py
@@ -6,6 +6,7 @@ from assertpy import assert_that
 
 from common.utils import load_yaml_dict
 from pcluster.schemas.imagebuilder_schema import ImageBuilderSchema
+from tests.pcluster.boto3.dummy_boto3 import DummyAWSApi
 
 
 @pytest.mark.parametrize(
@@ -50,10 +51,10 @@ from pcluster.schemas.imagebuilder_schema import ImageBuilderSchema
     ],
 )
 def test_imagebuilder_schema(mocker, test_datadir, config_file_name, response):
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
     mocker.patch("common.imagebuilder_utils.get_ami_id", return_value="ami-0185634c5a8a37250")
-    mocker.patch("pcluster.validators.ec2_validators.Ec2Client.__init__", return_value=None)
     mocker.patch(
-        "pcluster.validators.ec2_validators.Ec2Client.describe_image",
+        "common.boto3.ec2.Ec2Client.describe_image",
         return_value=response,
     )
     # Load imagebuilder model from Yaml file

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
@@ -12,7 +12,7 @@ Image:
     KmsKeyId: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 
 Build:
-  InstanceRole: TestRole
+  InstanceRole: arn:aws:iam::111122223333:role/executionServiceEC2Role/parallelcluster-imagebuilder-test-InstanceRole-J7MKRFYF6634
   InstanceType: c5.xlarge
   Components:
     - Type: arn

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -12,7 +12,6 @@
 import os
 
 import pytest
-import yaml
 from assertpy import assert_that
 
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
@@ -42,10 +41,27 @@ from ..models.imagebuilder_dummy_model import dummy_imagebuilder
                 ],
             },
             {
+                "Metadata": {
+                    "Config": "Build:\n  InstanceType: c5.xlarge\n  "
+                    "ParentImage: arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x\n\
+                    DevSettings:\n  UpdateOsAndReboot: true\nImage:\n  Name: Pcluster\n"
+                },
                 "Parameters": {
-                    "EnableNvidia": {"Type": "String", "Default": "false", "Description": "EnableNvidia"},
-                    "EnableDCV": {"Type": "String", "Default": "false", "Description": "EnableDCV"},
-                    "CustomNodePackage": {"Type": "String", "Default": "", "Description": "CustomNodePackage"},
+                    "CfnParamAttributeJson": {
+                        "Type": "String",
+                        "Default": '{"cfncluster": {"cfn_region": '
+                        '"{{ build.AWSRegion.outputs.stdout }}","nvidia": {"enabled": "false"}, '
+                        '"is_official_ami_build": "true", "custom_node_package":"", "cfn_base_os": '
+                        '"{{ build.OperatingSystemName.outputs.stdout }}"}}',
+                        "Description": "ChefAttributes",
+                    },
+                    "CfnParamChefCookbook": {"Type": "String", "Default": "", "Description": "ChefCookbook"},
+                    "CfnParamCincInstaller": {"Type": "String", "Default": "", "Description": "CincInstaller"},
+                    "CfnParamCookbookVersion": {
+                        "Type": "String",
+                        "Default": "2.10.1",
+                        "Description": "CookbookVersion",
+                    },
                 },
                 "Resources": {
                     "InstanceRole": {
@@ -126,15 +142,6 @@ from ..models.imagebuilder_dummy_model import dummy_imagebuilder
                             "InfrastructureConfigurationArn": {"Ref": "PClusterImageInfrastructureConfiguration"},
                         },
                     },
-                    "PClusterParameter": {
-                        "Type": "AWS::SSM::Parameter",
-                        "Properties": {
-                            "Type": "String",
-                            "Value": {"Fn::GetAtt": ["PClusterImage", "ImageId"]},
-                            "Description": "Image Id for PCluster",
-                            "Name": "/Test/Images/PCluster-qd6lpbzo8gd2j4dr",
-                        },
-                    },
                 },
             },
         ),
@@ -156,13 +163,24 @@ from ..models.imagebuilder_dummy_model import dummy_imagebuilder
                 ],
             },
             {
+                "Metadata": {
+                    "Config": "Build:\n  InstanceType: g4dn.xlarge\n  ParentImage: ami-0185634c5a8a37250\n\
+    DevSettings: {}\nImage:\n  Name: Pcluster\n"
+                },
                 "Parameters": {
-                    "EnableNvidia": {"Type": "String", "Default": "false", "Description": "EnableNvidia"},
-                    "EnableDCV": {"Type": "String", "Default": "false", "Description": "EnableDCV"},
-                    "CustomNodePackage": {
+                    "CfnParamAttributeJson": {
                         "Type": "String",
-                        "Default": "",
-                        "Description": "CustomNodePackage",
+                        "Default": '{"cfncluster": {"cfn_region": "{{ build.AWSRegion.outputs.stdout }}",'
+                        '"nvidia": {"enabled": "false"}, "is_official_ami_build": "true", '
+                        '"custom_node_package":"", "cfn_base_os": "{{ build.OperatingSystemName.outputs.stdout }}"}}',
+                        "Description": "ChefAttributes",
+                    },
+                    "CfnParamChefCookbook": {"Type": "String", "Default": "", "Description": "ChefCookbook"},
+                    "CfnParamCincInstaller": {"Type": "String", "Default": "", "Description": "CincInstaller"},
+                    "CfnParamCookbookVersion": {
+                        "Type": "String",
+                        "Default": "2.10.1",
+                        "Description": "CookbookVersion",
                     },
                 },
                 "Resources": {
@@ -228,15 +246,6 @@ from ..models.imagebuilder_dummy_model import dummy_imagebuilder
                             "InfrastructureConfigurationArn": {"Ref": "PClusterImageInfrastructureConfiguration"},
                         },
                     },
-                    "PClusterParameter": {
-                        "Type": "AWS::SSM::Parameter",
-                        "Properties": {
-                            "Type": "String",
-                            "Value": {"Fn::GetAtt": ["PClusterImage", "ImageId"]},
-                            "Description": "Image Id for PCluster",
-                            "Name": "/Test/Images/PCluster-gw85hm3tw3qka4fd",
-                        },
-                    },
                 },
             },
         ),
@@ -256,10 +265,9 @@ def test_imagebuilder(mocker, is_official_ami_build, response, expected_template
     )
     dummy_imagebuild = dummy_imagebuilder(is_official_ami_build)
     generated_template = CDKTemplateBuilder().build_ami(dummy_imagebuild)
-    print(yaml.dump(generated_template))
-    # TODO assert content of the template by matching expected template, re-enable it after cdk refactoring
-    # _test_parameters(generated_template.get("Parameters"), expected_template.get("Parameters"))
-    # _test_resources(generated_template.get("Resources"), expected_template.get("Resources"))
+    # TODO assert content of the template by matching expected template, re-enable it after refactoring
+    _test_parameters(generated_template.get("Parameters"), expected_template.get("Parameters"))
+    _test_resources(generated_template.get("Resources"), expected_template.get("Resources"))
 
 
 def _test_parameters(generated_parameters, expected_parameters):

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -257,9 +257,9 @@ def test_imagebuilder(mocker, is_official_ami_build, response, expected_template
     dummy_imagebuild = dummy_imagebuilder(is_official_ami_build)
     generated_template = CDKTemplateBuilder().build_ami(dummy_imagebuild)
     print(yaml.dump(generated_template))
-    # TODO assert content of the template by matching expected template
-    _test_parameters(generated_template.get("Parameters"), expected_template.get("Parameters"))
-    _test_resources(generated_template.get("Resources"), expected_template.get("Resources"))
+    # TODO assert content of the template by matching expected template, re-enable it after cdk refactoring
+    # _test_parameters(generated_template.get("Parameters"), expected_template.get("Parameters"))
+    # _test_resources(generated_template.get("Resources"), expected_template.get("Resources"))
 
 
 def _test_parameters(generated_parameters, expected_parameters):

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -13,6 +13,7 @@ import pytest
 
 from common.boto3.common import AWSClientError
 from pcluster.validators.ec2_validators import InstanceTypeBaseAMICompatibleValidator, InstanceTypeValidator
+from tests.pcluster.boto3.dummy_boto3 import DummyAWSApi
 from tests.pcluster.validators.utils import assert_failure_messages
 
 
@@ -20,10 +21,9 @@ from tests.pcluster.validators.utils import assert_failure_messages
     "instance_type, expected_message", [("t2.micro", None), ("c4.xlarge", None), ("c5.xlarge", "is not supported")]
 )
 def test_instance_type_validator(mocker, instance_type, expected_message):
-
-    mocker.patch("pcluster.validators.ec2_validators.Ec2Client.__init__", return_value=None)
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
     mocker.patch(
-        "pcluster.validators.ec2_validators.Ec2Client.describe_instance_type_offerings",
+        "common.boto3.ec2.Ec2Client.describe_instance_type_offerings",
         return_value=["t2.micro", "c4.xlarge"],
     )
 
@@ -142,14 +142,14 @@ def test_instance_type_base_ami_compatible_validator(
     instance_architectures,
 ):
     mocker.patch("common.imagebuilder_utils.get_ami_id", return_value="ami-0185634c5a8a37250")
-    mocker.patch("pcluster.validators.ec2_validators.Ec2Client.__init__", return_value=None)
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
     mocker.patch(
-        "pcluster.validators.ec2_validators.Ec2Client.describe_image",
+        "common.boto3.ec2.Ec2Client.describe_image",
         return_value=ami_response,
         side_effect=ami_side_effect,
     )
     mocker.patch(
-        "pcluster.validators.ec2_validators.Ec2Client.describe_instance_type_offerings",
+        "common.boto3.ec2.Ec2Client.describe_instance_type_offerings",
         return_value=instance_response,
     )
     mocker.patch("pcluster.utils.get_supported_architectures_for_instance_type", return_value=instance_architectures)

--- a/cli/tests/pcluster/validators/test_imagebuilder_validators.py
+++ b/cli/tests/pcluster/validators/test_imagebuilder_validators.py
@@ -12,6 +12,7 @@
 import pytest
 
 from pcluster.validators.imagebuilder_validators import AMIVolumeSizeValidator
+from tests.pcluster.boto3.dummy_boto3 import DummyAWSApi
 from tests.pcluster.validators.utils import assert_failure_messages
 
 
@@ -104,9 +105,9 @@ from tests.pcluster.validators.utils import assert_failure_messages
 )
 def test_ami_volume_size_validator(mocker, image, volume_size, expected_message, ami_response):
     mocker.patch("common.imagebuilder_utils.get_ami_id", return_value="ami-0185634c5a8a37250")
-    mocker.patch("pcluster.validators.imagebuilder_validators.Ec2Client.__init__", return_value=None)
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
     mocker.patch(
-        "pcluster.validators.imagebuilder_validators.Ec2Client.describe_image",
+        "common.boto3.ec2.Ec2Client.describe_image",
         return_value=ami_response,
     )
     actual_failures = AMIVolumeSizeValidator().execute(volume_size, image, pcluster_reserved_volume_size=15)

--- a/cli/tests/pcluster/validators/test_imagebuilder_validators.py
+++ b/cli/tests/pcluster/validators/test_imagebuilder_validators.py
@@ -62,8 +62,7 @@ from tests.pcluster.validators.utils import assert_failure_messages
         (
             "ami-0185634c5a8a37250",
             25,
-            "Root volume size 25 GB is less than the minimum required size 65 GB that equals base ami 50 GB plus "
-            "size 15 GB to allow PCluster software stack installation.",
+            "Root volume size 25 GB is less than the minimum required size 50 GB that equals parent ami volume size.",
             {
                 "Architecture": "x86_64",
                 "BlockDeviceMappings": [
@@ -80,27 +79,6 @@ from tests.pcluster.validators.utils import assert_failure_messages
                 ],
             },
         ),
-        (
-            "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x",
-            15,
-            "Root volume size 15 GB is less than the minimum required size 23 GB that equals base ami "
-            "8 GB plus size 15 GB to allow PCluster software stack installation.",
-            {
-                "Architecture": "x86_64",
-                "BlockDeviceMappings": [
-                    {
-                        "DeviceName": "/dev/xvda",
-                        "Ebs": {
-                            "DeleteOnTermination": True,
-                            "SnapshotId": "snap-0a20b6671bc5e3ead",
-                            "VolumeSize": 8,
-                            "VolumeType": "gp2",
-                            "Encrypted": False,
-                        },
-                    }
-                ],
-            },
-        ),
     ],
 )
 def test_ami_volume_size_validator(mocker, image, volume_size, expected_message, ami_response):
@@ -110,5 +88,5 @@ def test_ami_volume_size_validator(mocker, image, volume_size, expected_message,
         "common.boto3.ec2.Ec2Client.describe_image",
         return_value=ami_response,
     )
-    actual_failures = AMIVolumeSizeValidator().execute(volume_size, image, pcluster_reserved_volume_size=15)
+    actual_failures = AMIVolumeSizeValidator().execute(volume_size, image)
     assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/test_s3_validators.py
+++ b/cli/tests/pcluster/validators/test_s3_validators.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pcluster.validators.s3_validators import S3BucketUriValidator, UrlValidator
+from tests.pcluster.boto3.dummy_boto3 import DummyAWSApi
 from tests.pcluster.validators.utils import assert_failure_messages
 
 
@@ -19,9 +20,9 @@ from tests.pcluster.validators.utils import assert_failure_messages
     ],
 )
 def test_url_validator(mocker, url, response, expected_message):
-    mocker.patch("pcluster.validators.s3_validators.S3Client.__init__", return_value=None)
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
     mocker.patch(
-        "pcluster.validators.s3_validators.S3Client.head_object",
+        "common.boto3.s3.S3Client.head_object",
         return_value=response,
     )
     mocker.patch("pcluster.validators.s3_validators.urlopen")
@@ -41,9 +42,9 @@ def test_url_validator(mocker, url, response, expected_message):
     ],
 )
 def test_s3_bucket_uri_validator(mocker, url, expected_message):
-    mocker.patch("pcluster.validators.s3_validators.S3Client.__init__", return_value=None)
+    mocker.patch("common.aws.aws_api.AWSApi.instance", return_value=DummyAWSApi())
     mocker.patch(
-        "pcluster.validators.s3_validators.S3Client.head_bucket",
+        "common.boto3.s3.S3Client.head_bucket",
         return_value=True,
     )
     actual_failures = S3BucketUriValidator().execute(url=url)

--- a/cloudformation/imagebuilder/pcluster_install.yaml
+++ b/cloudformation/imagebuilder/pcluster_install.yaml
@@ -244,18 +244,7 @@ phases:
         action: CreateFile
         inputs:
           - path: /tmp/dna.json
-            content: |
-              {
-                "cfncluster" : {
-                  "cfn_region": "${AWS::Region}",
-                  "nvidia" : {
-                    "enabled" : "${EnableNvidia}"
-                  },
-                  "is_official_ami_build": "${UpdateAndReboot}",
-                  "custom_node_package" : "${CustomNodePackage}",
-                  "cfn_base_os" : "{{ build.OperatingSystemName.outputs.stdout }}"
-                }
-              }
+            content: ${CfnParamDnaJson}
             overwrite: true
 
       - name: InstallPClusterPackages

--- a/cloudformation/imagebuilder/pcluster_install.yaml
+++ b/cloudformation/imagebuilder/pcluster_install.yaml
@@ -288,6 +288,11 @@ phases:
               {{ build.PClusterCookbookVersionName.outputs.stdout }}
             overwrite: true
 
+      - name: KeepSSM
+        action: DeleteFile
+        inputs:
+          - path: /tmp/imagebuilder_service/ssm_installed
+
       - name: AmiCleanup
         action: ExecuteBash
         inputs:

--- a/cloudformation/imagebuilder/pcluster_install.yaml
+++ b/cloudformation/imagebuilder/pcluster_install.yaml
@@ -72,17 +72,6 @@ phases:
               [ -n "${CfnParamCincInstaller}" ] && CINC_URL=${CfnParamCincInstaller}
               echo "${!CINC_URL}"
 
-      # Get Cfn Bootstrap Url
-      - name: CfnBootstrapUrl
-        action: ExecuteBash
-        inputs:
-          commands:
-            - |
-              set -x
-              BUCKET="s3.amazonaws.com"
-              [[ ${AWS::Region} =~ ^cn- ]] && BUCKET="s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
-              echo "https://${!BUCKET}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"
-
       # Check input base AMI OS and get OS information, the output should be like centos.7 | centos.8 | amzn.2018.03 | amzn.2 | ubuntu.18.04 | ubuntu.16.04
       - name: OperatingSystemRelease
         action: ExecuteBash
@@ -143,6 +132,24 @@ phases:
                fi
 
                echo ${!PLATFORM}
+
+      # Get Cfn Bootstrap Url
+      - name: CfnBootstrapUrl
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              BUCKET="s3.amazonaws.com"
+              [[ ${AWS::Region} =~ ^cn- ]] && BUCKET="s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
+
+              OS='{{ build.OperatingSystemName.outputs.stdout }}'
+
+              if [[ ${!OS} =~ ^(centos8)$ ]]; then
+                echo "https://${!BUCKET}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
+              else
+                echo "https://${!BUCKET}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"
+              fi
 
       # Get input base AMI Architecture
       - name: OperatingSystemArchitecture
@@ -267,7 +274,7 @@ phases:
                 curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz {{ build.CfnBootstrapUrl.outputs.stdout }}
                 if [[ ${!OS} == centos8 ]]; then
                   dnf install -y python3-pip
-                  pip3 install /tmp/aws-cfn-bootstrap-py3-latest.tar.gz
+                  pip3 install /tmp/aws-cfn-bootstrap-latest.tar.gz
                 elif [[ ${!OS} == centos7 ]]; then
                   which pip2
                   if [ $? -eq 0 ]; then

--- a/cloudformation/imagebuilder/pcluster_install.yaml
+++ b/cloudformation/imagebuilder/pcluster_install.yaml
@@ -198,7 +198,7 @@ phases:
                     dnf -y install epel-release
                   fi
                   /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config
-                  /bin/sed -r -i -e 's/GRUB_CMDLINE_LINUX="(.*)"/GRUB_CMDLINE_LINUX="\\1 rd.driver.blacklist=nouveau nouveau.modeset=0"/' /etc/default/grub
+                  /bin/sed -r -i -e 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 rd.driver.blacklist=nouveau nouveau.modeset=0"/' /etc/default/grub
                   grub2-mkconfig -o /boot/grub2/grub.cfg
               elif [[ ${!OS} =~ ^ubuntu1(6|8)04$ ]]; then
                   apt-cache search build-essential

--- a/cloudformation/imagebuilder/pcluster_install.yaml
+++ b/cloudformation/imagebuilder/pcluster_install.yaml
@@ -12,6 +12,15 @@ phases:
           commands:
             - echo 1
 
+      # Get AWS Region
+      - name: AWSRegion
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -x
+              echo ${AWS::Region}
+
       # Get Chef Version
       - name: ChefVersion
         action: ExecuteBash
@@ -251,7 +260,8 @@ phases:
         action: CreateFile
         inputs:
           - path: /tmp/dna.json
-            content: ${CfnParamDnaJson}
+            content: |
+              ${CfnParamAttributeJson}
             overwrite: true
 
       - name: InstallPClusterPackages


### PR DESCRIPTION
* Amend boto3 Client to align with AWSApi singleton pattern
* Amend role and instance profile logic
* Move default root volume from resource to cdk, and won't store default root volume in imagebuilder resource
* Add custom components business logic
* Add ChefAttributes class to generate attribute json for chef client
* Modify AMIVolumeSizeValidator to only validate volume size is not less than parent ami size.

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
