### PR TITLE
Remove ap-northeast-3 from list of supported regions

### DIFF
--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -45,7 +45,6 @@ SUPPORTED_REGIONS = [
     "ap-east-1",
     "ap-northeast-1",
     "ap-northeast-2",
-    "ap-northeast-3",
     "ap-south-1",
     "ap-southeast-1",
     "ap-southeast-2",

--- a/cli/src/pcluster/configure/utils.py
+++ b/cli/src/pcluster/configure/utils.py
@@ -17,8 +17,9 @@ import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 from tabulate import tabulate
 
+from pcluster.config.validators import SUPPORTED_REGIONS
+
 LOGGER = logging.getLogger(__name__)
-unsupported_regions = ["ap-northeast-3"]
 
 
 def handle_client_exception(func):
@@ -197,7 +198,7 @@ def get_rows_and_header(items):
 def get_regions():
     ec2 = boto3.client("ec2")
     regions = ec2.describe_regions().get("Regions")
-    regions = [region.get("RegionName") for region in regions if region.get("RegionName") not in unsupported_regions]
+    regions = [region.get("RegionName") for region in regions if region.get("RegionName") in SUPPORTED_REGIONS]
     regions.sort()
     return regions
 

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -279,7 +279,12 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
     "region, base_os, scheduler, expected_message",
     [
         # verify awsbatch supported regions
-        ("ap-northeast-3", "alinux2", "awsbatch", "scheduler is not supported in the .* region"),
+        (
+            "ap-northeast-3",
+            "alinux2",
+            "awsbatch",
+            "Region 'ap-northeast-3' is not yet officially supported by ParallelCluster",
+        ),
         ("us-gov-east-1", "alinux2", "awsbatch", None),
         ("us-gov-west-1", "alinux2", "awsbatch", None),
         ("eu-west-1", "alinux2", "awsbatch", None),
@@ -287,13 +292,19 @@ def test_ec2_volume_validator(mocker, boto3_stubber):
         ("eu-north-1", "alinux2", "awsbatch", None),
         ("cn-north-1", "alinux2", "awsbatch", None),
         ("cn-northwest-1", "alinux2", "awsbatch", None),
-        # verify traditional schedulers are supported in all the regions
+        # verify traditional schedulers are supported in all the regions but ap-northeast-3
         ("cn-northwest-1", "alinux2", "sge", None),
-        ("ap-northeast-3", "alinux2", "sge", None),
+        ("us-gov-east-1", "alinux2", "sge", None),
         ("cn-northwest-1", "alinux2", "slurm", None),
-        ("ap-northeast-3", "alinux2", "slurm", None),
+        ("us-gov-east-1", "alinux2", "slurm", None),
         ("cn-northwest-1", "alinux2", "torque", None),
-        ("ap-northeast-3", "alinux2", "torque", None),
+        ("us-gov-east-1", "alinux2", "torque", None),
+        (
+            "ap-northeast-3",
+            "alinux2",
+            "sge",
+            "Region 'ap-northeast-3' is not yet officially supported by ParallelCluster",
+        ),
         # verify awsbatch supported OSes
         ("eu-west-1", "centos7", "awsbatch", "scheduler supports the following Operating Systems"),
         ("eu-west-1", "centos8", "awsbatch", "scheduler supports the following Operating Systems"),


### PR DESCRIPTION
ap-northeast-3 had never been supported: https://docs.aws.amazon.com/parallelcluster/latest/ug/supported-regions.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
