### PR TITLE
Add sanity check for instance usage classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 **ENHANCEMENTS**
 
 - Add validation to prevent using a `cluster_resource_bucket` that is in a different region than the cluster.
+- Add validation for `cluster_type` configuration parameter in `cluster` section
+- Add validation for `compute_type` configuration parameter in `queue` section
 
 **CHANGES**
 

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -58,6 +58,7 @@ from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import (
     architecture_os_validator,
     base_os_validator,
+    cluster_type_validator,
     cluster_validator,
     compute_instance_type_validator,
     compute_resource_validator,
@@ -99,6 +100,7 @@ from pcluster.config.validators import (
     intel_hpc_os_validator,
     kms_key_validator,
     maintain_initial_size_validator,
+    queue_compute_type_validator,
     queue_settings_validator,
     queue_validator,
     region_validator,
@@ -732,7 +734,7 @@ QUEUE = {
     "type": QueueJsonSection,
     "key": "queue",
     "default_label": "default",
-    "validators": [queue_validator],
+    "validators": [queue_validator, queue_compute_type_validator],
     "max_resources": 5,
     "params": OrderedDict([
         ("compute_type", {
@@ -1111,6 +1113,7 @@ CLUSTER_SIT = {
                 "default": "ondemand",
                 "allowed_values": ["ondemand", "spot"],
                 "cfn_param_mapping": "ClusterType",
+                "validators": [cluster_type_validator],
                 "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP
             }),
             ("spot_price", {

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -1222,7 +1222,7 @@ def queue_validator(section_key, section_label, pcluster_config):
 
     instance_types = []
     for compute_resource_label in compute_resource_labels:
-        compute_resource = pcluster_config.get_section("compute_resource", compute_resource_label)
+        compute_resource = pcluster_config.get_section("compute_resource", compute_resource_label.strip())
         if compute_resource:
             instance_type = compute_resource.get_param_value("instance_type")
             if instance_type in instance_types:
@@ -1242,6 +1242,21 @@ def queue_validator(section_key, section_label, pcluster_config):
     if queue_section.get_param_value("enable_efa_gdr") and not queue_section.get_param_value("enable_efa"):
         errors.append("The parameter 'enable_efa_gdr' can be used only in combination with 'enable_efa'")
 
+    return errors, warnings
+
+
+def queue_compute_type_validator(section_key, section_label, pcluster_config):
+    errors = []
+    warnings = []
+    queue_section = pcluster_config.get_section(section_key, section_label)
+    compute_resource_labels = str(queue_section.get_param_value("compute_resource_settings") or "").split(",")
+
+    for compute_resource_label in compute_resource_labels:
+        # Check that usage class set in queue section is supported by all compute resource instance types
+        compute_resource = pcluster_config.get_section("compute_resource", compute_resource_label.strip())
+        if compute_resource:
+            instance_type = compute_resource.get_param_value("instance_type")
+            check_usage_class(instance_type, queue_section.get_param_value("compute_type"), errors, warnings)
     return errors, warnings
 
 
@@ -1645,3 +1660,26 @@ def region_validator(section_key, section_label, pcluster_config):
     if pcluster_config.region not in SUPPORTED_REGIONS:
         errors.append("Region '{0}' is not yet officially supported by ParallelCluster".format(pcluster_config.region))
     return errors, []
+
+
+def cluster_type_validator(param_key, param_value, pcluster_config):
+    errors = []
+    warnings = []
+
+    scheduler = pcluster_config.get_section("cluster").get_param_value("scheduler")
+    if scheduler != "awsbatch":
+        compute_instance_type = pcluster_config.get_section("cluster").get_param_value("compute_instance_type")
+        check_usage_class(compute_instance_type, param_value, errors, warnings)
+
+    return errors, warnings
+
+
+def check_usage_class(instance_type, usage_class, errors, warnings):
+    supported_usage_classes = InstanceTypeInfo.init_from_instance_type(instance_type).supported_usage_classes()
+
+    if not supported_usage_classes:
+        warnings.append(
+            "Could not check support for usage class '{0}' with instance type '{1}'".format(usage_class, instance_type)
+        )
+    elif usage_class not in supported_usage_classes:
+        errors.append("Usage type '{0}' not supported with instance type '{1}'".format(usage_class, instance_type))

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -1356,3 +1356,12 @@ class InstanceTypeInfo:
     def is_efa_supported(self):
         """Check whether EFA is supported."""
         return self.instance_type_data.get("NetworkInfo").get("EfaSupported")
+
+    def supported_usage_classes(self):
+        """Return the list supported usage classes."""
+        supported_classes = self.instance_type_data.get("SupportedUsageClasses", [])
+        if "on-demand" in supported_classes:
+            # Replace official AWS with internal naming convention
+            supported_classes.remove("on-demand")
+            supported_classes.append("ondemand")
+        return supported_classes

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -27,6 +27,8 @@ from pcluster.config.validators import (
     FSX_SUPPORTED_ARCHITECTURES_OSES,
     LOGFILE_LOGGER,
     architecture_os_validator,
+    check_usage_class,
+    cluster_type_validator,
     compute_resource_validator,
     disable_hyperthreading_architecture_validator,
     efa_gdr_validator,
@@ -34,6 +36,7 @@ from pcluster.config.validators import (
     fsx_ignored_parameters_validator,
     instances_architecture_compatibility_validator,
     intel_hpc_architecture_validator,
+    queue_compute_type_validator,
     queue_validator,
     region_validator,
     s3_bucket_region_validator,
@@ -2937,3 +2940,96 @@ def test_region_validator(mocker, region, expected_message):
         assert_that(errors[0]).matches(expected_message)
     else:
         assert_that(errors).is_empty()
+
+
+@pytest.mark.parametrize(
+    "usage_class, supported_usage_classes, expected_error_message, expected_warning_message",
+    [
+        ("ondemand", ["ondemand", "spot"], None, None),
+        ("spot", ["ondemand", "spot"], None, None),
+        ("ondemand", ["ondemand"], None, None),
+        ("spot", ["spot"], None, None),
+        ("spot", [], None, "Could not check support for usage class 'spot' with instance type 'instance-type'"),
+        ("ondemand", [], None, "Could not check support for usage class 'ondemand' with instance type 'instance-type'"),
+        ("spot", ["ondemand"], "Usage type 'spot' not supported with instance type 'instance-type'", None),
+        ("ondemand", ["spot"], "Usage type 'ondemand' not supported with instance type 'instance-type'", None),
+    ],
+)
+def test_check_usage_class(
+    mocker, usage_class, supported_usage_classes, expected_error_message, expected_warning_message
+):
+    # This test checks the common logic triggered from cluster_type_validator and queue_compute_type_validator.
+    instance_type_info_mock = mocker.MagicMock()
+    mocker.patch(
+        "pcluster.config.cfn_param_types.InstanceTypeInfo.init_from_instance_type", return_value=instance_type_info_mock
+    )
+    instance_type_info_mock.supported_usage_classes.return_value = supported_usage_classes
+
+    errors = []
+    warnings = []
+    check_usage_class("instance-type", usage_class, errors, warnings)
+
+    if expected_error_message:
+        assert_that(errors).contains(expected_error_message)
+    else:
+        assert_that(errors).is_empty()
+
+    if expected_warning_message:
+        assert_that(warnings).contains(expected_warning_message)
+    else:
+        assert_that(warnings).is_empty()
+
+
+@pytest.mark.parametrize(
+    "scheduler, expected_usage_class_check", [("sge", True), ("torque", True), ("slurm", True), ("awsbatch", False)]
+)
+def test_cluster_type_validator(mocker, scheduler, expected_usage_class_check):
+    # Usage class validation logic is tested in `test_check_usage_class`.
+    # This test only makes sure that the logic is triggered from validator.
+    mock = mocker.patch("pcluster.config.validators.check_usage_class", return_value=None)
+    cluster_dict = {"compute_instance_type": "t2.micro", "scheduler": scheduler}
+    config_parser_dict = {"cluster default": cluster_dict}
+    config_parser = configparser.ConfigParser()
+    config_parser.read_dict(config_parser_dict)
+
+    pcluster_config = utils.init_pcluster_config_from_configparser(config_parser, False, auto_refresh=False)
+    errors, warnings = cluster_type_validator("compute_type", "spot", pcluster_config)
+    if expected_usage_class_check:
+        mock.assert_called_with("t2.micro", "spot", [], [])
+    else:
+        mock.assert_not_called()
+
+    assert_that(errors).is_equal_to([])
+    assert_that(warnings).is_equal_to([])
+
+
+@pytest.mark.parametrize("compute_type", [("ondemand"), ("spot")])
+def test_queue_compute_type_validator(mocker, compute_type):
+    # Usage class validation logic is tested in `test_check_usage_class`.
+    # This test only makes sure that the logic is triggered from validator.
+    mock = mocker.patch("pcluster.config.validators.check_usage_class", return_value=None)
+
+    config_parser_dict = {
+        "cluster default": {
+            "queue_settings": "q1",
+        },
+        "queue q1": {"compute_resource_settings": "q1cr1, q1cr2", "compute_type": compute_type},
+        "compute_resource q1cr1": {"instance_type": "q1cr1_instance_type"},
+        "compute_resource q1cr2": {"instance_type": "q1cr2_instance_type"},
+    }
+
+    config_parser = configparser.ConfigParser()
+    config_parser.read_dict(config_parser_dict)
+
+    pcluster_config = utils.init_pcluster_config_from_configparser(config_parser, False, auto_refresh=False)
+    errors, warnings = queue_compute_type_validator("queue", "q1", pcluster_config)
+    mock.assert_has_calls(
+        [
+            mocker.call("q1cr1_instance_type", compute_type, [], []),
+            mocker.call("q1cr2_instance_type", compute_type, [], []),
+        ],
+        any_order=True,
+    )
+
+    assert_that(errors).is_equal_to([])
+    assert_that(warnings).is_equal_to([])

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -140,6 +140,7 @@ def mock_instance_type_info(mocker, instance_type="t2.micro"):
                 "InstanceType": instance_type,
                 "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2},
                 "NetworkInfo": {"EfaSupported": False},
+                "SupportedUsageClasses": ["on-demand", "spot"],
             }
         ),
     )


### PR DESCRIPTION
This commit adds a validator for usage classes ("spot" or "ondemand") assigned to cluster nodes through the `cluster_type` (in `cluster` section) or `compute_type` (in `queue` section) configuration parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
