### PR TITLE
Add validation for s3 bucket to be in same region of cluster stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ------
 **ENHANCEMENTS**
 
+- Add validation to prevent using a `cluster_resource_bucket` that is in a different region than the cluster.
+
 **CHANGES**
 
 - Upgrade Slurm to version 20.11.4.

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -101,6 +101,7 @@ from pcluster.config.validators import (
     queue_settings_validator,
     queue_validator,
     region_validator,
+    s3_bucket_region_validator,
     s3_bucket_uri_validator,
     s3_bucket_validator,
     scheduler_validator,
@@ -1025,7 +1026,7 @@ CLUSTER_COMMON_PARAMS = [
     }),
     ("cluster_resource_bucket", {
         "cfn_param_mapping": "ResourcesS3Bucket",
-        "validators": [s3_bucket_validator],
+        "validators": [s3_bucket_validator, s3_bucket_region_validator],
         "update_policy": UpdatePolicy.READ_ONLY_RESOURCE_BUCKET,
     }),
     ("iam_lambda_role", {


### PR DESCRIPTION
Add a validator to validate that `cluster_resource_bucket` is in the same region with the cluster stack.
Tests:
When specify `cluster_resource_bucket` in a different region with where the cluster create, the validator will generate the following error:
ERROR: The configuration parameter 'cluster_resource_bucket' generated the following errors:
cluster_resource_bucket must be in the same region of the cluster.

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
