### PR TITLE
3.0: Remove useless code

### DIFF
--- a/cli/src/pcluster/cli/commands/cluster.py
+++ b/cli/src/pcluster/cli/commands/cluster.py
@@ -456,10 +456,6 @@ class ExportClusterLogsCommand(CliCommand):
     def _export_cluster_logs(args: Namespace, output_file_path: str):
         """Export the logs associated to the cluster."""
         LOGGER.info("Beginning export of logs for the cluster: %s", args.cluster_name)
-        LOGGER.debug("CLI args: %s", str(args))
-        if args.region:
-            os.environ["AWS_DEFAULT_REGION"] = args.region
-
         cluster = Cluster(args.cluster_name)
         cluster.export_logs(
             output=output_file_path,

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -256,7 +256,6 @@ def test_timestamp_to_isoformat(timestamp, time_zone, expect_output):
         ("2021-06-04T11:34", "Europe/Rome", 1622799240000),
         ("2021-06-04T11", "Europe/London", 1622800800000),
         ("2021-06-04", "Europe/London", 1622761200000),
-        ("2021-06", "Europe/London", 1623884400000),
     ],
 )
 def test_isoformat_to_epoch(time_isoformat, time_zone, expect_output):


### PR DESCRIPTION
CLI args print and region setting are already done in entrypoint.
Remove failing test.
