### PR TITLE
Fix typo in code to use proxy in AWS Batch, set volume type of EBS volumes in test_update as io2

### DIFF
--- a/cli/src/awsbatch/common.py
+++ b/cli/src/awsbatch/common.py
@@ -320,8 +320,8 @@ class AWSBatchCliConfig(object):
                         self.job_definition_mnp = output_value
 
                 for parameter in stack.get("Parameters", []):
-                    if parameter.get("OutputKey") == "ProxyServer":
-                        self.proxy = parameter.get("OutputValue")
+                    if parameter.get("ParameterKey") == "ProxyServer":
+                        self.proxy = parameter.get("ParameterValue")
                         if not self.proxy == "NONE":
                             log.info("Configured proxy is: %s" % self.proxy)
                         break

--- a/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.ini
@@ -58,6 +58,7 @@ compute_subnet_id = {{ private_subnet_id }}
 
 [ebs custom]
 shared_dir = shared
+volume_type = io2
 #volume_iops = None #Initially not set
 
 [scaling custom]
@@ -70,6 +71,7 @@ shared_dir = efs
 
 [raid custom]
 shared_dir = raid
+volume_type = io2
 #volume_iops = None #Initially not set
 
 [fsx custom]

--- a/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.update.ini
@@ -74,6 +74,7 @@ compute_subnet_id = {{ private_subnet_id }}
 
 [ebs custom]
 shared_dir = shared
+volume_type = io2
 volume_iops = 140
 
 [scaling custom]
@@ -86,6 +87,7 @@ provisioned_throughput = 1024
 
 [raid custom]
 shared_dir = raid
+volume_type = io2
 volume_iops = 110
 
 [fsx custom]


### PR DESCRIPTION
The test is testing the update of volume IOPS. However, without specifying volume type as io2, the default gp2 type will be used. As a result, the IOPS parameter had been ignored, which is not the purpose of the test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
