### PR TITLE
FSx in isolated subnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 **ENHANCEMENTS**
 
 - Add support for Ubuntu 20.04.
+- Add support for using FSx Lustre in subnet with no internet access.
 - Add validation to prevent using a `cluster_resource_bucket` that is in a different region than the cluster.
 
 **CHANGES**

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -27,6 +27,8 @@ from pcluster.config.cfn_param_types import (
     EFSCfnSection,
     ExtraJsonCfnParam,
     FloatCfnParam,
+    FSxDNSNameParam,
+    FSxMountNameParam,
     HeadNodeAvailabilityZoneCfnParam,
     HeadNodeInstanceTypeCfnParam,
     IntCfnParam,
@@ -575,7 +577,19 @@ FSX = {
                 "default": "NONE",
                 "allowed_values": ALLOWED_VALUES["fsx_drive_cache_type"],
                 "update_policy": UpdatePolicy.UNSUPPORTED
-            })
+            }),
+            ("existing_mount_name", {
+                "type": FSxMountNameParam,
+                "default": "NONE",
+                "update_policy": UpdatePolicy.IGNORED,
+                "visibility": Visibility.PRIVATE,
+            }),
+            ("existing_dns_name", {
+                "type": FSxDNSNameParam,
+                "default": "NONE",
+                "update_policy": UpdatePolicy.IGNORED,
+                "visibility": Visibility.PRIVATE,
+            }),
         ]
     )
 }

--- a/cli/src/pcluster/config/param_types.py
+++ b/cli/src/pcluster/config/param_types.py
@@ -519,11 +519,11 @@ class Section(ABC):
                 errors, warnings = validation_func(self.key, self.label, self.pcluster_config)
                 if errors:
                     self.pcluster_config.error(
-                        "The section [{0}] is wrongly configured\n" "{1}".format(section_name, "\n".join(errors))
+                        "The section [{0}] is incorrectly configured\n" "{1}".format(section_name, "\n".join(errors))
                     )
                 elif warnings:
                     self.pcluster_config.warn(
-                        "The section [{0}] is wrongly configured\n{1}".format(section_name, "\n".join(warnings))
+                        "The section [{0}] is incorrectly configured\n{1}".format(section_name, "\n".join(warnings))
                     )
                 else:
                     LOGGER.debug("Section '[%s]' is valid", section_name)

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -1354,8 +1354,9 @@ def fsx_ignored_parameters_validator(section_key, section_label, pcluster_config
 
     fsx_section = pcluster_config.get_section(section_key, section_label)
 
-    # If fsx_fs_id is specified, all parameters besides shared_dir are ignored.
-    relevant_when_using_existing_fsx = ["fsx_fs_id", "shared_dir"]
+    # If fsx_fs_id is specified, all input parameters besides shared_dir are ignored.
+    # Internal parameters are need to pass info about fsx into cookbook
+    relevant_when_using_existing_fsx = ["fsx_fs_id", "shared_dir", "existing_mount_name", "existing_dns_name"]
     if fsx_section.get_param_value("fsx_fs_id") is not None:
         for fsx_param in fsx_section.params:
             if fsx_param not in relevant_when_using_existing_fsx and FSX_PARAM_WITH_DEFAULT.get(

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -1361,3 +1361,15 @@ class InstanceTypeInfo:
             supported_classes.remove("on-demand")
             supported_classes.append("ondemand")
         return supported_classes
+
+
+@Cache.cached
+def get_fsx_info(fs_id):
+    try:
+        return boto3.client("fsx").describe_file_systems(FileSystemIds=[fs_id]).get("FileSystems")[0]
+    except ClientError as e:
+        error(
+            "Failed when retrieving FSx filesystem data for filesystem {0}: {1}".format(
+                fs_id, e.response.get("Error").get("Message")
+            )
+        )

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -87,6 +87,8 @@ DEFAULT_FSX_DICT = {
     "auto_import_policy": None,
     "storage_type": None,
     "drive_cache_type": "NONE",
+    "existing_mount_name": "NONE",
+    "existing_dns_name": "NONE",
 }
 
 DEFAULT_DCV_DICT = {"enable": None, "port": 8443, "access_from": "0.0.0.0/0"}
@@ -269,9 +271,7 @@ DEFAULT_EFS_CFN_PARAMS = {"EFSOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE
 
 DEFAULT_RAID_CFN_PARAMS = {"RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
-DEFAULT_FSX_CFN_PARAMS = {
-    "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
-}
+DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "{}".format(",".join(["NONE"] * 19))}
 
 DEFAULT_DCV_CFN_PARAMS = {"DCVOptions": "NONE,NONE,NONE"}
 DEFAULT_CW_LOG_CFN_PARAMS = {"CWLogOptions": "true,14"}
@@ -342,7 +342,7 @@ DEFAULT_CLUSTER_SIT_CFN_PARAMS = {
     # raid
     "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # fsx
-    "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+    "FSXOptions": "{}".format(",".join(["NONE"] * 19)),
     # dcv
     "DCVOptions": "NONE,NONE,NONE",
     # cw_log_settings
@@ -414,7 +414,7 @@ DEFAULT_CLUSTER_HIT_CFN_PARAMS = {
     # raid
     "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # fsx
-    "FSXOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+    "FSXOptions": "{}".format(",".join(["NONE"] * 19)),
     # dcv
     "DCVOptions": "NONE,NONE,NONE",
     # cw_log_settings

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -1154,7 +1154,7 @@ def test_cluster_section_to_cfn(
                     "RAIDOptions": "raid,NONE,2,gp2,20,NONE,false,NONE,125",
                     # fsx
                     "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,"
-                    "NONE,NONE",
+                    "NONE,NONE,NONE,NONE",
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                     "Scheduler": "sge",
@@ -1220,7 +1220,7 @@ def test_cluster_section_to_cfn(
                     "RAIDOptions": "raid,NONE,2,gp2,20,NONE,false,NONE,125",
                     # fsx
                     "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,"
-                    "NONE,NONE",
+                    "NONE,NONE,NONE,NONE",
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                 },

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -1418,13 +1418,17 @@ def test_fsx_id_validator(mocker, boto3_stubber, fsx_vpc, ip_permissions, networ
             )
 
     boto3_stubber("ec2", ec2_mocked_requests)
-
+    fsx_spy = mocker.patch(
+        "pcluster.config.cfn_param_types.get_fsx_info",
+        return_value={"DNSName": "my.fsx.dns.name", "LustreConfiguration": {"MountName": "somemountname"}},
+    )
     config_parser_dict = {
         "cluster default": {"fsx_settings": "default", "vpc_settings": "default"},
         "vpc default": {"master_subnet_id": "subnet-12345678"},
         "fsx default": {"fsx_fs_id": "fs-0ff8da96d57f3b4e3"},
     }
     utils.assert_param_validator(mocker, config_parser_dict, expected_message)
+    fsx_spy.assert_called_with("fs-0ff8da96d57f3b4e3")
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -211,7 +211,6 @@ def assert_section_from_cfn(
             section_dict[param_key] = param.value
 
     remove_ignored_params(section_dict)
-
     assert_that(section_dict).is_equal_to(expected_dict)
 
 

--- a/cli/tests/pcluster_config/test_pcluster_config_convert.py
+++ b/cli/tests/pcluster_config/test_pcluster_config_convert.py
@@ -38,10 +38,12 @@ def test_slurm_sit_simple(mocker, test_datadir, tmpdir, capsys):
 
 
 def test_slurm_sit_full(mocker, test_datadir, tmpdir, capsys):
+    _mock_fsx_info(mocker)
     _convert_and_assert_file_content(mocker, test_datadir, tmpdir, capsys, cluster_template="slurm-sit-full")
 
 
 def test_slurm_unrelated_sections(mocker, test_datadir, tmpdir, capsys):
+    _mock_fsx_info(mocker)
     _convert_and_assert_file_content(mocker, test_datadir, tmpdir, capsys, cluster_template="slurm-sit-full")
 
 
@@ -78,3 +80,10 @@ def _assert_files_are_equal(file, expected_file):
     with open(str(file)) as f, open(str(expected_file)) as exp_f:
         expected_file_content = exp_f.read()
         assert_that(f.read()).is_equal_to(expected_file_content)
+
+
+def _mock_fsx_info(mocker):
+    mocker.patch(
+        "pcluster.config.cfn_param_types.get_fsx_info",
+        return_value={"DNSName": "my.fsx.dns.name", "LustreConfiguration": {"MountName": "somemountname"}},
+    )

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -336,9 +336,9 @@
       "Default": "1"
     },
     "FSXOptions": {
-      "Description": "Comma separated list of FSx related options, 17 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id,auto_import_policy,storage_type,drive_cache_type]",
+      "Description": "Comma separated list of FSx related options, 19 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id,auto_import_policy,storage_type,drive_cache_type,existing_mount_name,existing_dns_name]",
       "Type": "String",
-      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
+      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },
     "EFSOptions": {
       "Description": "Comma separated list of EFS related options, 9 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,exists_valid_head_node_mt,exists_valid_compute_mt]",
@@ -3014,6 +3014,30 @@
               ""
             ]
           },
+          "FSXMountName": {
+            "Fn::If": [
+              "CreateFSXSubstack",
+              {
+                "Fn::GetAtt": [
+                  "FSXSubstack",
+                  "Outputs.MountName"
+                ]
+              },
+              ""
+            ]
+          },
+          "FSXDNSName": {
+            "Fn::If": [
+              "CreateFSXSubstack",
+              {
+                "Fn::GetAtt": [
+                  "FSXSubstack",
+                  "Outputs.DNSName"
+                ]
+              },
+              ""
+            ]
+          },
           "FSXOptions": {
             "Ref": "FSXOptions"
           },
@@ -3473,6 +3497,30 @@
               ""
             ]
           },
+          "FSXMountName": {
+            "Fn::If": [
+              "CreateFSXSubstack",
+              {
+                "Fn::GetAtt": [
+                  "FSXSubstack",
+                  "Outputs.MountName"
+                ]
+              },
+              ""
+            ]
+          },
+          "FSXDNSName": {
+            "Fn::If": [
+              "CreateFSXSubstack",
+              {
+                "Fn::GetAtt": [
+                  "FSXSubstack",
+                  "Outputs.DNSName"
+                ]
+              },
+              ""
+            ]
+          },
           "FSXOptions": {
             "Ref": "FSXOptions"
           },
@@ -3847,6 +3895,30 @@
                 "Fn::GetAtt": [
                   "FSXSubstack",
                   "Outputs.FileSystemId"
+                ]
+              },
+              ""
+            ]
+          },
+          "FSXMountName": {
+            "Fn::If": [
+              "CreateFSXSubstack",
+              {
+                "Fn::GetAtt": [
+                  "FSXSubstack",
+                  "Outputs.MountName"
+                ]
+              },
+              ""
+            ]
+          },
+          "FSXDNSName": {
+            "Fn::If": [
+              "CreateFSXSubstack",
+              {
+                "Fn::GetAtt": [
+                  "FSXSubstack",
+                  "Outputs.DNSName"
                 ]
               },
               ""

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -45,6 +45,10 @@ Parameters:
     Type: String
   FSXId:
     Type: String
+  FSXMountName:
+    Type: String
+  FSXDNSName:
+    Type: String
   FSXOptions:
     Type: String
   Scheduler:
@@ -326,6 +330,8 @@ Resources:
                         "cfn_efs": "${EFSId}",
                         "cfn_efs_shared_dir": "${EFSOptions}",
                         "cfn_fsx_fs_id": "${FSXId}",
+                        "cfn_fsx_mount_name": "${FSXMountName}",
+                        "cfn_fsx_dns_name": "${FSXDNSName}",
                         "cfn_fsx_options": "${FSXOptions}",
                         "cfn_scheduler": "${Scheduler}",
                         "cfn_scheduler_slots": "{{ compute_resource.vcpus }}",

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -54,6 +54,10 @@ Parameters:
     Type: String
   FSXId:
     Type: String
+  FSXMountName:
+    Type: String
+  FSXDNSName:
+    Type: String
   FSXOptions:
     Type: String
   Scheduler:
@@ -448,6 +452,8 @@ Resources:
                         "cfn_efs": "${EFSId}",
                         "cfn_efs_shared_dir": "${EFSOptions}",
                         "cfn_fsx_fs_id": "${FSXId}",
+                        "cfn_fsx_mount_name": "${FSXMountName}",
+                        "cfn_fsx_dns_name": "${FSXDNSName}",
                         "cfn_fsx_options": "${FSXOptions}",
                         "cfn_scheduler": "${Scheduler}",
                         "cfn_scheduler_slots": "${SchedulerSlots}",

--- a/cloudformation/fsx-substack.cfn.json
+++ b/cloudformation/fsx-substack.cfn.json
@@ -284,6 +284,23 @@
         },
         "HDD"
       ]
+    },
+    "UseDNSName": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "18",
+                {
+                  "Ref": "FSXOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
     }
   },
   "Outputs": {
@@ -305,6 +322,45 @@
           }
         ]
       }
+    },
+    "MountName": {
+      "Description": "Mount name of the FileSystem",
+      "Value": {
+        "Fn::If": [
+          "CreateFSX",
+          {
+            "Fn::GetAtt": [
+              "FileSystem",
+              "LustreMountName"
+            ]
+          },
+          {
+            "Fn::Select": [
+              "17",
+              {
+                "Ref": "FSXOptions"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "DNSName": {
+      "Description": "DNS Name of the FileSystem",
+      "Value": {
+        "Fn::If": [
+          "UseDNSName",
+          {
+            "Fn::Select": [
+              "18",
+              {
+                "Ref": "FSXOptions"
+              }
+            ]
+          },
+          ""
+        ]
+      }
     }
   },
   "Parameters": {
@@ -317,7 +373,7 @@
       "Type": "String"
     },
     "FSXOptions": {
-      "Description": "Comma separated list of fsx related options, 17 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id,auto_import_policy,storage_type,drive_cache_type]",
+      "Description": "Comma separated list of fsx related options, 19 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id,auto_import_policy,storage_type,drive_cache_type,existing_mount_name,existing_dns_name]",
       "Type": "CommaDelimitedList"
     },
     "SubnetId": {

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -60,6 +60,10 @@ Parameters:
     Type: String
   FSXId:
     Type: String
+  FSXMountName:
+    Type: String
+  FSXDNSName:
+    Type: String
   FSXOptions:
     Type: String
   Scheduler:
@@ -586,6 +590,8 @@ Resources:
                       "cfn_efs": "${EFSId}",
                       "cfn_efs_shared_dir": "${EFSOptions}",
                       "cfn_fsx_fs_id": "${FSXId}",
+                      "cfn_fsx_mount_name": "${FSXMountName}",
+                      "cfn_fsx_dns_name": "${FSXDNSName}",
                       "cfn_fsx_options": "${FSXOptions}",
                       "cfn_volume": "${EBSVolIds}",
                       "cfn_scheduler": "${Scheduler}",

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -199,7 +199,7 @@ def test_hit_substack_rendering(tmp_path, test_config):
             "vol1,vol2,vol3,vol4,vol5",
             "gp2,io1,sc1,st1,gp2",  # No io1 metrics
             "raid,1,2,gp2,20,100,false,NONE",
-            "/fsx,NONE,1200,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "/fsx,{}".format(",".join(["NONE"] * 18)),  # Test logic only depends on the first shared_dir param
             "efs,NONE,generalPurpose,NONE,NONE,false,bursting,NONE,Valid",
             "master,8443,0.0.0.0/0",
             "true,14",
@@ -211,7 +211,7 @@ def test_hit_substack_rendering(tmp_path, test_config):
             "vol1,NONE,NONE,NONE,NONE",  # single ebs section
             "io1,io1,io1,io1,io1",  # No gp2,sc1,st1 metrics
             "raid,1,2,io1,20,100,false,NONE",  # No gp2,sc1,st1 metrics
-            "/fsx,NONE,1200,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "/fsx,{}".format(",".join(["NONE"] * 18)),  # Test logic only depends on the first shared_dir param
             "efs,NONE,maxIO,NONE,NONE,false,bursting,NONE,Valid",  # No conditional EFS metric (maxIO)
             "master,8443,0.0.0.0/0",
             "true,14",
@@ -223,7 +223,7 @@ def test_hit_substack_rendering(tmp_path, test_config):
             "shared",  # No ebs section
             "standard,standard,standard,standard,standard",
             "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",  # No RAID metrics
-            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",  # No FSx metrics
+            "{}".format(",".join(["NONE"] * 19)),  # No FSx metrics
             "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",  # No EFS metrics
             "NONE,NONE,NONE",  # No DCV logs
             "true,14",
@@ -235,7 +235,7 @@ def test_hit_substack_rendering(tmp_path, test_config):
             "shared",
             "sc1,st1,gp2,sc1,st1",
             "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
-            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "{}".format(",".join(["NONE"] * 19)),
             "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
             "NONE,NONE,NONE",
             "false,14",  # No Head Node Logs
@@ -247,7 +247,7 @@ def test_hit_substack_rendering(tmp_path, test_config):
             "vol1,vol2,vol3,vol4,vol5",
             "NONE,NONE,NONE,NONE,NONE",
             "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
-            "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
+            "{}".format(",".join(["NONE"] * 19)),
             "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
             "NONE,NONE,NONE",
             "false,14",

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -171,7 +171,9 @@ class Cluster:
                 {"Name": "tag:Name", "Values": ["Master"]},
             ]
             instance = ec2.describe_instances(Filters=filters).get("Reservations")[0].get("Instances")[0]
-            return instance.get("PublicIpAddress")
+            return (
+                instance.get("PublicIpAddress") if instance.get("PublicIpAddress") else instance.get("PrivateIpAddress")
+            )
 
     @property
     def os(self):

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -14,7 +14,7 @@ import os
 import shlex
 
 from fabric import Connection
-from utils import get_username_for_os
+from utils import get_username_for_os, run_command
 
 
 class RemoteCommandExecutionError(Exception):
@@ -27,15 +27,29 @@ class RemoteCommandExecutionError(Exception):
 class RemoteCommandExecutor:
     """Execute remote commands on the cluster head node."""
 
-    def __init__(self, cluster, username=None):
+    def __init__(self, cluster, username=None, bastion=None):
         if not username:
             username = get_username_for_os(cluster.os)
-        self.__connection = Connection(
-            host=cluster.head_node_ip,
-            user=username,
-            forward_agent=False,
-            connect_kwargs={"key_filename": [cluster.ssh_key]},
-        )
+        connection_kwargs = {
+            "host": cluster.head_node_ip,
+            "user": username,
+            "forward_agent": False,
+            "connect_kwargs": {"key_filename": [cluster.ssh_key]},
+        }
+        if bastion:
+            # Need to execute simple ssh command before using Connection to avoid Paramiko _check_banner error
+            run_command(
+                "ssh -tt -i {key_path} -o StrictHostKeyChecking=no "
+                '-o ProxyCommand="ssh -tt -o StrictHostKeyChecking=no -W %h:%p -A {bastion}" '
+                "-A {user}@{head_node} hostname".format(
+                    key_path=cluster.ssh_key, bastion=bastion, user=username, head_node=cluster.head_node_ip
+                ),
+                timeout=30,
+                shell=True,
+            )
+            connection_kwargs["gateway"] = "ssh -W %h:%p -A {}".format(bastion)
+            connection_kwargs["forward_agent"] = True
+        self.__connection = Connection(**connection_kwargs)
         self.__user_at_hostname = "{0}@{1}".format(username, cluster.head_node_ip)
 
     def __del__(self):

--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -9,18 +9,100 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+import logging
+import time
+
 import pytest
+import utils
 from assertpy import assert_that
+from cfn_stacks_factory import CfnStack
+from remote_command_executor import RemoteCommandExecutor
+from troposphere import GetAtt, Output, Ref, Template, ec2
 from utils import get_compute_nodes_instance_ids
+
+from tests.common.schedulers_common import get_scheduler_commands
+from tests.common.utils import retrieve_latest_ami
+from tests.storage.test_fsx_lustre import (
+    get_fsx_fs_id,
+    test_fsx_lustre_correctly_mounted,
+    test_fsx_lustre_correctly_shared,
+)
 
 
 @pytest.mark.dimensions("us-west-2", "c5.xlarge", "alinux2", "slurm")
 @pytest.mark.dimensions("eu-west-2", "c5.xlarge", "centos7", "sge")
 @pytest.mark.usefixtures("os", "scheduler", "instance")
-def test_cluster_in_private_subnet(region, pcluster_config_reader, clusters_factory):
+def test_cluster_in_private_subnet(region, os, scheduler, pcluster_config_reader, clusters_factory, bastion_factory):
     # This test just creates a cluster in the private subnet and just checks that no failures occur
-    cluster_config = pcluster_config_reader()
+    fsx_mount_dir = "/fsx_mount"
+    cluster_config = pcluster_config_reader(fsx_mount_dir=fsx_mount_dir)
     cluster = clusters_factory(cluster_config)
     assert_that(cluster).is_not_none()
 
     assert_that(len(get_compute_nodes_instance_ids(cluster.cfn_name, region))).is_equal_to(1)
+    _test_fsx_in_private_subnet(cluster, os, region, scheduler, fsx_mount_dir, bastion_factory)
+
+
+def _test_fsx_in_private_subnet(cluster, os, region, scheduler, fsx_mount_dir, bastion_factory):
+    """Test FSx can be mounted in private subnet."""
+    bastion_ip = bastion_factory()
+    logging.info("Sleeping for 60 sec to wait for bastion ssh to become ready.")
+    time.sleep(60)
+    logging.info("Bastion_ip: {}".format(bastion_ip))
+    remote_command_executor = RemoteCommandExecutor(cluster, bastion="ec2-user@{}".format(bastion_ip))
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+    fsx_fs_id = get_fsx_fs_id(cluster, region)
+    test_fsx_lustre_correctly_mounted(remote_command_executor, fsx_mount_dir, os, region, fsx_fs_id)
+    test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, fsx_mount_dir)
+
+
+@pytest.fixture()
+def bastion_factory(vpc_stack, cfn_stacks_factory, request, region, key_name):
+    """Class to create bastion instance used to execute commands on cluster in private subnet."""
+    bastion_stack_name = utils.generate_stack_name(
+        "integ-tests-networking-bastion", request.config.getoption("stackname_suffix")
+    )
+
+    def _bastion_factory():
+        """Create bastion stack."""
+        bastion_template = Template()
+        bastion_template.set_version()
+        bastion_template.set_description("Create Networking bastion stack")
+
+        bastion_sg = ec2.SecurityGroup(
+            "NetworkingTestBastionSG",
+            GroupDescription="SecurityGroup for Bastion",
+            SecurityGroupIngress=[
+                ec2.SecurityGroupRule(
+                    IpProtocol="tcp",
+                    FromPort="22",
+                    ToPort="22",
+                    CidrIp="0.0.0.0/0",
+                ),
+            ],
+            VpcId=vpc_stack.cfn_outputs["VpcId"],
+        )
+
+        bastion_instance = ec2.Instance(
+            "NetworkingBastionInstance",
+            ImageId=retrieve_latest_ami(region, "alinux2"),
+            KeyName=key_name,
+            SecurityGroupIds=[Ref(bastion_sg)],
+            SubnetId=vpc_stack.cfn_outputs["PublicSubnetId"],
+        )
+        bastion_template.add_resource(bastion_sg)
+        bastion_template.add_resource(bastion_instance)
+        bastion_template.add_output(
+            Output("BastionIP", Value=GetAtt(bastion_instance, "PublicIp"), Description="The Bastion Public IP")
+        )
+        bastion_stack = CfnStack(
+            name=bastion_stack_name,
+            region=region,
+            template=bastion_template.to_json(),
+        )
+        cfn_stacks_factory.create_stack(bastion_stack)
+
+        return bastion_stack.cfn_outputs.get("BastionIP")
+
+    yield _bastion_factory
+    cfn_stacks_factory.delete_stack(bastion_stack_name, region)

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.ini
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.ini
@@ -14,6 +14,7 @@ compute_instance_type = {{ instance }}
 initial_queue_size = 1
 max_queue_size = 1
 maintain_initial_size = false
+fsx_settings = private_fsx
 
 
 [vpc parallelcluster-vpc]
@@ -21,3 +22,8 @@ vpc_id = {{ vpc_id }}
 master_subnet_id = {{ private_subnet_id }}
 compute_subnet_id = {{ private_subnet_id }}
 use_public_ips=false
+
+[fsx private_fsx]
+shared_dir = {{ fsx_mount_dir }}
+storage_capacity = 1200
+deployment_type = SCRATCH_2

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -187,9 +187,9 @@ def _test_fsx_lustre(
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
     fsx_fs_id = get_fsx_fs_id(cluster, region)
 
-    _test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
+    test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
     _test_import_path(remote_command_executor, mount_dir)
-    _test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir)
+    test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir)
     _test_export_path(remote_command_executor, mount_dir, bucket_name, region)
     _test_data_repository_task(remote_command_executor, mount_dir, bucket_name, fsx_fs_id, region)
 
@@ -230,7 +230,7 @@ def test_fsx_lustre_backup(region, pcluster_config_reader, clusters_factory, os,
     fsx_fs_id = get_fsx_fs_id(cluster, region)
 
     # Mount file system
-    _test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
+    test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
 
     # Create a text file in the mount directory.
     create_backup_test_file(scheduler_commands, remote_command_executor, mount_dir)
@@ -259,7 +259,7 @@ def test_fsx_lustre_backup(region, pcluster_config_reader, clusters_factory, os,
     fsx_fs_id_restore = get_fsx_fs_id(cluster_restore, region)
 
     # Mount the restored file system
-    _test_fsx_lustre_correctly_mounted(remote_command_executor_restore, mount_dir, os, region, fsx_fs_id_restore)
+    test_fsx_lustre_correctly_mounted(remote_command_executor_restore, mount_dir, os, region, fsx_fs_id_restore)
 
     # Validate whether text file created in the original file system is present in the restored file system.
     _test_restore_from_backup(remote_command_executor_restore, mount_dir)
@@ -360,7 +360,7 @@ def fsx_factory(vpc_stack, cfn_stacks_factory, request, region, key_name):
         cfn_stacks_factory.delete_stack(fsx_stack_name, region)
 
 
-def _test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id):
+def test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id):
     logging.info("Testing fsx lustre is correctly mounted")
     result = remote_command_executor.run_remote_command("df -h -t lustre | tail -n +2 | awk '{print $1, $2, $6}'")
     mount_name = get_mount_name(fsx_fs_id, region)
@@ -425,14 +425,10 @@ def _test_import_path(remote_command_executor, mount_dir):
     assert_that(result.stdout).is_equal_to("Downloaded by FSx Lustre")
 
 
-def _test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir):
+def test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir):
     logging.info("Testing fsx lustre correctly mounted on compute nodes")
     remote_command_executor.run_remote_command("touch {mount_dir}/test_file".format(mount_dir=mount_dir))
-    job_command = (
-        "cat {mount_dir}/s3_test_file "
-        "&& cat {mount_dir}/test_file "
-        "&& touch {mount_dir}/compute_output".format(mount_dir=mount_dir)
-    )
+    job_command = "cat {mount_dir}/test_file && touch {mount_dir}/compute_output".format(mount_dir=mount_dir)
     result = scheduler_commands.submit_command(job_command)
     job_id = scheduler_commands.assert_job_submitted(result.stdout)
     scheduler_commands.wait_job_completed(job_id)


### PR DESCRIPTION
* Do not query FSx API for MountName and DNSName
* For existing filesystems, MountName and DNSName are retrieved by CLI and passed into cookbook using attributes
* For filesystem created with cluster, MountName is retrieved from CFN filesystem resource attribute. DNSName is generated in hardcoded format
* Fix unit tests
* Add integration test for FSx in private subnet

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
