### PR TITLE
[3.0] Check EC2 image existance before checking stack existance

### DIFF
--- a/cli/src/pcluster/api/pcluster_api.py
+++ b/cli/src/pcluster/api/pcluster_api.py
@@ -26,8 +26,8 @@ from pcluster.models.cluster import (
     NodeType,
 )
 from pcluster.models.cluster_resources import ClusterInstance
-from pcluster.models.imagebuilder import ImageBuilder, ImageBuilderActionError
-from pcluster.models.imagebuilder_resources import ImageBuilderStack, StackError
+from pcluster.models.imagebuilder import ImageBuilder, ImageBuilderActionError, ImageError
+from pcluster.models.imagebuilder_resources import ImageBuilderStack
 from pcluster.utils import get_installed_version, get_region
 from pcluster.validators.common import FailureLevel
 
@@ -326,9 +326,10 @@ class PclusterApi:
             imagebuilder = ImageBuilder(image_name)
             imagebuilder.delete(force=force)
             try:
+                if imagebuilder.image:
+                    return ImageBuilderInfo(imagebuilder)
+            except ImageError:
                 return ImageBuilderInfo(imagebuilder, stack=imagebuilder.stack)
-            except StackError:
-                return ImageBuilderInfo(imagebuilder)
         except Exception as e:
             return ApiFailure(str(e))
 
@@ -346,9 +347,10 @@ class PclusterApi:
 
             imagebuilder = ImageBuilder(image_name)
             try:
+                if imagebuilder.image:
+                    return ImageBuilderInfo(imagebuilder)
+            except ImageError:
                 return ImageBuilderInfo(imagebuilder, stack=imagebuilder.stack)
-            except StackError:
-                return ImageBuilderInfo(imagebuilder)
         except Exception as e:
             return ApiFailure(str(e))
 


### PR DESCRIPTION
Check EC2 image existance before checking stack existance, unless check_stack param is True: in this case stack is checked first

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
