### PR TITLE
3.0: Encrypt EBS(root volume and shared EBS) by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ per cluster.
 - Rename NodeType and tags from Master to HeadNode.
 - Remove Ganglia support.
 - Add support for associating an existing Elastic IP to the head node.
+- Encrypt root EBS volumes and shared EBS volumes by default. 
+  Note that if the scheduler is AWS Batch, the root volumes of the compute nodes cannot be encrypted by ParallelCluster.
 
 2.x.x
 ------

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -138,9 +138,10 @@ class ClusterCdkStack(Stack):
         # Head Node EC2 Iam Role
         self._add_role_and_policies(self.config.head_node, "HeadNode")
 
-        # Compute Nodes EC2 Iam Roles
-        for queue in self.config.scheduling.queues:
-            self._add_role_and_policies(queue, queue.name)
+        if self._condition_is_slurm():
+            # Compute Nodes EC2 Iam Roles
+            for queue in self.config.scheduling.queues:
+                self._add_role_and_policies(queue, queue.name)
 
         # Managed security groups
         self._head_security_group, self._compute_security_group = self._add_security_groups()

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -42,14 +42,6 @@ Scheduling:
   Scheduler: awsbatch
   Queues:
     - Name: String  # queue
-      ComputeSettings:
-        LocalStorage:
-          RootVolume:
-            Size: 38  # 35
-            Encrypted: true  # true
-          EphemeralVolume:
-            Encrypted: true  # true
-            MountDir: String  # /scratch
       CapacityType: ONDEMAND  # ONDEMAND | SPOT
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
@@ -17,14 +17,6 @@ Scheduling:
         - Name: compute_resource1
           InstanceTypes: c4.xlarge
           MaxvCpus: 10
-      ComputeSettings:
-        LocalStorage:
-          RootVolume:
-            Size: 35
-            Encrypted: true
-          EphemeralVolume:
-            Encrypted: true
-            MountDir: /scratch
 SharedStorage:
   - MountDir: /my/mount/ebs1
     Name: name1

--- a/tests/integration-tests/constants.py
+++ b/tests/integration-tests/constants.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+# the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+OS_TO_ROOT_VOLUME_DEVICE = {
+    "centos7": "/dev/sda1",
+    "centos8": "/dev/sda1",
+    "alinux2": "/dev/xvda",
+    "ubuntu1804": "/dev/sda1",
+    "ubuntu2004": "/dev/sda1",
+}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -6,10 +6,19 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  LocalStorage:
+    RootVolume:
+      Encrypted: false # Test turning off root volume encryption
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:
     - Name: queue-0
+      {% if scheduler == "slurm" %}
+      ComputeSettings:
+        LocalStorage:
+          RootVolume:
+            Encrypted: false  # Test turning off root volume encryption
+      {% endif %}
       ComputeResources:
         - Name: compute-resource-0
           {% if scheduler == "awsbatch" %}


### PR DESCRIPTION
1. Change the default of encrypted to True
2. Create constants.py to share constants across tests
3. Amend test_ebs_single to test encryption by default
4. Amend test_ebs_multiple to test disabling encryption
5. Only allow queue compute settings if the scheduler is slurm
6. Only allow queue IAM if the scheduler is slurm

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
