### PR TITLE
3.0: Bump version to 2.10.2 and upload instance type infos to s3

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -21,7 +21,7 @@ def readme():
         return f.read()
 
 
-VERSION = "2.10.1"
+VERSION = "2.10.2"
 REQUIRES = [
     "setuptools",
     "boto3>=1.16.14",

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -69,7 +69,7 @@ class ClusterCdkStack(core.Stack):
     def _init_mappings(self):
         self.packages_versions = {
             "parallelcluster": utils.get_installed_version(),
-            "cookbook": "aws-parallelcluster-cookbook-2.10.1",
+            "cookbook": "aws-parallelcluster-cookbook-2.10.2",
             "chef": "15.11.8",
             "berkshelf": "7.0.10",
             "ami": "dev",
@@ -1093,6 +1093,8 @@ class ClusterCdkStack(core.Stack):
                     "cluster_s3_bucket": self._bucket.name,
                     "cluster_config_s3_key": f"{self._bucket.artifact_directory}/configs/cluster-config.yaml",
                     "cluster_config_version": self._cluster_config.config_version,
+                    "instance_types_data_s3_key": f"{self._bucket.artifact_directory}"
+                    "/configs/instance-types-data.json",
                 },
                 "run_list": f"recipe[aws-parallelcluster::{self._cluster_config.scheduling.scheduler}_config]",
             },

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -1105,6 +1105,7 @@ class InstanceTypeInfo:
 
     def gpu_count(self):
         """Return the number of GPUs for the instance."""
+        # FixMe: this method is not used in the pcluster3 CLI
         gpu_info = self.instance_type_data.get("GpuInfo", None)
 
         gpu_count = 0

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -1260,6 +1260,10 @@ def test_imagebuilder_distribution_configuraton(mocker, resource, response, expe
         "common.boto3.ec2.Ec2Client.describe_image",
         return_value=response,
     )
+    mocker.patch(
+        "pcluster.utils.get_installed_version",
+        return_value="2.10.1",
+    )
     dummy_imagebuild = imagebuilder_factory(resource).get("imagebuilder")
     generated_template = CDKTemplateBuilder().build_imagebuilder_template(dummy_imagebuild, "Pcluster")
 

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "AWS ParallelCluster Template. Version: aws-parallelcluster-2.10.1",
+  "Description": "AWS ParallelCluster Template. Version: aws-parallelcluster-2.10.2",
   "Parameters": {
     "KeyName": {
       "Description": "Name of an existing EC2 KeyPair to enable SSH access to the instances using the default cluster user.",
@@ -1245,8 +1245,8 @@
     },
     "PackagesVersions": {
       "default": {
-        "parallelcluster": "2.10.1",
-        "cookbook": "aws-parallelcluster-cookbook-2.10.1",
+        "parallelcluster": "2.10.2",
+        "cookbook": "aws-parallelcluster-cookbook-2.10.2",
         "chef": "15.11.8",
         "berkshelf": "7.0.10",
         "ami": "dev"

--- a/util/bump-version.sh
+++ b/util/bump-version.sh
@@ -13,4 +13,5 @@ CURRENT_VERSION=$(sed -ne "s/^VERSION = \"\(.*\)\"/\1/p" cli/setup.py)
 sed -i "s/aws-parallelcluster-$CURRENT_VERSION/aws-parallelcluster-$NEW_VERSION/g" cloudformation/aws-parallelcluster.cfn.json
 sed -i "s/\"parallelcluster\": \"$CURRENT_VERSION\"/\"parallelcluster\": \"$NEW_VERSION\"/g" cloudformation/aws-parallelcluster.cfn.json
 sed -i "s/aws-parallelcluster-cookbook-$CURRENT_VERSION/aws-parallelcluster-cookbook-$NEW_VERSION/g" cloudformation/aws-parallelcluster.cfn.json
+sed -i "s/aws-parallelcluster-cookbook-$CURRENT_VERSION/aws-parallelcluster-cookbook-$NEW_VERSION/g" cli/src/pcluster/templates/cluster_stack.py
 sed -i "s/VERSION = \"$CURRENT_VERSION\"/VERSION = \"$NEW_VERSION\"/g" cli/setup.py


### PR DESCRIPTION
To test cookbook changes, we need to use DevSettings. And the version has to be consistent with our current cookbook
This commit will also:
1. rename `_instance_type_info` in head node to `instance_type_info` and add it to compute resource
2. collect instance type infos (gpus, gpu_type, vcpus) and upload them to s3 to avoid calling `describe_instance_types` in cookbook
3. only validate custom template url if it not None.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
