### PR TITLE
Install AWS CLI if not present

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -61,6 +61,15 @@ phases:
             - |
               set -v
 
+              # Install AWS CLI
+              which aws
+              if [[ $? -ne 0 ]]; then
+                echo "Installing AWS CLI"
+                curl --retry 3 -L -o /tmp/awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip"
+                cd /tmp/ && unzip awscliv2.zip
+                ./aws/install
+              fi
+
               DESCRIPTION="AWS ParallelCluster AMI for {{ test.OperatingSystemName.outputs.stdout }}"
               append_description () {
                 VALUE="$1"


### PR DESCRIPTION
Install AWS CLI in tag component if not present. CLI is used to add tag and set description to the built AMI

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
