### PR TITLE
Fix list compreention in list_images

### DIFF
--- a/cli/src/pcluster/api/pcluster_api.py
+++ b/cli/src/pcluster/api/pcluster_api.py
@@ -384,9 +384,9 @@ class PclusterApi:
             images_response = [ImageBuilderImageInfo(imagebuilder=imagebuilder) for imagebuilder in imagebuilders]
 
             # get building image stacks by image name tag
+            stacks, _ = AWSApi.instance().cfn.get_imagebuilder_stacks()
             imagebuilder_stacks = [
-                ImageBuilder(image_id=stack.get("StackName"), stack=ImageBuilderStack(stack))
-                for stack, _ in AWSApi.instance().cfn.get_imagebuilder_stacks()
+                ImageBuilder(image_id=stack.get("StackName"), stack=ImageBuilderStack(stack)) for stack in stacks
             ]
             imagebuilder_stacks_response = [
                 ImageBuilderStackInfo(imagebuilder=imagebuilder) for imagebuilder in imagebuilder_stacks


### PR DESCRIPTION
This patch fixes the list comprehension with which we get the stacks for building images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
