### PR TITLE
Fix runtime_bake test with Ubuntu20

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -28,6 +28,10 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
         "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-*-server-*",
         "owners": ["099720109477", "513442679011", "837727238323"],
     },
+    "ubuntu2004": {
+        "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*-server-*",
+        "owners": ["099720109477"],
+    },
 }
 
 # Remarkable AMIs are latest deep learning base AMI and FPGA developer AMI without pcluster infrastructure


### PR DESCRIPTION
Official AMI mapping data needed for runtime bake tests was missing for Ubuntu 20.04.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
