### PR TITLE
Integ-tests: Fix CloudWatch integration test

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -141,9 +141,10 @@ class CloudWatchLoggingClusterState:
         """Turn the name of a base OS into the platform."""
         # Special case: alinux2 is how the config file refers to amazon linux 2, but in the chef cookbook
         # (and the cloudwatch log config produced by it) the platform is "amazon".
-        translations = {"alinux2": "amazon"}
-        no_digits = base_os.rstrip(string.digits)
-        return translations.get(no_digits, no_digits)
+        if base_os == "alinux2":
+            return "amazon"
+        else:
+            return base_os.rstrip(string.digits)
 
     def _set_head_node_instance(self, instance):
         """Set the head node instance field in self.cluster_log_state."""


### PR DESCRIPTION
The bug, which was introduced when deprecating alinux1. was only in the integration integration test. This commit uses a more straightforward logic to handle mapping between base os and platform names.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
