### PR TITLE
Add support for FSx DataCompressionType option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 - Add support for Ubuntu 20.04.
 - Add support for using FSx Lustre in subnet with no internet access.
 - Add support for Centos 7 ARM.
+- Add support for FSx Lustre DataCompressionType feature.
 - Add validation to prevent using a `cluster_resource_bucket` that is in a different region than the cluster.
 - Transition from IMDSv1 to IMDSv2.
 - Implement scaling protection mechanism with Slurm scheduler: compute fleet is automatically set to 'PROTECTED' state 

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -173,7 +173,8 @@ ALLOWED_VALUES = {
     "architectures": SUPPORTED_ARCHITECTURES,
     "fsx_auto_import_policy": ["NEW", "NEW_CHANGED"],
     "fsx_storage_type": ["SSD", "HDD"],
-    "fsx_drive_cache_type": ["READ"]
+    "fsx_drive_cache_type": ["READ"],
+    "fsx_data_compression_type": ["LZ4"]
 }
 
 AWS = {
@@ -589,6 +590,11 @@ FSX = {
                 "default": "NONE",
                 "update_policy": UpdatePolicy.IGNORED,
                 "visibility": Visibility.PRIVATE,
+            }),
+            ("data_compression_type", {
+                "default": "NONE",
+                "allowed_values": ALLOWED_VALUES["fsx_data_compression_type"],
+                "update_policy": UpdatePolicy.SUPPORTED
             }),
         ]
     )

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -92,7 +92,7 @@ FSX_SUPPORTED_ARCHITECTURES_OSES = {
     "arm64": SUPPORTED_OSS,
 }
 
-FSX_PARAM_WITH_DEFAULT = {"drive_cache_type": "NONE"}
+FSX_PARAM_WITH_DEFAULT = {"drive_cache_type": "NONE", "data_compression_type": "NONE"}
 
 EFA_UNSUPPORTED_ARCHITECTURES_OSES = {
     "x86_64": [],

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -89,6 +89,7 @@ DEFAULT_FSX_DICT = {
     "drive_cache_type": "NONE",
     "existing_mount_name": "NONE",
     "existing_dns_name": "NONE",
+    "data_compression_type": "NONE",
 }
 
 DEFAULT_DCV_DICT = {"enable": None, "port": 8443, "access_from": "0.0.0.0/0"}
@@ -271,7 +272,7 @@ DEFAULT_EFS_CFN_PARAMS = {"EFSOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE
 
 DEFAULT_RAID_CFN_PARAMS = {"RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"}
 
-DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "{}".format(",".join(["NONE"] * 19))}
+DEFAULT_FSX_CFN_PARAMS = {"FSXOptions": "{}".format(",".join(["NONE"] * 20))}
 
 DEFAULT_DCV_CFN_PARAMS = {"DCVOptions": "NONE,NONE,NONE"}
 DEFAULT_CW_LOG_CFN_PARAMS = {"CWLogOptions": "true,14"}
@@ -342,7 +343,7 @@ DEFAULT_CLUSTER_SIT_CFN_PARAMS = {
     # raid
     "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # fsx
-    "FSXOptions": "{}".format(",".join(["NONE"] * 19)),
+    "FSXOptions": "{}".format(",".join(["NONE"] * 20)),
     # dcv
     "DCVOptions": "NONE,NONE,NONE",
     # cw_log_settings
@@ -414,7 +415,7 @@ DEFAULT_CLUSTER_HIT_CFN_PARAMS = {
     # raid
     "RAIDOptions": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     # fsx
-    "FSXOptions": "{}".format(",".join(["NONE"] * 19)),
+    "FSXOptions": "{}".format(",".join(["NONE"] * 20)),
     # dcv
     "DCVOptions": "NONE,NONE,NONE",
     # cw_log_settings

--- a/cli/tests/pcluster/config/test_section_cluster.py
+++ b/cli/tests/pcluster/config/test_section_cluster.py
@@ -1153,8 +1153,7 @@ def test_cluster_section_to_cfn(
                     # raid
                     "RAIDOptions": "raid,NONE,2,gp2,20,NONE,false,NONE,125",
                     # fsx
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,"
-                    "NONE,NONE,NONE,NONE",
+                    "FSXOptions": "fsx,{}".format(",".join(["NONE"] * 19)),
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                     "Scheduler": "sge",
@@ -1219,8 +1218,7 @@ def test_cluster_section_to_cfn(
                     # raid
                     "RAIDOptions": "raid,NONE,2,gp2,20,NONE,false,NONE,125",
                     # fsx
-                    "FSXOptions": "fsx,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,"
-                    "NONE,NONE,NONE,NONE",
+                    "FSXOptions": "fsx,{}".format(",".join(["NONE"] * 19)),
                     # dcv
                     "DCVOptions": "master,8555,10.0.0.0/0",
                 },

--- a/cli/tests/pcluster/config/test_section_fsx/test_fsx_from_file_to_cfn/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_section_fsx/test_fsx_from_file_to_cfn/pcluster.config.ini
@@ -41,6 +41,7 @@ automatic_backup_retention_days = 5
 copy_tags_to_backups = false
 storage_type = HDD
 drive_cache_type = READ
+data_compression_type = LZ4
 
 
 [fsx test4]
@@ -110,3 +111,4 @@ daily_automatic_backup_start_time = 01:00
 automatic_backup_retention_days = 5
 copy_tags_to_backups = false
 storage_type = SSD
+data_compression_type = NONE

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -336,9 +336,9 @@
       "Default": "1"
     },
     "FSXOptions": {
-      "Description": "Comma separated list of FSx related options, 19 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id,auto_import_policy,storage_type,drive_cache_type,existing_mount_name,existing_dns_name]",
+      "Description": "Comma separated list of FSx related options, 20 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id,auto_import_policy,storage_type,drive_cache_type,existing_mount_name,existing_dns_name,data_compression_type]",
       "Type": "String",
-      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
+      "Default": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE"
     },
     "EFSOptions": {
       "Description": "Comma separated list of EFS related options, 9 parameters in total, [shared_dir,efs_fs_id,performance_mode,efs_kms_key_id,provisioned_throughput,encrypted,throughput_mode,exists_valid_head_node_mt,exists_valid_compute_mt]",

--- a/cloudformation/fsx-substack.cfn.json
+++ b/cloudformation/fsx-substack.cfn.json
@@ -285,6 +285,23 @@
         "HDD"
       ]
     },
+    "UseDataCompression": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Select": [
+                "19",
+                {
+                  "Ref": "FSXOptions"
+                }
+              ]
+            },
+            "NONE"
+          ]
+        }
+      ]
+    },
     "UseDNSName": {
       "Fn::Not": [
         {
@@ -373,7 +390,7 @@
       "Type": "String"
     },
     "FSXOptions": {
-      "Description": "Comma separated list of fsx related options, 19 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id,auto_import_policy,storage_type,drive_cache_type,existing_mount_name,existing_dns_name]",
+      "Description": "Comma separated list of fsx related options, 20 parameters in total, [shared_dir,fsx_fs_id,storage_capacity,fsx_kms_key_id,imported_file_chunk_size,export_path,import_path,weekly_maintenance_start_time,deployment_type,per_unit_storage_throughput,daily_automatic_backup_start_time,automatic_backup_retention_days,copy_tags_to_backups,fsx_backup_id,auto_import_policy,storage_type,drive_cache_type,existing_mount_name,existing_dns_name,data_compression_type]",
       "Type": "CommaDelimitedList"
     },
     "SubnetId": {
@@ -594,6 +611,22 @@
               {
                 "Fn::Select": [
                   "16",
+                  {
+                    "Ref": "FSXOptions"
+                  }
+                ]
+              },
+              {
+                "Ref": "AWS::NoValue"
+              }
+            ]
+          },
+          "DataCompressionType": {
+            "Fn::If": [
+              "UseDataCompression",
+              {
+                "Fn::Select": [
+                  "19",
                   {
                     "Ref": "FSXOptions"
                   }

--- a/cloudformation/fsx-substack.cfn.json
+++ b/cloudformation/fsx-substack.cfn.json
@@ -285,23 +285,6 @@
         "HDD"
       ]
     },
-    "UseDataCompression": {
-      "Fn::Not": [
-        {
-          "Fn::Equals": [
-            {
-              "Fn::Select": [
-                "19",
-                {
-                  "Ref": "FSXOptions"
-                }
-              ]
-            },
-            "NONE"
-          ]
-        }
-      ]
-    },
     "UseDNSName": {
       "Fn::Not": [
         {
@@ -622,18 +605,10 @@
             ]
           },
           "DataCompressionType": {
-            "Fn::If": [
-              "UseDataCompression",
+            "Fn::Select": [
+              "19",
               {
-                "Fn::Select": [
-                  "19",
-                  {
-                    "Ref": "FSXOptions"
-                  }
-                ]
-              },
-              {
-                "Ref": "AWS::NoValue"
+                "Ref": "FSXOptions"
               }
             ]
           }

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.ini
@@ -47,3 +47,6 @@ drive_cache_type = {{ drive_cache_type }}
 {% if storage_type %}
 storage_type = {{ storage_type }}
 {% endif %}
+{% if data_compression_type %}
+data_compression_type = {{ data_compression_type }}
+{% endif %}


### PR DESCRIPTION
* Add support for new DataCompressionType Lustre configuration option.
* Add new `data_compression_type` parameter in `fsx` section. Supported value is `LZ4`. Default is not specified and not enabled. To disable the feature, do not specify the parameter.
* Add new unit test and integration tests for the feature

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
