### PR TITLE
Release 2.10: Fix EFA OS architecture validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 **BUG FIXES**
 
 - Fix sanity checks with ARM instance types by using alinux2 AMI with correct architecture during dryrun
+- Fix `enable_efa` parameter validation when using Centos8 and Slurm or ARM instances.
 
 2.10.1
 ------

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -1561,7 +1561,8 @@ def efa_os_arch_validator(param_key, param_value, pcluster_config):
     architecture = cluster_section.get_param_value("architecture")
     base_os = cluster_section.get_param_value("base_os")
 
-    if base_os in EFA_UNSUPPORTED_ARCHITECTURES_OSES.get(architecture):
+    # The value can be "compute" when specified in the cluster section or True/False when specified in the queue
+    if param_value and base_os in EFA_UNSUPPORTED_ARCHITECTURES_OSES.get(architecture):
         errors.append("EFA currently not supported on {0} for {1} architecture".format(base_os, architecture))
 
     return errors, warnings

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -2719,11 +2719,13 @@ def test_extra_json_validator(mocker, capsys, extra_json, expected_message):
         ({"base_os": "alinux2", "enable_efa": "compute"}, "x86_64", None),
         ({"base_os": "alinux2", "enable_efa": "compute"}, "arm64", None),
         ({"base_os": "centos8", "enable_efa": "compute"}, "x86_64", None),
+        ({"base_os": "centos8"}, "x86_64", None),
         (
             {"base_os": "centos8", "enable_efa": "compute"},
             "arm64",
             "EFA currently not supported on centos8 for arm64 architecture",
         ),
+        ({"base_os": "centos8"}, "arm64", None),  # must not fail because by default EFA is disabled
         ({"base_os": "ubuntu1804", "enable_efa": "compute"}, "x86_64", None),
         ({"base_os": "ubuntu1804", "enable_efa": "compute"}, "arm64", None),
     ],


### PR DESCRIPTION
The efa_os_arch_validator has been introduced in the 2.10.1 version, with patch 2290.

The configuration files with the following combination of settings are affected by the issue:
`scheduler=slurm`, `base_os=centos8`, `queue_settings` specified in the file
and `enable_efa` not set in the `cluster` section or set to `false` in the `queue` section.

The error message is coming from the validation of the `enable_efa` parameter in the `queue` section,
because this parameter has a default value so the validator is always executed.

The code of the validator is not checking if the value is set to true so it is failing in any case.

Added two unit test to verify the cases on which there is no value for `enable_efa` in the `cluster` section.

Signed-off-by: Enrico Usai <usai@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
