### PR TITLE
3.0: Implement DescribeOfficialImages

### DIFF
--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -1054,12 +1054,6 @@ paths:
           schema:
             type: string
             description: Filter by architecture
-        - name: nextToken
-          in: query
-          description: Token to use for paginated requests.
-          schema:
-            type: string
-            description: Token to use for paginated requests.
       responses:
         "200":
           description: DescribeOfficialImages 200 response
@@ -1110,14 +1104,14 @@ components:
           type: string
         os:
           type: string
-        id:
+        name:
           type: string
         architecture:
           type: string
       required:
         - amiId
         - architecture
-        - id
+        - name
         - os
     BadRequestExceptionResponseContent:
       type: object
@@ -1470,9 +1464,6 @@ components:
     DescribeOfficialImagesResponseContent:
       type: object
       properties:
-        nextToken:
-          type: string
-          description: Token to use for paginated requests.
         items:
           type: array
           items:

--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -1030,12 +1030,6 @@ paths:
       description: Describe ParallelCluster AMIs.
       operationId: DescribeOfficialImages
       parameters:
-        - name: version
-          in: query
-          description: ParallelCluster version to retrieve AMIs for.
-          schema:
-            type: string
-            description: ParallelCluster version to retrieve AMIs for.
         - name: region
           in: query
           description: AWS Region. Defaults to the region the API is deployed to.
@@ -1106,6 +1100,8 @@ components:
           type: string
         name:
           type: string
+        version:
+          type: string
         architecture:
           type: string
       required:
@@ -1113,6 +1109,7 @@ components:
         - architecture
         - name
         - os
+        - version
     BadRequestExceptionResponseContent:
       type: object
       description: This exception is thrown when a client calls an API with wrong parameters

--- a/api/spec/smithy/model/operations/DescribeOfficialImages.smithy
+++ b/api/spec/smithy/model/operations/DescribeOfficialImages.smithy
@@ -16,9 +16,6 @@ operation DescribeOfficialImages {
 }
 
 structure DescribeOfficialImagesRequest {
-    @httpQuery("version")
-    @documentation("ParallelCluster version to retrieve AMIs for.")
-    version: Version,
     @httpQuery("region")
     region: Region,
     @httpQuery("os")
@@ -47,4 +44,6 @@ structure AmiInfo {
     name: String,
     @required
     os: String,
+    @required
+    version: Version,
 }

--- a/api/spec/smithy/model/operations/DescribeOfficialImages.smithy
+++ b/api/spec/smithy/model/operations/DescribeOfficialImages.smithy
@@ -4,7 +4,6 @@ namespace parallelcluster
 @http(method: "GET", uri: "/v3/images/official", code: 200)
 @tags(["Image Operations"])
 @documentation("Describe ParallelCluster AMIs.")
-@paginated
 operation DescribeOfficialImages {
     input: DescribeOfficialImagesRequest,
     output: DescribeOfficialImagesResponse,
@@ -28,13 +27,9 @@ structure DescribeOfficialImagesRequest {
     @httpQuery("architecture")
     @documentation("Filter by architecture")
     architecture: String,
-    @httpQuery("nextToken")
-    nextToken: PaginationToken,
 }
 
 structure DescribeOfficialImagesResponse {
-    nextToken: PaginationToken,
-
     @required
     items: AmisInfo,
 }
@@ -49,7 +44,7 @@ structure AmiInfo {
     @required
     amiId: String,
     @required
-    id: String,
+    name: String,
     @required
     os: String,
 }

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -242,7 +242,7 @@ def describe_image(image_id, region=None):
 
 
 @configure_aws_region()
-def describe_official_images(version=None, region=None, os=None, architecture=None, next_token=None):
+def describe_official_images(version=None, region=None, os=None, architecture=None):
     """
     Describe ParallelCluster AMIs.
 
@@ -254,8 +254,6 @@ def describe_official_images(version=None, region=None, os=None, architecture=No
     :type os: str
     :param architecture: Filter by architecture
     :type architecture: str
-    :param next_token: Token to use for paginated requests.
-    :type next_token: str
 
     :rtype: DescribeOfficialImagesResponseContent
     """

--- a/cli/src/pcluster/api/models/ami_info.py
+++ b/cli/src/pcluster/api/models/ami_info.py
@@ -19,7 +19,7 @@ class AmiInfo(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, ami_id=None, os=None, name=None, architecture=None):
+    def __init__(self, ami_id=None, os=None, name=None, version=None, architecture=None):
         """AmiInfo - a model defined in OpenAPI
 
         :param ami_id: The ami_id of this AmiInfo.
@@ -28,16 +28,25 @@ class AmiInfo(Model):
         :type os: str
         :param name: The name of this AmiInfo.
         :type name: str
+        :param version: The version of this AmiInfo.
+        :type version: st
         :param architecture: The architecture of this AmiInfo.
         :type architecture: str
         """
-        self.openapi_types = {"ami_id": str, "os": str, "name": str, "architecture": str}
+        self.openapi_types = {"ami_id": str, "os": str, "name": str, "version": str, "architecture": str}
 
-        self.attribute_map = {"ami_id": "amiId", "os": "os", "name": "name", "architecture": "architecture"}
+        self.attribute_map = {
+            "ami_id": "amiId",
+            "os": "os",
+            "name": "name",
+            "version": "version",
+            "architecture": "architecture",
+        }
 
         self._ami_id = ami_id
         self._os = os
         self._name = name
+        self._version = version
         self._architecture = architecture
 
     @classmethod
@@ -119,6 +128,29 @@ class AmiInfo(Model):
             raise ValueError("Invalid value for `name`, must not be `None`")
 
         self._name = name
+
+    @property
+    def version(self):
+        """Gets the version of this AmiInfo.
+
+
+        :return: The version of this AmiInfo.
+        :rtype: str
+        """
+        return self._version
+
+    @version.setter
+    def version(self, version):
+        """Sets the version of this AmiInfo.
+
+
+        :param version: The version of this AmiInfo.
+        :type version: str
+        """
+        if version is None:
+            raise ValueError("Invalid value for `version`, must not be `None`")  # noqa: E501
+
+        self._version = version
 
     @property
     def architecture(self):

--- a/cli/src/pcluster/api/models/describe_official_images_response_content.py
+++ b/cli/src/pcluster/api/models/describe_official_images_response_content.py
@@ -22,19 +22,16 @@ class DescribeOfficialImagesResponseContent(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, next_token=None, items=None):
+    def __init__(self, items=None):
         """DescribeOfficialImagesResponseContent - a model defined in OpenAPI
 
-        :param next_token: The next_token of this DescribeOfficialImagesResponseContent.
-        :type next_token: str
         :param items: The items of this DescribeOfficialImagesResponseContent.
         :type items: List[AmiInfo]
         """
-        self.openapi_types = {"next_token": str, "items": List[AmiInfo]}
+        self.openapi_types = {"items": List[AmiInfo]}
 
-        self.attribute_map = {"next_token": "nextToken", "items": "items"}
+        self.attribute_map = {"items": "items"}
 
-        self._next_token = next_token
         self._items = items
 
     @classmethod
@@ -47,29 +44,6 @@ class DescribeOfficialImagesResponseContent(Model):
         :rtype: DescribeOfficialImagesResponseContent
         """
         return util.deserialize_model(dikt, cls)
-
-    @property
-    def next_token(self):
-        """Gets the next_token of this DescribeOfficialImagesResponseContent.
-
-        Token to use for paginated requests.
-
-        :return: The next_token of this DescribeOfficialImagesResponseContent.
-        :rtype: str
-        """
-        return self._next_token
-
-    @next_token.setter
-    def next_token(self, next_token):
-        """Sets the next_token of this DescribeOfficialImagesResponseContent.
-
-        Token to use for paginated requests.
-
-        :param next_token: The next_token of this DescribeOfficialImagesResponseContent.
-        :type next_token: str
-        """
-
-        self._next_token = next_token
 
     @property
     def items(self):

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -1249,15 +1249,6 @@ paths:
           description: Filter by architecture
           type: string
         style: form
-      - description: Token to use for paginated requests.
-        explode: true
-        in: query
-        name: nextToken
-        required: false
-        schema:
-          description: Token to use for paginated requests.
-          type: string
-        style: form
       responses:
         "200":
           content:
@@ -1306,7 +1297,7 @@ components:
       example:
         amiId: amiId
         os: os
-        id: id
+        name: name
         architecture: architecture
       properties:
         amiId:
@@ -1315,8 +1306,8 @@ components:
         os:
           title: os
           type: string
-        id:
-          title: id
+        name:
+          title: name
           type: string
         architecture:
           title: architecture
@@ -1324,7 +1315,7 @@ components:
       required:
       - amiId
       - architecture
-      - id
+      - name
       - os
       title: AmiInfo
       type: object
@@ -1890,21 +1881,16 @@ components:
       type: object
     DescribeOfficialImagesResponseContent:
       example:
-        nextToken: nextToken
         items:
         - amiId: amiId
           os: os
-          id: id
+          name: name
           architecture: architecture
         - amiId: amiId
           os: os
-          id: id
+          name: name
           architecture: architecture
       properties:
-        nextToken:
-          description: Token to use for paginated requests.
-          title: nextToken
-          type: string
         items:
           items:
             $ref: '#/components/schemas/AmiInfo'

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -1213,15 +1213,6 @@ paths:
       description: Describe ParallelCluster AMIs.
       operationId: describe_official_images
       parameters:
-      - description: ParallelCluster version to retrieve AMIs for.
-        explode: true
-        in: query
-        name: version
-        required: false
-        schema:
-          description: ParallelCluster version to retrieve AMIs for.
-          type: string
-        style: form
       - description: AWS Region. Defaults to the region the API is deployed to.
         explode: true
         in: query
@@ -1298,6 +1289,7 @@ components:
         amiId: amiId
         os: os
         name: name
+        version: version
         architecture: architecture
       properties:
         amiId:
@@ -1309,6 +1301,9 @@ components:
         name:
           title: name
           type: string
+        version:
+          title: version
+          type: string
         architecture:
           title: architecture
           type: string
@@ -1316,6 +1311,7 @@ components:
       - amiId
       - architecture
       - name
+      - version
       - os
       title: AmiInfo
       type: object
@@ -1885,10 +1881,12 @@ components:
         - amiId: amiId
           os: os
           name: name
+          version: version
           architecture: architecture
         - amiId: amiId
           os: os
           name: name
+          version: version
           architecture: architecture
       properties:
         items:

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -8,12 +8,19 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import re
 from typing import List
 
 from pcluster import utils
 from pcluster.aws.aws_resources import ImageInfo, InstanceTypeInfo
 from pcluster.aws.common import AWSClientError, AWSExceptionHandler, Boto3Client, Cache, ImageNotFoundError
-from pcluster.constants import PCLUSTER_IMAGE_BUILD_STATUS_TAG, PCLUSTER_IMAGE_ID_TAG, SUPPORTED_ARCHITECTURES
+from pcluster.constants import (
+    IMAGE_NAME_PART_TO_OS_MAP,
+    OS_TO_IMAGE_NAME_PART_MAP,
+    PCLUSTER_IMAGE_BUILD_STATUS_TAG,
+    PCLUSTER_IMAGE_ID_TAG,
+    SUPPORTED_ARCHITECTURES,
+)
 
 
 class Ec2Client(Boto3Client):
@@ -221,6 +228,19 @@ class Ec2Client(Boto3Client):
             raise AWSClientError(function_name="describe_images", message="Cannot find official ParallelCluster AMI")
         return max(images, key=lambda image: image["CreationDate"]).get("ImageId")
 
+    def get_official_images(self, version=None, os=None, architecture=None):
+        """Get the list of official images, optionally filtered by os and architecture."""
+        try:
+            owners = ["amazon"]
+            version = version or "*"
+            os = OS_TO_IMAGE_NAME_PART_MAP.get(os, "") if os else "*"
+            architecture = architecture or "*"
+            name = f"aws-parallelcluster-{version}-{os}-{architecture}*"
+            filters = [{"Name": "name", "Values": [name]}]
+            return self.describe_images(ami_ids=[], owners=owners, filters=filters)
+        except ImageNotFoundError:
+            return []
+
     @AWSExceptionHandler.handle_client_exception
     @Cache.cached
     def get_eip_allocation_id(self, eip):
@@ -228,18 +248,19 @@ class Ec2Client(Boto3Client):
         return self._client.describe_addresses(PublicIps=[eip])["Addresses"][0]["AllocationId"]
 
     @staticmethod
+    def extract_os_from_official_image_name(name):
+        """Return the os from the os part in an official image name."""
+        name_pattern = "aws-parallelcluster-[^-]+-(?P<OsPart>.+-hvm)-.*"
+        matches = re.match(name_pattern, name)
+        os_part = matches.groupdict().get("OsPart") if matches else None
+        return IMAGE_NAME_PART_TO_OS_MAP.get(os_part, "linux")
+
+    @staticmethod
     def _get_official_image_name_prefix(os, architecture):
         """Return the prefix of the current official image, for the provided os-architecture combination."""
-        suffixes = {
-            "alinux2": "amzn2-hvm",
-            "centos7": "centos7-hvm",
-            "centos8": "centos8-hvm",
-            "ubuntu1804": "ubuntu-1804-lts-hvm",
-            "ubuntu2004": "ubuntu-2004-lts-hvm",
-        }
-        return "aws-parallelcluster-{version}-{suffix}-{arch}".format(
-            version=utils.get_installed_version(), suffix=suffixes[os], arch=architecture
-        )
+        version = utils.get_installed_version()
+        os_part = OS_TO_IMAGE_NAME_PART_MAP[os]
+        return f"aws-parallelcluster-{version}-{os_part}-{architecture}"
 
     @AWSExceptionHandler.handle_client_exception
     def terminate_instances(self, instance_ids):

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -32,6 +32,16 @@ OS_MAPPING = {
     "ubuntu2004": {"user": "ubuntu", "root-device": "/dev/sda1"},
 }
 
+OS_TO_IMAGE_NAME_PART_MAP = {
+    "alinux2": "amzn2-hvm",
+    "centos7": "centos7-hvm",
+    "centos8": "centos8-hvm",
+    "ubuntu1804": "ubuntu-1804-lts-hvm",
+    "ubuntu2004": "ubuntu-2004-lts-hvm",
+}
+
+IMAGE_NAME_PART_TO_OS_MAP = {value: key for key, value in OS_TO_IMAGE_NAME_PART_MAP.items()}
+
 # Describe the list of requirements to be satisfied by the Pcluster AWS Batch CLI to manage the cluster.
 # It must be in the form <package-name><comparison-operator><version>
 # It can contain multiple items separated by a colon.


### PR DESCRIPTION
### Notes
This patch implements the `DescribeOfficialImages` API. We search for images owned by "amazon" with the correct name prefix (`aws-parallelcluster-...`), optionally taking version, os and architecture parameters which are used to narrow down the search by constructing an appropriate prefix pattern. Note that in the `AmiInfo` structures in the response we need to parse the image name in order to retrieve the correct information about the operating system, as tags are not visible to accounts different from the one that owns the image (these are official images, not images that have been built by the customer), and the `PlatformDetails `section of the EC2 `describe_images` response is not specific enough (i.e. it generically identifies the images as a Linux image, for example, but won't distinguish between CentOS, Ubuntu, etc.)

### Tests
1. Unit tests
2. Test without parameters:
```
 curl --location --request GET 'http://<ENDPOINT>/v3/images/official?region=us-east-1'
{
  "items": [
    {
      "amiId": "ami-0012b0e32aeeb20bc",
      "architecture": "arm64",
      "name": "aws-parallelcluster-2.10.4-centos8-hvm-arm64-202105142101",
      "os": "centos8"
    },
    {
      "amiId": "ami-00144db1528d8942d",
      "architecture": "x86_64",
      "name": "aws-parallelcluster-2.3.2a1-ubuntu-1404-lts-hvm-201904261542",
      "os": "linux"
    },
    {
      "amiId": "ami-006da8413e239334a",
      "architecture": "x86_64",
      "name": "aws-parallelcluster-2.4.1-ubuntu-1404-lts-hvm-201907260654",
      "os": "linux"
    },
...
```
3. With architecture filter:
```
curl --location --request GET 'http://<ENDPOINT>/v3/images/official?region=us-east-1&architecture=x86_64' 
{
  "items": [
    {
      "amiId": "ami-006e29fa34278d9f1",
      "architecture": "x86_64",
      "name": "aws-parallelcluster-2.9.1-centos6-hvm-x86_64-202009142226",
      "os": "linux"
    },
    {
      "amiId": "ami-009428e2bfe97a05c",
      "architecture": "x86_64",
      "name": "aws-parallelcluster-2.8.0-amzn-hvm-x86_64-202007222100",
      "os": "linux"
    },
    {
      "amiId": "ami-0098ea5504ad7af97",
      "architecture": "x86_64",
      "name": "aws-parallelcluster-2.8.0-centos6-hvm-x86_64-202007222100",
      "os": "linux"
    },
...
```
4. With architecture and os filter:
```
curl --location --request GET 'http://<ENDPOINT>/v3/images/official?region=us-east-1&architecture=x86_64&os=linux'
{
  "items": [
    {
      "amiId": "ami-006e29fa34278d9f1",
      "architecture": "x86_64",
      "name": "aws-parallelcluster-2.9.1-centos6-hvm-x86_64-202009142226",
      "os": "linux"
    },
    {
      "amiId": "ami-009428e2bfe97a05c",
      "architecture": "x86_64",
      "name": "aws-parallelcluster-2.8.0-amzn-hvm-x86_64-202007222100",
      "os": "linux"
    },
    {
      "amiId": "ami-0098ea5504ad7af97",
      "architecture": "x86_64",
      "name": "aws-parallelcluster-2.8.0-centos6-hvm-x86_64-202007222100",
      "os": "linux"
    },
...
```
5. With version:
```
curl --location --request GET 'http://<ENDPOINT>/v3/images/official?region=us-east-1&version=2.0.0'
{
  "items": [
    {
      "amiId": "ami-017b013ef58a362fb",
      "architecture": "x86_64",
      "name": "aws-parallelcluster-2.0.0-centos7-hvm-201811120751",
      "os": "centos7"
    },
...
```

### Notes for the reviewer
I have decided to return '' as a suffix if the customer passes an os that is not present in our os-to-suffix map. This way we return an empty list, which is coherent with what happens in case we specify an architecture or version that does not exist (i.e. we build a name prefix that does not match against any official image name, thus return an empty list). See [related comment](https://github.com/aws/aws-parallelcluster/pull/2815#discussion_r647205194).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
