### PR TITLE
Backport: Increase scaledown time to 30 mins in update hit test

### DIFF
--- a/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.ini
@@ -61,7 +61,7 @@ shared_dir = shared
 #volume_iops = None #Initially not set
 
 [scaling custom]
-#scaledown_idletime = None #Initially not set
+scaledown_idletime = 30
 
 [efs custom]
 shared_dir = efs

--- a/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.update.ini
@@ -77,7 +77,7 @@ shared_dir = shared
 volume_iops = 140
 
 [scaling custom]
-#scaledown_idletime = None #Initially not set
+scaledown_idletime = 30
 
 [efs custom]
 shared_dir = efs


### PR DESCRIPTION
Increase scaledown time to 30 mins to keep t2.micro dynamic nodes up with initial_count = 1

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
