### PR TITLE
3.0: Change comment in CFN custom res lambda to satisfy tox check

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -693,8 +693,8 @@ Resources:
           def get_tag_from_image_arn(image_arn):
               """ Returns the Docker image tag given an ImageBuilder image ARN
 
-              Arn format: arn:aws:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/.../${Version}/${BuildNumber}
-              Tag format: ${Version}-${BuildNumber}
+              Arn format: arn:aws:imagebuilder:<region>:<account id>:image/.../<version>/<build number>
+              Tag format: <version>-<build number>
               """
               parts = image_arn.split('/')
               version = parts[-2]


### PR DESCRIPTION
If writing a pseudo parameter in the embedded Lambda code docstring the tox checks fails. This patch removes them from the dosctring, thus allowing the test to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
