### PR TITLE
3.0: Implement head node creation

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -22,6 +22,13 @@ SUPPORTED_OSES_FOR_SCHEDULER = {"slurm": SUPPORTED_OSES, "awsbatch": ["alinux2"]
 SUPPORTED_ARCHITECTURES = ["x86_64", "arm64"]
 SUPPORTED_OSES_FOR_ARCHITECTURE = {"x86_64": SUPPORTED_OSES, "arm64": ["alinux2", "ubuntu1804", "centos8"]}
 
+OS_MAPPING = {
+    "centos7": {"user": "centos", "root-device": "/dev/sda1"},
+    "centos8": {"user": "centos", "root-device": "/dev/sda1"},
+    "alinux2": {"user": "ec2-user", "root-device": "/dev/xvda"},
+    "ubuntu1804": {"user": "ubuntu", "root-device": "/dev/sda1"},
+}
+
 FSX_SSD_THROUGHPUT = [50, 100, 200]
 FSX_HDD_THROUGHPUT = [12, 40]
 

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -25,7 +25,7 @@ from common.aws.aws_api import AWSApi
 from common.aws.aws_resources import InstanceInfo, StackInfo
 from common.boto3.common import AWSClientError
 from pcluster.cli_commands.compute_fleet_status_manager import ComputeFleetStatus, ComputeFleetStatusManager
-from pcluster.constants import PCLUSTER_STACK_PREFIX
+from pcluster.constants import OS_MAPPING, PCLUSTER_STACK_PREFIX
 from pcluster.models.cluster_config import ClusterBucket, Tag
 from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
@@ -179,8 +179,7 @@ class ClusterStack(StackInfo):
 
     def get_default_user(self, os: str):
         """Get the default user for the given os."""
-        mappings = self.template.get("Mappings").get("OSFeatures")  # FIXME double check
-        return mappings[os]["User"]
+        return OS_MAPPING.get(os, []).get("user", None)
 
     @property
     def batch_compute_environment(self):

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -222,6 +222,7 @@ class Cluster:
     def config(self):
         """Return ClusterConfig object."""
         if not self.__config:
+            # TODO what if there is a ValidationError
             self.__config = ClusterSchema().load(self.source_config)
         return self.__config
 

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -244,13 +244,13 @@ class SharedFsx(Resource):
     def __init__(
         self,
         mount_dir: str,
-        storage_capacity: str = None,
+        storage_capacity: int = None,
         deployment_type: str = None,
         export_path: str = None,
         import_path: str = None,
-        imported_file_chunk_size: str = None,
+        imported_file_chunk_size: int = None,
         weekly_maintenance_start_time: str = None,
-        automatic_backup_retention_days: str = None,
+        automatic_backup_retention_days: int = None,
         copy_tags_to_backups: bool = None,
         daily_automatic_backup_start_time: str = None,
         per_unit_storage_throughput: int = None,
@@ -647,7 +647,6 @@ class HeadNode(Resource):
         instance_type: str,
         networking: HeadNodeNetworking,
         ssh: Ssh,
-        image: Image = None,
         disable_simultaneous_multithreading: bool = None,
         storage: Storage = None,
         dcv: Dcv = None,
@@ -662,7 +661,6 @@ class HeadNode(Resource):
         )
         self.networking = networking
         self.ssh = ssh
-        self.image = image
         self.storage = storage
         self.dcv = dcv
         self.efa = efa
@@ -702,7 +700,7 @@ class HeadNode(Resource):
 
     @property
     def instance_type_info(self):
-        """Return head node instance type information as returned from aws ec2 describe-instamce-types."""
+        """Return head node instance type information as returned from aws ec2 describe-instance-types."""
         return AWSApi.instance().ec2.get_instance_type_info(self.instance_type)
 
 
@@ -748,7 +746,6 @@ class BaseQueue(Resource):
         networking: QueueNetworking,
         storage: Storage = None,
         compute_type: str = None,
-        image: Image = None,
         iam: Iam = None,
     ):
         super().__init__()
@@ -756,7 +753,6 @@ class BaseQueue(Resource):
         self.networking = networking
         self.storage = storage
         self.compute_type = Resource.init_param(compute_type, default="ONDEMAND")
-        self.image = image
         self.iam = iam
 
     def _validate(self):

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -117,7 +117,7 @@ if [ "${!custom_cookbook}" != "NONE" ]; then
 fi
 cd /tmp
 # Call CloudFormation
-cfn-init -s ${AWS::StackName} --role=${IamRoleName} -v -c default -r MasterServerLaunchTemplate --region ${AWS::Region} || error_exit 'Failed to run cfn-init. If --norollback was specified, check /var/log/cfn-init.log and /var/log/cloud-init-output.log.'
+cfn-init -s ${AWS::StackName} --role=${IamRoleName} -v -c default -r HeadNodeLaunchTemplate --region ${AWS::Region} || error_exit 'Failed to run cfn-init. If --norollback was specified, check /var/log/cfn-init.log and /var/log/cloud-init-output.log.'
 cfn-signal --exit-code=0 --reason="MasterServer setup complete" --stack=${AWS::StackName} --role=${IamRoleName} --resource=MasterServer --region=${AWS::Region}
 # End of file
 --==BOUNDARY==

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -557,7 +557,6 @@ class HeadNodeSchema(BaseSchema):
     instance_type = fields.Str(required=True)
     disable_simultaneous_multithreading = fields.Bool()
     networking = fields.Nested(HeadNodeNetworkingSchema, required=True)
-    image = fields.Nested(ImageSchema)
     ssh = fields.Nested(SshSchema, required=True)
     storage = fields.Nested(StorageSchema)
     dcv = fields.Nested(DcvSchema)
@@ -616,7 +615,6 @@ class BaseQueueSchema(BaseSchema):
     networking = fields.Nested(QueueNetworkingSchema, required=True)
     storage = fields.Nested(StorageSchema)
     compute_type = fields.Str(validate=validate.OneOf(["ONDEMAND", "SPOT"]))
-    image = fields.Nested(ImageSchema)
     iam = fields.Nested(IamSchema)
 
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -33,6 +33,7 @@ from pcluster.models.cluster_config import (
     ClusterDevSettings,
     CommonSchedulingSettings,
     CustomAction,
+    CustomActionEvent,
     Dashboards,
     Dcv,
     Dns,
@@ -542,7 +543,7 @@ class CustomActionSchema(BaseSchema):
 
     script = fields.Str(required=True)
     args = fields.List(fields.Str())
-    event = fields.Str(validate=validate.OneOf(["NODE_START", "NODE_CONFIGURED"]))
+    event = fields.Str(validate=validate.OneOf([event.value for event in CustomActionEvent]))
     run_as = fields.Str()
 
     @post_load
@@ -561,7 +562,9 @@ class HeadNodeSchema(BaseSchema):
     storage = fields.Nested(StorageSchema)
     dcv = fields.Nested(DcvSchema)
     efa = fields.Nested(EfaSchema)
-    custom_actions = fields.Nested(CustomActionSchema, many=True)
+    custom_actions = fields.Nested(
+        CustomActionSchema, many=True
+    )  # TODO validate to avoid more than one script for event type or add support for them.
     iam = fields.Nested(IamSchema)
 
     @post_load()

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -45,6 +45,7 @@ from aws_cdk.core import CfnCustomResource, CfnOutput, CfnStack, CfnTag, Fn
 
 from common.aws.aws_api import AWSApi
 from pcluster import utils
+from pcluster.constants import OS_MAPPING
 from pcluster.models.cluster_config import (
     ClusterBucket,
     Ebs,
@@ -55,8 +56,9 @@ from pcluster.models.cluster_config import (
     SlurmClusterConfig,
 )
 
-
 # pylint: disable=too-many-lines
+
+
 class ClusterCdkStack(core.Stack):
     """Create the CloudFormation stack template for the Cluster."""
 
@@ -79,12 +81,6 @@ class ClusterCdkStack(core.Stack):
     # -- Mappings ---------------------------------------------------------------------------------------------------- #
 
     def _init_mappings(self):
-        self.os_features = {
-            "centos7": {"User": "centos", "RootDevice": "/dev/sda1"},
-            "centos8": {"User": "centos", "RootDevice": "/dev/sda1"},
-            "alinux2": {"User": "ec2-user", "RootDevice": "/dev/xvda"},
-            "ubuntu1804": {"User": "ubuntu", "RootDevice": "/dev/sda1"},
-        }
         self.packages_versions = {
             "parallelcluster": "2.10.1",
             "cookbook": "aws-parallelcluster-cookbook-2.10.1",
@@ -820,7 +816,7 @@ class ClusterCdkStack(core.Stack):
             )
         block_device_mappings.append(
             ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
-                device_name=self.os_features[self._cluster_config.image.os]["RootDevice"],
+                device_name=OS_MAPPING[self._cluster_config.image.os]["root-device"],
                 ebs=ec2.CfnLaunchTemplate.EbsProperty(
                     volume_size=root_volume.size,
                     volume_type=root_volume.volume_type,
@@ -997,7 +993,7 @@ class ClusterCdkStack(core.Stack):
             scope=self,
             id="ClusterUser",
             description="Username to login to head node",
-            value=self.os_features[self._cluster_config.image.os]["User"],
+            value=OS_MAPPING[self._cluster_config.image.os]["user"],
         )
 
         # Head Node Private IP

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -1122,10 +1122,9 @@ class InstanceTypeInfo:
 
         return gpu_count
 
-    def max_network_interface_count(self):
+    def max_network_interface_count(self) -> int:
         """Max number of NICs for the instance."""
-        needed_interfaces = int(self.instance_type_data.get("NetworkInfo").get("MaximumNetworkCards", 1))
-        return needed_interfaces
+        return int(self.instance_type_data.get("NetworkInfo").get("MaximumNetworkCards", 1))
 
     def default_threads_per_core(self):
         """Return the default threads per core for the given instance type."""
@@ -1140,7 +1139,7 @@ class InstanceTypeInfo:
             threads_per_core = 2 if "x86_64" in supported_architectures else 1
         return threads_per_core
 
-    def vcpus_count(self):
+    def vcpus_count(self) -> int:
         """Get number of vcpus for the given instance type."""
         try:
             vcpus_info = self.instance_type_data.get("VCpuInfo")

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -16,9 +16,6 @@ HeadNode:
     Proxy:
       HttpProxyAddress: String  # https://proxy-address:port
   DisableSimultaneousMultithreading: false
-  Image:
-    Os: centos8
-    CustomAmi: ami-23456789
   Ssh:
     KeyName: ec2-key-name
     AllowedIps: 1.2.3.4/32
@@ -75,9 +72,6 @@ Scheduling:
             InstanceType: c5.xlarge
           - Name: compute_resource2
             InstanceType: c4.xlarge
-        Image:
-          Os: centos8
-          CustomAmi: ami-23456789
         CustomActions:
           - Script: s3://test/template.tgz  # s3:// | https:// | file://*
             Args:

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -16,9 +16,6 @@ HeadNode:
     Proxy:
       HttpProxyAddress: String  # https://proxy-address:port
   DisableSimultaneousMultithreading: false
-  Image:
-    Os: centos8
-    CustomAmi: ami-23456789
   Ssh:
     KeyName: ec2-key-name
     AllowedIps: 1.2.3.4/32
@@ -75,9 +72,6 @@ Scheduling:
             InstanceType: c5.xlarge
           - Name: compute_resource2
             InstanceType: c4.xlarge
-        Image:
-          Os: centos8
-          CustomAmi: ami-23456789
         CustomActions:
           - Script: s3://test/template.tgz  # s3:// | https:// | file://*
             Args:

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_2.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_2.yaml
@@ -4,9 +4,6 @@ HeadNode:
   InstanceType: t2.micro  # t2.micro
   Networking:
     SubnetId: subnet-12345678  # subnet-xxx
-  Image:
-    Os: centos8
-    CustomAmi: ami-23456789
   Ssh:
     KeyName: ec2-key-name
     AllowedIps: 1.2.3.4/32


### PR DESCRIPTION
## Implement head node creation

###  Model
* Add CustomActionEvent to distinguish between pre and post install custom actions
  and use it for both schema and config.
* Defined disable_simultaneous_multithreading_via_cpu_options property
* Defined get_custom_action in the HeadNode to be able to retrieve pre/post install actions

###  Stack
* Defined _storage_resource_options to store shared storage options for Raid, EFS and FSx.
  They are required by the cookbook.
  TODO: we should save in the cookbook only the required options.
* Defined head_node_iam_role that will be created if head-node instance role is not specified
  TODO: we should use different roles for the queues.
* I defined CloudFormation::Init as a raw metadata because CfnInstance doesn't have "init" attribute,
  Instance construct has the "init" attribute to specify a CloudFormationInit object but it doesn't support
  launch template and we need it for cpu_options and network interfaces.
* Move head node creation as latest, because we need storage information.
* Removed Ganglia outputs and added head node  private ip/dns and public ip

### Tests
* The patch permits to create the head node but the recipes execution is failing for multiple reasons.
1. It fails if there are no EBS shared storages specified, because in cookbook code it is a requirement.
   We need to adapt the cookbook to avoid accepting a shared folder by default, but we can do it later,
   for now we can add a SharedStorage in the config file.
2. It's failing when trying to insert same data in the DynamoDB table because this part is still missing.


## Define OS_MAPPING in constants module

This mapping object can be reused to store all the information
related to a specific os (e.g. supported features, architectures, etc)


## Remove image from HeadNode and Queue

It's not supported, this can only be defined at root level.
