### PR TITLE
Fix lambda service principal

### DIFF
--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -730,7 +730,7 @@ class ImageBuilderCdkStack(Stack):
                 self,
                 "DeleteStackFunctionExecutionRole",
                 managed_policy_arns=managed_lambda_policy,
-                assume_role_policy_document=get_assume_role_policy_document("lambda.{0}".format(self.url_suffix)),
+                assume_role_policy_document=get_assume_role_policy_document("lambda.amazonaws.com"),
                 path="/{0}/".format(IMAGEBUILDER_RESOURCE_NAME_PREFIX),
                 policies=[
                     iam.CfnRole.PolicyProperty(

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -968,7 +968,7 @@ def test_imagebuilder_instance_role(
                             {
                                 "Action": "sts:AssumeRole",
                                 "Effect": "Allow",
-                                "Principal": {"Service": {"Fn::Join": ["", ["lambda.", {"Ref": "AWS::URLSuffix"}]]}},
+                                "Principal": {"Service": "lambda.amazonaws.com"},
                             }
                         ],
                         "Version": "2012-10-17",


### PR DESCRIPTION
Lambda service principal is "lambda.amazonaws.com" for all partitions

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
