### PR TITLE
Backport: Tests: add retries for MPI job submission check to avoid race condition

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -123,8 +123,6 @@ def _test_mpi_job_termination(remote_command_executor, test_datadir):
 
     # Check that mpi processes are started
     _assert_job_state(slurm_commands, job_id, job_state="RUNNING")
-    # Sleep a bit to avoid race condition
-    time.sleep(5)
     _check_mpi_process(remote_command_executor, slurm_commands, test_datadir, num_nodes=2, after_completion=False)
     slurm_commands.cancel_job(job_id)
 
@@ -135,6 +133,7 @@ def _test_mpi_job_termination(remote_command_executor, test_datadir):
     _check_mpi_process(remote_command_executor, slurm_commands, test_datadir, num_nodes=2, after_completion=True)
 
 
+@retry(wait_fixed=seconds(10), stop_max_attempt_number=4)
 def _check_mpi_process(remote_command_executor, slurm_commands, test_datadir, num_nodes, after_completion):
     """Submit script and check for MPI processes."""
     # Clean up old datafiles


### PR DESCRIPTION
The test_slurm submits an MPI job in two nodes that will start multiple IMB-MPI1 process.
The code waits for the job to be running and then run another job in one of the free slots of the compute instances to see if the IMB-MPI1 process is running.

We were sleeping 5 seconds before checking the MPI jobs but it can happen that the mpi job is running but for some reasons the IMB-MPI1 process is not yet active and this causes a failure in the tests.

The MPI jobs takes about 1m10s so we can safely have 4 retry attempts with a delay of 10 seconds.