### PR TITLE
3.0: Pylint fixes for AWS Batch CLI classes

### DIFF
--- a/cli/src/awsbatch/awsbhosts.py
+++ b/cli/src/awsbatch/awsbhosts.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2.6
-
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -49,7 +47,7 @@ def _get_parser():
     return parser
 
 
-class Host(object):
+class Host:
     """Generic host object."""
 
     def __init__(
@@ -86,7 +84,7 @@ class Host(object):
         self.mem_avail = mem_avail
 
 
-class AWSBhostsCommand(object):
+class AWSBhostsCommand:
     """awsbhosts command."""
 
     def __init__(self, log, boto3_factory):
@@ -305,7 +303,7 @@ def main():
         # parse input parameters and  config file
         args = _get_parser().parse_args()
         log = config_logger(args.log_level)
-        log.info("Input parameters: %s" % args)
+        log.info("Input parameters: %s", args)
         config = AWSBatchCliConfig(log, args.cluster)
         boto3_factory = Boto3ClientFactory(region=config.region, proxy=config.proxy)
 

--- a/cli/src/awsbatch/awsbkill.py
+++ b/cli/src/awsbatch/awsbkill.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2.6
-
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -48,7 +46,7 @@ def _get_parser():
     return parser
 
 
-class AWSBkillCommand(object):
+class AWSBkillCommand:
     """awsbkill command."""
 
     def __init__(self, log, boto3_factory):
@@ -91,12 +89,12 @@ class AWSBkillCommand(object):
         for job in jobs:
             status = job["status"]
             job_id = job["jobId"]
-            if status == "FAILED" or status == "SUCCEEDED":
+            if status in ["FAILED", "SUCCEEDED"]:
                 print("Job (%s) is already in (%s) status." % (job_id, status))
             else:
                 try:
                     self.batch_client.terminate_job(jobId=job_id, reason=reason)
-                    if status == "SUBMITTED" or status == "PENDING" or status == "RUNNABLE":
+                    if status in ["SUBMITTED", "PENDING", "RUNNABLE"]:
                         action = "cancellation"
                     else:
                         # status == 'STARTING' or status == 'RUNNING'
@@ -106,7 +104,6 @@ class AWSBkillCommand(object):
                     )
                 except Exception as e:
                     print("Error killing job (%s). Failed with exception: %s" % e)
-                    pass
 
 
 def main():
@@ -115,7 +112,7 @@ def main():
         # parse input parameters and config file
         args = _get_parser().parse_args()
         log = config_logger(args.log_level)
-        log.info("Input parameters: %s" % args)
+        log.info("Input parameters: %s", args)
         config = AWSBatchCliConfig(log=log, cluster=args.cluster)
         boto3_factory = Boto3ClientFactory(region=config.region, proxy=config.proxy)
         AWSBkillCommand(log, boto3_factory).run(job_ids=args.job_ids, reason=args.reason)

--- a/cli/src/awsbatch/awsbout.py
+++ b/cli/src/awsbatch/awsbout.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2.6
-
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -70,7 +68,7 @@ def _validate_parameters(args):
         fail("Parameters validation error: --stream-period can be used only with --stream option")
 
 
-class AWSBoutCommand(object):
+class AWSBoutCommand:
     """awsbout command."""
 
     def __init__(self, log, boto3_factory):
@@ -178,7 +176,7 @@ class AWSBoutCommand(object):
                         )
         except KeyboardInterrupt:
             self.log.info("Interrupted by the user")
-            exit(0)
+            sys.exit(0)
         except Exception as e:
             fail("Error listing jobs from AWS Batch. Failed with exception: %s" % e)
 
@@ -200,7 +198,7 @@ def main():
         args = _get_parser().parse_args()
         _validate_parameters(args)
         log = config_logger(args.log_level)
-        log.info("Input parameters: %s" % args)
+        log.info("Input parameters: %s", args)
         config = AWSBatchCliConfig(log=log, cluster=args.cluster)
         boto3_factory = Boto3ClientFactory(region=config.region, proxy=config.proxy)
 

--- a/cli/src/awsbatch/awsbqueues.py
+++ b/cli/src/awsbatch/awsbqueues.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2.6
-
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -49,7 +47,7 @@ def _get_parser():
     return parser
 
 
-class Queue(object):
+class Queue:
     """Generic queue object."""
 
     def __init__(self, arn, name, priority, status, status_reason):
@@ -61,7 +59,7 @@ class Queue(object):
         self.status_reason = status_reason
 
 
-class AWSBqueuesCommand(object):
+class AWSBqueuesCommand:
     """awsbqueues command."""
 
     def __init__(self, log, boto3_factory):
@@ -137,7 +135,7 @@ def main():
         # parse input parameters and config file
         args = _get_parser().parse_args()
         log = config_logger(args.log_level)
-        log.info("Input parameters: %s" % args)
+        log.info("Input parameters: %s", args)
         config = AWSBatchCliConfig(log=log, cluster=args.cluster)
         boto3_factory = Boto3ClientFactory(region=config.region, proxy=config.proxy)
 

--- a/cli/src/awsbatch/awsbstat.py
+++ b/cli/src/awsbatch/awsbstat.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2.6
-
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -74,7 +72,7 @@ def _get_parser():
     return parser
 
 
-class Job(object):
+class Job:
     """Generic job object."""
 
     def __init__(
@@ -119,7 +117,7 @@ class Job(object):
         self.s3_folder_url = s3_folder_url
 
 
-class JobConverter(object):
+class JobConverter:
     """Converter for AWS Batch simple job data object."""
 
     def convert(self, job):
@@ -246,7 +244,7 @@ class ArrayJobConverter(JobConverter):
         return "-", "-"
 
 
-class AWSBstatCommand(object):
+class AWSBstatCommand:
     """awsbstat command."""
 
     __JOB_CONVERTERS = {"SIMPLE": JobConverter(), "ARRAY": ArrayJobConverter(), "MNP": MNPJobConverter()}
@@ -490,7 +488,7 @@ def main(argv=None):
         # parse input parameters and config file
         args = _get_parser().parse_args(argv)
         log = config_logger(args.log_level)
-        log.info("Input parameters: %s" % args)
+        log.info("Input parameters: %s", args)
         config = AWSBatchCliConfig(log=log, cluster=args.cluster)
         boto3_factory = Boto3ClientFactory(region=config.region, proxy=config.proxy)
 

--- a/cli/src/awsbatch/awsbsub.py
+++ b/cli/src/awsbatch/awsbsub.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2.6
-
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -163,15 +161,15 @@ def _validate_parameters(args):
     :param args: args variable
     """
     if args.command_file:
-        if not type(args.command) == str:
+        if not isinstance(args.command, str):
             fail("The command parameter is required with --command-file option")
         elif not os.path.isfile(args.command):
             fail("The command parameter (%s) must be an existing file" % args.command)
     elif not sys.stdin.isatty():
         # stdin
-        if args.arguments or type(args.command) == str:
+        if args.arguments or isinstance(args.command, str):
             fail("Error: command and arguments cannot be specified when submitting by stdin.")
-    elif not type(args.command) == str:
+    elif not isinstance(args.command, str):
         fail("Parameters validation error: command parameter is required.")
 
     if args.depends_on and not re.match(r"^(jobId|type)=[^\s,]+([\s,]?(jobId|type)=[^\s]+)*$", args.depends_on):
@@ -242,7 +240,7 @@ def _upload_and_get_command(boto3_factory, args, job_s3_folder, job_name, config
         # define command to execute
         bash_command = _compose_bash_command(args, config.s3_bucket, config.region, job_s3_folder, job_script, env_file)
         command = ["/bin/bash", "-c", bash_command]
-    elif type(args.command) == str:
+    elif isinstance(args.command, str):
         log.info("Using command parameter")
         command = [args.command] + args.arguments
     else:
@@ -369,7 +367,7 @@ def _get_env_key_value_list(env_vars, log, env_blacklist_vars=None):
             # export variables explicitly specified by the user
             _add_env_var_to_list(key_value_list, var_name, log)
         else:
-            log.warn("Environment variable (%s) does not exist." % var_name)
+            log.warn("Environment variable (%s) does not exist.", var_name)
 
     return key_value_list
 
@@ -394,9 +392,9 @@ def _add_env_var_to_list(key_value_list, var_name, log):
     ):
         var_value = os.environ[var_name]
         key_value_list.append("export %s=%s;" % (var_name, pipes.quote(var_value)))
-        log.info("Exporting environment variable: (%s=%s)." % (var_name, var_value))
+        log.info("Exporting environment variable: (%s=%s).", var_name, var_value)
     else:
-        log.warn("Excluded variable: (%s)." % var_name)
+        log.warn("Excluded variable: (%s).", var_name)
 
 
 def _get_depends_on(args):
@@ -419,7 +417,7 @@ def _get_depends_on(args):
     return depends_on
 
 
-class AWSBsubCommand(object):
+class AWSBsubCommand:
     """awsbsub command."""
 
     def __init__(self, log, boto3_factory):
@@ -498,7 +496,7 @@ class AWSBsubCommand(object):
                 if timeout:
                     submission_args.update({"timeout": {"attemptDurationSeconds": timeout}})
 
-            self.log.debug("Job submission args: %s" % submission_args)
+            self.log.debug("Job submission args: %s", submission_args)
             response = self.batch_client.submit_job(**submission_args)
             print("Job %s (%s) has been submitted." % (response["jobId"], response["jobName"]))
         except Exception as e:
@@ -512,7 +510,7 @@ def main():
         args = _get_parser().parse_args()
         _validate_parameters(args)
         log = config_logger(args.log_level)
-        log.info("Input parameters: %s" % args)
+        log.info("Input parameters: %s", args)
         config = AWSBatchCliConfig(log=log, cluster=args.cluster)
         boto3_factory = Boto3ClientFactory(region=config.region, proxy=config.proxy)
 
@@ -527,7 +525,7 @@ def main():
             else:
                 # normalize name
                 job_name = re.sub(r"\W+", "_", os.path.basename(args.command))
-            log.info("Job name not specified, setting it to (%s)" % job_name)
+            log.info("Job name not specified, setting it to (%s)", job_name)
 
         # generate an internal unique job-id
         job_key = _generate_unique_job_key(job_name)

--- a/cli/src/awsbatch/common.py
+++ b/cli/src/awsbatch/common.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2.6
-
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -32,7 +30,7 @@ def _get_stack_name(cluster_name):
     return PCLUSTER_STACK_PREFIX + cluster_name
 
 
-class Output(object):
+class Output:
     """Generic Output object."""
 
     def __init__(self, mapping, items=None):
@@ -50,7 +48,7 @@ class Output(object):
 
     def add(self, items):
         """Add items to output."""
-        if type(items) == list:
+        if isinstance(items, list):
             self.items.extend(items)
         else:
             self.items.append(items)
@@ -98,14 +96,14 @@ class Output(object):
         return self.items
 
 
-class Boto3ClientFactory(object):
+class Boto3ClientFactory:
     """Boto3 configuration object."""
 
     def __init__(self, region, proxy="NONE"):
         """Initialize the object."""
         self.region = region
         self.proxy_config = Config()
-        if not proxy == "NONE":
+        if proxy != "NONE":
             self.proxy_config = Config(proxies={"https": proxy})
 
     def get_client(self, service):
@@ -121,7 +119,7 @@ class Boto3ClientFactory(object):
             fail("AWS %s service failed with exception: %s" % (service, e))
 
 
-class AWSBatchCliConfig(object):
+class AWSBatchCliConfig:
     """AWS ParallelCluster AWS Batch CLI configuration object."""
 
     def __init__(self, log, cluster):

--- a/cli/src/awsbatch/examples/awsbatch-cli.cfg
+++ b/cli/src/awsbatch/examples/awsbatch-cli.cfg
@@ -43,5 +43,4 @@ head_node_ip = x.x.x.x
 # Comma separated list of environment variable names to not export when submitting a job with "--env all" parameter
 #env_blacklist = HOME,PWD,USER,PATH,LD_LIBRARY_PATH,TERM,TERMCAP
 
-# NOTE: the CLI will also search for the credentials in the [aws] section of the AWS ParallelCluster config file
-# If not defined, boto3 will attempt to use environment or EC2 IAM role.
+# NOTE: the CLI will attempt to use credentials environment or EC2 IAM role.

--- a/cli/src/awsbatch/utils.py
+++ b/cli/src/awsbatch/utils.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2.6
-
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -27,7 +25,7 @@ def fail(error_message):
     :param error_message: message to print
     """
     print(error_message, file=sys.stderr)
-    exit(1)
+    sys.exit(1)
 
 
 def get_region_by_stack_id(stack_id):
@@ -110,7 +108,7 @@ def get_job_type(job):
     return "SIMPLE"
 
 
-class S3Uploader(object):
+class S3Uploader:
     """S3 uploader."""
 
     def __init__(self, boto3_factory, s3_bucket, default_folder=""):

--- a/cli/tests/awsbatch/test_awsbstat.py
+++ b/cli/tests/awsbatch/test_awsbstat.py
@@ -11,7 +11,7 @@ ALL_JOB_STATUS = ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING", "SU
 DEFAULT_JOB_STATUS = ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]
 
 
-class TestArgs(object):
+class TestArgs:
     def test_missing_cluster_parameter(self, failed_with_message):
         failed_with_message(awsbstat.main, "Error: cluster parameter is required\n", argv=[])
 
@@ -25,7 +25,7 @@ def boto3_stubber_path():
 
 @pytest.mark.usefixtures("awsbatchcliconfig_mock")
 @pytest.mark.usefixtures("convert_to_date_mock")
-class TestOutput(object):
+class TestOutput:
     def test_no_jobs_default_status(self, capsys, boto3_stubber, test_datadir):
         empty_response = {"jobSummaryList": []}
         mocked_requests = []


### PR DESCRIPTION
Note: object inheritance is useless for Python 3

* C0123: Use isinstance() rather than type() for a typecheck. (unidiomatic-typecheck)
* R0205: Class 'xxx' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
* W1201: Use lazy % formatting in logging functions (logging-not-lazy)
* R1722: Consider using sys.exit() (consider-using-sys-exit)
* R1710: Either all return statements in a function should return an expression, or none of them should.
* R1714: Consider merging these comparisons with "in" to "status in (...)" (consider-using-in)
* C0113: Consider changing "not xxx == 'NONE'" to "xxx != 'NONE'" (unneeded-not)

