### PR TITLE
3.0: Add Compute Fleet launch template resources and other refactoring

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -12,7 +12,6 @@
 # This module contains all the classes representing the Resources objects.
 # These objects are obtained from the configuration file through a conversion based on the Schema classes.
 #
-import copy
 import logging
 import time
 from enum import Enum

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -249,9 +249,10 @@ class Cluster:
 
         # Add tags information to the stack
         version = get_installed_version()
-        tags = copy.deepcopy(self.config.tags) or []
-        tags.append(Tag(key="Version", value=version))
-        tags = [{"Key": tag.key, "Value": tag.value} for tag in tags]
+        if self.config.tags is None:
+            self.config.tags = []
+        self.config.tags.append(Tag(key="Version", value=version))
+        cfn_tags = [{"Key": tag.key, "Value": tag.value} for tag in self.config.tags]
 
         # Create bucket if needed
         self._setup_cluster_bucket()
@@ -273,7 +274,7 @@ class Cluster:
                 stack_name=self.stack_name,
                 template_url=self.template_url,
                 disable_rollback=disable_rollback,
-                tags=tags,
+                tags=cfn_tags,
             )
 
             self.__stack = ClusterStack(AWSApi.instance().cfn.describe_stack(self.stack_name))

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -360,7 +360,7 @@ class _BaseNetworking(Resource):
         proxy: Proxy = None,
     ):
         super().__init__()
-        self.assign_public_ip = Resource.init_param(assign_public_ip, default=False)
+        self.assign_public_ip = Resource.init_param(assign_public_ip)
         self.security_groups = Resource.init_param(security_groups)
         self.additional_security_groups = Resource.init_param(additional_security_groups)
         self.proxy = proxy

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -769,6 +769,13 @@ class BaseComputeResource(Resource):
         return instance_type_info.supported_architecture()[0]
 
 
+class ComputeType(Enum):
+    """Enum to identify the type compute supported by the queues."""
+
+    ONDEMAND = "ONDEMAND"
+    SPOT = "SPOT"
+
+
 class BaseQueue(Resource):
     """Represent the generic Queue resource."""
 
@@ -784,7 +791,7 @@ class BaseQueue(Resource):
         self.name = Resource.init_param(name)
         self.networking = networking
         self.storage = storage
-        self.compute_type = Resource.init_param(compute_type, default="ONDEMAND")
+        self.compute_type = Resource.init_param(compute_type, default=ComputeType.ONDEMAND)
         self.iam = iam
 
     def _validate(self):

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -1,0 +1,201 @@
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+
+--==BOUNDARY==
+Content-Type: text/cloud-boothook; charset="us-ascii"
+MIME-Version: 1.0
+
+#!/bin/bash -x
+
+which dnf 2>/dev/null; dnf=$?
+which yum 2>/dev/null; yum=$?
+
+if [ "${!dnf}" == "0" ]; then
+  echo "proxy=${DnfProxy}" >> /etc/dnf/dnf.conf
+elif [ "${!yum}" == "0" ]; then
+  echo "proxy=${YumProxy}" >> /etc/yum.conf
+else
+  echo "Not yum system"
+fi
+
+which apt-get && echo "Acquire::http::Proxy \"${AptProxy}\";" >> /etc/apt/apt.conf || echo "Not apt system"
+
+proxy=${ProxyServer}
+if [ "${!proxy}" != "NONE" ]; then
+  proxy_host=$(echo "${!proxy}" | awk -F/ '{print $3}' | cut -d: -f1)
+  proxy_port=$(echo "${!proxy}" | awk -F/ '{print $3}' | cut -d: -f2)
+  echo -e "[Boto]\nproxy = ${!proxy_host}\nproxy_port = ${!proxy_port}\n" >/etc/boto.cfg
+  cat >> /etc/profile.d/proxy.sh <<PROXY
+export http_proxy="${!proxy}"
+export https_proxy="${!proxy}"
+export no_proxy="localhost,127.0.0.1,169.254.169.254"
+export HTTP_PROXY="${!proxy}"
+export HTTPS_PROXY="${!proxy}"
+export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
+PROXY
+fi
+
+--==BOUNDARY==
+Content-Type: text/cloud-config; charset=us-ascii
+MIME-Version: 1.0
+
+output:
+  all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"
+write_files:
+  - path: /tmp/dna.json
+    permissions: '0644'
+    owner: root:root
+    content: |
+      {
+        "cfncluster": {
+          "stack_name": "${AWS::StackName}",
+          "enable_efa": "${EnableEfa}",
+          "cfn_raid_parameters": "${RAIDOptions}",
+          "cfn_base_os": "${BaseOS}",
+          "cfn_preinstall": "${PreInstallScript}",
+          "cfn_preinstall_args": "${PreInstallArgs}",
+          "cfn_postinstall": "${PostInstallScript}",
+          "cfn_postinstall_args": "${PostInstallArgs}",
+          "cfn_region": "${AWS::Region}",
+          "cfn_efs": "${EFSId}",
+          "cfn_efs_shared_dir": "${EFSOptions}",
+          "cfn_fsx_fs_id": "${FSXId}",
+          "cfn_fsx_options": "${FSXOptions}",
+          "cfn_scheduler": "${Scheduler}",
+          "cfn_scheduler_slots": "${VCpus}",
+          "cfn_disable_hyperthreading_manually": "${DisableHyperThreadingManually}",
+          "cfn_scaledown_idletime": "{{ scaling_config.scaledown_idletime }}",
+          "cfn_encrypted_ephemeral": "${EncryptedEphemeral}",
+          "cfn_ephemeral_dir": "${EphemeralDir}",
+          "cfn_shared_dir": "${EbsSharedDirs}",
+          "cfn_proxy": "${ProxyServer}",
+          "cfn_ddb_table": "${DynamoDBTable}",
+          "cfn_dns_domain": "${ClusterDNSDomain}",
+          "cfn_hosted_zone": "${ClusterHostedZone}",
+          "cfn_node_type": "ComputeFleet",
+          "cfn_cluster_user": "${OSUser}",
+          "enable_intel_hpc_platform": "${IntelHPCPlatform}",
+          "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}",
+          "scheduler_queue_name": "${QueueName}",
+          "enable_efa_gdr": "${EnableEfaGdr}"
+        },
+        "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
+      }
+  - path: /etc/chef/client.rb
+    permissions: '0644'
+    owner: root:root
+    content: cookbook_path ['/etc/chef/cookbooks']
+  - path: /tmp/extra.json
+    permissions: '0644'
+    owner: root:root
+    content: |
+      ${ExtraJson}
+
+--==BOUNDARY==
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+
+#!/bin/bash -x
+
+function error_exit
+{
+  region=${AWS::Region}
+  instance_id=$(curl --retry 3 --retry-delay 0 --silent --fail http://169.254.169.254/latest/meta-data/instance-id)
+  log_dir=/home/logs/compute
+  mkdir -p ${!log_dir}
+  echo "Reporting instance as unhealthy and dumping logs to ${!log_dir}/${!instance_id}.tar.gz"
+  tar -czf ${!log_dir}/${!instance_id}.tar.gz /var/log
+  # TODO: add possibility to disable this behavior
+  # wait logs flush before signaling the failure
+  sleep 10
+  aws --region ${!region} ec2 terminate-instances --instance-ids ${!instance_id}
+  exit 1
+}
+function vendor_cookbook
+{
+  mkdir /tmp/cookbooks
+  cd /tmp/cookbooks
+  tar -xzf /etc/chef/aws-parallelcluster-cookbook.tgz
+  HOME_BAK="${!HOME}"
+  export HOME="/tmp"
+  for d in `ls /tmp/cookbooks`; do
+    cd /tmp/cookbooks/$d
+    LANG=en_US.UTF-8 /opt/cinc/embedded/bin/berks vendor /etc/chef/cookbooks --delete || error_exit 'Vendoring cookbook failed.'
+  done;
+  export HOME="${!HOME_BAK}"
+}
+function bootstrap_instance
+{
+  which dnf 2>/dev/null; dnf=$?
+  which yum 2>/dev/null; yum=$?
+  which apt-get 2>/dev/null; apt=$?
+  if [ "${!dnf}" == "0" ]; then
+    dnf -y groupinstall development && dnf -y install curl wget jq python3-pip
+    pip3 install awscli --upgrade --user
+  elif [ "${!yum}" == "0" ]; then
+    yum -y groupinstall development && yum -y install curl wget jq awscli python3-pip
+  fi
+  if [ "${!apt}" == "0" ]; then
+    apt-cache search build-essential; apt-get clean; apt-get update; apt-get -y install build-essential curl wget jq python-setuptools awscli python3-pip
+  fi
+  [[ ${!_region} =~ ^cn- ]] && s3_url="cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
+  which cfn-init 2>/dev/null || ( curl -s -L -o /tmp/aws-cfn-bootstrap-py3-latest.tar.gz https://s3.${!s3_url}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz; pip3 install -U /tmp/aws-cfn-bootstrap-py3-latest.tar.gz)
+  mkdir -p /etc/chef && chown -R root:root /etc/chef
+  curl --retry 3 -L https://${!_region}-aws-parallelcluster.s3.${!_region}.amazonaws.com$([ "${!_region}" != "${!_region#cn-*}" ] && echo ".cn" || exit 0)/archives/cinc/cinc-install.sh | bash -s -- -v ${!chef_version}
+  /opt/cinc/embedded/bin/gem install --no-document berkshelf:${!berkshelf_version}
+  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date ${!cookbook_url}.date
+  curl --retry 3 -s -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.md5 ${!cookbook_url}.md5
+  vendor_cookbook
+  mkdir /opt/parallelcluster
+}
+[ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh
+custom_cookbook=${CustomChefCookbook}
+export _region=${AWS::Region}
+s3_url=${AWS::URLSuffix}
+if [ "${!custom_cookbook}" != "NONE" ]; then
+  if [[ "${!custom_cookbook}" =~ ^s3:// ]]; then
+    cookbook_url=$(aws s3 presign "${!custom_cookbook}" --region "${!_region}")
+  else
+    cookbook_url=${!custom_cookbook}
+  fi
+else
+  cookbook_url=https://s3.${!_region}.${!s3_url}/${!_region}-aws-parallelcluster/cookbooks/${CookbookVersion}.tgz
+fi
+export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin
+export parallelcluster_version=aws-parallelcluster-${ParallelClusterVersion}
+export cookbook_version=${CookbookVersion}
+export chef_version=${ChefVersion}
+export berkshelf_version=${BerkshelfVersion}
+if [ -f /opt/parallelcluster/.bootstrapped ]; then
+  installed_version=$(cat /opt/parallelcluster/.bootstrapped)
+  if [ "${!cookbook_version}" != "${!installed_version}" ]; then
+    error_exit "This AMI was created with ${!installed_version}, but is trying to be used with ${!cookbook_version}. Please either use an AMI created with ${!cookbook_version} or change your ParallelCluster to ${!installed_version}"
+  fi
+else
+  bootstrap_instance
+fi
+if [ "${!custom_cookbook}" != "NONE" ]; then
+  curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz -z "$(cat /etc/chef/aws-parallelcluster-cookbook.tgz.date)" ${!cookbook_url}
+  vendor_cookbook
+fi
+cd /tmp
+
+mkdir -p /etc/chef/ohai/hints
+touch /etc/chef/ohai/hints/ec2.json
+jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cfncluster = $f1.cfncluster + $f2.cfncluster' > /etc/chef/dna.json || ( echo "jq not installed or invalid extra_json"; cp /tmp/dna.json /etc/chef/dna.json)
+{
+  pushd /etc/chef &&
+  chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::prep_env &&
+  /opt/parallelcluster/scripts/fetch_and_run -preinstall &&
+  chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json &&
+  /opt/parallelcluster/scripts/fetch_and_run -postinstall &&
+  chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::finalize &&
+  popd
+} || error_exit 'Failed to run bootstrap recipes. If --norollback was specified, check /var/log/cfn-init.log and /var/log/cloud-init-output.log.'
+
+if [ ! -f /opt/parallelcluster/.bootstrapped ]; then
+  echo ${!cookbook_version} | tee /opt/parallelcluster/.bootstrapped
+fi
+# End of file
+--==BOUNDARY==

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -32,6 +32,7 @@ from pcluster.models.cluster_config import (
     CloudWatchLogs,
     ClusterDevSettings,
     CommonSchedulingSettings,
+    ComputeType,
     CustomAction,
     CustomActionEvent,
     Dashboards,
@@ -617,7 +618,7 @@ class BaseQueueSchema(BaseSchema):
     name = fields.Str()
     networking = fields.Nested(QueueNetworkingSchema, required=True)
     storage = fields.Nested(StorageSchema)
-    compute_type = fields.Str(validate=validate.OneOf(["ONDEMAND", "SPOT"]))
+    compute_type = fields.Str(validate=validate.OneOf([event.value for event in ComputeType]))
     iam = fields.Nested(IamSchema)
 
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -903,13 +903,17 @@ class ClusterCdkStack(core.Stack):
 
         # LT network interfaces
         head_lt_nw_interfaces = [
-            CfnLaunchTemplate.NetworkInterfaceProperty(device_index=0, network_interface_id=self.head_eni.ref)
+            CfnLaunchTemplate.NetworkInterfaceProperty(
+                device_index=0,
+                network_interface_id=self.head_eni.ref,
+                associate_public_ip_address=head_node.networking.assign_public_ip,
+            )
         ]
-        for if_number in range(1, head_node.max_network_interface_count - 1):
+        for device_index in range(1, head_node.max_network_interface_count - 1):
             head_lt_nw_interfaces.append(
                 CfnLaunchTemplate.NetworkInterfaceProperty(
-                    device_index=if_number,
-                    network_card_index=if_number,
+                    device_index=device_index,
+                    network_card_index=device_index,
                     groups=head_lt_security_groups,
                     subnet_id=head_node.networking.subnet_id,
                 )

--- a/cli/tests/common/dummy_aws_api.py
+++ b/cli/tests/common/dummy_aws_api.py
@@ -89,19 +89,6 @@ class DummyEc2Client(Ec2Client):
         """Override Parent constructor. No real boto3 client is created."""
         pass
 
-    def get_availability_zone_of_subnet(self, subnet_id):
-        subnets_azs = {
-            "dummy-subnet-1": "dummy-az-1",
-            "dummy-subnet-2": "dummy-az-2",
-            "dummy-subnet-3": "dummy-az-3",
-        }
-        availability_zone = subnets_azs.get(subnet_id, None)
-        if not availability_zone:
-            raise AWSClientError(
-                self.get_availability_zone_of_subnet.__name__, "Invalid subnet ID: {0}".format(subnet_id)
-            )
-        return availability_zone
-
     def get_instance_type_info(self, instance_type):
         return DummyInstanceTypeInfo(instance_type)
 
@@ -133,20 +120,19 @@ class DummyEfsClient(Ec2Client):
 class DummyS3Client(S3Client):
     def __init__(self):
         """Override Parent constructor. No real boto3 client is created."""
-
-    pass
+        pass
 
 
 class DummyImageBuilderClient(ImageBuilderClient):
     def __init__(self):
         """Override Parent constructor. No real boto3 client is created."""
-
-    pass
+        pass
 
 
 class DummyKmsClient(KmsClient):
     def __init__(self):
         """Override Parent constructor. No real boto3 client is created."""
+        pass
 
 
 def dummy_ec2_client():

--- a/cli/tests/common/dummy_aws_api.py
+++ b/cli/tests/common/dummy_aws_api.py
@@ -12,7 +12,6 @@ import os
 
 from common.aws.aws_api import AWSApi
 from common.boto3.cfn import CfnClient
-from common.boto3.common import AWSClientError
 from common.boto3.ec2 import Ec2Client
 from common.boto3.imagebuilder import ImageBuilderClient
 from common.boto3.kms import KmsClient

--- a/cli/tests/pcluster/models/cluster_dummy_model.py
+++ b/cli/tests/pcluster/models/cluster_dummy_model.py
@@ -29,6 +29,7 @@ from pcluster.models.cluster_config import (
     SlurmQueue,
     SlurmScheduling,
     Ssh,
+    Tag,
 )
 from pcluster.models.common import Resource
 
@@ -83,7 +84,7 @@ def dummy_cluster(mocker):
     """Generate dummy cluster."""
     image = Image(os="alinux2")
     head_node = dummy_head_node(mocker)
-    compute_resources = [SlurmComputeResource(name="test", instance_type="test")]
+    compute_resources = [SlurmComputeResource(name="dummy_compute_resource1", instance_type="dummyc5.xlarge")]
     queue_networking1 = QueueNetworking(
         subnet_ids=["dummy-subnet-1", "dummy-subnet-2"], security_groups=["sg-1", "sg-2"]
     )
@@ -92,9 +93,9 @@ def dummy_cluster(mocker):
     )
     queue_networking3 = QueueNetworking(subnet_ids=["dummy-subnet-1"], security_groups=None)
     queues = [
-        SlurmQueue(name="testQueue1", networking=queue_networking1, compute_resources=compute_resources),
-        SlurmQueue(name="testQueue2", networking=queue_networking2, compute_resources=compute_resources),
-        SlurmQueue(name="testQueue3", networking=queue_networking3, compute_resources=compute_resources),
+        SlurmQueue(name="queue1", networking=queue_networking1, compute_resources=compute_resources),
+        SlurmQueue(name="queue2", networking=queue_networking2, compute_resources=compute_resources),
+        SlurmQueue(name="queue3", networking=queue_networking3, compute_resources=compute_resources),
     ]
     scheduling = SlurmScheduling(queues=queues)
     # shared storage
@@ -103,8 +104,7 @@ def dummy_cluster(mocker):
     shared_storage.append(dummy_ebs("/ebs1"))
     shared_storage.append(dummy_ebs("/ebs2", volume_id="vol-abc"))
     shared_storage.append(dummy_ebs("/ebs3", raid=Raid(raid_type=1, number_of_volumes=5)))
-    shared_storage.append(dummy_efs("/efs1"))
-    shared_storage.append(dummy_efs("/efs2", file_system_id="fs-efs-1"))
+    shared_storage.append(dummy_efs("/efs1", file_system_id="fs-efs-1"))
     shared_storage.append(dummy_raid("/raid1"))
 
     cluster = DummySlurmCluster(image=image, head_node=head_node, scheduling=scheduling, shared_storage=shared_storage)
@@ -117,6 +117,7 @@ def dummy_cluster(mocker):
         ]
     )
 
+    cluster.tags = [Tag(key="test", value="testvalue")]
     return cluster
 
 


### PR DESCRIPTION
# Add compute fleet Launch template resources 

### Model
* Added instance_type info and instance type related methods to BaseComputeResource
* Added get_custom_action to SlurmQueue to retrieve pre/post install scripts

### Stack generator
* Defined _get_block_device_mappings utility method to build device mapping for head node and queues.
* A root volume will be created for each Launch template if not defined in the config and added to the block_device_mappings.
* Created _get_custom_tags method and used it to add in the template custom tags from the users (they were missing in the head node too).
* Created _create_hash_suffix to generate random strings to be used as suffix for queue resources.
* Defined a generic _condition_disable_hyperthreading_manually that can check the setting for both head_node and compute_resource
* Added compute_node/user_data.sh file.

### Tests
* Small improvements to dummy_model

# Associate public ip to head node according to config param

I removed the default from the config because the cases are the following:
* assign_public_ip == true => set associate_public_ip_address to true in the LaunchTemplate
* assign_public_ip ==  false => set associate_public_ip_address to false in the LaunchTemplate
* unset => we don't set associate_public_ip_address e use the default from the subnet

# Add missing info in the dna.json

We're storing in the _storage_resource_options different values according to the
different storage type.

* EBS: List of mount_dirs that were previously mapped in the SharedDir param
* RAID: List of raid and volume info
* EFS: all storage info (but only a subset of them are really required by cookbook)
* FSX: all storage info (but only a subset of them are really required by cookbook)

# Other changes
* Define ComputeType enum and use it for validation …
* Reorder Launch template attributes and tags.
* Moved the user_data as latest attribute.
* Restored extra.json file.
* Append tags in the original configuration. We need them available in the config to be added to all the resources.
