### PR TITLE
Double timeout to execute mpi ring test

### DIFF
--- a/tests/integration-tests/tests/common/data/mpi/mpi_submit_openmpi.sh
+++ b/tests/integration-tests/tests/common/data/mpi/mpi_submit_openmpi.sh
@@ -3,4 +3,4 @@ set -e
 
 rm -f /shared/mpi.out
 module load openmpi
-mpirun --map-by ppr:1:node --timeout 10 "ring" >> /shared/mpi.out
+mpirun --map-by ppr:1:node --timeout 20 "ring" >> /shared/mpi.out


### PR DESCRIPTION
Leave enough time for the job to execute and terminate gracefully

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
