### PR TITLE
Integ-tests: Distinguish between released amis and newly built amis

### DIFF
--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -18,19 +18,18 @@ from remote_command_executor import RemoteCommandExecutor
 from utils import get_username_for_os
 
 from tests.common.assertions import assert_errors_in_logs
-from tests.common.utils import get_installed_parallelcluster_version, retrieve_latest_ami
+from tests.common.utils import get_installed_parallelcluster_version
 
 
 @pytest.mark.dimensions("eu-central-1", "c5.xlarge", "ubuntu1804", "*")
 @pytest.mark.usefixtures("instance", "scheduler")
-def test_create_wrong_os(region, os, pcluster_config_reader, clusters_factory, architecture):
+def test_create_wrong_os(region, os, pcluster_config_reader, clusters_factory, architecture, amis_dict):
     """Test error message when os provide is different from the os of custom AMI"""
     # ubuntu1804 is specified in the config file but an AMI of centos7 is provided
     wrong_os = "centos7"
     logging.info("Asserting os fixture is different from wrong_os variable")
     assert_that(os != wrong_os).is_true()
-    custom_ami = retrieve_latest_ami(region, wrong_os, ami_type="pcluster", architecture=architecture)
-    cluster_config = pcluster_config_reader(custom_ami=custom_ami)
+    cluster_config = pcluster_config_reader(custom_ami=amis_dict.get(wrong_os))
     cluster = clusters_factory(cluster_config, raise_on_error=False)
 
     _assert_head_node_is_running(region, cluster)


### PR DESCRIPTION
* Add logic to distinguish released amis and newly built ami in create cluster with wrong os ami test
* Get custom ami from custom cfn template, if custom cfn template doesn't exist, retrieve custom ami from public amis

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
