### PR TITLE
integ-tests: add AZ override for cn-north-1

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -517,6 +517,8 @@ AVAILABILITY_ZONE_OVERRIDES = {
     "ca-central-1": ["cac1-az1", "cac1-az2"],
     # instance can only be launch in placement group in eun1-az2
     "eu-north-1": ["eun1-az2"],
+    # FSx not available in cnn1-az4
+    "cn-north-1": ["cnn1-az1", "cnn1-az2"],
 }
 
 


### PR DESCRIPTION
FSx not available in cnn1-az4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
