### PR TITLE
3.0: Create S3 bucket per region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ CHANGELOG
 - Remove `amis.txt` file.
 - Remove additional EBS volume attached to the head node by default. 
 - Change NICE DCV session storage path to `/home/{UserName}`.
+- Create S3 bucket per region shared with cluster and image if custom bucket isn't specified instead creating bucket 
+per cluster. 
 
 2.x.x
 ------

--- a/cli/src/api/pcluster_api.py
+++ b/cli/src/api/pcluster_api.py
@@ -237,7 +237,7 @@ class PclusterApi:
             # Generate model from imagebuilder config dict
             if region:
                 os.environ["AWS_DEFAULT_REGION"] = region
-            imagebuilder = ImageBuilder(image_name, imagebuilder_config)
+            imagebuilder = ImageBuilder(image_name=image_name, config=imagebuilder_config)
             imagebuilder.create(disable_rollback)
             return ImageInfo(imagebuilder)
         except ImageBuilderActionError as e:

--- a/cli/src/common/aws/aws_api.py
+++ b/cli/src/common/aws/aws_api.py
@@ -16,6 +16,8 @@ from common.boto3.efs import EfsClient
 from common.boto3.imagebuilder import ImageBuilderClient
 from common.boto3.kms import KmsClient
 from common.boto3.s3 import S3Client
+from common.boto3.s3_resource import S3Resource
+from common.boto3.sts import StsClient
 
 
 class AWSApi:
@@ -39,6 +41,8 @@ class AWSApi:
         self.s3 = S3Client()
         self.kms = KmsClient()
         self.imagebuilder = ImageBuilderClient()
+        self.sts = StsClient()
+        self.s3_resource = S3Resource()
 
     @staticmethod
     def instance():

--- a/cli/src/common/boto3/cfn.py
+++ b/cli/src/common/boto3/cfn.py
@@ -58,8 +58,14 @@ class CfnClient(Boto3Client):
         )
 
     @AWSExceptionHandler.handle_client_exception
-    def update_stack_from_url(self, stack_name: str, tags: list, template_url: str):
+    def update_stack_from_url(self, stack_name: str, template_url: str, tags: list = None):
         """Update CFN stack by using the given template url."""
+        if tags is None:
+            return self._client.update_stack(
+                StackName=stack_name,
+                TemplateURL=template_url,
+                Capabilities=["CAPABILITY_IAM"],
+            )
         return self._client.update_stack(
             StackName=stack_name,
             TemplateURL=template_url,

--- a/cli/src/common/boto3/common.py
+++ b/cli/src/common/boto3/common.py
@@ -24,6 +24,14 @@ class AWSClientError(Exception):
         if error_code:
             message += f" Error code: {error_code}"
         super().__init__(message)
+        self.error_code = error_code
+
+
+class ImageNotFoundError(AWSClientError):
+    """Error during describe image if image is not found."""
+
+    def __init__(self, function_name: str):
+        super().__init__(function_name=function_name, message="No image matching the search criteria found")
 
 
 class AWSExceptionHandler:
@@ -69,3 +77,10 @@ class Boto3Client(ABC):
         for page in paginator.paginate(**kwargs).result_key_iters():
             for result in page:
                 yield result
+
+
+class Boto3Resource(ABC):
+    """Abstract Boto3 resource."""
+
+    def __init__(self, resource_name: str):
+        self._resource = boto3.resource(resource_name)

--- a/cli/src/common/boto3/s3.py
+++ b/cli/src/common/boto3/s3.py
@@ -80,6 +80,42 @@ class S3Client(Boto3Client):
                 error_code=client_error.response["Error"]["Code"],
             )
 
+    @AWSExceptionHandler.handle_client_exception
+    def create_bucket(self, bucket_name, region):
+        """Create S3 bucket."""
+        if region != "us-east-1":
+            self._client.create_bucket(Bucket=bucket_name, CreateBucketConfiguration={"LocationConstraint": region})
+        else:
+            self._client.create_bucket(Bucket=bucket_name)
+
+    @AWSExceptionHandler.handle_client_exception
+    def put_bucket_versioning(self, bucket_name, configuration):
+        """Set bucket versioning property."""
+        self._client.put_bucket_versioning(Bucket=bucket_name, VersioningConfiguration=configuration)
+
+    @AWSExceptionHandler.handle_client_exception
+    def put_bucket_encryption(self, bucket_name, configuration):
+        """Set bucket encryption property."""
+        self._client.put_bucket_encryption(
+            Bucket=bucket_name,
+            ServerSideEncryptionConfiguration=configuration,
+        )
+
+    @AWSExceptionHandler.handle_client_exception
+    def put_bucket_policy(self, bucket_name, policy):
+        """Set bucket policy property."""
+        self._client.put_bucket_policy(Bucket=bucket_name, Policy=policy)
+
+    @AWSExceptionHandler.handle_client_exception
+    def upload_fileobj(self, bucket_name, file_obj, key):
+        """Upload file-like object to S3 bucket."""
+        self._client.upload_fileobj(Fileobj=file_obj, Bucket=bucket_name, Key=key)
+
+    @AWSExceptionHandler.handle_client_exception
+    def upload_file(self, bucket_name, file_path, key):
+        """Upload file to S3 bucket."""
+        self._client.upload_file(Filename=file_path, Bucket=bucket_name, Key=key)
+
 
 def _process_s3_bucket_error(client_error, bucket_name):
     error_message = client_error.response.get("Error").get("Message")

--- a/cli/src/common/boto3/s3_resource.py
+++ b/cli/src/common/boto3/s3_resource.py
@@ -1,0 +1,45 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from common.boto3.common import AWSExceptionHandler, Boto3Resource
+from pcluster.utils import Cache
+
+
+class S3Resource(Boto3Resource):
+    """S3 Boto3 resource."""
+
+    def __init__(self):
+        super().__init__("s3")
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def get_bucket(self, bucket_name):
+        """Get bucket object by bucket name."""
+        return self._resource.Bucket(bucket_name)
+
+    @AWSExceptionHandler.handle_client_exception
+    def delete_object(self, bucket_name, prefix=None):
+        """Delete objects by filter."""
+        self.get_bucket(bucket_name).objects.filter(Prefix=prefix).delete()
+
+    @AWSExceptionHandler.handle_client_exception
+    def delete_all_objects(self, bucket_name):
+        """Delete all objects."""
+        self.get_bucket(bucket_name).objects.all().delete()
+
+    @AWSExceptionHandler.handle_client_exception
+    def delete_object_versions(self, bucket_name, prefix=None):
+        """Delete object versions by filter."""
+        self.get_bucket(bucket_name).object_versions.filter(Prefix=prefix).delete()
+
+    @AWSExceptionHandler.handle_client_exception
+    def delete_all_object_versions(self, bucket_name):
+        """Delete all object versions."""
+        self.get_bucket(bucket_name).object_versions.delete()

--- a/cli/src/common/boto3/sts.py
+++ b/cli/src/common/boto3/sts.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from common.boto3.common import AWSExceptionHandler, Boto3Client
+from pcluster.utils import Cache
+
+
+class StsClient(Boto3Client):
+    """STS Boto3 client."""
+
+    def __init__(self):
+        super().__init__("sts")
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def get_account_id(self):
+        """Get account id by get_caller_identity."""
+        return self._client.get_caller_identity().get("Account")

--- a/cli/src/common/imagebuilder_utils.py
+++ b/cli/src/common/imagebuilder_utils.py
@@ -66,3 +66,11 @@ def get_resources_directory():
     """Get imagebuilder resources directory."""
     current_dir = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(current_dir, "..", "pcluster", "resources")
+
+
+def search_tag(resource_info, tag_key):
+    """Search tag in tag list by given tag key."""
+    return next(
+        (tag["Value"] for tag in resource_info.get("Tags", []) if tag["Key"] == tag_key),
+        None,
+    )

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -62,6 +62,10 @@ CW_DASHBOARD_ENABLED_DEFAULT = True
 CW_LOGS_ENABLED_DEFAULT = True
 
 PCLUSTER_IMAGE_NAME_TAG = "parallelcluster:image_name"
+PCLUSTER_S3_IMAGE_DIR_TAG = "parallelcluster:s3_image_dir"
+PCLUSTER_S3_BUCKET_TAG = "parallelcluster:s3_bucket"
+
+PCLUSTER_S3_BUCKET_VERSION = "v1"
 
 SUPPORTED_REGIONS = [
     "af-south-1",

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -323,10 +323,10 @@ class Cluster:
         If no bucket specified, create a bucket associated to the given stack.
         Created bucket needs to be removed on cluster deletion.
         """
-        if self.config.cluster_s3_bucket:
+        if self.config.custom_s3_bucket:
             # Use user-provided bucket
             # Do not remove this bucket on deletion, but cleanup artifact directory
-            name = self.config.cluster_s3_bucket
+            name = self.config.custom_s3_bucket
             remove_on_deletion = False
             try:
                 check_s3_bucket_exists(name)
@@ -337,7 +337,7 @@ class Cluster:
             # Create 1 bucket per cluster named "parallelcluster-{random_string}" if bucket is not provided
             # This bucket needs to be removed on cluster deletion
             name = generate_random_name_with_prefix("parallelcluster")
-            # self.cluster_s3_bucket = name
+            # self.custom_s3_bucket = name
             remove_on_deletion = True
             LOGGER.debug("Creating S3 bucket for cluster resources, named %s", name)
             try:

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -33,7 +33,7 @@ from pcluster.constants import (
     MAX_STORAGE_COUNT,
 )
 from pcluster.models.common import BaseDevSettings, BaseTag, Resource
-from pcluster.utils import delete_s3_artifacts, delete_s3_bucket, get_partition, get_region
+from pcluster.utils import get_partition, get_region
 from pcluster.validators.awsbatch_validators import (
     AwsbatchComputeInstanceTypeValidator,
     AwsbatchComputeResourceSizeValidator,
@@ -1359,31 +1359,3 @@ class SlurmClusterConfig(BaseClusterConfig):
                     # FIXME: head_node.architecture vs compute_resource.architecture?
                     architecture=self.head_node.architecture,
                 )
-
-
-class ClusterBucket:
-    """Represent the cluster s3 bucket configuration."""
-
-    def __init__(
-        self,
-        name: str,
-        artifact_directory: str,
-        remove_on_deletion: bool,
-    ):
-        super().__init__()
-        self.name = name
-        self.artifact_directory = artifact_directory
-        self.remove_on_deletion = remove_on_deletion
-
-    def delete(self):
-        """Cleanup S3 bucket and/or artifact directory."""
-        LOGGER.debug(
-            "Cleaning up S3 resources bucket_name=%s, artifact_directory=%s, remove_bucket=%s",
-            self.name,
-            self.artifact_directory,
-            self.remove_on_deletion,
-        )
-        if self.artifact_directory:
-            delete_s3_artifacts(self.name, self.artifact_directory)
-        if self.remove_on_deletion:
-            delete_s3_bucket(self.name)

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -834,7 +834,7 @@ class BaseClusterConfig(Resource):
         additional_packages: AdditionalPackages = None,
         tags: List[Tag] = None,
         iam: ClusterIam = None,
-        cluster_s3_bucket: str = None,
+        custom_s3_bucket: str = None,
         additional_resources: str = None,
         dev_settings: ClusterDevSettings = None,
     ):
@@ -847,7 +847,7 @@ class BaseClusterConfig(Resource):
         self.additional_packages = additional_packages
         self.tags = tags
         self.iam = iam
-        self.cluster_s3_bucket = Resource.init_param(cluster_s3_bucket)
+        self.custom_s3_bucket = Resource.init_param(custom_s3_bucket)
         self._bucket = None
         self.additional_resources = Resource.init_param(additional_resources)
         self.dev_settings = dev_settings
@@ -890,9 +890,9 @@ class BaseClusterConfig(Resource):
                 IntelHpcArchitectureValidator,
                 architecture=self.head_node.architecture,
             )
-        if self.cluster_s3_bucket:
-            self._execute_validator(S3BucketValidator, bucket=self.cluster_s3_bucket)
-            self._execute_validator(S3BucketRegionValidator, bucket=self.cluster_s3_bucket, region=self.region)
+        if self.custom_s3_bucket:
+            self._execute_validator(S3BucketValidator, bucket=self.custom_s3_bucket)
+            self._execute_validator(S3BucketRegionValidator, bucket=self.custom_s3_bucket, region=self.region)
 
     def _register_storage_validators(self):
         storage_count = {"ebs": 0, "efs": 0, "fsx": 0, "raid": 0}

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -12,12 +12,24 @@
 # This module contains all the classes representing the Resources objects.
 # These objects are obtained from the configuration file through a conversion based on the Schema classes.
 #
+import hashlib
 import json
+import logging
+import os
 from abc import ABC
+from enum import Enum
 from typing import List
 
+import yaml
+
+from common.aws.aws_api import AWSApi
+from common.boto3.common import AWSClientError
+from pcluster.constants import PCLUSTER_S3_BUCKET_VERSION
+from pcluster.utils import get_partition, get_region, zip_dir
 from pcluster.validators.common import ValidationResult
 from pcluster.validators.s3_validators import UrlValidator
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Resource(ABC):
@@ -239,3 +251,357 @@ class ExtraChefAttributes:
         attribute_json = {"cfncluster": self._cfncluster_attributes}
         attribute_json.update(self._extra_attributes)
         return json.dumps(attribute_json, sort_keys=True)
+
+
+class S3FileFormat(Enum):
+    """Define S3 file format."""
+
+    YAML = "yaml"
+    JSON = "json"
+    TEXT = "text"
+
+
+class S3FileType(Enum):
+    """Define S3 file types."""
+
+    CONFIGS = "configs"
+    TEMPLATES = "templates"
+    CUSTOM_RESOURCES = "custom_resources"
+
+
+class S3Bucket:
+    """Represent the s3 bucket configuration."""
+
+    def __init__(
+        self,
+        service_name: str,
+        stack_name: str,
+        artifact_directory: str,
+        cleanup_on_deletion: bool = True,
+        name: str = None,
+        is_custom_bucket: bool = False,
+    ):
+        super().__init__()
+        self._service_name = service_name
+        self._stack_name = stack_name
+        self._cleanup_on_deletion = cleanup_on_deletion
+        self._root_directory = "parallelcluster"
+        self._bootstrapped_file_name = ".bootstrapped"
+        self.artifact_directory = artifact_directory
+        self._is_custom_bucket = is_custom_bucket
+        self.__partition = None
+        self.__region = None
+        self.__account_id = None
+        self.__name = name
+
+    @property
+    def name(self):
+        """Return bucket name."""
+        if self.__name is None:
+            self.__name = self.get_bucket_name(self.account_id, self.region)
+        return self.__name
+
+    @property
+    def partition(self):
+        """Return partition."""
+        if self.__partition is None:
+            self.__partition = get_partition()
+        return self.__partition
+
+    @property
+    def region(self):
+        """Return bucket region."""
+        if self.__region is None:
+            self.__region = get_region()
+        return self.__region
+
+    @property
+    def account_id(self):
+        """Return account id."""
+        if self.__account_id is None:
+            self.__account_id = AWSApi.instance().sts.get_account_id()
+        return self.__account_id
+
+    # --------------------------------------- S3 bucket utils --------------------------------------- #
+
+    @staticmethod
+    def get_bucket_name(account_id, region):
+        """
+        Get ParallelCluster bucket name.
+
+        :param account_id
+        :param region
+        :return ParallelCluster bucket name e.g. parallelcluster-b9033160b61390ef-v1-do-not-delete
+        """
+        return "-".join(
+            [
+                "parallelcluster",
+                S3Bucket.generate_s3_bucket_hash_suffix(account_id, region),
+                PCLUSTER_S3_BUCKET_VERSION,
+                "do",
+                "not",
+                "delete",
+            ]
+        )
+
+    @staticmethod
+    def generate_s3_bucket_hash_suffix(account_id, region):
+        """
+        Generate 16 characters hash suffix for ParallelCluster s3 bucket.
+
+        :param account_id
+        :param region
+        :return: 16 chars string e.g. 2238a84ac8a74529
+        """
+        return hashlib.sha256((account_id + region).encode()).hexdigest()[0:16]
+
+    def check_bucket_exists(self):
+        """Check bucket existence by bucket name."""
+        AWSApi.instance().s3.head_bucket(bucket_name=self.name)
+
+    def create_bucket(self):
+        """Create a new S3 bucket."""
+        AWSApi.instance().s3.create_bucket(bucket_name=self.name, region=self.region)
+
+    def configure_s3_bucket(self):
+        """Configure s3 bucket to satisfy pcluster setting."""
+        AWSApi.instance().s3.put_bucket_versioning(bucket_name=self.name, configuration={"Status": "Enabled"})
+        AWSApi.instance().s3.put_bucket_encryption(
+            bucket_name=self.name,
+            configuration={"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]},
+        )
+        deny_http_policy = (
+            '{{"Id":"DenyHTTP","Version":"2012-10-17","Statement":[{{"Sid":"AllowSSLRequestsOnly","Action":"s3:*",'
+            '"Effect":"Deny","Resource":["arn:{partition}:s3:::{bucket_name}","arn:{partition}:s3:::{bucket_name}/*"],'
+            '"Condition":{{"Bool":{{"aws:SecureTransport":"false"}}}},"Principal":"*"}}]}}'
+        ).format(bucket_name=self.name, partition=self.partition)
+        AWSApi.instance().s3.put_bucket_policy(bucket_name=self.name, policy=deny_http_policy)
+
+    # --------------------------------------- S3 objects utils --------------------------------------- #
+
+    def get_object_key(self, object_type, object_name):
+        """Get object key of an artifact."""
+        return "/".join([self.artifact_directory, object_type, object_name])
+
+    def delete_s3_artifacts(self):
+        """Cleanup S3 bucket artifact directory."""
+        LOGGER.debug(
+            "Cleaning up S3 resources bucket_name=%s, service_name=%s, remove_artifact=%s",
+            self.name,
+            self._service_name,
+            self._cleanup_on_deletion,
+        )
+        if self.artifact_directory and self._cleanup_on_deletion:
+            try:
+                LOGGER.info("Deleting artifacts under %s/%s", self.name, self.artifact_directory)
+                AWSApi.instance().s3_resource.delete_object(bucket_name=self.name, prefix=f"{self.artifact_directory}/")
+                AWSApi.instance().s3_resource.delete_object_versions(
+                    bucket_name=self.name, prefix=f"{self.artifact_directory}/"
+                )
+            except AWSClientError as e:
+                LOGGER.warning(
+                    "Failed to delete S3 artifact under %s/%s with error %s. Please delete them manually.",
+                    self.name,
+                    self.artifact_directory,
+                    str(e),
+                )
+
+    def upload_bootstrapped_file(self):
+        """Upload bootstrapped file to identify bucket is configured successfully."""
+        AWSApi.instance().s3.put_object(
+            bucket_name=self.name,
+            body="bucket is configured successfully.",
+            key="/".join([self._root_directory, self._bootstrapped_file_name]),
+        )
+
+    def check_bucket_is_bootstrapped(self):
+        """Check bucket is configured successfully or not by bootstrapped file."""
+        AWSApi.instance().s3.head_object(
+            bucket_name=self.name, object_name="/".join([self._root_directory, self._bootstrapped_file_name])
+        )
+
+    def upload_config(self, config, config_name, format=S3FileFormat.YAML):
+        """Upload config file to S3 bucket."""
+        return self._upload_file(
+            file_type=S3FileType.CONFIGS.value, content=config, file_name=config_name, format=format
+        )
+
+    def upload_cfn_template(self, template_body, template_name, format=S3FileFormat.YAML):
+        """Upload cloudformation template to S3 bucket."""
+        return self._upload_file(
+            file_type=S3FileType.TEMPLATES.value, content=template_body, file_name=template_name, format=format
+        )
+
+    def upload_resources(self, resource_dir, custom_artifacts_name):
+        """
+        Upload custom resources to S3 bucket.
+
+        All dirs contained in resource dir will be uploaded as zip files to
+        {bucket_name}/parallelcluster/clusters/{cluster_name}/{resource_dir}/artifacts.zip.
+        or {bucket_name}/parallelcluster/imagebuilders/{image_name}/{resource_dir}/artifacts.zip.
+        All files contained in root dir will be uploaded to
+        {bucket_name}/parallelcluster/clusters/{cluster_name}/{resource_dir}/artifact.
+        or {bucket_name}/parallelcluster/imagebuilders/{image_name}/{resource_dir}/artifacts
+        :param resource_dir: resource directory containing the resources to upload.
+        :param custom_artifacts_name: custom_artifacts_name for zipped dir
+        """
+        for res in os.listdir(resource_dir):
+            path = os.path.join(resource_dir, res)
+            if os.path.isdir(path):
+                AWSApi.instance().s3.upload_fileobj(
+                    file_obj=zip_dir(os.path.join(resource_dir, res)),
+                    bucket_name=self.name,
+                    key=self.get_object_key(S3FileType.CUSTOM_RESOURCES.value, custom_artifacts_name),
+                )
+            elif os.path.isfile(path):
+                AWSApi.instance().s3.upload_file(
+                    file_path=os.path.join(resource_dir, res),
+                    bucket_name=self.name,
+                    key=self.get_object_key(S3FileType.CUSTOM_RESOURCES.value, res),
+                )
+
+    def get_config(self, config_name, version_id=None, format=S3FileFormat.YAML):
+        """Get config file from S3 bucket."""
+        return self._get_file(
+            file_type=S3FileType.CONFIGS.value, file_name=config_name, version_id=version_id, format=format
+        )
+
+    def get_config_url(self, config_name):
+        """Get config file http url from S3 bucket."""
+        return self._get_file_url(file_name=config_name, file_type=S3FileType.CONFIGS.value)
+
+    def get_cfn_template(self, template_name, version_id=None, format=S3FileFormat.YAML):
+        """Get cfn template from S3 bucket."""
+        return self._get_file(
+            file_type=S3FileType.TEMPLATES.value, file_name=template_name, version_id=version_id, format=format
+        )
+
+    def get_cfn_template_url(self, template_name):
+        """Get cfn template http url from S3 bucket."""
+        return self._get_file_url(file_type=S3FileType.TEMPLATES.value, file_name=template_name)
+
+    def get_resource_url(self, resource_name):
+        """Get custom resource http url from S3 bucket."""
+        return self._get_file_url(file_type=S3FileType.CUSTOM_RESOURCES.value, file_name=resource_name)
+
+    # --------------------------------------- S3 private functions --------------------------------------- #
+
+    def _upload_file(self, content, file_name, file_type, format=S3FileFormat.YAML):
+        """Upload file to S3 bucket."""
+        if format == S3FileFormat.YAML:
+            result = AWSApi.instance().s3.put_object(
+                bucket_name=self.name,
+                body=yaml.dump(content),
+                key=self.get_object_key(file_type, file_name),
+            )
+        elif format == S3FileFormat.JSON:
+            result = AWSApi.instance().s3.put_object(
+                bucket_name=self.name,
+                body=json.dumps(content),
+                key=self.get_object_key(file_type, file_name),
+            )
+        else:
+            result = AWSApi.instance().s3.put_object(
+                bucket_name=self.name,
+                body=content,
+                key=self.get_object_key(file_type, file_name),
+            )
+        return result
+
+    def _get_file(self, file_name, file_type, version_id=None, format=S3FileFormat.YAML):
+        """Get file from S3 bucket."""
+        result = AWSApi.instance().s3.get_object(
+            bucket_name=self.name, key=self.get_object_key(file_type, file_name), version_id=version_id
+        )
+
+        file_content = result["Body"].read().decode("utf-8")
+
+        if format == S3FileFormat.YAML:
+            file = yaml.safe_load(file_content)
+        elif format == S3FileFormat.JSON:
+            file = json.loads(file_content)
+        else:
+            file = file_content
+        return file
+
+    def _get_file_url(self, file_name, file_type):
+        """Get file url from S3 bucket."""
+        url = "https://{bucket_name}.s3.{region}.amazonaws.com{partition_suffix}/{config_key}".format(
+            bucket_name=self.name,
+            region=self.region,
+            partition_suffix=".cn" if self.region.startswith("cn") else "",
+            config_key=self.get_object_key(file_type, file_name),
+        )
+        return url
+
+
+class S3BucketFactory:
+    """S3 bucket factory to return a bucket object with existence check and creation."""
+
+    @classmethod
+    def init_s3_bucket(cls, service_name: str, artifact_directory: str, stack_name: str, custom_s3_bucket: str):
+        """Initialize the s3 bucket."""
+        if custom_s3_bucket:
+            bucket = cls._check_custom_bucket(service_name, custom_s3_bucket, artifact_directory, stack_name)
+        else:
+            bucket = cls._check_default_bucket(service_name, artifact_directory, stack_name)
+
+        return bucket
+
+    @classmethod
+    def _check_custom_bucket(cls, service_name: str, custom_s3_bucket: str, artifact_directory: str, stack_name: str):
+        bucket = S3Bucket(
+            service_name=service_name,
+            name=custom_s3_bucket,
+            artifact_directory=artifact_directory,
+            stack_name=stack_name,
+            is_custom_bucket=True,
+        )
+        try:
+            bucket.check_bucket_exists()
+        except AWSClientError as e:
+            raise AWSClientError(
+                "check_bucket_exists", f"Unable to access config-specified S3 bucket {bucket.name}. Due to {str(e)}"
+            )
+
+        return bucket
+
+    @classmethod
+    def _check_default_bucket(cls, service_name: str, artifact_directory: str, stack_name: str):
+        bucket = S3Bucket(service_name=service_name, artifact_directory=artifact_directory, stack_name=stack_name)
+        try:
+            bucket.check_bucket_exists()
+        except AWSClientError as e:
+            cls._create_bucket(bucket, e)
+
+        try:
+            bucket.check_bucket_is_bootstrapped()
+        except AWSClientError as e:
+            cls._configure_bucket(bucket, e)
+
+        return bucket
+
+    @classmethod
+    def _create_bucket(cls, bucket: S3Bucket, e: AWSClientError):
+        if e.error_code == "404":
+            try:
+                bucket.create_bucket()
+            except AWSClientError as error:
+                LOGGER.error("Unable to create S3 bucket %s.", bucket.name)
+                raise error
+        else:
+            LOGGER.error("Unable to check S3 bucket %s existence.", bucket.name)
+            raise e
+
+    @classmethod
+    def _configure_bucket(cls, bucket: S3Bucket, e: AWSClientError):
+        if e.error_code == "404":
+            try:
+                bucket.configure_s3_bucket()
+                bucket.upload_bootstrapped_file()
+            except AWSClientError as error:
+                LOGGER.error("Configure S3 bucket %s failed.", bucket.name)
+                raise error
+        else:
+            LOGGER.error("Unable to check S3 bucket %s is configured properly.", bucket.name)
+            raise e

--- a/cli/src/pcluster/models/imagebuilder_config.py
+++ b/cli/src/pcluster/models/imagebuilder_config.py
@@ -139,12 +139,14 @@ class ImageBuilderConfig(Resource):
         image: Image = None,
         dev_settings: ImagebuilderDevSettings = None,
         custom_s3_bucket: str = None,
+        source_config: str = None
     ):
         super().__init__()
         self.image = image
         self.build = build
         self.dev_settings = dev_settings
         self.custom_s3_bucket = Resource.init_param(custom_s3_bucket)
+        self.source_config = source_config
 
     def _validate(self):
         # Volume size validator only validates specified volume size

--- a/cli/src/pcluster/models/imagebuilder_config.py
+++ b/cli/src/pcluster/models/imagebuilder_config.py
@@ -139,7 +139,7 @@ class ImageBuilderConfig(Resource):
         image: Image = None,
         dev_settings: ImagebuilderDevSettings = None,
         custom_s3_bucket: str = None,
-        source_config: str = None
+        source_config: str = None,
     ):
         super().__init__()
         self.image = image

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1101,7 +1101,7 @@ class ClusterSchema(BaseSchema):
     additional_packages = fields.Nested(AdditionalPackagesSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     tags = fields.Nested(TagSchema, many=True, metadata={"update_policy": UpdatePolicy.SUPPORTED, "update_key": "Key"})
     iam = fields.Nested(ClusterIamSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    cluster_s3_bucket = fields.Str(metadata={"update_policy": UpdatePolicy.READ_ONLY_RESOURCE_BUCKET})
+    custom_s3_bucket = fields.Str(metadata={"update_policy": UpdatePolicy.READ_ONLY_RESOURCE_BUCKET})
     additional_resources = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     dev_settings = fields.Nested(ClusterDevSettingsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
 

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -174,6 +174,7 @@ class ImageBuilderSchema(BaseSchema):
     image = fields.Nested(ImageSchema)
     build = fields.Nested(BuildSchema, required=True)
     dev_settings = fields.Nested(ImagebuilderDevSettingsSchema)
+    custom_s3_bucket = fields.Str()
 
     @post_load()
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -176,7 +176,7 @@ class ImageBuilderSchema(BaseSchema):
     dev_settings = fields.Nested(ImagebuilderDevSettingsSchema)
     custom_s3_bucket = fields.Str()
 
-    @post_load()
-    def make_resource(self, data, **kwargs):
+    @post_load(pass_original=True)
+    def make_resource(self, data, original_data, **kwargs):
         """Generate resource."""
-        return ImageBuilderConfig(**data)
+        return ImageBuilderConfig(source_config=original_data, **data)

--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -20,7 +20,8 @@ from aws_cdk import aws_lambda as awslambda
 from aws_cdk import aws_logs as logs
 from aws_cdk import core
 
-from pcluster.models.cluster_config import AwsbatchClusterConfig, CapacityType, ClusterBucket, SharedStorageType
+from pcluster.models.cluster_config import AwsbatchClusterConfig, CapacityType, SharedStorageType
+from pcluster.models.common import S3Bucket
 from pcluster.templates.cdk_builder_utils import (
     PclusterLambdaConstruct,
     add_lambda_cfn_role,
@@ -44,7 +45,7 @@ class AwsbatchConstruct(core.Construct):
         id: str,
         cluster_config: AwsbatchClusterConfig,
         stack_name: str,
-        bucket: ClusterBucket,
+        bucket: S3Bucket,
         create_lambda_roles: bool,
         compute_security_groups: dict,
         shared_storage_mappings: dict,

--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -19,6 +19,7 @@ from aws_cdk import core
 
 from common.utils import load_yaml_dict
 from pcluster.models.cluster_config import BaseClusterConfig, ClusterBucket
+from pcluster.models.common import S3Bucket
 from pcluster.models.imagebuilder_config import ImageBuilderConfig
 from pcluster.templates.cluster_stack import ClusterCdkStack
 from pcluster.templates.imagebuilder_stack import ImageBuilderCdkStack
@@ -40,12 +41,12 @@ class CDKTemplateBuilder:
         return generated_template
 
     @staticmethod
-    def build_imagebuilder_template(imagebuild: ImageBuilderConfig, image_name: str):
+    def build_imagebuilder_template(imagebuild: ImageBuilderConfig, image_name: str, bucket: S3Bucket):
         """Build template for the given imagebuilder and return as output in Yaml format."""
         with tempfile.TemporaryDirectory() as tempdir:
             output_file = "imagebuilder"
             app = core.App(outdir=str(tempdir))
-            ImageBuilderCdkStack(app, output_file, imagebuild, image_name)
+            ImageBuilderCdkStack(app, output_file, imagebuild, image_name, bucket)
             app.synth()
             generated_template = load_yaml_dict(os.path.join(tempdir, f"{output_file}.template.json"))
 

--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -18,7 +18,7 @@ import tempfile
 from aws_cdk import core
 
 from common.utils import load_yaml_dict
-from pcluster.models.cluster_config import BaseClusterConfig, ClusterBucket
+from pcluster.models.cluster_config import BaseClusterConfig
 from pcluster.models.common import S3Bucket
 from pcluster.models.imagebuilder_config import ImageBuilderConfig
 from pcluster.templates.cluster_stack import ClusterCdkStack
@@ -29,7 +29,7 @@ class CDKTemplateBuilder:
     """Create the template, starting from the given resources."""
 
     @staticmethod
-    def build_cluster_template(cluster_config: BaseClusterConfig, bucket: ClusterBucket, stack_name: str):
+    def build_cluster_template(cluster_config: BaseClusterConfig, bucket: S3Bucket, stack_name: str):
         """Build template for the given cluster and return as output in Yaml format."""
         with tempfile.TemporaryDirectory() as tempdir:
             output_file = str(stack_name)

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -30,11 +30,11 @@ from pcluster.models.cluster_config import (
     BaseClusterConfig,
     BaseComputeResource,
     BaseQueue,
-    ClusterBucket,
     Ebs,
     HeadNode,
     SharedStorageType,
 )
+from pcluster.models.common import S3Bucket
 from pcluster.utils import get_installed_version
 
 
@@ -271,7 +271,7 @@ class PclusterLambdaConstruct(core.Construct):
         scope: core.Construct,
         id: str,
         function_id: str,
-        bucket: ClusterBucket,
+        bucket: S3Bucket,
         config: BaseClusterConfig,
         execution_role: iam.CfnRole,
         handler_func: str,
@@ -294,7 +294,7 @@ class PclusterLambdaConstruct(core.Construct):
             function_name=function_name,
             code=awslambda.CfnFunction.CodeProperty(
                 s3_bucket=bucket.name,
-                s3_key=f"{bucket.artifact_directory}/custom_resources_code/artifacts.zip",
+                s3_key=f"{bucket.artifact_directory}/custom_resources/artifacts.zip",
             ),
             handler=f"{handler_func}.handler",
             memory_size=128,

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -29,7 +29,6 @@ from common.aws.aws_api import AWSApi
 from pcluster.constants import OS_MAPPING
 from pcluster.models.cluster_config import (
     BaseQueue,
-    ClusterBucket,
     CustomActionEvent,
     HeadNode,
     SharedEbs,
@@ -38,6 +37,7 @@ from pcluster.models.cluster_config import (
     SharedStorageType,
     SlurmClusterConfig,
 )
+from pcluster.models.common import S3Bucket
 from pcluster.templates.awsbatch_builder import AwsbatchConstruct
 from pcluster.templates.cdk_builder_utils import (
     PclusterLambdaConstruct,
@@ -72,7 +72,7 @@ class ClusterCdkStack(core.Stack):
         construct_id: str,
         stack_name: str,
         cluster_config: SlurmClusterConfig,
-        bucket: ClusterBucket,
+        bucket: S3Bucket,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -238,8 +238,6 @@ class ClusterCdkStack(core.Stack):
         cleanup_resources_lambda_role = None
         if self._condition_create_lambda_iam_role():
             s3_policy_actions = ["s3:DeleteObject", "s3:DeleteObjectVersion", "s3:ListBucket", "s3:ListBucketVersions"]
-            if self.bucket.remove_on_deletion:
-                s3_policy_actions.append("s3:DeleteBucket")
 
             cleanup_resources_lambda_role = add_lambda_cfn_role(
                 scope=self,
@@ -289,7 +287,6 @@ class ClusterCdkStack(core.Stack):
             properties={
                 "ResourcesS3Bucket": self.bucket.name,
                 "ArtifactS3RootDirectory": self.bucket.artifact_directory,
-                "RemoveBucketOnDeletion": "True" if self.bucket.remove_on_deletion else "False",
                 "Action": "DELETE_S3_ARTIFACTS",
             },
         )

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -30,7 +30,8 @@ from common.imagebuilder_utils import (
     InstanceRole,
 )
 from common.utils import get_url_scheme, load_yaml, parse_bucket_url
-from pcluster.models.common import BaseTag
+from pcluster.constants import PCLUSTER_S3_BUCKET_TAG, PCLUSTER_S3_IMAGE_DIR_TAG
+from pcluster.models.common import BaseTag, S3Bucket
 from pcluster.models.imagebuilder_config import ImageBuilderConfig, ImageBuilderExtraChefAttributes, Volume
 from pcluster.schemas.imagebuilder_schema import ImageBuilderSchema
 
@@ -39,7 +40,13 @@ class ImageBuilderCdkStack(core.Stack):
     """Create the Stack for imagebuilder."""
 
     def __init__(
-        self, scope: core.Construct, construct_id: str, imagebuild: ImageBuilderConfig, image_name: str, **kwargs
+        self,
+        scope: core.Construct,
+        construct_id: str,
+        imagebuild: ImageBuilderConfig,
+        image_name: str,
+        bucket: S3Bucket,
+        **kwargs
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
         self.imagebuild = imagebuild
@@ -101,6 +108,8 @@ class ImageBuilderCdkStack(core.Stack):
         # Add default ami tags information
         tags = copy.deepcopy(image.tags) if image and image.tags else []
         tags.append(BaseTag(key="pcluster_version", value=utils.get_installed_version()))
+        tags.append(BaseTag(key=PCLUSTER_S3_BUCKET_TAG, value=bucket.name))
+        tags.append(BaseTag(key=PCLUSTER_S3_IMAGE_DIR_TAG, value=bucket.artifact_directory))
         ami_tags = {tag.key: tag.value for tag in tags}
 
         # InfrastructureConfiguration

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -18,13 +18,8 @@ from aws_cdk import aws_route53 as route53
 from aws_cdk import core
 
 from pcluster.constants import OS_MAPPING
-from pcluster.models.cluster_config import (
-    CapacityType,
-    ClusterBucket,
-    CustomActionEvent,
-    SharedStorageType,
-    SlurmClusterConfig,
-)
+from pcluster.models.cluster_config import CapacityType, CustomActionEvent, SharedStorageType, SlurmClusterConfig
+from pcluster.models.common import S3Bucket
 from pcluster.templates.cdk_builder_utils import (
     PclusterLambdaConstruct,
     add_lambda_cfn_role,
@@ -52,7 +47,7 @@ class SlurmConstruct(core.Construct):
         id: str,
         stack_name: str,
         cluster_config: SlurmClusterConfig,
-        bucket: ClusterBucket,
+        bucket: S3Bucket,
         dynamodb_table: dynamodb.CfnTable,
         log_group: logs.CfnLogGroup,
         instance_roles: dict,
@@ -143,9 +138,7 @@ class SlurmConstruct(core.Construct):
                     iam.PolicyStatement(
                         sid="ResourcesS3Bucket",
                         effect=iam.Effect.ALLOW,
-                        actions=["s3:ListBucket", "s3:ListBucketVersions", "s3:GetObject*", "s3:PutObject*"]
-                        if self.bucket.remove_on_deletion
-                        else ["s3:*"],
+                        actions=["s3:*"],
                         resources=[
                             self._format_arn(service="s3", resource=self.bucket.name, region="", account=""),
                             self._format_arn(

--- a/cli/tests/common/dummy_aws_api.py
+++ b/cli/tests/common/dummy_aws_api.py
@@ -17,6 +17,8 @@ from common.boto3.ec2 import Ec2Client
 from common.boto3.imagebuilder import ImageBuilderClient
 from common.boto3.kms import KmsClient
 from common.boto3.s3 import S3Client
+from common.boto3.s3_resource import S3Resource
+from common.boto3.sts import StsClient
 
 
 class _DummyInstanceTypeInfo(InstanceTypeInfo):
@@ -74,6 +76,8 @@ class _DummyAWSApi(AWSApi):
         self.s3 = _DummyS3Client()
         self.imagebuilder = _DummyImageBuilderClient()
         self.kms = _DummyKmsClient()
+        self.sts = _DummyStsClient()
+        self.s3_resource = _DummyS3Resource()
         # TODO: mock all clients
 
 
@@ -139,6 +143,18 @@ class _DummyImageBuilderClient(ImageBuilderClient):
 
 
 class _DummyKmsClient(KmsClient):
+    def __init__(self):
+        """Override Parent constructor. No real boto3 client is created."""
+        pass
+
+
+class _DummyStsClient(StsClient):
+    def __init__(self):
+        """Override Parent constructor. No real boto3 client is created."""
+        pass
+
+
+class _DummyS3Resource(S3Resource):
     def __init__(self):
         """Override Parent constructor. No real boto3 client is created."""
         pass

--- a/cli/tests/common/test_aws_api.py
+++ b/cli/tests/common/test_aws_api.py
@@ -15,7 +15,7 @@
 import pytest
 from assertpy import assert_that
 
-from common.boto3.common import AWSClientError
+from common.boto3.common import AWSClientError, ImageNotFoundError
 from tests.common.dummy_aws_api import _DummyAWSApi, mock_aws_api
 
 FAKE_STACK_NAME = "parallelcluster-name"
@@ -44,7 +44,7 @@ def test_stack_exists(mocker, response, is_error):
     "response,is_error",
     [
         (
-            AWSClientError(function_name="describe_images", message="No image matching the search criteria found"),
+            ImageNotFoundError(function_name="describe_images"),
             True,
         ),
         ({"Images": [{"ImageId": FAKE_IMAGE_ID}]}, False),

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -406,17 +406,17 @@ def test_patch_check_cluster_resource_bucket(
     if expected_error_row:
         error_message_row = [
             [],
-            "ClusterS3Bucket",
+            "CustomS3Bucket",
             old_bucket_name,
             new_bucket_name,
             "ACTION NEEDED",
             (
-                "'ClusterS3Bucket' parameter is a read only parameter that cannot be updated. "
+                "'CustomS3Bucket' parameter is a read only parameter that cannot be updated. "
                 "New value '{0}' will be ignored and old value '{1}' will be used if you force the update.".format(
                     new_bucket_name, old_bucket_name
                 )
             ),
-            f"Restore the value of parameter 'ClusterS3Bucket' to '{old_bucket_name}'",
+            f"Restore the value of parameter 'CustomS3Bucket' to '{old_bucket_name}'",
         ]
         expected_message_rows.append(error_message_row)
     src_dict = {"cluster_resource_bucket": old_bucket_name, "ec2_iam_role": "some_old_role"}

--- a/cli/tests/pcluster/config/test_config_patch/test_patch_check_cluster_resource_bucket/pcluster.config.yaml
+++ b/cli/tests/pcluster/config/test_config_patch/test_patch_check_cluster_resource_bucket/pcluster.config.yaml
@@ -26,5 +26,5 @@ SharedStorage:
     Ebs:
       VolumeType: gp2
 {% if cluster_resource_bucket %}
-ClusterS3Bucket: {{ cluster_resource_bucket }}
+CustomS3Bucket: {{ cluster_resource_bucket }}
 {% endif %}

--- a/cli/tests/pcluster/models/cluster_dummy_model.py
+++ b/cli/tests/pcluster/models/cluster_dummy_model.py
@@ -136,7 +136,7 @@ def dummy_slurm_cluster_config(mocker):
     cluster = _DummySlurmClusterConfig(
         image=image, head_node=head_node, scheduling=scheduling, shared_storage=shared_storage
     )
-    cluster.cluster_s3_bucket = "s3://dummy-s3-bucket"
+    cluster.custom_s3_bucket = "s3://dummy-s3-bucket"
     cluster.additional_resources = "https://additional.template.url"
     cluster.config_version = "1.0"
     cluster.iam = ClusterIam()
@@ -167,7 +167,7 @@ def dummy_awsbatch_cluster_config(mocker):
     cluster = _DummyAwsbatchClusterConfig(
         image=image, head_node=head_node, scheduling=scheduling, shared_storage=shared_storage
     )
-    cluster.cluster_s3_bucket = "s3://dummy-s3-bucket"
+    cluster.custom_s3_bucket = "s3://dummy-s3-bucket"
     cluster.additional_resources = "https://additional.template.url"
     cluster.config_version = "1.0"
     cluster.iam = ClusterIam()

--- a/cli/tests/pcluster/models/cluster_dummy_model.py
+++ b/cli/tests/pcluster/models/cluster_dummy_model.py
@@ -16,7 +16,6 @@ from pcluster.models.cluster_config import (
     AwsbatchComputeResource,
     AwsbatchQueue,
     AwsbatchScheduling,
-    ClusterBucket,
     ClusterIam,
     Dcv,
     HeadNode,
@@ -36,7 +35,7 @@ from pcluster.models.cluster_config import (
     Ssh,
     Tag,
 )
-from pcluster.models.common import Resource
+from pcluster.models.common import Resource, S3Bucket
 
 
 class _DummySlurmClusterConfig(SlurmClusterConfig):
@@ -77,9 +76,119 @@ class _DummyAwsbatchClusterConfig(AwsbatchClusterConfig):
         return "dummy_vpc_id"
 
 
-def dummy_bucket():
+def dummy_cluster_bucket(
+    bucket_name="parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+    artifact_directory="parallelcluster/clusters/dummy-cluster-randomstring123",
+    service_name="dummy-cluster",
+):
     """Generate dummy cluster bucket."""
-    return ClusterBucket(name="dummy-bucket", artifact_directory="dummy_root_dir", remove_on_deletion=True)
+    return S3Bucket(
+        name=bucket_name,
+        stack_name=f"parallelcluster-{service_name}",
+        service_name=service_name,
+        artifact_directory=artifact_directory,
+    )
+
+
+def mock_bucket(
+    mocker,
+):
+    """Mock cluster bucket initialization."""
+    mocker.patch("pcluster.models.common.get_partition", return_value="fake_partition")
+    mocker.patch("pcluster.models.common.get_region", return_value="fake-region")
+    mocker.patch("common.boto3.sts.StsClient.get_account_id", return_value="fake-id")
+
+
+def mock_bucket_utils(
+    mocker,
+    bucket_name="parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+    root_service_dir="dummy-cluster-randomstring123",
+    check_bucket_exists_side_effect=None,
+    create_bucket_side_effect=None,
+    configure_bucket_side_effect=None,
+):
+    get_bucket_name_mock = mocker.patch("pcluster.models.common.S3Bucket.get_bucket_name", return_value=bucket_name)
+    create_bucket_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.create_bucket", side_effect=create_bucket_side_effect
+    )
+    check_bucket_exists_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.check_bucket_exists", side_effect=check_bucket_exists_side_effect
+    )
+    mocker.patch("pcluster.models.common.S3Bucket.generate_s3_bucket_hash_suffix", return_value=root_service_dir)
+    configure_s3_bucket_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.configure_s3_bucket", side_effect=configure_bucket_side_effect
+    )
+    mock_dict = {
+        "get_bucket_name": get_bucket_name_mock,
+        "create_bucket": create_bucket_mock,
+        "check_bucket_exists": check_bucket_exists_mock,
+        "configure_s3_bucket": configure_s3_bucket_mock,
+    }
+    return mock_dict
+
+
+def mock_bucket_object_utils(
+    mocker,
+    upload_config_side_effect=None,
+    get_config_side_effect=None,
+    upload_template_side_effect=None,
+    get_template_side_effect=None,
+    upload_resources_side_effect=None,
+    delete_s3_artifacts_side_effect=None,
+    upload_bootstrapped_file_side_effect=None,
+    check_bucket_is_bootstrapped_side_effect=None,
+):
+    # mock call from config
+    fake_config = {"Image": "image"}
+    upload_config_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.upload_config", side_effect=upload_config_side_effect
+    )
+    get_config_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.get_config", return_value=fake_config, side_effect=get_config_side_effect
+    )
+
+    # mock call from template
+    fake_template = {"Resources": "fake_resource"}
+    upload_cfn_template_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.upload_cfn_template", side_effect=upload_template_side_effect
+    )
+    get_cfn_template_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.get_cfn_template",
+        return_value=fake_template,
+        side_effect=get_template_side_effect,
+    )
+
+    # mock calls from custom resources
+    upload_resources_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.upload_resources", side_effect=upload_resources_side_effect
+    )
+
+    # mock delete_s3_artifacts
+    delete_s3_artifacts_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.delete_s3_artifacts", side_effect=delete_s3_artifacts_side_effect
+    )
+
+    # mock bootstrapped_file
+    upload_bootstrapped_file_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.upload_bootstrapped_file", side_effect=upload_bootstrapped_file_side_effect
+    )
+    check_bucket_is_bootstrapped_mock = mocker.patch(
+        "pcluster.models.common.S3Bucket.check_bucket_is_bootstrapped",
+        side_effect=check_bucket_is_bootstrapped_side_effect,
+    )
+
+    mock_dict = {
+        "upload_config": upload_config_mock,
+        "get_config": get_config_mock,
+        "upload_cfn_template": upload_cfn_template_mock,
+        "get_cfn_template": get_cfn_template_mock,
+        "upload_resources": upload_resources_mock,
+        "delete_s3_artifacts": delete_s3_artifacts_mock,
+        "upload_bootstrapped_file": upload_bootstrapped_file_mock,
+        "check_bucket_is_bootstrapped": check_bucket_is_bootstrapped_mock,
+    }
+
+    return mock_dict
 
 
 def dummy_head_node(mocker):

--- a/cli/tests/pcluster/models/imagebuilder_dummy_model.py
+++ b/cli/tests/pcluster/models/imagebuilder_dummy_model.py
@@ -8,7 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from pcluster.models.common import BaseTag, Cookbook
+from pcluster.models.common import BaseTag, Cookbook, S3Bucket
 from pcluster.models.imagebuilder_config import (
     Build,
     Component,
@@ -53,3 +53,17 @@ def imagebuilder_factory(resource):
         else:
             object_dict[r] = value
     return object_dict
+
+
+def dummy_imagebuilder_bucket(
+    bucket_name="parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+    artifact_directory="parallelcluster/imagebuilders/dummy-image-randomstring123",
+    service_name="dummy-image",
+):
+    """Generate dummy imagebuilder bucket."""
+    return S3Bucket(
+        name=bucket_name,
+        stack_name=service_name,
+        service_name=service_name,
+        artifact_directory=artifact_directory,
+    )

--- a/cli/tests/pcluster/models/test_common.py
+++ b/cli/tests/pcluster/models/test_common.py
@@ -8,10 +8,15 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+
 import pytest
 from assertpy import assert_that
 
+from common.boto3.common import AWSClientError
 from pcluster.models.common import Resource
+from tests.common.dummy_aws_api import mock_aws_api
+from tests.pcluster.models.cluster_dummy_model import dummy_cluster_bucket, mock_bucket
 
 
 @pytest.mark.parametrize(
@@ -53,3 +58,54 @@ def test_resource_params(value, default, expected_value, expected_implied):
     assert_that(param).is_not_none()
     assert_that(param.value).is_equal_to("new_value")
     assert_that(param.default).is_equal_to(default)
+
+
+@pytest.mark.parametrize(
+    "region,create_error",
+    [
+        ("eu-west-1", None),
+        ("us-east-1", None),
+        ("eu-west-1", AWSClientError("create_bucket", "An error occurred")),
+    ],
+)
+def test_create_s3_bucket(region, create_error, mocker):
+    bucket_name = "test"
+    expected_params = {"Bucket": bucket_name}
+    os.environ["AWS_DEFAULT_REGION"] = region
+    if region != "us-east-1":
+        # LocationConstraint specifies the region where the bucket will be created.
+        # When the region is us-east-1 we are not specifying this parameter because it's the default region.
+        expected_params["CreateBucketConfiguration"] = {"LocationConstraint": region}
+
+    mock_aws_api(mocker)
+    mocker.patch("common.boto3.s3.S3Client.create_bucket", side_effect=create_error)
+
+    mock_bucket(mocker)
+    bucket = dummy_cluster_bucket(bucket_name=bucket_name)
+
+    if create_error:
+        with pytest.raises(AWSClientError, match="An error occurred"):
+            bucket.create_bucket()
+
+
+@pytest.mark.parametrize(
+    "put_bucket_versioning_error, put_bucket_encryption_error, put_bucket_policy_error",
+    [
+        (None, None, None),
+        (AWSClientError("put_bucket_versioning", "An error occurred"), None, None),
+        (None, AWSClientError("put_bucket_encryption", "An error occurred"), None),
+        (None, None, AWSClientError("put_bucket_policy", "An error occurred")),
+    ],
+)
+def test_configure_s3_bucket(mocker, put_bucket_versioning_error, put_bucket_encryption_error, put_bucket_policy_error):
+    mock_aws_api(mocker)
+    mock_bucket(mocker)
+    bucket = dummy_cluster_bucket()
+
+    mocker.patch("common.boto3.s3.S3Client.put_bucket_versioning", side_effect=put_bucket_versioning_error)
+    mocker.patch("common.boto3.s3.S3Client.put_bucket_encryption", side_effect=put_bucket_encryption_error)
+    mocker.patch("common.boto3.s3.S3Client.put_bucket_policy", side_effect=put_bucket_policy_error)
+
+    if put_bucket_versioning_error or put_bucket_encryption_error or put_bucket_policy_error:
+        with pytest.raises(AWSClientError, match="An error occurred"):
+            bucket.configure_s3_bucket()

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -131,7 +131,7 @@ Tags:
     Value: String
   - Key: two
     Value: two22
-#ClusterS3Bucket: String
+#CustomS3Bucket: String
 #AdditionalResources: String  # https://template.url
 #DevSettings:
 #  ClusterTemplate: String

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -157,7 +157,7 @@ Tags:
     Value: String
   - Key: two
     Value: two22
-ClusterS3Bucket: String
+CustomS3Bucket: String
 AdditionalResources: String  # https://template.url
 DevSettings:
   ClusterTemplate: file:///tests/aws-parallelcluster-template-3.0.tgz

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
@@ -44,3 +44,5 @@ DevSettings:
     LaunchPermission: |
       { "UserIds": ["123456789012", "345678901234"] }
   TerminateInstanceOnFailure: True
+
+CustomS3Bucket: bucket-name

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -14,14 +14,22 @@ import yaml
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
 from tests.common.dummy_aws_api import mock_aws_api
 
-from ..models.cluster_dummy_model import dummy_awsbatch_cluster_config, dummy_bucket, dummy_slurm_cluster_config
+from ..models.cluster_dummy_model import (
+    dummy_awsbatch_cluster_config,
+    dummy_cluster_bucket,
+    dummy_slurm_cluster_config,
+    mock_bucket,
+)
 
 
 def test_slurm_cluster_builder(mocker):
     mock_aws_api(mocker)
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     generated_template = CDKTemplateBuilder().build_cluster_template(
         cluster_config=dummy_slurm_cluster_config(mocker),
-        bucket=dummy_bucket(),
+        bucket=dummy_cluster_bucket(),
         stack_name="parallelcluster-dummyname",
     )
     print(yaml.dump(generated_template))
@@ -30,9 +38,12 @@ def test_slurm_cluster_builder(mocker):
 
 def test_awsbatch_cluster_builder(mocker):
     mock_aws_api(mocker)
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     generated_template = CDKTemplateBuilder().build_cluster_template(
         cluster_config=dummy_awsbatch_cluster_config(mocker),
-        bucket=dummy_bucket(),
+        bucket=dummy_cluster_bucket(),
         stack_name="parallelcluster-dummyname",
     )
     print(yaml.dump(generated_template))

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -20,7 +20,7 @@ from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
 from tests.common.dummy_aws_api import mock_aws_api
 
-from ..models.cluster_dummy_model import dummy_bucket
+from ..models.cluster_dummy_model import dummy_cluster_bucket, mock_bucket
 
 
 @pytest.mark.parametrize(
@@ -39,11 +39,14 @@ def test_cw_dashboard_builder(mocker, test_datadir, config_file_name):
         "pcluster.models.cluster_config.HeadNodeNetworking.availability_zone",
         new_callable=PropertyMock(return_value="us-east-1a"),
     )
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     input_yaml = load_yaml_dict(test_datadir / config_file_name)
     cluster_config = ClusterSchema().load(input_yaml)
     print(cluster_config)
     generated_template = CDKTemplateBuilder().build_cluster_template(
-        cluster_config=cluster_config, bucket=dummy_bucket(), stack_name="parallelcluster-dummyname"
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="parallelcluster-dummyname"
     )
     output_yaml = yaml.dump(generated_template, width=float("inf"))
     print(output_yaml)

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -16,7 +16,8 @@ import pcluster.utils as utils
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
 from tests.common.dummy_aws_api import mock_aws_api
 
-from ..models.imagebuilder_dummy_model import imagebuilder_factory
+from ..models.cluster_dummy_model import mock_bucket
+from ..models.imagebuilder_dummy_model import dummy_imagebuilder_bucket, imagebuilder_factory
 
 
 @pytest.mark.parametrize(
@@ -272,8 +273,13 @@ def test_imagebuilder(mocker, resource, response, expected_template):
         "common.boto3.ec2.Ec2Client.describe_image",
         return_value=response,
     )
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     dummy_imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(dummy_imagebuild, "Pcluster")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(
+        dummy_imagebuild, "Pcluster", dummy_imagebuilder_bucket()
+    )
     # TODO assert content of the template by matching expected template, re-enable it after refactoring
     _test_parameters(generated_template.get("Parameters"), expected_template.get("Parameters"))
     _test_resources(generated_template.get("Resources"), expected_template.get("Resources"))
@@ -436,8 +442,13 @@ def test_imagebuilder_instance_role(
         "common.boto3.ec2.Ec2Client.describe_image",
         return_value=response,
     )
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(
+        imagebuild, "Pcluster", dummy_imagebuilder_bucket()
+    )
     assert_that(generated_template.get("Resources").get("InstanceRole")).is_equal_to(expected_instance_role)
     assert_that(generated_template.get("Resources").get("InstanceProfile")).is_equal_to(expected_instance_profile)
     assert_that(
@@ -589,8 +600,13 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
         "common.boto3.ec2.Ec2Client.describe_image",
         return_value=response,
     )
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(
+        imagebuild, "Pcluster", dummy_imagebuilder_bucket()
+    )
     assert_that(
         generated_template.get("Resources").get("ParallelClusterImageRecipe").get("Properties").get("Components")
     ).is_equal_to(expected_components)
@@ -639,6 +655,8 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
                             "keyTag1": "valueTag1",
                             "keyTag2": "valueTag2",
                             "pcluster_version": utils.get_installed_version(),
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
                         },
                     },
                     "Region": {"Fn::Sub": "${AWS::Region}"},
@@ -669,7 +687,11 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
-                        "AmiTags": {"pcluster_version": utils.get_installed_version()},
+                        "AmiTags": {
+                            "pcluster_version": utils.get_installed_version(),
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                        },
                     },
                     "Region": {"Fn::Sub": "${AWS::Region}"},
                 },
@@ -702,7 +724,11 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
-                        "AmiTags": {"pcluster_version": utils.get_installed_version()},
+                        "AmiTags": {
+                            "pcluster_version": utils.get_installed_version(),
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                        },
                     },
                     "Region": {"Fn::Sub": "${AWS::Region}"},
                 },
@@ -717,8 +743,13 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
         "common.boto3.ec2.Ec2Client.describe_image",
         return_value=response,
     )
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(
+        imagebuild, "Pcluster", dummy_imagebuilder_bucket()
+    )
     assert_that(
         generated_template.get("Resources")
         .get("ParallelClusterDistributionConfiguration")
@@ -832,8 +863,13 @@ def test_imagebuilder_build_tags(mocker, resource, response, expected_imagebuild
         "common.boto3.ec2.Ec2Client.describe_image",
         return_value=response,
     )
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(
+        imagebuild, "Pcluster", dummy_imagebuilder_bucket()
+    )
     for resource_name, resource in generated_template.get("Resources").items():
         if resource_name == "InstanceProfile":
             # InstanceProfile has no tags
@@ -901,8 +937,13 @@ def test_imagebuilder_subnet_id(mocker, resource, response, expected_imagebuilde
         "common.boto3.ec2.Ec2Client.describe_image",
         return_value=response,
     )
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(
+        imagebuild, "Pcluster", dummy_imagebuilder_bucket()
+    )
 
     assert_that(
         generated_template.get("Resources")
@@ -969,8 +1010,13 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
         "common.boto3.ec2.Ec2Client.describe_image",
         return_value=response,
     )
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(imagebuild, "Pcluster")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(
+        imagebuild, "Pcluster", dummy_imagebuilder_bucket()
+    )
 
     assert_that(
         generated_template.get("Resources")
@@ -1008,7 +1054,11 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
-                        "AmiTags": {"pcluster_version": "2.10.1"},
+                        "AmiTags": {
+                            "pcluster_version": "2.10.1",
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                        },
                     },
                     "Region": {"Fn::Sub": "${AWS::Region}"},
                 },
@@ -1043,7 +1093,11 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
-                        "AmiTags": {"pcluster_version": "2.10.1"},
+                        "AmiTags": {
+                            "pcluster_version": "2.10.1",
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                        },
                     },
                     "Region": {"Fn::Sub": "${AWS::Region}"},
                 },
@@ -1078,7 +1132,11 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
-                        "AmiTags": {"pcluster_version": "2.10.1"},
+                        "AmiTags": {
+                            "pcluster_version": "2.10.1",
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                        },
                     },
                     "Region": "eu-south-1",
                 },
@@ -1113,7 +1171,11 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
-                        "AmiTags": {"pcluster_version": "2.10.1"},
+                        "AmiTags": {
+                            "pcluster_version": "2.10.1",
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                        },
                         "LaunchPermissionConfiguration": "",
                     },
                     "Region": "eu-south-1",
@@ -1154,7 +1216,11 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
-                        "AmiTags": {"pcluster_version": "2.10.1"},
+                        "AmiTags": {
+                            "pcluster_version": "2.10.1",
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                        },
                         "LaunchPermissionConfiguration": {"UserIds": ["123456789012", "345678901234"]},
                     },
                     "Region": "eu-south-1",
@@ -1195,7 +1261,11 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
-                        "AmiTags": {"pcluster_version": "2.10.1"},
+                        "AmiTags": {
+                            "pcluster_version": "2.10.1",
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                        },
                         "LaunchPermissionConfiguration": {"UserIds": []},
                     },
                     "Region": "eu-south-1",
@@ -1236,7 +1306,11 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
-                        "AmiTags": {"pcluster_version": "2.10.1"},
+                        "AmiTags": {
+                            "pcluster_version": "2.10.1",
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                        },
                         "LaunchPermissionConfiguration": {"UserGroups": ["all"]},
                     },
                     "Region": "eu-south-1",
@@ -1244,7 +1318,11 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                 {
                     "AmiDistributionConfiguration": {
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
-                        "AmiTags": {"pcluster_version": "2.10.1"},
+                        "AmiTags": {
+                            "pcluster_version": "2.10.1",
+                            "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
+                            "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                        },
                         "LaunchPermissionConfiguration": {"UserGroups": ["all"]},
                     },
                     "Region": "us-west-1",
@@ -1264,8 +1342,13 @@ def test_imagebuilder_distribution_configuraton(mocker, resource, response, expe
         "pcluster.utils.get_installed_version",
         return_value="2.10.1",
     )
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+
     dummy_imagebuild = imagebuilder_factory(resource).get("imagebuilder")
-    generated_template = CDKTemplateBuilder().build_imagebuilder_template(dummy_imagebuild, "Pcluster")
+    generated_template = CDKTemplateBuilder().build_imagebuilder_template(
+        dummy_imagebuild, "Pcluster", dummy_imagebuilder_bucket()
+    )
 
     assert_that(
         generated_template.get("Resources")

--- a/cli/tests/pcluster/test_commands.py
+++ b/cli/tests/pcluster/test_commands.py
@@ -30,7 +30,7 @@ def _mock_cluster(mocker, scheduler, bucket_name=None):
     else:
         cluster.config = dummy_awsbatch_cluster_config(mocker)
 
-    cluster.config.cluster_s3_bucket = bucket_name
+    cluster.config.custom_s3_bucket = bucket_name
     return cluster
 
 

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -157,7 +157,7 @@ Tags:
     Value: String
   - Key: two
     Value: two22
-ClusterS3Bucket: String
+CustomS3Bucket: String
 AdditionalResources: String  # https://template.url
 DevSettings:
   ClusterTemplate: file:///tests/aws-parallelcluster-template-3.0.tgz

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.yaml
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.yaml
@@ -1,6 +1,6 @@
 Image:
   Os: {{ os }}
-ClusterS3Bucket: {{ resource_bucket }}
+CustomS3Bucket: {{ resource_bucket }}
 HeadNode:
   InstanceType: {{ instance }}
   Networking:

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
@@ -1,6 +1,6 @@
 Image:
   Os: {{ os }}
-ClusterS3Bucket: {{ resource_bucket }}
+CustomS3Bucket: {{ resource_bucket }}
 HeadNode:
   InstanceType: {{ instance }}
   Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -5,7 +5,7 @@ Tags:
     Value: value3
   - Key: key2
     Value: value2
-ClusterS3Bucket: {{ resource_bucket }}
+CustomS3Bucket: {{ resource_bucket }}
 HeadNode:
   InstanceType: {{ instance }}
   Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -5,7 +5,7 @@ Tags:
     Value: value3
   - Key: key2
     Value: value2
-ClusterS3Bucket: {{ resource_bucket }}
+CustomS3Bucket: {{ resource_bucket }}
 HeadNode:
   InstanceType: {{ instance }}
   Networking:


### PR DESCRIPTION
* Define S3Bucket model for common bucket utilities and object key generation.
* Define S3BucketFactory to check the bucket existence and manage bucket creation, configuration.
* Add custom bucket schema to imagebuilder config file
* Complete S3 bucket per region logic in `pcluster create`, `pcluster delete`, `pcluster update`, `pcluster build-image` commands.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
