### PR TITLE
Fix path used by CodeBuild to retrieve scheduler_resources

### DIFF
--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -721,7 +721,7 @@
         },
         "Source": {
           "Location": {
-            "Fn::Sub": "${ResourcesS3Bucket}/${ArtifactS3RootDirectory}/docker/artifacts.zip"
+            "Fn::Sub": "${ResourcesS3Bucket}/${ArtifactS3RootDirectory}/custom_resources/scheduler_resources.zip"
           },
           "Type": "S3"
         },


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
