### PR TITLE
3.0: Align S3 buckets tree by having parallelcluster/version as root folder 

### DIFF
--- a/cli/src/pcluster/cli_commands/configure/networking.py
+++ b/cli/src/pcluster/cli_commands/configure/networking.py
@@ -15,13 +15,13 @@ import sys
 from enum import Enum
 
 import boto3
-import pkg_resources
 
 from pcluster.cli_commands.configure.subnet_computation import evaluate_cidr, get_subnet_cidr
 from pcluster.cli_commands.configure.utils import handle_client_exception
 from pcluster.networking.vpc_factory import VpcFactory
 from pcluster.utils import (
     get_cli_log_file,
+    get_installed_version,
     get_region,
     get_stack,
     get_stack_output_value,
@@ -158,13 +158,12 @@ def _create_network_stack(configuration, parameters):
     LOGGER.info("Creating CloudFormation stack...")
     LOGGER.info("Do not leave the terminal until the process has finished")
     stack_name = "parallelclusternetworking-{0}{1}".format(configuration.stack_name_prefix, TIMESTAMP)
-    version = pkg_resources.get_distribution("aws-parallelcluster").version
     try:
         cfn_client = boto3.client("cloudformation")
         stack = cfn_client.create_stack_from_url(
             StackName=stack_name,
             TemplateURL=get_templates_bucket_path()
-            + "networking/%s-%s.cfn.json" % (configuration.template_name, version),
+            + "networking/%s-%s.cfn.json" % (configuration.template_name, get_installed_version()),
             Parameters=parameters,
             Capabilities=["CAPABILITY_IAM"],
         )

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -141,12 +141,13 @@ class Cluster:
         Generate artifact directory in S3 bucket.
 
         cluster artifact dir is generated before cfn stack creation and only generate once.
-        artifact_directory: e.g. parallelcluster/clusters/{cluster_name}-jfr4odbeonwb1w5k
+        artifact_directory: e.g. parallelcluster/{version}/clusters/{cluster_name}-jfr4odbeonwb1w5k
         """
         service_directory = generate_random_name_with_prefix(self.name)
         self.__s3_artifact_dir = "/".join(
             [
                 self._s3_artifacts_dict.get("root_directory"),
+                get_installed_version(),
                 self._s3_artifacts_dict.get("root_cluster_directory"),
                 service_directory,
             ]
@@ -338,9 +339,9 @@ class Cluster:
         Upload cluster specific resources and cluster template.
 
         All dirs contained in resource dir will be uploaded as zip files to
-        {bucket_name}/parallelcluster/clusters/{cluster_name}/{resource_dir}/artifacts.zip.
+        {bucket_name}/parallelcluster/{version}/clusters/{cluster_name}/{resource_dir}/artifacts.zip.
         All files contained in root dir will be uploaded to
-        {bucket_name}/parallelcluster/clusters/{cluster_name}/{resource_dir}/artifact.
+        {bucket_name}/parallelcluster/{version}/clusters/{cluster_name}/{resource_dir}/artifact.
         """
         try:
             resources = pkg_resources.resource_filename(__name__, "../resources/custom_resources")

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -241,12 +241,13 @@ class ImageBuilder:
         Generate artifact directory in S3 bucket.
 
         Image artifact dir is generated before cfn stack creation and only generate once.
-        artifact_directory: e.g. parallelcluster/imagebuilders/{image_name}-jfr4odbeonwb1w5k
+        artifact_directory: e.g. parallelcluster/{version}/imagebuilders/{image_name}-jfr4odbeonwb1w5k
         """
         service_directory = generate_random_name_with_prefix(self.image_name)
         self.__s3_artifact_dir = "/".join(
             [
                 self._s3_artifacts_dict.get("root_directory"),
+                get_installed_version(),
                 self._s3_artifacts_dict.get("root_image_directory"),
                 service_directory,
             ]
@@ -340,9 +341,9 @@ class ImageBuilder:
         Upload image specific resources and image template.
 
         All dirs contained in resource dir will be uploaded as zip files to
-        {bucket_name}/parallelcluster/imagebuilders/{image_name}/{resource_dir}/artifacts.zip.
+        {bucket_name}/parallelcluster/{version}/imagebuilders/{image_name}/{resource_dir}/artifacts.zip.
         All files contained in root dir will be uploaded to
-        {bucket_name}/parallelcluster/imagebuilder/{image_name}/{resource_dir}/artifact.
+        {bucket_name}/parallelcluster/{version}/imagebuilder/{image_name}/{resource_dir}/artifact.
         """
         try:
             if self.template_body:

--- a/cli/src/pcluster/models/s3_bucket.py
+++ b/cli/src/pcluster/models/s3_bucket.py
@@ -211,12 +211,6 @@ class S3Bucket:
         """
         Upload custom resources to S3 bucket.
 
-        All dirs contained in resource dir will be uploaded as zip files to
-        {bucket_name}/parallelcluster/clusters/{cluster_name}/{resource_dir}/artifacts.zip.
-        or {bucket_name}/parallelcluster/imagebuilders/{image_name}/{resource_dir}/artifacts.zip.
-        All files contained in root dir will be uploaded to
-        {bucket_name}/parallelcluster/clusters/{cluster_name}/{resource_dir}/artifact.
-        or {bucket_name}/parallelcluster/imagebuilders/{image_name}/{resource_dir}/artifacts
         :param resource_dir: resource directory containing the resources to upload.
         :param custom_artifacts_name: custom_artifacts_name for zipped dir
         """

--- a/util/upload-cfn-templates.py
+++ b/util/upload-cfn-templates.py
@@ -81,7 +81,7 @@ def upload_to_s3(args, region, aws_credentials=None):
         buckets = args.bucket.split(",")
     else:
         buckets = ["%s-aws-parallelcluster" % region]
-    key_path = "templates/"
+    key_path = "parallelcluster/{version}/templates/".format(version=args.version)
     template_paths = "cloudformation/"
 
     for t in args.templates:

--- a/util/upload-cli.sh
+++ b/util/upload-cli.sh
@@ -76,7 +76,7 @@ main() {
         fi
     fi
 
-    _version=$(grep "VERSION = \"" "${_srcdir}/cli/setup.py" |awk '{print $3}'| tr -d \")
+    _version=$(grep "^VERSION = \"" "${_srcdir}/cli/setup.py" |awk '{print $3}'| tr -d \")
     if [ -z "${_version}" ]; then
         _error_exit "Unable to detect AWS ParallelCluster version, are you in the right directory?"
     fi
@@ -90,7 +90,8 @@ main() {
     popd > /dev/null
 
     # upload package
-    aws ${_profile} --region "${_region}" s3 cp --acl public-read aws-parallelcluster-${_version}.tgz s3://${_bucket}/cli/aws-parallelcluster-${_version}.tgz || _error_exit 'Failed to push node to S3'
+    _key_path="parallelcluster/${_version}/cli"
+    aws ${_profile} --region "${_region}" s3 cp aws-parallelcluster-${_version}.tgz s3://${_bucket}/${_key_path}/aws-parallelcluster-${_version}.tgz || _error_exit 'Failed to push CLI to S3'
 
     _bucket_region=$(aws ${_profile} s3api get-bucket-location --bucket ${_bucket} --output text)
     if [ ${_bucket_region} == "None" ]; then
@@ -99,8 +100,10 @@ main() {
          _bucket_region=".${_bucket_region}"
      fi
 
-    echo "Done. Add the following variable to the pcluster create config file, under the DevSettings section"
-    echo "  AwsBatchCliPackage: https://s3${_bucket_region}.amazonaws.com/${_bucket}/cli/aws-parallelcluster-${_version}.tgz"
+    echo "Done. Add the following configuration to the pcluster create config file:"
+    echo ""
+    echo "DevSettings:"
+    echo "  AwsBatchCliPackage: s3://${_bucket}/${_key_path}/aws-parallelcluster-${_version}.tgz"
 }
 
 main "$@"

--- a/util/upload-cookbook.py
+++ b/util/upload-cookbook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You may not
 # use this file except in compliance with the License. A copy of the License
@@ -26,9 +26,12 @@ from datetime import datetime
 
 import argparse
 import boto3
+import pkg_resources
 from botocore.exceptions import ClientError
 
-_COOKBOOKS_DIR = "cookbooks"
+_COOKBOOKS_DIR = "parallelcluster/{version}/cookbooks".format(
+    version=pkg_resources.get_distribution("aws-parallelcluster").version
+)
 _BACKUP_DIR = "{0}/backup".format(_COOKBOOKS_DIR)
 _bck_date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 _bck_error_array = set()


### PR DESCRIPTION
```
Official buckets
└── parallelcluster  # new tree
    └── 3.0.0  # new folder, CLI version
        ├── cookbooks
        │   └── aws-parallelcluster-cookbook.*
        └── templates
             └── networking

parallelcluster-xxx-v1-do-not-delete  # bucket created by the CLI
└── parallelcluster
    └── 3.0.0 # new folder, CLI version
        ├── clusters
        └── images

custom-bucket  # bucket selected by user for custom artifacts
└── parallelcluster
    └── 3.0.0 # new folder
        ├── cli # uploaded by uploadCLI.sh script
        │   └── aws-parallelcluster.tgz
        ├── cookbooks  # uploaded by uploadCookbok.sh script
        │   └── aws-parallelcluster-cookbook.*
        └── node  # uploaded by uploadNode.sh script
            └── aws-parallelcluster-node.tgz
```

# Other
* Use existing utility to retrieve parallelcluster version in networking module

# Tests
* pcluster create
* uploadCLI.sh
* upload-cookbook --dryrun