### PR TITLE
Add validator to prevent using data_compression_type with fsx_backup_id

### DIFF
--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -1121,6 +1121,33 @@ def _kms_key_stubber(mocker, boto3_stubber, kms_key_id, expected_message, num_ca
             "'drive_cache_type' features can be used only with HDD filesystems",
             0,
         ),
+        (
+            {
+                "data_compression_type": "LZ4",
+                "fsx_backup_id": "backup-12345678",
+            },
+            None,
+            "FSx data compression option (LZ4) cannot be specified when creating a filesystem from backup",
+            0,
+        ),
+        (
+            {
+                "data_compression_type": "NONE",
+                "fsx_backup_id": "backup-12345678",
+            },
+            None,
+            "The configuration parameter 'data_compression_type' has an invalid value 'NONE'",
+            0,
+        ),
+        (
+            {
+                "data_compression_type": "LZ4",
+                "storage_capacity": 1200,
+            },
+            None,
+            None,
+            0,
+        ),
     ],
 )
 def test_fsx_validator(mocker, boto3_stubber, section_dict, bucket, expected_error, num_calls):

--- a/cloudformation/fsx-substack.cfn.json
+++ b/cloudformation/fsx-substack.cfn.json
@@ -605,10 +605,18 @@
             ]
           },
           "DataCompressionType": {
-            "Fn::Select": [
-              "19",
+            "Fn::If": [
+              "UseBackupId",
               {
-                "Ref": "FSXOptions"
+                "Ref": "AWS::NoValue"
+              },
+              {
+                "Fn::Select": [
+                  "19",
+                  {
+                    "Ref": "FSXOptions"
+                  }
+                ]
               }
             ]
           }


### PR DESCRIPTION
* DataCompressionType is not supported when creating filesystem from backup. The designed behavior is to use the existing compression setting from the backup. Add validator for this case
* DataCompressionType option cannot be specified in CFN when creating from backup, added logic to use `AWS:NoValue` if using backup

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
