### PR TITLE
Fix slurm test: expected version 20.11.7

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -791,7 +791,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
 def _test_slurm_version(remote_command_executor):
     logging.info("Testing Slurm Version")
     version = remote_command_executor.run_remote_command("sinfo -V").stdout
-    assert_that(version).is_equal_to("slurm 20.11.5")
+    assert_that(version).is_equal_to("slurm 20.11.7")
 
 
 def _test_job_dependencies(slurm_commands, region, stack_name, scaledown_idletime):


### PR DESCRIPTION
Fix slurm test: expected version 20.11.7

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
