### PR TITLE
Set update policy to UNSUPPORTED for instance_types_data

### DIFF
--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -1032,7 +1032,7 @@ CLUSTER_COMMON_PARAMS = [
         "type": JsonCfnParam,
         "default": {},
         "cfn_param_mapping": "InstanceTypesData",
-        "update_policy": UpdatePolicy.IGNORED
+        "update_policy": UpdatePolicy.UNSUPPORTED
     }),
 ]
 

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -1258,7 +1258,7 @@ class InstanceTypeInfo:
     @staticmethod
     def load_additional_instance_types_data(instance_types_data):
         """Load additional data to describe instance types."""
-        InstanceTypeInfo.__additional_instance_types_data.update(instance_types_data)
+        InstanceTypeInfo.__additional_instance_types_data = instance_types_data if instance_types_data else {}
 
     @staticmethod
     def clear_additional_instance_types_data():
@@ -1353,7 +1353,7 @@ class InstanceTypeInfo:
 
     def supported_usage_classes(self):
         """Return the list supported usage classes."""
-        supported_classes = self.instance_type_data.get("SupportedUsageClasses", [])
+        supported_classes = list(self.instance_type_data.get("SupportedUsageClasses", []))
         if "on-demand" in supported_classes:
             # Replace official AWS with internal naming convention
             supported_classes.remove("on-demand")


### PR DESCRIPTION
With this commit we replace completely instance types data rather than just update it to make sure data is consistent with the currently loaded configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
