### PR TITLE
2.10: Disable createami tests

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -95,14 +95,6 @@ create:
         oss: ["alinux"]
         schedulers: ["slurm"]
 createami:
-  test_createami.py::test_createami:
-    dimensions:
-      - regions: ["eu-west-3"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux", "alinux2", "ubuntu1604", "ubuntu1804"] # temporary disable FPGA AMI since there is not enough free space on root partition
-      - regions: ["us-gov-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1604", "ubuntu1804"] # alinux2 temporarily disabled due to incompatible device name
   test_createami.py::test_createami_post_install:
     dimensions:
       - regions: ["ap-southeast-2"]

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -216,9 +216,8 @@ class SgeCommands(SchedulerCommands):
             "echo '{0}' | qsub {1}".format(command, flags), raise_on_error=False
         )
 
-    def submit_script(
-        self, script, script_args=None, nodes=1, slots=None, additional_files=None, host=None
-    ):  # noqa: D102
+    def submit_script(self, script, script_args=None, nodes=1, slots=None, additional_files=None, host=None):
+        """Submit job with script."""
         if not additional_files:
             additional_files = []
         if not script_args:
@@ -319,7 +318,8 @@ class SlurmCommands(SchedulerCommands):
         constraint=None,
         other_options=None,
         raise_on_error=True,
-    ):  # noqa: D102
+    ):
+        """Submit job with command."""
         job_submit_command = "--wrap='{0}'".format(command)
 
         return self._submit_batch_job(
@@ -347,7 +347,8 @@ class SlurmCommands(SchedulerCommands):
         other_options=None,
         additional_files=None,
         raise_on_error=True,
-    ):  # noqa: D102
+    ):
+        """Submit job with script."""
         if not additional_files:
             additional_files = []
         if not script_args:


### PR DESCRIPTION
These tests can no longer pass because Slurm 2.10.4 package has been removed by SchedMD repo.
