### PR TITLE
3.0: Change name to image in OpenAPI spec, models and controllers for CustomImage APIs

### DIFF
--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -60,7 +60,7 @@ def build_image(
     build_image_request_content = BuildImageRequestContent.from_dict(build_image_request_content)
     return BuildImageResponseContent(
         image=ImageInfoSummary(
-            image_name="image",
+            image_id="image",
             image_build_status=ImageBuildStatus.BUILD_FAILED,
             cloudformation_stack_status=CloudFormationStatus.CREATE_COMPLETE,
             cloudformation_stack_arn="arn",
@@ -71,12 +71,12 @@ def build_image(
 
 
 @configure_aws_region()
-def delete_image(image_name, region=None, client_token=None, force=None):
+def delete_image(image_id, region=None, client_token=None, force=None):
     """
     Initiate the deletion of the custom ParallelCluster image.
 
-    :param image_name: Name of the image
-    :type image_name: str
+    :param image_id: Id of the image
+    :type image_id: str
     :param region: AWS Region. Defaults to the region the API is deployed to.
     :type region: str
     :param client_token: Idempotency token that can be set by the client so that retries for the same request are
@@ -89,7 +89,7 @@ def delete_image(image_name, region=None, client_token=None, force=None):
     """
     return DeleteImageResponseContent(
         image=ImageInfoSummary(
-            image_name="image",
+            image_id="image",
             image_build_status=ImageBuildStatus.BUILD_FAILED,
             cloudformation_stack_status=CloudFormationStatus.CREATE_COMPLETE,
             cloudformation_stack_arn="arn",
@@ -100,12 +100,12 @@ def delete_image(image_name, region=None, client_token=None, force=None):
 
 
 @configure_aws_region()
-def describe_image(image_name, region=None):
+def describe_image(image_id, region=None):
     """
     Get detailed information about an existing image.
 
-    :param image_name: Name of the image
-    :type image_name: str
+    :param image_id: Id of the image
+    :type image_id: str
     :param region: AWS Region. Defaults to the region the API is deployed to.
     :type region: str
 
@@ -113,7 +113,7 @@ def describe_image(image_name, region=None):
     """
     return DescribeImageResponseContent(
         image_configuration=ImageConfigurationStructure(s3_url="s3"),
-        image_name="imagename",
+        image_id="imageid",
         imagebuilder_image_status=ImageBuilderImageStatus.BUILDING,
         creation_time=datetime.now(),
         image_build_status=ImageBuildStatus.BUILD_FAILED,

--- a/cli/src/pcluster/api/models/build_image_request_content.py
+++ b/cli/src/pcluster/api/models/build_image_request_content.py
@@ -21,22 +21,22 @@ class BuildImageRequestContent(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, image_configuration=None, name=None, region=None):
+    def __init__(self, image_configuration=None, id=None, region=None):
         """BuildImageRequestContent - a model defined in OpenAPI
 
         :param image_configuration: The image_configuration of this BuildImageRequestContent.
         :type image_configuration: str
-        :param name: The name of this BuildImageRequestContent.
-        :type name: str
+        :param id: The id of this BuildImageRequestContent.
+        :type id: str
         :param region: The region of this BuildImageRequestContent.
         :type region: str
         """
-        self.openapi_types = {"image_configuration": str, "name": str, "region": str}
+        self.openapi_types = {"image_configuration": str, "id": str, "region": str}
 
-        self.attribute_map = {"image_configuration": "imageConfiguration", "name": "name", "region": "region"}
+        self.attribute_map = {"image_configuration": "imageConfiguration", "id": "id", "region": "region"}
 
         self._image_configuration = image_configuration
-        self._name = name
+        self._id = id
         self._region = region
 
     @classmethod
@@ -76,37 +76,35 @@ class BuildImageRequestContent(Model):
         self._image_configuration = image_configuration
 
     @property
-    def name(self):
-        """Gets the name of this BuildImageRequestContent.
+    def id(self):
+        """Gets the id of this BuildImageRequestContent.
 
-        Name of the image
+        Id of the image
 
-        :return: The name of this BuildImageRequestContent.
+        :return: The id of this BuildImageRequestContent.
         :rtype: str
         """
-        return self._name
+        return self._id
 
-    @name.setter
-    def name(self, name):
-        """Sets the name of this BuildImageRequestContent.
+    @id.setter
+    def id(self, id):
+        """Sets the id of this BuildImageRequestContent.
 
-        Name of the image
+        Id of the image
 
-        :param name: The name of this BuildImageRequestContent.
-        :type name: str
+        :param id: The id of this BuildImageRequestContent.
+        :type id: str
         """
-        if name is None:
-            raise ValueError("Invalid value for `name`, must not be `None`")
-        if name is not None and len(name) > 60:
-            raise ValueError("Invalid value for `name`, length must be less than or equal to `60`")
-        if name is not None and len(name) < 5:
-            raise ValueError("Invalid value for `name`, length must be greater than or equal to `5`")
-        if name is not None and not re.search(r"^[a-zA-Z][a-zA-Z0-9-]+$", name):
-            raise ValueError(
-                "Invalid value for `name`, must be a follow pattern or equal to `/^[a-zA-Z][a-zA-Z0-9-]+$/`"
-            )
+        if id is None:
+            raise ValueError("Invalid value for `id`, must not be `None`")
+        if id is not None and len(id) > 60:
+            raise ValueError("Invalid value for `id`, length must be less than or equal to `60`")
+        if id is not None and len(id) < 5:
+            raise ValueError("Invalid value for `id`, length must be greater than or equal to `5`")
+        if id is not None and not re.search(r"^[a-zA-Z][a-zA-Z0-9-]+$", id):
+            raise ValueError("Invalid value for `id`, must be a follow pattern or equal to `/^[a-zA-Z][a-zA-Z0-9-]+$/`")
 
-        self._name = name
+        self._id = id
 
     @property
     def region(self):

--- a/cli/src/pcluster/api/models/describe_image_response_content.py
+++ b/cli/src/pcluster/api/models/describe_image_response_content.py
@@ -31,7 +31,7 @@ class DescribeImageResponseContent(Model):
     def __init__(
         self,
         image_configuration=None,
-        image_name=None,
+        image_id=None,
         imagebuilder_image_status=None,
         creation_time=None,
         image_build_status=None,
@@ -47,8 +47,8 @@ class DescribeImageResponseContent(Model):
 
         :param image_configuration: The image_configuration of this DescribeImageResponseContent.
         :type image_configuration: ImageConfigurationStructure
-        :param image_name: The image_name of this DescribeImageResponseContent.
-        :type image_name: str
+        :param image_id: The image_id of this DescribeImageResponseContent.
+        :type image_id: str
         :param imagebuilder_image_status: The imagebuilder_image_status of this DescribeImageResponseContent.
         :type imagebuilder_image_status: ImageBuilderImageStatus
         :param creation_time: The creation_time of this DescribeImageResponseContent.
@@ -72,7 +72,7 @@ class DescribeImageResponseContent(Model):
         """
         self.openapi_types = {
             "image_configuration": ImageConfigurationStructure,
-            "image_name": str,
+            "image_id": str,
             "imagebuilder_image_status": ImageBuilderImageStatus,
             "creation_time": datetime,
             "image_build_status": ImageBuildStatus,
@@ -87,7 +87,7 @@ class DescribeImageResponseContent(Model):
 
         self.attribute_map = {
             "image_configuration": "imageConfiguration",
-            "image_name": "imageName",
+            "image_id": "imageId",
             "imagebuilder_image_status": "imagebuilderImageStatus",
             "creation_time": "creationTime",
             "image_build_status": "imageBuildStatus",
@@ -101,7 +101,7 @@ class DescribeImageResponseContent(Model):
         }
 
         self._image_configuration = image_configuration
-        self._image_name = image_name
+        self._image_id = image_id
         self._imagebuilder_image_status = imagebuilder_image_status
         self._creation_time = creation_time
         self._image_build_status = image_build_status
@@ -148,29 +148,29 @@ class DescribeImageResponseContent(Model):
         self._image_configuration = image_configuration
 
     @property
-    def image_name(self):
-        """Gets the image_name of this DescribeImageResponseContent.
+    def image_id(self):
+        """Gets the image_id of this DescribeImageResponseContent.
 
-        Name of the Image
+        id of the Image
 
-        :return: The image_name of this DescribeImageResponseContent.
+        :return: The image_id of this DescribeImageResponseContent.
         :rtype: str
         """
-        return self._image_name
+        return self._image_id
 
-    @image_name.setter
-    def image_name(self, image_name):
-        """Sets the image_name of this DescribeImageResponseContent.
+    @image_id.setter
+    def image_id(self, image_id):
+        """Sets the image_id of this DescribeImageResponseContent.
 
-        Name of the Image
+        id of the Image
 
-        :param image_name: The image_name of this DescribeImageResponseContent.
-        :type image_name: str
+        :param image_id: The image_id of this DescribeImageResponseContent.
+        :type image_id: str
         """
-        if image_name is None:
-            raise ValueError("Invalid value for `image_name`, must not be `None`")
+        if image_id is None:
+            raise ValueError("Invalid value for `image_id`, must not be `None`")
 
-        self._image_name = image_name
+        self._image_id = image_id
 
     @property
     def imagebuilder_image_status(self):

--- a/cli/src/pcluster/api/models/image_info_summary.py
+++ b/cli/src/pcluster/api/models/image_info_summary.py
@@ -25,7 +25,7 @@ class ImageInfoSummary(Model):
 
     def __init__(
         self,
-        image_name=None,
+        image_id=None,
         image_build_status=None,
         cloudformation_stack_status=None,
         cloudformation_stack_arn=None,
@@ -34,8 +34,8 @@ class ImageInfoSummary(Model):
     ):
         """ImageInfoSummary - a model defined in OpenAPI
 
-        :param image_name: The image_name of this ImageInfoSummary.
-        :type image_name: str
+        :param image_id: The image_id of this ImageInfoSummary.
+        :type image_id: str
         :param image_build_status: The image_build_status of this ImageInfoSummary.
         :type image_build_status: ImageBuildStatus
         :param cloudformation_stack_status: The cloudformation_stack_status of this ImageInfoSummary.
@@ -48,7 +48,7 @@ class ImageInfoSummary(Model):
         :type version: str
         """
         self.openapi_types = {
-            "image_name": str,
+            "image_id": str,
             "image_build_status": ImageBuildStatus,
             "cloudformation_stack_status": CloudFormationStatus,
             "cloudformation_stack_arn": str,
@@ -57,7 +57,7 @@ class ImageInfoSummary(Model):
         }
 
         self.attribute_map = {
-            "image_name": "imageName",
+            "image_id": "imageId",
             "image_build_status": "imageBuildStatus",
             "cloudformation_stack_status": "cloudformationStackStatus",
             "cloudformation_stack_arn": "cloudformationStackArn",
@@ -65,7 +65,7 @@ class ImageInfoSummary(Model):
             "version": "version",
         }
 
-        self._image_name = image_name
+        self._image_id = image_id
         self._image_build_status = image_build_status
         self._cloudformation_stack_status = cloudformation_stack_status
         self._cloudformation_stack_arn = cloudformation_stack_arn
@@ -84,37 +84,37 @@ class ImageInfoSummary(Model):
         return util.deserialize_model(dikt, cls)
 
     @property
-    def image_name(self):
-        """Gets the image_name of this ImageInfoSummary.
+    def image_id(self):
+        """Gets the image_id of this ImageInfoSummary.
 
-        Name of the image
+        Id of the image
 
-        :return: The image_name of this ImageInfoSummary.
+        :return: The image_id of this ImageInfoSummary.
         :rtype: str
         """
-        return self._image_name
+        return self._image_id
 
-    @image_name.setter
-    def image_name(self, image_name):
-        """Sets the image_name of this ImageInfoSummary.
+    @image_id.setter
+    def image_id(self, image_id):
+        """Sets the image_id of this ImageInfoSummary.
 
-        Name of the image
+        Id of the image
 
-        :param image_name: The image_name of this ImageInfoSummary.
-        :type image_name: str
+        :param image_id: The image_id of this ImageInfoSummary.
+        :type image_id: str
         """
-        if image_name is None:
-            raise ValueError("Invalid value for `image_name`, must not be `None`")
-        if image_name is not None and len(image_name) > 60:
-            raise ValueError("Invalid value for `image_name`, length must be less than or equal to `60`")
-        if image_name is not None and len(image_name) < 5:
-            raise ValueError("Invalid value for `image_name`, length must be greater than or equal to `5`")
-        if image_name is not None and not re.search(r"^[a-zA-Z][a-zA-Z0-9-]+$", image_name):
+        if image_id is None:
+            raise ValueError("Invalid value for `image_id`, must not be `None`")
+        if image_id is not None and len(image_id) > 60:
+            raise ValueError("Invalid value for `image_id`, length must be less than or equal to `60`")
+        if image_id is not None and len(image_id) < 5:
+            raise ValueError("Invalid value for `image_id`, length must be greater than or equal to `5`")
+        if image_id is not None and not re.search(r"^[a-zA-Z][a-zA-Z0-9-]+$", image_id):
             raise ValueError(
-                "Invalid value for `image_name`, must be a follow pattern or equal to `/^[a-zA-Z][a-zA-Z0-9-]+$/`"
+                "Invalid value for `image_id`, must be a follow pattern or equal to `/^[a-zA-Z][a-zA-Z0-9-]+$/`"
             )
 
-        self._image_name = image_name
+        self._image_id = image_id
 
     @property
     def image_build_status(self):

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -1036,18 +1036,18 @@ paths:
         uri:
           Fn::Sub: "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations"
       x-openapi-router-controller: pcluster.api.controllers.image_operations_controller
-  /v3/images/custom/{imageName}:
+  /v3/images/custom/{imageId}:
     delete:
       description: Initiate the deletion of the custom ParallelCluster image.
       operationId: delete_image
       parameters:
-      - description: Name of the image
+      - description: Id of the image
         explode: false
         in: path
-        name: imageName
+        name: imageId
         required: true
         schema:
-          description: Name of the image
+          description: Id of the image
           maxLength: 60
           minLength: 5
           pattern: "^[a-zA-Z][a-zA-Z0-9-]+$"
@@ -1137,13 +1137,13 @@ paths:
       description: Get detailed information about an existing image.
       operationId: describe_image
       parameters:
-      - description: Name of the image
+      - description: Id of the image
         explode: false
         in: path
-        name: imageName
+        name: imageId
         required: true
         schema:
-          description: Name of the image
+          description: Id of the image
           maxLength: 60
           minLength: 5
           pattern: "^[a-zA-Z][a-zA-Z0-9-]+$"
@@ -1304,7 +1304,7 @@ components:
       example:
         amiId: amiId
         os: os
-        name: name
+        id: id
         architecture: architecture
       properties:
         amiId:
@@ -1313,8 +1313,8 @@ components:
         os:
           title: os
           type: string
-        name:
-          title: name
+        id:
+          title: id
           type: string
         architecture:
           title: architecture
@@ -1322,7 +1322,7 @@ components:
       required:
       - amiId
       - architecture
-      - name
+      - id
       - os
       title: AmiInfo
       type: object
@@ -1352,15 +1352,15 @@ components:
     BuildImageRequestContent:
       example:
         imageConfiguration: imageConfiguration
-        name: name
+        id: id
         region: region
       properties:
         imageConfiguration:
           description: Image configuration as a YAML document
           format: byte
           type: string
-        name:
-          description: Name of the image
+        id:
+          description: Id of the image
           maxLength: 60
           minLength: 5
           pattern: "^[a-zA-Z][a-zA-Z0-9-]+$"
@@ -1370,12 +1370,12 @@ components:
           type: string
       required:
       - imageConfiguration
-      - name
+      - id
       type: object
     BuildImageResponseContent:
       example:
         image:
-          imageName: imageName
+          imageId: imageId
           imageBuildStatus: null
           cloudformationStackStatus: null
           cloudformationStackArn: cloudformationStackArn
@@ -1652,7 +1652,7 @@ components:
     DeleteImageResponseContent:
       example:
         image:
-          imageName: imageName
+          imageId: imageId
           imageBuildStatus: null
           cloudformationStackStatus: null
           cloudformationStackArn: cloudformationStackArn
@@ -1807,7 +1807,7 @@ components:
       example:
         imageConfiguration:
           s3Url: s3Url
-        imageName: imageName
+        imageId: imageId
         imagebuilderImageStatus: null
         creationTime: 2000-01-23T04:56:07.000+00:00
         imageBuildStatus: null
@@ -1834,9 +1834,9 @@ components:
       properties:
         imageConfiguration:
           $ref: '#/components/schemas/ImageConfigurationStructure'
-        imageName:
-          description: Name of the Image
-          title: imageName
+        imageId:
+          description: Id of the Image
+          title: imageId
           type: string
         imagebuilderImageStatus:
           $ref: '#/components/schemas/ImageBuilderImageStatus'
@@ -1880,7 +1880,7 @@ components:
       - creationTime
       - imageBuildStatus
       - imageConfiguration
-      - imageName
+      - imageId
       - region
       - tags
       - version
@@ -1892,11 +1892,11 @@ components:
         items:
         - amiId: amiId
           os: os
-          name: name
+          id: id
           architecture: architecture
         - amiId: amiId
           os: os
-          name: name
+          id: id
           architecture: architecture
       properties:
         nextToken:
@@ -2035,19 +2035,19 @@ components:
       type: object
     ImageInfoSummary:
       example:
-        imageName: imageName
+        imageId: imageId
         imageBuildStatus: null
         cloudformationStackStatus: null
         cloudformationStackArn: cloudformationStackArn
         region: region
         version: version
       properties:
-        imageName:
-          description: Name of the image
+        imageId:
+          description: Id of the image
           maxLength: 60
           minLength: 5
           pattern: "^[a-zA-Z][a-zA-Z0-9-]+$"
-          title: imageName
+          title: imageId
           type: string
         imageBuildStatus:
           $ref: '#/components/schemas/ImageBuildStatus'
@@ -2069,7 +2069,7 @@ components:
       - cloudformationStackArn
       - cloudformationStackStatus
       - imageBuildStatus
-      - imageName
+      - imageId
       - region
       - version
       title: ImageInfoSummary
@@ -2144,13 +2144,13 @@ components:
       example:
         nextToken: nextToken
         items:
-        - imageName: imageName
+        - imageId: imageId
           imageBuildStatus: null
           cloudformationStackStatus: null
           cloudformationStackArn: cloudformationStackArn
           region: region
           version: version
-        - imageName: imageName
+        - imageId: imageId
           imageBuildStatus: null
           cloudformationStackStatus: null
           cloudformationStackArn: cloudformationStackArn

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -20,7 +20,7 @@ class TestImageOperationsController:
         """Test case for build_image."""
         build_image_request_content = {
             "imageConfiguration": "imageConfiguration",
-            "name": "imagename",
+            "id": "imageid",
             "region": "eu-west-1",
         }
         query_string = [
@@ -51,7 +51,7 @@ class TestImageOperationsController:
             "Accept": "application/json",
         }
         response = client.open(
-            "/v3/images/custom/{image_name}".format(image_name="imagename"),
+            "/v3/images/custom/{image_id}".format(image_id="imageid"),
             method="DELETE",
             headers=headers,
             query_string=query_string,
@@ -65,7 +65,7 @@ class TestImageOperationsController:
             "Accept": "application/json",
         }
         response = client.open(
-            "/v3/images/custom/{image_name}".format(image_name="imagename"),
+            "/v3/images/custom/{image_id}".format(image_id="imageid"),
             method="GET",
             headers=headers,
             query_string=query_string,


### PR DESCRIPTION
This patch applies the changes to the CustomImage APIs made in [this patch](https://github.com/aws/aws-parallelcluster/pull/2788) by replacing the name with the id in the OpenApi spec, models and controllers

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
