### PR TITLE
3.0: Fix PolicyDocument syntax errors

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -410,10 +410,12 @@ class ClusterCdkStack(core.Stack):
                                 actions=s3_policy_actions,
                                 effect=Effect.ALLOW,
                                 resources=[
-                                    self.format_arn(service="s3", resource=self._bucket.name),
+                                    self.format_arn(service="s3", resource=self._bucket.name, region="", account=""),
                                     self.format_arn(
                                         service="s3",
                                         resource="{0}/{1}/*".format(self._bucket.name, self._bucket.artifact_directory),
+                                        region="",
+                                        account="",
                                     ),
                                 ],
                                 sid="S3BucketPolicy",
@@ -433,7 +435,7 @@ class ClusterCdkStack(core.Stack):
                     actions=["ec2:TerminateInstances"],
                     resources=["*"],
                     effect=Effect.ALLOW,
-                    conditions=[{"StringEquals": {"ec2:ResourceTag/Application": self.stack_name}}],
+                    conditions={"StringEquals": {"ec2:ResourceTag/Application": self.stack_name}},
                     sid="FleetTerminatePolicy",
                 ),
             )
@@ -503,6 +505,8 @@ class ClusterCdkStack(core.Stack):
                             self.format_arn(
                                 service="s3",
                                 resource="{0}-aws-parallelcluster/*".format(self.region),
+                                region="",
+                                account="",
                             )
                         ],
                     ),
@@ -514,6 +518,8 @@ class ClusterCdkStack(core.Stack):
                             self.format_arn(
                                 service="s3",
                                 resource="{0}/{1}/batch/".format(self._bucket.name, self._bucket.artifact_directory),
+                                region="",
+                                account="",
                             )
                         ],
                     ),
@@ -524,7 +530,7 @@ class ClusterCdkStack(core.Stack):
                         sid="BatchJobPassRole",
                         actions=["iam:PassRole"],
                         effect=Effect.ALLOW,
-                        resources=[self.format_arn(service="iam", resource="role/parallelcluster-*")],
+                        resources=[self.format_arn(service="iam", region="", resource="role/parallelcluster-*")],
                     ),
                     PolicyStatement(
                         sid="DcvLicense",
@@ -534,6 +540,8 @@ class ClusterCdkStack(core.Stack):
                             self.format_arn(
                                 service="s3",
                                 resource="dcv-license.{0}/*".format(self.region),
+                                region="",
+                                account="",
                             )
                         ],
                     ),
@@ -554,7 +562,7 @@ class ClusterCdkStack(core.Stack):
                         effect=Effect.ALLOW,
                         actions=["ec2:TerminateInstances"],
                         resources=["*"],
-                        conditions=[{"StringEquals": {"ec2:ResourceTag/Application": self.stack_name}}],
+                        conditions={"StringEquals": {"ec2:ResourceTag/Application": self.stack_name}},
                     ),
                     PolicyStatement(
                         sid="EC2",
@@ -575,10 +583,12 @@ class ClusterCdkStack(core.Stack):
                         if self._bucket.remove_on_deletion
                         else ["s3:*"],
                         resources=[
-                            self.format_arn(service="s3", resource=self._bucket.name),
+                            self.format_arn(service="s3", resource=self._bucket.name, region="", account=""),
                             self.format_arn(
                                 service="s3",
                                 resource="{0}/{1}/*".format(self._bucket.name, self._bucket.artifact_directory),
+                                region="",
+                                account="",
                             ),
                         ],
                     ),


### PR DESCRIPTION
1.There is an inconsistency between CDK and IAM. `condition` in IAM is called `conditions`(plural form) in CDK. However the `conditions` only accepts a dict instead of a list. This commit will pass dict to `conditions`.
2. `aws_cdk.core.Stack.format_arn()` always has the format `arn:{partition}:{service}:{region}:{account}:{resource}{sep}}{resource-name}`. However, for some services (s3, iam), `region` and/or `account` are not needed. We can bypass the issue by setting `region=""` and/or `account=""` or assembling arn by ourselves.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
