### PR TITLE
Integ Test: Fix retrieve_latest_ami

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -58,13 +58,14 @@ AMI_TYPE_DICT = {
 }
 
 
-def retrieve_latest_ami(region, os, amis_dict, ami_type="official", architecture="x86_64"):
+def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64"):
+    """
+    Retrieve latest non-pcluster AMIs.
+
+    Pcluster AMIs should be retrieved with amis_dict fixture.
+    """
     try:
-        if ami_type == "pcluster":
-            LOGGER.debug(f"CFN template amis_dict: {amis_dict}")
-            return amis_dict.get(os, "UNSUPPORTED")
-        else:
-            ami_name = AMI_TYPE_DICT.get(ami_type).get(os).get("name")
+        ami_name = AMI_TYPE_DICT.get(ami_type).get(os).get("name")
         response = boto3.client("ec2", region_name=region).describe_images(
             Filters=[{"Name": "name", "Values": [ami_name]}, {"Name": "architecture", "Values": [architecture]}],
             Owners=AMI_TYPE_DICT.get(ami_type).get(os).get("owners"),


### PR DESCRIPTION
* Pytest fixture can only be used by testing function or another fixture
* Remove logic that try to use amis_dict fixture in utility function
* Remove logic to retrieve pcluster AMIs with retrieve_latest_ami. Use amis_dict fixture instead.

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
