### PR TITLE
3.0: Add DependsOn attribute to imagebuilder stack resources

### DIFF
--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -504,6 +504,7 @@ def _test_resources(generated_resources, expected_resources):
             },
             {
                 "Type": "AWS::IAM::Role",
+                "DependsOn": ["DeleteStackFunctionExecutionRole"],
                 "Properties": {
                     "RoleName": "Pcluster-InstanceRole",
                     "AssumeRolePolicyDocument": {
@@ -557,6 +558,7 @@ def _test_resources(generated_resources, expected_resources):
             },
             {
                 "Type": "AWS::IAM::InstanceProfile",
+                "DependsOn": ["DeleteStackFunctionExecutionRole"],
                 "Properties": {"Roles": [{"Ref": "InstanceRole"}], "Path": "/ParallelClusterImage/"},
             },
             {"Ref": "InstanceProfile"},
@@ -587,6 +589,7 @@ def _test_resources(generated_resources, expected_resources):
             None,
             {
                 "Type": "AWS::IAM::InstanceProfile",
+                "DependsOn": ["DeleteStackFunctionExecutionRole"],
                 "Properties": {
                     "Roles": ["arn:aws:iam::xxxxxxxxxxxx:role/test-InstanceRole"],
                     "Path": "/ParallelClusterImage/",


### PR DESCRIPTION
* Add DependsOn to all the imagebuilder stack resources, ensure resources depend on DeleteStackFunctionExecutionRole. Therefore, during stack deletion, DeleteStackFunctionExecutionRole will be deleted at last.

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
