### PR TITLE
[3.0] Fix CW log group name for build log

### DIFF
--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -108,7 +108,8 @@ class ImageBuilderCdkStack(Stack):
             service="logs",
             resource="log-group",
             region=utils.get_region(),
-            resource_name=f":aws/imagebuilder/{self._build_image_recipe_name()}",
+            sep=":",
+            resource_name=f"/aws/imagebuilder/{self._build_image_recipe_name()}",
         )
         return log_group_arn
 

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -1348,7 +1348,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },
@@ -1395,7 +1395,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },
@@ -1445,7 +1445,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },
@@ -1927,7 +1927,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },
@@ -1975,7 +1975,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },
@@ -2023,7 +2023,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },
@@ -2071,7 +2071,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },
@@ -2124,7 +2124,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },
@@ -2178,7 +2178,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },
@@ -2232,7 +2232,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },
@@ -2257,7 +2257,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                                         {"Ref": "AWS::Partition"},
                                         ":logs:us-east-1:",
                                         {"Ref": "AWS::AccountId"},
-                                        ":log-group/:aws/imagebuilder/ParallelClusterImage-Pcluster",
+                                        ":log-group:/aws/imagebuilder/ParallelClusterImage-Pcluster",
                                     ],
                                 ]
                             },


### PR DESCRIPTION
cw loggroup arn format is
```
arn:aws:logs:region:account-id:log-group:log_group_name
```
see doc https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
