### PR TITLE
3.0: Implement DeleteImage API

### DIFF
--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -34,13 +34,15 @@ from pcluster.api.models.delete_image_response_content import DeleteImageRespons
 from pcluster.api.models.image_build_status import ImageBuildStatus
 from pcluster.models.imagebuilder import (
     BadRequestImageBuilderActionError,
+    BadRequestImageError,
     ImageBuilder,
     LimitExceededImageBuilderActionError,
     LimitExceededImageError,
     NonExistingImageError,
 )
 
-from ...models.imagebuilder_resources import LimitExceededStackError, NonExistingStackError
+from ...aws.common import BadRequestError, LimitExceededError
+from ...models.imagebuilder_resources import BadRequestStackError, LimitExceededStackError, NonExistingStackError
 
 
 def convert_imagebuilder_errors():
@@ -51,9 +53,19 @@ def convert_imagebuilder_errors():
                 return func(*args, **kwargs)
             except ParallelClusterApiException as e:
                 error = e
-            except (LimitExceededImageError, LimitExceededStackError, LimitExceededImageBuilderActionError) as e:
+            except (
+                LimitExceededError,
+                LimitExceededImageError,
+                LimitExceededStackError,
+                LimitExceededImageBuilderActionError,
+            ) as e:
                 error = LimitExceededException(str(e))
-            except BadRequestImageBuilderActionError as e:
+            except (
+                BadRequestError,
+                BadRequestImageError,
+                BadRequestStackError,
+                BadRequestImageBuilderActionError,
+            ) as e:
                 error = BadRequestException(str(e))
             except Exception as e:
                 error = InternalServiceException(str(e))

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -7,10 +7,12 @@
 # limitations under the License.
 
 # pylint: disable=W0613
-
+import os as os_lib
 from datetime import datetime
 
 from pcluster.api.controllers.common import configure_aws_region
+from pcluster.api.converters import cloud_formation_status_to_image_status
+from pcluster.api.errors import BadRequestException, NotFoundException
 from pcluster.api.models import (
     BuildImageRequestContent,
     BuildImageResponseContent,
@@ -24,6 +26,8 @@ from pcluster.api.models import (
 )
 from pcluster.api.models.delete_image_response_content import DeleteImageResponseContent
 from pcluster.api.models.image_build_status import ImageBuildStatus
+from pcluster.models.imagebuilder import ImageBuilder, NonExistingImageError
+from pcluster.models.imagebuilder_resources import NonExistingStackError
 
 
 @configure_aws_region(is_query_string_arg=False)
@@ -87,16 +91,51 @@ def delete_image(image_id, region=None, client_token=None, force=None):
 
     :rtype: DeleteImageResponseContent
     """
+    if client_token:
+        raise BadRequestException("clientToken is currently not supported for this operation")
+
+    force = force or False
+    imagebuilder = ImageBuilder(image_id=image_id)
+    image, stack = _get_underlying_image_or_stack(imagebuilder)
+
+    imagebuilder.delete(force=force)
+
+    if stack:
+        cloud_formation_status_after_deletion = _get_cloud_formation_status_after_deletion(stack.name)
+        image_build_status_after_deletion = cloud_formation_status_to_image_status(
+            cloud_formation_status_after_deletion
+        )
+
     return DeleteImageResponseContent(
         image=ImageInfoSummary(
-            image_id="image",
-            image_build_status=ImageBuildStatus.BUILD_FAILED,
-            cloudformation_stack_status=CloudFormationStatus.CREATE_COMPLETE,
-            cloudformation_stack_arn="arn",
-            region="region",
-            version="3.0.0",
+            image_id=image_id,
+            image_build_status=image_build_status_after_deletion if stack else ImageBuildStatus.DELETE_COMPLETE,
+            cloudformation_stack_status=cloud_formation_status_after_deletion if stack else None,
+            cloudformation_stack_arn=stack.id if stack else None,
+            region=os_lib.environ.get("AWS_DEFAULT_REGION"),
+            version=stack.version if stack else image.version,
         )
     )
+
+
+def _get_underlying_image_or_stack(imagebuilder):
+    image = None
+    stack = None
+    try:
+        image = imagebuilder.image
+    except NonExistingImageError:
+        try:
+            stack = imagebuilder.stack
+        except NonExistingStackError:
+            raise NotFoundException("Unable to find an image of stack with id: {}".format(imagebuilder.image_id))
+    return image, stack
+
+
+def _get_cloud_formation_status_after_deletion(stack_name):
+    try:
+        return ImageBuilder(image_id=stack_name).stack.status
+    except NonExistingStackError:
+        return CloudFormationStatus.DELETE_COMPLETE
 
 
 @configure_aws_region()

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -32,6 +32,7 @@ from pcluster.api.models import (
 )
 from pcluster.api.models.delete_image_response_content import DeleteImageResponseContent
 from pcluster.api.models.image_build_status import ImageBuildStatus
+from pcluster.aws.common import BadRequestError, LimitExceededError
 from pcluster.models.imagebuilder import (
     BadRequestImageBuilderActionError,
     BadRequestImageError,
@@ -40,9 +41,7 @@ from pcluster.models.imagebuilder import (
     LimitExceededImageError,
     NonExistingImageError,
 )
-
-from ...aws.common import BadRequestError, LimitExceededError
-from ...models.imagebuilder_resources import BadRequestStackError, LimitExceededStackError, NonExistingStackError
+from pcluster.models.imagebuilder_resources import BadRequestStackError, LimitExceededStackError, NonExistingStackError
 
 
 def convert_imagebuilder_errors():

--- a/cli/src/pcluster/api/converters.py
+++ b/cli/src/pcluster/api/converters.py
@@ -5,7 +5,7 @@
 #  or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 #  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 #  limitations under the License.
-from pcluster.api.models import CloudFormationStatus, ClusterStatus
+from pcluster.api.models import CloudFormationStatus, ClusterStatus, ImageBuildStatus
 
 
 def cloud_formation_status_to_cluster_status(cfn_status):
@@ -18,5 +18,27 @@ def cloud_formation_status_to_cluster_status(cfn_status):
         CloudFormationStatus.UPDATE_ROLLBACK_FAILED: ClusterStatus.UPDATE_FAILED,
         CloudFormationStatus.UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS: ClusterStatus.UPDATE_IN_PROGRESS,
         CloudFormationStatus.UPDATE_ROLLBACK_COMPLETE: ClusterStatus.UPDATE_FAILED,
+    }
+    return mapping.get(cfn_status, cfn_status)
+
+
+def cloud_formation_status_to_image_status(cfn_status):
+    mapping = {
+        CloudFormationStatus.CREATE_IN_PROGRESS: ImageBuildStatus.BUILD_IN_PROGRESS,
+        CloudFormationStatus.CREATE_FAILED: ImageBuildStatus.BUILD_FAILED,
+        CloudFormationStatus.CREATE_COMPLETE: ImageBuildStatus.BUILD_COMPLETE,
+        CloudFormationStatus.ROLLBACK_IN_PROGRESS: ImageBuildStatus.BUILD_IN_PROGRESS,
+        CloudFormationStatus.ROLLBACK_FAILED: ImageBuildStatus.BUILD_FAILED,
+        CloudFormationStatus.ROLLBACK_COMPLETE: ImageBuildStatus.BUILD_FAILED,
+        CloudFormationStatus.DELETE_IN_PROGRESS: ImageBuildStatus.DELETE_IN_PROGRESS,
+        CloudFormationStatus.DELETE_FAILED: ImageBuildStatus.DELETE_FAILED,
+        CloudFormationStatus.DELETE_COMPLETE: ImageBuildStatus.DELETE_COMPLETE,
+        CloudFormationStatus.UPDATE_IN_PROGRESS: ImageBuildStatus.BUILD_IN_PROGRESS,
+        CloudFormationStatus.UPDATE_COMPLETE_CLEANUP_IN_PROGRESS: ImageBuildStatus.BUILD_IN_PROGRESS,
+        CloudFormationStatus.UPDATE_COMPLETE: ImageBuildStatus.BUILD_COMPLETE,
+        CloudFormationStatus.UPDATE_ROLLBACK_IN_PROGRESS: ImageBuildStatus.BUILD_IN_PROGRESS,
+        CloudFormationStatus.UPDATE_ROLLBACK_FAILED: ImageBuildStatus.BUILD_FAILED,
+        CloudFormationStatus.UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS: ImageBuildStatus.BUILD_IN_PROGRESS,
+        CloudFormationStatus.UPDATE_ROLLBACK_COMPLETE: ImageBuildStatus.BUILD_FAILED,
     }
     return mapping.get(cfn_status, cfn_status)

--- a/cli/src/pcluster/aws/common.py
+++ b/cli/src/pcluster/aws/common.py
@@ -65,6 +65,13 @@ class LimitExceededError(AWSClientError):
         super().__init__(function_name=function_name, message=message, error_code=error_code)
 
 
+class BadRequestError(AWSClientError):
+    """Error caused by a problem in the request."""
+
+    def __init__(self, function_name: str, message: str, error_code: str = None):
+        super().__init__(function_name=function_name, message=message, error_code=error_code)
+
+
 class AWSExceptionHandler:
     """AWS Exception handler."""
 
@@ -77,7 +84,7 @@ class AWSExceptionHandler:
             try:
                 return func(*args, **kwargs)
             except ParamValidationError as validation_error:
-                error = AWSClientError(
+                error = BadRequestError(
                     func.__name__,
                     "Error validating parameter. Failed with exception: {0}".format(str(validation_error)),
                 )

--- a/cli/src/pcluster/models/imagebuilder_resources.py
+++ b/cli/src/pcluster/models/imagebuilder_resources.py
@@ -46,6 +46,13 @@ class LimitExceededStackError(StackError):
         super().__init__(message=message)
 
 
+class BadRequestStackError(StackError):
+    """Represent an error due to a problem in the request."""
+
+    def __init__(self, message: str):
+        super().__init__(message=message)
+
+
 class ImageBuilderStack(StackInfo):
     """Class representing a running stack associated to a building image."""
 

--- a/cli/src/pcluster/models/imagebuilder_resources.py
+++ b/cli/src/pcluster/models/imagebuilder_resources.py
@@ -39,6 +39,13 @@ class NonExistingStackError(StackError):
         super().__init__(f"ImageBuilder stack {stack_name} does not exist.")
 
 
+class LimitExceededStackError(StackError):
+    """Represent an error if we exceeded the limit of some downstream AWS service."""
+
+    def __init__(self, message: str):
+        super().__init__(message=message)
+
+
 class ImageBuilderStack(StackInfo):
     """Class representing a running stack associated to a building image."""
 

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -170,7 +170,7 @@ class TestDeleteImage:
         expected_response = {
             "image": {
                 "imageId": "image1",
-                "imageBuildStatus": ImageBuildStatus.DELETE_COMPLETE,
+                "imageBuildStatus": ImageBuildStatus.DELETE_IN_PROGRESS,
                 "region": "us-east-1",
                 "version": "3.0.0",
             }
@@ -182,7 +182,7 @@ class TestDeleteImage:
         expected_response = {
             "image": {
                 "imageId": "image1",
-                "imageBuildStatus": ImageBuildStatus.DELETE_COMPLETE,
+                "imageBuildStatus": ImageBuildStatus.DELETE_IN_PROGRESS,
                 "region": "us-east-1",
                 "version": "3.0.0",
             }
@@ -211,10 +211,10 @@ class TestDeleteImage:
         expected_response = {
             "image": {
                 "imageId": "image1",
-                "imageBuildStatus": ImageBuildStatus.DELETE_COMPLETE,
+                "imageBuildStatus": ImageBuildStatus.DELETE_IN_PROGRESS,
                 "region": "us-east-1",
                 "version": "3.0.0",
-                "cloudformationStackStatus": CloudFormationStatus.DELETE_COMPLETE,
+                "cloudformationStackStatus": CloudFormationStatus.DELETE_IN_PROGRESS,
                 "cloudformationStackArn": "arn:image1",
             }
         }

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -7,10 +7,15 @@
 #  limitations under the License.
 import json
 
-from assertpy import assert_that
+import pytest
+from assertpy import assert_that, soft_assertions
 
+from pcluster.api.models import CloudFormationStatus
 from pcluster.api.models.image_build_status import ImageBuildStatus
 from pcluster.api.models.validation_level import ValidationLevel
+from pcluster.aws.aws_resources import ImageInfo
+from pcluster.aws.common import ImageNotFoundError, StackNotFoundError
+from pcluster.models.imagebuilder import ImageBuilderActionError
 
 
 class TestImageOperationsController:
@@ -40,20 +45,6 @@ class TestImageOperationsController:
             headers=headers,
             data=json.dumps(build_image_request_content),
             content_type="application/json",
-            query_string=query_string,
-        )
-        assert_that(response.status_code).is_equal_to(200)
-
-    def test_delete_image(self, client):
-        """Test case for delete_image."""
-        query_string = [("region", "eu-west-1"), ("clientToken", "client_token_example"), ("force", True)]
-        headers = {
-            "Accept": "application/json",
-        }
-        response = client.open(
-            "/v3/images/custom/{image_id}".format(image_id="imageid"),
-            method="DELETE",
-            headers=headers,
             query_string=query_string,
         )
         assert_that(response.status_code).is_equal_to(200)
@@ -99,3 +90,190 @@ class TestImageOperationsController:
         }
         response = client.open("/v3/images/custom", method="GET", headers=headers, query_string=query_string)
         assert_that(response.status_code).is_equal_to(200)
+
+
+class TestDeleteImage:
+    url = "/v3/images/custom/{image_name}"
+    method = "DELETE"
+
+    def _send_test_request(self, client, image_name, region="us-east-1", force=True):
+        query_string = [
+            ("force", force),
+            ("region", region),
+        ]
+        headers = {
+            "Accept": "application/json",
+        }
+        return client.open(
+            self.url.format(image_name=image_name), method=self.method, headers=headers, query_string=query_string
+        )
+
+    def _create_image_info(self, image_id):
+        return ImageInfo(
+            {
+                "Tags": [
+                    {"Key": "parallelcluster:image_id", "Value": image_id},
+                    {"Key": "parallelcluster:version", "Value": "3.0.0"},
+                ],
+            }
+        )
+
+    def _create_stack(self, image_id, status):
+        return {
+            "StackId": "arn:{}".format(image_id),
+            "StackStatus": status,
+            "Tags": [
+                {"Key": "parallelcluster:image_id", "Value": image_id},
+                {"Key": "parallelcluster:version", "Value": "3.0.0"},
+            ],
+        }
+
+    def _assert_successful(
+        self, mocker, client, image_id, force, region, image, stack, expected_response, stack_after_deletion=None
+    ):
+        if image:
+            mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", return_value=image)
+        else:
+            mocker.patch(
+                "pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
+                side_effect=ImageNotFoundError("describe_image_by_id_tag"),
+            )
+
+        if stack:
+            if stack_after_deletion:
+                mocker.patch("pcluster.aws.cfn.CfnClient.describe_stack", side_effect=[stack, stack_after_deletion])
+            else:
+                mocker.patch(
+                    "pcluster.aws.cfn.CfnClient.describe_stack",
+                    side_effect=[stack, StackNotFoundError("describe_stack", "stack_name")],
+                )
+        else:
+            mocker.patch(
+                "pcluster.aws.cfn.CfnClient.describe_stack",
+                side_effect=StackNotFoundError("describe_stack", "stack_name"),
+            )
+
+        mocker.patch("pcluster.models.imagebuilder.ImageBuilder.delete", return_value=None)
+
+        response = self._send_test_request(client, image_id, region, force)
+
+        with soft_assertions():
+            assert_that(response.status_code).is_equal_to(200)
+            assert_that(response.get_json()).is_equal_to(expected_response)
+
+    def test_delete_available_ec2_image_with_stack_yet_to_be_removed_succeeds(self, mocker, client):
+        image = self._create_image_info("image1")
+        stack = self._create_stack("image1", CloudFormationStatus.DELETE_IN_PROGRESS)
+        expected_response = {
+            "image": {
+                "imageId": "image1",
+                "imageBuildStatus": ImageBuildStatus.DELETE_COMPLETE,
+                "region": "us-east-1",
+                "version": "3.0.0",
+            }
+        }
+        self._assert_successful(mocker, client, "image1", True, "us-east-1", image, stack, expected_response)
+
+    def test_delete_available_ec2_image_with_stack_already_removed_succeeds(self, mocker, client):
+        image = self._create_image_info("image1")
+        expected_response = {
+            "image": {
+                "imageId": "image1",
+                "imageBuildStatus": ImageBuildStatus.DELETE_COMPLETE,
+                "region": "us-east-1",
+                "version": "3.0.0",
+            }
+        }
+        self._assert_successful(mocker, client, "image1", True, "us-east-1", image, None, expected_response)
+
+    def test_delete_image_with_only_stack_and_no_available_image_succeeds(self, mocker, client):
+        stack = self._create_stack("image1", CloudFormationStatus.DELETE_FAILED)
+        stack_after_deletion = self._create_stack("image1", CloudFormationStatus.DELETE_IN_PROGRESS)
+        expected_response = {
+            "image": {
+                "imageId": "image1",
+                "imageBuildStatus": ImageBuildStatus.DELETE_IN_PROGRESS,
+                "region": "us-east-1",
+                "version": "3.0.0",
+                "cloudformationStackStatus": CloudFormationStatus.DELETE_IN_PROGRESS,
+                "cloudformationStackArn": "arn:image1",
+            }
+        }
+        self._assert_successful(
+            mocker, client, "image1", True, "us-east-1", None, stack, expected_response, stack_after_deletion
+        )
+
+    def test_delete_image_with_only_stack_when_stack_is_deleted_immediately(self, mocker, client):
+        stack = self._create_stack("image1", CloudFormationStatus.DELETE_FAILED)
+        expected_response = {
+            "image": {
+                "imageId": "image1",
+                "imageBuildStatus": ImageBuildStatus.DELETE_COMPLETE,
+                "region": "us-east-1",
+                "version": "3.0.0",
+                "cloudformationStackStatus": CloudFormationStatus.DELETE_COMPLETE,
+                "cloudformationStackArn": "arn:image1",
+            }
+        }
+        self._assert_successful(
+            mocker, client, "image1", True, "us-east-1", None, stack, expected_response, stack_after_deletion=None
+        )
+
+    def test_delete_image_with_no_available_image_or_stack_throws_not_found_exception(self, mocker, client):
+        mocker.patch(
+            "pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
+            side_effect=ImageNotFoundError("describe_image_by_id_tag"),
+        )
+        mocker.patch(
+            "pcluster.aws.cfn.CfnClient.describe_stack", side_effect=StackNotFoundError("describe_stack", "stack_name")
+        )
+        response = self._send_test_request(client, "nonExistentImage")
+
+        with soft_assertions():
+            assert_that(response.status_code).is_equal_to(404)
+            assert_that(response.get_json()).is_equal_to(
+                {"message": "Unable to find an image of stack with id: nonExistentImage"}
+            )
+
+    @pytest.mark.parametrize(
+        "region, image_id, force, expected_response",
+        [
+            pytest.param(
+                "us-east-",
+                "imageId",
+                True,
+                {"message": "Bad Request: invalid or unsupported region 'us-east-'"},
+                id="bad_region",
+            ),
+            pytest.param(None, "imageId", True, {"message": "Bad Request: region needs to be set"}, id="unset_region"),
+            pytest.param(
+                "us-east-1",
+                "_malformedImageId",
+                True,
+                {"message": "Bad Request: '_malformedImageId' does not match '^[a-zA-Z][a-zA-Z0-9-]+$'"},
+                id="invalid_image_id",
+            ),
+        ],
+    )
+    def test_malformed_request(self, client, region, image_id, force, expected_response):
+        response = self._send_test_request(client, image_id, region, force)
+
+        with soft_assertions():
+            assert_that(response.status_code).is_equal_to(400)
+            assert_that(response.get_json()).is_equal_to(expected_response)
+
+    def test_that_a_server_internal_error_is_thrown_if_the_delete_fails(self, client, mocker):
+        image = self._create_image_info("image1")
+        mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", return_value=image)
+        mocker.patch(
+            "pcluster.models.imagebuilder.ImageBuilder.delete", side_effect=ImageBuilderActionError("test error")
+        )
+        expected_error = {
+            "message": "Unexpected fatal exception. Please look "
+            "at the application logs for details on the encountered failure."
+        }
+        response = self._send_test_request(client, "image1")
+
+        with soft_assertions():
+            assert_that(response.status_code).is_equal_to(500)
+            assert_that(response.get_json()).is_equal_to(expected_error)

--- a/cli/tests/pcluster/models/test_imagebuilder.py
+++ b/cli/tests/pcluster/models/test_imagebuilder.py
@@ -15,8 +15,14 @@ import pytest
 from assertpy import assert_that
 
 from pcluster.aws.aws_resources import ImageInfo
-from pcluster.aws.common import AWSClientError
+from pcluster.aws.common import AWSClientError, BadRequestError, LimitExceededError
 from pcluster.config.imagebuilder_config import ImageBuilderExtraChefAttributes
+from pcluster.models.imagebuilder import (
+    BadRequestImageBuilderActionError,
+    ImageBuilder,
+    ImageBuilderActionError,
+    LimitExceededImageBuilderActionError,
+)
 from pcluster.validators.common import FailureLevel
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.config.dummy_imagebuilder_config import imagebuilder_factory
@@ -313,3 +319,34 @@ def _test_dev_settings(
         validation_failures, expected_failure_levels, expected_failure_messages
     ):
         assert_validation_result(validation_failure, expected_failure_level, expected_failure_message)
+
+
+@pytest.mark.parametrize(
+    "error, returned_error",
+    [
+        (BadRequestError(function_name="image_exists", message="test error"), BadRequestImageBuilderActionError),
+        (LimitExceededError(function_name="image_exists", message="test error"), LimitExceededImageBuilderActionError),
+        (AWSClientError(function_name="image_exists", message="test error"), ImageBuilderActionError),
+    ],
+)
+def test_delete_with_ec2_error(mocker, error, returned_error):
+    with pytest.raises(returned_error):
+        mock_aws_api(mocker)
+        mocker.patch("pcluster.aws.ec2.Ec2Client.image_exists", side_effect=(error))
+        ImageBuilder("imageId").delete(force=True)
+
+
+@pytest.mark.parametrize(
+    "error, returned_error",
+    [
+        (BadRequestError(function_name="image_exists", message="test error"), BadRequestImageBuilderActionError),
+        (LimitExceededError(function_name="image_exists", message="test error"), LimitExceededImageBuilderActionError),
+        (AWSClientError(function_name="image_exists", message="test error"), ImageBuilderActionError),
+    ],
+)
+def test_delete_with_cfn_error(mocker, error, returned_error):
+    with pytest.raises(returned_error):
+        mock_aws_api(mocker)
+        mocker.patch("pcluster.aws.ec2.Ec2Client.image_exists", return_value=False)
+        mocker.patch("pcluster.aws.cfn.CfnClient.stack_exists", side_effect=(error))
+        ImageBuilder("imageId").delete(force=True)


### PR DESCRIPTION
### Notes
This patch implements the DeleteImage API. We create an `ImageBuilder` class with the given image id and retrieve the associated image or stack, then we delete the image and, in case we only had the stack, we retrieve it with another `ImageBuilder` object (the stack is initialized only once, and if we tried to retrieve it after calling the delete operation we might be unable to describe it as it might have already transitioned to the `DELETE_COMPLETE` state).

One thing to note here is that the `ImageBuilder.delete()` call might fail raising an `ImageBuilderActionError`, which is surfaced to the caller of the DeleteImage API as a 500 with the message: "Unexpected fatal exception. Please look at the application logs for details on the encountered failure."

### Tests
1. Unit tests
2. Delete of an available image:
```
curl --location --request DELETE 'http://<ENDPOINT>/v3/images/custom/test7?region=us-east-1'
{
  "image": {
    "imageBuildStatus": "DELETE_IN_PROGRESS",
    "imageId": "test7",
    "region": "us-east-1",
    "version": "3.0.0"
  }
}
```
3. Delete of a stack:
```
curl --location --request DELETE 'http://<ENDPOINT>/v3/images/custom/test1?region=us-east-1'
{
  "image": {
    "cloudformationStackArn": <CFN ARN>,
    "cloudformationStackStatus": "DELETE_IN_PROGRESS",
    "imageBuildStatus": "DELETE_IN_PROGRESS",
    "imageId": "test1",
    "region": "us-east-1",
    "version": "3.0.0"
  }
}
```

### Notes for the reviewer
I would like to solicit feedback on the following points:
1. In the [pcluster_api.py implementation](https://github.com/aws/aws-parallelcluster/blob/wip/pcluster3/cli/src/pcluster/api/pcluster_api.py#L327-L350) we get the image/stack **after** calling the `delete` operation, I am not sure this is correct. Among other things, the stack deletion is asynchronous, and so the stack might or might not have already reached the `DELETE_COMPLETE` status, in which case it won't be visible in the describe, thus leading to a `NonExistingStackError`.
2. As mentioned above, the `ImageBuilder.delete()` wraps, among other exceptions, `AWSClientError` in `ImageBuilderActionError` exceptions. I think that this is not what we want to happen, for example, in cases where we have a `REQUEST_LIMIT_EXCEEDED` in one of the EC2/CloudFormation calls, which I believe we would like to surface as a `LimitExceededException`. I see that in https://github.com/aws/aws-parallelcluster/pull/2776 for the `CreateCluster` we have wrapped these exceptions in a `InternalServiceException`, with a message that at least surfaces the message of the underlying exception, however I still have some questions regrading the error code (`InternalServiceException` are 500s). **UPDATE: new approach explained [here](https://github.com/aws/aws-parallelcluster/pull/2806#issuecomment-854806810)**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
