### PR TITLE
Fix Batch container builds

### DIFF
--- a/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
+++ b/cli/src/pcluster/resources/batch/docker/alinux2/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 
-ENV USER root  # nosemgrep
+ENV USER root
 
 RUN yum update -y \
     && yum -y install \

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -199,6 +199,10 @@ commands =
 
 # semgrep is used to check for security issues
 # https://semgrep.dev/
+# The Dockerfile for Batch clusters is currently excluded for the because it
+# violates the last-user-is-root rule from https://semgrep.dev/p/dockerfile.
+# There doesn't appear to be a way to either disable this one rule without
+# using a custom set of rules.
 [testenv:semgrep]
 basepython = python3
 deps =
@@ -208,6 +212,7 @@ commands =
         --config p/r2c-security-audit \
         --config p/secrets \
         --exclude 'tests/**' \
+        --exclude 'Dockerfile' \
         --error
 
 # Target that groups all code linters to run in Travis.


### PR DESCRIPTION
Batch container builds were broken by a `# nosemgrep` comment placed after an `ENV` directive. This is [not allowed](https://docs.docker.com/engine/reference/builder/#format).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
