### PR TITLE
Backport: Only require account ID when git refs are used

### DIFF
--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -322,7 +322,7 @@ def parse_args():
     parser.add_argument(
         "--partition", type=str, help="commercial | china | govcloud", required=True, choices=PARTITIONS
     )
-    parser.add_argument("--account-id", type=str, help="AWS account id owning the AMIs", required=True)
+    parser.add_argument("--account-id", type=str, help="AWS account id owning the AMIs", required=False)
     parser.add_argument(
         "--cloudformation-template",
         type=str,
@@ -330,7 +330,10 @@ def parse_args():
         required=False,
         default="cloudformation/aws-parallelcluster.cfn.json",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.cookbook_git_ref and args.node_git_ref and not args.account_id:
+        raise Exception("Must specify value for --account-id when using --cookbook-git-ref and --node-git-ref.")
+    return args
 
 
 def main():


### PR DESCRIPTION
When --json-regions and --json-template are used (and the git ref args
are not) the account ID argument is unused.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
