### PR TITLE
3.0: Format strings with f"" form instead of format() call

### DIFF
--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -176,7 +176,7 @@ def _get_underlying_image_or_stack(imagebuilder):
             stack = imagebuilder.stack
         except NonExistingStackError:
             raise NotFoundException(
-                "Unable to find an image or stack for ParallelCluster image id: {}".format(imagebuilder.image_id)
+                f"Unable to find an image or stack for ParallelCluster image id: {imagebuilder.image_id}"
             )
     return image, stack
 

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -103,7 +103,7 @@ def _create_image_info(image_id):
 
 def _create_stack(image_id, status):
     return {
-        "StackId": "arn:{}".format(image_id),
+        "StackId": f"arn:{image_id}",
         "StackStatus": status,
         "Tags": [
             {"Key": "parallelcluster:image_id", "Value": image_id},


### PR DESCRIPTION
Replace string formatting using `f"..."` rather than `"...".format(...)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
