### PR TITLE
3.0:  Simplify status and delete commands loops 

### DIFF
--- a/cli/README
+++ b/cli/README
@@ -6,13 +6,13 @@ AWS ParallelCluster facilitates both quick start proof of concepts (POCs) and pr
 You can build higher level workflows, such as a Genomics portal that automates the entire DNA sequencing workflow, on top of AWS ParallelCluster.
 
     usage: pcluster [-h]
-                    {create,update,delete,start,stop,status,list,instances,ssh,configure,version,createami}
+                    {create,update,delete,start,stop,status,list,instances,ssh,configure,version,dcv,createami}
                     ...
 
     pcluster is a tool to launch and manage a cluster.
 
     positional arguments:
-      {create,update,delete,start,stop,status,list,instances,ssh,configure,version,createami}
+      {create,update,delete,start,stop,status,list,instances,ssh,configure,version,dcv,createami}
         create              Creates a cluster.
         update              Updates a running cluster.
         delete              Deletes a cluster.
@@ -24,6 +24,7 @@ You can build higher level workflows, such as a Genomics portal that automates t
         ssh                 Connects to the head node using SSH.
         configure           Starts the AWS ParallelCluster configuration.
         version             Displays version of AWS ParallelCluster.
+        dcv                 Permits to use NICE DCV related features.
         createami           (Linux/macOS) Creates a custom AMI to use with AWS ParallelCluster.
 
     optional arguments:

--- a/cli/src/pcluster/cli_commands/configure/networking.py
+++ b/cli/src/pcluster/cli_commands/configure/networking.py
@@ -171,7 +171,7 @@ def _create_network_stack(configuration, parameters):
         LOGGER.debug("StackId: %s", stack.get("StackId"))
         LOGGER.info("Stack Name: %s", stack_name)
         if not verify_stack_status(
-            stack_name, waiting_states=["CREATE_IN_PROGRESS"], successful_state="CREATE_COMPLETE"
+            stack_name, waiting_states=["CREATE_IN_PROGRESS"], successful_states=["CREATE_COMPLETE"]
         ):
             LOGGER.error("Could not create the network configuration")
             sys.exit(0)

--- a/cli/src/pcluster/cli_commands/update.py
+++ b/cli/src/pcluster/cli_commands/update.py
@@ -43,7 +43,7 @@ def execute(args):
                 verified = utils.verify_stack_status(
                     result.stack_name,
                     waiting_states=["UPDATE_IN_PROGRESS", "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS"],
-                    successful_state="UPDATE_COMPLETE",
+                    successful_states=["UPDATE_COMPLETE"],
                 )
                 if not verified:
                     LOGGER.critical("\nCluster update failed.  Failed events:")


### PR DESCRIPTION
In this way all the commands (create/delete/update/status) will use the same code:
- log_stack_failure_recursive to log failed events in case of errors
- verify_stack_status to perform a loop and waiting for a specific status

Other:
- Add missing dcv command to readme