### PR TITLE
Fix runtime_bake test with Ubuntu20

### DIFF
--- a/tests/integration-tests/tests/runtime_bake/test_runtime_bake/test_runtime_bake/pcluster.config.ini
+++ b/tests/integration-tests/tests/runtime_bake/test_runtime_bake/test_runtime_bake/pcluster.config.ini
@@ -25,6 +25,9 @@ s3_read_resource = arn:aws:s3:::{{ bucket_name }}/scripts/*
 {% endif %}
 pre_install = s3://{{ bucket_name }}/scripts/pre-install.sh
 extra_json = { "cluster" : { "skip_install_recipes" : "no" } }
+{% if custom_cookbook %}
+custom_chef_cookbook = {{ custom_cookbook }}
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}


### PR DESCRIPTION
Use official AMI with ubuntu2004 because DLAMI is not available yet

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
