### PR TITLE
3.0: Adapt schema to new configuration schema

### DIFF
--- a/cli/src/pcluster/configure/easyconfig.py
+++ b/cli/src/pcluster/configure/easyconfig.py
@@ -210,7 +210,7 @@ def configure(args):  # noqa: C901
                 compute_resources.append(
                     {
                         "Name": compute_resource_name,
-                        "InstanceType": "optimal",
+                        "InstanceTypes": "optimal",
                         "MinvCpus": min_cluster_size,
                         "DesiredvCpus": min_cluster_size,
                         "MaxvCpus": max_cluster_size,

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -748,12 +748,10 @@ class BaseComputeResource(Resource):
     def __init__(
         self,
         name: str,
-        instance_type: str,
         disable_simultaneous_multithreading: bool = None,
     ):
         super().__init__()
         self.name = Resource.init_param(name)
-        self.instance_type = Resource.init_param(instance_type)
         self.disable_simultaneous_multithreading = Resource.init_param(
             disable_simultaneous_multithreading, default=False
         )
@@ -1061,6 +1059,7 @@ class AwsbatchComputeResource(BaseComputeResource):
 
     def __init__(
         self,
+        instance_types: str = None,
         max_vcpus: int = None,
         min_vcpus: int = None,
         desired_vcpus: int = None,
@@ -1068,6 +1067,7 @@ class AwsbatchComputeResource(BaseComputeResource):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.instance_types = Resource.init_param(instance_types)
         self.max_vcpus = Resource.init_param(max_vcpus, default=DEFAULT_MAX_COUNT)
         self.min_vcpus = Resource.init_param(min_vcpus, default=DEFAULT_MIN_COUNT)
         self.desired_vcpus = Resource.init_param(desired_vcpus, default=self.min_vcpus)
@@ -1141,9 +1141,16 @@ class SlurmComputeResource(BaseComputeResource):
     """Represent the Slurm Compute Resource."""
 
     def __init__(
-        self, max_count: int = None, min_count: int = None, spot_price: float = None, efa: Efa = None, **kwargs
+        self,
+        instance_type: str = None,
+        max_count: int = None,
+        min_count: int = None,
+        spot_price: float = None,
+        efa: Efa = None,
+        **kwargs,
     ):
         super().__init__(**kwargs)
+        self.instance_type = Resource.init_param(instance_type)
         self.max_count = Resource.init_param(max_count, default=DEFAULT_MAX_COUNT)
         self.min_count = Resource.init_param(min_count, default=DEFAULT_MIN_COUNT)
         self.spot_price = Resource.init_param(spot_price)

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -449,18 +449,10 @@ class CloudWatchLogs(Resource):
         self,
         enabled: bool = None,
         retention_in_days: int = None,
-        log_group_id: str = None,
-        kms_key_id: str = None,
     ):
         super().__init__()
         self.enabled = Resource.init_param(enabled, default=CW_LOGS_ENABLED_DEFAULT)
         self.retention_in_days = Resource.init_param(retention_in_days, default=CW_LOGS_RETENTION_DAYS_DEFAULT)
-        self.log_group_id = Resource.init_param(log_group_id)
-        self.kms_key_id = Resource.init_param(kms_key_id)
-
-    def _validate(self):
-        if self.kms_key_id:
-            self._execute_validator(KmsKeyValidator, kms_key_id=self.kms_key_id)
 
 
 class CloudWatchDashboards(Resource):

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -159,6 +159,7 @@ class SharedEbs(Ebs):
     def __init__(
         self,
         mount_dir: str,
+        name: str,
         volume_type: str = None,
         iops: int = None,
         size: int = None,
@@ -169,20 +170,20 @@ class SharedEbs(Ebs):
         volume_id: str = None,
         raid: Raid = None,
     ):
-        super().__init__()
+        super().__init__(size=size, encrypted=encrypted)
         self.volume_type = Resource.init_param(volume_type, default=EBS_VOLUME_TYPE_DEFAULT)
         self.iops = Resource.init_param(iops, default=EBS_VOLUME_TYPE_IOPS_DEFAULT.get(self.volume_type))
-        self.size = Resource.init_param(size, default=EBS_VOLUME_SIZE_DEFAULT)
-        self.encrypted = Resource.init_param(encrypted, default=False)
         self.kms_key_id = Resource.init_param(kms_key_id)
         self.throughput = Resource.init_param(throughput, default=125 if self.volume_type == "gp3" else None)
         self.mount_dir = mount_dir
+        self.name = name
         self.shared_storage_type = SharedStorageType.RAID if raid else SharedStorageType.EBS
         self.snapshot_id = Resource.init_param(snapshot_id)
         self.volume_id = Resource.init_param(volume_id)
         self.raid = raid
 
     def _validate(self):
+        super()._validate()
         self._execute_validator(EbsVolumeTypeSizeValidator, volume_type=self.volume_type, volume_size=self.size)
         self._execute_validator(
             EbsVolumeIopsValidator,
@@ -214,6 +215,7 @@ class SharedEfs(Resource):
     def __init__(
         self,
         mount_dir: str,
+        name: str,
         encrypted: bool = None,
         kms_key_id: str = None,
         performance_mode: str = None,
@@ -223,6 +225,7 @@ class SharedEfs(Resource):
     ):
         super().__init__()
         self.mount_dir = mount_dir
+        self.name = name
         self.shared_storage_type = SharedStorageType.EFS
         self.encrypted = Resource.init_param(encrypted, default=False)
         self.kms_key_id = Resource.init_param(kms_key_id)
@@ -243,6 +246,7 @@ class SharedFsx(Resource):
     def __init__(
         self,
         mount_dir: str,
+        name: str,
         storage_capacity: int = None,
         deployment_type: str = None,
         export_path: str = None,
@@ -262,6 +266,7 @@ class SharedFsx(Resource):
     ):
         super().__init__()
         self.mount_dir = mount_dir
+        self.name = name
         self.shared_storage_type = SharedStorageType.FSX
         self.storage_capacity = Resource.init_param(storage_capacity)
         self.storage_type = Resource.init_param(storage_type)

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -1283,11 +1283,9 @@ class SlurmQueue(BaseQueue):
 class Dns(Resource):
     """Represent the DNS settings."""
 
-    def __init__(self, disable_managed_dns: bool = None, domain: str = None, hosted_zone_id: str = None):
+    def __init__(self, disable_managed_dns: bool = None):
         super().__init__()
         self.disable_managed_dns = Resource.init_param(disable_managed_dns, default=False)
-        self.domain = Resource.init_param(domain)
-        self.hosted_zone_id = Resource.init_param(hosted_zone_id)
 
 
 class SlurmSettings(CommonSchedulingSettings):

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -641,12 +641,11 @@ class CustomActionEvent(Enum):
 class CustomAction(Resource):
     """Represent a custom action resource."""
 
-    def __init__(self, script: str, args: List[str] = None, event: str = None, run_as: str = None):
+    def __init__(self, script: str, args: List[str] = None, event: str = None):
         super().__init__()
         self.script = Resource.init_param(script)
         self.args = Resource.init_param(args)
         self.event = Resource.init_param(event)
-        self.run_as = Resource.init_param(run_as)
 
     def _validate(self):
         self._execute_validator(UrlValidator, url=self.script)

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -525,11 +525,9 @@ class Roles(Resource):
 
     def __init__(
         self,
-        instance_role: str = None,
         custom_lambda_resources: str = None,
     ):
         super().__init__()
-        self.instance_role = Resource.init_param(instance_role)
         self.custom_lambda_resources = Resource.init_param(custom_lambda_resources)
 
 
@@ -561,18 +559,29 @@ class AdditionalIamPolicy(Resource):
 
 
 class Iam(Resource):
-    """Represent the IAM configuration."""
+    """Represent the IAM configuration for HeadNode and Queue."""
+
+    def __init__(
+        self,
+        s3_access: List[S3Access] = None,
+        additional_iam_policies: List[AdditionalIamPolicy] = None,
+        instance_role: str = None,
+    ):
+        super().__init__()
+        self.s3_access = s3_access
+        self.additional_iam_policies = additional_iam_policies
+        self.instance_role = Resource.init_param(instance_role)
+
+
+class ClusterIam(Resource):
+    """Represent the IAM configuration for Cluster."""
 
     def __init__(
         self,
         roles: Roles = None,
-        s3_access: List[S3Access] = None,
-        additional_iam_policies: List[AdditionalIamPolicy] = None,
     ):
         super().__init__()
         self.roles = roles
-        self.s3_access = s3_access
-        self.additional_iam_policies = additional_iam_policies
 
 
 class IntelSelectSolutions(Resource):
@@ -731,7 +740,7 @@ class HeadNode(Resource):
     @property
     def instance_role(self):
         """Return the IAM role for head node, if set."""
-        return self.iam.roles.instance_role if self.iam and self.iam.roles else None
+        return self.iam.instance_role if self.iam else None
 
     def get_custom_action(self, event: CustomActionEvent) -> CustomAction:
         """Return the first CustomAction corresponding to the specified event."""
@@ -791,7 +800,7 @@ class BaseQueue(Resource):
     @property
     def instance_role(self):
         """Return the IAM role for compute nodes, if set."""
-        return self.iam.roles.instance_role if self.iam and self.iam.roles else None
+        return self.iam.instance_role if self.iam else None
 
 
 class CommonSchedulingSettings(Resource):
@@ -813,7 +822,7 @@ class BaseClusterConfig(Resource):
         monitoring: Monitoring = None,
         additional_packages: AdditionalPackages = None,
         tags: List[Tag] = None,
-        iam: Iam = None,
+        iam: ClusterIam = None,
         cluster_s3_bucket: str = None,
         additional_resources: str = None,
         dev_settings: ClusterDevSettings = None,

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -166,7 +166,7 @@ class EphemeralVolume(Resource):
         self.mount_dir = Resource.init_param(mount_dir, default="/scratch")
 
 
-class Storage(Resource):
+class LocalStorage(Resource):
     """Represent the entire node storage configuration."""
 
     def __init__(self, root_volume: Ebs = None, ephemeral_volume: EphemeralVolume = None):
@@ -660,7 +660,7 @@ class HeadNode(Resource):
         networking: HeadNodeNetworking,
         ssh: Ssh,
         disable_simultaneous_multithreading: bool = None,
-        storage: Storage = None,
+        local_storage: LocalStorage = None,
         dcv: Dcv = None,
         efa: Efa = None,
         custom_actions: List[CustomAction] = None,
@@ -673,7 +673,7 @@ class HeadNode(Resource):
         )
         self.networking = networking
         self.ssh = ssh
-        self.storage = storage
+        self.local_storage = local_storage
         self.dcv = dcv
         self.efa = efa
         self.custom_actions = custom_actions
@@ -786,14 +786,14 @@ class BaseQueue(Resource):
         self,
         name: str,
         networking: QueueNetworking,
-        storage: Storage = None,
+        local_storage: LocalStorage = None,
         compute_type: str = None,
         iam: Iam = None,
     ):
         super().__init__()
         self.name = Resource.init_param(name)
         self.networking = networking
-        self.storage = storage
+        self.local_storage = local_storage
         self.compute_type = Resource.init_param(compute_type, default=ComputeType.ONDEMAND)
         self.iam = iam
 
@@ -966,8 +966,8 @@ class BaseClusterConfig(Resource):
             for storage in self.shared_storage:
                 mount_dir_list.append(storage.mount_dir)
 
-        if self.head_node.storage and self.head_node.storage.ephemeral_volume:
-            mount_dir_list.append(self.head_node.storage.ephemeral_volume.mount_dir)
+        if self.head_node.local_storage and self.head_node.local_storage.ephemeral_volume:
+            mount_dir_list.append(self.head_node.local_storage.ephemeral_volume.mount_dir)
 
         return mount_dir_list
 
@@ -1104,10 +1104,10 @@ class AwsbatchQueue(BaseQueue):
         name: str,
         networking: QueueNetworking,
         compute_resources: List[AwsbatchComputeResource],
-        storage: Storage = None,
+        local_storage: LocalStorage = None,
         compute_type: str = None,
     ):
-        super().__init__(name, networking, storage, compute_type)
+        super().__init__(name, networking, local_storage, compute_type)
         self.compute_resources = compute_resources
 
 

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -757,13 +757,11 @@ class BaseComputeResource(Resource):
         self,
         name: str,
         instance_type: str,
-        allocation_strategy: str = None,
         disable_simultaneous_multithreading: bool = None,
     ):
         super().__init__()
         self.name = Resource.init_param(name)
         self.instance_type = Resource.init_param(instance_type)
-        self.allocation_strategy = Resource.init_param(allocation_strategy, default="BEST_FIT")
         self.disable_simultaneous_multithreading = Resource.init_param(
             disable_simultaneous_multithreading, default=False
         )

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -539,11 +539,11 @@ class S3Access(Resource):
     def __init__(
         self,
         bucket_name: str,
-        type: str = None,
+        enable_write_access: bool = None,
     ):
         super().__init__()
         self.bucket_name = Resource.init_param(bucket_name)
-        self.type = Resource.init_param(type, default="READ_ONLY")
+        self.enable_write_access = Resource.init_param(enable_write_access, default=False)
 
 
 class AdditionalIamPolicy(Resource):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -75,11 +75,7 @@ from pcluster.validators.cluster_validators import FSX_MESSAGES
 class _BaseEbsSchema(BaseSchema):
     """Represent the schema shared by SharedEBS and RootVolume section."""
 
-    volume_type = fields.Str(validate=get_field_validator("volume_type"))
-    iops = fields.Int()
     size = fields.Int()
-    kms_key_id = fields.Str()
-    throughput = fields.Int()
     encrypted = fields.Bool()
 
 
@@ -115,8 +111,12 @@ class RaidSchema(BaseSchema):
 class EbsSchema(_BaseEbsSchema):
     """Represent the schema of EBS."""
 
+    iops = fields.Int()
+    kms_key_id = fields.Str()
+    throughput = fields.Int()
     snapshot_id = fields.Str(validate=validate.Regexp(r"^snap-[0-9a-z]{8}$|^snap-[0-9a-z]{17}$"))
     volume_id = fields.Str(validate=validate.Regexp(r"^vol-[0-9a-z]{8}$|^vol-[0-9a-z]{17}$"))
+    volume_type = fields.Str(validate=get_field_validator("volume_type"))
     raid = fields.Nested(RaidSchema)
 
 
@@ -238,6 +238,7 @@ class SharedStorageSchema(BaseSchema):
     """Represent the generic SharedStorage schema."""
 
     mount_dir = fields.Str(required=True, validate=get_field_validator("file_path"))
+    name = fields.Str()
     ebs = fields.Nested(EbsSchema)
     efs = fields.Nested(EfsSchema)
     fsx = fields.Nested(FsxSchema, data_key="FsxLustre")

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -585,7 +585,6 @@ class _ComputeResourceSchema(BaseSchema):
     """Represent the schema of the ComputeResource."""
 
     name = fields.Str(required=True)
-    allocation_strategy = fields.Str()
     disable_simultaneous_multithreading = fields.Bool()
     efa = fields.Nested(EfaSchema)
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -671,8 +671,6 @@ class DnsSchema(BaseSchema):
     """Represent the schema of Dns Settings."""
 
     disable_managed_dns = fields.Bool()
-    domain = fields.Str()
-    hosted_zone_id = fields.Str()
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -393,8 +393,6 @@ class CloudWatchLogsSchema(BaseSchema):
     retention_in_days = fields.Int(
         validate=validate.OneOf([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653])
     )
-    log_group_id = fields.Str()
-    kms_key_id = fields.Str()
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -604,7 +604,7 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
 class AwsbatchComputeResourceSchema(_ComputeResourceSchema):
     """Represent the schema of the Batch ComputeResource."""
 
-    instance_type = fields.Str(required=True)  # TODO it is a comma separated list
+    instance_types = fields.Str()  # TODO it is a comma separated list
     max_vcpus = fields.Int(data_key="MaxvCpus", validate=validate.Range(min=1))
     min_vcpus = fields.Int(data_key="MinvCpus", validate=validate.Range(min=0))
     desired_vcpus = fields.Int(data_key="DesiredvCpus", validate=validate.Range(min=0))

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -606,7 +606,6 @@ class CustomActionSchema(BaseSchema):
     script = fields.Str(required=True)
     args = fields.List(fields.Str())
     event = fields.Str(validate=validate.OneOf([event.value for event in CustomActionEvent]))
-    run_as = fields.Str()
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -570,7 +570,6 @@ class HeadNodeSchema(BaseSchema):
     ssh = fields.Nested(SshSchema, required=True)
     local_storage = fields.Nested(LocalStorageSchema)
     dcv = fields.Nested(DcvSchema)
-    efa = fields.Nested(EfaSchema)
     custom_actions = fields.Nested(
         CustomActionSchema, many=True
     )  # TODO validate to avoid more than one script for event type or add support for them.

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -335,7 +335,9 @@ class PlacementGroupSchema(BaseSchema):
 class QueueNetworkingSchema(BaseNetworkingSchema):
     """Represent the schema of the Networking, child of Queue."""
 
-    subnet_ids = fields.List(fields.Str(validate=get_field_validator("subnet_id")), required=True)
+    subnet_ids = fields.List(
+        fields.Str(validate=get_field_validator("subnet_id")), validate=validate.Length(equal=1), required=True
+    )
     placement_group = fields.Nested(PlacementGroupSchema)
 
     @post_load

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -465,7 +465,7 @@ class S3AccessSchema(BaseSchema):
     """Represent the schema of S3 access."""
 
     bucket_name = fields.Str(required=True)
-    type = fields.Str(validate=validate.OneOf(["READ_ONLY", "READ_WRITE"]))
+    enable_write_access = fields.Bool()
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -53,18 +53,23 @@ class BaseSchema(Schema):
         if field_obj.data_key is None:
             field_obj.data_key = camelcase(field_name)
 
-    def only_one_field(self, data, field_list, **kwargs):
+    def fields_coexist(self, data, field_list, one_required=False, **kwargs):
         """
-        Check that the Schema contains only one of the given fields.
+        Check if at least two fileds in the filed lists co-exist in the schema.
 
-        :param data: the
+        :param data: data to be checked
         :param field_list: list including the name of the fields to check
+        :param one_required: True if one of the field is required to be existed
         :return: True if one and only one field is not None
         """
         if kwargs.get("partial"):
             # If the schema is to be loaded partially, do not check existence constrain.
             return True
-        return len([data.get(field_name) for field_name in field_list if data.get(field_name)]) == 1
+        if one_required:
+            result = len([data.get(field_name) for field_name in field_list if data.get(field_name)]) != 1
+        else:
+            result = len([data.get(field_name) for field_name in field_list if data.get(field_name)]) > 1
+        return result
 
     @pre_dump
     def remove_implied_values(self, data, **kwargs):

--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -145,7 +145,7 @@ class AwsbatchConstruct(core.Construct):
                 minv_cpus=self.compute_resource.min_vcpus,
                 desiredv_cpus=self.compute_resource.desired_vcpus,
                 maxv_cpus=self.compute_resource.max_vcpus,
-                instance_types=self.compute_resource.instance_type.split(","),
+                instance_types=self.compute_resource.instance_types.split(","),
                 subnets=self.queue.networking.subnet_ids,
                 security_group_ids=get_queue_security_groups_full(self.compute_security_groups, self.queue),
                 # ec2_key_pair=  TODO?

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -49,7 +49,7 @@ def get_block_device_mappings(node_config: Union[HeadNode, BaseQueue], os: str):
         )
 
     # Root volume
-    if node_config.storage and node_config.storage.root_volume:
+    if node_config.local_storage and node_config.local_storage.root_volume:
         root_volume = copy.deepcopy(node_config.storage.root_volume)
     else:
         root_volume = Ebs()

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -57,10 +57,7 @@ def get_block_device_mappings(node_config: Union[HeadNode, BaseQueue], os: str):
     block_device_mappings.append(
         ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
             device_name=OS_MAPPING[os]["root-device"],
-            ebs=ec2.CfnLaunchTemplate.EbsProperty(
-                volume_size=root_volume.size,
-                volume_type=root_volume.volume_type,
-            ),
+            ebs=ec2.CfnLaunchTemplate.EbsProperty(volume_size=root_volume.size, encrypted=root_volume.encrypted),
         )
     )
     return block_device_mappings

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -415,10 +415,10 @@ class ClusterCdkStack(core.Stack):
     def _add_s3_access_policies_to_role(self, role_ref: str, name: str):
         """Attach S3 policies to given role."""
         read_only_s3_resources = [
-            s3_access.bucket_name for s3_access in self.config.iam.s3_access if s3_access.type == "READ_ONLY"
+            s3_access.bucket_name for s3_access in self.config.iam.s3_access if not s3_access.enable_write_access
         ]
         read_write_s3_resources = [
-            s3_access.bucket_name for s3_access in self.config.iam.s3_access if s3_access.type != "READ_ONLY"
+            s3_access.bucket_name for s3_access in self.config.iam.s3_access if s3_access.enable_write_access
         ]
 
         s3_access_policy = iam.CfnPolicy(

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -941,12 +941,12 @@ class ClusterCdkStack(core.Stack):
                     "cfn_volume": get_shared_storage_ids_by_type(self.shared_storage_mappings, SharedStorageType.EBS),
                     "cfn_scheduler": self.config.scheduling.scheduler,
                     "cfn_encrypted_ephemeral": "true"
-                    if head_node.storage
-                    and head_node.storage.ephemeral_volume
-                    and head_node.storage.ephemeral_volume.encrypted
+                    if head_node.local_storage
+                    and head_node.local_storage.ephemeral_volume
+                    and head_node.local_storage.ephemeral_volume.encrypted
                     else "NONE",
-                    "cfn_ephemeral_dir": head_node.storage.ephemeral_volume.mount_dir
-                    if head_node.storage and head_node.storage.ephemeral_volume
+                    "cfn_ephemeral_dir": head_node.local_storage.ephemeral_volume.mount_dir
+                    if head_node.local_storage and head_node.local_storage.ephemeral_volume
                     else "/scratch",
                     "cfn_shared_dir": get_shared_storage_options_by_type(
                         self.shared_storage_options, SharedStorageType.EBS

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -912,7 +912,6 @@ class ClusterCdkStack(core.Stack):
             {
                 "cfncluster": {
                     "stack_name": self._stack_name,
-                    "enable_efa": "true" if head_node.efa and head_node.efa.enabled else "NONE",
                     "cfn_raid_vol_ids": get_shared_storage_ids_by_type(
                         self.shared_storage_mappings, SharedStorageType.RAID
                     ),

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -487,12 +487,12 @@ class SlurmConstruct(core.Construct):
                                 ),
                                 "Scheduler": self.config.scheduling.scheduler,
                                 "EncryptedEphemeral": "true"
-                                if queue.storage
-                                and queue.storage.ephemeral_volume
-                                and queue.storage.ephemeral_volume.encrypted
+                                if queue.local_storage
+                                and queue.local_storage.ephemeral_volume
+                                and queue.local_storage.ephemeral_volume.encrypted
                                 else "NONE",
-                                "EphemeralDir": queue.storage.ephemeral_volume.mount_dir
-                                if queue.storage and queue.storage.ephemeral_volume
+                                "EphemeralDir": queue.local_storage.ephemeral_volume.mount_dir
+                                if queue.local_storage and queue.local_storage.ephemeral_volume
                                 else "/scratch",
                                 "EbsSharedDirs": get_shared_storage_options_by_type(
                                     self.shared_storage_options, SharedStorageType.EBS

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
       - Name: queue_0
         ComputeResources:
           - Name: compute_resource_0
-            InstanceType: optimal
+            InstanceTypes: optimal
             MinvCpus: 13
             DesiredvCpus: 13
             MaxvCpus: 14

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.yaml
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
       - Name: queue_0
         ComputeResources:
           - Name: compute_resource_0
-            InstanceType: optimal
+            InstanceTypes: optimal
             MinvCpus: 13
             DesiredvCpus: 13
             MaxvCpus: 14

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
       - Name: queue_0
         ComputeResources:
           - Name: compute_resource_0
-            InstanceType: optimal
+            InstanceTypes: optimal
             MinvCpus: 13
             DesiredvCpus: 13
             MaxvCpus: 14

--- a/cli/tests/pcluster/models/cluster_dummy_model.py
+++ b/cli/tests/pcluster/models/cluster_dummy_model.py
@@ -136,8 +136,8 @@ def dummy_slurm_cluster_config(mocker):
     cluster.config_version = "1.0"
     cluster.iam = Iam(
         s3_access=[
-            S3Access("dummy-readonly-bucket", type="READ_ONLY"),
-            S3Access("dummy-readwrite-bucket", type="READ_WRITE"),
+            S3Access("dummy-readonly-bucket", enable_write_access=True),
+            S3Access("dummy-readwrite-bucket"),
         ]
     )
 
@@ -174,8 +174,8 @@ def dummy_awsbatch_cluster_config(mocker):
     cluster.config_version = "1.0"
     cluster.iam = Iam(
         s3_access=[
-            S3Access("dummy-readonly-bucket", type="READ_ONLY"),
-            S3Access("dummy-readwrite-bucket", type="READ_WRITE"),
+            S3Access("dummy-readonly-bucket", enable_write_access=False),
+            S3Access("dummy-readwrite-bucket", enable_write_access=True),
         ]
     )
 

--- a/cli/tests/pcluster/models/cluster_dummy_model.py
+++ b/cli/tests/pcluster/models/cluster_dummy_model.py
@@ -150,7 +150,7 @@ def dummy_awsbatch_cluster_config(mocker):
     image = Image(os="alinux2")
     head_node = dummy_head_node(mocker)
     compute_resources = [
-        AwsbatchComputeResource(name="dummy_compute_resource1", instance_type="dummyc5.xlarge,optimal")
+        AwsbatchComputeResource(name="dummy_compute_resource1", instance_types="dummyc5.xlarge,optimal")
     ]
     queue_networking = QueueNetworking(
         subnet_ids=["dummy-subnet-1", "dummy-subnet-2"], security_groups=["sg-1", "sg-2"]

--- a/cli/tests/pcluster/models/cluster_dummy_model.py
+++ b/cli/tests/pcluster/models/cluster_dummy_model.py
@@ -174,10 +174,11 @@ def dummy_awsbatch_cluster_config(mocker):
     return cluster
 
 
-def dummy_fsx(file_system_id=None, mount_dir="/shared"):
+def dummy_fsx(file_system_id=None, mount_dir="/shared", name="name"):
     """Generate dummy fsx."""
     return SharedFsx(
         mount_dir=mount_dir,
+        name=name,
         file_system_id=file_system_id,
         storage_capacity=300,
         deployment_type="SCRATCH_1",
@@ -197,9 +198,10 @@ def dummy_fsx(file_system_id=None, mount_dir="/shared"):
     )
 
 
-def dummy_ebs(mount_dir, volume_id=None, raid=None):
+def dummy_ebs(mount_dir, name="name", volume_id=None, raid=None):
     return SharedEbs(
         mount_dir=mount_dir,
+        name=name,
         kms_key_id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         snapshot_id="snapshot-abdcef76",
         volume_type="gp2",
@@ -209,9 +211,10 @@ def dummy_ebs(mount_dir, volume_id=None, raid=None):
     )
 
 
-def dummy_raid(mount_dir, volume_id=None):
+def dummy_raid(mount_dir, name="name", volume_id=None):
     return SharedEbs(
         mount_dir=mount_dir,
+        name="name",
         kms_key_id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         snapshot_id="snapshot-abdcef76",
         volume_type="gp2",
@@ -221,9 +224,10 @@ def dummy_raid(mount_dir, volume_id=None):
     )
 
 
-def dummy_efs(mount_dir, file_system_id=None):
+def dummy_efs(mount_dir, name="name", file_system_id=None):
     return SharedEfs(
         mount_dir=mount_dir,
+        name=name,
         encrypted=False,
         kms_key_id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
         performance_mode="generalPurpose",

--- a/cli/tests/pcluster/models/cluster_dummy_model.py
+++ b/cli/tests/pcluster/models/cluster_dummy_model.py
@@ -17,6 +17,7 @@ from pcluster.models.cluster_config import (
     AwsbatchQueue,
     AwsbatchScheduling,
     ClusterBucket,
+    ClusterIam,
     Dcv,
     HeadNode,
     HeadNodeNetworking,
@@ -107,16 +108,18 @@ def dummy_slurm_cluster_config(mocker):
     """Generate dummy cluster."""
     image = Image(os="alinux2")
     head_node = dummy_head_node(mocker)
+    queue_iam = Iam(
+        s3_access=[
+            S3Access("dummy-readonly-bucket", enable_write_access=True),
+            S3Access("dummy-readwrite-bucket"),
+        ]
+    )
     compute_resources = [SlurmComputeResource(name="dummy_compute_resource1", instance_type="dummyc5.xlarge")]
-    queue_networking1 = QueueNetworking(
-        subnet_ids=["dummy-subnet-1", "dummy-subnet-2"], security_groups=["sg-1", "sg-2"]
-    )
-    queue_networking2 = QueueNetworking(
-        subnet_ids=["dummy-subnet-1", "dummy-subnet-2", "dummy-subnet-3"], security_groups=["sg-1", "sg-3"]
-    )
+    queue_networking1 = QueueNetworking(subnet_ids=["dummy-subnet-1"], security_groups=["sg-1", "sg-2"])
+    queue_networking2 = QueueNetworking(subnet_ids=["dummy-subnet-1"], security_groups=["sg-1", "sg-3"])
     queue_networking3 = QueueNetworking(subnet_ids=["dummy-subnet-1"], security_groups=None)
     queues = [
-        SlurmQueue(name="queue1", networking=queue_networking1, compute_resources=compute_resources),
+        SlurmQueue(name="queue1", networking=queue_networking1, compute_resources=compute_resources, iam=queue_iam),
         SlurmQueue(name="queue2", networking=queue_networking2, compute_resources=compute_resources),
         SlurmQueue(name="queue3", networking=queue_networking3, compute_resources=compute_resources),
     ]
@@ -134,12 +137,7 @@ def dummy_slurm_cluster_config(mocker):
     cluster.cluster_s3_bucket = "s3://dummy-s3-bucket"
     cluster.additional_resources = "https://additional.template.url"
     cluster.config_version = "1.0"
-    cluster.iam = Iam(
-        s3_access=[
-            S3Access("dummy-readonly-bucket", enable_write_access=True),
-            S3Access("dummy-readwrite-bucket"),
-        ]
-    )
+    cluster.iam = ClusterIam()
 
     cluster.tags = [Tag(key="test", value="testvalue")]
     return cluster
@@ -152,9 +150,7 @@ def dummy_awsbatch_cluster_config(mocker):
     compute_resources = [
         AwsbatchComputeResource(name="dummy_compute_resource1", instance_types="dummyc5.xlarge,optimal")
     ]
-    queue_networking = QueueNetworking(
-        subnet_ids=["dummy-subnet-1", "dummy-subnet-2"], security_groups=["sg-1", "sg-2"]
-    )
+    queue_networking = QueueNetworking(subnet_ids=["dummy-subnet-1"], security_groups=["sg-1", "sg-2"])
     queues = [AwsbatchQueue(name="queue1", networking=queue_networking, compute_resources=compute_resources)]
     scheduling = AwsbatchScheduling(queues=queues)
     # shared storage
@@ -172,12 +168,7 @@ def dummy_awsbatch_cluster_config(mocker):
     cluster.cluster_s3_bucket = "s3://dummy-s3-bucket"
     cluster.additional_resources = "https://additional.template.url"
     cluster.config_version = "1.0"
-    cluster.iam = Iam(
-        s3_access=[
-            S3Access("dummy-readonly-bucket", enable_write_access=False),
-            S3Access("dummy-readwrite-bucket", enable_write_access=True),
-        ]
-    )
+    cluster.iam = ClusterIam()
 
     cluster.tags = [Tag(key="test", value="testvalue")]
     return cluster

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import json
+from copy import deepcopy
 
 import pytest
 import yaml
@@ -27,7 +28,8 @@ def _check_cluster_schema(test_datadir, config_file_name):
     # Load cluster model from Yaml file
     input_yaml = load_yaml_dict(test_datadir / config_file_name)
     print(input_yaml)
-    cluster = ClusterSchema().load(input_yaml)
+    copy_input_yaml = deepcopy(input_yaml)
+    cluster = ClusterSchema().load(copy_input_yaml)
     print(cluster)
 
     # Re-create Yaml file from model and compare content

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -7,9 +7,6 @@ HeadNode:
     SubnetId: subnet-12345678  # subnet-xxx
     ElasticIp: String  # true|false|EIP-id
     AssignPublicIp: true  # true|false
-    SecurityGroups:
-      - sg-12345678  # sg-xxxx
-      - sg-23456789
     AdditionalSecurityGroups:
       - sg-12345678  # sg-xxxx
       - sg-23456789
@@ -25,7 +22,7 @@ HeadNode:
   Ssh:
     KeyName: String  # ec2-key-name
     AllowedIps: 1.2.3.4/32  # 1.2.3.4/32
-  Storage:
+  LocalStorage:
     RootVolume:
       Size: 37  # 35
       Encrypted: true  # true
@@ -44,7 +41,7 @@ Scheduling:
   Awsbatch:
     Queues:
       - Name: String  # queue
-        Storage:
+        LocalStorage:
           RootVolume:
             Size: 38  # 35
             Encrypted: true  # true
@@ -62,8 +59,6 @@ Scheduling:
             - subnet-23456789
           AssignPublicIp: true  # true|false
           SecurityGroups:
-            - sg-12345678  # sg-xxxx
-          AdditionalSecurityGroups:
             - sg-12345678  # sg-xxxx
           PlacementGroup:
             Enabled: true  # true

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -67,7 +67,9 @@ Scheduling:
             #AllocationStrategy: String
 SharedStorage:
   - MountDir: /my/mount/point
-    Ebs:
+    StorageType: Ebs
+    Name: name1
+    Settings:
       VolumeType: gp2  # gp2 | gp3 | io1 | io2 | sc1 | st1 | standard
       Iops: 10
       Size: 20
@@ -79,7 +81,9 @@ SharedStorage:
         Type: 0  # 0|1
         NumberOfVolumes: 2  # [2-5]
   - MountDir: /my/mount/point2
-    Efs:
+    StorageType: Efs
+    Name: name2
+    Settings:
       Encrypted: true  # true
       KmsKeyId: String  # id-xxx
       PerformanceMode: maxIO  # generalPurpose | maxIO
@@ -87,7 +91,9 @@ SharedStorage:
       ProvisionedThroughput: 1024  # 1024
       FileSystemId: fs-12345678  # fs-xxxx
   - MountDir: /my/mount/point3
-    FsxLustre:
+    StorageType: FsxLustre
+    Name: name3
+    Settings:
       StorageCapacity: 3600  # 3600
       DeploymentType: SCRATCH_1  # PERSISTENT_1 | SCRATCH_1 | SCRATCH_2
       ImportedFileChunkSize: 10  # 1024

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -114,14 +114,7 @@ SharedStorage:
       StorageType: HDD  # HDD | SSD
 Iam:
   Roles:
-    InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
     CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
-  S3Access:
-    - BucketName: String
-      EnableWriteAccess: False
-  AdditionalIamPolicies:
-    - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
-    - Policy: policy2
 Monitoring:
   DetailedMonitoring: true  # false
   Logs:

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -56,7 +56,6 @@ Scheduling:
         Networking:
           SubnetIds:
             - subnet-12345678
-            - subnet-23456789
           AssignPublicIp: true  # true|false
           SecurityGroups:
             - sg-12345678  # sg-xxxx

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -26,10 +26,6 @@ HeadNode:
     RootVolume:
       Size: 37  # 35
       Encrypted: true  # true
-      KmsKeyId: String
-      VolumeType: gp2  # gp2 | gp3 | io1 | io2 | sc1 | st1 | standard
-      Iops: 23
-      Throughput: 21
     EphemeralVolume:
       Encrypted: true  # true
       MountDir: String  # /scratch
@@ -45,10 +41,6 @@ Scheduling:
           RootVolume:
             Size: 38  # 35
             Encrypted: true  # true
-            KmsKeyId: String
-            VolumeType: sc1  # gp2 | gp3 | io1 | io2 | sc1 | st1 | standard
-            Iops: 1
-            Throughput: 2
           EphemeralVolume:
             Encrypted: true  # true
             MountDir: String  # /scratch

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -93,7 +93,7 @@ SharedStorage:
       ImportedFileChunkSize: 10  # 1024
       ExportPath: String  # s3://bucket/folder
       ImportPath: String  # s3://bucket
-      #WeeklyMaintenanceStartTime: 1:00:00  # 1:00:00
+      WeeklyMaintenanceStartTime: "1:00:00"  # "1:00:00"
       AutomaticBackupRetentionDays: 1  # 0
       CopyTagsToBackups: true  # true
       DailyAutomaticBackupStartTime: 01:03  # 01:03

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -118,7 +118,7 @@ Iam:
     CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
   S3Access:
     - BucketName: String
-      Type: READ_WRITE # READ_ONLY | READ_WRITE
+      EnableWriteAccess: False
   AdditionalIamPolicies:
     - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
     - Policy: policy2

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -66,7 +66,7 @@ Scheduling:
             HttpProxyAddress: String  # https://proxy-address:port
         ComputeResources:  # this maps to a Batch compute environment (initially we support only 1)
           - Name: compute_resource
-            InstanceType: optimal,c4.xlarge,c5.large
+            InstanceTypes: optimal,c4.xlarge,c5.large
             MinvCpus: 0  # 0
             DesiredvCpus: 10
             MaxvCpus: 20

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -128,8 +128,6 @@ Monitoring:
     CloudWatch:
       Enabled: true  # true
       RetentionInDays: 14  # 14
-      LogGroupId: String
-      KmsKeyId: String
   Dashboards:
     CloudWatch:
       Enabled: true  # true

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.simple.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.simple.yaml
@@ -19,7 +19,9 @@ Scheduling:
             MaxvCpus: 10
 SharedStorage:
   - MountDir: /shared
-    Ebs:
+    Name: ebs1
+    StorageType: Ebs
+    Settings:
       VolumeType: gp2  # gp2 | gp3 | io1 | io2 | sc1 | st1 | standard
       Iops: 100
       Size: 150

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.simple.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.simple.yaml
@@ -13,7 +13,6 @@ Scheduling:
         Networking:
           SubnetIds:
             - subnet-12345678
-            - subnet-23456789
         ComputeResources:
           - Name: compute_resource1
             InstanceType: c4.xlarge,c5.large|optimal|c5,c4

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.simple.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.simple.yaml
@@ -15,7 +15,7 @@ Scheduling:
             - subnet-12345678
         ComputeResources:
           - Name: compute_resource1
-            InstanceType: c4.xlarge,c5.large|optimal|c5,c4
+            InstanceTypes: c4.xlarge,c5.large|optimal|c5,c4
             MaxvCpus: 10
 SharedStorage:
   - MountDir: /shared

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -115,7 +115,6 @@ Scheduling:
             Efa:
               Enabled: true
               GdrSupport: false
-            AllocationStrategy: String
 SharedStorage:
   - MountDir: /my/mount/point1
     Ebs:

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -44,7 +44,7 @@ HeadNode:
       CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
     S3Access:
       - BucketName: String
-        Type: READ_ONLY
+        EnableWriteAccess: True
     AdditionalIamPolicies:
       - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
 Scheduling:
@@ -77,7 +77,7 @@ Scheduling:
             CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
           S3Access:
             - BucketName: String
-              Type: READ_ONLY
+              EnableWriteAccess: False
           AdditionalIamPolicies:
             - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
       - Name: queue2
@@ -153,7 +153,7 @@ Iam:
     CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
   S3Access:
     - BucketName: String
-      Type: READ_ONLY
+      EnableWriteAccess: False
   AdditionalIamPolicies:
     - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
     - Policy: policy2

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -7,9 +7,6 @@ HeadNode:
     SubnetId: subnet-12345678  # subnet-xxx
     ElasticIp: String  # true|false|EIP-id
     AssignPublicIp: True  # true|false
-    SecurityGroups:
-      - sg-12345678
-      - sg-23456789
     AdditionalSecurityGroups:
       - sg-34567890
       - sg-45678901
@@ -19,7 +16,7 @@ HeadNode:
   Ssh:
     KeyName: ec2-key-name
     AllowedIps: 1.2.3.4/32
-  Storage:
+  LocalStorage:
     RootVolume:
       Size: 40
       Encrypted: true
@@ -89,7 +86,7 @@ Scheduling:
           AdditionalIamPolicies:
             - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
       - Name: queue2
-        Storage:
+        LocalStorage:
           RootVolume:
             Size:  35
             Encrypted:  true
@@ -107,8 +104,6 @@ Scheduling:
           AssignPublicIp: true
           SecurityGroups:
             - sg-12345678
-          AdditionalSecurityGroups:
-            - sg-23456789
           PlacementGroup:
             Enabled: true
             Id: String

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -102,7 +102,9 @@ Scheduling:
               GdrSupport: false
 SharedStorage:
   - MountDir: /my/mount/point1
-    Ebs:
+    Name: name1
+    StorageType: Ebs
+    Settings:
       VolumeType: gp2  # gp2 | gp3 | io1 | io2 | sc1 | st1 | standard
       Iops: 100
       Size: 150
@@ -111,11 +113,15 @@ SharedStorage:
       SnapshotId: snap-12345678
       VolumeId: vol-12345678
   - MountDir: /my/mount/point2
-    Efs:
+    Name: name2
+    StorageType: Efs
+    Settings:
       ThroughputMode: provisioned  # bursting | provisioned
       ProvisionedThroughput: 1024
   - MountDir: /my/mount/point3
-    FsxLustre:
+    Name: name3
+    StorageType: FsxLustre
+    Settings:
       StorageCapacity: 3600
       DeploymentType: PERSISTENT_1  # PERSISTENT_1 | SCRATCH_1 | SCRATCH_2
       ImportedFileChunkSize: 1024

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -100,7 +100,6 @@ Scheduling:
         Networking:
           SubnetIds:
             - subnet-12345678
-            - subnet-23456789
           AssignPublicIp: true
           SecurityGroups:
             - sg-12345678

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -53,8 +53,6 @@ Scheduling:
       ScaledownIdletime: 10
       Dns:
         DisableManagedDns: true
-        Domain: String
-        HostedZoneId: String
     Queues:
       - Name: queue1
         ComputeType: ONDEMAND

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -38,9 +38,6 @@ HeadNode:
         - stirng2
       Event: NODE_START
       RunAs: String
-  Efa:
-    Enabled: false
-    GdrSupport: false
   Iam:
     Roles:
       InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -163,8 +163,6 @@ Monitoring:
     CloudWatch:
       Enabled: true  # true
       RetentionInDays: 30  # 14
-      LogGroupId: String
-      KmsKeyId: String
   Dashboards:
     CloudWatch:
       Enabled: true  # true

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -39,14 +39,10 @@ HeadNode:
       Event: NODE_START
       RunAs: String
   Iam:
-    Roles:
-      InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
-      CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
+    InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
     S3Access:
       - BucketName: String
         EnableWriteAccess: True
-    AdditionalIamPolicies:
-      - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
 Scheduling:
   Slurm:
     Settings:
@@ -72,9 +68,6 @@ Scheduling:
             Event: NODE_START
             RunAs: String
         Iam:
-          Roles:
-            InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
-            CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
           S3Access:
             - BucketName: String
               EnableWriteAccess: False
@@ -149,14 +142,7 @@ SharedStorage:
       StorageType: HDD  # HDD | SSD
 Iam:
   Roles:
-    InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
     CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
-  S3Access:
-    - BucketName: String
-      EnableWriteAccess: False
-  AdditionalIamPolicies:
-    - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
-    - Policy: policy2
 Monitoring:
   DetailedMonitoring: true  # false
   Logs:

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -121,7 +121,7 @@ SharedStorage:
       ImportedFileChunkSize: 1024
       ExportPath: String  # s3://bucket/folder
       ImportPath: String  # s3://bucket
-      # WeeklyMaintenanceStartTime: 1:00:00
+      WeeklyMaintenanceStartTime: "1:00:00"
       AutomaticBackupRetentionDays: 0
       CopyTagsToBackups: true
       DailyAutomaticBackupStartTime: 01:03

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -20,10 +20,6 @@ HeadNode:
     RootVolume:
       Size: 40
       Encrypted: true
-      KmsKeyId: String
-      VolumeType: gp2
-      Iops: 100
-      Throughput: 150
     EphemeralVolume:
       Encrypted: true
       MountDir: /test
@@ -78,10 +74,6 @@ Scheduling:
           RootVolume:
             Size:  35
             Encrypted:  true
-            KmsKeyId: String
-            VolumeType: gp2
-            Iops: 100
-            Throughput: 100
           EphemeralVolume:
             Encrypted: true
             MountDir: /scratch

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -33,7 +33,6 @@ HeadNode:
         - String  # arg1
         - stirng2
       Event: NODE_START
-      RunAs: String
   Iam:
     InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
     S3Access:
@@ -62,7 +61,6 @@ Scheduling:
               - String  # arg1
               - stirng2
             Event: NODE_START
-            RunAs: String
         Iam:
           S3Access:
             - BucketName: String

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -153,12 +153,12 @@ def test_awsbatch_compute_resource_validator(section_dict, expected_message):
     "section_dict, expected_message",
     [
         ({"ComputeResources": []}, "Length must be 1"),
-        ({"ComputeResources": [{"Name": "compute_resource1", "InstanceType": "c5.xlarge"}]}, None),
+        ({"ComputeResources": [{"Name": "compute_resource1", "InstanceTypes": "c5.xlarge"}]}, None),
         (
             {
                 "ComputeResources": [
-                    {"Name": "compute_resource1", "InstanceType": "c5.xlarge"},
-                    {"Name": "compute_resource1", "InstanceType": "c4.xlarge"},
+                    {"Name": "compute_resource1", "InstanceTypes": "c4.xlarge,c5.xlarge"},
+                    {"Name": "compute_resource1", "InstanceTypes": "c4.xlarge"},
                 ]
             },
             "Length must be 1",

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
@@ -13,7 +13,6 @@ Scheduling:
         Networking:
           SubnetIds:
             - subnet-12345678
-            - subnet-23456789
         ComputeResources:
           - Name: compute_resource1
             InstanceType: c4.xlarge

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
@@ -15,7 +15,7 @@ Scheduling:
             - subnet-12345678
         ComputeResources:
           - Name: compute_resource1
-            InstanceType: c4.xlarge
+            InstanceTypes: c4.xlarge
             MaxvCpus: 10
 SharedStorage:
   - MountDir: /my/mount/ebs1

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
@@ -19,19 +19,29 @@ Scheduling:
             MaxvCpus: 10
 SharedStorage:
   - MountDir: /my/mount/ebs1
-    Ebs:
+    Name: name1
+    StorageType: Ebs
+    Settings:
       VolumeType: sc1
   - MountDir: /my/mount/ebs2
-    Ebs:
+    Name: name2
+    StorageType: Ebs
+    Settings:
       VolumeType: st1
   - MountDir: /my/mount/ebs3
-    Ebs:
+    Name: name3
+    StorageType: Ebs
+    Settings:
       VolumeType: gp2
   - MountDir: /my/mount/ebs4
-    Ebs:
+    Name: name4
+    StorageType: Ebs
+    Settings:
       VolumeType: sc1
   - MountDir: /my/mount/ebs5
-    Ebs:
+    Name: name5
+    StorageType: Ebs
+    Settings:
       VolumeType: st1
 Monitoring:
   DetailedMonitoring: true

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
@@ -39,8 +39,6 @@ Monitoring:
     CloudWatch:
       Enabled: false
       RetentionInDays: 14
-      LogGroupId: String
-      KmsKeyId: String
   Dashboards:
     CloudWatch:
       Enabled: true

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.slurm.conditional_vol.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.slurm.conditional_vol.yaml
@@ -34,12 +34,16 @@ Scheduling:
             InstanceType: c4.2xlarge
 SharedStorage:
   - MountDir: /my/mount/ebs1
-    Ebs:
+    Name: name1
+    StorageType: Ebs
+    Settings:
       VolumeType: io1
       Size: 150
       Encrypted: True
   - MountDir: /my/mount/raid1
-    Ebs:
+    Name: name2
+    StorageType: Ebs
+    Settings:
       VolumeType: io1
       Size: 20
       Iops: 100
@@ -48,12 +52,16 @@ SharedStorage:
         Type: 1
         NumberOfVolumes: 2
   - MountDir: /my/mount/efs1
-    Efs:
+    Name: name3
+    StorageType: Efs
+    Settings:
       ThroughputMode: bursting
       PerformanceMode: maxIO
       Encrypted: False
   - MountDir: /my/mount/fsx1
-    FsxLustre:
+    Name: name4
+    StorageType: FsxLustre
+    Settings:
       StorageCapacity: 1200
 Monitoring:
   DetailedMonitoring: true

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.slurm.conditional_vol.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.slurm.conditional_vol.yaml
@@ -61,8 +61,6 @@ Monitoring:
     CloudWatch:
       Enabled: true
       RetentionInDays: 14
-      LogGroupId: String
-      KmsKeyId: String
   Dashboards:
     CloudWatch:
       Enabled: true

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos8.slurm.full.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos8.slurm.full.yaml
@@ -73,6 +73,7 @@ SharedStorage:
   - MountDir: /my/mount/fsx1
     FsxLustre:
       StorageCapacity: 1200
+      WeeklyMaintenanceStartTime: "1:00:00"
 Monitoring:
   DetailedMonitoring: true
   Logs:

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos8.slurm.full.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos8.slurm.full.yaml
@@ -79,8 +79,6 @@ Monitoring:
     CloudWatch:
       Enabled: true
       RetentionInDays: 14
-      LogGroupId: String
-      KmsKeyId: String
   Dashboards:
     CloudWatch:
       Enabled: true

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos8.slurm.full.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos8.slurm.full.yaml
@@ -34,30 +34,42 @@ Scheduling:
             InstanceType: c4.2xlarge
 SharedStorage:
   - MountDir: /my/mount/ebs1
-    Ebs:
+    Name: name1
+    StorageType: Ebs
+    Settings:
       VolumeType: gp2
       Size: 150
       Encrypted: True
   - MountDir: /my/mount/ebs2
-    Ebs:
+    Name: name2
+    StorageType: Ebs
+    Settings:
       VolumeType: io1
       Size: 150
       Encrypted: True
   - MountDir: /my/mount/ebs3
-    Ebs:
+    Name: name3
+    StorageType: Ebs
+    Settings:
       VolumeType: sc1
       Size: 150
       Encrypted: True
   - MountDir: /my/mount/ebs4
-    Ebs:
+    Name: name4
+    StorageType: Ebs
+    Settings:
       VolumeType: st1
       Encrypted: True
   - MountDir: /my/mount/ebs5
-    Ebs:
+    Name: name5
+    StorageType: Ebs
+    Settings:
       VolumeType: gp2
       Encrypted: True
   - MountDir: /my/mount/raid1
-    Ebs:
+    Name: name6
+    StorageType: Ebs
+    Settings:
       VolumeType: gp2
       Size: 20
       Iops: 100
@@ -66,12 +78,16 @@ SharedStorage:
         Type: 1
         NumberOfVolumes: 2
   - MountDir: /my/mount/efs1
-    Efs:
+    Name: name7
+    StorageType: Efs
+    Settings:
       ThroughputMode: bursting
       PerformanceMode: generalPurpose
       Encrypted: False
   - MountDir: /my/mount/fsx1
-    FsxLustre:
+    Name: name8
+    StorageType: FsxLustre
+    Settings:
       StorageCapacity: 1200
       WeeklyMaintenanceStartTime: "1:00:00"
 Monitoring:

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/ubuntu18.slurm.no_dashboard.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/ubuntu18.slurm.no_dashboard.yaml
@@ -54,8 +54,6 @@ Monitoring:
     CloudWatch:
       Enabled: true
       RetentionInDays: 14
-      LogGroupId: String
-      KmsKeyId: String
   Dashboards:
     CloudWatch:
       Enabled: false

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/ubuntu18.slurm.no_dashboard.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/ubuntu18.slurm.no_dashboard.yaml
@@ -34,19 +34,29 @@ Scheduling:
             InstanceType: c4.2xlarge
 SharedStorage:
   - MountDir: /my/mount/ebs1
-    Ebs:
+    Name: name1
+    StorageType: Ebs
+    Settings:
       VolumeType: gp2
   - MountDir: /my/mount/ebs2
-    Ebs:
+    Name: name2
+    StorageType: Ebs
+    Settings:
       VolumeType: io1
   - MountDir: /my/mount/ebs3
-    Ebs:
+    Name: name3
+    StorageType: Ebs
+    Settings:
       VolumeType: sc1
   - MountDir: /my/mount/ebs4
-    Ebs:
+    Name: name4
+    StorageType: Ebs
+    Settings:
       VolumeType: st1
   - MountDir: /my/mount/ebs5
-    Ebs:
+    Name: name5
+    StorageType: Ebs
+    Settings:
       VolumeType: gp2
 Monitoring:
   DetailedMonitoring: false

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/ubuntu18.slurm.simple.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/ubuntu18.slurm.simple.yaml
@@ -34,8 +34,6 @@ Monitoring:
     CloudWatch:
       Enabled: true
       RetentionInDays: 14
-      LogGroupId: String
-      KmsKeyId: String
   Dashboards:
     CloudWatch:
       Enabled: true

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -100,7 +100,6 @@ Scheduling:
         Networking:
           SubnetIds:
             - subnet-12345678
-            - subnet-23456789
           AssignPublicIp: true
           AdditionalSecurityGroups:
             - sg-23456789

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -115,7 +115,6 @@ Scheduling:
             Efa:
               Enabled: true
               GdrSupport: false
-            AllocationStrategy: String
 SharedStorage:
   - MountDir: /my/mount/point1
     Ebs:

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -44,7 +44,7 @@ HeadNode:
       CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
     S3Access:
       - BucketName: String
-        Type: READ_ONLY
+        EnableWriteAccess: True
     AdditionalIamPolicies:
       - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
 Scheduling:
@@ -77,7 +77,7 @@ Scheduling:
             CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
           S3Access:
             - BucketName: String
-              Type: READ_ONLY
+              EnableWriteAccess: False
           AdditionalIamPolicies:
             - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
       - Name: queue2
@@ -153,7 +153,6 @@ Iam:
     CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
   S3Access:
     - BucketName: String
-      Type: READ_ONLY
   AdditionalIamPolicies:
     - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
     - Policy: policy2

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -102,7 +102,9 @@ Scheduling:
               GdrSupport: false
 SharedStorage:
   - MountDir: /my/mount/point1
-    Ebs:
+    Name: name1
+    StorageType: Ebs
+    Settings:
       VolumeType: gp2  # gp2 | gp3 | io1 | io2 | sc1 | st1 | standard
       Iops: 100
       Size: 150
@@ -111,11 +113,15 @@ SharedStorage:
       SnapshotId: snap-12345678
       VolumeId: vol-12345678
   - MountDir: /my/mount/point2
-    Efs:
+    Name: name2
+    StorageType: Efs
+    Settings:
       ThroughputMode: provisioned  # bursting | provisioned
       ProvisionedThroughput: 1024
   - MountDir: /my/mount/point3
-    FsxLustre:
+    Name: name3
+    StorageType: FsxLustre
+    Settings:
       StorageCapacity: 3600
       DeploymentType: PERSISTENT_1  # PERSISTENT_1 | SCRATCH_1 | SCRATCH_2
       ImportedFileChunkSize: 1024

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -53,8 +53,6 @@ Scheduling:
       ScaledownIdletime: 10
       Dns:
         DisableManagedDns: true
-        Domain: String
-        HostedZoneId: String
     Queues:
       - Name: queue1
         ComputeType: ONDEMAND

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -38,9 +38,6 @@ HeadNode:
         - stirng2
       Event: NODE_START
       RunAs: String
-  Efa:
-    Enabled: false
-    GdrSupport: false
   Iam:
     Roles:
       InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -163,8 +163,6 @@ Monitoring:
     CloudWatch:
       Enabled: true  # true
       RetentionInDays: 30  # 14
-      LogGroupId: String
-      KmsKeyId: String
   Dashboards:
     CloudWatch:
       Enabled: true  # true

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -10,16 +10,13 @@ HeadNode:
     SecurityGroups:
       - sg-12345678
       - sg-23456789
-    AdditionalSecurityGroups:
-      - sg-34567890
-      - sg-45678901
     Proxy:
       HttpProxyAddress: String  # https://proxy-address:port
   DisableSimultaneousMultithreading: false
   Ssh:
     KeyName: ec2-key-name
     AllowedIps: 1.2.3.4/32
-  Storage:
+  LocalStorage:
     RootVolume:
       Size: 40
       Encrypted: true
@@ -89,7 +86,7 @@ Scheduling:
           AdditionalIamPolicies:
             - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
       - Name: queue2
-        Storage:
+        LocalStorage:
           RootVolume:
             Size:  35
             Encrypted:  true
@@ -105,8 +102,6 @@ Scheduling:
             - subnet-12345678
             - subnet-23456789
           AssignPublicIp: true
-          SecurityGroups:
-            - sg-12345678
           AdditionalSecurityGroups:
             - sg-23456789
           PlacementGroup:

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -39,14 +39,10 @@ HeadNode:
       Event: NODE_START
       RunAs: String
   Iam:
-    Roles:
-      InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
-      CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
+    InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
     S3Access:
       - BucketName: String
         EnableWriteAccess: True
-    AdditionalIamPolicies:
-      - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
 Scheduling:
   Slurm:
     Settings:
@@ -72,9 +68,6 @@ Scheduling:
             Event: NODE_START
             RunAs: String
         Iam:
-          Roles:
-            InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
-            CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
           S3Access:
             - BucketName: String
               EnableWriteAccess: False
@@ -149,13 +142,7 @@ SharedStorage:
       StorageType: HDD  # HDD | SSD
 Iam:
   Roles:
-    InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
     CustomLambdaResources: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
-  S3Access:
-    - BucketName: String
-  AdditionalIamPolicies:
-    - Policy: String  # arn:aws:iam::aws:policy/AdministratorAccess
-    - Policy: policy2
 Monitoring:
   DetailedMonitoring: true  # false
   Logs:

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -121,7 +121,7 @@ SharedStorage:
       ImportedFileChunkSize: 1024
       ExportPath: String  # s3://bucket/folder
       ImportPath: String  # s3://bucket
-      # WeeklyMaintenanceStartTime: 1:00:00
+      WeeklyMaintenanceStartTime: "1:00:00"
       AutomaticBackupRetentionDays: 0
       CopyTagsToBackups: true
       DailyAutomaticBackupStartTime: 01:03

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -20,10 +20,6 @@ HeadNode:
     RootVolume:
       Size: 40
       Encrypted: true
-      KmsKeyId: String
-      VolumeType: gp2
-      Iops: 100
-      Throughput: 150
     EphemeralVolume:
       Encrypted: true
       MountDir: /test
@@ -78,10 +74,6 @@ Scheduling:
           RootVolume:
             Size:  35
             Encrypted:  true
-            KmsKeyId: String
-            VolumeType: gp2
-            Iops: 100
-            Throughput: 100
           EphemeralVolume:
             Encrypted: true
             MountDir: /scratch

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -33,7 +33,6 @@ HeadNode:
         - String  # arg1
         - stirng2
       Event: NODE_START
-      RunAs: String
   Iam:
     InstanceRole: String  # arn:aws:iam::aws:role/CustomHeadNodeRole
     S3Access:
@@ -62,7 +61,6 @@ Scheduling:
               - String  # arg1
               - stirng2
             Event: NODE_START
-            RunAs: String
         Iam:
           S3Access:
             - BucketName: String

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_2.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_2.yaml
@@ -20,8 +20,12 @@ Scheduling:
             InstanceType: c5.xlarge
 SharedStorage:
   - MountDir: /my/mount/point2
-    Efs:
+    Name: name1
+    StorageType: Efs
+    Settings:
       FileSystemId: fs-12345678123456789
   - MountDir: /my/mount/point3
-    FsxLustre:
+    Name: name2
+    StorageType: FsxLustre
+    Settings:
       FileSystemId: fs-12345678123456789

--- a/cli/tests/pcluster/validators/test_all_validators/test_validators_are_called_with_correct_argument/slurm.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_validators_are_called_with_correct_argument/slurm.yaml
@@ -31,12 +31,18 @@ Scheduling:
             InstanceType: c4.4xlarge
 SharedStorage:
   - MountDir: /my/mount/point1
-    Ebs:
+    Name: name1
+    StorageType: Ebs
+    Settings:
       VolumeId: vol-12345678
   - MountDir: /my/mount/point2
-    Efs:
+    Name: name2
+    StorageType: Efs
+    Settings:
       Encrypted: True
       KmsKeyId: 1234abcd-12ab-34cd-56ef-1234567890ab
   - MountDir: /my/mount/point3
-    FsxLustre:
+    Name: name3
+    StorageType: FsxLustre
+    Settings:
       StorageCapacity: 3600

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -215,9 +215,9 @@ class SgeCommands(SchedulerCommands):
             "echo '{0}' | qsub {1}".format(command, flags), raise_on_error=False
         )
 
-    def submit_script(
+    def submit_script(  # noqa: D102
         self, script, script_args=None, nodes=1, slots=None, additional_files=None, host=None
-    ):  # noqa: D102
+    ):
         if not additional_files:
             additional_files = []
         if not script_args:
@@ -307,7 +307,7 @@ class SlurmCommands(SchedulerCommands):
         assert_that(match).is_not_none()
         return match.group(1)
 
-    def submit_command(
+    def submit_command(  # noqa: D102
         self,
         command,
         nodes=0,
@@ -318,7 +318,7 @@ class SlurmCommands(SchedulerCommands):
         constraint=None,
         other_options=None,
         raise_on_error=True,
-    ):  # noqa: D102
+    ):
         job_submit_command = "--wrap='{0}'".format(command)
 
         return self._submit_batch_job(
@@ -333,7 +333,7 @@ class SlurmCommands(SchedulerCommands):
             raise_on_error=raise_on_error,
         )
 
-    def submit_script(
+    def submit_script(  # noqa: D102
         self,
         script,
         script_args=None,
@@ -346,7 +346,7 @@ class SlurmCommands(SchedulerCommands):
         other_options=None,
         additional_files=None,
         raise_on_error=True,
-    ):  # noqa: D102
+    ):
         if not additional_files:
             additional_files = []
         if not script_args:


### PR DESCRIPTION
- Add validation for not allowing AdditionalSecurityGroups and SecurityGroups to co-exist
- Rename Storage to LocalStorage in HeadNode and Queue
- Remove CustomActions/RunAs* (not supported for now)
- Fixed broken unit tests when making these changes
- Remove KMSKey,VolumeType, Iops, Throughput from RootVolume
- Update HeadNode and Queue IAM to be the same as document, validate InstanceRole and AdditionalIamPolicies are mutually exclusive
- Change ComputeResources/InstanceType --> InstanceTypes when using AWsBatch
- Change S3Access/Type(READ_ONLY|READ_WRITE) to S3Access/EnableWriteAccess
- Remove Logs/CloudWatch/LogGroupId and KmsKeyId, Queue/ComputeResource/AllocationStrategy, Slurm/Settings/Dns/Domain and HostedZoneId, HeadNode Efa
- Validate SubnetIds in Queue only support one SubnetId
