### PR TITLE
3.0: Pcluster build image command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ CHANGELOG
 - Add `--disable-update-check` parameter for the `create` command.
 - Deprecate `--config` parameter for `delete`, `status`, `start`, `stop`, `instances` and `list` commands.
 - Remove possibility to specify aliases for `ssh` command in the configuration file.
-
+- Rename `createami` command to `build-image` command, deprecate `--ami-id`, `--os`, `--instance-type`, 
+  `--ami-name-prefix`, `--custom-cookbook`, `--post-install`, `--no-public-ip`, `--cluster-template`, `--vpc-id`,
+   `--subnet-id`.
+- Add `--image-name`, `--config`, `--region` to `build-image` command
 
 2.10.1
 ------

--- a/cli/src/common/boto3/cfn.py
+++ b/cli/src/common/boto3/cfn.py
@@ -21,8 +21,19 @@ class CfnClient(Boto3Client):
         super().__init__("cloudformation")
 
     @AWSExceptionHandler.handle_client_exception
-    def create_stack(self, stack_name: str, template_url: str, disable_rollback: bool, tags: list):
+    def create_stack(self, stack_name: str, disable_rollback: bool, tags: list, template_body: str):
         """Create CFN stack by using the given template."""
+        return self._client.create_stack(
+            StackName=stack_name,
+            TemplateBody=template_body,
+            Capabilities=["CAPABILITY_IAM"],
+            DisableRollback=disable_rollback,
+            Tags=tags,
+        )
+
+    @AWSExceptionHandler.handle_client_exception
+    def create_stack_from_url(self, stack_name: str, disable_rollback: bool, tags: list, template_url: str):
+        """Create CFN stack by using the given template url."""
         return self._client.create_stack(
             StackName=stack_name,
             TemplateURL=template_url,
@@ -74,3 +85,8 @@ class CfnClient(Boto3Client):
             for stack in self._paginate_results(self._client.describe_stacks)
             if stack.get("ParentId") is None and stack.get("StackName").startswith(PCLUSTER_STACK_PREFIX)
         ]
+
+    @AWSExceptionHandler.handle_client_exception
+    def describe_stack_resource(self, stack_name: str, logic_resource_id: str):
+        """Get stack resource information."""
+        self._client.describe_stack_resource(StackName=stack_name, LogicalResourceId=logic_resource_id)

--- a/cli/src/pcluster/cli.py
+++ b/cli/src/pcluster/cli.py
@@ -24,7 +24,6 @@ from botocore.exceptions import NoCredentialsError
 import pcluster.cli_commands.update as pcluster_update
 import pcluster.commands as pcluster
 import pcluster.configure.easyconfig as easyconfig
-import pcluster.createami as createami
 import pcluster.utils as utils
 from pcluster.dcv.connect import dcv_connect
 
@@ -79,8 +78,8 @@ def stop(args):
     pcluster.stop(args)
 
 
-def create_ami(args):
-    createami.create_ami(args)
+def build_image(args):
+    pcluster.build_image(args)
 
 
 def config_logger():
@@ -297,69 +296,17 @@ Returns an ssh command with the cluster username and IP address pre-populated::
     pssh.set_defaults(func=ssh)
 
     # createami command subparser
-    pami = subparsers.add_parser(
-        "createami", help="(Linux/macOS) Creates a custom AMI to use with AWS ParallelCluster."
-    )
-    pami.add_argument(
-        "-ai",
-        "--ami-id",
-        dest="base_ami_id",
-        required=True,
-        help="Specifies the base AMI to use for building the AWS ParallelCluster AMI.",
-    )
-    pami.add_argument(
-        "-os",
-        "--os",
-        dest="base_ami_os",
-        required=True,
-        help="Specifies the OS of the base AMI. "
-        "Valid options are: alinux, ubuntu1604, ubuntu1804, centos7, centos8.",
-    )
+    pami = subparsers.add_parser("build-image", help="Creates a custom AMI to use with AWS ParallelCluster.")
     pami.add_argument(
         "-i",
-        "--instance-type",
-        dest="instance_type",
-        default="t2.xlarge",
-        help="Sets instance type to build the ami on. Defaults to t2.xlarge.",
-    )
-    pami.add_argument(
-        "-ap",
-        "--ami-name-prefix",
-        dest="custom_ami_name_prefix",
-        default="custom-ami-",
-        help="Specifies the prefix name of the resulting AWS ParallelCluster AMI.",
-    )
-    pami.add_argument(
-        "-cc",
-        "--custom-cookbook",
-        dest="custom_ami_cookbook",
-        help="Specifies the cookbook to use to build the AWS ParallelCluster AMI.",
-    )
-    pami.add_argument(
-        "--post-install",
-        dest="post_install_script",
-        help="Specifies the post install script to use to build the AWS ParallelCluster AMI.",
-    )
-    pami.add_argument(
-        "--no-public-ip",
-        dest="associate_public_ip",
-        action="store_false",
-        default=True,
-        help="Do not associate public IP to the Packer instance. Defaults to associate public ip",
+        "--image-name",
+        dest="image_name",
+        required=True,
+        help="Specifies the image name to use for building the AWS ParallelCluster AMI.",
     )
     _addarg_config(pami)
-    pami_group1 = pami.add_argument_group("Build AMI by using VPC settings from configuration file")
-    pami_group1.add_argument(
-        "-t",
-        "--cluster-template",
-        help="Specifies the 'cluster' section of the configuration file to retrieve VPC settings.",
-    )
-    pami_group2 = pami.add_argument_group("Build AMI in a custom VPC and Subnet")
-    pami_group2.add_argument("--vpc-id", help="Specifies the VPC to use to build the AWS ParallelCluster AMI.")
-    pami_group2.add_argument("--subnet-id", help="Specifies the Subnet to use to build the AWS ParallelCluster AMI.")
     _addarg_region(pami)
-    pami.set_defaults(template_url=None)
-    pami.set_defaults(func=create_ami)
+    pami.set_defaults(func=build_image)
 
     # configure command subparser
     pconfigure = subparsers.add_parser("configure", help="Start the AWS ParallelCluster configuration.")

--- a/cli/src/pcluster/commands.py
+++ b/cli/src/pcluster/commands.py
@@ -559,3 +559,19 @@ def _get_default_template_url(region):
             REGION=region, SUFFIX=".cn" if region.startswith("cn") else "", VERSION=utils.get_installed_version()
         )
     )
+
+
+def build_image(args):
+    """Build AWS ParallelCluster AMI."""
+    LOGGER.info("Building AWS ParallelCluster AMI. This could take a while...")
+    try:
+        response = PclusterApi().build_image(
+            imagebuilder_config=load_yaml_dict(args.config_file), image_name=args.image_name, region=utils.get_region()
+        )
+        LOGGER.info("Response:")
+        LOGGER.info({"image": response.__repr__()})
+    except Exception as e:
+        utils.error(
+            "Error parsing configuration file {0}.\nDouble check it's a valid Yaml file. "
+            "Error: {1}".format(args.config_file, str(e))
+        )

--- a/cli/src/pcluster/configure/networking.py
+++ b/cli/src/pcluster/configure/networking.py
@@ -168,7 +168,7 @@ def _create_network_stack(configuration, parameters):
     version = pkg_resources.get_distribution("aws-parallelcluster").version
     try:
         cfn_client = boto3.client("cloudformation")
-        stack = cfn_client.create_stack(
+        stack = cfn_client.create_stack_from_url(
             StackName=stack_name,
             TemplateURL=get_templates_bucket_path()
             + "networking/%s-%s.cfn.json" % (configuration.template_name, version),

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -269,7 +269,7 @@ class Cluster:
             self._upload_artifacts()
 
             LOGGER.info("Creating stack named: %s", self.stack_name)
-            creation_result = AWSApi.instance().cfn.create_stack(
+            creation_result = AWSApi.instance().cfn.create_stack_from_url(
                 stack_name=self.stack_name,
                 template_url=self.template_url,
                 disable_rollback=disable_rollback,

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -202,8 +202,10 @@ class BaseDevSettings(Resource):
         self.aws_batch_cli_package = Resource.init_param(aws_batch_cli_package)
 
     def _validate(self):
-        self._execute_validator(UrlValidator, url=self.node_package)
-        self._execute_validator(UrlValidator, url=self.aws_batch_cli_package)
+        if self.node_package:
+            self._execute_validator(UrlValidator, url=self.node_package)
+        if self.aws_batch_cli_package:
+            self._execute_validator(UrlValidator, url=self.aws_batch_cli_package)
 
 
 # ------------ Common attributes class between ImageBuilder an Cluster models ----------- #

--- a/cli/src/pcluster/models/imagebuilder_config.py
+++ b/cli/src/pcluster/models/imagebuilder_config.py
@@ -1,0 +1,189 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This module contains all the classes representing the Resources objects.
+# These objects are obtained from the configuration file through a conversion based on the Schema classes.
+#
+
+from typing import List
+
+from common.imagebuilder_utils import ROOT_VOLUME_TYPE
+from pcluster.models.common import BaseDevSettings, BaseTag, ExtraChefAttributes, Resource
+from pcluster.validators.ebs_validators import EbsVolumeTypeSizeValidator
+from pcluster.validators.ec2_validators import InstanceTypeBaseAMICompatibleValidator
+from pcluster.validators.imagebuilder_validators import AMIVolumeSizeValidator
+from pcluster.validators.kms_validators import KmsKeyIdEncryptedValidator, KmsKeyValidator
+
+# ---------------------- Image ---------------------- #
+
+
+class Volume(Resource):
+    """Represent the volume configuration for the ImageBuilder."""
+
+    def __init__(self, size: int = None, encrypted: bool = None, kms_key_id: str = None):
+        super().__init__()
+        self.size = Resource.init_param(size)
+        self.encrypted = Resource.init_param(encrypted, default=False)
+        self.kms_key_id = Resource.init_param(kms_key_id)
+
+    def _validate(self):
+        if self.kms_key_id:
+            self._execute_validator(KmsKeyIdEncryptedValidator, kms_key_id=self.kms_key_id, encrypted=self.encrypted)
+            self._execute_validator(KmsKeyValidator, kms_key_id=self.kms_key_id)
+
+
+class Image(Resource):
+    """Represent the image configuration for the ImageBuilder."""
+
+    def __init__(
+        self,
+        name: str,
+        tags: List[BaseTag] = None,
+        root_volume: Volume = None,
+    ):
+        super().__init__()
+        self.name = Resource.init_param(name)
+        self.tags = tags
+        self.root_volume = root_volume
+
+
+# ---------------------- Build ---------------------- #
+
+
+class Component(Resource):
+    """Represent the components configuration for the ImageBuilder."""
+
+    def __init__(self, type: str, value: str):
+        super().__init__()
+        self.type = Resource.init_param(type)
+        self.value = Resource.init_param(value)
+
+
+class DistributionConfiguration(Resource):
+    """Represent the distribution configuration for the ImageBuilder."""
+
+    def __init__(self, regions: str, launch_permission: str = None):
+        super().__init__()
+        self.regions = Resource.init_param(regions)
+        self.launch_permission = Resource.init_param(launch_permission)
+
+
+class Build(Resource):
+    """Represent the build configuration for the ImageBuilder."""
+
+    def __init__(
+        self,
+        instance_type: str,
+        parent_image: str,
+        instance_role: str = None,
+        subnet_id: str = None,
+        tags: List[BaseTag] = None,
+        security_group_ids: List[str] = None,
+        components: List[Component] = None,
+    ):
+        super().__init__()
+        self.instance_type = Resource.init_param(instance_type)
+        self.parent_image = Resource.init_param(parent_image)
+        self.instance_role = Resource.init_param(instance_role)
+        self.tags = tags
+        self.subnet_id = Resource.init_param(subnet_id)
+        self.security_group_ids = security_group_ids
+        self.components = components
+
+    def _validate(self):
+        self._execute_validator(
+            InstanceTypeBaseAMICompatibleValidator,
+            instance_type=self.instance_type,
+            image=self.parent_image,
+        )
+
+
+# ---------------------- Dev Settings ---------------------- #
+
+
+class ImagebuilderDevSettings(BaseDevSettings):
+    """Represent the dev settings configuration for the ImageBuilder."""
+
+    def __init__(
+        self,
+        update_os_and_reboot: bool = None,
+        disable_pcluster_component: bool = None,
+        distribution_configuration: DistributionConfiguration = None,
+        terminate_instance_on_failure: bool = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.update_os_and_reboot = Resource.init_param(update_os_and_reboot, default=False)
+        self.disable_pcluster_component = Resource.init_param(disable_pcluster_component, default=False)
+        self.distribution_configuration = distribution_configuration
+        self.terminate_instance_on_failure = Resource.init_param(terminate_instance_on_failure, default=True)
+
+
+# ---------------------- ImageBuilder ---------------------- #
+
+
+class ImageBuilderConfig(Resource):
+    """Represent the configuration of an ImageBuilder."""
+
+    def __init__(
+        self,
+        image: Image,
+        build: Build,
+        dev_settings: ImagebuilderDevSettings = None,
+    ):
+        super().__init__()
+        self.image = image
+        self.build = build
+        self.dev_settings = dev_settings
+
+    def _validate(self):
+        # Volume size validator only validates specified volume size
+        if self.image.root_volume and self.image.root_volume.size:
+            self._execute_validator(
+                EbsVolumeTypeSizeValidator,
+                volume_type=ROOT_VOLUME_TYPE,
+                volume_size=self.image.root_volume.size,
+            )
+            self._execute_validator(
+                AMIVolumeSizeValidator,
+                volume_size=self.image.root_volume.size,
+                image=self.build.parent_image,
+            )
+
+
+# ------------ Attributes class used in imagebuilder resources ----------- #
+
+
+class ImageBuilderExtraChefAttributes(ExtraChefAttributes):
+    """Extra Attributes for ImageBuilder Chef Client."""
+
+    def __init__(self, dev_settings: ImagebuilderDevSettings):
+        super().__init__(dev_settings)
+        self.cfn_region = None
+        self.nvidia = None
+        self.is_official_ami_build = None
+        self.custom_node_package = None
+        self.custom_awsbatchcli_package = None
+        self.cfn_base_os = None
+        self._set_default(dev_settings)
+
+    def _set_default(self, dev_settings: ImagebuilderDevSettings):
+        self.cfn_region = "{{ build.AWSRegion.outputs.stdout }}"
+        self.nvidia = {"enabled": "false"}
+        self.is_official_ami_build = "true" if dev_settings and dev_settings.update_os_and_reboot else "false"
+        self.custom_node_package = dev_settings.node_package if dev_settings and dev_settings.node_package else ""
+        self.custom_awsbatchcli_package = (
+            dev_settings.aws_batch_cli_package if dev_settings and dev_settings.aws_batch_cli_package else ""
+        )
+        self.cfn_base_os = "{{ build.OperatingSystemName.outputs.stdout }}"
+        for key, value in self.__dict__.items():
+            if not key.startswith("_") and key not in self._cfncluster_attributes:
+                self._cfncluster_attributes.update({key: value})

--- a/cli/src/pcluster/models/imagebuilder_config.py
+++ b/cli/src/pcluster/models/imagebuilder_config.py
@@ -45,12 +45,10 @@ class Image(Resource):
 
     def __init__(
         self,
-        name: str,
         tags: List[BaseTag] = None,
         root_volume: Volume = None,
     ):
         super().__init__()
-        self.name = Resource.init_param(name)
         self.tags = tags
         self.root_volume = root_volume
 
@@ -135,8 +133,8 @@ class ImageBuilderConfig(Resource):
 
     def __init__(
         self,
-        image: Image,
         build: Build,
+        image: Image = None,
         dev_settings: ImagebuilderDevSettings = None,
     ):
         super().__init__()
@@ -146,7 +144,7 @@ class ImageBuilderConfig(Resource):
 
     def _validate(self):
         # Volume size validator only validates specified volume size
-        if self.image.root_volume and self.image.root_volume.size:
+        if self.image and self.image.root_volume and self.image.root_volume.size:
             self._execute_validator(
                 EbsVolumeTypeSizeValidator,
                 volume_type=ROOT_VOLUME_TYPE,

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -19,12 +19,12 @@ from marshmallow import ValidationError, fields, post_load, validate, validates,
 
 from common.imagebuilder_utils import AMI_NAME_REQUIRED_SUBSTRING
 from common.utils import get_url_scheme, validate_json_format
-from pcluster.models.imagebuilder import (
+from pcluster.models.imagebuilder_config import (
     Build,
     Component,
     DistributionConfiguration,
     Image,
-    ImageBuilder,
+    ImageBuilderConfig,
     ImagebuilderDevSettings,
     Volume,
 )
@@ -184,4 +184,4 @@ class ImageBuilderSchema(BaseSchema):
     @post_load()
     def make_resource(self, data, **kwargs):
         """Generate resource."""
-        return ImageBuilder(**data)
+        return ImageBuilderConfig(**data)

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -17,7 +17,6 @@ import re
 
 from marshmallow import ValidationError, fields, post_load, validate, validates, validates_schema
 
-from common.imagebuilder_utils import AMI_NAME_REQUIRED_SUBSTRING
 from common.utils import get_url_scheme, validate_json_format
 from pcluster.models.imagebuilder_config import (
     Build,
@@ -55,11 +54,6 @@ class VolumeSchema(BaseSchema):
 class ImageSchema(BaseSchema):
     """Represent the schema of the ImageBuilder Image."""
 
-    name = fields.Str(
-        validate=validate.Regexp(r"^[-_A-Za-z-0-9][-_A-Za-z0-9 ]{1,126}[-_A-Za-z-0-9]$")
-        and validate.Length(max=1024 - len(AMI_NAME_REQUIRED_SUBSTRING)),
-        required=True,
-    )
     tags = fields.List(fields.Nested(TagSchema))
     root_volume = fields.Nested(VolumeSchema)
 
@@ -177,7 +171,7 @@ class ImagebuilderDevSettingsSchema(BaseDevSettingsSchema):
 class ImageBuilderSchema(BaseSchema):
     """Represent the schema of the ImageBuilder."""
 
-    image = fields.Nested(ImageSchema, required=True)
+    image = fields.Nested(ImageSchema)
     build = fields.Nested(BuildSchema, required=True)
     dev_settings = fields.Nested(ImagebuilderDevSettingsSchema)
 

--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -19,7 +19,7 @@ from aws_cdk import core
 
 from common.utils import load_yaml_dict
 from pcluster.models.cluster_config import BaseClusterConfig, ClusterBucket
-from pcluster.models.imagebuilder import ImageBuilder
+from pcluster.models.imagebuilder_config import ImageBuilderConfig
 from pcluster.templates.cluster_stack import ClusterCdkStack
 from pcluster.templates.imagebuilder_stack import ImageBuilderCdkStack
 
@@ -40,12 +40,12 @@ class CDKTemplateBuilder:
         return generated_template
 
     @staticmethod
-    def build_imagebuilder_template(imagebuild: ImageBuilder):
+    def build_imagebuilder_template(imagebuild: ImageBuilderConfig, image_name: str):
         """Build template for the given imagebuilder and return as output in Yaml format."""
         with tempfile.TemporaryDirectory() as tempdir:
             output_file = "imagebuilder"
             app = core.App(outdir=str(tempdir))
-            ImageBuilderCdkStack(app, output_file, imagebuild)
+            ImageBuilderCdkStack(app, output_file, imagebuild, image_name)
             app.synth()
             generated_template = load_yaml_dict(os.path.join(tempdir, f"{output_file}.template.json"))
 

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -99,7 +99,7 @@ class ImageBuilderCdkStack(core.Stack):
         build_tags = {tag.key: tag.value for tag in tags}
 
         # Add default ami tags information
-        tags = copy.deepcopy(image.tags) or []
+        tags = copy.deepcopy(image.tags) if image and image.tags else []
         tags.append(BaseTag(key="pcluster_version", value=utils.get_installed_version()))
         ami_tags = {tag.key: tag.value for tag in tags}
 
@@ -352,13 +352,13 @@ class ImageBuilderCdkStack(core.Stack):
         image = self.imagebuild.image
         build = self.imagebuild.build
 
-        if image.root_volume is None or image.root_volume.size is None:
+        if image is None or image.root_volume is None or image.root_volume.size is None:
             ami_id = imagebuilder_utils.get_ami_id(build.parent_image)
             ami_info = AWSApi.instance().ec2.describe_image(ami_id)
             default_root_volume_size = (
                 ami_info.get("BlockDeviceMappings")[0].get("Ebs").get("VolumeSize") + PCLUSTER_RESERVED_VOLUME_SIZE
             )
-            if image.root_volume is None:
+            if image is None or image.root_volume is None:
                 default_root_volume = Volume(size=default_root_volume_size)
             else:
                 default_root_volume = copy.deepcopy(image.root_volume)

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -30,16 +30,20 @@ from common.imagebuilder_utils import (
     InstanceRole,
 )
 from common.utils import get_url_scheme, load_yaml, parse_bucket_url
-from pcluster.models.imagebuilder import ImageBuilder, ImageBuilderExtraChefAttributes, Volume
+from pcluster.models.common import BaseTag
+from pcluster.models.imagebuilder_config import ImageBuilderConfig, ImageBuilderExtraChefAttributes, Volume
 from pcluster.schemas.imagebuilder_schema import ImageBuilderSchema
 
 
 class ImageBuilderCdkStack(core.Stack):
     """Create the Stack for imagebuilder."""
 
-    def __init__(self, scope: core.Construct, construct_id: str, imagebuild: ImageBuilder, **kwargs) -> None:
+    def __init__(
+        self, scope: core.Construct, construct_id: str, imagebuild: ImageBuilderConfig, image_name: str, **kwargs
+    ) -> None:
         super().__init__(scope, construct_id, **kwargs)
         self.imagebuild = imagebuild
+        image = imagebuild.image
         build = imagebuild.build
         dev_settings = imagebuild.dev_settings
 
@@ -89,8 +93,15 @@ class ImageBuilderCdkStack(core.Stack):
             self._set_default_instance_role()
             self._set_instance_profile()
 
-        build_tags = {tag.key: tag.value for tag in build.tags} if build.tags else None
-        ami_tags = {tag.key: tag.value for tag in self.imagebuild.image.tags} if self.imagebuild.image.tags else None
+        # Add default build tags information
+        tags = copy.deepcopy(build.tags) or []
+        tags.append(BaseTag(key="pcluster_build_image", value=utils.get_installed_version()))
+        build_tags = {tag.key: tag.value for tag in tags}
+
+        # Add default ami tags information
+        tags = copy.deepcopy(image.tags) or []
+        tags.append(BaseTag(key="pcluster_version", value=utils.get_installed_version()))
+        ami_tags = {tag.key: tag.value for tag in tags}
 
         # InfrastructureConfiguration
         imagebuilder.CfnInfrastructureConfiguration(
@@ -182,7 +193,7 @@ class ImageBuilderCdkStack(core.Stack):
         )
 
         ami_distribution_configuration = {
-            "Name": self._set_ami_name(),
+            "Name": image_name + AMI_NAME_REQUIRED_SUBSTRING,
             "AmiTags": ami_tags,
             "LaunchPermissionConfiguration": dev_settings.distribution_configuration.launch_permission
             if dev_settings and dev_settings.distribution_configuration
@@ -224,9 +235,6 @@ class ImageBuilderCdkStack(core.Stack):
             infrastructure_configuration_arn=core.Fn.ref("ParallelClusterInfrastructureConfiguration"),
             distribution_configuration_arn=core.Fn.ref("ParallelClusterDistributionConfiguration"),
         )
-
-    def _set_ami_name(self):
-        return self.imagebuild.image.name + AMI_NAME_REQUIRED_SUBSTRING
 
     def _get_instance_role_type(self):
         """Get instance role type based on instance_role in config."""

--- a/cli/tests/api/test_pcluster_api.py
+++ b/cli/tests/api/test_pcluster_api.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+from api.pcluster_api import PclusterApi
+from common.utils import load_yaml_dict
+
+
+def test_pcluster_api_build_image(test_datadir):
+    # A draft test to verify stack creation
+    input_yaml = load_yaml_dict(test_datadir / "imagebuilder_config_required.yaml")
+
+    response = PclusterApi.build_image(
+        imagebuilder_config=input_yaml, image_name="test10", region="us-east-1", disable_rollback=False
+    )
+
+    print(response.__repr__())

--- a/cli/tests/api/test_pcluster_api/test_pcluster_api_build_image/imagebuilder_config_dev.yaml
+++ b/cli/tests/api/test_pcluster_api/test_pcluster_api_build_image/imagebuilder_config_dev.yaml
@@ -1,5 +1,4 @@
 Image:
-  Name: Pcluster
   Tags:
     - Key: Name
       Value: ParallelCluster-3.0-AMI

--- a/cli/tests/api/test_pcluster_api/test_pcluster_api_build_image/imagebuilder_config_dev.yaml
+++ b/cli/tests/api/test_pcluster_api/test_pcluster_api_build_image/imagebuilder_config_dev.yaml
@@ -1,0 +1,33 @@
+Image:
+  Name: Pcluster
+  Tags:
+    - Key: Name
+      Value: ParallelCluster-3.0-AMI
+    - Key: Version
+      Value: 3.0.0
+  RootVolume:
+    Size: 50
+    Encrypted: True
+
+Build:
+  InstanceType: c5.xlarge
+  Components:
+    - Type: script
+      Value: s3://test-slurm/run.sh
+    - Type: script
+      Value: https://test-slurm.s3.us-east-2.amazonaws.com/post_install_script.sh
+    - Type: arn
+      Value: arn:aws:imagebuilder:us-east-1:aws:component/amazon-cloudwatch-agent-linux/1.0.0
+  ParentImage: arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x
+  Tags:
+    - Key: Name
+      Value: ParallelCluster-3.0-Build
+    - Key: Date
+      Value: 2022.1.1
+
+DevSettings:
+  UpdateOsAndReboot: True
+  DisablePclusterComponent: False
+  DistributionConfiguration:
+    Regions: us-east-2,eu-south-1
+  TerminateInstanceOnFailure: True

--- a/cli/tests/api/test_pcluster_api/test_pcluster_api_build_image/imagebuilder_config_required.yaml
+++ b/cli/tests/api/test_pcluster_api/test_pcluster_api_build_image/imagebuilder_config_required.yaml
@@ -1,0 +1,9 @@
+Image:
+  Name: Pcluster
+  Tags:
+    - Key: Name
+      Value: ParallelCluster-3.0-AMI
+
+Build:
+  InstanceType: c5.xlarge
+  ParentImage: ami-0185634c5a8a37250

--- a/cli/tests/api/test_pcluster_api/test_pcluster_api_build_image/imagebuilder_config_required.yaml
+++ b/cli/tests/api/test_pcluster_api/test_pcluster_api_build_image/imagebuilder_config_required.yaml
@@ -1,9 +1,3 @@
-Image:
-  Name: Pcluster
-  Tags:
-    - Key: Name
-      Value: ParallelCluster-3.0-AMI
-
 Build:
   InstanceType: c5.xlarge
   ParentImage: ami-0185634c5a8a37250

--- a/cli/tests/pcluster/models/imagebuilder_dummy_model.py
+++ b/cli/tests/pcluster/models/imagebuilder_dummy_model.py
@@ -9,18 +9,18 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 from pcluster.models.common import BaseTag, Cookbook
-from pcluster.models.imagebuilder import (
+from pcluster.models.imagebuilder_config import (
     Build,
     Component,
     DistributionConfiguration,
     Image,
-    ImageBuilder,
+    ImageBuilderConfig,
     ImagebuilderDevSettings,
     Volume,
 )
 
 CLASS_DICT = {
-    "imagebuilder": ImageBuilder,
+    "imagebuilder": ImageBuilderConfig,
     "image": Image,
     "build": Build,
     "dev_settings": ImagebuilderDevSettings,

--- a/cli/tests/pcluster/models/test_imagebuilder_model.py
+++ b/cli/tests/pcluster/models/test_imagebuilder_model.py
@@ -29,7 +29,6 @@ from tests.pcluster.models.test_cluster import _assert_validation_result
             {
                 "imagebuilder": {
                     "image": {
-                        "name": "Pcluster",
                         "root_volume": {"size": 25, "kms_key_id": "key_id"},
                         "tags": [
                             {"key": "name", "value": "pcluster"},

--- a/cli/tests/pcluster/models/test_imagebuilder_model.py
+++ b/cli/tests/pcluster/models/test_imagebuilder_model.py
@@ -15,7 +15,7 @@ import pytest
 from assertpy import assert_that
 
 from common.boto3.common import AWSClientError
-from pcluster.models.imagebuilder import ImageBuilderExtraChefAttributes
+from pcluster.models.imagebuilder_config import ImageBuilderExtraChefAttributes
 from pcluster.validators.common import FailureLevel
 from tests.common.dummy_aws_api import DummyAWSApi
 from tests.pcluster.models.imagebuilder_dummy_model import imagebuilder_factory
@@ -64,10 +64,10 @@ from tests.pcluster.models.test_cluster import _assert_validation_result
         )
     ],
 )
-def test_imagebuilder_ebs_volume_kms_key_id_validator_and_ami_volume_size_validator(
+def test_imagebuilder_kms_key_id_encrypted_validator_and_ami_volume_size_validator(
     mocker, resource, ami_response, ami_side_effect, expected_failure_messages, expected_failure_levels
 ):
-    """Test EBSVolumeKmsKeyIdValidator and AMIVolumeSizeValidator."""
+    """Test KmsKeyIdEncryptedValidator and AMIVolumeSizeValidator."""
     fake_instance_response = ["c5.xlarge", "m6g.xlarge"]
     fake_supported_architecture = ["x86_64"]
     _test_imagebuilder(

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
@@ -1,5 +1,4 @@
 Image:
-  Name: Pcluster
   Tags:
     - Key: Name
       Value: ParallelCluster-3.0-AMI

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_required.yaml
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_required.yaml
@@ -1,6 +1,3 @@
-Image:
-  Name: Pcluster
-
 Build:
   InstanceType: c5.xlarge
   ParentImage: ami-0185634c5a8a37250

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -275,7 +275,7 @@ def test_imagebuilder(mocker, resource, response, expected_template):
         return_value=response,
     )
     dummy_imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(dummy_imagebuild)
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(dummy_imagebuild, "test")
     # TODO assert content of the template by matching expected template, re-enable it after refactoring
     _test_parameters(generated_template.get("Parameters"), expected_template.get("Parameters"))
     _test_resources(generated_template.get("Resources"), expected_template.get("Resources"))
@@ -442,7 +442,7 @@ def test_imagebuilder_instance_role(
         return_value=response,
     )
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild)
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "test")
     assert_that(generated_template.get("Resources").get("InstanceRole")).is_equal_to(expected_instance_role)
     assert_that(generated_template.get("Resources").get("InstanceProfile")).is_equal_to(expected_instance_profile)
     assert_that(
@@ -598,7 +598,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
         return_value=response,
     )
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild)
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "test")
     assert_that(
         generated_template.get("Resources").get("ParallelClusterImageRecipe").get("Properties").get("Components")
     ).is_equal_to(expected_components)
@@ -643,7 +643,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
             [
                 {
                     "AmiDistributionConfiguration": {
-                        "Name": "my AMI 1 {{ imagebuilder:buildDate }}",
+                        "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {
                             "keyTag1": "valueTag1",
                             "keyTag2": "valueTag2",
@@ -678,7 +678,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
             [
                 {
                     "AmiDistributionConfiguration": {
-                        "Name": "my AMI 2 {{ imagebuilder:buildDate }}",
+                        "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {"pcluster_version": utils.get_installed_version()},
                     },
                     "Region": {"Fn::Sub": "${AWS::Region}"},
@@ -712,7 +712,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
             [
                 {
                     "AmiDistributionConfiguration": {
-                        "Name": "my AMI 1 {{ imagebuilder:buildDate }}",
+                        "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {"pcluster_version": utils.get_installed_version()},
                     },
                     "Region": {"Fn::Sub": "${AWS::Region}"},
@@ -729,7 +729,7 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
         return_value=response,
     )
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild)
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
     assert_that(
         generated_template.get("Resources")
         .get("ParallelClusterDistributionConfiguration")
@@ -778,10 +778,7 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
                     }
                 ],
             },
-            {
-                "keyTag1": "valueTag1",
-                "keyTag2": "valueTag2",
-            },
+            {"keyTag1": "valueTag1", "keyTag2": "valueTag2", "pcluster_build_image": utils.get_installed_version()},
             [
                 {
                     "Key": "keyTag1",
@@ -814,7 +811,7 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
                     }
                 ],
             },
-            None,
+            {"pcluster_build_image": utils.get_installed_version()},
             None,
         ),
         (
@@ -841,7 +838,7 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
                     }
                 ],
             },
-            None,
+            {"pcluster_build_image": utils.get_installed_version()},
             None,
         ),
     ],
@@ -854,8 +851,7 @@ def test_imagebuilder_build_tags(mocker, resource, response, expected_imagebuild
         return_value=response,
     )
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild)
-
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
     for resource_name, resource in generated_template.get("Resources").items():
         if resource_name == "InstanceProfile":
             # InstanceProfile has no tags
@@ -928,7 +924,7 @@ def test_imagebuilder_subnet_id(mocker, resource, response, expected_imagebuilde
         return_value=response,
     )
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild)
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
 
     assert_that(
         generated_template.get("Resources")
@@ -1000,7 +996,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
         return_value=response,
     )
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild)
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
 
     assert_that(
         generated_template.get("Resources")
@@ -1298,7 +1294,7 @@ def test_imagebuilder_distribution_configuraton(mocker, resource, response, expe
         return_value=response,
     )
     dummy_imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(dummy_imagebuild)
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(dummy_imagebuild, "Pcluster")
 
     assert_that(
         generated_template.get("Resources")

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -25,7 +25,6 @@ from ..models.imagebuilder_dummy_model import imagebuilder_factory
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x",
                         "instance_type": "c5.xlarge",
@@ -155,7 +154,6 @@ from ..models.imagebuilder_dummy_model import imagebuilder_factory
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Parallelcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -275,7 +273,7 @@ def test_imagebuilder(mocker, resource, response, expected_template):
         return_value=response,
     )
     dummy_imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(dummy_imagebuild, "test")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(dummy_imagebuild, "Pcluster")
     # TODO assert content of the template by matching expected template, re-enable it after refactoring
     _test_parameters(generated_template.get("Parameters"), expected_template.get("Parameters"))
     _test_resources(generated_template.get("Resources"), expected_template.get("Resources"))
@@ -297,7 +295,6 @@ def _test_resources(generated_resouces, expected_resources):
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -362,7 +359,6 @@ def _test_resources(generated_resouces, expected_resources):
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -398,7 +394,6 @@ def _test_resources(generated_resouces, expected_resources):
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -442,7 +437,7 @@ def test_imagebuilder_instance_role(
         return_value=response,
     )
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "test")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
     assert_that(generated_template.get("Resources").get("InstanceRole")).is_equal_to(expected_instance_role)
     assert_that(generated_template.get("Resources").get("InstanceProfile")).is_equal_to(expected_instance_profile)
     assert_that(
@@ -459,7 +454,6 @@ def test_imagebuilder_instance_role(
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -502,7 +496,6 @@ def test_imagebuilder_instance_role(
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -547,7 +540,6 @@ def test_imagebuilder_instance_role(
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -598,7 +590,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
         return_value=response,
     )
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "test")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
     assert_that(
         generated_template.get("Resources").get("ParallelClusterImageRecipe").get("Properties").get("Components")
     ).is_equal_to(expected_components)
@@ -611,7 +603,6 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
             {
                 "imagebuilder": {
                     "image": {
-                        "name": "my AMI 1",
                         "tags": [
                             {
                                 "key": "keyTag1",
@@ -657,7 +648,6 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "my AMI 2"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -689,7 +679,6 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
             {
                 "imagebuilder": {
                     "image": {
-                        "name": "my AMI 1",
                         "tags": [],
                     },
                     "build": {
@@ -744,9 +733,6 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
         (
             {
                 "imagebuilder": {
-                    "image": {
-                        "name": "my AMI 1",
-                    },
                     "build": {
                         "parent_image": "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x",
                         "instance_type": "c5.xlarge",
@@ -793,7 +779,6 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "my AMI 2"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -817,9 +802,6 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
         (
             {
                 "imagebuilder": {
-                    "image": {
-                        "name": "my AMI 1",
-                    },
                     "build": {
                         "parent_image": "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x",
                         "instance_type": "c5.xlarge",
@@ -868,9 +850,6 @@ def test_imagebuilder_build_tags(mocker, resource, response, expected_imagebuild
         (
             {
                 "imagebuilder": {
-                    "image": {
-                        "name": "my AMI 1",
-                    },
                     "build": {
                         "parent_image": "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x",
                         "instance_type": "c5.xlarge",
@@ -893,7 +872,6 @@ def test_imagebuilder_build_tags(mocker, resource, response, expected_imagebuild
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "my AMI 2"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -940,9 +918,6 @@ def test_imagebuilder_subnet_id(mocker, resource, response, expected_imagebuilde
         (
             {
                 "imagebuilder": {
-                    "image": {
-                        "name": "my AMI 1",
-                    },
                     "build": {
                         "parent_image": "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x",
                         "instance_type": "c5.xlarge",
@@ -965,7 +940,6 @@ def test_imagebuilder_subnet_id(mocker, resource, response, expected_imagebuilde
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "my AMI 2"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -1012,7 +986,6 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x",
                         "instance_type": "c5.xlarge",
@@ -1044,7 +1017,6 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -1080,7 +1052,6 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -1116,7 +1087,6 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -1153,7 +1123,6 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -1195,7 +1164,6 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
@@ -1237,7 +1205,6 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
         (
             {
                 "imagebuilder": {
-                    "image": {"name": "Pcluster"},
                     "build": {
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",


### PR DESCRIPTION
# Use the new model for build-image command

## PclusterApi
* Created an ImageInfo class to contain the information of API response
* Add build_image API method 

## Imagebuilder
* Add a sub class ImagebuilderStack, that contains imagebuilder stack info
* Add an Imagebuilder class contains config and stack info. This class manages methods from API call, add `create` function to create imagebuilder stack.

## Imagebuilder_config
* rename imagebuilder resource class to imagebuilder_config
* Remove name attribute from image config

## imagebuilder cdk
* Use image_name from cli rather than config file to generate ImagebuilderImage AWS resource.

## tests 
manual test for pcluster `build-image` command.
config.yaml
```
Build:
  InstanceType: c5.xlarge
  ParentImage: ami-0185634c5a8a37250
```
command
```
pcluster build-image -i test-pcluster -c config.yaml -r us-east-1
```
output
```
Building AWS ParallelCluster AMI. This could take a while...
Creating stack named: test-pcluster
Status: CREATE_IN_PROGRESS
Response:
{'image': '{"image_name": "test-pcluster", "imagebuild_status": "BUILD_IN_PROGRESS", "stack_status": "CREATE_IN_PROGRESS", "stack_arn": "arn:aws:cloudformation:us-east-1:xxxxxxxxxxxxx:stack/test-pcluster/4d532880-7aef-11eb-b853-0e71a2c850a7", "region": "us-east-1", "version": "2.10.1"}'}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
