### PR TITLE
3.0: Fix some issues in config validation and bucket deletion

### DIFF
--- a/cli/src/api/pcluster_api.py
+++ b/cli/src/api/pcluster_api.py
@@ -16,7 +16,7 @@ from pkg_resources import packaging
 
 from common.aws.aws_api import AWSApi
 from pcluster.cli_commands.compute_fleet_status_manager import ComputeFleetStatus
-from pcluster.models.cluster import Cluster, ClusterActionError, ClusterStack
+from pcluster.models.cluster import Cluster, ClusterActionError, ClusterStack, ClusterUpdateError, ConfigValidationError
 from pcluster.models.imagebuilder import ImageBuilder, ImageBuilderActionError
 from pcluster.utils import get_installed_version, get_region
 from pcluster.validators.common import FailureLevel
@@ -112,8 +112,8 @@ class PclusterApi:
             cluster = Cluster(cluster_name, cluster_config)
             cluster.create(disable_rollback, suppress_validators, validation_failure_level)
             return ClusterInfo(cluster.stack)
-        except ClusterActionError as e:
-            return ApiFailure(str(e), e.validation_failures)
+        except ConfigValidationError as e:
+            return ApiFailure(str(e), validation_failures=e.validation_failures)
         except Exception as e:
             return ApiFailure(str(e))
 
@@ -178,8 +178,10 @@ class PclusterApi:
 
             cluster.update(cluster_config, suppress_validators, validation_failure_level, force)  # TODO add dryrun
             return ClusterInfo(cluster.stack, cluster)
-        except ClusterActionError as e:
-            return ApiFailure(str(e), update_changes=e.update_changes, validation_failures=e.validation_failures)
+        except ConfigValidationError as e:
+            return ApiFailure(str(e), validation_failures=e.validation_failures)
+        except ClusterUpdateError as e:
+            return ApiFailure(str(e), update_changes=e.update_changes)
         except Exception as e:
             return ApiFailure(str(e))
 

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -307,6 +307,7 @@ class Cluster:
     ):
         """Create cluster."""
         creation_result = None
+        artifacts_uploaded = False
         try:
             # check cluster existence
             if AWSApi.instance().cfn.stack_exists(self.stack_name):
@@ -325,6 +326,7 @@ class Cluster:
 
             # upload cluster artifacts and generated template
             self._upload_artifacts()
+            artifacts_uploaded = True
 
             LOGGER.info("Creating stack named: %s", self.stack_name)
             creation_result = AWSApi.instance().cfn.create_stack_from_url(
@@ -341,7 +343,7 @@ class Cluster:
             LOGGER.info("Status: %s", self.stack.status)
 
         except Exception as e:
-            if not creation_result:
+            if not creation_result and artifacts_uploaded:
                 # Cleanup S3 artifacts if stack is not created yet
                 self.bucket.delete_s3_artifacts()
             raise ClusterActionError(f"Cluster creation failed.\n{e}")

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -52,9 +52,23 @@ class NodeType(Enum):
 class ClusterActionError(Exception):
     """Represent an error during the execution of an action on the cluster."""
 
-    def __init__(self, message: str, validation_failures: list = None, update_changes: list = None):
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class ConfigValidationError(ClusterActionError):
+    """Represent an error during the validation of the configuration."""
+
+    def __init__(self, message: str, validation_failures: list):
         super().__init__(message)
         self.validation_failures = validation_failures or []
+
+
+class ClusterUpdateError(ClusterActionError):
+    """Represent an error during the update of the cluster."""
+
+    def __init__(self, message: str, update_changes: list):
+        super().__init__(message)
         self.update_changes = update_changes or []
 
 
@@ -305,7 +319,12 @@ class Cluster:
         suppress_validators: bool = False,
         validation_failure_level: FailureLevel = FailureLevel.ERROR,
     ):
-        """Create cluster."""
+        """
+        Create cluster.
+
+        raises ClusterActionError: in case of generic error
+        raises ConfigValidationError: if configuration is invalid
+        """
         creation_result = None
         artifacts_uploaded = False
         try:
@@ -342,6 +361,8 @@ class Cluster:
             LOGGER.debug("StackId: %s", self.stack.id)
             LOGGER.info("Status: %s", self.stack.status)
 
+        except ConfigValidationError as e:
+            raise e
         except Exception as e:
             if not creation_result and artifacts_uploaded:
                 # Cleanup S3 artifacts if stack is not created yet
@@ -367,13 +388,13 @@ class Cluster:
                 for failure in validation_failures:
                     if failure.level.value >= FailureLevel(validation_failure_level).value:
                         # Raise the exception if there is a failure with a level greater than the specified one
-                        raise ClusterActionError("Configuration is invalid", validation_failures=validation_failures)
+                        raise ConfigValidationError("Configuration is invalid", validation_failures=validation_failures)
             LOGGER.info("Validation succeeded.")
 
         except ValidationError as e:
             # syntactic failure
             validation_failures = [ValidationResult(str(e), FailureLevel.ERROR)]
-            raise ClusterActionError("Configuration is invalid", validation_failures=validation_failures)
+            raise ConfigValidationError("Configuration is invalid", validation_failures=validation_failures)
 
         return config
 
@@ -647,7 +668,13 @@ class Cluster:
         validation_failure_level: FailureLevel = FailureLevel.ERROR,
         force: bool = False,
     ):
-        """Update cluster."""
+        """
+        Update cluster.
+
+        raises ClusterActionError: in case of generic error
+        raises ConfigValidationError: if configuration is invalid
+        raises ClusterUpdateError: if update is not allowed
+        """
         try:
             # check cluster existence
             if not AWSApi.instance().cfn.stack_exists(self.stack_name):
@@ -663,7 +690,7 @@ class Cluster:
             patch = ConfigPatch(cluster=self, base_config=self.source_config, target_config=cluster_config)
             patch_allowed, update_changes = patch.check()
             if not (patch_allowed or force):
-                raise ClusterActionError("Update failure", update_changes=update_changes)
+                raise ClusterUpdateError("Update failure", update_changes=update_changes)
 
             self._add_version_tag()
             self._upload_config()
@@ -691,6 +718,7 @@ class Cluster:
             LOGGER.info("Status: %s", self.stack.status)
 
         except ClusterActionError as e:
+            # It can be a ConfigValidationError or ClusterUpdateError
             raise e
         except Exception as e:
             LOGGER.critical(e)

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -292,6 +292,7 @@ class ImageBuilder:
         cfn_tags = [{"Key": tag.key, "Value": tag.value} for tag in cfn_tags]
 
         creation_result = None
+        artifacts_uploaded = False
         try:
             self._upload_config()
 
@@ -304,6 +305,7 @@ class ImageBuilder:
 
             # upload generated template
             self._upload_artifacts()
+            artifacts_uploaded = True
 
             # Stack creation
             creation_result = AWSApi.instance().cfn.create_stack_from_url(
@@ -321,7 +323,7 @@ class ImageBuilder:
 
         except Exception as e:
             LOGGER.critical(e)
-            if not creation_result:
+            if not creation_result and artifacts_uploaded:
                 # Cleanup S3 artifacts if stack is not created yet
                 self.bucket.delete_s3_artifacts()
             raise ImageBuilderActionError(f"ParallelCluster image build infrastructure creation failed.\n{e}")

--- a/cli/src/pcluster/validators/common.py
+++ b/cli/src/pcluster/validators/common.py
@@ -36,25 +36,14 @@ class ValidationResult:
         self.level = level
 
 
-class ConfigValidationError(Exception):
-    """Configuration file validation error."""
-
-    def __init__(self, validation_result: ValidationResult):
-        message = f"{validation_result.level.name}: {validation_result.message}"
-        super().__init__(message)
-
-
 class Validator(ABC):
     """Abstract validator. The children must implement the validate method."""
 
-    def __init__(self, raise_on_error=False):
+    def __init__(self):
         self._failures = []
-        self._raise_on_error = raise_on_error
 
     def _add_failure(self, message: str, level: FailureLevel):
         result = ValidationResult(message, level)
-        if self._raise_on_error:
-            raise ConfigValidationError(result)
         self._failures.append(result)
 
     def execute(self, *arg, **kwargs):


### PR DESCRIPTION
* Do not modify source data during pre_dump/pre_load actions. This was causing errors when trying to reuse the same source dict.
* Cleanup S3 bucket only if artifacts are uploaded 
* Remove useless ConfigValidationError and raise_on_error option from Validator
* Use different exceptions for validation and update failures. In this way it's easier to distinguish the failure type and re-raise these exception that contain additional info (i.e. validation failures and update changes).