### PR TITLE
[3.0] Improve build Image process

### DIFF
--- a/cli/src/pcluster/api/pcluster_api.py
+++ b/cli/src/pcluster/api/pcluster_api.py
@@ -16,7 +16,6 @@ from typing import List, Union
 from pkg_resources import packaging
 
 from pcluster.aws.aws_api import AWSApi
-from pcluster.aws.aws_resources import ImageInfo
 from pcluster.cli_commands.compute_fleet_status_manager import ComputeFleetStatus
 from pcluster.models.cluster import (
     Cluster,
@@ -336,7 +335,7 @@ class PclusterApi:
             if region:
                 os.environ["AWS_DEFAULT_REGION"] = region
             # retrieve imagebuilder config and generate model
-            imagebuilder = ImageBuilder(image_name)
+            imagebuilder = ImageBuilder(image_name=image_name)
             imagebuilder.delete(force=force)
             try:
                 return ImageBuilderImageInfo(imagebuilder=imagebuilder, image=imagebuilder.image)
@@ -344,8 +343,7 @@ class PclusterApi:
                 try:
                     return ImageBuilderStackInfo(imagebuilder=imagebuilder, stack=imagebuilder.stack)
                 except NonExistingStackError:
-                    raise ImageBuilderActionError(f"Image {image_name} and imagebuilder stack do not exist.")
-
+                    raise ImageBuilderActionError(f"Image {image_name} does not exist.")
         except Exception as e:
             return ApiFailure(str(e))
 
@@ -361,14 +359,14 @@ class PclusterApi:
             if region:
                 os.environ["AWS_DEFAULT_REGION"] = region
 
-            imagebuilder = ImageBuilder(image_name)
+            imagebuilder = ImageBuilder(image_name=image_name)
             try:
                 return ImageBuilderImageInfo(imagebuilder=imagebuilder, image=imagebuilder.image)
             except NonExistingImageError:
                 try:
                     return ImageBuilderStackInfo(imagebuilder=imagebuilder, stack=imagebuilder.stack)
                 except NonExistingStackError:
-                    raise ImageBuilderActionError(f"Image {image_name} and imagebuilder stack do not exist.")
+                    raise ImageBuilderActionError(f"Image {image_name} does not exist.")
         except Exception as e:
             return ApiFailure(str(e))
 
@@ -386,7 +384,7 @@ class PclusterApi:
 
             # get built images by image name tag
             images = AWSApi.instance().ec2.get_images()
-            imagebuilders = [ImageBuilder(image_name=image.original_image_name) for image in images]
+            imagebuilders = [ImageBuilder(image=image, image_name=image.original_image_name) for image in images]
             images_response = [
                 ImageBuilderImageInfo(imagebuilder=imagebuilder, image=imagebuilder.image)
                 for imagebuilder in imagebuilders

--- a/cli/src/pcluster/api/pcluster_api.py
+++ b/cli/src/pcluster/api/pcluster_api.py
@@ -16,6 +16,7 @@ from typing import List, Union
 from pkg_resources import packaging
 
 from pcluster.aws.aws_api import AWSApi
+from pcluster.aws.aws_resources import ImageInfo
 from pcluster.cli_commands.compute_fleet_status_manager import ComputeFleetStatus
 from pcluster.models.cluster import (
     Cluster,

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -97,7 +97,7 @@ class Ec2Client(Boto3Client):
             return [ImageInfo(image) for image in result.get("Images")]
         raise ImageNotFoundError(function_name="describe_images")
 
-    def image_exists(self, image_name: str, build_status_avaliable: bool = False):
+    def image_exists(self, image_name: str, build_status_avaliable: bool = True):
         """Return a boolean describing whether or not an image with the given search criteria exists."""
         try:
             self.describe_image_by_name_tag(image_name, build_status_avaliable)
@@ -106,7 +106,7 @@ class Ec2Client(Boto3Client):
             return False
 
     @AWSExceptionHandler.handle_client_exception
-    def describe_image_by_name_tag(self, image_name: str, build_status_avaliable: bool = False):
+    def describe_image_by_name_tag(self, image_name: str, build_status_avaliable: bool = True):
         """Return a dict of image info by searching image name tag as filter."""
         filters = [{"Name": "tag:" + PCLUSTER_IMAGE_NAME_TAG, "Values": [image_name]}]
         if build_status_avaliable:

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -144,7 +144,7 @@ class Ec2Client(Boto3Client):
         """Return existing pcluster images by pcluster image name tag."""
         try:
             filters = [
-                {"Name": f"tag:{PCLUSTER_IMAGE_NAME_TAG}", "Values": ["*"]},
+                {"Name": "tag-key", "Values": [PCLUSTER_IMAGE_NAME_TAG]},
                 {"Name": f"tag:{PCLUSTER_IMAGE_BUILD_STATUS_TAG}", "Values": ["available"]},
             ]
             owners = ["self"]

--- a/cli/src/pcluster/cli_commands/commands.py
+++ b/cli/src/pcluster/cli_commands/commands.py
@@ -430,6 +430,8 @@ def delete_image(args):
         # delete image raises an exception if stack does not exist
         result = PclusterApi().delete_image(image_name=args.image_name, region=utils.get_region(), force=args.force)
         if isinstance(result, ImageBuilderInfo):
+            result.imagebuild_status = "DELETE_IN_PROGRESS"
+
             print(f"Image deletion started correctly. {result}")
         else:
             utils.error(f"Image deletion failed. {result.message}")

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -267,7 +267,7 @@ class ImageBuilder:
         self._validate_image_name()
 
         # check image existence
-        if AWSApi.instance().ec2.image_exists(self.image_name, build_status_avaliable=True):
+        if AWSApi.instance().ec2.image_exists(self.image_name):
             raise ImageBuilderActionError(f"ParallelCluster image {self.image_name} already exists")
 
         # check stack existence
@@ -366,7 +366,7 @@ class ImageBuilder:
         """Delete CFN Stack and associate resources and deregister the image."""
         if force or (not self._check_instance_using_image() and not self._check_image_is_shared()):
             try:
-                if AWSApi.instance().ec2.image_exists(self.image_name):
+                if AWSApi.instance().ec2.image_exists(image_name=self.image_name, build_status_avaliable=False):
                     # Deregister image
                     AWSApi.instance().ec2.deregister_image(self.image.id)
 

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -19,6 +19,7 @@ import re
 import pkg_resources
 
 from pcluster.aws.aws_api import AWSApi
+from pcluster.aws.aws_resources import ImageInfo
 from pcluster.aws.common import AWSClientError, ImageNotFoundError, StackNotFoundError
 from pcluster.config.common import BaseTag
 from pcluster.constants import (
@@ -92,11 +93,13 @@ class NonExistingImageError(ImageError):
 class ImageBuilder:
     """Represent a building image, composed by an ImageBuilder config and an ImageBuilderStack."""
 
-    def __init__(self, image_name: str = None, config: dict = None, stack: ImageBuilderStack = None):
+    def __init__(
+        self, image: ImageInfo = None, image_name: str = None, config: dict = None, stack: ImageBuilderStack = None
+    ):
         self.image_name = image_name
         self.__source_config = config
         self.__stack = stack
-        self.__image = None
+        self.__image = image
         self.__config = None
         self.__bucket = None
         self.template_body = None

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/delete_image_stack.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/delete_image_stack.py
@@ -46,7 +46,7 @@ def handler(event, context):
             try:
                 # tag EC2 AMI
                 image_id = message_json["outputResources"]["amis"][0]["image"]
-                aws_partition = message_json["arn"].split(':')[1]
+                aws_partition = message_json["arn"].split(":")[1]
                 parent_image = message_json["imageRecipe"]["parentImage"]
                 image_arn = f"arn:{aws_partition}:ec2:{aws_region}::image/{image_id}"
                 logger.info("Tagging EC2 AMI %s", image_arn)
@@ -58,7 +58,7 @@ def handler(event, context):
                     Tags={
                         "parallelcluster:build_status": "available",
                         "parallelcluster:parent_image": parent_image,
-                    }
+                    },
                 )
             except KeyError as e:
                 logger.error("Failed to parse message with exception: %s", e)

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -83,7 +83,7 @@ phases:
                   KEY="$(echo ${KEY} | cut -c -128)"
                   VALUE="$(echo ${VALUE} | cut -c -256)"
                   echo "Adding Tag Key=${KEY},Value=${VALUE}"
-                  aws ec2 create-tags --region {{ test.AWSRegion.outputs.stdout }} --resource {{ test.AmiId.outputs.stdout }} --tags "Key=${KEY},Value=${VALUE}" || { echo "Not able to set AMI tag"; exit 1; }
+                  aws ec2 create-tags --region {{ test.AWSRegion.outputs.stdout }} --resource {{ test.AmiId.outputs.stdout }} --tags "Key=${KEY},Value=${VALUE}" || echo "Not able to set AMI tag"
                 fi
               }
 
@@ -170,6 +170,3 @@ phases:
 
               # Add description
               add_description
-
-              # Add build status
-              add_tag "parallelcluster:build_status" "available"

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -518,6 +518,25 @@ class ImageBuilderCdkStack(Stack):
 
             self._add_resource_delete_policy(
                 policy_statements,
+                ["ec2:CreateTags"],
+                [
+                    self.format_arn(
+                        service="ec2",
+                        account="",
+                        resource="image",
+                        resource_name="*",
+                    )
+                ],
+            )
+
+            self._add_resource_delete_policy(
+                policy_statements,
+                ["tag:TagResources"],
+                ["*"],
+            )
+
+            self._add_resource_delete_policy(
+                policy_statements,
                 ["iam:DetachRolePolicy", "iam:DeleteRole", "iam:DeleteRolePolicy"],
                 [
                     self.format_arn(

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -972,6 +972,27 @@ def test_imagebuilder_instance_role(
                                         },
                                     },
                                     {
+                                        "Action": "ec2:CreateTags",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":ec2:",
+                                                    {"Ref": "AWS::Region"},
+                                                    "::image/*",
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "tag:TagResources",
+                                        "Effect": "Allow",
+                                        "Resource": "*",
+                                    },
+                                    {
                                         "Action": ["iam:DetachRolePolicy", "iam:DeleteRole", "iam:DeleteRolePolicy"],
                                         "Effect": "Allow",
                                         "Resource": {


### PR DESCRIPTION
* Describe the image before stack in image commands 
* Tag Image availability status after ImageBuilder notification 
* Improve speed of describe images 
* Avoid calling describe image twice when listing images
* Check existence of all EC2 AMI on delete

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
