### PR TITLE
[3.0] Fix sns service principal

### DIFF
--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -776,7 +776,7 @@ class ImageBuilderCdkStack(Stack):
             self,
             "DeleteStackFunctionPermission",
             action="lambda:InvokeFunction",
-            principal="sns.{0}".format(self.url_suffix),
+            principal="sns.amazonaws.com",
             function_name=lambda_cleanup.attr_arn,
             source_arn=Fn.ref("BuildNotificationTopic"),
         )


### PR DESCRIPTION
Sns service principal is "sns.amazonaws.com" for all partitions

### **Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
