### PR TITLE
Fix instance type sanity checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 2.10.2
 ------
+**ENHANCEMENTS**
+
+- Improve cluster config validation by using cluster target AMI when invoking RunInstances in dryrun mode
 
 **CHANGES**
 
@@ -13,6 +16,7 @@ CHANGELOG
 **BUG FIXES**
 
 - Fix `enable_efa` parameter validation when using Centos8 and Slurm or ARM instances.
+- Fix sanity checks with ARM instance types by using cluster AMIs when performing validation      
 
 2.10.1
 ------

--- a/cli/src/pcluster/models/hit/hit_cluster_model.py
+++ b/cli/src/pcluster/models/hit/hit_cluster_model.py
@@ -72,7 +72,7 @@ class HITClusterModel(ClusterModel):
             else {}
         )
         try:
-            latest_alinux_ami_id = self._get_latest_alinux_ami_id()
+            cluster_ami_id = self._get_cluster_ami_id(pcluster_config)
 
             head_node_network_interfaces = self.build_launch_network_interfaces(
                 network_interfaces_count=int(cluster_section.get_param_value("network_interfaces_count")[0]),
@@ -88,7 +88,7 @@ class HITClusterModel(ClusterModel):
                 InstanceType=head_node_instance_type,
                 MinCount=1,
                 MaxCount=1,
-                ImageId=latest_alinux_ami_id,
+                ImageId=cluster_ami_id,
                 CpuOptions=head_node_cpu_options,
                 NetworkInterfaces=head_node_network_interfaces,
                 DryRun=True,
@@ -111,7 +111,7 @@ class HITClusterModel(ClusterModel):
                     pcluster_config,
                     compute_resource_section,
                     disable_hyperthreading=disable_hyperthreading,
-                    ami_id=latest_alinux_ami_id,
+                    ami_id=cluster_ami_id,
                     subnet=compute_subnet,
                     security_groups_ids=security_groups_ids,
                     placement_group=queue_placement_group,

--- a/cli/src/pcluster/models/sit/sit_cluster_model.py
+++ b/cli/src/pcluster/models/sit/sit_cluster_model.py
@@ -111,7 +111,7 @@ class SITClusterModel(ClusterModel):
         )
 
         try:
-            latest_alinux_ami_id = self._get_latest_alinux_ami_id()
+            cluster_ami_id = self._get_cluster_ami_id(pcluster_config)
 
             head_node_network_interfaces = self.build_launch_network_interfaces(
                 network_interfaces_count=int(cluster_section.get_param_value("network_interfaces_count")[0]),
@@ -127,7 +127,7 @@ class SITClusterModel(ClusterModel):
                 InstanceType=head_node_instance_type,
                 MinCount=1,
                 MaxCount=1,
-                ImageId=latest_alinux_ami_id,
+                ImageId=cluster_ami_id,
                 CpuOptions=head_node_cpu_options,
                 NetworkInterfaces=head_node_network_interfaces,
                 Placement=head_node_placement_group,
@@ -153,7 +153,7 @@ class SITClusterModel(ClusterModel):
                 InstanceType=compute_instance_type,
                 MinCount=1,
                 MaxCount=1,
-                ImageId=latest_alinux_ami_id,
+                ImageId=cluster_ami_id,
                 CpuOptions=compute_cpu_options,
                 Placement=compute_placement_group,
                 NetworkInterfaces=network_interfaces,

--- a/cli/tests/pcluster/config/test_pcluster_config.py
+++ b/cli/tests/pcluster/config/test_pcluster_config.py
@@ -13,6 +13,7 @@ import pytest
 from assertpy import assert_that
 from pytest import fail
 
+from pcluster.utils import get_installed_version
 from tests.common import MockedBoto3Request
 from tests.pcluster.config.utils import get_mocked_pcluster_config, init_pcluster_config_from_configparser
 
@@ -143,3 +144,85 @@ def test_load_from_file_errors(capsys, config_parser_dict, expected_message):
             assert_that(e.args[0]).matches(expected_message)
         else:
             fail("Unexpected failure when loading file")
+
+
+@pytest.mark.parametrize(
+    "custom_ami_id, os, architecture, expected_ami_suffix, expected_ami_id, expected_error_message, raise_boto3_error",
+    [
+        # Official AMIs
+        (None, "alinux", "x86_64", "amzn-hvm-x86_64", "ami-official", None, False),
+        (None, "alinux2", "x86_64", "amzn2-hvm-x86_64", "ami-official", None, False),
+        (None, "centos7", "x86_64", "centos7-hvm-x86_64", "ami-official", None, False),
+        (None, "centos8", "x86_64", "centos8-hvm-x86_64", "ami-official", None, False),
+        (None, "ubuntu1604", "x86_64", "ubuntu-1604-lts-hvm-x86_64", "ami-official", None, False),
+        (None, "ubuntu1804", "x86_64", "ubuntu-1804-lts-hvm-x86_64", "ami-official", None, False),
+        (None, "alinux", "arm_64", "amzn-hvm-arm_64", "ami-official", None, False),
+        (None, "alinux2", "arm_64", "amzn2-hvm-arm_64", "ami-official", None, False),
+        (None, "centos7", "arm_64", "centos7-hvm-arm_64", "ami-official", None, False),
+        (None, "centos8", "arm_64", "centos8-hvm-arm_64", "ami-official", None, False),
+        (None, "ubuntu1604", "arm_64", "ubuntu-1604-lts-hvm-arm_64", "ami-official", None, False),
+        (None, "ubuntu1804", "arm_64", "ubuntu-1804-lts-hvm-arm_64", "ami-official", None, False),
+        # Custom AMIs
+        ("ami-custom", "alinux2", "x86_64", None, "ami-custom", None, False),
+        ("ami-custom", "alinux2", "arm_64", None, "ami-custom", None, False),
+        # No AMI found
+        (None, "alinux2", "x86_64", "amzn2-hvm-x86_64", None, "No official image id found", False),
+        # Boto3 error
+        (None, "alinux2", "x86_64", "amzn2-hvm-x86_64", None, "Unable to retrieve official image id", True),
+    ],
+)
+def test_get_cluster_ami_id(
+    mocker,
+    boto3_stubber,
+    custom_ami_id,
+    os,
+    architecture,
+    expected_ami_suffix,
+    expected_ami_id,
+    expected_error_message,
+    raise_boto3_error,
+):
+    if not custom_ami_id:
+        mocked_requests = [
+            MockedBoto3Request(
+                method="describe_images",
+                response={
+                    "Images": [
+                        {
+                            "Architecture": "arm64",
+                            "CreationDate": "2020-12-22T13:30:33.000Z",
+                            "ImageId": expected_ami_id,
+                        }
+                    ]
+                    if expected_ami_id
+                    else []
+                },
+                expected_params={
+                    "Filters": [
+                        {
+                            "Name": "name",
+                            "Values": [
+                                "aws-parallelcluster-{version}-{suffix}*".format(
+                                    version=get_installed_version(), suffix=expected_ami_suffix
+                                )
+                            ],
+                        },
+                        {"Name": "owner-alias", "Values": ["amazon"]},
+                    ],
+                },
+                generate_error=raise_boto3_error,
+            )
+        ]
+        boto3_stubber("ec2", mocked_requests)
+
+    pcluster_config = get_mocked_pcluster_config(mocker)
+    pcluster_config.get_section("cluster").get_param("custom_ami").value = custom_ami_id
+    pcluster_config.get_section("cluster").get_param("base_os").value = os
+    pcluster_config.get_section("cluster").get_param("architecture").value = architecture
+
+    if expected_error_message:
+        with pytest.raises(SystemExit, match=expected_error_message):
+            _ = pcluster_config.cluster_model._get_cluster_ami_id(pcluster_config)
+    else:
+        cluster_ami_id = pcluster_config.cluster_model._get_cluster_ami_id(pcluster_config)
+        assert_that(cluster_ami_id).is_equal_to(expected_ami_id)


### PR DESCRIPTION
This commmit replaces the latest linux image id with the actual cluster ami in dryrun run-instances calls performed during sanity checks.

This new behaviour fixes in particular the issue occurring when the architecture of the instance types is different from the one of the latest linux AMI, and provides a more reliable check when custom amis are used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
