### PR TITLE
Add cluster region validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 - Make `key_name` parameter optional to support cluster configurations without a key pair. 
 - Remove support for Python 3.4
 - Root volume size increased from 25GB to 35GB on all AMIs. Minimum root volume size is now 35GB.
+- Add sanity check to prevent cluster creation in non officially supported AWS regions 
 
 2.10.2
 ------

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -100,6 +100,7 @@ from pcluster.config.validators import (
     maintain_initial_size_validator,
     queue_settings_validator,
     queue_validator,
+    region_validator,
     s3_bucket_uri_validator,
     s3_bucket_validator,
     scheduler_validator,
@@ -109,7 +110,7 @@ from pcluster.config.validators import (
 )
 from pcluster.constants import CIDR_ALL_IPS, FSX_HDD_THROUGHPUT, FSX_SSD_THROUGHPUT, SUPPORTED_ARCHITECTURES
 
-CLUSTER_COMMON_VALIDATORS = [duplicate_shared_dir_validator]
+CLUSTER_COMMON_VALIDATORS = [duplicate_shared_dir_validator, region_validator]
 # This file contains a definition of all the sections and the parameters configurable by the user
 # in the configuration file.
 

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -40,6 +40,34 @@ from pcluster.utils import (
 
 LOGFILE_LOGGER = logging.getLogger("cli_log_file")
 
+SUPPORTED_REGIONS = [
+    "af-south-1",
+    "ap-east-1",
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-northeast-3",
+    "ap-south-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ca-central-1",
+    "cn-north-1",
+    "cn-northwest-1",
+    "eu-central-1",
+    "eu-north-1",
+    "eu-south-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "me-south-1",
+    "sa-east-1",
+    "us-east-1",
+    "us-east-2",
+    "us-gov-east-1",
+    "us-gov-west-1",
+    "us-west-1",
+    "us-west-2",
+]
+
 DCV_MESSAGES = {
     "warnings": {
         "access_from_world": "With this configuration you are opening dcv port ({port}) to the world (0.0.0.0/0). "
@@ -1601,3 +1629,10 @@ def ebs_volume_throughput_validator(section_key, section_label, pcluster_config)
             )
 
     return errors, warnings
+
+
+def region_validator(section_key, section_label, pcluster_config):
+    errors = []
+    if pcluster_config.region not in SUPPORTED_REGIONS:
+        errors.append("Region '{0}' is not yet officially supported by ParallelCluster".format(pcluster_config.region))
+    return errors, []


### PR DESCRIPTION
A new validator to check to allow clusters being created only in officially supported regions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
