### PR TITLE
Install Python3 in Batch Dockerfile

### DIFF
--- a/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
@@ -13,9 +13,8 @@ RUN yum update -y \
     openssh-clients \
     openmpi \
     openmpi-devel \
-    python2 \
-    python2-setuptools \
-    python2-pip \
+    python3 \
+    python3-pip \
     which  \
     hostname \
     && yum clean all \


### PR DESCRIPTION
* Alinux2 docker image comes with python2 already installed as default python
* Keep python2 as default python and install python3 so it's available for use

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
