### PR TITLE
Restore instance type sanity check using cluster ami

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ CHANGELOG
 
 **BUG FIXES**
 
-- Fix sanity checks with ARM instance types by using alinux2 AMI with correct architecture during dryrun  
+- Fix sanity checks with ARM instance types by using cluster AMI when performing validation  
 - Fix `enable_efa` parameter validation when using Centos8 and Slurm or ARM instances.
 - Use non interactive `apt update` command when building custom Ubuntu AMIs.
 - Fix `encrypted_ephemeral = true` when using Alinux2 or CentOS8

--- a/cli/src/pcluster/cluster_model.py
+++ b/cli/src/pcluster/cluster_model.py
@@ -16,8 +16,9 @@ import boto3
 from botocore.exceptions import ClientError
 
 from pcluster.utils import (
-    error,
+    Cache,
     get_availability_zone_of_subnet,
+    get_installed_version,
     get_supported_az_for_one_instance_type,
     is_hit_enabled_cluster,
 )
@@ -115,20 +116,70 @@ class ClusterModel(ABC):
                     "Please double check your cluster configuration.\n{1}".format(kwargs["InstanceType"], message)
                 )
 
-    def _get_latest_alinux_ami_id(self, architecture):
-        """Get latest alinux ami id."""
+    @Cache.cached
+    def _get_official_image_id(self, os, architecture):
+        """Return the id of the current official image, for the provided os-architecture combination."""
+        ami_id = None
         try:
-            alinux_ami_id = (
-                boto3.client("ssm")
-                .get_parameter(Name="/aws/service/ami-amazon-linux-latest/amzn2-ami-minimal-hvm-%s-ebs" % architecture)
-                .get("Parameter")
-                .get("Value")
-            )
+            image_prefix = self._get_official_image_name_prefix(os, architecture)
+            # Look for public ParallelCluster AMI in released version
+            ami_id = self._get_image_id(image_prefix, "amazon", True)
+            if not ami_id:
+                # Look for dev account owner during development
+                ami_id = self._get_image_id(image_prefix, "self", False)
         except ClientError as e:
-            error("Unable to retrieve Amazon Linux 2 AMI id.\n{0}".format(e.response.get("Error").get("Message")))
-            raise
+            raise Exception(
+                "Unable to retrieve official image id for base_os='{0}' and architecture='{1}': {2}".format(
+                    os, architecture, e.response.get("Error").get("Message")
+                )
+            )
+        if not ami_id:
+            raise Exception(
+                "No official image id found for base_os='{0}' and architecture='{1}'".format(os, architecture)
+            )
 
-        return alinux_ami_id
+        return ami_id
+
+    def _get_image_id(self, image_prefix, owner, public=False):
+        """Search for the ami with the specified prefix from the given account and returns the id if found."""
+        filters = [
+            {
+                "Name": "name",
+                "Values": ["{0}*".format(image_prefix)],
+            }
+        ]
+        if public:
+            filters.append({"Name": "is-public", "Values": ["true"]})
+
+        images = boto3.client("ec2").describe_images(Filters=filters, Owners=[owner]).get("Images")
+        return images[0].get("ImageId") if images else None
+
+    def _get_official_image_name_prefix(self, os, architecture):
+        """Return the prefix of the current official image, for the provided os-architecture combination."""
+        suffixes = {
+            "alinux": "amzn-hvm",
+            "alinux2": "amzn2-hvm",
+            "centos7": "centos7-hvm",
+            "centos8": "centos8-hvm",
+            "ubuntu1604": "ubuntu-1604-lts-hvm",
+            "ubuntu1804": "ubuntu-1804-lts-hvm",
+        }
+        return "aws-parallelcluster-{version}-{suffix}-{arch}".format(
+            version=get_installed_version(), suffix=suffixes[os], arch=architecture
+        )
+
+    def _get_cluster_ami_id(self, pcluster_config):
+        """Get the image id of the cluster."""
+        cluster_ami = None
+        os = pcluster_config.get_section("cluster").get_param_value("base_os")
+        architecture = pcluster_config.get_section("cluster").get_param_value("architecture")
+        custom_ami = pcluster_config.get_section("cluster").get_param_value("custom_ami")
+        try:
+            cluster_ami = custom_ami if custom_ami else self._get_official_image_id(os, architecture)
+        except Exception as e:
+            pcluster_config.error("Error when resolving cluster ami id: {0}".format(e))
+
+        return cluster_ami
 
     def public_ips_in_compute_subnet(self, pcluster_config, network_interfaces_count):
         """Tell if public IPs will be used in compute subnet."""

--- a/cli/src/pcluster/models/hit/hit_cluster_model.py
+++ b/cli/src/pcluster/models/hit/hit_cluster_model.py
@@ -73,7 +73,7 @@ class HITClusterModel(ClusterModel):
         )
         try:
 
-            latest_alinux_ami_id = self._get_latest_alinux_ami_id(cluster_section.get_param_value("architecture"))
+            cluster_ami_id = self._get_cluster_ami_id(pcluster_config)
 
             head_node_network_interfaces = self.build_launch_network_interfaces(
                 network_interfaces_count=int(cluster_section.get_param_value("network_interfaces_count")[0]),
@@ -89,7 +89,7 @@ class HITClusterModel(ClusterModel):
                 InstanceType=head_node_instance_type,
                 MinCount=1,
                 MaxCount=1,
-                ImageId=latest_alinux_ami_id,
+                ImageId=cluster_ami_id,
                 CpuOptions=head_node_cpu_options,
                 NetworkInterfaces=head_node_network_interfaces,
                 DryRun=True,
@@ -112,7 +112,7 @@ class HITClusterModel(ClusterModel):
                     pcluster_config,
                     compute_resource_section,
                     disable_hyperthreading=disable_hyperthreading,
-                    ami_id=latest_alinux_ami_id,
+                    ami_id=cluster_ami_id,
                     subnet=compute_subnet,
                     security_groups_ids=security_groups_ids,
                     placement_group=queue_placement_group,

--- a/cli/src/pcluster/models/sit/sit_cluster_model.py
+++ b/cli/src/pcluster/models/sit/sit_cluster_model.py
@@ -111,7 +111,7 @@ class SITClusterModel(ClusterModel):
         )
 
         try:
-            latest_alinux_ami_id = self._get_latest_alinux_ami_id(cluster_section.get_param_value("architecture"))
+            cluster_ami_id = self._get_cluster_ami_id(pcluster_config)
 
             head_node_network_interfaces = self.build_launch_network_interfaces(
                 network_interfaces_count=int(cluster_section.get_param_value("network_interfaces_count")[0]),
@@ -127,7 +127,7 @@ class SITClusterModel(ClusterModel):
                 InstanceType=head_node_instance_type,
                 MinCount=1,
                 MaxCount=1,
-                ImageId=latest_alinux_ami_id,
+                ImageId=cluster_ami_id,
                 CpuOptions=head_node_cpu_options,
                 NetworkInterfaces=head_node_network_interfaces,
                 Placement=head_node_placement_group,
@@ -153,7 +153,7 @@ class SITClusterModel(ClusterModel):
                 InstanceType=compute_instance_type,
                 MinCount=1,
                 MaxCount=1,
-                ImageId=latest_alinux_ami_id,
+                ImageId=cluster_ami_id,
                 CpuOptions=compute_cpu_options,
                 Placement=compute_placement_group,
                 NetworkInterfaces=network_interfaces,


### PR DESCRIPTION
This commit restores the fix for instance type sanity checks using the actual cluster AMI, including new logic to handle the case where the AMIs are still under development.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
