### PR TITLE
3.0: Use id instead of image name in build image command 

### DIFF
--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -12,7 +12,7 @@ import logging
 
 from pcluster.constants import (
     PCLUSTER_IMAGE_BUILD_LOG_TAG,
-    PCLUSTER_IMAGE_NAME_TAG,
+    PCLUSTER_IMAGE_ID_TAG,
     PCLUSTER_S3_BUCKET_TAG,
     PCLUSTER_S3_IMAGE_DIR_TAG,
     PCLUSTER_VERSION_TAG,
@@ -238,7 +238,7 @@ class FsxFileSystemInfo:
 
 
 class ImageInfo:
-    """Object to store Image information, initialized with the describe_image or describe_images in ec2 client."""
+    """Object to store Ec2 Image information, initialized with the describe_image or describe_images in ec2 client."""
 
     def __init__(self, image_data: dict):
         self._image_data = image_data
@@ -249,9 +249,9 @@ class ImageInfo:
         return self._image_data.get("Name")
 
     @property
-    def original_image_name(self) -> str:
-        """Return original image name without date."""
-        return self._get_tag(PCLUSTER_IMAGE_NAME_TAG)
+    def pcluster_image_id(self) -> str:
+        """Return pcluster image id."""
+        return self._get_tag(PCLUSTER_IMAGE_ID_TAG)
 
     @property
     def id(self) -> str:

--- a/cli/src/pcluster/aws/cfn.py
+++ b/cli/src/pcluster/aws/cfn.py
@@ -12,7 +12,7 @@ import json
 
 from pcluster.aws.aws_resources import StackInfo
 from pcluster.aws.common import AWSExceptionHandler, Boto3Client, StackNotFoundError
-from pcluster.constants import PCLUSTER_CLUSTER_VERSION_TAG, PCLUSTER_IMAGE_NAME_TAG
+from pcluster.constants import PCLUSTER_CLUSTER_VERSION_TAG, PCLUSTER_IMAGE_ID_TAG
 
 
 class CfnClient(Boto3Client):
@@ -128,6 +128,6 @@ class CfnClient(Boto3Client):
         """List existing imagebuilder stacks."""
         stack_list = []
         for stack in self._paginate_results(self._client.describe_stacks):
-            if stack.get("ParentId") is None and StackInfo(stack).get_tag(PCLUSTER_IMAGE_NAME_TAG):
+            if stack.get("ParentId") is None and StackInfo(stack).get_tag(PCLUSTER_IMAGE_ID_TAG):
                 stack_list.append(stack)
         return stack_list

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -13,7 +13,7 @@ from typing import List
 from pcluster import utils
 from pcluster.aws.aws_resources import ImageInfo, InstanceTypeInfo
 from pcluster.aws.common import AWSClientError, AWSExceptionHandler, Boto3Client, ImageNotFoundError
-from pcluster.constants import PCLUSTER_IMAGE_BUILD_STATUS_TAG, PCLUSTER_IMAGE_NAME_TAG, SUPPORTED_ARCHITECTURES
+from pcluster.constants import PCLUSTER_IMAGE_BUILD_STATUS_TAG, PCLUSTER_IMAGE_ID_TAG, SUPPORTED_ARCHITECTURES
 from pcluster.utils import Cache
 
 
@@ -97,18 +97,18 @@ class Ec2Client(Boto3Client):
             return [ImageInfo(image) for image in result.get("Images")]
         raise ImageNotFoundError(function_name="describe_images")
 
-    def image_exists(self, image_name: str, build_status_avaliable: bool = True):
+    def image_exists(self, image_id: str, build_status_avaliable: bool = True):
         """Return a boolean describing whether or not an image with the given search criteria exists."""
         try:
-            self.describe_image_by_name_tag(image_name, build_status_avaliable)
+            self.describe_image_by_id_tag(image_id, build_status_avaliable)
             return True
         except ImageNotFoundError:
             return False
 
     @AWSExceptionHandler.handle_client_exception
-    def describe_image_by_name_tag(self, image_name: str, build_status_avaliable: bool = True):
-        """Return a dict of image info by searching image name tag as filter."""
-        filters = [{"Name": "tag:" + PCLUSTER_IMAGE_NAME_TAG, "Values": [image_name]}]
+    def describe_image_by_id_tag(self, image_id: str, build_status_avaliable: bool = True):
+        """Return a dict of image info by searching image id tag as filter."""
+        filters = [{"Name": "tag:" + PCLUSTER_IMAGE_ID_TAG, "Values": [image_id]}]
         if build_status_avaliable:
             filters.append({"Name": "tag:" + PCLUSTER_IMAGE_BUILD_STATUS_TAG, "Values": ["available"]})
         owners = ["self"]
@@ -144,7 +144,7 @@ class Ec2Client(Boto3Client):
         """Return existing pcluster images by pcluster image name tag."""
         try:
             filters = [
-                {"Name": "tag-key", "Values": [PCLUSTER_IMAGE_NAME_TAG]},
+                {"Name": "tag-key", "Values": [PCLUSTER_IMAGE_ID_TAG]},
                 {"Name": f"tag:{PCLUSTER_IMAGE_BUILD_STATUS_TAG}", "Values": ["available"]},
             ]
             owners = ["self"]

--- a/cli/src/pcluster/cli/commands/image.py
+++ b/cli/src/pcluster/cli/commands/image.py
@@ -31,11 +31,11 @@ class BuildImageCommand(CliCommand):
 
     def register_command_args(self, parser: ArgumentParser) -> None:  # noqa: D102
         parser.add_argument(
-            "-n",
-            "--name",
-            dest="image_name",
+            "-i",
+            "--id",
+            dest="id",
             required=True,
-            help="Specifies the image name to use for building the AWS ParallelCluster AMI.",
+            help="Specifies the id to use for building the AWS ParallelCluster Image.",
         )
 
     def execute(self, args: Namespace, extra_args: List[str]) -> None:  # noqa: D102
@@ -57,7 +57,7 @@ class DeleteImageCommand(CliCommand):
 
     def register_command_args(self, parser: ArgumentParser) -> None:  # noqa: D102
         parser.add_argument(
-            "-n", "--name", dest="image_name", required=True, help="Name of the AWS ParallelCluster AMI to delete."
+            "-i", "--id", dest="id", required=True, help="Id of the AWS ParallelCluster Image to delete."
         )
         parser.add_argument(
             "-f",
@@ -85,7 +85,7 @@ class DescribeImageCommand(CliCommand):
 
     def register_command_args(self, parser: ArgumentParser) -> None:  # noqa: D102
         parser.add_argument(
-            "-n", "--name", dest="image_name", required=True, help="Name of the AWS ParallelCluster AMI to describe."
+            "-i", "--id", dest="id", required=True, help="Id of the AWS ParallelCluster Image to describe."
         )
 
     def execute(self, args: Namespace, extra_args: List[str]) -> None:  # noqa: D102

--- a/cli/src/pcluster/cli_commands/commands.py
+++ b/cli/src/pcluster/cli_commands/commands.py
@@ -383,7 +383,7 @@ def build_image(args):
     LOGGER.info("Building AWS ParallelCluster image. This could take a while...")
     try:
         response = PclusterApi().build_image(
-            imagebuilder_config=load_yaml_dict(args.config_file), image_name=args.image_name, region=utils.get_region()
+            imagebuilder_config=load_yaml_dict(args.config_file), image_id=args.id, region=utils.get_region()
         )
 
         if isinstance(response, ApiFailure):
@@ -425,11 +425,11 @@ def update(args):
 
 def delete_image(args):
     """Delete image described by image_name."""
-    LOGGER.info("Deleting: %s", args.image_name)
+    LOGGER.info("Deleting: %s", args.image_id)
     LOGGER.debug("CLI args: %s", str(args))
     try:
         # delete image raises an exception if stack does not exist
-        result = PclusterApi().delete_image(image_name=args.image_name, region=utils.get_region(), force=args.force)
+        result = PclusterApi().delete_image(image_id=args.id, region=utils.get_region(), force=args.force)
         if isinstance(result, ImageBuilderInfo):
             result.imagebuild_status = "DELETE_IN_PROGRESS"
 
@@ -457,7 +457,7 @@ def delete_image(args):
 def describe_image(args):
     """Describe image info by image_name."""
     try:
-        result = PclusterApi().describe_image(image_name=args.image_name, region=utils.get_region())
+        result = PclusterApi().describe_image(image_id=args.id, region=utils.get_region())
         LOGGER.info("Response:")
         if isinstance(result, ApiFailure):
             LOGGER.info("Build image error %s", result.message)

--- a/cli/src/pcluster/config/imagebuilder_config.py
+++ b/cli/src/pcluster/config/imagebuilder_config.py
@@ -48,10 +48,12 @@ class Image(Resource):
 
     def __init__(
         self,
+        name: str = None,
         tags: List[BaseTag] = None,
         root_volume: Volume = None,
     ):
         super().__init__()
+        self.name = name
         self.tags = tags
         self.root_volume = root_volume
 

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -61,7 +61,11 @@ CW_LOGS_RETENTION_DAYS_DEFAULT = 14
 CW_DASHBOARD_ENABLED_DEFAULT = True
 CW_LOGS_ENABLED_DEFAULT = True
 
+PCLUSTER_IMAGE_NAME_REGEX = r"^[-_A-Za-z0-9{][-_A-Za-z0-9\s:{}\.]+[-_A-Za-z0-9}]$"
+PCLUSTER_IMAGE_ID_REGEX = r"^([a-zA-Z][a-zA-Z0-9-]{0,127})$"
+
 PCLUSTER_IMAGE_NAME_TAG = "parallelcluster:image_name"
+PCLUSTER_IMAGE_ID_TAG = "parallelcluster:image_id"
 PCLUSTER_IMAGE_BUILD_STATUS_TAG = "parallelcluster:build_status"
 PCLUSTER_S3_IMAGE_DIR_TAG = "parallelcluster:s3_image_dir"
 PCLUSTER_S3_CLUSTER_DIR_TAG = "parallelcluster:cluster_dir"

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -24,12 +24,13 @@ from pcluster.aws.common import AWSClientError, ImageNotFoundError, StackNotFoun
 from pcluster.config.common import BaseTag
 from pcluster.constants import (
     PCLUSTER_IMAGE_BUILD_LOG_TAG,
+    PCLUSTER_IMAGE_ID_REGEX,
+    PCLUSTER_IMAGE_ID_TAG,
     PCLUSTER_IMAGE_NAME_TAG,
     PCLUSTER_S3_BUCKET_TAG,
     PCLUSTER_S3_IMAGE_DIR_TAG,
     PCLUSTER_VERSION_TAG,
 )
-from pcluster.imagebuilder_utils import AMI_NAME_REQUIRED_SUBSTRING
 from pcluster.models.imagebuilder_resources import ImageBuilderStack, NonExistingStackError, StackError
 from pcluster.models.s3_bucket import S3Bucket, S3BucketFactory
 from pcluster.schemas.imagebuilder_schema import ImageBuilderSchema
@@ -86,17 +87,17 @@ class ImageError(Exception):
 class NonExistingImageError(ImageError):
     """Represent an error if image does not exist."""
 
-    def __init__(self, image_name):
-        super().__init__(f"Image {image_name} does not exist.")
+    def __init__(self, image_id):
+        super().__init__(f"Image {image_id} does not exist.")
 
 
 class ImageBuilder:
     """Represent a building image, composed by an ImageBuilder config and an ImageBuilderStack."""
 
     def __init__(
-        self, image: ImageInfo = None, image_name: str = None, config: dict = None, stack: ImageBuilderStack = None
+        self, image: ImageInfo = None, image_id: str = None, config: dict = None, stack: ImageBuilderStack = None
     ):
-        self.image_name = image_name
+        self.image_id = image_id
         self.__source_config = config
         self.__stack = stack
         self.__image = image
@@ -129,11 +130,11 @@ class ImageBuilder:
         """Return the ImageBuilderStack object."""
         if not self.__stack:
             try:
-                self.__stack = ImageBuilderStack(AWSApi.instance().cfn.describe_stack(self.image_name))
+                self.__stack = ImageBuilderStack(AWSApi.instance().cfn.describe_stack(self.image_id))
             except StackNotFoundError:
-                raise NonExistingStackError(self.image_name)
+                raise NonExistingStackError(self.image_id)
             except AWSClientError as e:
-                raise StackError(f"Unable to find imagebuilder stack {self.image_name}, due to {e}")
+                raise StackError(f"Unable to get image {self.image_id}, due to {e}")
         return self.__stack
 
     @property
@@ -141,11 +142,11 @@ class ImageBuilder:
         """Return Image object."""
         if not self.__image:
             try:
-                self.__image = AWSApi.instance().ec2.describe_image_by_name_tag(self.image_name)
+                self.__image = AWSApi.instance().ec2.describe_image_by_id_tag(self.image_id)
             except ImageNotFoundError:
-                raise NonExistingImageError(self.image_name)
+                raise NonExistingImageError(self.image_id)
             except AWSClientError as e:
-                raise ImageError(f"Unable to get Image {self.image_name} info, due to {e}.")
+                raise ImageError(f"Unable to get image {self.image_id}, due to {e}.")
 
         return self.__image
 
@@ -159,7 +160,7 @@ class ImageBuilder:
                     return key
             return None
         except StackError as e:
-            raise ImageBuilderActionError(f"Unable to get imagebuilder {self.image_name} status, due to {e}")
+            raise ImageBuilderActionError(f"Unable to get image {self.image_id} status , due to {e}")
 
     @property
     def source_config(self):
@@ -185,8 +186,8 @@ class ImageBuilder:
             custom_bucket_name = self._get_custom_bucket()
 
         self.__bucket = S3BucketFactory.init_s3_bucket(
-            service_name=self.image_name,
-            stack_name=self.image_name,
+            service_name=self.image_id,
+            stack_name=self.image_id,
             custom_s3_bucket=custom_bucket_name,
             artifact_directory=self.s3_artifact_dir,
         )
@@ -199,13 +200,13 @@ class ImageBuilder:
             custom_bucket_name = self.image.s3_bucket_name
         except ImageError as e:
             if not isinstance(e, NonExistingImageError):
-                raise ImageBuilderActionError(f"Unable to get S3 bucket name from image {self.image_name} tag. {e}")
+                raise ImageBuilderActionError(f"Unable to get S3 bucket name from image {self.image_id} . {e}")
 
         if custom_bucket_name is None:
             try:
                 custom_bucket_name = self.stack.s3_bucket_name
             except StackError as e:
-                raise ImageBuilderActionError(f"Unable to get S3 bucket name from stack {self.image_name} tag. {e}")
+                raise ImageBuilderActionError(f"Unable to get S3 bucket name from image {self.image_id}. {e}")
 
         return (
             custom_bucket_name
@@ -220,8 +221,8 @@ class ImageBuilder:
             s3_artifact_dir = self.image.s3_artifact_directory
         except ImageError as e:
             if not isinstance(e, NonExistingImageError):
-                LOGGER.error("Unable to find tag %s in image %s.", PCLUSTER_S3_IMAGE_DIR_TAG, self.image_name)
-                raise ImageBuilderActionError(f"Unable to get artifact directory from image {self.image_name} tag. {e}")
+                LOGGER.error("Unable to find tag %s in image %s.", PCLUSTER_S3_IMAGE_DIR_TAG, self.image_id)
+                raise ImageBuilderActionError(f"Unable to get artifact directory from image {self.image_id}. {e}")
 
         if s3_artifact_dir is None:
             try:
@@ -232,10 +233,7 @@ class ImageBuilder:
                         "No artifact directory found in image tag and cloudformation stack tag."
                     )
             except StackError as e:
-                raise ImageBuilderActionError(
-                    f"Unable to get artifact directory from image {self.image_name} tag "
-                    f"and cloudformation stack tag. {e}"
-                )
+                raise ImageBuilderActionError(f"Unable to get artifact directory from image {self.image_id}. {e}")
 
         return s3_artifact_dir
 
@@ -244,9 +242,9 @@ class ImageBuilder:
         Generate artifact directory in S3 bucket.
 
         Image artifact dir is generated before cfn stack creation and only generate once.
-        artifact_directory: e.g. parallelcluster/{version}/imagebuilders/{image_name}-jfr4odbeonwb1w5k
+        artifact_directory: e.g. parallelcluster/{version}/images/{image_id}-jfr4odbeonwb1w5k
         """
-        service_directory = generate_random_name_with_prefix(self.image_name)
+        service_directory = generate_random_name_with_prefix(self.image_id)
         self.__s3_artifact_dir = "/".join(
             [
                 self._s3_artifacts_dict.get("root_directory"),
@@ -263,17 +261,17 @@ class ImageBuilder:
         validation_failure_level: FailureLevel = FailureLevel.ERROR,
     ):
         """Create the CFN Stack and associate resources."""
-        # validate image name
-        self._validate_image_name()
+        # validate image id
+        self._validate_id()
 
         # check image existence
-        if AWSApi.instance().ec2.image_exists(self.image_name):
-            raise ImageBuilderActionError(f"ParallelCluster image {self.image_name} already exists")
+        if AWSApi.instance().ec2.image_exists(self.image_id):
+            raise ImageBuilderActionError(f"ParallelCluster image {self.image_id} already exists.")
 
         # check stack existence
-        if AWSApi.instance().cfn.stack_exists(self.image_name):
+        if AWSApi.instance().cfn.stack_exists(self.image_id):
             raise ImageBuilderActionError(
-                f"ParallelCluster build infrastructure for image {self.image_name} already exists"
+                f"ParallelCluster build infrastructure for image {self.image_id} already exists"
             )
 
         if not suppress_validators:
@@ -291,11 +289,11 @@ class ImageBuilder:
         try:
             self._upload_config()
 
-            LOGGER.info("Building ParallelCluster image named: %s", self.image_name)
+            LOGGER.info("Building ParallelCluster image: %s", self.image_id)
 
             # Generate cdk cfn template
             self.template_body = CDKTemplateBuilder().build_imagebuilder_template(
-                image_config=self.config, image_name=self.image_name, bucket=self.bucket
+                image_config=self.config, image_id=self.image_id, bucket=self.bucket
             )
 
             # upload generated template
@@ -304,7 +302,7 @@ class ImageBuilder:
 
             # Stack creation
             creation_result = AWSApi.instance().cfn.create_stack_from_url(
-                stack_name=self.image_name,
+                stack_name=self.image_id,
                 template_url=self.bucket.get_cfn_template_url(
                     template_name=self._s3_artifacts_dict.get("template_name")
                 ),
@@ -313,7 +311,7 @@ class ImageBuilder:
                 capabilities="CAPABILITY_NAMED_IAM",
             )
 
-            self.__stack = ImageBuilderStack(AWSApi.instance().cfn.describe_stack(self.image_name))
+            self.__stack = ImageBuilderStack(AWSApi.instance().cfn.describe_stack(self.image_id))
 
             LOGGER.debug("StackId: %s", self.stack.id)
             LOGGER.info("Status: %s", self.stack.status)
@@ -344,9 +342,9 @@ class ImageBuilder:
         Upload image specific resources and image template.
 
         All dirs contained in resource dir will be uploaded as zip files to
-        {bucket_name}/parallelcluster/{version}/imagebuilders/{image_name}/{resource_dir}/artifacts.zip.
+        /{version}/parallelcluster/{version}/images/{image_id}-jfr4odbeonwb1w5k/{resource_dir}/artifacts.zip.
         All files contained in root dir will be uploaded to
-        {bucket_name}/parallelcluster/{version}/imagebuilder/{image_name}/{resource_dir}/artifact.
+        /{version}/parallelcluster/{version}/images/{image_id}-jfr4odbeonwb1w5k/{resource_dir}/artifact.
         """
         try:
             if self.template_body:
@@ -366,20 +364,20 @@ class ImageBuilder:
         """Delete CFN Stack and associate resources and deregister the image."""
         if force or (not self._check_instance_using_image() and not self._check_image_is_shared()):
             try:
-                if AWSApi.instance().ec2.image_exists(image_name=self.image_name, build_status_avaliable=False):
+                if AWSApi.instance().ec2.image_exists(id=self.image_id, build_status_avaliable=False):
                     # Deregister image
                     AWSApi.instance().ec2.deregister_image(self.image.id)
 
                     # Delete snapshot
                     for snapshot_id in self.image.snapshot_ids:
                         AWSApi.instance().ec2.delete_snapshot(snapshot_id)
-                if AWSApi.instance().cfn.stack_exists(self.image_name):
+                if AWSApi.instance().cfn.stack_exists(self.image_id):
                     if self.stack.imagebuilder_image_is_building:
                         raise ImageBuilderActionError(
                             "Image cannot be deleted because EC2 ImageBuilder Image has a running workflow."
                         )
                     # Delete stack
-                    AWSApi.instance().cfn.delete_stack(self.image_name)
+                    AWSApi.instance().cfn.delete_stack(self.image_id)
 
                 # Delete s3 image directory
                 try:
@@ -397,9 +395,9 @@ class ImageBuilder:
             result = AWSApi.instance().ec2.get_image_shared_account_ids(self.image.id)
             if result:
                 logging.error(
-                    "Image %s is shared with accounts or group %s. In case you want to delete the image, "
-                    "please use the --force flag.",
-                    self.image_name,
+                    "Image %s is shared with accounts or group %s. "
+                    "In case you want to delete the image, please use the --force flag.",
+                    self.image_id,
                     str(result),
                 )
                 raise ImageBuilderActionError("Unable to delete image and stack")
@@ -415,9 +413,9 @@ class ImageBuilder:
             result = AWSApi.instance().ec2.get_instance_ids_by_ami_id(self.image.id)
             if result:
                 logging.error(
-                    "Image %s is used by instances %s. In case you want to delete the image, "
-                    "please use the --force flag.",
-                    self.image_name,
+                    "Image %s is used by instances %s. "
+                    "In case you want to delete the image, please use the --force flag.",
+                    self.image_id,
                     str(result),
                 )
                 raise ImageBuilderActionError("Unable to delete image and stack")
@@ -427,26 +425,25 @@ class ImageBuilder:
                 return False
             raise ImageBuilderActionError(f"Unable to delete image and stack, due to {str(e)}")
 
-    def _validate_image_name(self):
-        match = re.match(r"^[-_A-Za-z-0-9][-_A-Za-z0-9 ]{1,126}[-_A-Za-z-0-9]$", self.image_name)
+    def _validate_id(self):
+        match = re.match(PCLUSTER_IMAGE_ID_REGEX, self.image_id)
         if match is None:
             raise ImageBuilderActionError(
-                "Image name '{0}' failed to satisfy constraint: ".format(self.image_name)
-                + "Member must satisfy regular expression pattern: [-_A-Za-z-0-9][-_A-Za-z0-9 ]{1,126}[-_A-Za-z-0-9]"
-            )
-        if len(self.image_name) > 1024 - len(AMI_NAME_REQUIRED_SUBSTRING):
-            raise ImageBuilderActionError(
-                "Image name failed to satisfy constraint, the length should be shorter than {0}".format(
-                    str(1024 - len(AMI_NAME_REQUIRED_SUBSTRING))
-                )
+                "Image id '{0}' failed to satisfy constraint: ".format(self.image_id)
+                + "The process id can contain only alphanumeric characters (case-sensitive) and hyphens. "
+                + "It must start with an alphabetic character and can't be longer than 128 characters."
             )
 
     def _get_cfn_tags(self):
         """Get cfn tags."""
         cfn_tags = copy.deepcopy(self.config.build.tags) or []
         tag_list = [
+            {
+                "key": PCLUSTER_IMAGE_NAME_TAG,
+                "value": self.config.image.name if self.config.image and self.config.image.name else self.image_id,
+            },
             {"key": PCLUSTER_VERSION_TAG, "value": get_installed_version()},
-            {"key": PCLUSTER_IMAGE_NAME_TAG, "value": self.image_name},
+            {"key": PCLUSTER_IMAGE_ID_TAG, "value": self.image_id},
             {"key": PCLUSTER_S3_BUCKET_TAG, "value": self.bucket.name},
             {"key": PCLUSTER_S3_IMAGE_DIR_TAG, "value": self.s3_artifact_dir},
             {"key": PCLUSTER_IMAGE_BUILD_LOG_TAG, "value": self._get_log_group_arn()},
@@ -457,7 +454,7 @@ class ImageBuilder:
 
     def _get_log_group_arn(self):
         """Get log group arn."""
-        image_recipe_name = "{0}-{1}".format(RESOURCE_NAME_PREFIX, self.image_name)[0:1024]
+        image_recipe_name = "{0}-{1}".format(RESOURCE_NAME_PREFIX, self.image_id)
         return "arn:{0}:logs:{1}:{2}:log-group:/aws/imagebuilder/{3}".format(
             get_partition(), get_region(), AWSApi.instance().sts.get_account_id(), image_recipe_name
         )

--- a/cli/src/pcluster/models/imagebuilder_resources.py
+++ b/cli/src/pcluster/models/imagebuilder_resources.py
@@ -17,7 +17,7 @@ from pcluster.aws.aws_resources import StackInfo
 from pcluster.aws.common import AWSClientError
 from pcluster.constants import (
     PCLUSTER_IMAGE_BUILD_LOG_TAG,
-    PCLUSTER_IMAGE_NAME_TAG,
+    PCLUSTER_IMAGE_ID_TAG,
     PCLUSTER_S3_BUCKET_TAG,
     PCLUSTER_S3_IMAGE_DIR_TAG,
     PCLUSTER_VERSION_TAG,
@@ -64,7 +64,7 @@ class ImageBuilderStack(StackInfo):
     @property
     def image_name(self):
         """Return image name tag value."""
-        return self.get_tag(PCLUSTER_IMAGE_NAME_TAG)
+        return self.get_tag(PCLUSTER_IMAGE_ID_TAG)
 
     @property
     def version(self):

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -27,6 +27,8 @@ from pcluster.config.imagebuilder_config import (
     ImagebuilderDevSettings,
     Volume,
 )
+from pcluster.constants import PCLUSTER_IMAGE_NAME_REGEX
+from pcluster.imagebuilder_utils import AMI_NAME_REQUIRED_SUBSTRING
 from pcluster.schemas.common_schema import (
     ALLOWED_VALUES,
     BaseDevSettingsSchema,
@@ -56,6 +58,10 @@ class VolumeSchema(BaseSchema):
 class ImageSchema(BaseSchema):
     """Represent the schema of the ImageBuilder Image."""
 
+    name = fields.Str(
+        validate=validate.Regexp(PCLUSTER_IMAGE_NAME_REGEX)
+        and validate.Length(max=128 - len(AMI_NAME_REQUIRED_SUBSTRING)),
+    )
     tags = fields.List(fields.Nested(TagSchema))
     root_volume = fields.Nested(VolumeSchema)
 

--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -41,7 +41,7 @@ class CDKTemplateBuilder:
         return generated_template
 
     @staticmethod
-    def build_imagebuilder_template(image_config: ImageBuilderConfig, image_name: str, bucket: S3Bucket):
+    def build_imagebuilder_template(image_config: ImageBuilderConfig, image_id: str, bucket: S3Bucket):
         """Build template for the given imagebuilder and return as output in Yaml format."""
         from aws_cdk.core import App  # pylint: disable=C0415
 
@@ -50,7 +50,7 @@ class CDKTemplateBuilder:
         with tempfile.TemporaryDirectory() as tempdir:
             output_file = "imagebuilder"
             app = App(outdir=str(tempdir))
-            ImageBuilderCdkStack(app, output_file, image_config, image_name, bucket)
+            ImageBuilderCdkStack(app, output_file, image_config, image_id, bucket)
             app.synth()
             generated_template = load_yaml_dict(os.path.join(tempdir, f"{output_file}.template.json"))
 

--- a/cli/tests/pcluster/models/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/models/test_imagebuilder_stack.py
@@ -14,7 +14,7 @@ from assertpy import assert_that
 from pcluster.aws.aws_resources import ImageInfo
 from pcluster.constants import (
     PCLUSTER_IMAGE_BUILD_LOG_TAG,
-    PCLUSTER_IMAGE_NAME_TAG,
+    PCLUSTER_IMAGE_ID_TAG,
     PCLUSTER_S3_BUCKET_TAG,
     PCLUSTER_S3_IMAGE_DIR_TAG,
     PCLUSTER_VERSION_TAG,
@@ -95,7 +95,7 @@ FAKE_IMAGEBUILDER_STACK_NAME = "pcluster1"
                     {"Key": PCLUSTER_S3_IMAGE_DIR_TAG, "Value": "parallelcluster/images/image-abced"},
                     {"Key": PCLUSTER_IMAGE_BUILD_LOG_TAG, "Value": "arn:aws:log:us-east-1:1111111111111:log-group"},
                     {"Key": PCLUSTER_VERSION_TAG, "Value": get_installed_version()},
-                    {"Key": PCLUSTER_IMAGE_NAME_TAG, "Value": FAKE_IMAGEBUILDER_STACK_NAME},
+                    {"Key": PCLUSTER_IMAGE_ID_TAG, "Value": FAKE_IMAGEBUILDER_STACK_NAME},
                 ],
                 "VirtualizationType": "hvm",
             },
@@ -107,7 +107,7 @@ FAKE_IMAGEBUILDER_STACK_NAME = "pcluster1"
                 "s3_artifact_directory": "parallelcluster/images/image-abced",
                 "build_log": "arn:aws:log:us-east-1:1111111111111:log-group",
                 "version": get_installed_version(),
-                "original_image_name": FAKE_IMAGEBUILDER_STACK_NAME,
+                "pcluster_image_id": FAKE_IMAGEBUILDER_STACK_NAME,
             },
         )
     ],

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
@@ -1,4 +1,5 @@
 Image:
+  Name: pcluster-3.0.0_ami
   Tags:
     - Key: Name
       Value: ParallelCluster-3.0-AMI

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -558,9 +558,13 @@ def _test_resources(generated_resources, expected_resources):
                     ],
                     "Tags": [
                         {
+                            "Key": "parallelcluster:image_id",
+                            "Value": "Pcluster",
+                        },
+                        {
                             "Key": "parallelcluster:image_name",
                             "Value": "Pcluster",
-                        }
+                        },
                     ],
                 },
             },
@@ -1089,9 +1093,13 @@ def test_imagebuilder_instance_role(
                     ],
                     "Tags": [
                         {
+                            "Key": "parallelcluster:image_id",
+                            "Value": "My-Image",
+                        },
+                        {
                             "Key": "parallelcluster:image_name",
                             "Value": "My-Image",
-                        }
+                        },
                     ],
                 },
             },
@@ -1337,6 +1345,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
                             "keyTag1": "valueTag1",
                             "keyTag2": "valueTag2",
                             "parallelcluster:image_name": "Pcluster",
+                            "parallelcluster:image_id": "Pcluster",
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
@@ -1386,6 +1395,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
+                            "parallelcluster:image_id": "Pcluster",
                             "parallelcluster:image_name": "Pcluster",
                             "parallelcluster:build_log": {
                                 "Fn::Join": [
@@ -1409,6 +1419,7 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
             {
                 "imagebuilder": {
                     "image": {
+                        "name": "pcluster_3.0.0",
                         "tags": [],
                     },
                     "build": {
@@ -1431,12 +1442,13 @@ def test_imagebuilder_components(mocker, resource, response, expected_components
             [
                 {
                     "AmiDistributionConfiguration": {
-                        "Name": "Pcluster {{ imagebuilder:buildDate }}",
+                        "Name": "pcluster_3.0.0 {{ imagebuilder:buildDate }}",
                         "AmiTags": {
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
-                            "parallelcluster:image_name": "Pcluster",
+                            "parallelcluster:image_id": "Pcluster",
+                            "parallelcluster:image_name": "pcluster_3.0.0",
                             "parallelcluster:build_log": {
                                 "Fn::Join": [
                                     "",
@@ -1516,6 +1528,7 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
             {
                 "keyTag1": "valueTag1",
                 "keyTag2": "valueTag2",
+                "parallelcluster:image_id": "Pcluster",
                 "parallelcluster:image_name": "Pcluster",
             },
             [
@@ -1527,6 +1540,7 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
                     "Key": "keyTag2",
                     "Value": "valueTag2",
                 },
+                {"Key": "parallelcluster:image_id", "Value": "Pcluster"},
                 {"Key": "parallelcluster:image_name", "Value": "Pcluster"},
             ],
         ),
@@ -1550,8 +1564,11 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
                     }
                 ],
             },
-            {"parallelcluster:image_name": "Pcluster"},
-            [{"Key": "parallelcluster:image_name", "Value": "Pcluster"}],
+            {"parallelcluster:image_id": "Pcluster", "parallelcluster:image_name": "Pcluster"},
+            [
+                {"Key": "parallelcluster:image_id", "Value": "Pcluster"},
+                {"Key": "parallelcluster:image_name", "Value": "Pcluster"},
+            ],
         ),
         (
             {
@@ -1574,8 +1591,11 @@ def test_imagebuilder_ami_tags(mocker, resource, response, expected_ami_distribu
                     }
                 ],
             },
-            {"parallelcluster:image_name": "Pcluster"},
-            [{"Key": "parallelcluster:image_name", "Value": "Pcluster"}],
+            {"parallelcluster:image_id": "Pcluster", "parallelcluster:image_name": "Pcluster"},
+            [
+                {"Key": "parallelcluster:image_id", "Value": "Pcluster"},
+                {"Key": "parallelcluster:image_name", "Value": "Pcluster"},
+            ],
         ),
     ],
 )
@@ -1916,6 +1936,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {
                             "parallelcluster:image_name": "Pcluster",
+                            "parallelcluster:image_id": "Pcluster",
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
@@ -1964,6 +1985,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {
                             "parallelcluster:image_name": "Pcluster",
+                            "parallelcluster:image_id": "Pcluster",
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
@@ -2012,6 +2034,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {
                             "parallelcluster:image_name": "Pcluster",
+                            "parallelcluster:image_id": "Pcluster",
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
@@ -2060,6 +2083,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {
                             "parallelcluster:image_name": "Pcluster",
+                            "parallelcluster:image_id": "Pcluster",
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
@@ -2113,6 +2137,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {
                             "parallelcluster:image_name": "Pcluster",
+                            "parallelcluster:image_id": "Pcluster",
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
@@ -2167,6 +2192,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {
                             "parallelcluster:image_name": "Pcluster",
+                            "parallelcluster:image_id": "Pcluster",
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
@@ -2221,6 +2247,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {
                             "parallelcluster:image_name": "Pcluster",
+                            "parallelcluster:image_id": "Pcluster",
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",
@@ -2246,6 +2273,7 @@ def test_imagebuilder_security_group_ids(mocker, resource, response, expected_im
                         "Name": "Pcluster {{ imagebuilder:buildDate }}",
                         "AmiTags": {
                             "parallelcluster:image_name": "Pcluster",
+                            "parallelcluster:image_id": "Pcluster",
                             "parallelcluster:version": utils.get_installed_version(),
                             "parallelcluster:s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
                             "parallelcluster:s3_image_dir": "parallelcluster/imagebuilders/dummy-image-randomstring123",


### PR DESCRIPTION
* add image name property in config file image section
* Use id instead of image name in build image command 

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
