### PR TITLE
3.0: Add image description attribute automatically

### DIFF
--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -47,13 +47,11 @@ class Image(Resource):
     def __init__(
         self,
         name: str,
-        description: str = None,
         tags: List[BaseTag] = None,
         root_volume: Volume = None,
     ):
         super().__init__()
         self.name = Resource.init_param(name)
-        self.description = Resource.init_param(description)
         self.tags = tags
         self.root_volume = root_volume
         self._set_default()

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -58,12 +58,27 @@ phases:
             - |
               set -v
 
+              DESCRIPTION="AWS ParallelCluster AMI for {{ test.OperatingSystemName.outputs.stdout }}."
+              append_description () {
+                VALUE="$1"
+                if [[ ! "${VALUE}" =~ NOT_INSTALLED ]] && [[ -n "${VALUE}" ]]; then
+                  echo "Appending ${VALUE} to decription"
+                  DESCRIPTION="${DESCRIPTION} ${VALUE}"
+                fi
+              }
+
+              add_description () {
+                DESCRIPTION="$(echo ${DESCRIPTION} | cut -c -1024)"
+                echo "Setting decription to ${DESCRIPTION}"
+                aws ec2 modify-image-attribute --region {{ test.AWSRegion.outputs.stdout }} --image-id {{ test.AmiId.outputs.stdout }} --description "${DESCRIPTION}" || echo "Not able to set AMI description"
+              }
+
               add_tag () {
                 KEY="$1"
                 VALUE="$2"
-                if [[ ! "${VALUE}" =~ NOT_INSTALLED ]]; then
-                  echo "Adding Tag Key=${KEY},Value=${VALUE} to AMI {{ test.AmiId.outputs.stdout }}"
-                  aws ec2 create-tags --region {{ test.AWSRegion.outputs.stdout }} --resource {{ test.AmiId.outputs.stdout }} --tags "Key=${KEY},Value=${VALUE}"
+                if [[ ! "${VALUE}" =~ NOT_INSTALLED ]] && [[ -n "${VALUE}" ]]; then
+                  echo "Adding Tag Key=${KEY},Value=${VALUE}"
+                  aws ec2 create-tags --region {{ test.AWSRegion.outputs.stdout }} --resource {{ test.AmiId.outputs.stdout }} --tags "Key=${KEY},Value=${VALUE}" || echo "Not able to set AMI tag"
                 fi
               }
 
@@ -71,11 +86,19 @@ phases:
                 set -o pipefail
                 PACKAGE_NAME="$1"
                 if [ $(which apt 2> /dev/null) ]; then
-                  VERSION=$(dpkg -s "${PACKAGE_NAME}" 2> /dev/null | grep -i version | cut -d' ' -f2 || echo "NOT_INSTALLED")
+                  VERSION=$(dpkg -s "${PACKAGE_NAME}" 2> /dev/null | grep -i "^version:" | tr -s ' ' | cut -d' ' -f2 || echo "NOT_INSTALLED")
                   echo "${PACKAGE_NAME}-${VERSION}"
                 elif [ $(which yum 2> /dev/null) ]; then
                   echo $(rpm -q "${PACKAGE_NAME}" 2> /dev/null || echo "NOT_INSTALLED")
                 fi
+                set +o pipefail
+              }
+
+              get_modinfo () {
+                set -o pipefail
+                MODULE_NAME="$1"
+                VERSION=$(modinfo "${MODULE_NAME}" 2> /dev/null | grep -i "^version:" | tr -s ' ' | cut -d' ' -f2 || echo "NOT_INSTALLED")
+                echo "${MODULE_NAME}-${VERSION}"
                 set +o pipefail
               }
 
@@ -94,17 +117,25 @@ phases:
               add_tag "pcluster_os" "{{ test.OperatingSystemName.outputs.stdout }}"
 
               # Kernel
-              add_tag "pcluster_kernel" "$(uname -r)"
+              KERNEL_VERSION="$(uname -r)"
+              add_tag "pcluster_kernel" "${KERNEL_VERSION}"
+              append_description "kernel-${KERNEL_VERSION}"
 
               # sudo
               add_tag "pcluster_sudo" "$(get_package_version "sudo")"
 
               # Lustre
-              add_tag "pcluster_lustre" "$(get_package_version "lustre-client")"
-              add_tag "pcluster_lustre" "$(get_package_version "lustre-client-modules-aws")"
+              LUSTRE_VERSION="$(get_package_version "lustre-client")"
+              add_tag "pcluster_lustre" "${LUSTRE_VERSION}"
+              append_description "${LUSTRE_VERSION}"
+              LUSTRE_VERSION="$(get_package_version "lustre-client-modules-aws")"
+              add_tag "pcluster_lustre" "${LUSTRE_VERSION}"
+              append_description "${LUSTRE_VERSION}"
 
               # EFA
-              add_tag "pcluster_efa" "$(get_package_version "efa")"
+              EFA_VERSION="$(get_package_version "efa")"
+              add_tag "pcluster_efa" "${EFA_VERSION}"
+              append_description "${EFA_VERSION}"
               add_tag "pcluster_efa_profile" "$(get_package_version "efa-profile")"
               add_tag "pcluster_efa_config" "$(get_package_version "efa-config")"
               add_tag "pcluster_efa_rdma_core" "$(get_package_version "rdma-core")"
@@ -112,13 +143,23 @@ phases:
               add_tag "pcluster_efa_openmpi40_aws" "$(get_package_version "openmpi40-aws")"
 
               # DCV
-              add_tag "pcluster_dcv_server" "$(get_package_version "nice-dcv-server")"
+              DCV_VERSION="$(get_package_version "nice-dcv-server")"
+              add_tag "pcluster_dcv_server" "${DCV_VERSION}"
+              append_description "${DCV_VERSION}"
               add_tag "pcluster_dcv_xdcv" "$(get_package_version "nice-xdcv")"
 
               # Slurm, Munge and PMIx
-              add_tag "pcluster_slurm" "$(get_source_version "slurm")"
+              SLURM_VERSION="$(get_source_version "slurm")"
+              add_tag "pcluster_slurm" "${SLURM_VERSION}"
+              append_description "${SLURM_VERSION}"
               add_tag "pcluster_munge" "$(get_source_version "munge")"
               add_tag "pcluster_pmix" "$(get_source_version "pmix")"
 
-              # TODO Nvidia and Cuda
+              # Nvidia and Cuda
+              NVIDIA_VERSION="$(get_modinfo "nvidia")"
+              add_tag "pcluster_nvidia" "${NVIDIA_VERSION}"
+              append_description "${NVIDIA_VERSION}"
+              # TODO Cuda
 
+              # Add description
+              add_description

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -47,7 +47,6 @@ class ImageSchema(BaseSchema):
     """Represent the schema of the ImageBuilder Image."""
 
     name = fields.Str(validate=validate.Regexp(r"^[-_A-Za-z-0-9][-_A-Za-z0-9 ]{1,126}[-_A-Za-z-0-9]$"), required=True)
-    description = fields.Str()
     tags = fields.List(fields.Nested(TagSchema))
     root_volume = fields.Nested(VolumeSchema)
 

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -173,7 +173,6 @@ class ImageBuilderStack(core.Stack):
 
         ami_distribution_configuration = {
             "Name": self._set_ami_name(),
-            "Description": self.imagebuild.image.description,
             "AmiTags": ami_tags,
         }
 
@@ -225,7 +224,7 @@ class ImageBuilderStack(core.Stack):
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Action": ["ec2:CreateTags"],
+                    "Action": ["ec2:CreateTags", "ec2:ModifyImageAttribute"],
                     "Resource": [
                         core.Fn.sub("arn:${AWS::Partition}:ec2:*::image/*"),
                     ],

--- a/cli/tests/pcluster/models/test_imagebuilder_model.py
+++ b/cli/tests/pcluster/models/test_imagebuilder_model.py
@@ -27,7 +27,6 @@ from tests.pcluster.models.test_cluster_model import _assert_validation_result
                 "imagebuilder": {
                     "image": {
                         "name": "Pcluster",
-                        "description": "Pcluster 3.0 Image",
                         "root_volume": {"size": 25, "kms_key_id": "key_id"},
                         "tags": [
                             {"key": "name", "value": "pcluster"},

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -297,7 +297,7 @@ def _test_resources(generated_resouces, expected_resources):
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster", "description": "Pcluster 3.0 Image"},
+                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -342,7 +342,7 @@ def _test_resources(generated_resouces, expected_resources):
                                 "Statement": [
                                     {
                                         "Effect": "Allow",
-                                        "Action": ["ec2:CreateTags"],
+                                        "Action": ["ec2:CreateTags", "ec2:ModifyImageAttribute"],
                                         "Resource": [{"Fn::Sub": "arn:${AWS::Partition}:ec2:*::image/*"}],
                                     }
                                 ],
@@ -362,7 +362,7 @@ def _test_resources(generated_resouces, expected_resources):
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster", "description": "Pcluster 3.0 Image"},
+                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -398,7 +398,7 @@ def _test_resources(generated_resouces, expected_resources):
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster", "description": "Pcluster 3.0 Image"},
+                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -459,7 +459,7 @@ def test_imagebuilder_instance_role(
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster", "description": "Pcluster 3.0 Image"},
+                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -502,7 +502,7 @@ def test_imagebuilder_instance_role(
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster", "description": "Pcluster 3.0 Image"},
+                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -613,7 +613,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "my AMI 2", "description": "my description"},
+                    "image": {"name": "my AMI 2"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -635,7 +635,6 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "my AMI 2 {{ imagebuilder:buildDate }}",
-                        "Description": "my description",
                         "AmiTags": {"pcluster_version": utils.get_installed_version()},
                     },
                     "Region": {"Fn::Sub": "${AWS::Region}"},
@@ -753,7 +752,7 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "my AMI 2", "description": "my description"},
+                    "image": {"name": "my AMI 2"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",


### PR DESCRIPTION
Image description is added automatically at the end of the build, reporting info on the packages installed

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
