### PR TITLE
3.0: Implement DescribeImage

### DIFF
--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -1498,6 +1498,9 @@ components:
         amiId:
           type: string
           description: EC2 AMI id
+        description:
+          type: string
+          description: EC2 AMI description
         state:
           $ref: '#/components/schemas/Ec2AmiState'
         tags:
@@ -1512,6 +1515,7 @@ components:
         - amiId
         - amiName
         - architecture
+        - description
         - state
         - tags
     Ec2AmiState:

--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -1414,8 +1414,14 @@ components:
     DescribeImageResponseContent:
       type: object
       properties:
+        cloudformationStackStatusReason:
+          type: string
+          description: Reason for the CloudFormation stack status
         imageConfiguration:
           $ref: '#/components/schemas/ImageConfigurationStructure'
+        imagebuilderImageStatusReason:
+          type: string
+          description: Reason for the ImageBuilder Image status.
         imageId:
           type: string
           description: Id of the Image
@@ -1427,9 +1433,6 @@ components:
           format: date-time
         imageBuildStatus:
           $ref: '#/components/schemas/ImageBuildStatus'
-        failureReason:
-          type: string
-          description: Describe the reason of the failure when the stack is in CREATE_FAILED, UPDATE_FAILED or DELETE_FAILED status
         cloudformationStackStatus:
           $ref: '#/components/schemas/CloudFormationStatus'
         cloudformationStackArn:
@@ -1443,20 +1446,11 @@ components:
         version:
           type: string
           description: ParallelCluster version used to build the image
-        tags:
-          type: array
-          items:
-            $ref: '#/components/schemas/Tag'
-          description: Tags of the infrastructure to build the Image
       required:
-        - cloudformationStackArn
-        - cloudformationStackStatus
-        - creationTime
         - imageBuildStatus
         - imageConfiguration
         - imageId
         - region
-        - tags
         - version
     DescribeOfficialImagesResponseContent:
       type: object

--- a/api/spec/smithy/model/operations/DescribeImage.smithy
+++ b/api/spec/smithy/model/operations/DescribeImage.smithy
@@ -37,27 +37,23 @@ structure DescribeImageResponse {
     @required
     @documentation("Status of the image build.")
     imageBuildStatus: ImageBuildStatus,
-    @required
     @documentation("Status of the CloudFormation stack for the image build process.")
     cloudformationStackStatus: CloudFormationStatus,
-    @required
+    @documentation("Reason for the CloudFormation stack status")
+    cloudformationStackStatusReason: String,
     @documentation("ARN of the main CloudFormation stack")
     cloudformationStackArn: String,
-    @required
     @documentation("Timestamp representing the image creation time")
     @timestampFormat("date-time")
     creationTime: Timestamp,
     @required
     @documentation("Configuration for the image build process")
     imageConfiguration: ImageConfigurationStructure,
-    @required
-    @documentation("Tags of the infrastructure to build the Image")
-    tags: Tags,
     @documentation("Status of the ImageBuilder Image resource for the image build process.")
     imagebuilderImageStatus: ImageBuilderImageStatus,
+    @documentation("Reason for the ImageBuilder Image status.")
+    imagebuilderImageStatusReason: String,
     // ImageBuilderImageArn or ImageBuilderImageInfo structure
     @documentation("EC2 ami info")
     ec2AmiInfo: Ec2AmiInfo,
-    @documentation("Describe the reason of the failure when the stack is in CREATE_FAILED, UPDATE_FAILED or DELETE_FAILED status")
-    failureReason: String,
 }

--- a/api/spec/smithy/model/types/Image.smithy
+++ b/api/spec/smithy/model/types/Image.smithy
@@ -20,7 +20,10 @@ structure Ec2AmiInfo {
     architecture: String,
     @required
     @documentation("EC2 AMI state")
-    state: Ec2AmiState
+    state: Ec2AmiState,
+    @required
+    @documentation("EC2 AMI description")
+    description: String,
 }
 
 structure ImageInfoSummary {

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -253,6 +253,7 @@ def _image_to_describe_image_response(imagebuilder):
             state=imagebuilder.image.state.upper(),
             tags=imagebuilder.image.tags,
             architecture=imagebuilder.image.architecture,
+            description=imagebuilder.image.description,
         ),
         region=os_lib.environ.get("AWS_DEFAULT_REGION"),
         version=imagebuilder.image.version,

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -9,7 +9,6 @@
 # pylint: disable=W0613
 import functools
 import os as os_lib
-from datetime import datetime
 
 from pcluster.api.controllers.common import configure_aws_region, parse_config
 from pcluster.api.converters import (
@@ -34,7 +33,7 @@ from pcluster.api.models import (
     CloudFormationStatus,
     DescribeImageResponseContent,
     DescribeOfficialImagesResponseContent,
-    ImageBuilderImageStatus,
+    Ec2AmiInfo,
     ImageConfigurationStructure,
     ImageInfoSummary,
     ImageStatusFilteringOption,
@@ -219,6 +218,7 @@ def _get_underlying_image_or_stack(imagebuilder):
 
 
 @configure_aws_region()
+@convert_imagebuilder_errors()
 def describe_image(image_id, region=None):
     """
     Get detailed information about an existing image.
@@ -230,18 +230,48 @@ def describe_image(image_id, region=None):
 
     :rtype: DescribeImageResponseContent
     """
+    imagebuilder = ImageBuilder(image_id=image_id)
+
+    try:
+        return _image_to_describe_image_response(imagebuilder)
+    except NonExistingImageError:
+        try:
+            return _stack_to_describe_image_response(imagebuilder)
+        except NonExistingStackError:
+            raise NotFoundException("No image or stack associated to parallelcluster image id {}.".format(image_id))
+
+
+def _image_to_describe_image_response(imagebuilder):
     return DescribeImageResponseContent(
-        image_configuration=ImageConfigurationStructure(s3_url="s3"),
-        image_id="imageid",
-        imagebuilder_image_status=ImageBuilderImageStatus.BUILDING,
-        creation_time=datetime.now(),
-        image_build_status=ImageBuildStatus.BUILD_FAILED,
-        failure_reason=":D",
-        cloudformation_stack_status=CloudFormationStatus.CREATE_COMPLETE,
-        cloudformation_stack_arn="arn",
-        region="region",
-        version="3.0.0",
-        tags=[],
+        creation_time=imagebuilder.image.creation_date,
+        image_configuration=ImageConfigurationStructure(s3_url=imagebuilder.config_url),
+        image_id=imagebuilder.image_id,
+        image_build_status=ImageBuildStatus.BUILD_COMPLETE,
+        ec2_ami_info=Ec2AmiInfo(
+            ami_name=imagebuilder.image.name,
+            ami_id=imagebuilder.image.id,
+            state=imagebuilder.image.state.upper(),
+            tags=imagebuilder.image.tags,
+            architecture=imagebuilder.image.architecture,
+        ),
+        region=os_lib.environ.get("AWS_DEFAULT_REGION"),
+        version=imagebuilder.image.version,
+    )
+
+
+def _stack_to_describe_image_response(imagebuilder):
+    imagebuilder_image_state = imagebuilder.stack.image_state or dict()
+    return DescribeImageResponseContent(
+        image_configuration=ImageConfigurationStructure(s3_url=imagebuilder.config_url),
+        image_id=imagebuilder.image_id,
+        image_build_status=imagebuilder.imagebuild_status,
+        imagebuilder_image_status=imagebuilder_image_state.get("status", None),
+        imagebuilder_image_status_reason=imagebuilder_image_state.get("reason", None),
+        cloudformation_stack_status=imagebuilder.stack.status,
+        cloudformation_stack_status_reason=imagebuilder.stack.status_reason,
+        cloudformation_stack_arn=imagebuilder.stack.id,
+        region=os_lib.environ.get("AWS_DEFAULT_REGION"),
+        version=imagebuilder.stack.version,
     )
 
 

--- a/cli/src/pcluster/api/models/describe_image_response_content.py
+++ b/cli/src/pcluster/api/models/describe_image_response_content.py
@@ -10,7 +10,6 @@
 
 
 from datetime import datetime
-from typing import List
 
 from pcluster.api import util
 from pcluster.api.models.base_model_ import Model
@@ -19,7 +18,6 @@ from pcluster.api.models.ec2_ami_info import Ec2AmiInfo
 from pcluster.api.models.image_build_status import ImageBuildStatus
 from pcluster.api.models.image_builder_image_status import ImageBuilderImageStatus
 from pcluster.api.models.image_configuration_structure import ImageConfigurationStructure
-from pcluster.api.models.tag import Tag
 
 
 class DescribeImageResponseContent(Model):
@@ -33,15 +31,15 @@ class DescribeImageResponseContent(Model):
         image_configuration=None,
         image_id=None,
         imagebuilder_image_status=None,
+        imagebuilder_image_status_reason=None,
         creation_time=None,
         image_build_status=None,
-        failure_reason=None,
         cloudformation_stack_status=None,
+        cloudformation_stack_status_reason=None,
         cloudformation_stack_arn=None,
         region=None,
         ec2_ami_info=None,
         version=None,
-        tags=None,
     ):
         """DescribeImageResponseContent - a model defined in OpenAPI
 
@@ -51,14 +49,18 @@ class DescribeImageResponseContent(Model):
         :type image_id: str
         :param imagebuilder_image_status: The imagebuilder_image_status of this DescribeImageResponseContent.
         :type imagebuilder_image_status: ImageBuilderImageStatus
+        :param imagebuilder_image_status_reason: The imagebuilder_image_status_reason
+                                                 of this DescribeImageResponseContent.
+        :type imagebuilder_image_status_reason: str
         :param creation_time: The creation_time of this DescribeImageResponseContent.
         :type creation_time: datetime
         :param image_build_status: The image_build_status of this DescribeImageResponseContent.
         :type image_build_status: ImageBuildStatus
-        :param failure_reason: The failure_reason of this DescribeImageResponseContent.
-        :type failure_reason: str
         :param cloudformation_stack_status: The cloudformation_stack_status of this DescribeImageResponseContent.
         :type cloudformation_stack_status: CloudFormationStatus
+        :param cloudformation_stack_status_reason: The cloudformation_stack_status_reason
+                                                   of this DescribeImageResponseContent.
+        :type cloudformation_stack_status_reason: str
         :param cloudformation_stack_arn: The cloudformation_stack_arn of this DescribeImageResponseContent.
         :type cloudformation_stack_arn: str
         :param region: The region of this DescribeImageResponseContent.
@@ -67,51 +69,49 @@ class DescribeImageResponseContent(Model):
         :type ec2_ami_info: Ec2AmiInfo
         :param version: The version of this DescribeImageResponseContent.
         :type version: str
-        :param tags: The tags of this DescribeImageResponseContent.
-        :type tags: List[Tag]
         """
         self.openapi_types = {
             "image_configuration": ImageConfigurationStructure,
             "image_id": str,
             "imagebuilder_image_status": ImageBuilderImageStatus,
+            "imagebuilder_image_status_reason": str,
             "creation_time": datetime,
             "image_build_status": ImageBuildStatus,
-            "failure_reason": str,
             "cloudformation_stack_status": CloudFormationStatus,
+            "cloudformation_stack_status_reason": str,
             "cloudformation_stack_arn": str,
             "region": str,
             "ec2_ami_info": Ec2AmiInfo,
             "version": str,
-            "tags": List[Tag],
         }
 
         self.attribute_map = {
             "image_configuration": "imageConfiguration",
             "image_id": "imageId",
             "imagebuilder_image_status": "imagebuilderImageStatus",
+            "imagebuilder_image_status_reason": "imagebuilderImageStatusReason",
             "creation_time": "creationTime",
             "image_build_status": "imageBuildStatus",
-            "failure_reason": "failureReason",
             "cloudformation_stack_status": "cloudformationStackStatus",
+            "cloudformation_stack_status_reason": "cloudformationStackStatusReason",
             "cloudformation_stack_arn": "cloudformationStackArn",
             "region": "region",
             "ec2_ami_info": "ec2AmiInfo",
             "version": "version",
-            "tags": "tags",
         }
 
         self._image_configuration = image_configuration
         self._image_id = image_id
         self._imagebuilder_image_status = imagebuilder_image_status
+        self._imagebuilder_image_status_reason = imagebuilder_image_status_reason
         self._creation_time = creation_time
         self._image_build_status = image_build_status
-        self._failure_reason = failure_reason
         self._cloudformation_stack_status = cloudformation_stack_status
+        self._cloudformation_stack_status_reason = cloudformation_stack_status_reason
         self._cloudformation_stack_arn = cloudformation_stack_arn
         self._region = region
         self._ec2_ami_info = ec2_ami_info
         self._version = version
-        self._tags = tags
 
     @classmethod
     def from_dict(cls, dikt) -> "DescribeImageResponseContent":
@@ -194,6 +194,30 @@ class DescribeImageResponseContent(Model):
         self._imagebuilder_image_status = imagebuilder_image_status
 
     @property
+    def imagebuilder_image_status_reason(self):
+        """Gets the imagebuilder_image_status_reason of this DescribeImageResponseContent.
+
+        Reason for the ImageBuilder Image status.
+
+        :return: The imagebuilder_image_status_reason of this DescribeImageResponseContent.
+        :rtype: str
+        """
+        return self._imagebuilder_image_status_reason
+
+    @imagebuilder_image_status_reason.setter
+    def imagebuilder_image_status_reason(self, imagebuilder_image_status_reason):
+        """Sets the imagebuilder_image_status_reason of this DescribeImageResponseContent.
+
+        Reason for the ImageBuilder Image status.
+
+        :param imagebuilder_image_status_reason: The imagebuilder_image_status_reason
+                                                 of this DescribeImageResponseContent.
+        :type imagebuilder_image_status_reason: str
+        """
+
+        self._imagebuilder_image_status_reason = imagebuilder_image_status_reason
+
+    @property
     def creation_time(self):
         """Gets the creation_time of this DescribeImageResponseContent.
 
@@ -213,9 +237,6 @@ class DescribeImageResponseContent(Model):
         :param creation_time: The creation_time of this DescribeImageResponseContent.
         :type creation_time: datetime
         """
-        if creation_time is None:
-            raise ValueError("Invalid value for `creation_time`, must not be `None`")
-
         self._creation_time = creation_time
 
     @property
@@ -242,29 +263,6 @@ class DescribeImageResponseContent(Model):
         self._image_build_status = image_build_status
 
     @property
-    def failure_reason(self):
-        """Gets the failure_reason of this DescribeImageResponseContent.
-
-        Describe the reason of the failure when the stack is in CREATE_FAILED, UPDATE_FAILED or DELETE_FAILED status
-
-        :return: The failure_reason of this DescribeImageResponseContent.
-        :rtype: str
-        """
-        return self._failure_reason
-
-    @failure_reason.setter
-    def failure_reason(self, failure_reason):
-        """Sets the failure_reason of this DescribeImageResponseContent.
-
-        Describe the reason of the failure when the stack is in CREATE_FAILED, UPDATE_FAILED or DELETE_FAILED status
-
-        :param failure_reason: The failure_reason of this DescribeImageResponseContent.
-        :type failure_reason: str
-        """
-
-        self._failure_reason = failure_reason
-
-    @property
     def cloudformation_stack_status(self):
         """Gets the cloudformation_stack_status of this DescribeImageResponseContent.
 
@@ -282,10 +280,31 @@ class DescribeImageResponseContent(Model):
         :param cloudformation_stack_status: The cloudformation_stack_status of this DescribeImageResponseContent.
         :type cloudformation_stack_status: CloudFormationStatus
         """
-        if cloudformation_stack_status is None:
-            raise ValueError("Invalid value for `cloudformation_stack_status`, must not be `None`")
-
         self._cloudformation_stack_status = cloudformation_stack_status
+
+    @property
+    def cloudformation_stack_status_reason(self):
+        """Gets the cloudformation_stack_status_reason of this DescribeImageResponseContent.
+
+        Reason for the CloudFormation stack status
+
+        :return: The cloudformation_stack_status_reason of this DescribeImageResponseContent.
+        :rtype: str
+        """
+        return self._cloudformation_stack_status_reason
+
+    @cloudformation_stack_status_reason.setter
+    def cloudformation_stack_status_reason(self, cloudformation_stack_status_reason):
+        """Sets the cloudformation_stack_status_reason of this DescribeImageResponseContent.
+
+        Reason for the CloudFormation stack status
+
+        :param cloudformation_stack_status_reason: The cloudformation_stack_status_reason
+                                                   of this DescribeImageResponseContent.
+        :type cloudformation_stack_status_reason: str
+        """
+
+        self._cloudformation_stack_status_reason = cloudformation_stack_status_reason
 
     @property
     def cloudformation_stack_arn(self):
@@ -307,9 +326,6 @@ class DescribeImageResponseContent(Model):
         :param cloudformation_stack_arn: The cloudformation_stack_arn of this DescribeImageResponseContent.
         :type cloudformation_stack_arn: str
         """
-        if cloudformation_stack_arn is None:
-            raise ValueError("Invalid value for `cloudformation_stack_arn`, must not be `None`")
-
         self._cloudformation_stack_arn = cloudformation_stack_arn
 
     @property
@@ -382,28 +398,3 @@ class DescribeImageResponseContent(Model):
             raise ValueError("Invalid value for `version`, must not be `None`")
 
         self._version = version
-
-    @property
-    def tags(self):
-        """Gets the tags of this DescribeImageResponseContent.
-
-        Tags of the infrastructure to build the Image
-
-        :return: The tags of this DescribeImageResponseContent.
-        :rtype: List[Tag]
-        """
-        return self._tags
-
-    @tags.setter
-    def tags(self, tags):
-        """Sets the tags of this DescribeImageResponseContent.
-
-        Tags of the infrastructure to build the Image
-
-        :param tags: The tags of this DescribeImageResponseContent.
-        :type tags: List[Tag]
-        """
-        if tags is None:
-            raise ValueError("Invalid value for `tags`, must not be `None`")
-
-        self._tags = tags

--- a/cli/src/pcluster/api/models/ec2_ami_info.py
+++ b/cli/src/pcluster/api/models/ec2_ami_info.py
@@ -23,13 +23,15 @@ class Ec2AmiInfo(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, ami_name=None, ami_id=None, state=None, tags=None, architecture=None):
+    def __init__(self, ami_name=None, ami_id=None, description=None, state=None, tags=None, architecture=None):
         """Ec2AmiInfo - a model defined in OpenAPI
 
         :param ami_name: The ami_name of this Ec2AmiInfo.
         :type ami_name: str
         :param ami_id: The ami_id of this Ec2AmiInfo.
         :type ami_id: str
+        :param description: The description of this Ec2AmiInfo.
+        :type description: str
         :param state: The state of this Ec2AmiInfo.
         :type state: Ec2AmiState
         :param tags: The tags of this Ec2AmiInfo.
@@ -40,6 +42,7 @@ class Ec2AmiInfo(Model):
         self.openapi_types = {
             "ami_name": str,
             "ami_id": str,
+            "description": str,
             "state": Ec2AmiState,
             "tags": List[Tag],
             "architecture": str,
@@ -48,6 +51,7 @@ class Ec2AmiInfo(Model):
         self.attribute_map = {
             "ami_name": "amiName",
             "ami_id": "amiId",
+            "description": "description",
             "state": "state",
             "tags": "tags",
             "architecture": "architecture",
@@ -55,6 +59,7 @@ class Ec2AmiInfo(Model):
 
         self._ami_name = ami_name
         self._ami_id = ami_id
+        self._description = description
         self._state = state
         self._tags = tags
         self._architecture = architecture
@@ -119,6 +124,31 @@ class Ec2AmiInfo(Model):
             raise ValueError("Invalid value for `ami_id`, must not be `None`")
 
         self._ami_id = ami_id
+
+    @property
+    def description(self):
+        """Gets the description of this Ec2AmiInfo.
+
+        EC2 AMI description  # noqa: E501
+
+        :return: The description of this Ec2AmiInfo.
+        :rtype: str
+        """
+        return self._description
+
+    @description.setter
+    def description(self, description):
+        """Sets the description of this Ec2AmiInfo.
+
+        EC2 AMI description  # noqa: E501
+
+        :param description: The description of this Ec2AmiInfo.
+        :type description: str
+        """
+        if description is None:
+            raise ValueError("Invalid value for `description`, must not be `None`")  # noqa: E501
+
+        self._description = description
 
     @property
     def state(self):

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -1808,6 +1808,7 @@ components:
         ec2AmiInfo:
           amiName: amiName
           amiId: amiId
+          description: description
           state: null
           tags:
           - value: value
@@ -1935,6 +1936,7 @@ components:
       example:
         amiName: amiName
         amiId: amiId
+        description: description
         state: null
         tags:
         - value: value
@@ -1951,6 +1953,10 @@ components:
           description: EC2 AMI id
           title: amiId
           type: string
+        description:
+          description: EC2 AMI description
+          title: description
+          type: string
         state:
           $ref: '#/components/schemas/Ec2AmiState'
         tags:
@@ -1966,6 +1972,7 @@ components:
       required:
       - amiId
       - amiName
+      - description
       - architecture
       - state
       - tags

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -1798,11 +1798,12 @@ components:
           s3Url: s3Url
         imageId: imageId
         imagebuilderImageStatus: null
+        imagebuilderImageStatusReason: imagebuilderImageStatusReason
         creationTime: 2000-01-23T04:56:07.000+00:00
         imageBuildStatus: null
-        failureReason: failureReason
         cloudformationStackStatus: null
         cloudformationStackArn: cloudformationStackArn
+        cloudformationStackStatusReason: cloudformationStackStatusReason
         region: region
         ec2AmiInfo:
           amiName: amiName
@@ -1815,11 +1816,6 @@ components:
             key: key
           architecture: architecture
         version: version
-        tags:
-        - value: value
-          key: key
-        - value: value
-          key: key
       properties:
         imageConfiguration:
           $ref: '#/components/schemas/ImageConfigurationStructure'
@@ -1836,13 +1832,16 @@ components:
           type: string
         imageBuildStatus:
           $ref: '#/components/schemas/ImageBuildStatus'
-        failureReason:
-          description: "Describe the reason of the failure when the stack is in CREATE_FAILED,\
-            \ UPDATE_FAILED or DELETE_FAILED status"
-          title: failureReason
+        cloudformationStackStatusReason:
+          description: Reason for the CloudFormation stack status
+          title: cloudformationStackStatusReason
           type: string
         cloudformationStackStatus:
           $ref: '#/components/schemas/CloudFormationStatus'
+        imagebuilderImageStatusReason:
+          description: Reason for the ImageBuilder Image status.
+          title: imagebuilderImageStatusReason
+          type: string
         cloudformationStackArn:
           description: ARN of the main CloudFormation stack
           title: cloudformationStackArn
@@ -1857,21 +1856,11 @@ components:
           description: ParallelCluster version used to build the image
           title: version
           type: string
-        tags:
-          description: Tags of the infrastructure to build the Image
-          items:
-            $ref: '#/components/schemas/Tag'
-          title: tags
-          type: array
       required:
-      - cloudformationStackArn
-      - cloudformationStackStatus
-      - creationTime
       - imageBuildStatus
       - imageConfiguration
       - imageId
       - region
-      - tags
       - version
       title: DescribeImageResponseContent
       type: object

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -53,6 +53,11 @@ class StackInfo:
         return self._stack_data.get("StackStatus")
 
     @property
+    def status_reason(self):
+        """Return the reason the stack is in its current status."""
+        return self._stack_data.get("StackStatusReason", None)
+
+    @property
     def creation_time(self):
         """Return creation time of the stack."""
         return str(self._stack_data.get("CreationTime"))

--- a/cli/src/pcluster/aws/imagebuilder.py
+++ b/cli/src/pcluster/aws/imagebuilder.py
@@ -13,7 +13,12 @@ class ImageBuilderClient(Boto3Client):
         return self._client.get_image(imageBuildVersionArn=image_arn)
 
     @AWSExceptionHandler.handle_client_exception
+    def get_image_state(self, image_arn):
+        """Get image state by ami arn."""
+        return self.get_image_resources(image_arn).get("image", {}).get("state", {})
+
+    @AWSExceptionHandler.handle_client_exception
     def get_image_id(self, image_arn):
         """Retrieve image id by image arn."""
-        ami_list = self.get_image_resources(image_arn).get("image", []).get("outputResources", []).get("amis", [])
+        ami_list = self.get_image_resources(image_arn).get("image", {}).get("outputResources", {}).get("amis", None)
         return ami_list[0].get("image") if ami_list else None

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -222,7 +222,7 @@ class ImageBuilder:
             except StackNotFoundError:
                 raise NonExistingStackError(self.image_id)
             except AWSClientError as e:
-                raise _stack_error_mapper(e, f"Unable to get image {self.image_id}, due to {e}")
+                raise _stack_error_mapper(e, f"Unable to get image {self.image_id}, due to {e}.")
         return self.__stack
 
     @property

--- a/cli/src/pcluster/models/imagebuilder_resources.py
+++ b/cli/src/pcluster/models/imagebuilder_resources.py
@@ -128,3 +128,14 @@ class ImageBuilderStack(StackInfo):
             except (AWSClientError, KeyError):
                 return None
         return None
+
+    @property
+    def image_state(self):
+        """Return the ImageBuilder image state."""
+        if self._imagebuilder_image_resource:
+            try:
+                image_build_version_arn = self._imagebuilder_image_resource["StackResourceDetail"]["PhysicalResourceId"]
+                return AWSApi.instance().imagebuilder.get_image_state(image_build_version_arn)
+            except (AWSClientError, KeyError):
+                return None
+        return None

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -48,6 +48,7 @@ def _create_image_info(image_id):
             "State": Ec2AmiState.AVAILABLE,
             "Architecture": "x86_64",
             "CreationDate": datetime(2021, 4, 12),
+            "Description": "description",
             "Tags": [
                 {"Key": "parallelcluster:image_id", "Value": image_id},
                 {"Key": "parallelcluster:version", "Value": "3.0.0"},
@@ -724,6 +725,7 @@ class TestDescribeImage:
                 "amiName": "image1",
                 "architecture": "x86_64",
                 "state": Ec2AmiState.AVAILABLE,
+                "description": "description",
                 "tags": [
                     {"Key": "parallelcluster:image_id", "Value": "image1"},
                     {"Key": "parallelcluster:version", "Value": "3.0.0"},

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -6,11 +6,18 @@
 #  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 #  limitations under the License.
 import json
+from datetime import datetime
 
 import pytest
 from assertpy import assert_that, soft_assertions
 
-from pcluster.api.models import CloudFormationStatus, ImageBuildStatus, ImageStatusFilteringOption
+from pcluster.api.models import (
+    CloudFormationStatus,
+    Ec2AmiState,
+    ImageBuilderImageStatus,
+    ImageBuildStatus,
+    ImageStatusFilteringOption,
+)
 from pcluster.api.models.validation_level import ValidationLevel
 from pcluster.aws.aws_resources import ImageInfo
 from pcluster.aws.common import (
@@ -33,44 +40,39 @@ from pcluster.utils import get_installed_version
 from pcluster.validators.common import FailureLevel, ValidationResult
 
 
-class TestImageOperationsController:
-    """ImageOperationsController integration test stubs."""
-
-    def test_describe_image(self, client):
-        """Test case for describe_image."""
-        query_string = [("region", "eu-west-1")]
-        headers = {
-            "Accept": "application/json",
-        }
-        response = client.open(
-            "/v3/images/custom/{image_id}".format(image_id="imageid"),
-            method="GET",
-            headers=headers,
-            query_string=query_string,
-        )
-        assert_that(response.status_code).is_equal_to(200)
-
-
 def _create_image_info(image_id):
     return ImageInfo(
         {
+            "Name": image_id,
+            "ImageId": image_id,
+            "State": Ec2AmiState.AVAILABLE,
+            "Architecture": "x86_64",
+            "CreationDate": datetime(2021, 4, 12),
             "Tags": [
                 {"Key": "parallelcluster:image_id", "Value": image_id},
                 {"Key": "parallelcluster:version", "Value": "3.0.0"},
+                {"Key": "parallelcluster:build_config", "Value": "test_url"},
             ],
         }
     )
 
 
-def _create_stack(image_id, status):
-    return {
+def _create_stack(image_id, status, reason=None):
+    stack = {
         "StackId": f"arn:{image_id}",
+        "StackName": f"arn:{image_id}",
         "StackStatus": status,
         "Tags": [
             {"Key": "parallelcluster:image_id", "Value": image_id},
             {"Key": "parallelcluster:version", "Value": "3.0.0"},
+            {"Key": "parallelcluster:build_config", "Value": "test_url"},
         ],
     }
+
+    if reason:
+        stack["StackStatusReason"] = reason
+
+    return stack
 
 
 class TestListImages:
@@ -691,4 +693,149 @@ class TestDescribeOfficialImages:
 
         with soft_assertions():
             assert_that(response.status_code).is_equal_to(status_code)
+            assert_that(response.get_json()).is_equal_to(expected_error)
+
+
+class TestDescribeImage:
+    url = "/v3/images/custom/{image_name}"
+    method = "GET"
+
+    def _send_test_request(self, client, image_name, region="us-east-1"):
+        query_string = []
+        if region:
+            query_string.append(("region", region))
+        headers = {
+            "Accept": "application/json",
+        }
+        return client.open(
+            self.url.format(image_name=image_name), method=self.method, headers=headers, query_string=query_string
+        )
+
+    def test_describe_of_image_already_available(self, client, mocker):
+        mocker.patch(
+            "pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
+            return_value=_create_image_info("image1"),
+        )
+
+        expected_response = {
+            "creationTime": "2021-04-12T00:00:00Z",
+            "ec2AmiInfo": {
+                "amiId": "image1",
+                "amiName": "image1",
+                "architecture": "x86_64",
+                "state": Ec2AmiState.AVAILABLE,
+                "tags": [
+                    {"Key": "parallelcluster:image_id", "Value": "image1"},
+                    {"Key": "parallelcluster:version", "Value": "3.0.0"},
+                    {"Key": "parallelcluster:build_config", "Value": "test_url"},
+                ],
+            },
+            "imageBuildStatus": ImageBuildStatus.BUILD_COMPLETE,
+            "imageConfiguration": {"s3Url": "test_url"},
+            "imageId": "image1",
+            "region": "us-east-1",
+            "version": "3.0.0",
+        }
+
+        response = self._send_test_request(client, "image1")
+
+        with soft_assertions():
+            assert_that(response.status_code).is_equal_to(200)
+            assert_that(response.get_json()).is_equal_to(expected_response)
+
+    def test_describe_of_image_not_yet_available_with_no_associated_imagebuilder_image(self, client, mocker):
+        mocker.patch(
+            "pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
+            side_effect=ImageNotFoundError("describe_image_by_id_tag"),
+        )
+        mocker.patch(
+            "pcluster.aws.cfn.CfnClient.describe_stack",
+            return_value=_create_stack("image1", CloudFormationStatus.CREATE_IN_PROGRESS),
+        )
+
+        expected_response = {
+            "imageConfiguration": {"s3Url": "test_url"},
+            "imageId": "image1",
+            "imageBuildStatus": ImageBuildStatus.BUILD_IN_PROGRESS,
+            "cloudformationStackStatus": CloudFormationStatus.CREATE_IN_PROGRESS,
+            "cloudformationStackArn": "arn:image1",
+            "region": "us-east-1",
+            "version": "3.0.0",
+        }
+
+        response = self._send_test_request(client, "image1")
+
+        with soft_assertions():
+            assert_that(response.status_code).is_equal_to(200)
+            assert_that(response.get_json()).is_equal_to(expected_response)
+
+    def test_describe_image_in_failed_state_with_reasons_and_associated_imagebuilder_image(self, client, mocker):
+        mocker.patch(
+            "pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
+            side_effect=ImageNotFoundError("describe_image_by_id_tag"),
+        )
+        mocker.patch(
+            "pcluster.aws.cfn.CfnClient.describe_stack",
+            return_value=_create_stack("image1", CloudFormationStatus.CREATE_FAILED, "cfn test reason"),
+        )
+        mocker.patch(
+            "pcluster.aws.cfn.CfnClient.describe_stack_resource",
+            return_value={"StackResourceDetail": {"PhysicalResourceId": "test_id"}},
+        )
+        mocker.patch(
+            "pcluster.aws.imagebuilder.ImageBuilderClient.get_image_state",
+            return_value={"status": ImageBuilderImageStatus.FAILED, "reason": "img test reason"},
+        )
+
+        expected_response = {
+            "cloudformationStackArn": "arn:image1",
+            "cloudformationStackStatus": CloudFormationStatus.CREATE_FAILED,
+            "cloudformationStackStatusReason": "cfn test reason",
+            "imageBuildStatus": ImageBuildStatus.BUILD_FAILED,
+            "imageConfiguration": {"s3Url": "test_url"},
+            "imageId": "image1",
+            "imagebuilderImageStatus": ImageBuilderImageStatus.FAILED,
+            "imagebuilderImageStatusReason": "img test reason",
+            "region": "us-east-1",
+            "version": "3.0.0",
+        }
+
+        response = self._send_test_request(client, "image1")
+
+        with soft_assertions():
+            assert_that(response.status_code).is_equal_to(200)
+            assert_that(response.get_json()).is_equal_to(expected_response)
+
+    @pytest.mark.parametrize(
+        "method_to_patch, error, error_code",
+        [
+            ("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", LimitExceededError, 429),
+            ("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", BadRequestError, 400),
+            ("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", AWSClientError, 500),
+            ("pcluster.aws.cfn.CfnClient.describe_stack", LimitExceededError, 429),
+            ("pcluster.aws.cfn.CfnClient.describe_stack", BadRequestError, 400),
+            ("pcluster.aws.cfn.CfnClient.describe_stack", AWSClientError, 500),
+            ("pcluster.aws.cfn.CfnClient.describe_stack", StackNotFoundError, 404),
+        ],
+    )
+    def test_that_errors_are_converted(self, client, mocker, method_to_patch, error, error_code):
+        method = method_to_patch.split(".")[-1]
+        if method == "describe_stack":
+            mocker.patch(
+                "pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
+                side_effect=ImageNotFoundError("describe_image_by_id_tag"),
+            )
+        mocker.patch(method_to_patch, side_effect=error(method, "test error"))
+
+        if error == StackNotFoundError:
+            expected_error = {"message": "No image or stack associated to parallelcluster image id image1."}
+        elif error == BadRequestError:
+            expected_error = {"message": "Bad Request: Unable to get image image1, due to test error."}
+        else:
+            expected_error = {"message": "Unable to get image image1, due to test error."}
+
+        response = self._send_test_request(client, "image1")
+
+        with soft_assertions():
+            assert_that(response.status_code).is_equal_to(error_code)
             assert_that(response.get_json()).is_equal_to(expected_error)


### PR DESCRIPTION
### Notes
This patch implements the DescribeImage API. We initialize an imageBuilder object, and try to retrieve the available image or, in case it is not yet available, the CloudFormation stack (eventually with its associated ImageBuilder image information). In case there are no available images or stacks associated with the provided image id, we throw a 404 to indicate that we did not find a matching image.

### Tests
1. Unit tests
2. Describe image with stack and failure reasons:
```
curl --location --request GET 'http://<ENDPOINT>/v3/images/custom/testfailed?region=us-east-1'
{
  "cloudformationStackArn": <CLOUDFORMATION STACK ARN>,
  "cloudformationStackStatus": "DELETE_FAILED",
  "cloudformationStackStatusReason": "The following resource(s) failed to delete: [ParallelClusterImage]. ",
  "imageBuildStatus": "DELETE_FAILED",
  "imageConfiguration": {
    "s3Url": <S3 URL>
  },
  "imageId": "testfailed",
  "imagebuilderImageStatus": "FAILED",
  "imagebuilderImageStatusReason": <FAILURE REASON>,
  "region": "us-east-1",
  "version": "3.0.0"
}
```
3. Describe available image:
```
curl --location --request GET 'http://<ENDPOINT>/v3/images/custom/test6?region=us-east-1'
{
  "creationTime": "2021-06-09T08:51:38.000Z",
  "ec2AmiInfo": {
    "amiId": <AMI ID>,
    "amiName": "test6 2021-06-09T08-21-40.869Z",
    "architecture": "x86_64",
    "state": "AVAILABLE",
    "tags": [
      {
        "Key": "parallelcluster:parent_image",
        "Value": <PARENT IMAGE>
      },
      ... -lines omitted-
    ]
  },
  "imageBuildStatus": "BUILD_COMPLETE",
  "imageConfiguration": {
    "s3Url": <S3 URL>
  },
  "imageId": "test6",
  "region": "us-east-1",
  "version": "3.0.0"
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
