### PR TITLE
integ-tests: add AZ override for cn-north-1

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -549,6 +549,8 @@ AVAILABILITY_ZONE_OVERRIDES = {
     "eu-north-1": ["eun1-az2"],
     # g3.8xlarge is not supported in euc1-az1
     "eu-central-1": ["euc1-az2", "euc1-az3"],
+    # FSx not available in cnn1-az4
+    "cn-north-1": ["cnn1-az1", "cnn1-az2"],
 }
 
 


### PR DESCRIPTION
FSx not available in cnn1-az4


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
