### PR TITLE
Integ-tests framework:Delete region property from Cluster

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -154,11 +154,6 @@ class Cluster:
         return "parallelcluster-" + self.name
 
     @property
-    def region(self):
-        """Return the aws region the cluster is created in."""
-        return self.region
-
-    @property
     def head_node_ip(self):
         """Return the public ip of the cluster head node."""
         if "MasterPublicIP" in self.cfn_outputs:

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
         CustomActions:
           - Script: s3://{{ bucket_name }}/post_install.sh
         ComputeResources:
-          - Name: default
+          - Name: compute-i1
             InstanceType: {{ instance }}
         Networking:
           SubnetIds:

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
@@ -11,7 +11,7 @@ Scheduling:
     Queues:
       - Name: compute
         ComputeResources:
-          - Name: default
+          - Name: compute-i1
             {% if scheduler == "Awsbatch" %}InstanceTypes:{% else %}InstanceType:{% endif %} {{ instance }}
             {% if scheduler == "Awsbatch" %}DesiredvCpus:{% else %}MinCount:{% endif %} {{ queue_size }}
         Networking:

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
     Queues:
       - Name: compute
         ComputeResources:
-          - Name: default
+          - Name: compute-i1
             InstanceType: {{ instance }}
         Networking:
           SubnetIds:

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
     Queues:
       - Name: compute
         ComputeResources:
-          - Name: default
+          - Name: compute-i1
             InstanceType: {{ instance }}
         Networking:
           SubnetIds:

--- a/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
+++ b/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
       - Name: compute
         ComputeType: SPOT
         ComputeResources:
-          - Name: default
+          - Name: compute-i1
             InstanceType: {{ instance }}
             MinCount: {{ min_count }}
         Networking:


### PR DESCRIPTION
We added region as an attribute of the Cluster class, and forgot the property.
This commit also corrects compute resource names. Because `default` is not allowed as a name.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
