### PR TITLE
3.0: Add pagination to get_imagebuilder_stacks

### DIFF
--- a/cli/src/pcluster/api/pcluster_api.py
+++ b/cli/src/pcluster/api/pcluster_api.py
@@ -395,7 +395,7 @@ class PclusterApi:
             # get building image stacks by image name tag
             imagebuilder_stacks = [
                 ImageBuilder(image_id=stack.get("StackName"), stack=ImageBuilderStack(stack))
-                for stack in AWSApi.instance().cfn.get_imagebuilder_stacks()
+                for stack, _ in AWSApi.instance().cfn.get_imagebuilder_stacks()
             ]
             imagebuilder_stacks_response = [
                 ImageBuilderStackInfo(imagebuilder=imagebuilder, stack=imagebuilder.stack)

--- a/cli/tests/pcluster/aws/test_cfn.py
+++ b/cli/tests/pcluster/aws/test_cfn.py
@@ -172,3 +172,80 @@ class TestCfnClient:
         verified = utils.verify_stack_status(FAKE_NAME, ["CREATE_IN_PROGRESS"], "CREATE_COMPLETE")
         assert_that(verified).is_false()
         sleep_mock.assert_called_with(5)
+
+    @pytest.mark.parametrize(
+        "next_token, describe_stacks_response, expected_stacks",
+        [
+            (None, {"Stacks": []}, set()),
+            (
+                None,
+                {
+                    "Stacks": [
+                        {
+                            "StackName": "stackWithImageIdTagAndNoParentId",
+                            "CreationTime": datetime.now(),
+                            "StackStatus": "CREATE_IN_PROGRESS",
+                            "Tags": [{"Key": "parallelcluster:image_id", "Value": "image_id_1"}],
+                        },
+                        {"StackName": "name2", "CreationTime": datetime.now(), "StackStatus": "CREATE_IN_PROGRESS"},
+                        {
+                            "StackName": "name3",
+                            "CreationTime": datetime.now(),
+                            "StackStatus": "CREATE_IN_PROGRESS",
+                            "Tags": [{"Key": "parallelcluster:image_id", "Value": "image_id_2"}],
+                            "ParentId": "id",
+                        },
+                    ],
+                },
+                {"stackWithImageIdTagAndNoParentId"},
+            ),
+            (
+                "token",
+                {
+                    "Stacks": [
+                        {
+                            "StackName": "name1",
+                            "CreationTime": datetime.now(),
+                            "StackStatus": "CREATE_IN_PROGRESS",
+                            "Tags": [{"Key": "parallelcluster:image_id", "Value": "image_id_3"}],
+                        },
+                        {
+                            "StackName": "name2",
+                            "CreationTime": datetime.now(),
+                            "StackStatus": "CREATE_IN_PROGRESS",
+                            "Tags": [{"Key": "parallelcluster:image_id", "Value": "image_id_4"}],
+                        },
+                    ],
+                    "NextToken": "token",
+                },
+                {"name1", "name2"},
+            ),
+            ("invalid", Exception(), set()),
+        ],
+    )
+    def test_get_imagebuilder_stacks(
+        self, set_env, boto3_stubber, next_token, describe_stacks_response, expected_stacks
+    ):
+        set_env("AWS_DEFAULT_REGION", "us-east-1")
+
+        expected_describe_stacks_params = {} if not next_token else {"NextToken": next_token}
+        generate_error = isinstance(describe_stacks_response, Exception)
+        mocked_requests = [
+            MockedBoto3Request(
+                method="describe_stacks",
+                response=describe_stacks_response if not generate_error else "error",
+                expected_params=expected_describe_stacks_params,
+                generate_error=generate_error,
+                error_code="error" if generate_error else None,
+            )
+        ]
+        boto3_stubber("cloudformation", mocked_requests)
+
+        if not generate_error:
+            stacks, next_token = CfnClient().get_imagebuilder_stacks(next_token=next_token)
+            assert_that(next_token).is_equal_to(describe_stacks_response.get("NextToken"))
+            assert_that({s["StackName"] for s in stacks}).is_equal_to(expected_stacks)
+        else:
+            with pytest.raises(AWSClientError) as e:
+                CfnClient().list_pcluster_stacks(next_token=next_token)
+            assert_that(e.value.error_code).is_equal_to("error")


### PR DESCRIPTION
### Notes
For the ParallelCluster API we need to do some paginated operations (such as list_clusters and list_images). This patch adds pagination to get_imagebuilder_stacks as we already did for list_pcluster_stacks.

### Tests
Unit tests

### Notes for the reviewer
As we did previously for the [list_clusters()](https://github.com/aws/aws-parallelcluster/commit/8fc717a09ac88878ca5b65f64d389c404effe40d#diff-75778cd9f43e4ba38c589aa5189e7d8fae0b3e791095652cfb21453e9a03ea6eR249) API, we return only the first page of results in the `pcluster_api.py` implementation. The previous code unrolled the pagination and returned a list of results, talking with @demartinofra this was done because it was the smallest change that kept the tests passing, and the `pcluster_api.py` file is going to be removed anyway

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
