### PR TITLE
3.0: Raise ConfigValidationError as is to preserve the validation failures details

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -333,6 +333,8 @@ class Cluster:
             ClusterSchema.process_validation_message(e)
             validation_failures = [ValidationResult(str(e), FailureLevel.ERROR)]
             raise ConfigValidationError("Configuration is invalid", validation_failures=validation_failures)
+        except ConfigValidationError as e:
+            raise e
         except Exception as e:
             raise ConfigValidationError(f"Configuration is invalid: {e}")
 


### PR DESCRIPTION
### Changes
1. Raise ConfigValidationError as is to preserve the validation failures details

### Tests
1. Manual test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
