### PR TITLE
Fix integration test_create_wrong_os

### DIFF
--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -40,7 +40,7 @@ def test_create_wrong_os(region, os, pcluster_config_reader, clusters_factory, a
     logging.info("Verifying error in logs")
     assert_errors_in_logs(
         remote_command_executor,
-        ["/var/log/cfn-init.log"],
+        ["/var/log/chef-client.log"],
         ["RuntimeError", fr"custom AMI.+{wrong_os}.+base.+os.+config file.+{os}"],
     )
 


### PR DESCRIPTION
The assertion failure is because it can not find the expected error message in /var/log/cfn-init.log. The error raise in the recipes for new cinc client will be in /var/log/chef-client.log, while the old version, the error will be in /var/log/cfn-init.log

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
