### PR TITLE
Only retrieve released pcluster AMIs.

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -49,7 +49,7 @@ OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
 }
 
 # Get official pcluster AMIs or get from dev account
-PCLUSTER_AMI_OWNERS = ["amazon", "self"]
+PCLUSTER_AMI_OWNERS = ["amazon"]
 # Pcluster AMIs are latest ParallelCluster official AMIs that align with cli version
 OS_TO_PCLUSTER_AMI_NAME_OWNER_MAP = {
     "alinux": {"name": "amzn-hvm-x86_64-*", "owners": PCLUSTER_AMI_OWNERS},


### PR DESCRIPTION
This change only applies to integration tests for released versions.

In the develop code, we should conditionally retrieve AMI depending if the test is running as released test or develop test.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
