### PR TITLE
[3.0] Update version of cinc and berkshelf

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -52,8 +52,8 @@ MAX_STORAGE_COUNT = {"ebs": 5, "efs": 1, "fsx": 1, "raid": 1}
 COOKBOOK_PACKAGES_VERSIONS = {
     "parallelcluster": "3.0.0",
     "cookbook": "aws-parallelcluster-cookbook-3.0.0",
-    "chef": "15.11.8",
-    "berkshelf": "7.0.10",
+    "chef": "16.13.16",
+    "berkshelf": "7.2.0",
     "ami": "dev",
 }
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -28,7 +28,7 @@ phases:
           commands:
             - |
               set -v
-              echo "15.11.8"
+              echo "16.13.16"
 
       # Get Berkshelf Version
       - name: BerkshelfVersion
@@ -37,7 +37,7 @@ phases:
           commands:
             - |
               set -v
-              echo "7.0.10"
+              echo "7.2.0"
 
       # Get Cookbook name
       - name: PClusterCookbookVersionName


### PR DESCRIPTION
chef from 15.11.8 to 16.13.16
berkshelf from 7.0.10 to 7.2.0

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
