### PR TITLE
Fix import of packaging.version

### DIFF
--- a/cli/src/api/pcluster_api.py
+++ b/cli/src/api/pcluster_api.py
@@ -12,7 +12,7 @@ import json
 import logging
 import os
 
-from packaging import version
+from pkg_resources import packaging
 
 from common.aws.aws_api import AWSApi
 from pcluster.cli_commands.compute_fleet_status_manager import ComputeFleetStatus
@@ -221,7 +221,7 @@ class PclusterApi:
 
     @staticmethod
     def _is_version_2(cluster):
-        return version.parse(cluster.stack.version) < version.parse("3.0.0")
+        return packaging.version.parse(cluster.stack.version) < packaging.version.parse("3.0.0")
 
     @staticmethod
     def build_image(imagebuilder_config: dict, image_name: str, region: str, disable_rollback: bool = True):

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -79,7 +79,7 @@ def pytest_addoption(parser):
     parser.addoption("--node-git-ref", help="Git ref of the custom node package used to build the AMI.")
     parser.addoption(
         "--ami-owner",
-        help="Override the owner value when fetching AMIs to use with cluster." " By default pcluster uses amazon.",
+        help="Override the owner value when fetching AMIs to use with cluster. By default pcluster uses amazon.",
     )
     parser.addoption("--createami-custom-node-package", help="url to a custom node package for the createami command")
     parser.addoption("--custom-awsbatch-template-url", help="url to a custom awsbatch template")


### PR DESCRIPTION
`from packaging import version` was breaking when installing the CLI in a clean env (e.g. after creating the wheel dist).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
