### PR TITLE
3.0: FSx in isolated subnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ per cluster.
 **ENHANCEMENTS**
 
 - Add support for Ubuntu 20.04.
+- Add support for using FSx Lustre in subnet with no internet access.
 - Add validation to prevent using a `cluster_resource_bucket` that is in a different region than the cluster.
 
 **CHANGES**

--- a/cli/src/common/aws/aws_api.py
+++ b/cli/src/common/aws/aws_api.py
@@ -13,6 +13,7 @@ from common.boto3.cfn import CfnClient
 from common.boto3.dynamodb import DynamodbClient
 from common.boto3.ec2 import Ec2Client
 from common.boto3.efs import EfsClient
+from common.boto3.fsx import FSxClient
 from common.boto3.iam import IamClient
 from common.boto3.imagebuilder import ImageBuilderClient
 from common.boto3.kms import KmsClient
@@ -37,6 +38,7 @@ class AWSApi:
         self.cfn = CfnClient()
         self.ec2 = Ec2Client()
         self.efs = EfsClient(ec2_client=self.ec2)
+        self.fsx = FSxClient()
         self.dynamodb = DynamodbClient()
         # pylint: disable=C0103
         self.s3 = S3Client()

--- a/cli/src/common/aws/aws_resources.py
+++ b/cli/src/common/aws/aws_resources.py
@@ -194,3 +194,20 @@ class InstanceTypeInfo:
             supported_classes.remove("on-demand")
             supported_classes.append("ondemand")
         return supported_classes
+
+
+class FsxFileSystemInfo:
+    """Data object wrapping the result of a describe_file_systems call."""
+
+    def __init__(self, file_system_data):
+        self.file_system_data = file_system_data
+
+    @property
+    def mount_name(self):
+        """Return MountName of the filesystem."""
+        return self.file_system_data.get("LustreConfiguration").get("MountName")
+
+    @property
+    def dns_name(self):
+        """Return DNSName of the filesystem."""
+        return self.file_system_data.get("DNSName")

--- a/cli/src/common/boto3/fsx.py
+++ b/cli/src/common/boto3/fsx.py
@@ -1,0 +1,31 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from common.aws.aws_resources import FsxFileSystemInfo
+from common.boto3.common import AWSExceptionHandler, Boto3Client
+from pcluster.utils import Cache
+
+
+class FSxClient(Boto3Client):
+    """S3 Boto3 client."""
+
+    def __init__(self):
+        super().__init__("fsx")
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def get_filesystem_info(self, fsx_fs_id):
+        """
+        Return FSx filesystem info.
+
+        :param fsx_fs_id: FSx file system Id
+        :return: filesystem info
+        """
+        return FsxFileSystemInfo(self._client.describe_file_systems(FileSystemIds=[fsx_fs_id]).get("FileSystems")[0])

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -356,16 +356,12 @@ class SharedFsx(Resource):
     @property
     def existing_mount_name(self):
         """Return MountName if using existing FSx filesystem."""
-        if self.file_system_id:
-            return self.file_system_data.mount_name
-        return ""
+        return self.file_system_data.mount_name if self.file_system_id else ""
 
     @property
     def existing_dns_name(self):
         """Return DNSName if using existing FSx filesystem."""
-        if self.file_system_id:
-            return self.file_system_data.dns_name
-        return ""
+        return self.file_system_data.dns_name if self.file_system_id else ""
 
 
 # ---------------------- Networking ---------------------- #

--- a/cli/src/pcluster/models/cluster_config.py
+++ b/cli/src/pcluster/models/cluster_config.py
@@ -289,6 +289,7 @@ class SharedFsx(Resource):
         self.auto_import_policy = Resource.init_param(auto_import_policy)
         self.drive_cache_type = Resource.init_param(drive_cache_type)
         self.fsx_storage_type = Resource.init_param(fsx_storage_type)
+        self.__file_system_data = None
 
     def _validate(self):
         self._execute_validator(NameValidator, name=self.name)
@@ -344,6 +345,27 @@ class SharedFsx(Resource):
             self._execute_validator(
                 FsxAutoImportValidator, auto_import_policy=self.auto_import_policy, import_path=self.import_path
             )
+
+    @property
+    def file_system_data(self):
+        """Return filesystem information if using existing FSx."""
+        if not self.__file_system_data and self.file_system_id:
+            self.__file_system_data = AWSApi.instance().fsx.get_filesystem_info(self.file_system_id)
+        return self.__file_system_data
+
+    @property
+    def existing_mount_name(self):
+        """Return MountName if using existing FSx filesystem."""
+        if self.file_system_id:
+            return self.file_system_data.mount_name
+        return ""
+
+    @property
+    def existing_dns_name(self):
+        """Return DNSName if using existing FSx filesystem."""
+        if self.file_system_id:
+            return self.file_system_data.dns_name
+        return ""
 
 
 # ---------------------- Networking ---------------------- #

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -60,6 +60,8 @@ write_files:
           "efs_fs_id": "${EFSId}",
           "efs_shared_dir": "${EFSOptions}",
           "fsx_fs_id": "${FSXId}",
+          "fsx_mount_name": "${FSXMountName}",
+          "fsx_dns_name": "${FSXDNSName}",
           "fsx_options": "${FSXOptions}",
           "scheduler": "${Scheduler}",
           "disable_hyperthreading_manually": "${DisableHyperThreadingManually}",

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -58,6 +58,7 @@ class SlurmConstruct(core.Construct):
         compute_security_groups: dict,
         shared_storage_mappings: dict,
         shared_storage_options: dict,
+        shared_storage_attributes: dict,
         **kwargs,
     ):
         super().__init__(scope, id)
@@ -74,6 +75,7 @@ class SlurmConstruct(core.Construct):
         self.compute_security_groups = compute_security_groups
         self.shared_storage_mappings = shared_storage_mappings
         self.shared_storage_options = shared_storage_options
+        self.shared_storage_attributes = shared_storage_attributes
 
         self._add_resources()
 
@@ -486,6 +488,10 @@ class SlurmConstruct(core.Construct):
                                 "FSXId": get_shared_storage_ids_by_type(
                                     self.shared_storage_mappings, SharedStorageType.FSX
                                 ),
+                                "FSXMountName": self.shared_storage_attributes[SharedStorageType.FSX].get(
+                                    "MountName", ""
+                                ),
+                                "FSXDNSName": self.shared_storage_attributes[SharedStorageType.FSX].get("DNSName", ""),
                                 "FSXOptions": get_shared_storage_options_by_type(
                                     self.shared_storage_options, SharedStorageType.FSX
                                 ),

--- a/cli/tests/common/dummy_aws_api.py
+++ b/cli/tests/common/dummy_aws_api.py
@@ -14,6 +14,7 @@ from common.aws.aws_api import AWSApi
 from common.aws.aws_resources import InstanceTypeInfo
 from common.boto3.cfn import CfnClient
 from common.boto3.ec2 import Ec2Client
+from common.boto3.fsx import FSxClient
 from common.boto3.iam import IamClient
 from common.boto3.imagebuilder import ImageBuilderClient
 from common.boto3.kms import KmsClient
@@ -73,6 +74,7 @@ class _DummyAWSApi(AWSApi):
         os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
         self.ec2 = _DummyEc2Client()
         self.efs = _DummyEfsClient()
+        self.fsx = _DummyFSxClient()
         self.cfn = _DummyCfnClient()
         self.s3 = _DummyS3Client()
         self.imagebuilder = _DummyImageBuilderClient()
@@ -130,6 +132,20 @@ class _DummyEfsClient(Ec2Client):
             mt_id = mt_dict.get(avail_zone)
 
         return mt_id
+
+
+class _DummyFSxClient(FSxClient):
+    def __init__(self):
+        """Override Parent constructor. No real boto3 client is created."""
+        pass
+
+    def get_filesystem_info(self, fsx_fs_id):
+        return {
+            "DNSName": "dummy-fsx-dns-name",
+            "LustreConfiguration": {
+                "MountName": "dummy-fsx-mount-name",
+            },
+        }
 
 
 class _DummyS3Client(S3Client):

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -159,7 +159,9 @@ class Cluster:
                 {"Name": "tag:Name", "Values": ["HeadNode"]},
             ]
             instance = ec2.describe_instances(Filters=filters).get("Reservations")[0].get("Instances")[0]
-            return instance.get("PublicIpAddress")
+            return (
+                instance.get("PublicIpAddress") if instance.get("PublicIpAddress") else instance.get("PrivateIpAddress")
+            )
 
     @property
     def os(self):

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -14,7 +14,7 @@ import os
 import shlex
 
 from fabric import Connection
-from utils import get_username_for_os
+from utils import get_username_for_os, run_command
 
 
 class RemoteCommandExecutionError(Exception):
@@ -27,15 +27,29 @@ class RemoteCommandExecutionError(Exception):
 class RemoteCommandExecutor:
     """Execute remote commands on the cluster head node."""
 
-    def __init__(self, cluster, username=None):
+    def __init__(self, cluster, username=None, bastion=None):
         if not username:
             username = get_username_for_os(cluster.os)
-        self.__connection = Connection(
-            host=cluster.head_node_ip,
-            user=username,
-            forward_agent=False,
-            connect_kwargs={"key_filename": [cluster.ssh_key]},
-        )
+        connection_kwargs = {
+            "host": cluster.head_node_ip,
+            "user": username,
+            "forward_agent": False,
+            "connect_kwargs": {"key_filename": [cluster.ssh_key]},
+        }
+        if bastion:
+            # Need to execute simple ssh command before using Connection to avoid Paramiko _check_banner error
+            run_command(
+                "ssh -tt -i {key_path} -o StrictHostKeyChecking=no "
+                '-o ProxyCommand="ssh -tt -o StrictHostKeyChecking=no -W %h:%p -A {bastion}" '
+                "-A {user}@{head_node} hostname".format(
+                    key_path=cluster.ssh_key, bastion=bastion, user=username, head_node=cluster.head_node_ip
+                ),
+                timeout=30,
+                shell=True,
+            )
+            connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
+            connection_kwargs["forward_agent"] = True
+        self.__connection = Connection(**connection_kwargs)
         self.__user_at_hostname = "{0}@{1}".format(username, cluster.head_node_ip)
 
     def __del__(self):

--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -9,25 +9,40 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+import logging
+import time
+
 import pytest
+import utils
 from assertpy import assert_that
 from cfn_stacks_factory import CfnStack
 from fabric import Connection
-from troposphere import Template
+from remote_command_executor import RemoteCommandExecutor
+from troposphere import GetAtt, Output, Ref, Template, ec2
 from troposphere.ec2 import EIP
 from utils import generate_stack_name, get_compute_nodes_instance_ids, get_username_for_os
+
+from tests.common.schedulers_common import get_scheduler_commands
+from tests.common.utils import retrieve_latest_ami
+from tests.storage.test_fsx_lustre import (
+    assert_fsx_lustre_correctly_mounted,
+    assert_fsx_lustre_correctly_shared,
+    get_fsx_fs_id,
+)
 
 
 @pytest.mark.dimensions("us-west-2", "c5.xlarge", "alinux2", "slurm")
 @pytest.mark.dimensions("eu-west-2", "c5.xlarge", "centos7", "slurm")
 @pytest.mark.usefixtures("os", "scheduler", "instance")
-def test_cluster_in_private_subnet(region, pcluster_config_reader, clusters_factory):
+def test_cluster_in_private_subnet(region, os, scheduler, pcluster_config_reader, clusters_factory, bastion_factory):
     # This test just creates a cluster in the private subnet and just checks that no failures occur
-    cluster_config = pcluster_config_reader()
+    fsx_mount_dir = "/fsx_mount"
+    cluster_config = pcluster_config_reader(fsx_mount_dir=fsx_mount_dir)
     cluster = clusters_factory(cluster_config)
     assert_that(cluster).is_not_none()
 
     assert_that(len(get_compute_nodes_instance_ids(cluster.cfn_name, region))).is_equal_to(1)
+    _test_fsx_in_private_subnet(cluster, os, region, scheduler, fsx_mount_dir, bastion_factory)
 
 
 @pytest.fixture(scope="class")
@@ -63,3 +78,68 @@ def test_existing_eip(existing_eip, pcluster_config_reader, clusters_factory):
     )
     # Run arbitrary command to test if we can use the elastic ip to log into the instance.
     connection.run("cat /var/log/cfn-init.log", timeout=60)
+
+
+def _test_fsx_in_private_subnet(cluster, os, region, scheduler, fsx_mount_dir, bastion_factory):
+    """Test FSx can be mounted in private subnet."""
+    bastion_ip = bastion_factory()
+    logging.info("Sleeping for 60 sec to wait for bastion ssh to become ready.")
+    time.sleep(60)
+    logging.info(f"Bastion_ip: {bastion_ip}")
+    remote_command_executor = RemoteCommandExecutor(cluster, bastion=f"ec2-user@{bastion_ip}")
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+    fsx_fs_id = get_fsx_fs_id(cluster, region)
+    assert_fsx_lustre_correctly_mounted(remote_command_executor, fsx_mount_dir, os, region, fsx_fs_id)
+    assert_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, fsx_mount_dir)
+
+
+@pytest.fixture()
+def bastion_factory(vpc_stack, cfn_stacks_factory, request, region, key_name):
+    """Class to create bastion instance used to execute commands on cluster in private subnet."""
+    bastion_stack_name = utils.generate_stack_name(
+        "integ-tests-networking-bastion", request.config.getoption("stackname_suffix")
+    )
+
+    def _bastion_factory():
+        """Create bastion stack."""
+        bastion_template = Template()
+        bastion_template.set_version()
+        bastion_template.set_description("Create Networking bastion stack")
+
+        bastion_sg = ec2.SecurityGroup(
+            "NetworkingTestBastionSG",
+            GroupDescription="SecurityGroup for Bastion",
+            SecurityGroupIngress=[
+                ec2.SecurityGroupRule(
+                    IpProtocol="tcp",
+                    FromPort="22",
+                    ToPort="22",
+                    CidrIp="0.0.0.0/0",
+                ),
+            ],
+            VpcId=vpc_stack.cfn_outputs["VpcId"],
+        )
+
+        bastion_instance = ec2.Instance(
+            "NetworkingBastionInstance",
+            ImageId=retrieve_latest_ami(region, "alinux2"),
+            KeyName=key_name,
+            SecurityGroupIds=[Ref(bastion_sg)],
+            SubnetId=vpc_stack.cfn_outputs["PublicSubnetId"],
+        )
+        bastion_template.add_resource(bastion_sg)
+        bastion_template.add_resource(bastion_instance)
+        bastion_template.add_output(
+            Output("BastionIP", Value=GetAtt(bastion_instance, "PublicIp"), Description="The Bastion Public IP")
+        )
+        bastion_stack = CfnStack(
+            name=bastion_stack_name,
+            region=region,
+            template=bastion_template.to_json(),
+        )
+        cfn_stacks_factory.create_stack(bastion_stack)
+
+        return bastion_stack.cfn_outputs.get("BastionIP")
+
+    yield _bastion_factory
+    cfn_stacks_factory.delete_stack(bastion_stack_name, region)

--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -122,6 +122,7 @@ def bastion_factory(vpc_stack, cfn_stacks_factory, request, region, key_name):
 
         bastion_instance = ec2.Instance(
             "NetworkingBastionInstance",
+            InstanceType="c5.xlarge",
             ImageId=retrieve_latest_ami(region, "alinux2"),
             KeyName=key_name,
             SecurityGroupIds=[Ref(bastion_sg)],

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
@@ -22,3 +22,10 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+SharedStorage:
+  - MountDir: {{ fsx_mount_dir }}
+    Name: privatefsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 1200
+      DeploymentType: SCRATCH_2

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -187,9 +187,9 @@ def _test_fsx_lustre(
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
     fsx_fs_id = get_fsx_fs_id(cluster, region)
 
-    _test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
+    assert_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
     _test_import_path(remote_command_executor, mount_dir)
-    _test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir)
+    assert_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir)
     _test_export_path(remote_command_executor, mount_dir, bucket_name, region)
     _test_data_repository_task(remote_command_executor, mount_dir, bucket_name, fsx_fs_id, region)
 
@@ -230,7 +230,7 @@ def test_fsx_lustre_backup(region, pcluster_config_reader, clusters_factory, os,
     fsx_fs_id = get_fsx_fs_id(cluster, region)
 
     # Mount file system
-    _test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
+    assert_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
 
     # Create a text file in the mount directory.
     create_backup_test_file(scheduler_commands, remote_command_executor, mount_dir)
@@ -259,7 +259,7 @@ def test_fsx_lustre_backup(region, pcluster_config_reader, clusters_factory, os,
     fsx_fs_id_restore = get_fsx_fs_id(cluster_restore, region)
 
     # Mount the restored file system
-    _test_fsx_lustre_correctly_mounted(remote_command_executor_restore, mount_dir, os, region, fsx_fs_id_restore)
+    assert_fsx_lustre_correctly_mounted(remote_command_executor_restore, mount_dir, os, region, fsx_fs_id_restore)
 
     # Validate whether text file created in the original file system is present in the restored file system.
     _test_restore_from_backup(remote_command_executor_restore, mount_dir)
@@ -360,7 +360,7 @@ def fsx_factory(vpc_stack, cfn_stacks_factory, request, region, key_name):
         cfn_stacks_factory.delete_stack(fsx_stack_name, region)
 
 
-def _test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id):
+def assert_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id):
     logging.info("Testing fsx lustre is correctly mounted")
     result = remote_command_executor.run_remote_command("df -h -t lustre | tail -n +2 | awk '{print $1, $2, $6}'")
     mount_name = get_mount_name(fsx_fs_id, region)
@@ -424,14 +424,10 @@ def _test_import_path(remote_command_executor, mount_dir):
     assert_that(result.stdout).is_equal_to("Downloaded by FSx Lustre")
 
 
-def _test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir):
+def assert_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir):
     logging.info("Testing fsx lustre correctly mounted on compute nodes")
     remote_command_executor.run_remote_command("touch {mount_dir}/test_file".format(mount_dir=mount_dir))
-    job_command = (
-        "cat {mount_dir}/s3_test_file "
-        "&& cat {mount_dir}/test_file "
-        "&& touch {mount_dir}/compute_output".format(mount_dir=mount_dir)
-    )
+    job_command = "cat {mount_dir}/test_file && touch {mount_dir}/compute_output".format(mount_dir=mount_dir)
     result = scheduler_commands.submit_command(job_command)
     job_id = scheduler_commands.assert_job_submitted(result.stdout)
     scheduler_commands.wait_job_completed(job_id)

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -28,28 +28,35 @@ def retry_if_subprocess_error(exception):
     return isinstance(exception, subprocess.CalledProcessError)
 
 
-def run_command(command, capture_output=True, log_error=True, env=None, timeout=None, raise_on_error=True):
+def run_command(command, capture_output=True, log_error=True, env=None, timeout=None, raise_on_error=True, shell=False):
     """Execute shell command."""
-    if isinstance(command, str):
+    if isinstance(command, str) and not shell:
         command = shlex.split(command)
-    logging.info("Executing command: " + " ".join(command))
+    log_command = command if isinstance(command, str) else " ".join(command)
+    logging.info("Executing command: {}".format(log_command))
     try:
         result = subprocess.run(
-            command, capture_output=capture_output, universal_newlines=True, encoding="utf-8", env=env, timeout=timeout
+            command,
+            capture_output=capture_output,
+            universal_newlines=True,
+            encoding="utf-8",
+            env=env,
+            timeout=timeout,
+            shell=shell,
         )
         result.check_returncode()
     except subprocess.CalledProcessError:
         if log_error:
             logging.error(
                 "Command {0} failed with error:\n{1}\nand output:\n{2}".format(
-                    " ".join(command), result.stderr, result.stdout
+                    log_command, result.stderr, result.stdout
                 )
             )
         if raise_on_error:
             raise
     except subprocess.TimeoutExpired:
         if log_error:
-            logging.error("Command {0} timed out after {1} sec".format(" ".join(command), timeout))
+            logging.error("Command {0} timed out after {1} sec".format(log_command, timeout))
         if raise_on_error:
             raise
 


### PR DESCRIPTION
* Do not query FSx API for MountName and DNSName
* For existing filesystems, MountName and DNSName are retrieved by CLI and passed into cookbook using attributes
* For filesystem created with cluster, MountName is retrieved from CFN filesystem resource attribute. DNSName is generated in hardcoded format
* Add integration test for FSx in private subnet

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
