### PR TITLE
Fix additional_instance_types data injection in integration tests

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -419,7 +419,7 @@ def inject_additional_config_settings(cluster_config, request, region):
         config[cluster_template]["extra_json"] = json.dumps(extra_json)
 
     # Additional instance types data is copied it into config files to make it available at cluster creation
-    instance_types_data = request.config.getoption("instance_types_data")
+    instance_types_data = request.config.getoption("instance_types_data", None)
     if instance_types_data:
         config[cluster_template]["instance_types_data"] = json.dumps(instance_types_data)
 


### PR DESCRIPTION
Check that the option exists before trying to inject it into config file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
