### PR TITLE
Drop support for python versions < 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         name:
-          - Python 2.7 Tests
-          - Python 3.5 Tests
           - Python 3.6 Tests
           - Python 3.7 Tests
           - Python 3.8 Tests
@@ -21,14 +19,6 @@ jobs:
           - CloudFormation Templates Checks
           - Integration Tests Config Checks
         include:
-          - name: Python 2.7 Tests
-            python: 2.7
-            toxdir: cli
-            toxenv: py27-nocov
-          - name: Python 3.5 Tests
-            python: 3.5
-            toxdir: cli
-            toxenv: py35-nocov
           - name: Python 3.6 Tests
             python: 3.6
             toxdir: cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ CHANGELOG
   - Add new SlurmctldParameters, power_save_min_interval=30, so power actions will be processed every 30 seconds
   - Specify instance GPU model as GRES GPU Type in gres.conf, instead of previous hardcoded value for all GPU, Type=tesla
 - Make `key_name` parameter optional to support cluster configurations without a key pair. 
-- Remove support for Python 3.4
+- Remove support for Python versions < 3.6.
+- Remove dependency on `future` package and `__future__` module.
 - Root volume size increased from 25GB to 35GB on all AMIs. Minimum root volume size is now 35GB.
 - Add sanity check to prevent cluster creation in non officially supported AWS regions 
 

--- a/cli/.isort.cfg
+++ b/cli/.isort.cfg
@@ -1,6 +1,5 @@
 [settings]
 line_length=120
-known_future_library=future,__future__
 known_third_party=boto3,botocore,awscli,tabulate,argparse,configparser,pytest,pytest,pytest-datadir,pytest-html,pytest-rerunfailures,pytest-xdist,argparse,retrying,junitparser,Jinja2
 # 3 - Vertical Hanging Indent
 # from third_party import (

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -1,5 +1,4 @@
 boto3>=1.16.14
-future>=0.18.2
 tabulate>=0.8.2,<=0.8.7
 ipaddress>=1.0.22
 enum34>=1.1.6

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -25,7 +25,6 @@ VERSION = "2.10.3"
 REQUIRES = [
     "setuptools",
     "boto3>=1.16.14",
-    "future>=0.16.0,<=0.18.2",
     "tabulate==0.8.5" if sys.version_info.major == 3 and sys.version_info.minor <= 4 else "tabulate>=0.8.2,<=0.8.7",
     "ipaddress>=1.0.22",
     "PyYAML==5.2" if sys.version_info.major == 3 and sys.version_info.minor <= 4 else "PyYAML>=5.3.1",
@@ -46,7 +45,7 @@ setup(
     license="Apache License 2.0",
     package_dir={"": "src"},
     packages=find_packages("src"),
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires=">=3.6",
     install_requires=REQUIRES,
     entry_points={
         "console_scripts": [
@@ -68,10 +67,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/cli/src/awsbatch/awsbhosts.py
+++ b/cli/src/awsbatch/awsbhosts.py
@@ -11,7 +11,6 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-from __future__ import print_function
 
 import collections
 import sys

--- a/cli/src/awsbatch/awsbkill.py
+++ b/cli/src/awsbatch/awsbkill.py
@@ -11,7 +11,6 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-from __future__ import print_function
 
 import sys
 

--- a/cli/src/awsbatch/awsbout.py
+++ b/cli/src/awsbatch/awsbout.py
@@ -11,7 +11,6 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-from __future__ import print_function
 
 import sys
 import time

--- a/cli/src/awsbatch/awsbqueues.py
+++ b/cli/src/awsbatch/awsbqueues.py
@@ -11,7 +11,6 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-from __future__ import print_function
 
 import collections
 import sys

--- a/cli/src/awsbatch/awsbstat.py
+++ b/cli/src/awsbatch/awsbstat.py
@@ -11,7 +11,6 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-from __future__ import print_function
 
 import collections
 import re

--- a/cli/src/awsbatch/awsbsub.py
+++ b/cli/src/awsbatch/awsbsub.py
@@ -11,7 +11,6 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-from __future__ import print_function
 
 import os
 import pipes

--- a/cli/src/awsbatch/common.py
+++ b/cli/src/awsbatch/common.py
@@ -11,7 +11,6 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-from __future__ import print_function
 
 import errno
 import logging

--- a/cli/src/awsbatch/utils.py
+++ b/cli/src/awsbatch/utils.py
@@ -11,7 +11,6 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-from __future__ import print_function
 
 import pipes
 import re
@@ -115,9 +114,6 @@ def is_mnp_job(job):
 def get_job_type(job):
     """
     Get the type of the job.
-
-    Job type is of type string and not enum since enums have been introduced
-    since Python 3.4.
 
     :param job: the job dictionary returned by AWS Batch api
     :return: one of ["SIMPLE", "ARRAY", "MNP"]

--- a/cli/src/pcluster/cli.py
+++ b/cli/src/pcluster/cli.py
@@ -8,7 +8,6 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
 
 import errno
 import json

--- a/cli/src/pcluster/cli_commands/update.py
+++ b/cli/src/pcluster/cli_commands/update.py
@@ -9,8 +9,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
 import logging
 import sys
 import time

--- a/cli/src/pcluster/commands.py
+++ b/cli/src/pcluster/commands.py
@@ -14,8 +14,6 @@
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-statements
 
-from __future__ import absolute_import, print_function
-
 import json
 import logging
 import os

--- a/cli/src/pcluster/config/cfn_param_types.py
+++ b/cli/src/pcluster/config/cfn_param_types.py
@@ -268,8 +268,6 @@ class JsonCfnParam(CfnParam):
         """Return internal representation starting from CFN/user-input value."""
         param_value = self.get_default_value()
         try:
-            # Do not convert empty string and use format and yaml.load in place of json.loads
-            # for Python 2.7 compatibility because it returns unicode chars
             if string_value:
                 string_value = str(string_value).strip()
                 if string_value != "NONE":

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -8,7 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from future.moves.collections import OrderedDict
+from collections import OrderedDict
 
 import boto3
 
@@ -326,8 +326,7 @@ EBS = {
     "max_resources": 5,
     "validators": [ebs_volume_type_size_validator, ebs_volume_iops_validator, ebs_volume_size_snapshot_validator,
                    ebs_volume_throughput_validator],
-    "params": OrderedDict([  # Use OrderedDict because the in python 3.5 a dict is not ordered by default, need it in
-        # the test of hit converter
+    "params": OrderedDict([
         ("shared_dir", {
             "allowed_values": ALLOWED_VALUES["file_path"],
             "cfn_param_mapping": "SharedDir",

--- a/cli/src/pcluster/config/pcluster_config.py
+++ b/cli/src/pcluster/config/pcluster_config.py
@@ -8,14 +8,13 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from future.moves.collections import OrderedDict
-
 import errno
 import json
 import logging
 import os
 import stat
 import sys
+from collections import OrderedDict
 
 import boto3
 import configparser

--- a/cli/src/pcluster/configure/easyconfig.py
+++ b/cli/src/pcluster/configure/easyconfig.py
@@ -8,11 +8,6 @@
 # or in the 'LICENSE.txt' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-# fmt: off
-from __future__ import absolute_import, print_function  # isort:skip
-from future import standard_library  # isort:skip
-standard_library.install_aliases()
-# fmt: on
 
 import logging
 import os

--- a/cli/src/pcluster/configure/networking.py
+++ b/cli/src/pcluster/configure/networking.py
@@ -8,9 +8,8 @@
 # or in the 'LICENSE.txt' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from future.backports import datetime
-
 import abc
+import datetime
 import logging
 import sys
 from enum import Enum
@@ -151,9 +150,6 @@ class PublicPrivateNetworkConfig(BaseNetworkConfig):
 
 class NetworkConfiguration(Enum):
     """Contain all possible network configuration."""
-
-    # py2.7 compatibility, need to specify the order
-    __order__ = "PUBLIC_PRIVATE PUBLIC"
 
     PUBLIC_PRIVATE = PublicPrivateNetworkConfig()
     PUBLIC = PublicNetworkConfig()

--- a/cli/src/pcluster/configure/subnet_computation.py
+++ b/cli/src/pcluster/configure/subnet_computation.py
@@ -8,12 +8,10 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import unicode_literals
 
 from ipaddress import ip_address, ip_network, summarize_address_range
 
 
-# py2.7 compatibility
 def unicode(ip):
     return "{0}".format(ip)
 

--- a/cli/src/pcluster/createami.py
+++ b/cli/src/pcluster/createami.py
@@ -14,8 +14,6 @@
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-statements
 
-from __future__ import absolute_import, print_function
-
 import datetime
 import json
 import logging

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/crhelper/log_helper.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/crhelper/log_helper.py
@@ -1,6 +1,5 @@
 # Imported from https://github.com/aws-cloudformation/custom-resource-helper
 # flake8: noqa
-from __future__ import print_function
 
 import json
 import logging

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/crhelper/resource_helper.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/crhelper/resource_helper.py
@@ -9,8 +9,6 @@ TODO:
 * Functional tests
 """
 
-from __future__ import print_function
-
 import json
 import logging
 import os

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/crhelper/utils.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/crhelper/utils.py
@@ -1,7 +1,6 @@
 # Imported from https://github.com/aws-cloudformation/custom-resource-helper
 # The file has been modified to drop dependency on requests package
 # flake8: noqa
-from __future__ import print_function
 
 import json
 import logging as logging

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -8,15 +8,8 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-# fmt: off
-from __future__ import absolute_import, print_function  # isort:skip
 
 import functools
-
-from future import standard_library  # isort:skip
-standard_library.install_aliases()
-# fmt: on
-
 import hashlib
 import json
 import logging

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -3,7 +3,6 @@ This module loads pytest fixtures and plugins needed by all tests.
 
 It's very useful for fixtures that need to be shared among all tests.
 """
-from __future__ import print_function
 
 import os
 

--- a/cli/tests/pcluster/configure/test_pcluster_configure.py
+++ b/cli/tests/pcluster/configure/test_pcluster_configure.py
@@ -397,7 +397,6 @@ def get_file_path(test_datadir):
     config = test_datadir / "pcluster.config.ini"
     output = test_datadir / "output.txt"
     error = test_datadir / "error.txt"
-    #  str for python 2.7 compatibility
     return str(config), str(error), str(output)
 
 

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 toxworkdir=../.tox
 envlist =
-    py{27,34,35,36,37,38,39}-{cov,nocov}
+    py{36,37,38,39}-{cov,nocov}
     code-linters
     cfn-{tests,lint,format-check}
 


### PR DESCRIPTION
* Remove dependency on `future` package and `__future__` module. `absolute_import`, `print_function`, `unicode_literals` are available natively with python3
* Remove comments about older versions of python

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
