### PR TITLE
3.0: Image Builder: support for dev settings cookbook as S3 URI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 .tox/
 *.iml
 .coverage
+coverage.xml
 assets/
 report.html
 tests_outputs/

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -55,8 +55,8 @@ phases:
           commands:
             - |
               set -v
-              COOKBOOK_URL=https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.${AWS::URLSuffix}/cookbooks/{{ build.PClusterCookbookVersionName.outputs.stdout }}.tgz
-              [ -n "${CfnParamChefCookbook}" ] && COOKBOOK_URL=${CfnParamChefCookbook}
+              COOKBOOK_URL="https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.${AWS::URLSuffix}/cookbooks/{{ build.PClusterCookbookVersionName.outputs.stdout }}.tgz"
+              [ -n "${CfnParamChefCookbook}" ] && COOKBOOK_URL="${CfnParamChefCookbook}"
               echo "${!COOKBOOK_URL}"
 
       # Get Cinc Url
@@ -66,8 +66,8 @@ phases:
           commands:
             - |
               set -v
-              CINC_URL=https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.${AWS::URLSuffix}/archives/cinc/cinc-install.sh
-              [ -n "${CfnParamCincInstaller}" ] && CINC_URL=${CfnParamCincInstaller}
+              CINC_URL="https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.${AWS::URLSuffix}/archives/cinc/cinc-install.sh"
+              [ -n "${CfnParamCincInstaller}" ] && CINC_URL="${CfnParamCincInstaller}"
               echo "${!CINC_URL}"
 
       # Check input base AMI OS and get OS information, the output should be like centos.7 | centos.8 | amzn.2 | ubuntu.18.04
@@ -246,9 +246,7 @@ phases:
             - |
               set -v
               mkdir -p /etc/chef && sudo chown -R root:root /etc/chef
-              curl --retry 3 -L -o /etc/chef/aws-parallelcluster-cookbook.tgz {{ build.CookbookUrl.outputs.stdout }}
-              curl --retry 3 -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.date {{ build.CookbookUrl.outputs.stdout }}.date
-              curl --retry 3 -L -o /etc/chef/aws-parallelcluster-cookbook.tgz.md5 {{ build.CookbookUrl.outputs.stdout }}.md5
+              curl --retry 3 -L -o /etc/chef/aws-parallelcluster-cookbook.tgz "{{ build.CookbookUrl.outputs.stdout }}"
 
               mkdir /tmp/cookbooks
               cd /tmp/cookbooks

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -456,6 +456,98 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                 },
             },
         ),
+        (
+            {
+                "imagebuilder": {
+                    "build": {
+                        "parent_image": "ami-0185634c5a8a37250",
+                        "instance_type": "c5.xlarge",
+                    },
+                    "dev_settings": {"cookbook": {"chef_cookbook": "s3://bucket_name/path/to/custom/cookbook"}},
+                }
+            },
+            {
+                "Architecture": "x86_64",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "VolumeSize": 50,
+                        },
+                    }
+                ],
+            },
+            {
+                "Parameters": {
+                    "CfnParamChefDnaJson": {},
+                    "CfnParamChefCookbook": {"Default": "https://presigned.url"},
+                    "CfnParamCincInstaller": {},
+                    "CfnParamCookbookVersion": {},
+                    "CfnParamUpdateOsAndReboot": {},
+                },
+                "Resources": {
+                    "InstanceRole": {},
+                    "InstanceProfile": {},
+                    "InfrastructureConfiguration": {},
+                    "ParallelClusterComponent": {},
+                    "ParallelClusterTagComponent": {},
+                    "ImageRecipe": {},
+                    "ParallelClusterImage": {},
+                    "BuildNotificationTopic": {},
+                    "DistributionConfiguration": {},
+                    "DeleteStackFunctionExecutionRole": {},
+                    "DeleteStackFunction": {},
+                    "DeleteStackFunctionPermission": {},
+                    "DeleteStackFunctionLog": {},
+                },
+            },
+        ),
+        (
+            {
+                "imagebuilder": {
+                    "build": {
+                        "parent_image": "ami-0185634c5a8a37250",
+                        "instance_type": "c5.xlarge",
+                    },
+                    "dev_settings": {"cookbook": {"chef_cookbook": "https://custom.cookbook.url"}},
+                }
+            },
+            {
+                "Architecture": "x86_64",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "VolumeSize": 50,
+                        },
+                    }
+                ],
+            },
+            {
+                "Parameters": {
+                    "CfnParamChefDnaJson": {},
+                    "CfnParamChefCookbook": {"Default": "https://custom.cookbook.url"},
+                    "CfnParamCincInstaller": {},
+                    "CfnParamCookbookVersion": {},
+                    "CfnParamUpdateOsAndReboot": {},
+                },
+                "Resources": {
+                    "InstanceRole": {},
+                    "InstanceProfile": {},
+                    "InfrastructureConfiguration": {},
+                    "ParallelClusterComponent": {},
+                    "ParallelClusterTagComponent": {},
+                    "ImageRecipe": {},
+                    "ParallelClusterImage": {},
+                    "BuildNotificationTopic": {},
+                    "DistributionConfiguration": {},
+                    "DeleteStackFunctionExecutionRole": {},
+                    "DeleteStackFunction": {},
+                    "DeleteStackFunctionPermission": {},
+                    "DeleteStackFunctionLog": {},
+                },
+            },
+        ),
     ],
 )
 def test_imagebuilder_parameters_and_resources(mocker, resource, response, expected_template):
@@ -465,6 +557,7 @@ def test_imagebuilder_parameters_and_resources(mocker, resource, response, expec
         "pcluster.aws.ec2.Ec2Client.describe_image",
         return_value=ImageInfo(response),
     )
+    mocker.patch("pcluster.aws.s3.S3Client.create_presigned_url", return_value="https://presigned.url")
     # mock bucket initialization parameters
     mock_bucket(mocker)
 


### PR DESCRIPTION
### Changes
1. Added support for custom cookbook expressed as S3 URI in DevSettings section.
2. Added coverage.xml to gitignore

### Testing
Executed `pcluster build-image` with the following configuration:
```
Build:
  InstanceType: c5.xlarge
  ParentImage: arn:aws:imagebuilder:eu-west-1:aws:image/amazon-linux-2-x86/2020.12.21

DevSettings:
  Cookbook:
    ChefCookbook: s3://aws-parallelcluster-mgiacomo/parallelcluster/3.0.0/cookbooks/aws-parallelcluster-cookbook-3.0.0.tgz
    ExtraChefAttributes: '{"cluster": {"skip_install_recipes": "no"}}'
```
CW Logs reporting successful step `DownloadCookbook` using custom cookbook:

```
CmdExecution: Stderr: mkdir -p /etc/chef &amp;&amp; sudo chown -R root:root /etc/chefcurl --retry 3 -L -o /etc/chef/aws-parallelcluster-cookbook.tgz "https://aws-parallelcluster-mgiacomo.s3.amazonaws.com/parallelcluster/3.0.0/cookbooks/aws-parallelcluster-cookbook-3.0.0.tgz?AWSAccessKeyId=AKIAUUXUVBC4TVRSE2PJ&amp;Signature=IWiZNZBWp69DOy4%2FG6TigBHbgko%3D&amp;Expires=1621333640"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
