### PR TITLE
3.0: Add Lambda to push AWS credentials to the head node for the cluster admin user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,14 @@ CHANGELOG
 - Add `--suppress-validators`, `--validation-failure-level` and`--disable-update-check` parameters to `create` command.
 - Add `--suppress-validators` and `--validation-failure-level` parameters to `update` command.
 - Remove possibility to specify aliases for `ssh` command in the configuration file.
-- Rename `createami` command to `build-image` command, deprecate `--ami-id`, `--os`, `--instance-type`, 
+- Rename `createami` command to `build-image` command, deprecate `--ami-id`, `--os`, `--instance-type`,
   `--ami-name-prefix`, `--custom-cookbook`, `--post-install`, `--no-public-ip`, `--cluster-template`, `--vpc-id`,
    `--subnet-id`.
 - Add `--image-name`, `--config`, `--region` parameters to `build-image` command.
 - Add `delete-image` command with `--name`, `--region`, `--force` parameters.
 - Add `describe-image` command with `--name`, `--region` parameters.
 - Add`list-images` command with `--region`, `--color`parameters.
-- Split head node and compute fleet instance roles and add possibility to configure a different instance role 
+- Split head node and compute fleet instance roles and add possibility to configure a different instance role
   for each queue.
 - Add possibility to configure different security groups for each queue.
 - Add support for multiple subnets when using AWS Batch.
@@ -29,9 +29,9 @@ CHANGELOG
 - Add timestamp suffix to CloudWatch Log Group name created for the cluster.
 - Remove `pcluster-config` CLI utility.
 - Remove `amis.txt` file.
-- Remove additional EBS volume attached to the head node by default. 
+- Remove additional EBS volume attached to the head node by default.
 - Change NICE DCV session storage path to `/home/{UserName}`.
-- Create S3 bucket per region shared with cluster and image if custom bucket isn't specified instead creating bucket 
+- Create S3 bucket per region shared with cluster and image if custom bucket isn't specified instead creating bucket
 per cluster.
 - Rename MasterServer to HeadNode in cli outputs.
 - Rename variable exported in the AWS Batch job environment from MASTER_IP to PCLUSTER_HEAD_NODE_IP.
@@ -39,12 +39,13 @@ per cluster.
 - Rename NodeType and tags from Master to HeadNode.
 - Remove Ganglia support.
 - Add support for associating an existing Elastic IP to the head node.
-- Encrypt root EBS volumes and shared EBS volumes by default. 
+- Encrypt root EBS volumes and shared EBS volumes by default.
   Note that if the scheduler is AWS Batch, the root volumes of the compute nodes cannot be encrypted by ParallelCluster.
 - Change tags prefix from `aws-parallelcluster-` to `parallelcluster:`.
 - Enable EFA for a compute resource by default if the instance type supports EFA.
 - Use tags prefix `parallelcluster:`.
 - Prevent runtime baking, i.e. pcluster create-cluster only works for official AMIs or custom AMIs created by pcluster createami command.
+- Add Lambda to push AWS credentials to the head node for the cluster admin user.
 
 2.x.x
 ------
@@ -61,12 +62,12 @@ per cluster.
 - Upgrade Slurm to version 20.11.5.
   - Add new SlurmctldParameters, power_save_min_interval=30, so power actions will be processed every 30 seconds
   - Specify instance GPU model as GRES GPU Type in gres.conf, instead of previous hardcoded value for all GPU, Type=tesla
-- Upgrade Arm Performance Libraries (APL) to version 21.0.0  
-- Make `key_name` parameter optional to support cluster configurations without a key pair. 
+- Upgrade Arm Performance Libraries (APL) to version 21.0.0
+- Make `key_name` parameter optional to support cluster configurations without a key pair.
 - Remove support for Python versions < 3.6.
 - Remove dependency on `future` package and `__future__` module.
 - Root volume size increased from 25GB to 35GB on all AMIs. Minimum root volume size is now 35GB.
-- Add sanity check to prevent cluster creation in non officially supported AWS regions 
+- Add sanity check to prevent cluster creation in non officially supported AWS regions
 
 2.10.3
 ------
@@ -88,7 +89,7 @@ per cluster.
 
 **BUG FIXES**
 
-- Fix issue with ``awsbsub`` command when setting environment variables for the job submission 
+- Fix issue with ``awsbsub`` command when setting environment variables for the job submission
 
 2.10.2
 ------
@@ -103,7 +104,7 @@ per cluster.
 
 **BUG FIXES**
 
-- Fix sanity checks with ARM instance types by using cluster AMI when performing validation  
+- Fix sanity checks with ARM instance types by using cluster AMI when performing validation
 - Fix `enable_efa` parameter validation when using Centos8 and Slurm or ARM instances.
 - Use non interactive `apt update` command when building custom Ubuntu AMIs.
 - Fix `encrypted_ephemeral = true` when using Alinux2 or CentOS8
@@ -121,13 +122,13 @@ per cluster.
 - Install Arm Performance Libraries (APL) 20.2.1 on ARM AMIs (CentOS8, Alinux2, Ubuntu1804).
 - Install EFA kernel module on ARM instances with `alinux2` and `ubuntu1804`. This enables support for `c6gn` instances.
 - Add support for io2 and gp3 EBS volume type.
-- Add `iam_lambda_role` parameter under `cluster` section to enable the possibility to specify an existing IAM role to 
-  be used by AWS Lambda functions in CloudFormation. 
-  When using `sge`, `torque`, or `slurm` as the scheduler, 
+- Add `iam_lambda_role` parameter under `cluster` section to enable the possibility to specify an existing IAM role to
+  be used by AWS Lambda functions in CloudFormation.
+  When using `sge`, `torque`, or `slurm` as the scheduler,
   `pcluster` will not create any IAM role if both `ec2_iam_role` and `iam_lambda_role` are provided.
 - Improve robustness of a Slurm cluster when clustermgtd is down.
 - Configure NFS threads to be max(8, num_cores) for performance. This enhancement will not take effect on Ubuntu 16.04.
-- Optimize calls to DescribeInstanceTypes EC2 API when validating cluster configuration. 
+- Optimize calls to DescribeInstanceTypes EC2 API when validating cluster configuration.
 
 **CHANGES**
 
@@ -144,7 +145,7 @@ per cluster.
   The runlevel is set to graphical.target on head node only when DCV is enabled. This prevents the execution of
   graphical services, such as x/gdm, when they are not required.
 - Download Intel MPI and HPC packages from S3 rather than Intel yum repos.
-- Change the default of instance types from the hardcoded `t2.micro` to the free tier instance type 
+- Change the default of instance types from the hardcoded `t2.micro` to the free tier instance type
     (`t2.micro` or `t3.micro` dependent on region). In regions without free tier, the default is `t3.micro`.
 - Enable support for p4d as head node instance type (p4d was already supported as compute node in 2.10.0).
 - Pull Amazon Linux Docker images from public ECR when building docker image for `awsbatch` scheduler.
@@ -160,7 +161,7 @@ per cluster.
 - Set the default EBS volume size to 500 GiB when volume type is `st1` or `sc1`.
 - Fix installation of Intel PSXE package on CentOS 7 by using yum4.
 - Fix routing issues with multiple Network Interfaces on Ubuntu 18.04.
-  
+
 2.10.0
 ------
 
@@ -175,9 +176,9 @@ per cluster.
 - FSx Lustre:
   - Add possibility to configure Auto Import policy through the new `auto_import_policy` parameter.
   - Add support to HDD storage type and the new `storage_type` and `drive_cache_type` configuration parameters.
-- Create a CloudWatch Dashboard for the cluster, named `<clustername>-<region>`, including head node EC2 metrics and 
+- Create a CloudWatch Dashboard for the cluster, named `<clustername>-<region>`, including head node EC2 metrics and
   cluster logs. It can be disabled by configuring the `enable` parameter in the `dashboard` section.
-- Add `-r/-region` arg to `pcluster configure` command. If this arg is provided, configuration will 
+- Add `-r/-region` arg to `pcluster configure` command. If this arg is provided, configuration will
   skip region selection.
 - Add `-r/-region` arg to`ssh` and `dcv connect` commands.
 - Add `cluster_resource_bucket` parameter under `cluster` section to allow the user to specify an existing S3 bucket.
@@ -333,13 +334,13 @@ per cluster.
 - Upgrade EFA installer to version 1.9.4:
   - Kernel module: ``efa-2.6.0`` (from efa-1.5.1)
   - RDMA core: ``rdma-core-28.amzn0`` (from rdma-core-25.0)
-  - Libfabric: ``libfabric-1.10.1amzn1.1`` (updated from libfabric-aws-1.9.0amzn1.1) 
+  - Libfabric: ``libfabric-1.10.1amzn1.1`` (updated from libfabric-aws-1.9.0amzn1.1)
   - Open MPI: openmpi40-aws-4.0.3 (no change)
 - Avoid unnecessary validation of IAM policies.
 - Removed unused dependency on supervisor from the Batch Dockerfile.
 - Move all LogGroup definitions in the CloudFormation templates into the CloudWatch substack.
 - Disable libvirtd service on CentOS 7. Virtual bridge interfaces are incorrectly detected by Open MPI and
-  cause MPI applications to hang, see https://www.open-mpi.org/faq/?category=tcp#tcp-selection for details 
+  cause MPI applications to hang, see https://www.open-mpi.org/faq/?category=tcp#tcp-selection for details
 - Use CINC instead of Chef for provisioning instances. See https://cinc.sh/about/ for details.
 - Retry when mounting an NFS mount fails.
 - Install the ``pyenv`` virtual environments used by ParallelCluster cookbook and node daemon code under

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/handle_head_node.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/handle_head_node.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+import boto3
+from crhelper import CfnResource
+
+helper = CfnResource(json_logging=False, log_level="INFO", boto_level="ERROR", sleep_on_delete=0)
+
+# Logging
+logger = logging.getLogger()
+
+# Clients
+EC2 = boto3.client("ec2")
+LAMBDA = boto3.client("lambda")
+
+
+@helper.delete
+@helper.update
+def no_op(_, __):
+    pass
+
+
+@helper.create
+def create(event, _):
+    logger.info(f"Handling CREATE event: {event}")
+
+    cluster_name = event["ResourceProperties"]["ClusterName"]
+    lambda_name = event["ResourceProperties"]["AwsCredentialsLambda"]
+    filters = [
+        {"Name": "tag:parallelcluster:cluster-name", "Values": [cluster_name]},
+        {"Name": "tag:parallelcluster:node-type", "Values": ["HeadNode"]},
+    ]
+
+    logger.info(f"Waiting head node for cluster {cluster_name} to be running")
+    EC2.get_waiter("instance_running").wait(Filters=filters, WaiterConfig={"Delay": 10, "MaxAttempts": 30})
+
+    logger.info(f"Waiting lambda function to be active: {lambda_name}")
+    LAMBDA.get_waiter("function_active").wait(FunctionName=lambda_name, WaiterConfig={"Delay": 5, "MaxAttempts": 60})
+
+    logger.info(f"Invoking lambda function: {lambda_name}")
+    LAMBDA.invoke(FunctionName=lambda_name, InvocationType="Event")
+
+
+def handler(event, context):
+    helper(event, context)

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/write_aws_credentials.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/write_aws_credentials.py
@@ -1,0 +1,161 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+#  the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+from os import getenv
+from time import sleep
+
+import boto3
+from botocore.exceptions import WaiterError
+
+# Environment Variables
+CLUSTER_NAME = getenv("CLUSTER_NAME")
+ROLE_ARN = getenv("ROLE_ARN")
+SSM_CW_LOG_GROUP_NAME = getenv("SSM_CW_LOG_GROUP_NAME")
+SSM_CW_LOG_GROUP_ENABLED = bool(getenv("SSM_CW_LOG_GROUP_ENABLED"))
+
+# Logging
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+# Clients
+EC2 = boto3.client("ec2")
+STS = boto3.client("sts")
+SSM = boto3.client("ssm")
+
+
+def handler(event, context):
+    log.debug(f"Received event: {event}")
+
+    head_node_instance_id, head_node_instance_state = get_head_node_instance_id(CLUSTER_NAME)
+
+    if head_node_instance_state != "running":
+        log.warning(f"Head node not running (state: {head_node_instance_state}). Skipping workflow.")
+        return 304, "UNMODIFIED"
+
+    assumed_role_arn, credentials = get_credentials(ROLE_ARN)
+
+    write_credentials_to_node(head_node_instance_id, assumed_role_arn, credentials)
+
+    return 200, "SUCCESS"
+
+
+def get_head_node_instance_id(cluster_name):
+    log.info(f"Retrieving head node for cluster: {cluster_name}")
+
+    filters = [
+        {"Name": "tag:parallelcluster:cluster-name", "Values": [cluster_name]},
+        {"Name": "tag:parallelcluster:node-type", "Values": ["HeadNode"]},
+    ]
+
+    response = EC2.describe_instances(Filters=filters)
+
+    log.debug(f"EC2.describe_instances response: {response}")
+
+    reservations = response["Reservations"]
+
+    if len(reservations) != 1 or len(reservations[0]["Instances"]) != 1:
+        raise Exception(
+            f"Found {len(reservations)} instances matching head node for cluster {cluster_name}, but expected 1"
+        )
+
+    head_node_instance = reservations[0]["Instances"][0]
+    head_node_instance_id = head_node_instance["InstanceId"]
+    head_node_instance_state = head_node_instance["State"]["Name"]
+
+    log.info(f"Head node instance found: {head_node_instance_id} (state: {head_node_instance_state})")
+
+    return head_node_instance_id, head_node_instance_state
+
+
+def get_credentials(role_arn):
+    log.info(f"Retrieving credentials for role: {role_arn}")
+
+    response = STS.assume_role(RoleArn=role_arn, RoleSessionName="cluster-admin")
+
+    log.debug(f"STS.assume_role response: {response}")
+
+    assumed_role_arn = response["AssumedRoleUser"]["Arn"]
+
+    credentials = {
+        "aws_acces_key_id": response["Credentials"]["AccessKeyId"],
+        "aws_secret_access_key": response["Credentials"]["SecretAccessKey"],
+        "aws_session_token": response["Credentials"]["SessionToken"],
+    }
+
+    log.info(f"Credentials retrieved for assumable role: {assumed_role_arn}")
+
+    return assumed_role_arn, credentials
+
+
+def write_credentials_to_node(instance_id, assumed_role, credentials):
+    log.info(f"Writing credentials to instance {instance_id} for role: {assumed_role}")
+
+    response = SSM.send_command(
+        DocumentName="AWS-RunShellScript",
+        InstanceIds=[instance_id],
+        Parameters={"commands": get_ssm_commands(assumed_role, credentials), "executionTimeout": ["10"]},
+        Comment=f"Write AWS Credentials to Cluster Head Node: {CLUSTER_NAME}/{instance_id}",
+        TimeoutSeconds=30,
+        CloudWatchOutputConfig={
+            "CloudWatchLogGroupName": SSM_CW_LOG_GROUP_NAME,
+            "CloudWatchOutputEnabled": SSM_CW_LOG_GROUP_ENABLED,
+        },
+    )
+
+    log.debug(f"SSM.send_command response: {response}")
+
+    command_id = response["Command"]["CommandId"]
+
+    log.info(f"Waiting for SSM command to succeed: {command_id}")
+
+    # Sleep time required to avoid InvocationDoesNotExist errors on the SSM waiter due to latency issues
+    sleep(5)
+
+    try:
+        SSM.get_waiter("command_executed").wait(
+            CommandId=command_id, InstanceId=instance_id, WaiterConfig={"Delay": 3, "MaxAttempts": 20}
+        )
+    except WaiterError:
+        response = SSM.get_command_invocation(CommandId=command_id, InstanceId=instance_id)
+        status = response["Status"]
+        status_details = response["StatusDetails"]
+        if status == "TimedOut":
+            error_info = "SSM Agent may not be running on instance."
+        else:
+            error_info = f"Command stderr: {response['StandardErrorContent']}"
+        error_message = (
+            f"SSM command {command_id} failed on instance {instance_id} "
+            f"with status {status} ({status_details}). "
+            f"{error_info}"
+        )
+        log.error(error_message)
+        raise Exception(error_message)
+
+    log.info("Credentials written to node")
+
+
+def get_ssm_commands(assumed_role, credentials):
+    script = f"""
+AWS_IAM_ASSUMED_ROLE_ARN={assumed_role}
+AWS_ACCESS_KEY_ID={credentials["aws_acces_key_id"]}
+AWS_SECRET_ACCESS_KEY={credentials["aws_secret_access_key"]}
+AWS_SESSION_TOKEN={credentials["aws_session_token"]}
+
+# cfnconfig: contains node variables
+source "/etc/parallelcluster/cfnconfig"
+SCRIPT="$scripts_dir/ssm/write_aws_credentials.sh"
+
+bash $SCRIPT $AWS_IAM_ASSUMED_ROLE_ARN $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY $AWS_SESSION_TOKEN
+"""
+
+    return script.split("\n")


### PR DESCRIPTION
### Changes
1. Add Lambda to push AWS credentials to the head node for the cluster admin user

#### Important Notes:
1. This PR requires [Cookbook:PR-968](https://github.com/aws/aws-parallelcluster-cookbook/pull/968) to be merged first.
2. Pre-commit checks reformatted some changelog lines.

### Tests
1. Tested on personal account.
2. Jenkins tests pending. Going to start them after code review.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
