### PR TITLE
Rename functions to avoid labeling as integ tests

### DIFF
--- a/tests/integration-tests/tests/common/scaling_common.py
+++ b/tests/integration-tests/tests/common/scaling_common.py
@@ -183,7 +183,7 @@ def get_batch_ce_min_size(stack_name, region):
     )
 
 
-def test_maintain_initial_size(stack_name, region, maintain_initial_size, initial_size):
+def assert_maintain_initial_size_behavior(stack_name, region, maintain_initial_size, initial_size):
     min_size = get_min_asg_capacity(region, stack_name)
     if maintain_initial_size == "true":
         assert_that(min_size).is_equal_to(initial_size)

--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -23,9 +23,9 @@ from utils import get_compute_nodes_instance_ids
 from tests.common.schedulers_common import get_scheduler_commands
 from tests.common.utils import retrieve_latest_ami
 from tests.storage.test_fsx_lustre import (
+    assert_fsx_lustre_correctly_mounted,
+    assert_fsx_lustre_correctly_shared,
     get_fsx_fs_id,
-    test_fsx_lustre_correctly_mounted,
-    test_fsx_lustre_correctly_shared,
 )
 
 
@@ -52,8 +52,8 @@ def _test_fsx_in_private_subnet(cluster, os, region, scheduler, fsx_mount_dir, b
     remote_command_executor = RemoteCommandExecutor(cluster, bastion="ec2-user@{}".format(bastion_ip))
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
     fsx_fs_id = get_fsx_fs_id(cluster, region)
-    test_fsx_lustre_correctly_mounted(remote_command_executor, fsx_mount_dir, os, region, fsx_fs_id)
-    test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, fsx_mount_dir)
+    assert_fsx_lustre_correctly_mounted(remote_command_executor, fsx_mount_dir, os, region, fsx_fs_id)
+    assert_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, fsx_mount_dir)
 
 
 @pytest.fixture()

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -22,9 +22,9 @@ from utils import get_compute_nodes_instance_ids, get_instance_ids_compute_hostn
 from tests.common.assertions import assert_instance_replaced_or_terminating, assert_no_errors_in_logs
 from tests.common.hit_common import wait_for_num_nodes_in_scheduler
 from tests.common.scaling_common import (
+    assert_maintain_initial_size_behavior,
     get_compute_nodes_allocation,
     get_desired_asg_capacity,
-    test_maintain_initial_size,
 )
 from tests.common.schedulers_common import get_scheduler_commands
 
@@ -113,7 +113,7 @@ def test_nodewatcher_terminates_failing_node(scheduler, region, pcluster_config_
     )
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)
-    test_maintain_initial_size(cluster.cfn_name, region, maintain_initial_size, initial_queue_size)
+    assert_maintain_initial_size_behavior(cluster.cfn_name, region, maintain_initial_size, initial_queue_size)
 
 
 @retry(wait_fixed=seconds(30), stop_max_delay=minutes(15))

--- a/tests/integration-tests/tests/schedulers/test_sge.py
+++ b/tests/integration-tests/tests/schedulers/test_sge.py
@@ -18,7 +18,7 @@ from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 
 from tests.common.assertions import assert_no_errors_in_logs, assert_scaling_worked
-from tests.common.scaling_common import test_maintain_initial_size
+from tests.common.scaling_common import assert_maintain_initial_size_behavior
 from tests.common.schedulers_common import SgeCommands
 from tests.schedulers.common import assert_overscaling_when_job_submitted_during_scaledown
 
@@ -46,7 +46,7 @@ def test_sge(region, pcluster_config_reader, clusters_factory):
     remote_command_executor = RemoteCommandExecutor(cluster)
     initial_queue_size = cluster.config.get("cluster default", "initial_queue_size")
 
-    test_maintain_initial_size(cluster.cfn_name, region, maintain_initial_size, initial_queue_size)
+    assert_maintain_initial_size_behavior(cluster.cfn_name, region, maintain_initial_size, initial_queue_size)
     _test_sge_version(remote_command_executor)
     _test_non_runnable_jobs(remote_command_executor, max_queue_size, max_slots, region, cluster, scaledown_idletime)
     _test_job_dependencies(remote_command_executor, region, cluster.cfn_name, scaledown_idletime)

--- a/tests/integration-tests/tests/schedulers/test_torque.py
+++ b/tests/integration-tests/tests/schedulers/test_torque.py
@@ -21,7 +21,7 @@ from retrying import retry
 from time_utils import minutes, seconds
 
 from tests.common.assertions import assert_no_errors_in_logs, assert_scaling_worked
-from tests.common.scaling_common import test_maintain_initial_size, watch_compute_nodes
+from tests.common.scaling_common import assert_maintain_initial_size_behavior, watch_compute_nodes
 from tests.common.schedulers_common import TorqueCommands
 from tests.schedulers.common import assert_overscaling_when_job_submitted_during_scaledown
 
@@ -51,7 +51,7 @@ def test_torque(region, pcluster_config_reader, clusters_factory):
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     maintain_initial_size = cluster.config.get("cluster default", "maintain_initial_size")
-    test_maintain_initial_size(cluster.cfn_name, region, maintain_initial_size, initial_queue_size)
+    assert_maintain_initial_size_behavior(cluster.cfn_name, region, maintain_initial_size, initial_queue_size)
     _test_torque_version(remote_command_executor)
     _test_jobs_executed_concurrently(remote_command_executor, max_slots)
     _test_non_runnable_jobs(remote_command_executor, max_queue_size, max_slots, region, cluster, scaledown_idletime)

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -187,9 +187,9 @@ def _test_fsx_lustre(
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
     fsx_fs_id = get_fsx_fs_id(cluster, region)
 
-    test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
+    assert_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
     _test_import_path(remote_command_executor, mount_dir)
-    test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir)
+    assert_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir)
     _test_export_path(remote_command_executor, mount_dir, bucket_name, region)
     _test_data_repository_task(remote_command_executor, mount_dir, bucket_name, fsx_fs_id, region)
 
@@ -230,7 +230,7 @@ def test_fsx_lustre_backup(region, pcluster_config_reader, clusters_factory, os,
     fsx_fs_id = get_fsx_fs_id(cluster, region)
 
     # Mount file system
-    test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
+    assert_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id)
 
     # Create a text file in the mount directory.
     create_backup_test_file(scheduler_commands, remote_command_executor, mount_dir)
@@ -259,7 +259,7 @@ def test_fsx_lustre_backup(region, pcluster_config_reader, clusters_factory, os,
     fsx_fs_id_restore = get_fsx_fs_id(cluster_restore, region)
 
     # Mount the restored file system
-    test_fsx_lustre_correctly_mounted(remote_command_executor_restore, mount_dir, os, region, fsx_fs_id_restore)
+    assert_fsx_lustre_correctly_mounted(remote_command_executor_restore, mount_dir, os, region, fsx_fs_id_restore)
 
     # Validate whether text file created in the original file system is present in the restored file system.
     _test_restore_from_backup(remote_command_executor_restore, mount_dir)
@@ -360,7 +360,7 @@ def fsx_factory(vpc_stack, cfn_stacks_factory, request, region, key_name):
         cfn_stacks_factory.delete_stack(fsx_stack_name, region)
 
 
-def test_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id):
+def assert_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, os, region, fsx_fs_id):
     logging.info("Testing fsx lustre is correctly mounted")
     result = remote_command_executor.run_remote_command("df -h -t lustre | tail -n +2 | awk '{print $1, $2, $6}'")
     mount_name = get_mount_name(fsx_fs_id, region)
@@ -425,7 +425,7 @@ def _test_import_path(remote_command_executor, mount_dir):
     assert_that(result.stdout).is_equal_to("Downloaded by FSx Lustre")
 
 
-def test_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir):
+def assert_fsx_lustre_correctly_shared(scheduler_commands, remote_command_executor, mount_dir):
     logging.info("Testing fsx lustre correctly mounted on compute nodes")
     remote_command_executor.run_remote_command("touch {mount_dir}/test_file".format(mount_dir=mount_dir))
     job_command = "cat {mount_dir}/test_file && touch {mount_dir}/compute_output".format(mount_dir=mount_dir)


### PR DESCRIPTION
This commit renames functions that had names of the form `test_`. This
was done because the logic that identifies unused integration tests was
mistakenly claiming that these functions had been created but not
included in any configuration files used to run tests.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
