### PR TITLE
3.0: new AMI build improvements

### DIFF
--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -52,7 +52,7 @@ class Image(Resource):
         root_volume: Volume = None,
     ):
         super().__init__()
-        self.name = Resource.init_param(name + " {{ imagebuilder:buildDate }}")
+        self.name = Resource.init_param(name)
         self.description = Resource.init_param(description)
         self.tags = tags
         self.root_volume = root_volume

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -52,7 +52,7 @@ class Image(Resource):
         root_volume: Volume = None,
     ):
         super().__init__()
-        self.name = Resource.init_param(name)
+        self.name = Resource.init_param(name + " {{ imagebuilder:buildDate }}")
         self.description = Resource.init_param(description)
         self.tags = tags
         self.root_volume = root_volume

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -62,7 +62,7 @@ class Image(Resource):
     def _set_default(self):
         if self.tags is None:
             self.tags = []
-        default_tag = BaseTag("PclusterVersion", utils.get_installed_version())
+        default_tag = BaseTag("pcluster_version", utils.get_installed_version())
         default_tag.implied = True
         self.tags.append(default_tag)
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -87,8 +87,8 @@ phases:
                 echo "${filename}"
               }
 
-              # ParallelCluster Cookbook
-              add_tag "pcluster_cookbook" "$(cat /opt/parallelcluster/.bootstrapped)"
+              # ParallelCluster bootstrap file
+              add_tag "pcluster_bootstrap_file" "$(cat /opt/parallelcluster/.bootstrapped)"
 
               # OS
               add_tag "pcluster_os" "{{ test.OperatingSystemName.outputs.stdout }}"

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -70,10 +70,10 @@ phases:
               get_package_version () {
                 set -o pipefail
                 PACKAGE_NAME="$1"
-                if [ $(which dpkg 2> /dev/null) ]; then
+                if [ $(which apt 2> /dev/null) ]; then
                   VERSION=$(dpkg -s "${PACKAGE_NAME}" 2> /dev/null | grep -i version | cut -d' ' -f2 || echo "NOT_INSTALLED")
                   echo "${PACKAGE_NAME}-${VERSION}"
-                elif [ $(which rpm 2> /dev/null) ]; then
+                elif [ $(which yum 2> /dev/null) ]; then
                   echo $(rpm -q "${PACKAGE_NAME}" 2> /dev/null || echo "NOT_INSTALLED")
                 fi
                 set +o pipefail

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -81,7 +81,10 @@ phases:
 
               get_source_version () {
                 PACKAGE_NAME="$1"
-                basename $(ls "/opt/parallelcluster/sources/${PACKAGE_NAME}"* 2> /dev/null || echo "NOT_INSTALLED")
+                filename="$(basename $(ls "/opt/parallelcluster/sources/${PACKAGE_NAME}"* 2> /dev/null || echo "NOT_INSTALLED"))"
+                filename="${filename%%.tar.gz}"
+                filename="${filename%%.zip}"
+                echo "${filename}"
               }
 
               # ParallelCluster Cookbook

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -172,7 +172,7 @@ class ImageBuilderStack(core.Stack):
         )
 
         ami_distribution_configuration = {
-            "Name": self.imagebuild.image.name,
+            "Name": self._set_ami_name(),
             "Description": self.imagebuild.image.description,
             "AmiTags": ami_tags,
         }
@@ -199,6 +199,11 @@ class ImageBuilderStack(core.Stack):
             infrastructure_configuration_arn=core.Fn.ref("PClusterImageInfrastructureConfiguration"),
             distribution_configuration_arn=core.Fn.ref("ParallelClusterDistributionConfiguration"),
         )
+
+    def _set_ami_name(self):
+        if "{{ imagebuilder:buildDate }}" not in self.imagebuild.image.name:
+            return self.imagebuild.image.name + " {{ imagebuilder:buildDate }}"
+        return self.imagebuild.image.name
 
     def _get_instance_role_type(self):
         """Get instance role type based on instance_role in config."""

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -812,38 +812,12 @@ def test_imagebuilder_build_tags(mocker, resource, response, expected_imagebuild
     )
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
     generated_template = CDKTemplateBuilder().build_ami(imagebuild)
-    assert_that(
-        generated_template.get("Resources")
-        .get("ParallelClusterDistributionConfiguration")
-        .get("Properties")
-        .get("Tags")
-    ).is_equal_to(expected_imagebuilder_resource_tags)
-    assert_that(
-        generated_template.get("Resources")
-        .get("PClusterImageInfrastructureConfiguration")
-        .get("Properties")
-        .get("Tags")
-    ).is_equal_to(expected_imagebuilder_resource_tags)
-    assert_that(generated_template.get("Resources").get("PClusterComponent").get("Properties").get("Tags")).is_equal_to(
-        expected_imagebuilder_resource_tags
-    )
-    assert_that(
-        generated_template.get("Resources").get("ParallelClusterTag").get("Properties").get("Tags")
-    ).is_equal_to(expected_imagebuilder_resource_tags)
-    assert_that(
-        generated_template.get("Resources").get("PClusterImageRecipe").get("Properties").get("Tags")
-    ).is_equal_to(expected_imagebuilder_resource_tags)
-    assert_that(
-        generated_template.get("Resources")
-        .get("ParallelClusterDistributionConfiguration")
-        .get("Properties")
-        .get("Tags")
-    ).is_equal_to(expected_imagebuilder_resource_tags)
-    if generated_template.get("Resources").get("UpdateAndRebootComponent"):
-        assert_that(
-            generated_template.get("Resources").get("UpdateAndRebootComponent").get("Properties").get("Tags")
-        ).is_equal_to(expected_imagebuilder_resource_tags)
-    if generated_template.get("Resources").get("InstanceRole"):
-        assert_that(generated_template.get("Resources").get("InstanceRole").get("Properties").get("Tags")).is_equal_to(
-            expected_role_tags
-        )
+
+    for resource_name, resource in generated_template.get("Resources").items():
+        if resource_name == "InstanceProfile":
+            # InstanceProfile has no tags
+            continue
+        elif resource_name == "InstanceRole":
+            assert_that(resource.get("Properties").get("Tags")).is_equal_to(expected_role_tags)
+        else:
+            assert_that(resource.get("Properties").get("Tags")).is_equal_to(expected_imagebuilder_resource_tags)


### PR DESCRIPTION
* Fix package manager detection
* Remove extension from source package filename 
* Rename tag for bootstrap file 
* Change default AMI tag name containing PCluster version
* AMI name must contain ImageBuilder date
* Tag build infrastructure and AMI
 
**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
