### PR TITLE
3.0: Add CFN conversion via CDK of Main Stack Resources

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -14,3 +14,5 @@ aws-cdk.aws-imagebuilder
 aws-cdk.aws-iam
 aws-cdk.aws-ssm
 aws-cdk.aws-efs
+aws-cdk.aws-sqs
+aws_cdk.aws_lambda

--- a/cli/src/pcluster/resources/user_data/head_node/head_node.sh
+++ b/cli/src/pcluster/resources/user_data/head_node/head_node.sh
@@ -1,0 +1,123 @@
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+
+--==BOUNDARY==
+Content-Type: text/cloud-boothook; charset="us-ascii"
+MIME-Version: 1.0
+
+#!/bin/bash -x
+
+which dnf 2>/dev/null; dnf=$?
+which yum 2>/dev/null; yum=$?
+
+if [ "${!dnf}" == "0" ]; then
+  echo "proxy=${DnfProxy}" >> /etc/dnf/dnf.conf
+elif [ "${!yum}" == "0" ]; then
+  echo "proxy=${YumProxy}" >> /etc/yum.conf
+else
+  echo "Not yum system"
+fi
+
+which apt-get && echo "Acquire::http::Proxy \"${AptProxy}\";" >> /etc/apt/apt.conf || echo "Not apt system"
+
+proxy=${ProxyServer}
+if [ "${!proxy}" != "NONE" ]; then
+  proxy_host=$(echo "${!proxy}" | awk -F/ '{print $3}' | cut -d: -f1)
+  proxy_port=$(echo "${!proxy}" | awk -F/ '{print $3}' | cut -d: -f2)
+  echo -e "[Boto]\nproxy = ${!proxy_host}\nproxy_port = ${!proxy_port}\n" >/etc/boto.cfg
+  cat >> /etc/profile.d/proxy.sh <<PROXY
+export http_proxy="${!proxy}"
+export https_proxy="${!proxy}"
+export no_proxy="localhost,127.0.0.1,169.254.169.254"
+export HTTP_PROXY="${!proxy}"
+export HTTPS_PROXY="${!proxy}"
+export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
+PROXY
+fi
+--==BOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+
+#!/bin/bash -x
+
+function error_exit
+{
+  # wait logs flush before signaling the failure
+  sleep 10
+  cfn-signal --exit-code=1 --reason="$1" --stack=${AWS::StackName} --role=${IamRoleName} --resource=MasterServer --region=${AWS::Region}
+  exit 1
+}
+function vendor_cookbook
+{
+  mkdir /tmp/cookbooks
+  cd /tmp/cookbooks
+  tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz
+  HOME_BAK="${!HOME}"
+  export HOME="/tmp"
+  for d in `ls /tmp/cookbooks`; do
+    cd /tmp/cookbooks/$d
+    LANG=en_US.UTF-8 /opt/cinc/embedded/bin/berks vendor /etc/chef/cookbooks --delete || error_exit 'Vendoring cookbook failed.'
+  done;
+  export HOME="${!HOME_BAK}"
+}
+function bootstrap_instance
+{
+  which dnf 2>/dev/null; dnf=$?
+  which yum 2>/dev/null; yum=$?
+  which apt-get 2>/dev/null; apt=$?
+  if [ "${!dnf}" == "0" ]; then
+    dnf -y groupinstall development && dnf -y install curl wget jq python3-pip
+    pip3 install awscli --upgrade --user
+  elif [ "${!yum}" == "0" ]; then
+    yum -y groupinstall development && yum -y install curl wget jq awscli python3-pip
+  fi
+  if [ "${!apt}" == "0" ]; then
+    apt-cache search build-essential; apt-get clean; apt-get update; apt-get -y install build-essential curl wget jq python-setuptools awscli python3-pip
+  fi
+  [[ ${!_region} =~ ^cn- ]] && s3_url="cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
+  which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-py3-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz; pip3 install -U /tmp/aws-cfn-bootstrap-py3-latest.tar.gz)
+  mkdir -p /etc/chef && chown -R root:root /etc/chef
+  curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn" || exit 0)/archives/cinc/cinc-install.sh | bash -s -- -v ${!chef_version}
+  /opt/cinc/embedded/bin/gem install --no-document berkshelf:${!berkshelf_version}
+  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${!cookbook_url}.date
+  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.md5 ${!cookbook_url}.md5
+  vendor_cookbook
+  mkdir /opt/parallelcluster
+}
+[ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh
+custom_cookbook=${CustomChefCookbook}
+export _region=${AWS::Region}
+s3_url=${AWSDomain}
+if [ "${!custom_cookbook}" != "NONE" ]; then
+  if [[ "${!custom_cookbook}" =~ ^s3:// ]]; then
+    cookbook_url=$(aws s3 presign "${!custom_cookbook}" --region "${!_region}")
+  else
+    cookbook_url=${!custom_cookbook}
+  fi
+else
+  cookbook_url=https://s3.${!_region}.${!s3_url}/${!_region}-aws-parallelcluster/cookbooks/${CookbookVersion}.tgz
+fi
+export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin
+export parallelcluster_version=aws-parallelcluster-${ParallelClusterVersion}
+export cookbook_version=${CookbookVersion}
+export chef_version=${ChefVersion}
+export berkshelf_version=${BerkshelfVersion}
+if [ -f /opt/parallelcluster/.bootstrapped ]; then
+  installed_version=$(cat /opt/parallelcluster/.bootstrapped)
+  if [ "${!cookbook_version}" != "${!installed_version}" ]; then
+    error_exit "This AMI was created with ${!installed_version}, but is trying to be used with ${!cookbook_version}. Please either use an AMI created with ${!cookbook_version} or change your ParallelCluster to ${!installed_version}"
+  fi
+else
+  bootstrap_instance
+fi
+if [ "${!custom_cookbook}" != "NONE" ]; then
+  curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz -z "$(cat /etc/chef/aws-parallelcluster-cookbook.tgz.date)" ${!cookbook_url}
+  vendor_cookbook
+fi
+cd /tmp
+# Call CloudFormation
+cfn-init -s ${AWS::StackName} --role=${IamRoleName} -v -c default -r MasterServerLaunchTemplate --region ${AWS::Region} || error_exit 'Failed to run cfn-init. If --norollback was specified, check /var/log/cfn-init.log and /var/log/cloud-init-output.log.'
+cfn-signal --exit-code=0 --reason="MasterServer setup complete" --stack=${AWS::StackName} --role=${IamRoleName} --resource=MasterServer --region=${AWS::Region}
+# End of file
+--==BOUNDARY==

--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -30,7 +30,7 @@ class CDKTemplateBuilder:
     def build(self, cluster: SlurmCluster):
         """Build template for the given cluster and return as output in Yaml format."""
         with tempfile.TemporaryDirectory() as tempdir:
-            output_file = "cluster"
+            output_file = "parallelcluster-cluster"  # TODO: pass stack name as argument
             app = core.App(outdir=str(tempdir))
             ClusterStack(app, output_file, cluster=cluster)
             app.synth()

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -17,205 +17,621 @@ from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_efs as efs
 from aws_cdk import aws_fsx as fsx
 from aws_cdk import core
+from aws_cdk.aws_ec2 import (
+    CfnEIP,
+    CfnEIPAssociation,
+    CfnNetworkInterface,
+    CfnSecurityGroup,
+    CfnSecurityGroupEgress,
+    CfnSecurityGroupIngress,
+)
+from aws_cdk.aws_iam import (
+    CfnInstanceProfile,
+    CfnPolicy,
+    CfnRole,
+    Effect,
+    PolicyDocument,
+    PolicyStatement,
+    ServicePrincipal,
+)
+from aws_cdk.aws_lambda import CfnFunction
+from aws_cdk.core import CfnCustomResource, CfnOutput, CfnStack, Fn
 
 from common.aws.aws_api import AWSApi
 from pcluster.models.cluster import HeadNode, SharedEbs, SharedEfs, SharedFsx, SharedStorageType
 from pcluster.models.cluster_slurm import SlurmCluster
 
 
-class HeadNodeConstruct(core.Construct):
-    """Create the resources related to the HeadNode."""
-
-    # https://cdkworkshop.com/30-python/40-hit-counter/100-api.html
-    def __init__(self, scope: core.Construct, id: str, head_node: HeadNode, **kwargs):
-        super().__init__(scope, id)
-        self.head_node = head_node
-
-        # TODO: use attributes from head_node instead of using these static variables.
-        master_instance_type = self.head_node.instance_type
-        master_core_count = "-1,true"
-        # compute_core_count = "-1"
-        key_name = "keyname"
-        root_device = "root_device"
-        root_volume_size = 10
-        main_stack_name = "main_stack_name"
-        # proxy_server = "proxy_server"
-        placement_group = "placement_group"
-        # update_waiter_function_arn = "update_waiter_function_arn"
-        # use_master_public_ip = True
-        master_network_interfaces_count = 5
-        master_eni = "master_eni"
-        master_security_groups = ["master_security_groups"]
-        master_subnet_id = "master_subnet_id"
-        image_id = "image_id"
-        iam_instance_profile = "iam_instance_profile"
-
-        # Conditions
-        master_core_info = master_core_count.split(",")
-        disable_master_hyperthreading = master_core_info[0] != -1 and master_core_info[0] != "NONE"
-        # disable_compute_hyperthreading = master_core_info != -1 and master_core_info != "NONE"
-        disable_hyperthreading_via_cpu_options = disable_master_hyperthreading and master_core_info[1] == "true"
-        # disable_hyperthreading_manually = disable_master_hyperthreading and not disable_hyperthreading_via_cpu_options
-        is_master_instance_ebs_opt = master_instance_type not in [
-            "cc2.8xlarge",
-            "cr1.8xlarge",
-            "m3.medium",
-            "m3.large",
-            "c3.8xlarge",
-            "c3.large",
-            "",
-        ]
-        # use_proxy = proxy_server != "NONE"
-        use_placement_group = placement_group != "NONE"
-        # has_update_waiter_function = update_waiter_function_arn != "NONE"
-        # has_master_public_ip = use_master_public_ip == "true"
-        # use_nic1 = master_network_interfaces_count ... TODO
-
-        cpu_options = ec2.CfnLaunchTemplate.CpuOptionsProperty(
-            core_count=int(master_core_info[0]),
-            threads_per_core=1,
-        )
-        block_device_mappings = []
-        for _, (device_name_index, virtual_name_index) in enumerate(zip(list(map(chr, range(97, 121))), range(0, 24))):
-            device_name = "/dev/xvdb{0}".format(device_name_index)
-            virtual_name = "ephemeral{0}".format(virtual_name_index)
-            block_device_mappings.append(
-                ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(device_name=device_name, virtual_name=virtual_name)
-            )
-
-        block_device_mappings.append(
-            ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
-                device_name=root_device,
-                ebs=ec2.CfnLaunchTemplate.EbsProperty(
-                    volume_size=root_volume_size,
-                    volume_type="gp2",
-                ),
-            )
-        )
-
-        tags_raw = [
-            ("Application", main_stack_name),
-            ("Name", "Master"),
-            ("aws-parallelcluster-node-type", "Master"),
-            ("ClusterName", "parallelcluster-{0}".format(main_stack_name)),
-            # ... TODO
-        ]
-        tags = []
-        for key, value in tags_raw:
-            tags.append(core.CfnTag(key=key, value=value))
-        tag_specifications = [
-            ec2.CfnLaunchTemplate.TagSpecificationProperty(resource_type="instance", tags=tags),
-            ec2.CfnLaunchTemplate.TagSpecificationProperty(resource_type="volume", tags=tags),  # FIXME
-        ]
-
-        network_interfaces = [
-            ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
-                network_interface_id=master_eni,
-                device_index=0,
-            )
-        ]
-        for index in range(1, master_network_interfaces_count + 1):
-            network_interfaces.append(
-                ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
-                    device_index=index,
-                    network_card_index=index,
-                    groups=master_security_groups,
-                    subnet_id=master_subnet_id,
-                )
-            )
-
-        launch_template_data = ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
-            instance_type=master_instance_type,
-            cpu_options=cpu_options if disable_hyperthreading_via_cpu_options else None,
-            block_device_mappings=block_device_mappings,
-            key_name=key_name,
-            tag_specifications=tag_specifications,
-            network_interfaces=network_interfaces,
-            image_id=image_id,
-            ebs_optimized=is_master_instance_ebs_opt,
-            iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(name=iam_instance_profile),
-            placement=ec2.CfnLaunchTemplate.PlacementProperty(
-                group_name=placement_group if use_placement_group else None
-            ),
-            # user_data= TODO
-            # https://stackoverflow.com/questions/57753032/how-to-obtain-pseudo-parameters-user-data-with-aws-cdk
-        )
-
-        launch_template = ec2.CfnLaunchTemplate(
-            self, id="MasterServerLaunchTemplate", launch_template_data=launch_template_data
-        )
-
-        master_instance = ec2.CfnInstance(
-            self,
-            id="MasterServer",
-            launch_template=ec2.CfnInstance.LaunchTemplateSpecificationProperty(
-                launch_template_id=launch_template.ref, version=launch_template.attr_latest_version_number
-            ),
-        )
-
-        core.CfnOutput(
-            self,
-            id="privateip",
-            description="Private IP Address of the Master host",
-            value=master_instance.attr_public_ip,
-        )
-        core.CfnOutput(
-            self,
-            id="publicip",
-            description="Public IP Address of the Master host",
-            value=master_instance.attr_public_ip,
-        )
-        core.CfnOutput(
-            self,
-            id="dnsname",
-            description="Private DNS name of the Master host",
-            value=master_instance.attr_private_dns_name,
-        )
-
-        # TODO metadata?
-
-        # https://docs.aws.amazon.com/cdk/latest/guide/use_cfn_template.html
-        # with open('master-server-substack.cfn.yaml', 'r') as f:
-        # template = yaml.load(f, Loader=yaml.SafeLoader)
-        # include = core.CfnInclude(self, 'ExistingInfrastructure',
-        #    template=template,
-        # )
-
-
+# pylint: disable=too-many-lines
 class ClusterStack(core.Stack):
-    """Create the Stack and delegate to specific Construct for the creation of all the resources for the Cluster."""
+    """Create the CloudFormation stack template for the Cluster."""
 
     def __init__(self, scope: core.Construct, construct_id: str, cluster: SlurmCluster, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
         self._cluster = cluster
 
+        self._init_mappings()
+        self._add_resources()
+        self._add_ouputs()
+
+    # -- Mappings ---------------------------------------------------------------------------------------------------- #
+    def _init_mappings(self):
+        # OS Features
+        self.os_features = {
+            "centos7": {"User": "centos", "RootDevice": "/dev/sda1"},
+            "centos8": {"User": "centos", "RootDevice": "/dev/sda1"},
+            "alinux": {"User": "ec2-user", "RootDevice": "/dev/xvda"},
+            "alinux2": {"User": "ec2-user", "RootDevice": "/dev/xvda"},
+            "ubuntu1604": {"User": "ubuntu", "RootDevice": "/dev/sda1"},
+            "ubuntu1804": {"User": "ubuntu", "RootDevice": "/dev/sda1"},
+        }
+
         # Storage filesystem Ids
-        self._storage_resource_ids = {storage_type: [] for storage_type in SharedStorageType}
+        self._storage_resource_ids = {storage_type: [] for storage_type in SharedStorage.Type}
 
-        # Compute security group Ids
-        # TODO: add sgs created from main stack
-        self._compute_security_groups = []
-        self._compute_security_groups.extend(self._cluster.compute_security_groups)
+    # -- Resources --------------------------------------------------------------------------------------------------- #
+    def _add_resources(self):
+        # CloudWatchLogsSubstack
+        # TODO: inline cw-logs-substack
 
-        HeadNodeConstruct(self, "HeadNode", cluster.head_node)
+        # RootRole
+        if self._condition_create_ec2_iam_role():
+            self.root_iam_role = self._add_root_iam_role()
 
-        if cluster.shared_storage:
-            for storage in cluster.shared_storage:
+        # RootInstanceProfile
+        self._add_root_instance_profile()
+
+        # ParallelClusterPolicies
+        if self._condition_create_ec2_iam_role():
+            self._add_parallelcluster_policies()
+
+        # ParallelClusterHITPolicies
+        if self._condition_add_hit_iam_policies():
+            self._add_parallelcluster_hit_policies()
+
+        # S3AccessPolicies
+        if self._condition_create_s3_access_policies():
+            self._add_s3_access_policies()
+
+        # MasterEIP
+        if self._cluster.head_node.networking.assign_public_ip:
+            self._head_eip = CfnEIP(scope=self, id="MasterEIP", domain="vpc")
+
+        # ParallelCluster managed security groups
+        self._add_security_groups()
+
+        # MasterENI
+        self.head_eni = self._add_head_eni()
+
+        # AdditionalCfnStack
+        if self._cluster.additional_resources:
+            CfnStack(scope=self, id="AdditionalCfnStack", template_url=self._cluster.additional_resources)
+
+        # AWSBatchStack
+        # TODO: inline resources
+
+        # CleanupResourcesFunctionExecutionRole
+        if self._condition_create_lambda_iam_role():
+            self._add_iam_lambda_role()
+
+        # CleanupResourcesFunction
+        self.cleanup_resources_function = self._add_cleanup_resources_function()
+
+        # CleanupResourcesS3BucketCustomResource
+        self.cleanup_resources_bucket_custom_resource = self._add_cleanup_resources_bucket_custom_resource()
+
+        # TerminateComputeFleetCustomResource
+        self._add_terminate_compute_fleet_custom_resource()
+
+        # RAIDSubstack
+        # TODO: inline resources
+
+        # MasterServerSubstack
+        # TODO: double check head node creation
+        self._add_head_node()
+
+        # ComputeFleetHITSubstack
+        # TODO: inline resources
+
+        # CloudWatchDashboardSubstack
+        # TODO: inline resources
+
+        if self._cluster.shared_storage:
+            for storage in self._cluster.shared_storage:
                 self._add_shared_storage(storage)
 
-        self._add_shared_storage_outputs()
+    def _add_terminate_compute_fleet_custom_resource(self):
+        if self._condition_create_hit_substack():
+            self.terminate_compute_fleet_custom_resource = CfnCustomResource(
+                scope=self,
+                id="TerminateComputeFleetCustomResource",
+                service_token=self.cleanup_resources_function.attr_arn,
+            )
+            self.terminate_compute_fleet_custom_resource.add_property_override("StackName", self.stack_name)
+            self.terminate_compute_fleet_custom_resource.add_property_override("Action", "TERMINATE_EC2_INSTANCES")
 
-    def _add_shared_storage(self, storage):
+            # TODO: add depends_on resources from CloudWatchLogsSubstack, ComputeFleetHITSubstack
+            # self.terminate_compute_fleet_custom_resource.add_depends_on(...)
+
+    def _add_cleanup_resources_function(self):
+        return CfnFunction(
+            scope=self,
+            id="CleanupResourcesFunction",
+            function_name=Fn.sub(
+                "pcluster-CleanupResources-${StackId}", {"StackId": Fn.select(2, Fn.split("/", self.stack_id))}
+            ),
+            code=CfnFunction.CodeProperty(
+                s3_bucket=self._cluster.cluster_s3_bucket,
+                s3_key="{0}/custom_resources_code/artifacts.zip".format(self._cluster.artifacts_s3_root_directory),
+            ),
+            handler="cleanup_resources.handler",
+            memory_size=128,
+            role=self.cleanup_resources_function_execution_role.attr_arn
+            if self._condition_create_lambda_iam_role()
+            else self.format_arn(
+                service="iam", region="", resource="role/{0}".format(self._cluster.iam.roles.custom_lambda_resources)
+            ),
+            runtime="python3.8",
+            timeout=900,
+        )
+
+    def _add_head_eni(self):
+        head_eni_groupset = []
+        if self._cluster.head_node.networking.additional_security_groups:
+            head_eni_groupset.extend(self._cluster.head_node.networking.additional_security_groups)
+        if self._condition_create_head_security_group():
+            head_eni_groupset.append(self._head_security_group.ref)
+        elif self._cluster.head_node.networking.security_groups:
+            head_eni_groupset.extend(self._cluster.head_node.networking.security_groups)
+        head_eni = CfnNetworkInterface(
+            scope=self,
+            id="MasterENI",
+            description="AWS ParallelCluster head node interface",
+            subnet_id=self._cluster.head_node.networking.subnet_id,
+            source_dest_check=False,
+            group_set=head_eni_groupset,
+        )
+        # AssociateEIP
+        if self._cluster.head_node.networking.assign_public_ip:
+            CfnEIPAssociation(
+                scope=self,
+                id="AssociateEIP",
+                allocation_id=self._head_eip.attr_allocation_id,
+                network_interface_id=head_eni.ref,
+            )
+        return head_eni
+
+    def _add_security_groups(self):
+        # MasterSecurityGroup
+        if self._condition_create_head_security_group():
+            self._head_security_group = self._add_head_security_group()
+        # ComputeSecurityGroup
+        if self._condition_create_compute_security_group():
+            self._compute_security_group = self._add_compute_security_group()
+        # MasterSecurityGroupIngress
+        # Access to head node from compute nodes
+        if self._condition_create_head_security_group() and self._condition_create_compute_security_group():
+            CfnSecurityGroupIngress(
+                scope=self,
+                id="MasterSecurityGroupIngress",
+                ip_protocol="-1",
+                from_port=0,
+                to_port=65535,
+                source_security_group_id=self._compute_security_group.ref,
+                group_id=self._head_security_group.ref,
+            )
+        if self._condition_create_compute_security_group():
+            # ComputeSecurityGroupEgress
+            # Access to other compute nodes from compute nodes
+            compute_security_group_egress = CfnSecurityGroupEgress(
+                scope=self,
+                id="ComputeSecurityGroupEgress",
+                ip_protocol="-1",
+                from_port=0,
+                to_port=65535,
+                destination_security_group_id=self._compute_security_group.ref,
+                group_id=self._compute_security_group.ref,
+            )
+
+            # ComputeSecurityGroupNormalEgress
+            # Internet access from compute nodes
+            CfnSecurityGroupEgress(
+                scope=self,
+                id="ComputeSecurityGroupNormalEgress",
+                ip_protocol="-1",
+                from_port=0,
+                to_port=65535,
+                cidr_ip="0.0.0.0/0",
+                group_id=self._compute_security_group.ref,
+            ).add_depends_on(compute_security_group_egress)
+
+            # ComputeSecurityGroupIngress
+            # Access to compute nodes from other compute nodes
+            CfnSecurityGroupIngress(
+                scope=self,
+                id="ComputeSecurityGroupIngress",
+                ip_protocol="-1",
+                from_port=0,
+                to_port=65535,
+                source_security_group_id=self._compute_security_group.ref,
+                group_id=self._compute_security_group.ref,
+            )
+
+    def _add_compute_security_group(self):
+        return CfnSecurityGroup(
+            scope=self,
+            id="ComputeSecurityGroup",
+            group_description="Allow access to resources in subnets behind front",
+            vpc_id=self._cluster.vpc_id,
+            security_group_ingress=[
+                # Access from master security group
+                CfnSecurityGroup.IngressProperty(
+                    source_security_group_id=self._head_security_group.ref,
+                    ip_protocol="-1",
+                    from_port=0,
+                    to_port=65535,
+                )
+            ],
+        )
+
+    def _add_s3_access_policies(self):
+        read_only_s3_resources = [
+            s3_access.bucket_name for s3_access in self._cluster.iam.s3_access if s3_access.type == "READ_ONLY"
+        ]
+        read_write_s3_resources = [
+            s3_access.bucket_name for s3_access in self._cluster.iam.s3_access if s3_access.type != "READ_ONLY"
+        ]
+        s3_access_policy = CfnPolicy(
+            scope=self,
+            id="S3AccessPolicies",
+            policy_document=PolicyDocument(statements=[]),
+            roles=[self.root_iam_role.ref],
+            policy_name="S3Access",
+        )
+        if read_only_s3_resources:
+            s3_access_policy.policy_document.add_statements(
+                PolicyStatement(
+                    sid="S3Read",
+                    effect=Effect.ALLOW,
+                    actions=["s3:Get*", "s3:List*"],
+                    resources=read_only_s3_resources,
+                )
+            )
+        if read_write_s3_resources:
+            s3_access_policy.policy_document.add_statements(
+                PolicyStatement(
+                    sid="S3ReadWrite", effect=Effect.ALLOW, actions=["s3:*"], resources=read_write_s3_resources
+                )
+            )
+
+    def _add_root_instance_profile(self):
+        root_instance_profile_roles = [
+            self.root_iam_role.ref if hasattr(self, "root_iam_role") else None,
+            self._cluster.head_iam_role,
+            self._cluster.compute_iam_role,
+        ]
+        CfnInstanceProfile(
+            scope=self,
+            id="RootInstanceProfile",
+            roles=[role for role in root_instance_profile_roles if role is not None],
+            path="/",
+        )
+
+    def _add_root_iam_role(self):
+        return CfnRole(
+            scope=self,
+            id="RootRole",
+            managed_policy_arns=self._cluster.iam.additional_iam_policies if self._cluster.iam else None,
+            assume_role_policy_document=PolicyDocument(
+                statements=[
+                    PolicyStatement(
+                        effect=Effect.ALLOW,
+                        principals=[
+                            ServicePrincipal(
+                                service="ec2.{0}".format(self.url_suffix),
+                            )
+                        ],
+                        actions=["sts:AssumeRole"],
+                    )
+                ]
+            ),
+            path="/",
+        )
+
+    def _add_iam_lambda_role(self):
+        s3_policy_actions = ["s3:DeleteObject", "s3:DeleteObjectVersion", "s3:ListBucket", "s3:ListBucketVersions"]
+        if self._cluster.remove_s3_bucket_on_deletion:
+            s3_policy_actions.append("s3:DeleteBucket")
+        self.cleanup_resources_function_execution_role = CfnRole(
+            scope=self,
+            id="CleanupResourcesFunctionExecutionRole",
+            assume_role_policy_document=PolicyDocument(
+                statements=[
+                    PolicyStatement(
+                        actions=["sts:AssumeRole"],
+                        effect=Effect.ALLOW,
+                        principals=[ServicePrincipal(service="lambda.amazonaws.com")],
+                    )
+                ],
+            ),
+            path="/",
+            policies=[
+                CfnRole.PolicyProperty(
+                    policy_document=PolicyDocument(
+                        statements=[
+                            PolicyStatement(
+                                actions=["logs:CreateLogStream", "logs:PutLogEvents"],
+                                effect=Effect.ALLOW,
+                                resources=[self.format_arn(service="logs", account="*", region="*", resource="*")],
+                                sid="CloudWatchLogsPolicy",
+                            ),
+                            PolicyStatement(
+                                actions=s3_policy_actions,
+                                effect=Effect.ALLOW,
+                                resources=[
+                                    self.format_arn(
+                                        service="s3", account="", region="", resource=self._cluster.cluster_s3_bucket
+                                    ),
+                                    self.format_arn(
+                                        service="s3",
+                                        account="",
+                                        region="",
+                                        resource="{0}/{1}/*".format(
+                                            self._cluster.cluster_s3_bucket, self._cluster.artifacts_s3_root_directory
+                                        ),
+                                    ),
+                                ],
+                                sid="S3BucketPolicy",
+                            ),
+                        ],
+                    ),
+                    policy_name="LambdaPolicy",
+                ),
+            ],
+        )
+        if self._condition_create_hit_substack():
+            self.cleanup_resources_function_execution_role.policies[0].policy_document.add_statements(
+                PolicyStatement(
+                    actions=["ec2:DescribeInstances"], resources=["*"], effect=Effect.ALLOW, sid="DescribeInstances"
+                ),
+                PolicyStatement(
+                    actions=["ec2:TerminateInstances"],
+                    resources=["*"],
+                    effect=Effect.ALLOW,
+                    conditions=[{"StringEquals": {"ec2:ResourceTag/Application": self.stack_name}}],
+                    sid="FleetTerminatePolicy",
+                ),
+            )
+
+    def _add_parallelcluster_policies(self):
+        CfnPolicy(
+            scope=self,
+            id="ParallelClusterPolicies",
+            policy_name="parallelcluster",
+            policy_document=PolicyDocument(
+                statements=[
+                    PolicyStatement(
+                        sid="Ec2",
+                        actions=[
+                            "ec2:DescribeVolumes",
+                            "ec2:AttachVolume",
+                            "ec2:DescribeInstanceAttribute",
+                            "ec2:DescribeInstanceStatus",
+                            "ec2:DescribeInstances",
+                            "ec2:DescribeInstanceTypes",
+                        ],
+                        effect=Effect.ALLOW,
+                        resources=["*"],
+                    ),
+                    PolicyStatement(
+                        sid="DynamoDBList", actions=["dynamodb:ListTables"], effect=Effect.ALLOW, resources=["*"]
+                    ),
+                    PolicyStatement(
+                        sid="SQSQueue",
+                        actions=[
+                            "sqs:SendMessage",
+                            "sqs:ReceiveMessage",
+                            "sqs:ChangeMessageVisibility",
+                            "sqs:DeleteMessage",
+                            "sqs:GetQueueUrl",
+                        ],
+                        effect=Effect.ALLOW,
+                        resources=[self.format_arn(service="sqs", resource=self.stack_name)],
+                    ),
+                    PolicyStatement(
+                        sid="Cloudformation",
+                        actions=[
+                            "cloudformation:DescribeStacks",
+                            "cloudformation:DescribeStackResource",
+                            "cloudformation:SignalResource",
+                        ],
+                        effect=Effect.ALLOW,
+                        resources=[self.format_arn(service="cloudformation", resource="stack/parallelcluster-*/*")],
+                    ),
+                    PolicyStatement(
+                        sid="DynamoDBTable",
+                        actions=[
+                            "dynamodb:PutItem",
+                            "dynamodb:BatchWriteItem",
+                            "dynamodb:GetItem",
+                            "dynamodb:DeleteItem",
+                            "dynamodb:DescribeTable",
+                        ],
+                        effect=Effect.ALLOW,
+                        resources=[self.format_arn(service="dynamodb", resource="table/${AWS::StackName}")],
+                    ),
+                    PolicyStatement(
+                        sid="S3GetObj",
+                        actions=["s3:GetObject"],
+                        effect=Effect.ALLOW,
+                        resources=[
+                            self.format_arn(
+                                service="s3",
+                                account=None,  # No account ID needed here
+                                region=None,  # No region needed here
+                                resource="{0}-aws-parallelcluster/*".format(self.region),
+                            )
+                        ],
+                    ),
+                    PolicyStatement(
+                        sid="S3PutObj",
+                        actions=["s3:PutObject"],
+                        effect=Effect.ALLOW,
+                        resources=[
+                            self.format_arn(
+                                service="s3",
+                                account=None,  # No account ID needed here
+                                region=None,  # No region needed here
+                                resource="{0}/{1}/batch/".format(
+                                    self._cluster.cluster_s3_bucket, self._cluster.artifacts_s3_root_directory
+                                ),
+                            )
+                        ],
+                    ),
+                    PolicyStatement(
+                        sid="FSx", actions=["fsx:DescribeFileSystems"], effect=Effect.ALLOW, resources=["*"]
+                    ),
+                    PolicyStatement(
+                        sid="BatchJobPassRole",
+                        actions=["iam:PassRole"],
+                        effect=Effect.ALLOW,
+                        resources=[self.format_arn(service="iam", resource="role/parallelcluster-*")],
+                    ),
+                    PolicyStatement(
+                        sid="DcvLicense",
+                        actions=["s3:GetObject"],
+                        effect=Effect.ALLOW,
+                        resources=[
+                            self.format_arn(
+                                service="s3",
+                                account=None,  # No account ID needed here
+                                region=None,  # No region needed here
+                                resource="dcv-license.{0}/*".format(self.region),
+                            )
+                        ],
+                    ),
+                ]
+            ),
+            roles=[self.root_iam_role.ref],
+        )
+
+    def _add_parallelcluster_hit_policies(self):
+        CfnPolicy(
+            scope=self,
+            id="ParallelClusterHITPolicies",
+            policy_name="parallelcluster-hit",
+            policy_document=PolicyDocument(
+                statements=[
+                    PolicyStatement(
+                        sid="EC2Terminate",
+                        effect=Effect.ALLOW,
+                        actions=["ec2:TerminateInstances"],
+                        resources=["*"],
+                        conditions=[{"StringEquals": {"ec2:ResourceTag/Application": self.stack_name}}],
+                    ),
+                    PolicyStatement(
+                        sid="EC2",
+                        effect=Effect.ALLOW,
+                        actions=[
+                            "ec2:DescribeInstances",
+                            "ec2:DescribeLaunchTemplates",
+                            "ec2:RunInstances",
+                            "ec2:DescribeInstanceStatus",
+                            "ec2:CreateTags",
+                        ],
+                        resources=["*"],
+                    ),
+                    PolicyStatement(
+                        sid="ResourcesS3Bucket",
+                        effect=Effect.ALLOW,
+                        actions=["s3:ListBucket", "s3:ListBucketVersions", "s3:GetObject*", "s3:PutObject*"]
+                        if self._cluster.remove_s3_bucket_on_deletion
+                        else ["s3:*"],
+                        resources=[
+                            self.format_arn(
+                                service="s3", account="", region="", resource=self._cluster.cluster_s3_bucket
+                            ),
+                            self.format_arn(
+                                service="s3",
+                                account="",
+                                region="",
+                                resource="{0}/{1}/*".format(
+                                    self._cluster.cluster_s3_bucket, self._cluster.artifacts_s3_root_directory
+                                ),
+                            ),
+                        ],
+                    ),
+                    PolicyStatement(
+                        sid="DynamoDBTableQuery",
+                        effect=Effect.ALLOW,
+                        actions=["dynamodb:Query"],
+                        resources=[
+                            self.format_arn(service="dynamodb", resource="table/{0}".format(self.stack_name)),
+                            self.format_arn(service="dynamodb", resource="table/{0}/index/*".format(self.stack_name)),
+                        ],
+                    ),
+                ]
+            ),
+            roles=[self.root_iam_role.ref],
+        )
+
+    def _add_head_security_group(self):
+        head_security_group_ingress = [
+            # SSH access
+            CfnSecurityGroup.IngressProperty(
+                ip_protocol="tcp",
+                from_port=22,
+                to_port=22,
+                cidr_ip=self._cluster.head_node.ssh.allowed_ips,
+            ),
+        ]
+        if self._cluster.head_node.dcv and self._cluster.head_node.dcv.enabled:
+            head_security_group_ingress.append(
+                # DCV access
+                CfnSecurityGroup.IngressProperty(
+                    ip_protocol="tcp",
+                    from_port=self._cluster.head_node.dcv.port,
+                    to_port=self._cluster.head_node.dcv.port,
+                    cidr_ip=self._cluster.head_node.dcv.allowed_ips,
+                )
+            )
+        return CfnSecurityGroup(
+            scope=self,
+            id="MasterSecurityGroup",
+            group_description="Enable access to the head node",
+            vpc_id=self._cluster.vpc_id,
+            security_group_ingress=head_security_group_ingress,
+        )
+
+    def _add_cleanup_resources_bucket_custom_resource(self):
+        cleanup_resources_bucket_custom_resource = CfnCustomResource(
+            scope=self,
+            id="CleanupResourcesS3BucketCustomResource",
+            service_token=self.cleanup_resources_function.attr_arn,
+        )
+        cleanup_resources_bucket_custom_resource.add_property_override(
+            "ResourcesS3Bucket", self._cluster.cluster_s3_bucket
+        )
+        cleanup_resources_bucket_custom_resource.add_property_override(
+            "ArtifactS3RootDirectory", self._cluster.artifacts_s3_root_directory
+        )
+        cleanup_resources_bucket_custom_resource.add_property_override(
+            "RemoveBucketOnDeletion", self._cluster.remove_s3_bucket_on_deletion
+        )
+        cleanup_resources_bucket_custom_resource.add_property_override("Action", "DELETE_S3_ARTIFACTS")
+        return cleanup_resources_bucket_custom_resource
+
+    def _add_shared_storage(self, storage: SharedStorage):
         """Add specific Cfn Resources to map the shared storage and store the output filesystem id."""
         storage_id = None
         cfn_resource_id = "{0}{1}".format(
             storage.shared_storage_type.name, len(self._storage_resource_ids[storage.shared_storage_type])
         )
-        if storage.shared_storage_type == SharedStorageType.FSX:
+        if storage.shared_storage_type == SharedStorage.Type.FSX:
             storage_id = self._add_fsx_storage(cfn_resource_id, storage)
-        elif storage.shared_storage_type == SharedStorageType.EBS:
+        elif storage.shared_storage_type == SharedStorage.Type.EBS:
             storage_id = self._add_ebs_volume(cfn_resource_id, storage)
-        elif storage.shared_storage_type == SharedStorageType.EFS:
+        elif storage.shared_storage_type == SharedStorage.Type.EFS:
             storage_id = self._add_efs_storage(cfn_resource_id, storage)
 
         # Store filesystem id
@@ -224,16 +640,6 @@ class ClusterStack(core.Stack):
             storage_ids_list = []
             self._storage_resource_ids[storage.shared_storage_type] = storage_ids_list
         storage_ids_list.append(storage_id)
-
-    def _add_shared_storage_outputs(self):
-        """Add the ids of the managed filesystem to the Stack Outputs."""
-        for storage_type, storage_ids in self._storage_resource_ids.items():
-            core.CfnOutput(
-                scope=self,
-                id="{0}Ids".format(storage_type.name),
-                description="{0} Filesystem IDs".format(storage_type.name),
-                value=",".join(storage_ids),
-            )
 
     def _add_fsx_storage(self, id: str, shared_fsx: SharedFsx):
         """Add specific Cfn Resources to map the FSX storage."""
@@ -341,3 +747,281 @@ class ClusterStack(core.Stack):
             ebs_id = ebs_resource.ref
 
         return ebs_id
+
+    def _add_head_node(self):
+        # TODO: use attributes from head_node instead of using these static variables. Double check compliance with
+        # MasterServerSubStack
+        master_instance_type = self._cluster.head_node.instance_type
+        master_core_count = "-1,true"
+        # compute_core_count = "-1"
+        key_name = self._cluster.head_node.ssh.key_name
+        root_device = self.os_features[self._cluster.image.os]["RootDevice"]
+        root_volume_size = 10
+        # proxy_server = "proxy_server"
+        placement_group = "placement_group"
+        # update_waiter_function_arn = "update_waiter_function_arn"
+        # use_master_public_ip = True
+        master_network_interfaces_count = 5
+        head_eni = "head_eni"
+        master_security_groups = ["master_security_groups"]
+        master_subnet_id = "master_subnet_id"
+        image_id = "image_id"
+        iam_instance_profile = "iam_instance_profile"
+
+        # Conditions
+        master_core_info = master_core_count.split(",")
+        disable_master_hyperthreading = master_core_info[0] != -1 and master_core_info[0] != "NONE"
+        # disable_compute_hyperthreading = master_core_info != -1 and master_core_info != "NONE"
+        disable_hyperthreading_via_cpu_options = disable_master_hyperthreading and master_core_info[1] == "true"
+        # disable_hyperthreading_manually = disable_master_hyperthreading and not disable_hyperthreading_via_cpu_options
+        is_master_instance_ebs_opt = master_instance_type not in [
+            "cc2.8xlarge",
+            "cr1.8xlarge",
+            "m3.medium",
+            "m3.large",
+            "c3.8xlarge",
+            "c3.large",
+            "",
+        ]
+        # use_proxy = proxy_server != "NONE"
+        use_placement_group = placement_group != "NONE"
+        # has_update_waiter_function = update_waiter_function_arn != "NONE"
+        # has_master_public_ip = use_master_public_ip == "true"
+        # use_nic1 = master_network_interfaces_count ... TODO
+
+        cpu_options = ec2.CfnLaunchTemplate.CpuOptionsProperty(
+            core_count=int(master_core_info[0]),
+            threads_per_core=1,
+        )
+        block_device_mappings = []
+        for _, (device_name_index, virtual_name_index) in enumerate(zip(list(map(chr, range(97, 121))), range(0, 24))):
+            device_name = "/dev/xvdb{0}".format(device_name_index)
+            virtual_name = "ephemeral{0}".format(virtual_name_index)
+            block_device_mappings.append(
+                ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(device_name=device_name, virtual_name=virtual_name)
+            )
+
+        block_device_mappings.append(
+            ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                device_name=root_device,
+                ebs=ec2.CfnLaunchTemplate.EbsProperty(
+                    volume_size=root_volume_size,
+                    volume_type="gp2",
+                ),
+            )
+        )
+
+        tags_raw = [
+            ("Application", self.stack_name),
+            ("Name", "Master"),
+            ("aws-parallelcluster-node-type", "Master"),
+            ("ClusterName", "parallelcluster-{0}".format(self.stack_name)),
+            # ... TODO
+        ]
+        tags = []
+        for key, value in tags_raw:
+            tags.append(core.CfnTag(key=key, value=value))
+        tag_specifications = [
+            ec2.CfnLaunchTemplate.TagSpecificationProperty(resource_type="instance", tags=tags),
+            ec2.CfnLaunchTemplate.TagSpecificationProperty(resource_type="volume", tags=tags),  # FIXME
+        ]
+
+        network_interfaces = [
+            ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
+                network_interface_id=head_eni,
+                device_index=0,
+            )
+        ]
+        for index in range(1, master_network_interfaces_count + 1):
+            network_interfaces.append(
+                ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
+                    device_index=index,
+                    network_card_index=index,
+                    groups=master_security_groups,
+                    subnet_id=master_subnet_id,
+                )
+            )
+
+        launch_template_data = ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
+            instance_type=master_instance_type,
+            cpu_options=cpu_options if disable_hyperthreading_via_cpu_options else None,
+            block_device_mappings=block_device_mappings,
+            key_name=key_name,
+            tag_specifications=tag_specifications,
+            network_interfaces=network_interfaces,
+            image_id=image_id,
+            ebs_optimized=is_master_instance_ebs_opt,
+            iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(name=iam_instance_profile),
+            placement=ec2.CfnLaunchTemplate.PlacementProperty(
+                group_name=placement_group if use_placement_group else None
+            ),
+            # user_data= TODO
+            # https://stackoverflow.com/questions/57753032/how-to-obtain-pseudo-parameters-user-data-with-aws-cdk
+        )
+
+        launch_template = ec2.CfnLaunchTemplate(
+            scope=self, id="MasterServerLaunchTemplate", launch_template_data=launch_template_data
+        )
+
+        master_instance = ec2.CfnInstance(
+            self,
+            id="MasterServer",
+            launch_template=ec2.CfnInstance.LaunchTemplateSpecificationProperty(
+                launch_template_id=launch_template.ref, version=launch_template.attr_latest_version_number
+            ),
+        )
+
+        core.CfnOutput(
+            self,
+            id="privateip",
+            description="Private IP Address of the Master host",
+            value=master_instance.attr_public_ip,
+        )
+        core.CfnOutput(
+            self,
+            id="publicip",
+            description="Public IP Address of the Master host",
+            value=master_instance.attr_public_ip,
+        )
+        core.CfnOutput(
+            self,
+            id="dnsname",
+            description="Private DNS name of the Master host",
+            value=master_instance.attr_private_dns_name,
+        )
+
+        # TODO metadata?
+
+        # https://docs.aws.amazon.com/cdk/latest/guide/use_cfn_template.html
+        # with open('master-server-substack.cfn.yaml', 'r') as f:
+        # template = yaml.load(f, Loader=yaml.SafeLoader)
+        # include = core.CfnInclude(self, 'ExistingInfrastructure',
+        #    template=template,
+        # )
+
+    # -- Conditions -------------------------------------------------------------------------------------------------- #
+
+    def _condition_create_ec2_iam_role(self):
+        """Root role is created if head instance role or one of compute node instance roles is not specified."""
+        # TODO: split root role in head and compute roles
+        head_node = self._cluster.head_node
+        role_needed = (
+            not head_node.iam
+            or not head_node.iam.roles
+            or not head_node.iam.roles.instance_role
+            or head_node.iam.roles.instance_role == "AUTO"
+        )
+
+        if not role_needed:
+            for queue in self._cluster.scheduling.queues:
+                role_needed = (
+                    not queue.head_node.iam
+                    or not queue.iam.roles
+                    or not queue.iam.roles.instance_role
+                    or queue.iam.roles.instance_role == "AUTO"
+                )
+                if role_needed:
+                    break
+        return role_needed
+
+    def _condition_create_lambda_iam_role(self):
+        return (
+            not self._cluster.iam
+            or not self._cluster.iam.roles
+            or not self._cluster.iam.roles.custom_lambda_resources
+            or self._cluster.iam.roles.get_param("custom_lambda_resources").implied
+        )
+
+    def _condition_create_s3_access_policies(self):
+        return self._cluster.iam and self._cluster.iam.s3_access
+
+    def _condition_add_hit_iam_policies(self):
+        return self._condition_create_ec2_iam_role() and self._cluster.scheduling.scheduler == "slurm"
+
+    def _condition_create_compute_security_group(self):
+        # Compute security group must be created if at list one queue's networking does not specify security groups
+        condition = False
+        for queue in self._cluster.scheduling.queues:
+            if not queue.networking.security_groups:
+                condition = True
+        return condition
+
+    def _condition_create_head_security_group(self):
+        return not self._cluster.head_node.networking.security_groups
+
+    def _condition_create_hit_substack(self):
+        return self._cluster.scheduling.scheduler == "slurm"
+
+    # -- Outputs ----------------------------------------------------------------------------------------------------- #
+
+    def _add_ouputs(self):
+        # Storage filesystem Ids
+        self._add_shared_storage_outputs()
+
+        # ClusterUser
+        CfnOutput(
+            scope=self,
+            id="ClusterUser",
+            description="Username to login to head node",
+            value=self.os_features[self._cluster.image.os]["User"],
+        )
+
+        # MasterPrivateIP
+        # TODO: take from created head node
+        head_private_ip = "10.0.0.2"
+
+        # MasterPublicIP
+        # TODO: take from created head node
+        head_public_ip = "176.32.103.200"
+
+        # GangliaPrivateURL
+        CfnOutput(
+            scope=self,
+            id="GangliaPrivateURL",
+            description="Private URL to access Ganglia (disabled by default)",
+            value="http://{0}/ganglia/".format(head_private_ip),
+        )
+
+        # GangliaPublicURL
+        CfnOutput(
+            scope=self,
+            id="GangliaPublicURL",
+            description="Public URL to access Ganglia (disabled by default)",
+            value="http://{0}/ganglia/".format(head_public_ip),
+        )
+
+        # ResourcesS3Bucket
+        CfnOutput(
+            scope=self,
+            id="ResourcesS3Bucket",
+            description="S3 user bucket where AWS ParallelCluster resources are stored",
+            value=self._cluster.cluster_s3_bucket,
+        )
+
+        # ArtifactS3RootDirectory
+        CfnOutput(
+            scope=self,
+            id="ArtifactS3RootDirectory",
+            description="Root directory in S3 bucket where cluster artifacts are stored",
+            value=self._cluster.artifacts_s3_root_directory,
+        )
+
+        # BatchComputeEnvironmentArn
+        # BatchJobQueueArn
+        # BatchJobDefinitionArn
+        # BatchJobDefinitionMnpArn
+        # BatchUserRole
+        # TODO: take values from Batch resources
+
+        # IsHITCluster
+        CfnOutput(id="IsHITCluster", scope=self, value=str(self._condition_create_hit_substack()).lower())
+
+    def _add_shared_storage_outputs(self):
+        """Add the ids of the managed filesystem to the Stack Outputs."""
+        for storage_type, storage_ids in self._storage_resource_ids.items():
+            core.CfnOutput(
+                scope=self,
+                id="{0}Ids".format(storage_type.name),
+                description="{0} Filesystem IDs".format(storage_type.name),
+                value=",".join(storage_ids),
+            )

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -1325,3 +1325,32 @@ class InstanceTypeInfo:
     def is_efa_supported(self):
         """Check whether EFA is supported."""
         return self.instance_type_data.get("NetworkInfo").get("EfaSupported")
+
+    def instance_type(self):
+        """Get the instance type."""
+        return self.instance_type_data.get("InstanceType")
+
+    def is_cpu_options_supported_in_lt(self):
+        """Check whether hyperthreading can be disabled via CPU options."""
+        instance_type = self.instance_type()
+        res = all(
+            [
+                # If default threads per core is 1, HT doesn't need to be disabled
+                self.default_threads_per_core() > 1,
+                # Currently, hyperthreading must be disabled manually on *.metal instances
+                not (
+                    instance_type.endswith(".metal")
+                    or instance_type.startswith("m4.")
+                    or instance_type in ["cc2.8xlarge"]
+                ),
+            ]
+        )
+        return res
+
+    def is_ebs_optimized(self):
+        """Check whether the instance has optimized EBS support."""
+        ebs_optimized = False
+        ebs_info = self.instance_type_data.get("EbsInfo")
+        if ebs_info:
+            ebs_optimized = ebs_info.get("EbsOptimizedSupport") != "unsupported"
+        return ebs_optimized

--- a/cli/tests/pcluster/boto3/dummy_boto3.py
+++ b/cli/tests/pcluster/boto3/dummy_boto3.py
@@ -14,6 +14,53 @@ from common.boto3.ec2 import Ec2Client
 from common.boto3.imagebuilder import ImageBuilderClient
 from common.boto3.kms import KmsClient
 from common.boto3.s3 import S3Client
+from pcluster.utils import InstanceTypeInfo
+
+
+class DummyInstanceTypeInfo(InstanceTypeInfo):
+    def __init__(
+        self,
+        instance_type,
+        gpu_count=0,
+        interfaces_count=1,
+        default_threads_per_core=1,
+        vcpus=1,
+        supported_architectures=None,
+        efa_supported=False,
+        ebs_optimized=False,
+    ):
+        self._gpu_count = gpu_count
+        self._max_network_interface_count = interfaces_count
+        self._default_threads_per_core = default_threads_per_core
+        self._vcpus = vcpus
+        self._supported_architectures = supported_architectures if supported_architectures else ["x86_64"]
+        self._efa_supported = efa_supported
+        self._instance_type = instance_type
+        self._ebs_optimized = ebs_optimized
+
+    def gpu_count(self):
+        return self._gpu_count
+
+    def max_network_interface_count(self):
+        return self._max_network_interface_count
+
+    def default_threads_per_core(self):
+        return self._default_threads_per_core
+
+    def vcpus_count(self):
+        return self._vcpus
+
+    def supported_architecture(self):
+        return self._supported_architectures
+
+    def is_efa_supported(self):
+        return self._efa_supported
+
+    def instance_type(self):
+        return self._instance_type
+
+    def is_ebs_optimized(self):
+        return self._ebs_optimized
 
 
 class DummyAWSApi(AWSApi):
@@ -43,6 +90,12 @@ class DummyEc2Client(Ec2Client):
                 self.get_availability_zone_of_subnet.__name__, "Invalid subnet ID: {0}".format(subnet_id)
             )
         return availability_zone
+
+    def get_instance_type_info(self, instance_type):
+        return DummyInstanceTypeInfo(instance_type)
+
+    def get_official_image_id(self, os, architecture):
+        return "dummy-ami-id"
 
 
 class DummyEfsClient(Ec2Client):

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -9,43 +9,16 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import yaml
-from aws_cdk import core
 
-from common.utils import load_yaml_dict
-from pcluster.models.cluster import HeadNode
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
-from pcluster.templates.cluster_stack import HeadNodeConstruct
 
 from ..boto3.dummy_boto3 import mock_aws_api
-from ..models.cluster_dummy_model import dummy_cluster, dummy_head_node
+from ..models.cluster_dummy_model import dummy_cluster
 
 
 def test_cluster_builder():
     mock_aws_api()
     generated_template = CDKTemplateBuilder().build(cluster=dummy_cluster())
-    print(yaml.dump(generated_template))
-    # TODO assert content of the template by matching expected template
-
-
-def test_head_node_construct(tmpdir):
-    # TODO verify if it's really useful
-
-    class DummyStack(core.Stack):
-        """Simple Stack to test a specific construct."""
-
-        def __init__(self, scope: core.Construct, construct_id: str, head_node: HeadNode, **kwargs) -> None:
-            super().__init__(scope, construct_id, **kwargs)
-
-            HeadNodeConstruct(self, "HeadNode", head_node)
-
-    output_file = "cluster"
-    app = core.App(outdir=str(tmpdir))
-    DummyStack(app, output_file, head_node=dummy_head_node())
-    app.synth()
-    generated_template = load_yaml_dict(os.path.join(tmpdir, f"{output_file}.template.json"))
-
     print(yaml.dump(generated_template))
     # TODO assert content of the template by matching expected template

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -14,3 +14,5 @@ aws-cdk.aws-iam
 aws-cdk.aws-ssm
 aws-cdk.aws-fsx
 aws-cdk.aws-efs
+aws-cdk.aws-sqs
+aws_cdk.aws_lambda


### PR DESCRIPTION
This commit adds support for the creation of all the CFN resources contained in the legacy main CloudFormation template.

The following differences will be found between this new set of instances and the old ones:

- ASG related resources are not longer required because only Slurm clusters are supported, so they have not been included in the new stack
- The configuration structure has changed (e.g. iam roles for head and compute nodes are now declared separately).
- The dynamic creation logic allows to unify resources that were managed separately in the json template (e.g. S3Read/ReadWritePolicies are now unified under the new S3AccessPolicies).

NOTE: Resources managed from substacks in the old Cfn Template have not been included in this commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
