### PR TITLE
Introduce new configuration parameter for development

### DIFF
--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -30,6 +30,7 @@ from pcluster.config.cfn_param_types import (
     HeadNodeAvailabilityZoneCfnParam,
     HeadNodeInstanceTypeCfnParam,
     IntCfnParam,
+    JsonCfnParam,
     MaintainInitialSizeCfnParam,
     NetworkInterfacesCountCfnParam,
     QueueSizeCfnParam,
@@ -1032,6 +1033,12 @@ CLUSTER_COMMON_PARAMS = [
     ("iam_lambda_role", {
         "cfn_param_mapping": "IAMLambdaRoleName",
         "update_policy": UpdatePolicy.SUPPORTED,
+    }),
+    ("instance_types_data", {
+        "type": JsonCfnParam,
+        "default": {},
+        "cfn_param_mapping": "InstanceTypesData",
+        "update_policy": UpdatePolicy.SUPPORTED
     }),
 ]
 

--- a/cli/src/pcluster/config/pcluster_config.py
+++ b/cli/src/pcluster/config/pcluster_config.py
@@ -26,6 +26,7 @@ from pcluster.config.cfn_param_types import ClusterCfnSection
 from pcluster.config.mappings import ALIASES, AWS, GLOBAL
 from pcluster.config.param_types import StorageData
 from pcluster.utils import (
+    InstanceTypeInfo,
     get_cfn_param,
     get_file_section_name,
     get_installed_version,
@@ -100,6 +101,8 @@ class PclusterConfig(object):
             self.__init_sections_from_cfn(cluster_name)
         else:
             self.__init_sections_from_file(cluster_label, self.config_parser, fail_on_file_absence)
+            # Load instance types data if present in config file
+            self.__init_additional_instance_types_data()
 
         self.__autorefresh = auto_refresh  # Initialization completed
 
@@ -587,3 +590,9 @@ class PclusterConfig(object):
         config_metadata_param = self.get_section("cluster").get_param("cluster_config_metadata")
         self.__sections = pcluster_config.__sections
         self.get_section("cluster").set_param("cluster_config_metadata", config_metadata_param)
+
+    def __init_additional_instance_types_data(self):
+        """Store additional instance type information coming from instance_types_data parameter."""
+        InstanceTypeInfo.load_additional_instance_types_data(
+            self.get_section("cluster").get_param_value("instance_types_data")
+        )

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -1303,6 +1303,12 @@ def _get_efa_enabled_instance_types(errors):
             Filters=[{"Name": "network-info.efa-supported", "Values": ["true"]}],
         ):
             instance_types.append(response.get("InstanceType"))
+
+        # Add data from additional instance types
+        for instance_type in InstanceTypeInfo.additional_instance_types_data().keys():
+            instance_type_info = InstanceTypeInfo.init_from_instance_type(instance_type)
+            if instance_type_info.is_efa_supported() and instance_type not in instance_types:
+                instance_types.append(instance_type)
     except ClientError as e:
         errors.append(
             "Failed retrieving efa enabled instance types: {0}".format(e.response.get("Error").get("Message"))

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -148,6 +148,7 @@ DEFAULT_CLUSTER_SIT_DICT = {
     "network_interfaces_count": ["1", "1"],
     "cluster_resource_bucket": None,
     "iam_lambda_role": None,
+    "instance_types_data": {},
 }
 
 DEFAULT_CLUSTER_HIT_DICT = {
@@ -198,6 +199,7 @@ DEFAULT_CLUSTER_HIT_DICT = {
     "network_interfaces_count": ["1", "1"],
     "cluster_resource_bucket": None,  # cluster_resource_bucket no default, but this is here to make testing easier
     "iam_lambda_role": None,
+    "instance_types_data": {},
 }
 
 DEFAULT_CW_LOG_DICT = {"enable": True, "retention_days": 14}
@@ -230,8 +232,8 @@ class DefaultDict(Enum):
 # ------------------ Default CFN parameters ------------------ #
 
 # number of CFN parameters created by the PclusterConfig object.
-CFN_SIT_CONFIG_NUM_OF_PARAMS = 63
-CFN_HIT_CONFIG_NUM_OF_PARAMS = 53
+CFN_SIT_CONFIG_NUM_OF_PARAMS = 64
+CFN_HIT_CONFIG_NUM_OF_PARAMS = 54
 
 # CFN parameters created by the pcluster CLI
 CFN_CLI_RESERVED_PARAMS = ["ArtifactS3RootDirectory", "RemoveBucketOnDeletion"]
@@ -350,6 +352,7 @@ DEFAULT_CLUSTER_SIT_CFN_PARAMS = {
     "Architecture": "x86_64",
     "NetworkInterfacesCount": "1,1",
     "IAMLambdaRoleName": "NONE",
+    "InstanceTypesData": "{}",
 }
 
 
@@ -421,6 +424,7 @@ DEFAULT_CLUSTER_HIT_CFN_PARAMS = {
     "Architecture": "x86_64",
     "NetworkInterfacesCount": "1,1",
     "IAMLambdaRoleName": "NONE",
+    "InstanceTypesData": "{}",
 }
 
 

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -17,6 +17,12 @@ from pcluster.config.mappings import CLUSTER_HIT, CLUSTER_SIT
 from tests.pcluster.config.defaults import DefaultCfnParams, DefaultDict
 
 
+@pytest.fixture()
+def boto3_stubber_path():
+    """Specify that boto3_mocker should stub calls to boto3 for the pcluster.utils module."""
+    return "pcluster.utils.boto3"
+
+
 @pytest.mark.parametrize(
     "cfn_params_dict, expected_section_dict, expected_section_label",
     [

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -152,6 +152,7 @@ def assert_param_validator(
     capsys=None,
     expected_warning=None,
     extra_patches=None,
+    use_mock_instance_type_info=True,
 ):
     config_parser = configparser.ConfigParser()
 
@@ -163,7 +164,8 @@ def assert_param_validator(
     config_parser.read_dict(config_parser_dict)
 
     mock_pcluster_config(mocker, config_parser_dict.get("cluster default").get("scheduler"), extra_patches)
-    mock_instance_type_info(mocker)
+    if use_mock_instance_type_info:
+        mock_instance_type_info(mocker)
 
     if expected_error:
         with pytest.raises(SystemExit, match=expected_error):

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -383,6 +383,11 @@
       "Description": "Comma separated string of [head node network interfaces], [compute network interfaces].",
       "Type": "CommaDelimitedList",
       "Default": "1,1"
+    },
+    "InstanceTypesData": {
+      "Description": "Json string with information about instance types, as returned from EC2 describe-instance-types",
+      "Type": "String",
+      "Default": "{}"
     }
   },
   "Conditions": {
@@ -3252,6 +3257,9 @@
                 "Ref": "NetworkInterfacesCount"
               }
             ]
+          },
+          "InstanceTypesData": {
+            "Ref": "InstanceTypesData"
           }
         },
         "TemplateURL": {
@@ -3677,6 +3685,9 @@
                 "Ref": "NetworkInterfacesCount"
               }
             ]
+          },
+          "InstanceTypesData": {
+            "Ref": "InstanceTypesData"
           }
         },
         "TemplateURL": {

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -108,6 +108,8 @@ Parameters:
     Type: String
   ComputeNetworkInterfacesCount:
     Type: Number
+  InstanceTypesData:
+    Type: String
 Conditions:
   EnableEFA: !Not
     - !Equals
@@ -464,6 +466,7 @@ Resources:
                         "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}",
                         "enable_efa_gdr": "${EFAGDR}"
                       },
+                      "instance_types_data": ${InstanceTypesData},
                       "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
                     }
 

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -124,6 +124,8 @@ Parameters:
     Type: Number
   MasterSecurityGroups:
     Type: List<AWS::EC2::SecurityGroup::Id>
+  InstanceTypesData:
+    Type: String
 Conditions:
   DisableMasterHyperthreading: !Not
     - !Or
@@ -607,6 +609,7 @@ Resources:
                       "cluster_config_s3_key": "${ArtifactS3RootDirectory}/configs/cluster-config.json",
                       "cluster_config_version": "${HITConfigVersion}"
                     },
+                    "instance_types_data": ${InstanceTypesData},
                     "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
                   }
                 - SchedulerSlots: !If

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -43,6 +43,7 @@ from jinja2 import Environment, FileSystemLoader
 from network_template_builder import Gateways, NetworkTemplateBuilder, SubnetConfig, VPCConfig
 from retrying import retry
 from utils import (
+    InstanceTypesData,
     create_s3_bucket,
     delete_s3_bucket,
     generate_stack_name,
@@ -86,6 +87,7 @@ def pytest_addoption(parser):
     parser.addoption("--post-install", help="url to post install script")
     parser.addoption("--vpc-stack", help="Name of an existing vpc stack.")
     parser.addoption("--cluster", help="Use an existing cluster instead of creating one.")
+    parser.addoption("--instance-types-data-file", help="JSON file with additional instance types data")
     parser.addoption(
         "--credential", help="STS credential endpoint, in the format <region>,<endpoint>,<ARN>,<externalId>.", nargs="+"
     )
@@ -121,6 +123,12 @@ def pytest_configure(config):
     # read tests config file if used
     if config.getoption("tests_config_file", None):
         config.option.tests_config = read_config_file(config.getoption("tests_config_file"))
+
+    # Read instance types data file if used
+    if config.getoption("instance_types_data_file", None):
+        config.option.instance_types_data = _read_json_file(config.getoption("instance_types_data_file"))
+        # Load additional instance types data
+        _set_additional_instance_types_data(config.option.instance_types_data)
 
     # register additional markers
     config.addinivalue_line("markers", "instances(instances_list): run test only against the listed instances.")
@@ -197,6 +205,11 @@ def _log_collected_tests(session):
         with open(f"{out_dir}/collected_tests.txt", "a") as out_f:
             out_f.write("\n".join(collected_tests))
             out_f.write("\n")
+
+
+def _set_additional_instance_types_data(instance_types_data):
+    InstanceTypesData.additional_instance_types_data = instance_types_data
+    logging.info("Additional instance types data loaded: {0}".format(InstanceTypesData.additional_instance_types_data))
 
 
 def pytest_exception_interact(node, call, report):
@@ -363,14 +376,14 @@ def pcluster_config_reader(test_datadir, vpc_stack, region, request):
         env = Environment(loader=file_loader)
         rendered_template = env.get_template(config_file).render(**{**kwargs, **default_values})
         config_file_path.write_text(rendered_template)
-        add_custom_packages_configs(config_file_path, request, region)
+        inject_additional_config_settings(config_file_path, request, region)
         _enable_sanity_check_if_unset(config_file_path)
         return config_file_path
 
     return _config_renderer
 
 
-def add_custom_packages_configs(cluster_config, request, region):
+def inject_additional_config_settings(cluster_config, request, region):
     config = configparser.ConfigParser()
     config.read(cluster_config)
     cluster_template = "cluster {0}".format(config.get("global", "cluster_template", fallback="default"))
@@ -404,6 +417,11 @@ def add_custom_packages_configs(cluster_config, request, region):
                 extra_json["cluster"] = cluster
     if extra_json:
         config[cluster_template]["extra_json"] = json.dumps(extra_json)
+
+    # Additional instance types data is copied it into config files to make it available at cluster creation
+    instance_types_data = request.config.getoption("instance_types_data")
+    if instance_types_data:
+        config[cluster_template]["instance_types_data"] = json.dumps(instance_types_data)
 
     with cluster_config.open(mode="w") as f:
         config.write(f)
@@ -848,3 +866,12 @@ def pcluster_ami_without_standard_naming(region, os, architecture):
     if ami_id:
         client = boto3.client("ec2", region_name=region)
         client.deregister_image(ImageId=ami_id)
+
+
+def _read_json_file(file):
+    """Read a Json file into a String and raise an exception if the file is invalid."""
+    try:
+        with open(file) as f:
+            return json.load(f)
+    except Exception:
+        logging.exception("Failed when reading json file %s", file)

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -71,6 +71,7 @@ TEST_DEFAULTS = {
     "keep_logs_on_cluster_failure": False,
     "keep_logs_on_test_failure": False,
     "tests_root_dir": "./tests",
+    "instance_types_data": None,
 }
 
 
@@ -251,6 +252,13 @@ def _init_argparser():
     custom_group.add_argument(
         "--post-install", help="URL to a post install script", default=TEST_DEFAULTS.get("post_install")
     )
+    custom_group.add_argument(
+        "--instance-types-data",
+        help="Additional information about instance types used in the tests. The format is a JSON map "
+        "instance_type -> data, where data must respect the same structure returned by ec2 "
+        "describe-instance-types",
+        default=TEST_DEFAULTS.get("instance_types_data"),
+    )
 
     banchmarks_group = parser.add_argument_group("Benchmarks")
     banchmarks_group.add_argument(
@@ -380,6 +388,9 @@ def _get_pytest_args(args, regions, log_file, out_dir):  # noqa: C901
         pytest_args.append(" or ".join(list(_join_with_not(args.features))))
     if args.tests_config:
         _set_tests_config_args(args, pytest_args, out_dir)
+    if args.instance_types_data:
+        pytest_args.append("--instance-types-data-file={0}".format(args.instance_types_data))
+
     if regions:
         pytest_args.append("--regions")
         pytest_args.extend(regions)

--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -17,7 +17,7 @@ import configparser
 import pexpect
 import pytest
 from assertpy import assert_that
-from conftest import add_custom_packages_configs
+from conftest import inject_additional_config_settings
 
 
 @pytest.mark.regions(["us-east-1"])
@@ -55,7 +55,7 @@ def test_pcluster_configure(
         config_path,
     )
 
-    add_custom_packages_configs(config_path, request, region)
+    inject_additional_config_settings(config_path, request, region)
     clusters_factory(config_path)
 
 

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -23,6 +23,33 @@ from assertpy import assert_that
 from retrying import retry
 
 
+class InstanceTypesData:
+    """Utility class to retrieve instance types information needed for integration tests."""
+
+    # Additional instance types data provided via tests configuration
+    additional_instance_types_data = {}
+
+    @staticmethod
+    def get_instance_info(instance_type, region_name=None):
+        """Return the results of calling EC2's DescribeInstanceTypes API for the given instance type."""
+        if (
+            InstanceTypesData.additional_instance_types_data
+            and instance_type in InstanceTypesData.additional_instance_types_data.keys()
+        ):
+            instance_info = InstanceTypesData.additional_instance_types_data[instance_type]
+        else:
+            try:
+                ec2_client = boto3.client("ec2", region_name=region_name)
+                instance_info = ec2_client.describe_instance_types(InstanceTypes=[instance_type]).get("InstanceTypes")[
+                    0
+                ]
+            except Exception as exception:
+                logging.error(f"Failed to get instance type info for instance type: {exception}")
+                raise
+
+        return instance_info
+
+
 def retry_if_subprocess_error(exception):
     """Return True if we should retry (in this case when it's a CalledProcessError), False otherwise"""
     return isinstance(exception, subprocess.CalledProcessError)
@@ -357,12 +384,7 @@ def remove_keys_from_known_hosts(hostname, host_keys_file, env):
 
 def get_instance_info(instance_type, region_name=None):
     """Return the results of calling EC2's DescribeInstanceTypes API for the given instance type."""
-    try:
-        ec2_client = boto3.client("ec2", region_name=region_name)
-        return ec2_client.describe_instance_types(InstanceTypes=[instance_type]).get("InstanceTypes")[0]
-    except Exception as exception:
-        logging.error(f"Failed to get instance type info for instance type: {exception}")
-        raise
+    return InstanceTypesData.get_instance_info(instance_type, region_name)
 
 
 def get_architecture_supported_by_instance_type(instance_type, region_name=None):


### PR DESCRIPTION
This commit introduces a new hidden `instance_types_data` parameter that allows to provide additional information about instance types which is temporarily or permanently missing from Ec2 APIs, or to override the existing data for development purposes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
