### PR TITLE
Fix pcluster update behavior with additional instance types data

### DIFF
--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -1032,7 +1032,7 @@ CLUSTER_COMMON_PARAMS = [
         "type": JsonCfnParam,
         "default": {},
         "cfn_param_mapping": "InstanceTypesData",
-        "update_policy": UpdatePolicy.SUPPORTED
+        "update_policy": UpdatePolicy.IGNORED
     }),
 ]
 

--- a/cli/src/pcluster/config/pcluster_config.py
+++ b/cli/src/pcluster/config/pcluster_config.py
@@ -101,8 +101,9 @@ class PclusterConfig(object):
             self.__init_sections_from_cfn(cluster_name)
         else:
             self.__init_sections_from_file(cluster_label, self.config_parser, fail_on_file_absence)
-            # Load instance types data if present in config file
-            self.__init_additional_instance_types_data()
+
+        # Load instance types data if available
+        self.__init_additional_instance_types_data()
 
         self.__autorefresh = auto_refresh  # Initialization completed
 


### PR DESCRIPTION
Additional instance types data must be loaded not only when loading the configuration from file, but also from CloudFormation in order to allow the refresh operations to work correctly.

This commit also marks as ignored the update policy of the `instance_types_data` parameter to avoid changes being displayed just because of the json data re-ordering.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
