### PR TITLE
[3.0] Use AWS::URLSuffix in place of computing the domain value

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -48,17 +48,6 @@ phases:
               set -v
               echo "aws-parallelcluster-cookbook-${CfnParamCookbookVersion}"
 
-      # Get AWS domain
-      - name: AWSDomain
-        action: ExecuteBash
-        inputs:
-          commands:
-            - |
-              set -v
-              DOMAIN=".amazonaws.com"
-              [[ ${AWS::Region} =~ ^cn- ]] && DOMAIN=".amazonaws.com.cn"
-              echo ${!DOMAIN}
-
       # Get Cookbook Url
       - name: CookbookUrl
         action: ExecuteBash
@@ -66,7 +55,7 @@ phases:
           commands:
             - |
               set -v
-              COOKBOOK_URL=https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}{{ build.AWSDomain.outputs.stdout }}/cookbooks/{{ build.PClusterCookbookVersionName.outputs.stdout }}.tgz
+              COOKBOOK_URL=https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.${AWS::URLSuffix}/cookbooks/{{ build.PClusterCookbookVersionName.outputs.stdout }}.tgz
               [ -n "${CfnParamChefCookbook}" ] && COOKBOOK_URL=${CfnParamChefCookbook}
               echo "${!COOKBOOK_URL}"
 
@@ -77,7 +66,7 @@ phases:
           commands:
             - |
               set -v
-              CINC_URL=https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}{{ build.AWSDomain.outputs.stdout }}/archives/cinc/cinc-install.sh
+              CINC_URL=https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.${AWS::URLSuffix}/archives/cinc/cinc-install.sh
               [ -n "${CfnParamCincInstaller}" ] && CINC_URL=${CfnParamCincInstaller}
               echo "${!CINC_URL}"
 


### PR DESCRIPTION
Use pseudo parameter AWS::URLSuffix in place of computing the domain …

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
