### PR TITLE
CDK: Add DynamoDB and some fixed

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -8,6 +8,7 @@ PyYAML>=5.3.1
 jinja2>=2.11.0
 marshmallow
 aws-cdk.core
+aws-cdk.aws-dynamodb
 aws-cdk.aws-ec2
 aws-cdk.aws-fsx
 aws-cdk.aws-imagebuilder

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -261,7 +261,7 @@ class Cluster:
             # Create template if not provided by the user
             if not (self.config.dev_settings and self.config.dev_settings.cluster_template):
                 self.template_body = CDKTemplateBuilder().build_cluster_template(
-                    cluster_config=self.config, bucket=self.bucket
+                    cluster_config=self.config, bucket=self.bucket, stack_name=self.stack_name
                 )
                 # print(yaml.dump(cluster.cluster_template_body))
 

--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -28,10 +28,10 @@ class CDKTemplateBuilder:
     """Create the template, starting from the given resources."""
 
     @staticmethod
-    def build_cluster_template(cluster_config: BaseClusterConfig, bucket: ClusterBucket):
+    def build_cluster_template(cluster_config: BaseClusterConfig, bucket: ClusterBucket, stack_name: str):
         """Build template for the given cluster and return as output in Yaml format."""
         with tempfile.TemporaryDirectory() as tempdir:
-            output_file = "parallelcluster-cluster"  # TODO: pass stack name as argument
+            output_file = str(stack_name)
             app = core.App(outdir=str(tempdir))
             ClusterCdkStack(app, output_file, cluster_config, bucket)
             app.synth()

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -20,8 +20,7 @@ from ..models.cluster_dummy_model import dummy_bucket, dummy_cluster
 def test_cluster_builder(mocker):
     mock_aws_api()
     generated_template = CDKTemplateBuilder().build_cluster_template(
-        cluster_config=dummy_cluster(mocker),
-        bucket=dummy_bucket(),
+        cluster_config=dummy_cluster(mocker), bucket=dummy_bucket(), stack_name="parallelcluster-dummyname"
     )
     print(yaml.dump(generated_template))
     # TODO assert content of the template by matching expected template

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -8,6 +8,7 @@ assertpy
 recordclass
 marshmallow
 aws-cdk.core
+aws-cdk.aws-dynamodb
 aws-cdk.aws-ec2
 aws-cdk.aws-imagebuilder
 aws-cdk.aws-iam


### PR DESCRIPTION
1. Migrate DynamoDB from compute-fleet-hit-substack.py
2. Fix stack_name attribute to be the actual stack name
3. Provide automatically created security groups to mount points of EFS
4. We should be aware of that `Ref` values cannot be passed into boto3 calls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
