### PR TITLE
3.0: Integ-tests: test efa enable/disable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ per cluster.
 - Encrypt root EBS volumes and shared EBS volumes by default. 
   Note that if the scheduler is AWS Batch, the root volumes of the compute nodes cannot be encrypted by ParallelCluster.
 - Change tags prefix from `aws-parallelcluster-` to `parallelcluster:`.
+- Enable EFA for a compute resource by default if the instance type supports EFA.
 
 2.x.x
 ------

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -45,37 +45,45 @@ def test_hit_efa(
     """
     max_queue_size = 2
     slots_per_instance = fetch_instance_slots(region, instance)
-    cluster_config = pcluster_config_reader(max_queue_size=max_queue_size)
+    no_efa_instance = "t3.micro" if architecture == "x86_64" else "t4g.micro"
+    cluster_config = pcluster_config_reader(max_queue_size=max_queue_size, no_efa_instance=no_efa_instance)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
 
     _test_efa_installation(scheduler_commands, remote_command_executor, efa_installed=True, partition="efa-enabled")
+    _test_efa_installation(
+        scheduler_commands, remote_command_executor, efa_installed=True, partition="efa-enabled-by-default"
+    )
     _test_efa_installation(scheduler_commands, remote_command_executor, efa_installed=False, partition="efa-disabled")
+    _test_efa_installation(
+        scheduler_commands, remote_command_executor, efa_installed=False, partition="efa-disabled-by-default"
+    )
     _test_mpi(remote_command_executor, slots_per_instance, scheduler, partition="efa-enabled")
     logging.info("Running on Instances: {0}".format(get_compute_nodes_instance_ids(cluster.cfn_name, region)))
-    _test_osu_benchmarks_latency(
-        "openmpi",
-        remote_command_executor,
-        scheduler_commands,
-        test_datadir,
-        slots_per_instance,
-        partition="efa-enabled",
-    )
-    if architecture == "x86_64":
+    for efa_queue_name in ["efa-enabled", "efa-enabled-by-default"]:
         _test_osu_benchmarks_latency(
-            "intelmpi",
+            "openmpi",
             remote_command_executor,
             scheduler_commands,
             test_datadir,
             slots_per_instance,
-            partition="efa-enabled",
+            partition=efa_queue_name,
         )
-    if network_interfaces_count > 1:
-        _test_osu_benchmarks_multiple_bandwidth(
-            remote_command_executor, scheduler_commands, test_datadir, slots_per_instance, partition="efa-enabled"
-        )
-    _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor, partition="efa-enabled")
+        if architecture == "x86_64":
+            _test_osu_benchmarks_latency(
+                "intelmpi",
+                remote_command_executor,
+                scheduler_commands,
+                test_datadir,
+                slots_per_instance,
+                partition=efa_queue_name,
+            )
+        if network_interfaces_count > 1:
+            _test_osu_benchmarks_multiple_bandwidth(
+                remote_command_executor, scheduler_commands, test_datadir, slots_per_instance, partition=efa_queue_name
+            )
+        _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor, partition=efa_queue_name)
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)
 

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.yaml
@@ -37,6 +37,26 @@ Scheduling:
           MinCount: 1
           Efa:
             Enabled: false
+    - Name: efa-disabled-by-default
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: efa-disabled-by-default-i1
+          InstanceType: {{ no_efa_instance }}
+          MaxCount: {{ max_queue_size }}
+          MinCount: 1
+    - Name: efa-enabled-by-default
+      Networking:
+        PlacementGroup:
+          Enabled: true
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: efa-enabled-by-default-i1
+          InstanceType: {{ instance }}
+          MaxCount: {{ max_queue_size }}
+          MinCount: 2
 SharedStorage:
   - MountDir: /shared
     Name: name1


### PR DESCRIPTION
By default, pcluster enable EFA if the instance type supports it

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
