### PR TITLE
2.10: Upgrade Slurm from 20.02.4 to 20.02.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+2.10.4
+------
+
+**CHANGES**
+
+- Upgrade Slurm to version 20.02.7.
+
 2.10.3
 ------
 **ENHANCEMENTS**

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -299,7 +299,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
 def _test_slurm_version(remote_command_executor):
     logging.info("Testing Slurm Version")
     version = remote_command_executor.run_remote_command("sinfo -V").stdout
-    assert_that(version).is_equal_to("slurm 20.02.4")
+    assert_that(version).is_equal_to("slurm 20.02.7")
 
 
 def _test_job_dependencies(slurm_commands, region, stack_name, scaledown_idletime):


### PR DESCRIPTION
Related to: https://github.com/aws/aws-parallelcluster-cookbook/pull/951
