### PR TITLE
3.0: Execute integration tests using customer role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.xml
 assets/
 report.html
 tests_outputs/
+pytest.log

--- a/cli/src/pcluster/validators/s3_validators.py
+++ b/cli/src/pcluster/validators/s3_validators.py
@@ -58,7 +58,9 @@ class UrlValidator(Validator):
 
         except AWSClientError:
             # Todo: Check that bucket is in s3_read_resource or s3_read_write_resource.
-            self._add_failure(("The S3 object does not exist or you do not have access to it."), FailureLevel.ERROR)
+            self._add_failure(
+                (f"The S3 object '{url}' does not exist or you do not have access to it."), FailureLevel.ERROR
+            )
 
 
 class S3BucketUriValidator(Validator):

--- a/cli/tests/pcluster/models/test_imagebuilder.py
+++ b/cli/tests/pcluster/models/test_imagebuilder.py
@@ -114,7 +114,8 @@ def test_imagebuilder_kms_key_id_encrypted_validator_and_ami_volume_size_validat
             [
                 "The url 'file:///test/aws-parallelcluster-cookbook-3.0.tgz' causes URLError, the error reason is "
                 "'[Errno 2] No such file or directory: '/test/aws-parallelcluster-cookbook-3.0.tgz''",
-                "The S3 object does not exist or you do not have access to it.",
+                "The S3 object 's3://test/aws-parallelcluster-node-3.0.tgz' "
+                "does not exist or you do not have access to it.",
                 "The value 'ftp://test/aws-parallelcluster-batch-3.0.tgz' is not a valid URL, choose URL with "
                 "'https', 's3' or 'file' prefix.",
             ],

--- a/tests/integration-tests/permissions_template_builder.py
+++ b/tests/integration-tests/permissions_template_builder.py
@@ -1,0 +1,99 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+from awacs.aws import Allow, Condition, Policy, Principal, Statement, StringLike
+from awacs.sts import AssumeRole
+from troposphere import GetAtt, Output, Ref, Sub, Template
+from troposphere.iam import PolicyType as IAMPolicy
+from troposphere.iam import Role
+from utils import (
+    filename_without_extension,
+    get_resources,
+    list_files_in_path,
+    random_alphanumeric,
+    read_json_file,
+    snake_to_camel,
+)
+
+SCHEDULERS = ["awsbatch", "slurm"]
+POLICY_DOCUMENTS = {
+    scheduler: [file for file in list_files_in_path(get_resources("customer_roles", scheduler))]
+    for scheduler in SCHEDULERS
+}
+
+
+class PermissionsTemplateBuilder:
+    """Build troposphere CFN templates for IAM permissions resources."""
+
+    def __init__(self, description="Permissions built by PermissionsTemplateBuilder"):
+        self.__template = Template()
+        self.__template.set_version("2010-09-09")
+        self.__template.set_description(description)
+
+    def build(self):
+        """Build the template."""
+
+        for scheduler in SCHEDULERS:
+            self.__build_customer_role_for_scheduler(scheduler)
+
+        return self.__template
+
+    def __build_customer_role_for_scheduler(self, scheduler):
+        customer_role = self.__template.add_resource(get_customer_role_for_scheduler(scheduler))
+
+        for policy_document in POLICY_DOCUMENTS[scheduler]:
+            self.__template.add_resource(get_policy_from_document(policy_document, customer_role))
+
+        self.__template.add_output(
+            Output(
+                f"CustomerRole{scheduler.title()}",
+                Value=GetAtt(customer_role, "Arn"),
+                Description=f"The role used by the customer to manage a cluster with {scheduler}",
+            )
+        )
+
+
+def get_customer_role_for_scheduler(scheduler):
+    return Role(
+        f"CustomerRole{scheduler.title()}",
+        AssumeRolePolicyDocument=Policy(
+            Statement=[
+                Statement(
+                    Effect=Allow,
+                    Action=[AssumeRole],
+                    Principal=Principal("AWS", Sub("arn:aws:iam::${AWS::AccountId}:root")),
+                    Condition=Condition(
+                        StringLike(
+                            {
+                                "aws:PrincipalArn": [
+                                    Sub(
+                                        "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/"
+                                        "Jenkins-JenkinsInstanceRole-*"
+                                    )
+                                ],
+                            }
+                        )
+                    ),
+                ),
+            ]
+        ),
+    )
+
+
+def get_policy_from_document(policy_document, role):
+    policy_id = f"CustomerPolicy{snake_to_camel(filename_without_extension(policy_document))}"
+    return IAMPolicy(
+        policy_id,
+        PolicyName=f"{policy_id}{random_alphanumeric()}",
+        PolicyDocument=read_json_file(policy_document),
+        Roles=[Ref(role)],
+    )

--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -1,5 +1,6 @@
 argparse
 assertpy
+awacs
 aws-parallelcluster
 boto3
 cfn_flip

--- a/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_building.json
+++ b/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_building.json
@@ -1,0 +1,16 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "codebuild:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/parallelcluster-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/integ-tests-*" }
+      ],
+      "Sid": "CodeBuild"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_cloudformation.json
+++ b/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_cloudformation.json
@@ -1,0 +1,25 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResource",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:DescribeStacks",
+        "cloudformation:ListStacks",
+        "cloudformation:ListStackResources",
+        "cloudformation:GetTemplate",
+        "cloudformation:CreateStack",
+        "cloudformation:DeleteStack",
+        "cloudformation:UpdateStack"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/parallelcluster-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/integ-tests-*" }
+      ],
+      "Sid": "CloudFormation"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_communications.json
+++ b/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_communications.json
@@ -1,0 +1,44 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "sns:ListTopics",
+        "sns:GetTopicAttributes",
+        "sns:CreateTopic",
+        "sns:Subscribe",
+        "sns:Unsubscribe",
+        "sns:DeleteTopic"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "SNS"
+    },
+    {
+      "Action": [
+        "sqs:GetQueueAttributes",
+        "sqs:CreateQueue",
+        "sqs:SetQueueAttributes",
+        "sqs:DeleteQueue",
+        "sqs:TagQueue"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "SQS"
+    },
+    {
+      "Action": [
+        "sqs:SendMessage",
+        "sqs:ReceiveMessage",
+        "sqs:ChangeMessageVisibility",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueUrl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:parallelcluster-*" }
+      ],
+      "Sid": "SQSQueue"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_compute.json
+++ b/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_compute.json
@@ -1,0 +1,133 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "ec2:DescribeKeyPairs",
+        "ec2:DescribeRegions",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribePlacementGroups",
+        "ec2:DescribeImages",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeInstanceTypeOfferings",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeAddresses",
+        "ec2:CreateTags",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeAvailabilityZones"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "EC2Describe"
+    },
+    {
+      "Action": [
+        "ec2:CreateLaunchTemplate",
+        "ec2:CreateLaunchTemplateVersion",
+        "ec2:ModifyLaunchTemplate",
+        "ec2:DeleteLaunchTemplate",
+        "ec2:DescribeLaunchTemplates",
+        "ec2:DescribeLaunchTemplateVersions"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "EC2LaunchTemplate"
+    },
+    {
+      "Action": [
+        "ec2:CreateVpc",
+        "ec2:ModifyVpcAttribute",
+        "ec2:DescribeNatGateways",
+        "ec2:CreateNatGateway",
+        "ec2:DescribeInternetGateways",
+        "ec2:CreateInternetGateway",
+        "ec2:AttachInternetGateway",
+        "ec2:DescribeRouteTables",
+        "ec2:CreateRoute",
+        "ec2:CreateRouteTable",
+        "ec2:AssociateRouteTable",
+        "ec2:CreateSubnet",
+        "ec2:ModifySubnetAttribute"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "NetworkingEasyConfig"
+    },
+    {
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:RunInstances",
+        "ec2:AllocateAddress",
+        "ec2:AssociateAddress",
+        "ec2:AttachNetworkInterface",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateNetworkInterface",
+        "ec2:CreateSecurityGroup",
+        "ec2:ModifyVolumeAttribute",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DeleteVolume",
+        "ec2:TerminateInstances",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DisassociateAddress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:ReleaseAddress",
+        "ec2:CreatePlacementGroup",
+        "ec2:DeletePlacementGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "EC2Modify"
+    },
+    {
+      "Action": [
+        "batch:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "Batch"
+    },
+    {
+      "Action": [
+        "ecs:DescribeContainerInstances",
+        "ecs:ListContainerInstances"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "ECS"
+    },
+    {
+      "Action": [
+        "lambda:CreateFunction",
+        "lambda:DeleteFunction",
+        "lambda:GetFunction",
+        "lambda:GetFunctionConfiguration",
+        "lambda:InvokeFunction",
+        "lambda:AddPermission",
+        "lambda:RemovePermission"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:parallelcluster-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:pcluster-*" }
+      ],
+      "Sid": "Lambda"
+    },
+    {
+      "Action": [
+        "ecr:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "ECR"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_data.json
+++ b/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_data.json
@@ -1,0 +1,68 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:CreateTable",
+        "dynamodb:DeleteTable",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:Query",
+        "dynamodb:TagResource"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/parallelcluster-*" }
+      ],
+      "Sid": "DynamoDB"
+    },
+    {
+      "Action": [
+        "elasticfilesystem:CreateFileSystem",
+        "elasticfilesystem:CreateMountTarget",
+        "elasticfilesystem:DeleteFileSystem",
+        "elasticfilesystem:DeleteMountTarget",
+        "elasticfilesystem:DescribeFileSystems",
+        "elasticfilesystem:DescribeMountTargets"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "EFS"
+    },
+    {
+      "Action": [
+        "fsx:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "FSx"
+    },
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::aws-parallelcluster-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::aws-parallelcluster-*/*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::parallelcluster-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::parallelcluster-*/*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::integ-tests-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::integ-tests-*/*" }
+      ],
+      "Sid": "S3ResourcesBucket"
+    },
+    {
+      "Action": [
+        "s3:Get*",
+        "s3:List*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::${AWS::Region}-aws-parallelcluster/*" }
+      ],
+      "Sid": "S3ParallelClusterReadOnly"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_dns.json
+++ b/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_dns.json
@@ -1,0 +1,21 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "route53:ChangeResourceRecordSets",
+        "route53:ChangeTagsForResource",
+        "route53:CreateHostedZone",
+        "route53:DeleteHostedZone",
+        "route53:GetChange",
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:route53:::hostedzone/*" }
+      ],
+      "Sid": "Route53HostedZones"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_monitoring.json
+++ b/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_monitoring.json
@@ -1,0 +1,34 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "cloudwatch:PutDashboard",
+        "cloudwatch:ListDashboards",
+        "cloudwatch:DeleteDashboards",
+        "cloudwatch:GetDashboard"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "CloudWatch"
+    },
+    {
+      "Action": [
+        "logs:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*" }
+      ],
+      "Sid": "Logs"
+    },
+    {
+      "Action": [
+        "events:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "AmazonCloudWatchEvents"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_security.json
+++ b/tests/integration-tests/resources/customer_roles/awsbatch/user_awsbatch_policy_security.json
@@ -1,0 +1,51 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:PassRole",
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:TagRole",
+        "iam:SimulatePrincipalPolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*" }
+      ],
+      "Sid": "IAMRole"
+    },
+    {
+      "Action": [
+        "iam:CreateInstanceProfile",
+        "iam:DeleteInstanceProfile",
+        "iam:GetInstanceProfile",
+        "iam:PassRole"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*" }
+      ],
+      "Sid": "IAMInstanceProfile"
+    },
+    {
+      "Action": [
+        "iam:AddRoleToInstanceProfile",
+        "iam:RemoveRoleFromInstanceProfile",
+        "iam:GetRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:CreatePolicy",
+        "iam:DeletePolicy",
+        "iam:DeleteRolePolicy",
+        "iam:GetPolicy",
+        "iam:AttachRolePolicy",
+        "iam:DetachRolePolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "IAM"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_cloudformation.json
+++ b/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_cloudformation.json
@@ -1,0 +1,29 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "cloudformation:DescribeStackEvents",
+        "cloudformation:DescribeStackResource",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:DescribeStacks",
+        "cloudformation:ListStacks",
+        "cloudformation:ListStackResources",
+        "cloudformation:GetTemplate"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "CloudFormationDescribe"
+    },
+    {
+      "Action": [
+        "cloudformation:CreateStack",
+        "cloudformation:DeleteStack",
+        "cloudformation:UpdateStack"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "CloudFormationModify"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_communications.json
+++ b/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_communications.json
@@ -1,0 +1,44 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "sns:ListTopics",
+        "sns:GetTopicAttributes"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "SNSDescribe"
+    },
+    {
+      "Action": [
+        "sns:CreateTopic",
+        "sns:Subscribe",
+        "sns:Unsubscribe",
+        "sns:DeleteTopic"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "SNSModify"
+    },
+    {
+      "Action": [
+        "sqs:GetQueueAttributes"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "SQSDescribe"
+    },
+    {
+      "Action": [
+        "sqs:CreateQueue",
+        "sqs:SetQueueAttributes",
+        "sqs:DeleteQueue",
+        "sqs:TagQueue"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "SQSModify"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_compute.json
+++ b/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_compute.json
@@ -1,0 +1,126 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "ec2:DescribeKeyPairs",
+        "ec2:DescribeRegions",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribePlacementGroups",
+        "ec2:DescribeImages",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeInstanceTypeOfferings",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeAddresses",
+        "ec2:CreateTags",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeAvailabilityZones"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "EC2Describe"
+    },
+    {
+      "Action": [
+        "ec2:CreateVpc",
+        "ec2:ModifyVpcAttribute",
+        "ec2:DescribeNatGateways",
+        "ec2:CreateNatGateway",
+        "ec2:DescribeInternetGateways",
+        "ec2:CreateInternetGateway",
+        "ec2:AttachInternetGateway",
+        "ec2:DescribeRouteTables",
+        "ec2:CreateRoute",
+        "ec2:CreateRouteTable",
+        "ec2:AssociateRouteTable",
+        "ec2:CreateSubnet",
+        "ec2:ModifySubnetAttribute"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "NetworkingEasyConfig"
+    },
+    {
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:RunInstances",
+        "ec2:AllocateAddress",
+        "ec2:AssociateAddress",
+        "ec2:AttachNetworkInterface",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateNetworkInterface",
+        "ec2:CreateSecurityGroup",
+        "ec2:ModifyVolumeAttribute",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DeleteVolume",
+        "ec2:TerminateInstances",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DisassociateAddress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupEgress",
+        "ec2:ReleaseAddress",
+        "ec2:CreatePlacementGroup",
+        "ec2:DeletePlacementGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "EC2Modify"
+    },
+    {
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "AutoScalingDescribe"
+    },
+    {
+      "Action": [
+        "autoscaling:CreateAutoScalingGroup",
+        "ec2:CreateLaunchTemplate",
+        "ec2:CreateLaunchTemplateVersion",
+        "ec2:ModifyLaunchTemplate",
+        "ec2:DeleteLaunchTemplate",
+        "ec2:DescribeLaunchTemplates",
+        "ec2:DescribeLaunchTemplateVersions",
+        "autoscaling:PutNotificationConfiguration",
+        "autoscaling:UpdateAutoScalingGroup",
+        "autoscaling:PutScalingPolicy",
+        "autoscaling:DescribeScalingActivities",
+        "autoscaling:DeleteAutoScalingGroup",
+        "autoscaling:DeletePolicy",
+        "autoscaling:DisableMetricsCollection",
+        "autoscaling:EnableMetricsCollection"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "AutoScalingModify"
+    },
+    {
+      "Action": [
+        "lambda:CreateFunction",
+        "lambda:DeleteFunction",
+        "lambda:GetFunctionConfiguration",
+        "lambda:GetFunction",
+        "lambda:InvokeFunction",
+        "lambda:AddPermission",
+        "lambda:RemovePermission"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:parallelcluster-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:pcluster-*" }
+      ],
+      "Sid": "Lambda"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_data.json
+++ b/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_data.json
@@ -1,0 +1,91 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:ListTagsOfResource"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "DynamoDBDescribe"
+    },
+    {
+      "Action": [
+        "dynamodb:CreateTable",
+        "dynamodb:DeleteTable",
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
+        "dynamodb:Query",
+        "dynamodb:TagResource"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "DynamoDBModify"
+    },
+    {
+      "Action": [
+        "elasticfilesystem:DescribeMountTargets",
+        "elasticfilesystem:DescribeMountTargetSecurityGroups",
+        "ec2:DescribeNetworkInterfaceAttribute"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "EFSDescribe"
+    },
+    {
+      "Action": [
+        "elasticfilesystem:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "EFS"
+    },
+    {
+      "Action": [
+        "fsx:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "FSx"
+    },
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::aws-parallelcluster-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::aws-parallelcluster-*/*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::parallelcluster-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::parallelcluster-*/*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::integ-tests-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::integ-tests-*/*" }
+      ],
+      "Sid": "S3ResourcesBucket"
+    },
+    {
+      "Action": [
+        "s3:Get*",
+        "s3:List*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::${AWS::Region}-aws-parallelcluster/*" }
+      ],
+      "Sid": "S3ParallelClusterReadOnly"
+    },
+    {
+      "Action": [
+        "s3:DeleteBucket",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:s3:::parallelcluster-*" }
+      ],
+      "Sid": "S3Delete"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_dns.json
+++ b/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_dns.json
@@ -1,0 +1,20 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "route53:ChangeResourceRecordSets",
+        "route53:ChangeTagsForResource",
+        "route53:CreateHostedZone",
+        "route53:DeleteHostedZone",
+        "route53:GetChange",
+        "route53:GetHostedZone",
+        "route53:ListResourceRecordSets",
+        "route53:ListQueryLoggingConfigs"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "Route53HostedZones"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_monitoring.json
+++ b/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_monitoring.json
@@ -1,0 +1,32 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "cloudwatch:PutDashboard",
+        "cloudwatch:ListDashboards",
+        "cloudwatch:DeleteDashboards",
+        "cloudwatch:GetDashboard"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "CloudWatch"
+    },
+    {
+      "Action": [
+        "logs:DeleteLogGroup",
+        "logs:PutRetentionPolicy",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+        "logs:CreateLogGroup",
+        "logs:FilterLogEvents",
+        "logs:CreateExportTask",
+        "logs:GetLogEvents",
+        "logs:DescribeExportTasks"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "CloudWatchLogs"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_ops.json
+++ b/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_ops.json
@@ -1,0 +1,13 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "ssm:GetParametersByPath"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "SSMDescribe"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_security.json
+++ b/tests/integration-tests/resources/customer_roles/slurm/user_slurm_policy_security.json
@@ -1,0 +1,65 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "iam:PassRole",
+        "iam:CreateRole",
+        "iam:CreateServiceLinkedRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:TagRole",
+        "iam:SimulatePrincipalPolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster-*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/*" },
+        { "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*" }
+      ],
+      "Sid": "IAMModify"
+    },
+    {
+      "Action": [
+        "iam:CreateInstanceProfile",
+        "iam:DeleteInstanceProfile"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        { "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*" }
+      ],
+      "Sid": "IAMCreateInstanceProfile"
+    },
+    {
+      "Action": [
+        "iam:AddRoleToInstanceProfile",
+        "iam:RemoveRoleFromInstanceProfile",
+        "iam:GetRolePolicy",
+        "iam:CreatePolicy",
+        "iam:DeletePolicy",
+        "iam:GetPolicy",
+        "iam:AttachRolePolicy",
+        "iam:DetachRolePolicy",
+        "iam:PutRolePolicy",
+        "iam:DeleteRolePolicy"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "IAMInstanceProfile"
+    },
+    {
+      "Action": [
+        "kms:CreateAlias",
+        "kms:CreateKey",
+        "kms:DeleteKey",
+        "kms:ListAliases",
+        "kms:PutKeyPolicy",
+        "kms:ScheduleKeyDeletion",
+        "kms:DescribeKey"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Sid": "KMS"
+    }
+  ],
+  "Version": "2012-10-17"
+}


### PR DESCRIPTION
### Changes
1. Add fixture to configure aws credentials to be used when executing tests, according to the region and the specified scheduler.
2. Add assumed role arn into a log line within utility function that sets credentials. Since we are going to switch credentials more often, it is useful to specify not only the region where we are setting credentials, but also the assumed role.
3. Add S3 URL within the S3 validation error log line in order to better specify what went wrong
4. Add to gitignore: pytest.log

### Testing
1. Integration tests (ongoing)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
