### PR TITLE
3.0: Allow to set up a private API

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -46,6 +46,11 @@ Parameters:
     Type: String
     Default: '' # TODO change with actual URI
 
+  VpcEndpointId:
+    Description: When specified, configure a private API with the specified endpoint
+    Type: String
+    Default: ''
+
 
 Mappings:
   ParallelCluster:
@@ -80,13 +85,18 @@ Conditions:
   UseCustomDomainAndRoute53Configuration: !And
     - !Condition UseCustomDomain
     - !Condition UseRoute53Configuration
-  DoNotUseCustomDomain: !Not [!Condition UseCustomDomain]
   IsMultiRegion: !Equals [!Ref EnableMultiRegionSupport, true]
+  UsePrivateVpcEndpoint: !And
+    - !Not [!Condition UseCustomDomainAndRoute53Configuration]
+    - !Not [!Equals [!Ref VpcEndpointId, '']]
+  DoNotUseCustomDomain: !And
+    - !Not [!Condition UsePrivateVpcEndpoint]
+    - !Not [!Condition UseCustomDomain]
 
 
 Resources:
 
-  # We need to define two AWS::Serverless::Api due to an issue with the handling of AWS::NoValue
+  # We need to define three AWS::Serverless::Api due to an issue with the handling of AWS::NoValue
   # See related GitHub issue: https://github.com/aws/serverless-application-model/issues/1435
   ApiGatewayApiWithCustomDomainAndRoute53Configuration:
     Condition: UseCustomDomainAndRoute53Configuration
@@ -118,6 +128,26 @@ Resources:
           Name: AWS::Include
           Parameters:
             Location: !Ref ApiDefinitionS3Uri
+
+  ApiGatewayApiWithPrivateVpcEndpoint:
+    Condition: UsePrivateVpcEndpoint
+    Type: AWS::Serverless::Api
+    Properties:
+      Tags:
+        'parallelcluster:version': !FindInMap [ParallelCluster, Constants, Version]
+      StageName: !FindInMap [ParallelCluster, Constants, Stage]
+      DefinitionBody:
+        Fn::Transform:
+          Name: AWS::Include
+          Parameters:
+            Location: !Ref ApiDefinitionS3Uri
+      EndpointConfiguration:
+        Type: PRIVATE
+        VPCEndpointIds: [!Ref VpcEndpointId]
+      Auth:
+        DefaultAuthorizer: AWS_IAM
+        ResourcePolicy:
+          IntrinsicVpceWhitelist: [!Ref VpcEndpointId]
 
   # Note that even for Chinese regions here we need to use apigateway.amazonaws.com instead of apigateway.amazonaws.com.cn
   APIGatewayExecutionRole:
@@ -761,7 +791,12 @@ Outputs:
         - { CustomDomain: !Ref CustomDomainName }
       - !Sub
         - https://${Api}.execute-api.${AWS::Region}.${AWS::URLSuffix}/${StageName}
-        - Api: !Ref ApiGatewayApiWithoutCustomDomain
+        - Api: !If
+            - UsePrivateVpcEndpoint
+            - !Sub
+              - '${restApiId}-${vpceId}'
+              - { restApiId: !Ref ApiGatewayApiWithPrivateVpcEndpoint, vpceId: !Ref VpcEndpointId }
+            - !Ref ApiGatewayApiWithoutCustomDomain
           StageName: !FindInMap [ParallelCluster, Constants, Stage]
 
   UriOfCopyOfPublicEcrImage:


### PR DESCRIPTION
### Notes
We want to give the customer the ability to configure a private API. At the moment we are not interested in configuring the lambda to access resources in a VPC with no internet access. In other words, the goal is simply to enable someone to call the API from an EC2 instance running in an isolated network.

This patch allows the customer to optionally specify a VPC endpoint id, in which case CFN will set up a private API associating the VPC endpoint. Then the customer will be able to call the API from an instance in an isolated subnet in the VPC that can contact the endpoint by calling one of the following URLs:

1. `https://{rest-api-id}.execute-api.{region}.amazonaws.com/prod` (only if private DNS is enabled)
2. `https://{rest-api-id}-{vpce-id}.execute-api.{region}.amazonaws.com/prod`

### Tests
Tested in private account with an EC2 instance in an isolated subnet using both endpoints

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
