### PR TITLE
Return supported instance types as list

### DIFF
--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -322,7 +322,7 @@ def get_supported_instance_types():
             offering.get("InstanceType") for offering in paginate_boto3(ec2_client.describe_instance_type_offerings)
         )
         supported_instance_types.update(InstanceTypeInfo.additional_instance_types_data().keys())
-        return supported_instance_types
+        return list(supported_instance_types)
     except ClientError as client_err:
         error(
             "Error when getting supported instance types via DescribeInstanceTypeOfferings: {0}".format(

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -843,7 +843,7 @@ def test_get_cce_emsg_containing_supported_instance_types(mocker, boto3_stubber,
 def test_get_supported_instance_types(mocker, boto3_stubber, generate_error):
     """Verify that get_supported_instance_types behaves as expected."""
     dummy_message = "dummy error message"
-    dummy_instance_types = {"c5.xlarge", "m6g.xlarge"}
+    dummy_instance_types = ["c5.xlarge", "m6g.xlarge"]
     error_patch = mocker.patch("pcluster.utils.error")
     mocked_requests = [
         MockedBoto3Request(
@@ -863,6 +863,7 @@ def test_get_supported_instance_types(mocker, boto3_stubber, generate_error):
         )
         error_patch.assert_called_with(expected_error_message)
     else:
+        list.sort(return_value)
         assert_that(return_value).is_equal_to(dummy_instance_types)
         error_patch.assert_not_called()
 


### PR DESCRIPTION
The `get_supported_instance_types` function has been changed in commit #e717cb36 to return a set but this breaks integration tests with awsbatch. Fixed to return a list as before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
