### PR TITLE
3.0:  Change ListImages Smithy and OpenAPI model

### DIFF
--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -1587,8 +1587,6 @@ components:
           type: string
           description: ParallelCluster version used to build the image
       required:
-        - cloudformationStackArn
-        - cloudformationStackStatus
         - imageBuildStatus
         - imageId
         - region

--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -726,12 +726,6 @@ paths:
           schema:
             type: string
             description: List Images built into a given AWS Region. Defaults to the AWS region the API is deployed to.
-        - name: nextToken
-          in: query
-          description: Token to use for paginated requests.
-          schema:
-            type: string
-            description: Token to use for paginated requests.
         - name: imageStatus
           in: query
           description: Filter by image status.
@@ -1635,9 +1629,6 @@ components:
     ListImagesResponseContent:
       type: object
       properties:
-        nextToken:
-          type: string
-          description: Token to use for paginated requests.
         items:
           type: array
           items:

--- a/api/spec/smithy/model/operations/ListImages.smithy
+++ b/api/spec/smithy/model/operations/ListImages.smithy
@@ -1,6 +1,13 @@
 namespace parallelcluster
 
-@paginated
+@suppress(["MissingPaginatedTrait"])
+// FIXME We unroll the describe_stacks pagination due to potential inconsistency in the transition (i.e. when the stack has
+// produced an image is becomes DELETE_IN_PROGRESS we could have it both in the describe_images and describe_stacks, and
+// depending on how we chose to handle the issue we could either return the same image twice in different pages, or ignore
+// the describe stack data and risk never returning the data for the image, in case it was not present in the first page
+// describe_images ImageInfoSummaries -the results of the describe_images vary across calls, and we cannot return them
+// multiple times, or we would have repetitions in different pages-)
+//@paginated
 @readonly
 @http(method: "GET", uri: "/v3/images/custom", code: 200)
 @tags(["Image Operations"])
@@ -20,15 +27,15 @@ structure ListImagesRequest {
     @httpQuery("region")
     @documentation("List Images built into a given AWS Region. Defaults to the AWS region the API is deployed to.")
     region: Region,
-    @httpQuery("nextToken")
-    nextToken: PaginationToken,
+    //@httpQuery("nextToken")
+    //nextToken: PaginationToken,
     @httpQuery("imageStatus")
     @documentation("Filter by image status.")
     imageStatus: ImageStatusFilteringOptions,
 }
 
 structure ListImagesResponse {
-    nextToken: PaginationToken,
+    //nextToken: PaginationToken,
 
     @required
     items: ImageInfoSummaries,

--- a/api/spec/smithy/model/types/Image.smithy
+++ b/api/spec/smithy/model/types/Image.smithy
@@ -33,13 +33,11 @@ structure ImageInfoSummary {
     @required
     @documentation("ParallelCluster version used to build the image")
     version: Version,
-    @required
     @documentation("ARN of the main CloudFormation stack")
     cloudformationStackArn: String,
     @required
     @documentation("Status of the image build.")
     imageBuildStatus: ImageBuildStatus,
-    @required
     @documentation("Status of the CloudFormation stack for the image build process.")
     cloudformationStackStatus: CloudFormationStatus,
 }


### PR DESCRIPTION
For `ListImages` we chose to unroll the describe_stacks call in order to avoid consistency issue with stacks that might complete the build and produce an available image (which would be picked up by the EC2 `describe_images` call), or might be deleted and appear in `DELETION_IN_PROGRESS` state before disappearing, etc.

In order to support this change, we remove the pagination from the Smithy model (note that we had to suppress the `MissingPaginatedTrait` validator since List* APIs require the `@paginated` trait).

Additionally, we delete the stack used to create an image as soon as we are notified that it is available, before the stack goes in `CREATE_COMPLETED`. Therefore, we don't have the stack of available images, and the stack ARN and CloudFormation status are not returned for images in `BUILD_COMPLETE` state.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
