### PR TITLE
Add protected mode and integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 - Add support for Centos 7 ARM.
 - Add validation to prevent using a `cluster_resource_bucket` that is in a different region than the cluster.
 - Transition from IMDSv1 to IMDSv2.
+- Add Slurm protected mode.
 
 **CHANGES**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ CHANGELOG
 - Add support for Centos 7 ARM.
 - Add validation to prevent using a `cluster_resource_bucket` that is in a different region than the cluster.
 - Transition from IMDSv1 to IMDSv2.
-- Add Slurm protected mode.
+- Implement scaling protection mechanism with Slurm scheduler: compute fleet is automatically set to 'PROTECTED' state 
+  in case recurrent failures are encountered when provisioning nodes.
 
 **CHANGES**
 

--- a/cli/src/pcluster/cli_commands/compute_fleet_status_manager.py
+++ b/cli/src/pcluster/cli_commands/compute_fleet_status_manager.py
@@ -27,7 +27,8 @@ class ComputeFleetStatus(Enum):
     STARTING = "STARTING"  # clustermgtd is handling the start request.
     STOP_REQUESTED = "STOP_REQUESTED"  # A request to stop the fleet has been submitted.
     START_REQUESTED = "START_REQUESTED"  # A request to start the fleet has been submitted.
-    PROTECTED = "PROTECTED"  # Bootstrap failure partitions are inactive.
+    # PROTECTED indicates that some partitions have consistent bootstrap failures. Affected partitions are inactive.
+    PROTECTED = "PROTECTED"
 
     def __str__(self):
         return str(self.value)

--- a/cli/src/pcluster/cli_commands/compute_fleet_status_manager.py
+++ b/cli/src/pcluster/cli_commands/compute_fleet_status_manager.py
@@ -27,6 +27,7 @@ class ComputeFleetStatus(Enum):
     STARTING = "STARTING"  # clustermgtd is handling the start request.
     STOP_REQUESTED = "STOP_REQUESTED"  # A request to stop the fleet has been submitted.
     START_REQUESTED = "START_REQUESTED"  # A request to start the fleet has been submitted.
+    PROTECTED = "PROTECTED"  # Bootstrap failure partitions are inactive.
 
     def __str__(self):
         return str(self.value)

--- a/cli/tests/pcluster/cli_commands/test_compute_fleet_status_manager.py
+++ b/cli/tests/pcluster/cli_commands/test_compute_fleet_status_manager.py
@@ -113,6 +113,19 @@ class TestComputeFleetStatusManager:
                 True,
             ),
             (
+                ComputeFleetStatus.STOP_REQUESTED,
+                [
+                    ComputeFleetStatus.PROTECTED,
+                    ComputeFleetStatus.STOP_REQUESTED,
+                    ComputeFleetStatus.STOPPING,
+                    ComputeFleetStatus.STOPPED,
+                ],
+                [None],
+                None,
+                None,
+                True,
+            ),
+            (
                 ComputeFleetStatus.START_REQUESTED,
                 [
                     ComputeFleetStatus.STOPPED,

--- a/cli/tests/pcluster/cli_commands/test_compute_fleet_status_manager.py
+++ b/cli/tests/pcluster/cli_commands/test_compute_fleet_status_manager.py
@@ -102,6 +102,19 @@ class TestComputeFleetStatusManager:
             (
                 ComputeFleetStatus.START_REQUESTED,
                 [
+                    ComputeFleetStatus.PROTECTED,
+                    ComputeFleetStatus.START_REQUESTED,
+                    ComputeFleetStatus.STARTING,
+                    ComputeFleetStatus.RUNNING,
+                ],
+                [None],
+                None,
+                None,
+                True,
+            ),
+            (
+                ComputeFleetStatus.START_REQUESTED,
+                [
                     ComputeFleetStatus.STOPPED,
                     ComputeFleetStatus.START_REQUESTED,
                     ComputeFleetStatus.STARTING,

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -516,6 +516,18 @@ class SlurmCommands(SchedulerCommands):
         result = self.submit_command(**submit_command_args)
         return self.assert_job_submitted(result.stdout)
 
+    def get_partition_state(self, partition):
+        """Get the state of the partition."""
+        return self._remote_command_executor.run_remote_command(
+            f'/opt/slurm/bin/scontrol show partition={partition} | grep -oP "State=\\K(\\S+)"'
+        ).stdout
+
+    @retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))
+    def wait_job_running(self, job_id):
+        """Wait till job starts running."""
+        result = self._remote_command_executor.run_remote_command("scontrol show jobs -o {0}".format(job_id))
+        assert_that(result.stdout).contains("JobState=RUNNING")
+
 
 class TorqueCommands(SchedulerCommands):
     """Implement commands for torque scheduler."""

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.ini
@@ -1,0 +1,44 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = slurm
+master_instance_type = {{ instance }}
+queue_settings = ondemand1, ondemand2
+scaling_settings = custom
+
+[queue ondemand1]
+compute_resource_settings = ondemand_i1,ondemand_i2
+
+[queue ondemand2]
+compute_resource_settings = ondemand_i3,ondemand_i4
+
+[compute_resource ondemand_i1]
+instance_type = c5.large
+
+[compute_resource ondemand_i2]
+instance_type = {{ instance }}
+min_count = 2
+
+[compute_resource ondemand_i3]
+instance_type = c5.large
+
+[compute_resource ondemand_i4]
+instance_type = {{ instance }}
+min_count = 2
+initial_count = 3
+
+[scaling custom]
+scaledown_idletime = {{ scaledown_idletime }}
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.ini
@@ -10,32 +10,29 @@ key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = slurm
 master_instance_type = {{ instance }}
-queue_settings = ondemand1, ondemand2
-scaling_settings = custom
+queue_settings = broken, half-broken, normal
+s3_read_resource = arn:aws:s3:::{{ bucket }}/scripts/*
 
-[queue ondemand1]
-compute_resource_settings = ondemand_i1,ondemand_i2
+[queue broken]
+compute_resource_settings = broken-static
 
-[queue ondemand2]
-compute_resource_settings = ondemand_i3,ondemand_i4
+[queue half-broken]
+compute_resource_settings = broken-dynamic,working-static
 
-[compute_resource ondemand_i1]
+[queue normal]
+compute_resource_settings = normal
+
+[compute_resource broken-static] # instance type has bootstrap failure
 instance_type = c5.large
 
-[compute_resource ondemand_i2]
-instance_type = {{ instance }}
-min_count = 2
+[compute_resource working-static] # instance type work as expected
+instance_type = c5.xlarge
 
-[compute_resource ondemand_i3]
+[compute_resource broken-dynamic] # instance type has bootstrap failure
 instance_type = c5.large
 
-[compute_resource ondemand_i4]
-instance_type = {{ instance }}
-min_count = 2
-initial_count = 3
-
-[scaling custom]
-scaledown_idletime = {{ scaledown_idletime }}
+[compute_resource normal] # instance type work as expected
+instance_type = c5.xlarge
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.update.ini
@@ -1,0 +1,41 @@
+[global]
+cluster_template = default
+
+[aws]
+aws_region_name = {{ region }}
+
+[cluster default]
+base_os = {{ os }}
+key_name = {{ key_name }}
+vpc_settings = parallelcluster-vpc
+scheduler = slurm
+master_instance_type = {{ instance }}
+queue_settings = problematic, normal
+s3_read_resource = arn:aws:s3:::{{ bucket }}/scripts/*
+pre_install = s3://{{ bucket }}/scripts/preinstall.sh
+extra_json = { "cluster" : { "custom_node_package" : "https://s3.amazonaws.com/amibucket11223/node/aws-parallelcluster-node-2.10.3.tgz" } }
+
+[queue problematic]
+compute_resource_settings = problematic
+
+[queue dynamic]
+compute_resource_settings = problematic_dynamic
+
+[queue normal]
+compute_resource_settings = normal
+
+[compute_resource problematic_static] # instance type has bootstrap failure
+instance_type = c5.large
+min_count = 10
+[compute_resource problematic_dynamic] # instance type has bootstrap failure
+instance_type = c5.large
+
+[compute_resource normal] # instance type work as expected
+instance_type = {{ instance }}
+min_count = 1
+
+[vpc parallelcluster-vpc]
+vpc_id = {{ vpc_id }}
+master_subnet_id = {{ public_subnet_id }}
+compute_subnet_id = {{ private_subnet_id }}
+use_public_ips = false

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.update.ini
@@ -10,29 +10,38 @@ key_name = {{ key_name }}
 vpc_settings = parallelcluster-vpc
 scheduler = slurm
 master_instance_type = {{ instance }}
-queue_settings = problematic, normal
+queue_settings = broken, half-broken, normal
 s3_read_resource = arn:aws:s3:::{{ bucket }}/scripts/*
+# pre-install script to make c5.large instance type instance has bootstrap error
 pre_install = s3://{{ bucket }}/scripts/preinstall.sh
-extra_json = { "cluster" : { "custom_node_package" : "https://s3.amazonaws.com/amibucket11223/node/aws-parallelcluster-node-2.10.3.tgz" } }
 
-[queue problematic]
-compute_resource_settings = problematic
+[queue broken]
+compute_resource_settings = broken-static
 
-[queue dynamic]
-compute_resource_settings = problematic_dynamic
+[queue half-broken]
+compute_resource_settings = broken-dynamic,working-static
 
 [queue normal]
 compute_resource_settings = normal
 
-[compute_resource problematic_static] # instance type has bootstrap failure
+[compute_resource broken-static] # instance type has bootstrap failure
 instance_type = c5.large
-min_count = 10
-[compute_resource problematic_dynamic] # instance type has bootstrap failure
+min_count = 2
+max_count = 250
+
+[compute_resource working-static] # instance type work as expected
+instance_type = c5.xlarge
+min_count = 1
+max_count = 250
+
+[compute_resource broken-dynamic] # instance type has bootstrap failure
 instance_type = c5.large
+max_count = 250
 
 [compute_resource normal] # instance type work as expected
-instance_type = {{ instance }}
+instance_type = c5.xlarge
 min_count = 1
+max_count = 250
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/preinstall.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/preinstall.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+function get_instance_type() {
+  token=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+  instance_type_url="http://169.254.169.254/latest/meta-data/instance-type"
+  instance_type=$(curl --retry 3 --retry-delay 0 --silent --fail -H "X-aws-ec2-metadata-token: ${token}" "${instance_type_url}")
+}
+get_instance_type
+if [ "${instance_type}" == "c5.large" ]; then
+  echo "Test Bootstrap error that causes instance to self terminate."
+  exit 1
+fi
+


### PR DESCRIPTION
* Add new compute fleet status `PROTECTED` and unit tests.
* Add integration test for Slurm protected mode, test static and dynamic nodes with bootstrap failures will turn cluster into protected mode, test jobs can be run in healthy queue under the protected mode:
  * Create a healthy cluster with three queues.
  * Update the cluster with a pre-install script, with the script, the queue `queue broken` contains all nodes are broken,`queue half-broken` contains one compute resource is broken and one compute resource work as expected, `queue normal` contains dynamic and static node work as expected. 
 
 Tests cover the following logics:
* Bootstrap failures have no affect on cluster when protected mode is disabled.
* Cluster is not placed into protected mode when there is an active job running
* Cluster will be placed into protected mode when there's no active job running in problematic queue
* Under protected mode, job can run successfully in normal queue 
* After recover from protected mode, pending job that is in the queue when cluster entered protected mode will be run again when cluster is taken out of protected mode
* Jobs can be run successfully in all queues after recover from protected mode.
