### PR TITLE
3.0: Add integration test for Infrastructure API CloudFormation template

### DIFF
--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -19,11 +19,12 @@ from utils import retrieve_cfn_outputs, retrieve_cfn_resources, set_credentials,
 class CfnStack:
     """Identify a CloudFormation stack."""
 
-    def __init__(self, name, region, template, parameters=None):
+    def __init__(self, name, region, template, parameters=None, capabilities=None):
         self.name = name
         self.region = region
         self.template = template
         self.parameters = parameters or []
+        self.capabilities = capabilities or []
         self.cfn_stack_id = None
         self.__cfn_outputs = None
         self.__cfn_resources = None
@@ -73,7 +74,12 @@ class CfnStacksFactory:
         self.__created_stacks[id] = stack
         try:
             cfn_client = boto3.client("cloudformation", region_name=region)
-            result = cfn_client.create_stack(StackName=name, TemplateBody=stack.template, Parameters=stack.parameters)
+            result = cfn_client.create_stack(
+                StackName=name,
+                TemplateBody=stack.template,
+                Parameters=stack.parameters,
+                Capabilities=stack.capabilities,
+            )
             stack.cfn_stack_id = result["StackId"]
             final_status = self.__wait_for_stack_creation(stack.cfn_stack_id, cfn_client)
             self.__assert_stack_status(final_status, "CREATE_COMPLETE")

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -91,6 +91,10 @@ def pytest_addoption(parser):
     parser.addoption("--post-install", help="url to post install script")
     parser.addoption("--vpc-stack", help="Name of an existing vpc stack.")
     parser.addoption("--cluster", help="Use an existing cluster instead of creating one.")
+    parser.addoption("--public-ecr-image-uri", help="S3 URI of the ParallelCluster API spec")
+    parser.addoption(
+        "--api-definition-s3-uri", help="URI of the Docker image for the Lambda of the ParallelCluster API"
+    )
     parser.addoption(
         "--credential", help="STS credential endpoint, in the format <region>,<endpoint>,<ARN>,<externalId>.", nargs="+"
     )
@@ -778,6 +782,16 @@ def _create_iam_policies(iam_policy_name, region, policy_filename):
 @pytest.fixture(scope="class")
 def vpc_stack(vpc_stacks, region):
     return vpc_stacks[region]
+
+
+@pytest.fixture(scope="class")
+def public_ecr_image_uri(request):
+    return request.config.getoption("public_ecr_image_uri")
+
+
+@pytest.fixture(scope="class")
+def api_definition_s3_uri(request):
+    return request.config.getoption("api_definition_s3_uri")
 
 
 # If stack creation fails it'll retry once more. This is done to mitigate failures due to resources

--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -17,3 +17,4 @@ PyYAML
 retrying
 troposphere
 untangle
+requests

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -65,6 +65,8 @@ TEST_DEFAULTS = {
     "post_install": None,
     "vpc_stack": None,
     "cluster": None,
+    "api_definition_s3_uri": None,
+    "public_ecr_image_uri": None,
     "no_delete": False,
     "benchmarks": False,
     "benchmarks_target_capacity": 200,
@@ -282,6 +284,16 @@ def _init_argparser():
         "--cluster", help="Use an existing cluster instead of creating one.", default=TEST_DEFAULTS.get("cluster")
     )
     debug_group.add_argument(
+        "--api-definition-s3-uri",
+        help="URI of the Docker image for the Lambda of the ParallelCluster API",
+        default=TEST_DEFAULTS.get("api_definition_s3_uri"),
+    )
+    debug_group.add_argument(
+        "--public-ecr-image-uri",
+        help="S3 URI of the ParallelCluster API spec",
+        default=TEST_DEFAULTS.get("public_ecr_image_uri"),
+    )
+    debug_group.add_argument(
         "--no-delete",
         action="store_true",
         help="Don't delete stacks after tests are complete.",
@@ -481,6 +493,12 @@ def _set_custom_stack_args(args, pytest_args):
 
     if args.cluster:
         pytest_args.extend(["--cluster", args.cluster])
+
+    if args.api_definition_s3_uri:
+        pytest_args.extend(["--api-definition-s3-uri", args.api_definition_s3_uri])
+
+    if args.public_ecr_image_uri:
+        pytest_args.extend(["--public-ecr-image-uri", args.public_ecr_image_uri])
 
     if args.no_delete:
         pytest_args.append("--no-delete")

--- a/tests/integration-tests/tests/api_infrastructure/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/api_infrastructure/test_api_infrastructure.py
@@ -1,0 +1,152 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import os
+import re
+
+import boto3
+import botocore
+import pytest
+import requests
+from assertpy import assert_that, soft_assertions
+from cfn_stacks_factory import CfnStack, CfnStacksFactory
+from utils import generate_stack_name
+
+
+@pytest.fixture()
+@pytest.mark.usefixtures("setup_sts_credentials")
+def api_infrastructure_stack_factory(request):
+    """Define a fixture to manage the creation and destruction of the API Infrastructure CloudFormation stack."""
+    factory = CfnStacksFactory(request.config.getoption("credential"))
+
+    def _create_api_infrastructure(region, parameters):
+        template_path = os.path.join("..", "..", "api", "infrastructure", "parallelcluster-api.yaml")
+        file_content = extract_template(template_path)
+        stack = CfnStack(
+            name=generate_stack_name("integ-tests-api-infrastructure", request.config.getoption("stackname_suffix")),
+            region=region,
+            template=file_content,
+            parameters=parameters,
+            capabilities=["CAPABILITY_AUTO_EXPAND", "CAPABILITY_IAM"],
+        )
+        factory.create_stack(stack)
+        return stack
+
+    def extract_template(template_path):
+        with open(template_path) as cfn_file:
+            file_content = cfn_file.read()
+        return file_content
+
+    yield _create_api_infrastructure
+    factory.delete_all_stacks()
+
+
+@pytest.mark.skip_regions(["cn-north-1", "cn-northwest-1"])  # TODO No Lambda container support in China regions
+def test_api_infrastructure_with_default_parameters(
+    region, api_definition_s3_uri, public_ecr_image_uri, api_infrastructure_stack_factory
+):
+    """Test that creating the API Infrastructure stack with the defaults correctly sets up the Lambda and APIGateway API
+
+    :param region: the region where the stack is run
+    :api_definition_s3_uri: a fixture, the S3 URI of the API definition
+    :public_ecr_image_uri: a fixture, the URI of the published Lambda Docker image
+    :api_infrastructure_stack_factory: a fixture, the factory used to create the regional API Infrastructure stack
+    """
+    parameters = [
+        {"ParameterKey": "ApiDefinitionS3Uri", "ParameterValue": api_definition_s3_uri},
+        {"ParameterKey": "PublicEcrImageUri", "ParameterValue": public_ecr_image_uri},
+    ]
+    stack = api_infrastructure_stack_factory(region, parameters)
+
+    lambda_client = boto3.client("lambda", region_name=region)
+    apigateway_client = boto3.client("apigateway", region_name=region)
+
+    parallelcluster_lambda_name = stack.cfn_resources["ParallelClusterFunction"]
+    parallelcluster_lambda_arn = stack.cfn_outputs["ParallelClusterLambdaArn"]
+    parallelcluster_api_copied_image_uri = stack.cfn_outputs["UriOfCopyOfPublicEcrImage"]
+
+    parallelcluster_api_id = stack.cfn_resources["ApiGatewayApiWithoutCustomDomain"]
+    parallelcluster_api_url = stack.cfn_outputs["ParallelClusterApiInvokeUrl"]
+
+    with soft_assertions():
+        _assert_parallelcluster_lambda(
+            client=lambda_client,
+            lambda_name=parallelcluster_lambda_name,
+            lambda_arn=parallelcluster_lambda_arn,
+            lambda_image_uri=parallelcluster_api_copied_image_uri,
+        )
+
+        _assert_parallelcluster_api(
+            client=apigateway_client, api_id=parallelcluster_api_id, api_url=parallelcluster_api_url
+        )
+
+        _assert_can_call_list_clusters(region=region, api_url=parallelcluster_api_url)
+
+
+def _assert_parallelcluster_lambda(client, lambda_name, lambda_arn, lambda_image_uri):
+    """Check that the ParallelCluster Lambda is correctly configured
+
+    :param client: the Lambda client
+    :param lambda_name: the name of the ParallelCluster Lambda
+    :param lambda_arn: the ARN of the ParallelCluster Lambda
+    :param lambda_image_uri: the URI of the local copy of the ParallelCluster Lambda Docker image
+    """
+    lambda_resource = client.get_function(FunctionName=lambda_name)
+    lambda_configuration = lambda_resource["Configuration"]
+    assert_that(lambda_configuration["FunctionArn"]).is_equal_to(lambda_arn)
+    assert_that(lambda_configuration["Timeout"]).is_equal_to(30)
+    assert_that(lambda_configuration["MemorySize"]).is_equal_to(256)
+    assert_that(lambda_configuration["TracingConfig"]["Mode"]).is_equal_to("Active")
+    assert_that(lambda_resource["Tags"]).contains("parallelcluster:version")
+    assert_that(lambda_resource["Code"]["ImageUri"]).is_equal_to(lambda_image_uri)
+
+
+def _assert_parallelcluster_api(client, api_id, api_url):
+    """Check that the ParallelCluster APIGateway API is correctly configured
+
+    :param client: the APIGateway client
+    :param api_id: the id of the ParallelCluster API
+    :param api_url: the URL of the ParallelCluster API
+    """
+    apigateway_resource = client.get_rest_api(restApiId=api_id)
+    assert_that(apigateway_resource["endpointConfiguration"]["types"]).is_equal_to(["REGIONAL"])
+
+    api_id_from_url = _parse_api_url(api_url)["ApiId"]
+    assert_that(api_url).ends_with("/prod")
+    assert_that(api_id_from_url).is_equal_to(api_id)
+
+    stage_resource = client.get_stage(restApiId=api_id, stageName="prod")
+    assert_that(stage_resource["tags"]).contains("parallelcluster:version")
+    assert_that(stage_resource["tracingEnabled"]).is_true()
+
+
+def _assert_can_call_list_clusters(region, api_url):
+    """Executed a SigV4 signed request to the ListClusters API
+
+    :param region: the region where to execute the request
+    :param api_url: the APIGateway API invoke url
+    """
+    session = botocore.session.Session()
+    request = botocore.awsrequest.AWSRequest(method="GET", url="{}/v3/clusters".format(api_url))
+    botocore.auth.SigV4Auth(session.get_credentials(), "execute-api", region).add_auth(request)
+    prepared_request = request.prepare()
+    response = requests.get(prepared_request.url, headers=prepared_request.headers, timeout=10)
+    assert_that(response.status_code).is_equal_to(requests.codes.ok)
+
+
+def _parse_api_url(url):
+    """Parse an APIGateway URL
+
+    :param url: the APIGateway API URL
+    :return: a dictionary with two keys, ApiId and VpcEndpointId
+    """
+    url_pattern = "https://(?P<ApiId>[^-.]+)(-(?P<VpcEndpointId>[^.]+))?\\..+"
+    return re.match(url_pattern, url).groupdict()

--- a/tests/integration-tests/tests/networking/test_networking.py
+++ b/tests/integration-tests/tests/networking/test_networking.py
@@ -14,38 +14,10 @@ import os
 import boto3
 import pytest
 from assertpy import assert_that
-from cfn_stacks_factory import CfnStack, CfnStacksFactory
-from utils import generate_stack_name
-
-
-@pytest.fixture()
-@pytest.mark.usefixtures("setup_sts_credentials")
-def networking_stack_factory(request):
-    """Define a fixture to manage the creation and destruction of CloudFormation stacks."""
-    factory = CfnStacksFactory(request.config.getoption("credential"))
-
-    def _create_network(region, template_path, parameters):
-        file_content = extract_template(template_path)
-        stack = CfnStack(
-            name=generate_stack_name("integ-tests-networking", request.config.getoption("stackname_suffix")),
-            region=region,
-            template=file_content,
-            parameters=parameters,
-        )
-        factory.create_stack(stack)
-        return stack
-
-    def extract_template(template_path):
-        with open(template_path) as cfn_file:
-            file_content = cfn_file.read()
-        return file_content
-
-    yield _create_network
-    factory.delete_all_stacks()
 
 
 @pytest.mark.regions(["eu-central-1", "us-gov-east-1", "cn-northwest-1"])
-def test_public_network_topology(region, vpc_stack, networking_stack_factory, random_az_selector):
+def test_public_network_topology(region, vpc_stack, parameterized_cfn_stacks_factory, random_az_selector):
     ec2_client = boto3.client("ec2", region_name=region)
     vpc_id = vpc_stack.cfn_outputs["VpcId"]
     public_subnet_cidr = "192.168.3.0/24"
@@ -56,7 +28,8 @@ def test_public_network_topology(region, vpc_stack, networking_stack_factory, ra
         availability_zone, internet_gateway_id=internet_gateway_id, vpc_id=vpc_id, public_cidr=public_subnet_cidr
     )
     path = os.path.join("..", "..", "cloudformation", "networking", "public.cfn.json")
-    stack = networking_stack_factory(region, path, parameters)
+    stack_prefix = "integ-tests-networking"
+    stack = parameterized_cfn_stacks_factory(region, path, stack_prefix, parameters)
 
     public_subnet_id = stack.cfn_outputs["PublicSubnetId"]
     _assert_subnet_cidr(ec2_client, public_subnet_id, expected_subnet_cidr=public_subnet_cidr)
@@ -68,7 +41,7 @@ def test_public_network_topology(region, vpc_stack, networking_stack_factory, ra
 
 
 @pytest.mark.regions(["eu-central-1", "us-gov-east-1", "cn-northwest-1"])
-def test_public_private_network_topology(region, vpc_stack, networking_stack_factory, random_az_selector):
+def test_public_private_network_topology(region, vpc_stack, parameterized_cfn_stacks_factory, random_az_selector):
     ec2_client = boto3.client("ec2", region_name=region)
     vpc_id = vpc_stack.cfn_outputs["VpcId"]
     public_subnet_cidr = "192.168.5.0/24"
@@ -84,7 +57,8 @@ def test_public_private_network_topology(region, vpc_stack, networking_stack_fac
         private_cidr=private_subnet_cidr,
     )
     path = os.path.join("..", "..", "cloudformation", "networking", "public-private.cfn.json")
-    stack = networking_stack_factory(region, path, parameters)
+    stack_prefix = "integ-tests-networking"
+    stack = parameterized_cfn_stacks_factory(region, path, stack_prefix, parameters)
 
     public_subnet_id = stack.cfn_outputs["PublicSubnetId"]
     private_subnet_id = stack.cfn_outputs["PrivateSubnetId"]


### PR DESCRIPTION
### Notes
This patch adds an infrastructure tests validating that when creating a stack with the Infrastructure API CloudFormation template using the default parameters the APIGateway API backed by Lambda is correctly set up. The test requires inputting two parameters, the URI of the published Docker image for the ParallelCluster Lambda and the S3 URI of the API definition.

### Tests
Test run in personal account

### Notes for the reviewer
1. This test exercises creates the stack with default parameters. There are two notable alternative scenarios: one where we specify a custom domain name, another where we create a PRIVATE API (instead of a REGIONAL one) associating it to a VPC endpoint. Both these scenarios require the customer to run the test in an account where they have created those resources, eventually we could add appropriate parameters (custom domain name and HostedZone, VPC endpoint id)
2. I wrote the test with multiple assertions to be coherent with the rest of the integration tests. To my knowledge `assertpy`'s default behavior does not support multiple failures like other tools (such as [pytest-check](https://github.com/okken/pytest-check)): an assertion failure will halt test execution immediately by raising an error. I have wrapped the assertions inside a [soft_assertions()](https://github.com/assertpy/assertpy#soft-assertions) context manager to to collect assertion failures together, to be raise all at once at the end, without halting the test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
