### PR TITLE
3.0: generate-ami-list utility must merge existing json file and not override it

### DIFF
--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -266,6 +266,32 @@ def write_json_file(json_file_path, json_data):
         json_file.write("\n")
 
 
+def update_json_file(json_file_path, amis_to_update):
+    """Update in-place the mappings section of json_file_path with the AMI IDs contained in amis_to_update."""
+    # Read in existing json file
+    json_data = read_json_file(json_file_path)
+    # update id for new amis without removing regions that are not in the amis_to_update dict
+    for mapping_name in ARCHITECTURES_TO_MAPPING_NAME.values():
+        current_amis_for_mapping = json_data.get(mapping_name, {})
+        for region, amis_to_update_region_mapping in amis_to_update.get(mapping_name, {}).items():
+            if not amis_to_update_region_mapping:
+                # No new AMIs for this region in this mapping
+                continue
+            elif region not in current_amis_for_mapping and amis_to_update_region_mapping:
+                # There are no AMIs for this region in the existing mapping, but there are in the updated version
+                current_amis_for_mapping[region] = amis_to_update_region_mapping
+            else:
+                current_amis_for_mapping[region].update(amis_to_update_region_mapping)
+            current_amis_for_mapping[region] = OrderedDict(sorted(current_amis_for_mapping[region].items()))
+
+        # enforce alphabetical regions order
+        current_amis_for_mapping = OrderedDict(sorted(current_amis_for_mapping.items()))
+        json_data[mapping_name] = current_amis_for_mapping
+
+    # Write back modified json file
+    write_json_file(json_file_path, json_data)
+
+
 def write_amis_txt(amis_txt_file, json_file):
     """Write amis_txt_file using the updated information contained in json_file."""
     json_data = read_json_file(json_file)
@@ -353,7 +379,7 @@ def main():
         regions = get_aws_regions_from_file(args.json_regions)
         amis_dict = get_ami_list_from_file(regions, args.json_amis)
 
-    write_json_file(json_file_path=args.json_file, json_data=amis_dict)
+    update_json_file(json_file_path=args.json_file, amis_to_update=amis_dict)
     write_amis_txt(amis_txt_file=args.txt_file, json_file=args.json_file)
 
 


### PR DESCRIPTION
Tested by executing 
```
$ python util/generate-ami-list.py --json-amis ${WORKSPACE}/commercial_amis  --json-regions ${WORKSPACE}/commercial_regions --partition commercial
```

and then:
```
$ python util/generate-ami-list.py --json-amis ${WORKSPACE}/china_amis  --json-regions ${WORKSPACE}/china_regions --partition china
```
after this and checking the amis.json and amis.txt files to contain both the regions.