### PR TITLE
Add sanity check for instance usage classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ CHANGELOG
 ------
 **ENHANCEMENTS**
 
-- Enable support for ARM instances in China and GovCloud regions when using Ubuntu 18.04 or Amazon Linux 2. 
+- Enable support for ARM instances in China and GovCloud regions when using Ubuntu 18.04 or Amazon Linux 2.
+- Add validation for `cluster_type` configuration parameter in `cluster` section
+- Add validation for `compute_type` configuration parameter in `queue` section
+ 
 
 **CHANGES**
 

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -58,6 +58,7 @@ from pcluster.config.update_policy import UpdatePolicy
 from pcluster.config.validators import (
     architecture_os_validator,
     base_os_validator,
+    cluster_type_validator,
     cluster_validator,
     compute_instance_type_validator,
     compute_resource_validator,
@@ -99,6 +100,7 @@ from pcluster.config.validators import (
     intel_hpc_os_validator,
     kms_key_validator,
     maintain_initial_size_validator,
+    queue_compute_type_validator,
     queue_settings_validator,
     queue_validator,
     s3_bucket_uri_validator,
@@ -723,7 +725,7 @@ QUEUE = {
     "type": QueueJsonSection,
     "key": "queue",
     "default_label": "default",
-    "validators": [queue_validator],
+    "validators": [queue_validator, queue_compute_type_validator],
     "max_resources": 5,
     "params": OrderedDict([
         ("compute_type", {
@@ -1103,6 +1105,7 @@ CLUSTER_SIT = {
                 "default": "ondemand",
                 "allowed_values": ["ondemand", "spot"],
                 "cfn_param_mapping": "ClusterType",
+                "validators": [cluster_type_validator],
                 "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP
             }),
             ("spot_price", {

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -1350,3 +1350,12 @@ class InstanceTypeInfo:
     def is_efa_supported(self):
         """Check whether EFA is supported."""
         return self.instance_type_data.get("NetworkInfo").get("EfaSupported")
+
+    def supported_usage_classes(self):
+        """Return the list supported usage classes."""
+        supported_classes = self.instance_type_data.get("SupportedUsageClasses", [])
+        if "on-demand" in supported_classes:
+            # Replace official AWS with internal naming convention
+            supported_classes.remove("on-demand")
+            supported_classes.append("ondemand")
+        return supported_classes

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -140,6 +140,7 @@ def mock_instance_type_info(mocker, instance_type="t2.micro"):
                 "InstanceType": instance_type,
                 "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2},
                 "NetworkInfo": {"EfaSupported": False},
+                "SupportedUsageClasses": ["on-demand", "spot"],
             }
         ),
     )


### PR DESCRIPTION
This commit adds a validator for usage classes ("spot" or "ondemand") assigned to cluster nodes through the `cluster_type` (in `cluster` section) or `compute_type` (in `queue` section) configuration parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
