### PR TITLE
3.0: Build image process fix and enhancement

### DIFF
--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -130,6 +130,16 @@ class Ec2Client(Boto3Client):
             for instance in result.get("Instances")
         ]
 
+    @AWSExceptionHandler.handle_client_exception
+    def get_image_shared_account_ids(self, image_id):
+        """Get account ids that image is shared with."""
+        return [
+            permission.get("UserId") or permission.get("Group")
+            for permission in self._client.describe_image_attribute(Attribute="launchPermission", ImageId=image_id).get(
+                "LaunchPermissions"
+            )
+        ]
+
     def get_images(self):
         """Return existing pcluster images by pcluster image name tag."""
         try:

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -370,6 +370,10 @@ class ImageBuilder:
                     for snapshot_id in self.image.snapshot_ids:
                         AWSApi.instance().ec2.delete_snapshot(snapshot_id)
                 if AWSApi.instance().cfn.stack_exists(self.image_name):
+                    if self.stack.imagebuilder_image_is_building:
+                        raise ImageBuilderActionError(
+                            "Image cannot be deleted because EC2 ImageBuilder Image has a running workflow."
+                        )
                     # Delete stack
                     AWSApi.instance().cfn.delete_stack(self.image_name)
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -222,10 +222,11 @@ phases:
                   /bin/sed -r -i -e 's/SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config
                   /bin/sed -r -i -e 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="\1 rd.driver.blacklist=nouveau nouveau.modeset=0"/' /etc/default/grub
                   grub2-mkconfig -o /boot/grub2/grub.cfg
-              elif [[ ${!OS} =~ ^ubuntu(18|20)04$ ]]; then
+              elif [[ ${!PLATFORM} == DEBIAN ]]; then
+                  [ ${CfnParamUpdateOsAndReboot} == false ] && flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)\/?'$/\1/")/daily_lock systemctl stop apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service
                   apt-cache search build-essential
                   apt-get clean
-                  apt-get update
+                  apt-get update -y
               fi
 
               if [[ ${!PLATFORM} == RHEL ]]; then

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -733,7 +733,7 @@ class ImageBuilderCdkStack(Stack):
             self,
             id="InstanceProfile",
             path="/{0}/".format(RESOURCE_NAME_PREFIX),
-            roles=[instance_role or Fn.ref("InstanceRole")],
+            roles=[instance_role.split("/")[-1] if instance_role else Fn.ref("InstanceRole")],
         )
 
         if not self.custom_cleanup_lambda_role:

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -591,7 +591,7 @@ def _test_resources(generated_resources, expected_resources):
                 "Type": "AWS::IAM::InstanceProfile",
                 "DependsOn": ["DeleteStackFunctionExecutionRole"],
                 "Properties": {
-                    "Roles": ["arn:aws:iam::xxxxxxxxxxxx:role/test-InstanceRole"],
+                    "Roles": ["test-InstanceRole"],
                     "Path": "/ParallelClusterImage/",
                 },
             },


### PR DESCRIPTION
* Pass custom role name to instance profile instead of role arn 
* Disable apt-daily.timer to avoid dpkg lock issue when building custom AMI
* Prevent image deletion if image is shared with other account 
* Prevent image deletion if ImageBuilder Image is in CREATE_IN_PROGRESS

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
