### PR TITLE
3.0: Add build_status tag during AMI build process

### DIFF
--- a/cli/src/pcluster/api/pcluster_api.py
+++ b/cli/src/pcluster/api/pcluster_api.py
@@ -365,26 +365,21 @@ class PclusterApi:
                 os.environ["AWS_DEFAULT_REGION"] = region
 
             # get built images by image name tag
-            built_images = AWSApi.instance().ec2.list_pcluster_images()
-
-            built_images_response = [
-                ImageBuilderInfo(imagebuilder=ImageBuilder(image_name=image.original_image_name))
-                for image in built_images
+            images = AWSApi.instance().ec2.get_images()
+            images_response = [
+                ImageBuilderInfo(imagebuilder=ImageBuilder(image_name=image.original_image_name)) for image in images
             ]
 
             # get building image stacks by image name tag
-            imagebuilder_stacks = AWSApi.instance().cfn.list_imagebuilder_stacks()
-
-            imagebuilder_list = [
+            imagebuilder_stacks = [
                 ImageBuilder(image_name=stack.get("StackName"), stack=ImageBuilderStack(stack))
-                for stack in imagebuilder_stacks
+                for stack in AWSApi.instance().cfn.get_imagebuilder_stacks()
             ]
-
-            building_stacks_response = [
+            imagebuilder_stacks_response = [
                 ImageBuilderInfo(imagebuilder=imagebuilder, stack=imagebuilder.stack)
-                for imagebuilder in imagebuilder_list
+                for imagebuilder in imagebuilder_stacks
             ]
 
-            return built_images_response + building_stacks_response
+            return images_response + imagebuilder_stacks_response
         except Exception as e:
             return ApiFailure(str(e))

--- a/cli/src/pcluster/aws/cfn.py
+++ b/cli/src/pcluster/aws/cfn.py
@@ -119,7 +119,7 @@ class CfnClient(Boto3Client):
         return self._client.describe_stack_resource(StackName=stack_name, LogicalResourceId=logic_resource_id)
 
     @AWSExceptionHandler.handle_client_exception
-    def list_imagebuilder_stacks(self):
+    def get_imagebuilder_stacks(self):
         """List existing imagebuilder stacks."""
         stack_list = []
         for stack in self._paginate_results(self._client.describe_stacks):

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -62,6 +62,7 @@ CW_DASHBOARD_ENABLED_DEFAULT = True
 CW_LOGS_ENABLED_DEFAULT = True
 
 PCLUSTER_IMAGE_NAME_TAG = "parallelcluster:image_name"
+PCLUSTER_IMAGE_BUILD_STATUS_TAG = "parallelcluster:build_status"
 PCLUSTER_S3_IMAGE_DIR_TAG = "parallelcluster:s3_image_dir"
 PCLUSTER_S3_BUCKET_TAG = "parallelcluster:s3_bucket"
 PCLUSTER_IMAGE_BUILD_LOG_TAG = "parallelcluster:build_log"

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -263,7 +263,7 @@ class ImageBuilder:
         self._validate_image_name()
 
         # check image existence
-        if AWSApi.instance().ec2.image_exists(self.image_name):
+        if AWSApi.instance().ec2.image_exists(self.image_name, build_status_avaliable=True):
             raise ImageBuilderActionError(f"ParallelCluster image {self.image_name} already exists")
 
         # check stack existence
@@ -370,7 +370,7 @@ class ImageBuilder:
                     # Delete snapshot
                     for snapshot_id in self.image.snapshot_ids:
                         AWSApi.instance().ec2.delete_snapshot(snapshot_id)
-                elif AWSApi.instance().cfn.stack_exists(self.image_name):
+                if AWSApi.instance().cfn.stack_exists(self.image_name):
                     # Delete stack
                     AWSApi.instance().cfn.delete_stack(self.image_name)
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -79,8 +79,10 @@ phases:
                 KEY="$1"
                 VALUE="$2"
                 if [[ -n "${VALUE}" ]] && [[ ! "${VALUE}" =~ NOT_INSTALLED ]]; then
+                  KEY="$(echo ${KEY} | cut -c -128)"
+                  VALUE="$(echo ${VALUE} | cut -c -256)"
                   echo "Adding Tag Key=${KEY},Value=${VALUE}"
-                  aws ec2 create-tags --region {{ test.AWSRegion.outputs.stdout }} --resource {{ test.AmiId.outputs.stdout }} --tags "Key=${KEY},Value=${VALUE}" || echo "Not able to set AMI tag"
+                  aws ec2 create-tags --region {{ test.AWSRegion.outputs.stdout }} --resource {{ test.AmiId.outputs.stdout }} --tags "Key=${KEY},Value=${VALUE}" || echo "Not able to set AMI tag"; exit 1
                 fi
               }
 
@@ -113,7 +115,9 @@ phases:
               }
 
               # ParallelCluster bootstrap file
-              add_tag "parallelcluster:bootstrap_file" "$(cat /opt/parallelcluster/.bootstrapped)"
+              if [[ -f /opt/parallelcluster/.bootstrapped ]]; then
+                add_tag "parallelcluster:bootstrap_file" "$(cat /opt/parallelcluster/.bootstrapped)"
+              fi
 
               # OS
               add_tag "parallelcluster:os" "{{ test.OperatingSystemName.outputs.stdout }}"
@@ -165,3 +169,6 @@ phases:
 
               # Add description
               add_description
+
+              # Add build status
+              add_tag "parallelcluster:build_status" "available"


### PR DESCRIPTION
Add parallelcluster:build_status tag at the end of the build process and fail if not able to set the tag
When checking for instance by AMI id, exclude instances that are terminated or shutting-down

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
