### PR TITLE
3.0: Update armpl integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ per cluster.
 - Upgrade Slurm to version 20.11.5.
   - Add new SlurmctldParameters, power_save_min_interval=30, so power actions will be processed every 30 seconds
   - Specify instance GPU model as GRES GPU Type in gres.conf, instead of previous hardcoded value for all GPU, Type=tesla
+- Upgrade Arm Performance Libraries (APL) to version 21.0.0  
 - Make `key_name` parameter optional to support cluster configurations without a key pair. 
 - Remove support for Python versions < 3.6.
 - Remove dependency on `future` package and `__future__` module.


### PR DESCRIPTION
- Code changes to make test_arm_pl work correctly with armpl 21.0.0 integration.
- Added new check to verify that EULA docs are really available at the path specified in the output  when loading the module

Signed-off-by: ddeidda <ddeidda@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
