### PR TITLE
Remove Ubuntu 20.04 from dcv tests on ARM instances

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -139,7 +139,7 @@ dcv:
       # DCV on ARM
       - regions: ["eu-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{common.OSS_COMMERCIAL_ARM}}
+        oss: ["alinux2", "centos8", "ubuntu1804"]
         schedulers: ["slurm"]
       # DCV on Batch
       - regions: ["eu-west-1"]


### PR DESCRIPTION
DCV is currently not supported on ARM with Ubuntu 20.04

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
