### PR TITLE
3.0: Handle updates of a stack with a template for a newer version of ParallelCluster

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -603,8 +603,8 @@ Resources:
     Type: AWS::ImageBuilder::InfrastructureConfiguration
     Properties:
       Name: !Sub
-        - ParallelClusterImageBuilderInfrastructureConfiguration-${StackIdSuffix}
-        - { StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+        - ParallelClusterImageBuilderInfrastructureConfiguration-${Version}-${StackIdSuffix}
+        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelCluster, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
       InstanceProfileName: !Ref ImageBuilderInstanceProfile
       TerminateInstanceOnFailure: true
 
@@ -613,8 +613,11 @@ Resources:
     Type: AWS::ECR::Repository
     Properties:
       RepositoryName: !Sub
-        - 'aws-parallelcluster-${Version}-${StackIdSuffix}'
-        - { Version: !FindInMap [ParallelCluster, Constants, Version], StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+        - 'aws-parallelcluster-${StackIdSuffix}'
+        - { StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+      Tags:
+        - Key: 'parallelcluster:version'
+          Value: !FindInMap [ParallelCluster, Constants, Version]
 
   EcrImageRecipe:
     Condition: DoNotUseCustomEcrImageUri
@@ -624,8 +627,8 @@ Resources:
         - ComponentArn: !Sub arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/update-linux/x.x.x
       ContainerType: DOCKER
       Name: !Sub
-        - 'ImportPublicEcrImage-${StackIdSuffix}'
-        - { StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+        - 'ImportPublicEcrImage-${Version}-${StackIdSuffix}'
+        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelCluster, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
       Version: !FindInMap [ParallelCluster, Constants, Version]
       ParentImage: !Ref PublicEcrImageUri
       PlatformOverride: Linux

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -729,7 +729,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub arn:${AWS::Partition}:logs:*:*:*
-        - PolicyName: S3Policy
+        - PolicyName: BatchDeletePolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -668,13 +668,6 @@ Resources:
               build_number = parts[-1]
               return '{}-{}'.format(version, build_number)
 
-          def handle_deletion_event(event):
-              """ Handle deletion event by removing the created Docker image from the ECR repository
-              """
-              ecr_repository_name = event['ResourceProperties']['EcrRepositoryName']
-              tag = get_tag_from_image_arn(event['ResourceProperties']['ImageToDeleteArn'])
-              return ecr.batch_delete_image(repositoryName=ecr_repository_name, imageIds=[{'imageTag': tag}])
-
           def handler(event, context):
               print(event)
               print('boto version {}'.format(boto3.__version__))
@@ -684,17 +677,21 @@ Resources:
 
               if event['RequestType'] == 'Create':
                   response_data['Message'] = 'Resource creation successful!'
-              elif event['RequestType'] == 'Update':
-                  response_data['Message'] = 'Resource update successful!'
-              elif event['RequestType'] == 'Delete':
+              elif event['RequestType'] == 'Update' or event['RequestType'] == 'Delete':
                   try:
-                      handle_deletion_event(event)
-                      response_data['Message'] = 'Resource deletion successful!'
+                      resource_key = 'OldResourceProperties' if 'OldResourceProperties' in event else 'ResourceProperties'
+
+                      ecr_repository_name = event[resource_key]['EcrRepositoryName']
+                      tag = get_tag_from_image_arn(event[resource_key]['ImageToDeleteArn'])
+
+                      ecr.batch_delete_image(repositoryName=ecr_repository_name, imageIds=[{'imageTag': tag}])
+
+                      response_data['Message'] = 'Image deletion successful!'
                   except ecr.exceptions.RepositoryNotFoundException:
                       response_data['Message'] = 'Repository was not found, considering image deletion successfull'
                   except Exception as exception:
                       response_status = cfnresponse.FAILED
-                      response_data['Message'] = 'Failed resource deletion with error: {}'.format(exception)
+                      response_data['Message'] = 'Failed image deletion with error: {}'.format(exception)
 
               cfnresponse.send(event, context, response_status, response_data)
 

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -693,7 +693,7 @@ Resources:
                   except ecr.exceptions.RepositoryNotFoundException:
                       response_data['Message'] = 'Repository was not found, considering image deletion successfull'
                   except Exception as exception:
-                      response_status = cfnresponse.FAILURE
+                      response_status = cfnresponse.FAILED
                       response_data['Message'] = 'Failed resource deletion with error: {}'.format(exception)
 
               cfnresponse.send(event, context, response_status, response_data)


### PR DESCRIPTION
### Notes
This patch allows to update an existing ParallelCluster API stack using a template for a newer version of ParallelCluster.

In order to trigger the update of the necessary resources, we encode the ParallelCluster version in the name of the infrastructure configuration (so as to trigger a rebuild of the Image) and of the container recipe (so as to avoid creating a new resource with the same ARN, thus causing the stack update to fail).

On the other hand, we do not encode the version in the name of the private ECR repository, since doing this would cause its ARN to change, something that we want to avoid, given that we use it in the execution policy of the custom resource responsible for deleting the old Docker image during a stack update/delete.

I have instead adopted the solution we [previously discussed](https://github.com/aws/aws-parallelcluster/pull/2714#discussion_r628021109) of tagging the created ECR repository with the ParallelCluster version, as we already do for the ParallelCluster Lambda function and APIGateway API.

### Tests
Tested stack update using template with newer version in personal account. Tested deletion of updated stack in personal account.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
