### PR TITLE
Increase scaledown time to 30 mins in update hit test

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -216,9 +216,8 @@ class SgeCommands(SchedulerCommands):
             "echo '{0}' | qsub {1}".format(command, flags), raise_on_error=False
         )
 
-    def submit_script(
-        self, script, script_args=None, nodes=1, slots=None, additional_files=None, host=None
-    ):  # noqa: D102
+    def submit_script(self, script, script_args=None, nodes=1, slots=None, additional_files=None, host=None):
+        """Submit job with script."""
         if not additional_files:
             additional_files = []
         if not script_args:
@@ -319,7 +318,8 @@ class SlurmCommands(SchedulerCommands):
         constraint=None,
         other_options=None,
         raise_on_error=True,
-    ):  # noqa: D102
+    ):
+        """Submit job with command."""
         job_submit_command = "--wrap='{0}'".format(command)
 
         return self._submit_batch_job(
@@ -347,7 +347,8 @@ class SlurmCommands(SchedulerCommands):
         other_options=None,
         additional_files=None,
         raise_on_error=True,
-    ):  # noqa: D102
+    ):
+        """Submit job with script."""
         if not additional_files:
             additional_files = []
         if not script_args:

--- a/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.ini
@@ -61,7 +61,7 @@ shared_dir = shared
 #volume_iops = None #Initially not set
 
 [scaling custom]
-#scaledown_idletime = None #Initially not set
+scaledown_idletime = 30
 
 [efs custom]
 shared_dir = efs

--- a/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.update.ini
@@ -77,7 +77,7 @@ shared_dir = shared
 volume_iops = 140
 
 [scaling custom]
-#scaledown_idletime = None #Initially not set
+scaledown_idletime = 30
 
 [efs custom]
 shared_dir = efs


### PR DESCRIPTION
* Increase scaledown time to 30 mins to keep t2.micro dynamic nodes up with initial_count = 1
* Fix D102 failure in CI

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
