### PR TITLE
3.0: Fix path used by CodeBuild to retrieve scheduler_resources.

### DIFF
--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -560,7 +560,8 @@ class AwsbatchConstruct(core.Construct):
             name=f"{cluster_name(self.stack_name)}-build-docker-images-project",
             service_role=self._code_build_role.ref,
             source=codebuild.CfnProject.SourceProperty(
-                location=f"{self.bucket.name}/{self.bucket.artifact_directory}/docker/artifacts.zip",
+                location=f"{self.bucket.name}/{self.bucket.artifact_directory}"
+                "/custom_resources/scheduler_resources.zip",
                 type="S3",
             ),
             logs_config=codebuild.CfnProject.LogsConfigProperty(


### PR DESCRIPTION
Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
