### PR TITLE
3.0: Add changes  to the ListImages OpenAPI spec, models and controllers

### DIFF
--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -148,14 +148,12 @@ def describe_official_images(version=None, region=None, os=None, architecture=No
 
 
 @configure_aws_region()
-def list_images(region=None, next_token=None, image_status=None):
+def list_images(region=None, image_status=None):
     """
     Retrieve the list of existing custom images managed by the API. Deleted images are not showed by default.
 
     :param region: List Images built into a given AWS Region. Defaults to the AWS region the API is deployed to.
     :type region: str
-    :param next_token: Token to use for paginated requests.
-    :type next_token: str
     :param image_status: Filter by image status.
     :type image_status: list | bytes
 

--- a/cli/src/pcluster/api/models/image_info_summary.py
+++ b/cli/src/pcluster/api/models/image_info_summary.py
@@ -157,9 +157,6 @@ class ImageInfoSummary(Model):
         :param cloudformation_stack_status: The cloudformation_stack_status of this ImageInfoSummary.
         :type cloudformation_stack_status: CloudFormationStatus
         """
-        if cloudformation_stack_status is None:
-            raise ValueError("Invalid value for `cloudformation_stack_status`, must not be `None`")
-
         self._cloudformation_stack_status = cloudformation_stack_status
 
     @property
@@ -182,9 +179,6 @@ class ImageInfoSummary(Model):
         :param cloudformation_stack_arn: The cloudformation_stack_arn of this ImageInfoSummary.
         :type cloudformation_stack_arn: str
         """
-        if cloudformation_stack_arn is None:
-            raise ValueError("Invalid value for `cloudformation_stack_arn`, must not be `None`")
-
         self._cloudformation_stack_arn = cloudformation_stack_arn
 
     @property

--- a/cli/src/pcluster/api/models/list_images_response_content.py
+++ b/cli/src/pcluster/api/models/list_images_response_content.py
@@ -25,16 +25,13 @@ class ListImagesResponseContent(Model):
     def __init__(self, next_token=None, items=None):
         """ListImagesResponseContent - a model defined in OpenAPI
 
-        :param next_token: The next_token of this ListImagesResponseContent.
-        :type next_token: str
         :param items: The items of this ListImagesResponseContent.
         :type items: List[ImageInfoSummary]
         """
-        self.openapi_types = {"next_token": str, "items": List[ImageInfoSummary]}
+        self.openapi_types = {"items": List[ImageInfoSummary]}
 
-        self.attribute_map = {"next_token": "nextToken", "items": "items"}
+        self.attribute_map = {"items": "items"}
 
-        self._next_token = next_token
         self._items = items
 
     @classmethod
@@ -47,29 +44,6 @@ class ListImagesResponseContent(Model):
         :rtype: ListImagesResponseContent
         """
         return util.deserialize_model(dikt, cls)
-
-    @property
-    def next_token(self):
-        """Gets the next_token of this ListImagesResponseContent.
-
-        Token to use for paginated requests.
-
-        :return: The next_token of this ListImagesResponseContent.
-        :rtype: str
-        """
-        return self._next_token
-
-    @next_token.setter
-    def next_token(self, next_token):
-        """Sets the next_token of this ListImagesResponseContent.
-
-        Token to use for paginated requests.
-
-        :param next_token: The next_token of this ListImagesResponseContent.
-        :type next_token: str
-        """
-
-        self._next_token = next_token
 
     @property
     def items(self):

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -857,15 +857,6 @@ paths:
             AWS region the API is deployed to.
           type: string
         style: form
-      - description: Token to use for paginated requests.
-        explode: true
-        in: query
-        name: nextToken
-        required: false
-        schema:
-          description: Token to use for paginated requests.
-          type: string
-        style: form
       - description: Filter by image status.
         explode: true
         in: query
@@ -2066,8 +2057,6 @@ components:
           title: version
           type: string
       required:
-      - cloudformationStackArn
-      - cloudformationStackStatus
       - imageBuildStatus
       - imageId
       - region
@@ -2142,7 +2131,6 @@ components:
       type: object
     ListImagesResponseContent:
       example:
-        nextToken: nextToken
         items:
         - imageId: imageId
           imageBuildStatus: null
@@ -2157,10 +2145,6 @@ components:
           region: region
           version: version
       properties:
-        nextToken:
-          description: Token to use for paginated requests.
-          title: nextToken
-          type: string
         items:
           items:
             $ref: '#/components/schemas/ImageInfoSummary'

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -91,7 +91,6 @@ class TestImageOperationsController:
         """Test case for list_images."""
         query_string = [
             ("region", "eu-west-1"),
-            ("nextToken", "next_token_example"),
             ("imageStatus", ImageBuildStatus.BUILD_FAILED),
             ("imageStatus", ImageBuildStatus.BUILD_COMPLETE),
         ]


### PR DESCRIPTION
This patch adds the changes to the OpenAPI spec, models and controllers from the changes to the Smithy model in PR: https://github.com/aws/aws-parallelcluster/pull/2797

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
