### PR TITLE
[3.0] Print cinc log to stdout during build

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -295,7 +295,7 @@ phases:
               set -v
               echo "Calling chef-client with /tmp/dna.json"
               cat /tmp/dna.json
-              chef-client --local-mode --config /etc/chef/client.rb --log_level info --logfile /var/log/chef-client.log --force-formatter --no-color --chef-zero-port 8889 --json-attributes /tmp/dna.json --override-runlist aws-parallelcluster::default
+              chef-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /tmp/dna.json --override-runlist aws-parallelcluster::default
 
       - name: InstallCfnBootstrap
         action: ExecuteBash


### PR DESCRIPTION
New cinc version 16.13.16 doesn't write output log on both file specified through logfile flag and stdout, like old version was doing.
Swtich log printing to use stdout

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
