### PR TITLE
3.0: Fix the naming of the ParallelClusterFunction log group

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -567,9 +567,9 @@ Resources:
               Sid: CloudWatchLogs
 
   ParallelClusterFunctionLogGroup:
-    DependsOn: ParallelClusterFunction
     Type: AWS::Logs::LogGroup
     Properties:
+      LogGroupName: !Sub /aws/lambda/${ParallelClusterFunction}
       RetentionInDays: 30
 
   ImageBuilderInstanceRole:


### PR DESCRIPTION
### Notes
This patch changes the name of the ParallelClusterFunction log group to make it follow the same convention adopted for the Lambda of the custom resources delegated to the removal of the old Docker image. The format is the following: `/aws/lambda/${ParallelClusterFunction}`.

I have verified that if we change the name to something else, the log group is created, but at the first execution of the
ParallelClusterFunction a new log group that never expries  with the name: `/aws/lambda/${ParallelClusterFunction}` is created, in addition to the30-day log group.

### Tests
Tested with stack creation/update/delete in personal account

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
