### PR TITLE
 Add support for additional instance types to integration tests 

### DIFF
--- a/tests/integration-tests/configs/additional_instances.yaml
+++ b/tests/integration-tests/configs/additional_instances.yaml
@@ -1,0 +1,10 @@
+{%- import 'common.jinja2' as common -%}
+---
+test-suites:
+  schedulers:
+    test_slurm.py::test_slurm:
+      dimensions:
+        - regions: ["us-east-2"]
+          instances: {{ ADDITIONAL_INSTANCES }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -385,6 +385,10 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
+      - regions: ["us-east-2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        schedulers: ["slurm"]
   test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
     dimensions:
       - regions: ["ap-southeast-2"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -121,15 +121,18 @@ def pytest_generate_tests(metafunc):
 
 def pytest_configure(config):
     """This hook is called for every plugin and initial conftest file after command line options have been parsed."""
-    # read tests config file if used
-    if config.getoption("tests_config_file", None):
-        config.option.tests_config = read_config_file(config.getoption("tests_config_file"))
-
     # Read instance types data file if used
+    logging.info("configuring - 0")
     if config.getoption("instance_types_data_file", None):
         config.option.instance_types_data = _read_json_file(config.getoption("instance_types_data_file"))
         # Load additional instance types data
         _set_additional_instance_types_data(config.option.instance_types_data)
+    logging.info("configuring - 1")
+
+    # read tests config file if used
+    if config.getoption("tests_config_file", None):
+        config.option.tests_config = read_config_file(config.getoption("tests_config_file"))
+    logging.info("configuring - 2")
 
     # register additional markers
     config.addinivalue_line("markers", "instances(instances_list): run test only against the listed instances.")
@@ -209,8 +212,14 @@ def _log_collected_tests(session):
 
 
 def _set_additional_instance_types_data(instance_types_data):
+    logging.info("Loading additional instance types data...")
     InstanceTypesData.additional_instance_types_data = instance_types_data
     logging.info("Additional instance types data loaded: {0}".format(InstanceTypesData.additional_instance_types_data))
+    if instance_types_data:
+        logging.info("Extracting additional instance types...")
+        InstanceTypesData.additional_instance_types = [instance_type for instance_type, _ in instance_types_data.items()]
+        logging.info("Additional instance types: {0}".format(InstanceTypesData.additional_instance_types))
+
 
 
 def pytest_exception_interact(node, call, report):

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -15,6 +15,7 @@ from functools import lru_cache
 
 import yaml
 from jinja2 import Environment, FileSystemLoader
+from utils import InstanceTypesData
 
 
 def read_config_file(config_file, print_rendered=False):
@@ -56,7 +57,11 @@ def _render_config_file(config_file):
         config_dir = os.path.dirname(config_file)
         config_name = os.path.basename(config_file)
         file_loader = FileSystemLoader(config_dir)
-        return Environment(loader=file_loader).get_template(config_name).render()
+        return (
+            Environment(loader=file_loader)
+            .get_template(config_name)
+            .render(ADDITIONAL_INSTANCES=InstanceTypesData.additional_instance_types)
+        )
     except Exception:
         logging.error("Failed when rendering config file %s", config_file)
         raise

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -28,6 +28,7 @@ class InstanceTypesData:
 
     # Additional instance types data provided via tests configuration
     additional_instance_types_data = {}
+    additional_instance_types = []
 
     @staticmethod
     def get_instance_info(instance_type, region_name=None):


### PR DESCRIPTION
This commit allows integration tests configuration files to use instance types provided via the `additional_instance_types` parameter to the `test_runner`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
