### PR TITLE
Integration-tests: add retry for getting ec2-metadata

### DIFF
--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
@@ -43,11 +43,13 @@ def _get_private_ip_addresses(instance_id, region, remote_command_executor):
 def _test_head_node_nics(remote_command_executor, region):
     # On the head node we just check that all the private IPs have been assigned to NICs
     token = remote_command_executor.run_remote_command(
-        "curl -s -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 300'"
+        "curl --retry 3 --retry-delay 0  --fail -s -X PUT 'http://169.254.169.254/latest/api/token' "
+        "-H 'X-aws-ec2-metadata-token-ttl-seconds: 300'"
     ).stdout
 
     head_node_instance_id = remote_command_executor.run_remote_command(
-        f'curl -s -H "X-aws-ec2-metadata-token: {token}" http://169.254.169.254/latest/meta-data/instance-id'
+        f'curl --retry 3 --retry-delay 0  --fail -s -H "X-aws-ec2-metadata-token: {token}" '
+        "http://169.254.169.254/latest/meta-data/instance-id"
     ).stdout
 
     head_node_ip_addresses = _get_private_ip_addresses(head_node_instance_id, region, remote_command_executor)

--- a/tests/integration-tests/tests/networking/test_placement_group.py
+++ b/tests/integration-tests/tests/networking/test_placement_group.py
@@ -143,10 +143,12 @@ def _check_head_node_placement_group(remote_command_executor, region, expected_p
     logging.info("Checking placement group for head node")
 
     token = remote_command_executor.run_remote_command(
-        "curl -s -X PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 300'"
+        "curl --retry 3 --retry-delay 0 --fail -s -X "
+        "PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 300'"
     ).stdout
     head_node_instance_id = remote_command_executor.run_remote_command(
-        f'curl -s -H "X-aws-ec2-metadata-token: {token}" http://169.254.169.254/latest/meta-data/instance-id'
+        "curl --retry 3 --retry-delay 0 --fail -s "
+        f'-H "X-aws-ec2-metadata-token: {token}" http://169.254.169.254/latest/meta-data/instance-id'
     ).stdout
     head_node_placement_group = boto3.client("ec2", region_name=region).describe_instances(
         InstanceIds=[head_node_instance_id]

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/test_mpi_job.sh
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/test_mpi_job.sh
@@ -2,8 +2,8 @@
 set -e
 
 echo "ip container: $(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)"
-TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
-echo "ip host: $(curl -s -H "X-aws-ec2-metadata-token: ${TOKEN}" "http://169.254.169.254/latest/meta-data/local-ipv4")"
+TOKEN=$(curl --retry 3 --retry-delay 0  --fail -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+echo "ip host: $(curl --retry 3 --retry-delay 0  --fail -s -H "X-aws-ec2-metadata-token: ${TOKEN}" "http://169.254.169.254/latest/meta-data/local-ipv4")"
 
 # get shared dir
 IFS=',' _shared_dirs=(${PCLUSTER_SHARED_DIRS})


### PR DESCRIPTION
Add retry for getting ec2 metadata in integration tests to make the test more robust
Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
