### PR TITLE
3.0: Add validation messages to BuildImage result

### DIFF
--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -155,8 +155,13 @@ def build_image(
             imagebuilder.validate_create_request(suppress_validators, validation_failure_level)
             raise DryrunOperationException()
 
-        imagebuilder.create(disable_rollback, suppress_validators, validation_failure_level)
-        return BuildImageResponseContent(image=_imagebuilder_stack_to_image_info_summary(imagebuilder.stack))
+        suppressed_validation_failures = imagebuilder.create(
+            disable_rollback, suppress_validators, validation_failure_level
+        )
+        return BuildImageResponseContent(
+            image=_imagebuilder_stack_to_image_info_summary(imagebuilder.stack),
+            validation_messages=validation_results_to_config_validation_errors(suppressed_validation_failures) or None,
+        )
     except BadRequestImageBuilderActionError as e:
         errors = validation_results_to_config_validation_errors(e.validation_failures)
         raise BuildImageBadRequestException(

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -347,13 +347,15 @@ class ImageBuilder:
 
         :param suppress_validators: the validators we want to suppress when checking the configuration
         :param validation_failure_level: the level above which we throw an exception when validating the configuration
+        :return: the list of suppressed validation failures
         """
         self._validate_id()
         self._validate_no_existing_image()
-        self._validate_config(suppress_validators, validation_failure_level)
+        return self._validate_config(suppress_validators, validation_failure_level)
 
     def _validate_config(self, suppress_validators, validation_failure_level):
         """Validate the configuration, throwing an exception for failures above a given failure level."""
+        validation_failures = []
         if not suppress_validators:
             validation_failures = self.config.validate()
             for failure in validation_failures:
@@ -361,6 +363,7 @@ class ImageBuilder:
                     raise BadRequestImageBuilderActionError(
                         message="Configuration is invalid", validation_failures=validation_failures
                     )
+        return validation_failures
 
     def _validate_no_existing_image(self):
         """Validate that no existing image or stack with the same ImageBuilder image_id exists."""
@@ -379,7 +382,7 @@ class ImageBuilder:
         validation_failure_level: FailureLevel = FailureLevel.ERROR,
     ):
         """Create the CFN Stack and associate resources."""
-        self.validate_create_request(suppress_validators, validation_failure_level)
+        suppressed_validation_failures = self.validate_create_request(suppress_validators, validation_failure_level)
 
         # Generate artifact directory for image
         self._generate_artifact_dir()
@@ -415,6 +418,8 @@ class ImageBuilder:
 
             LOGGER.debug("StackId: %s", self.stack.id)
             LOGGER.info("Status: %s", self.stack.status)
+
+            return suppressed_validation_failures
 
         except Exception as e:
             LOGGER.critical(e)


### PR DESCRIPTION
### Notes
If when validating the configuration we have errors greater or equal to the current error level, we fail the validation. With this patch, if we have validation errors below the error threshold, then we return the validation messages in the BuildImage response.

### Tests
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
