### PR TITLE
Fix for test_createami_wrong_os

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -115,7 +115,7 @@ createami:
     dimensions:
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1804"]  # os must be different from alinux2 to test os validation logic when wrong os is provided
+        oss: ["ubuntu1804"]  # os must be different from centos8 to test os validation logic when wrong os is provided
   test_createami.py::test_createami_wrong_pcluster_version:
     dimensions:
       - regions: ["ca-central-1"]

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -122,8 +122,8 @@ def test_createami_wrong_os(region, instance, os, request, pcluster_config_reade
     """Test error message when os provide is different from the os of custom AMI"""
     cluster_config = pcluster_config_reader()
 
-    # ubuntu1804 is specified in the config file but an AMI of alinux2 is provided
-    wrong_os = "alinux2"
+    # ubuntu1804 is specified in the config file but an AMI of centos8 is provided
+    wrong_os = "centos8"
     logging.info("Asserting os fixture is different from wrong_os variable")
     assert_that(os != wrong_os).is_true()
     base_ami = retrieve_latest_ami(region, wrong_os, ami_type="pcluster", architecture=architecture)


### PR DESCRIPTION
Fix is to use two OS that use the same root device name

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
