### PR TITLE
3.0: Add CFN stack events to logs command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ CHANGELOG
 - Add `delete-image` command with `--name`, `--region`, `--force` parameters.
 - Add `describe-image` command with `--name`, `--region` parameters.
 - Add `list-images` command with `--region`, `--color`parameters.
-- Add `export-cluster-logs`, `list-cluster-logs` and `get-cluster-log-events` commands.
+- Add `export-cluster-logs`, `list-cluster-logs` and `get-cluster-log-events` commands to retrieve both CloudWatch Logs 
+  and CloudFormation Stack Events.
 - Distribute AWS Batch commands: `awsbhosts`, `awsbkill`, `awsbout`, `awsbqueues`, `awsbstat` and `awsbsub`
   as a separate `aws-parallelcluster-awsbatch-cli` PyPI package.
 - Split head node and compute fleet instance roles and add possibility to configure a different instance role 

--- a/cli/src/pcluster/aws/cfn.py
+++ b/cli/src/pcluster/aws/cfn.py
@@ -101,8 +101,19 @@ class CfnClient(Boto3Client):
     @AWSExceptionHandler.handle_client_exception
     @AWSExceptionHandler.retry_on_boto3_throttling
     def get_stack_events(self, stack_name):
-        """Return events of a stack."""
-        return self._client.describe_stack_events(StackName=stack_name).get("StackEvents")
+        """Return all the events of a stack."""
+        return list(self._paginate_results(self._client.describe_stack_events, StackName=stack_name))
+
+    @staticmethod
+    def format_event(event):
+        """Format CFN Stack event."""
+        return "{} {} {} {} {}".format(
+            event.get("Timestamp").isoformat(timespec="seconds"),
+            event.get("ResourceStatus"),
+            event.get("ResourceType"),
+            event.get("LogicalResourceId"),
+            event.get("ResourceStatusReason", ""),
+        )
 
     def stack_exists(self, stack_name: str):
         """Return a boolean describing whether or not a stack by the given name exists."""

--- a/cli/src/pcluster/cli/commands/cluster.py
+++ b/cli/src/pcluster/cli/commands/cluster.py
@@ -466,7 +466,7 @@ class ExportClusterLogsCommand(CliCommand):
             end_time=args.end_time,
             filters=" ".join(args.filters) if args.filters else None,
         )
-        LOGGER.info("Cluster's logs exported correctly to %s.", output_file_path)
+        LOGGER.info("Cluster's logs exported correctly to %s", output_file_path)
 
 
 class ListClusterLogsCommand(CliCommand):
@@ -483,7 +483,7 @@ class ListClusterLogsCommand(CliCommand):
     def register_command_args(self, parser: ArgumentParser) -> None:  # noqa: D102
         parser.add_argument("cluster_name", help="List the logs of the cluster name provided here.")
         # Filters
-        filters_arg = _FiltersArg(accepted_filters=["private-dns-name"])
+        filters_arg = _FiltersArg(accepted_filters=["private-dns-name", "node-type"])
         parser.add_argument(
             "--filters",
             nargs="+",
@@ -504,9 +504,6 @@ class ListClusterLogsCommand(CliCommand):
 
     @staticmethod
     def _list_cluster_logs(args: Namespace):
-        if args.region:
-            os.environ["AWS_DEFAULT_REGION"] = args.region
-
         cluster = Cluster(args.cluster_name)
         response = cluster.list_logs(
             filters=" ".join(args.filters) if args.filters else None,
@@ -529,9 +526,9 @@ class ListClusterLogsCommand(CliCommand):
                         value = utils.timestamp_to_isoformat(value)
                     filtered_item[output_key] = value
                 filtered_result.append(filtered_item)
-            LOGGER.info(tabulate(filtered_result, headers="keys", tablefmt="plain"))
+            print(tabulate(filtered_result, headers="keys", tablefmt="plain"))
             if response.get("nextToken", None):
-                LOGGER.info("\nnextToken is: %s", response["nextToken"])
+                print("\nnextToken is: %s", response["nextToken"])
 
 
 class _FiltersArg:
@@ -620,8 +617,6 @@ class GetClusterLogEventsCommand(CliCommand):
 
     def _get_cluster_log_events(self, args: Namespace):
         """Get log events for a specific log stream of the cluster saved in CloudWatch."""
-        if args.region:
-            os.environ["AWS_DEFAULT_REGION"] = args.region
         kwargs = {
             "log_stream_name": args.log_stream_name,
             "start_time": args.start_time,

--- a/cli/src/pcluster/cli/commands/common.py
+++ b/cli/src/pcluster/cli/commands/common.py
@@ -39,7 +39,9 @@ class CliCommand(ABC):
         if region_arg:
             parser.add_argument("-r", "--region", help="AWS Region to use.", choices=SUPPORTED_REGIONS)
         if config_arg:
-            parser.add_argument("-c", "--config", dest="config_file", help="Defines an alternative config file.")
+            parser.add_argument(
+                "-c", "--config", dest="config_file", help="Defines an alternative config file.", required=True
+            )
         if nowait_arg:
             parser.add_argument(
                 "-nw",

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -52,7 +52,7 @@ from pcluster.models.common import BadRequest, Conflict, LimitExceeded, parse_co
 from pcluster.models.s3_bucket import S3Bucket, S3BucketFactory, S3FileFormat
 from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
-from pcluster.utils import generate_random_name_with_prefix, get_installed_version, grouper
+from pcluster.utils import generate_random_name_with_prefix, get_installed_version, grouper, isoformat_to_epoch
 from pcluster.validators.cluster_validators import ClusterNameValidator
 from pcluster.validators.common import FailureLevel, ValidationResult
 
@@ -992,8 +992,8 @@ class Cluster:
     def get_log_events(
         self,
         log_stream_name: str,
-        start_time: int = None,
-        end_time: int = None,
+        start_time: str = None,
+        end_time: str = None,
         start_from_head: bool = False,
         limit: int = None,
         next_token: str = None,
@@ -1002,10 +1002,8 @@ class Cluster:
         Get the log stream events.
 
         :param log_stream_name: Log stream name
-        :param start_time: Start time of interval of interest for log events,
-            expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.
-        :param end_time: End time of interval of interest for log events,
-            expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.
+        :param start_time: Start time of interval of interest for log events. ISO 8601 format: YYYY-MM-DDThh:mm:ssTZD
+        :param end_time: End time of interval of interest for log events. ISO 8601 format: YYYY-MM-DDThh:mm:ssTZD
         :param start_from_head: If the value is true, the earliest log events are returned first.
             If the value is false, the latest log events are returned first. The default value is false.
         :param limit: The maximum number of log events returned. If you don't specify a value,
@@ -1024,8 +1022,8 @@ class Cluster:
                 return AWSApi.instance().logs.get_log_events(
                     log_group_name=self.stack.log_group_name,
                     log_stream_name=log_stream_name,
-                    end_time=end_time,
-                    start_time=start_time,
+                    end_time=isoformat_to_epoch(end_time) if end_time else None,
+                    start_time=isoformat_to_epoch(start_time) if start_time else None,
                     limit=limit,
                     start_from_head=start_from_head,
                     next_token=next_token,

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -58,6 +58,8 @@ from pcluster.validators.common import FailureLevel, ValidationResult
 
 LOGGER = logging.getLogger(__name__)
 
+# pylint: disable=C0302
+
 
 class NodeType(Enum):
     """Enum that identifies the cluster node type."""

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -1031,6 +1031,13 @@ class Cluster:
                     next_token=next_token,
                 )
             else:
-                return {"events": AWSApi.instance().cfn.get_stack_events(self.stack_name)}
+                stack_events = AWSApi.instance().cfn.get_stack_events(self.stack_name)
+                stack_events.reverse()
+                if limit:
+                    if start_from_head:
+                        stack_events = stack_events[:limit]
+                    else:
+                        stack_events = stack_events[len(stack_events) - limit :]  # noqa E203
+                return {"events": stack_events}
         except AWSClientError as e:
             raise _cluster_error_mapper(e, f"Unexpected error when retrieving log events: {e}")

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -169,7 +169,7 @@ def log_stack_failure_recursive(stack_name, failed_states=None, indent=2):
     events = AWSApi.instance().cfn.get_stack_events(stack_name)
     for event in events:
         if event.get("ResourceStatus") in failed_states:
-            _log_failed_cfn_event(event, indent)
+            _log_cfn_event(event, indent)
             if event.get("ResourceType") == "AWS::CloudFormation::Stack":
                 # Sample substack error:
                 # "Embedded stack arn:aws:cloudformation:us-east-2:704743599507:stack/
@@ -182,17 +182,9 @@ def log_stack_failure_recursive(stack_name, failed_states=None, indent=2):
                     log_stack_failure_recursive(substack_name, indent=indent + 2)
 
 
-def _log_failed_cfn_event(event, indent):
+def _log_cfn_event(event, indent):
     """Log failed CFN events."""
-    LOGGER.info(
-        "%s- %s %s %s %s %s",
-        " " * indent,
-        event.get("Timestamp"),
-        event.get("ResourceStatus"),
-        event.get("ResourceType"),
-        event.get("LogicalResourceId"),
-        event.get("ResourceStatusReason"),
-    )
+    print("%s- %s", " " * indent, AWSApi.instance().cfn.format_event(event))
 
 
 def get_templates_bucket_path():
@@ -284,7 +276,7 @@ def timestamp_to_isoformat(timestamp, timezone=None):
     if not timezone:
         timezone = tz.tzlocal()
     # Forcing microsecond to 0 to avoid having them displayed.
-    return datetime.fromtimestamp(timestamp / 1000, tz=timezone).replace(microsecond=0).isoformat()
+    return datetime.fromtimestamp(timestamp / 1000, tz=timezone).isoformat(timespec="seconds")
 
 
 def isoformat_to_epoch(time_isoformat):

--- a/cli/tests/pcluster/cli/test_get_cluster_log_events.py
+++ b/cli/tests/pcluster/cli/test_get_cluster_log_events.py
@@ -37,8 +37,8 @@ class TestGetClusterLogEventsCommand:
     @pytest.mark.parametrize(
         "args, error_message",
         [
-            ({"start_time": "wrong"}, "invalid int value"),
-            ({"end_time": "wrong"}, "invalid int value"),
+            ({"start_time": "wrong"}, "Start time and end time filters must be in the ISO 8601 format"),
+            ({"end_time": "1622802790248"}, "Start time and end time filters must be in the ISO 8601 format"),
             ({"head": "wrong"}, "invalid int value"),
             ({"tail": "wrong"}, "invalid int value"),
             ({"stream_period": "wrong"}, "invalid int value"),
@@ -61,7 +61,16 @@ class TestGetClusterLogEventsCommand:
             ({"stream_period": "5"}, "can be used only with"),
             # success
             ({}, None),
-            ({"head": "6", "start_time": "1622802790248", "end_time": "1622802790390", "next_token": "f/1234"}, None),
+            ({"tail": "6", "start_time": "2021-06-02", "end_time": "2021-06-02"}, None),
+            (
+                {
+                    "head": "6",
+                    "start_time": "2021-06-02T15:55:10+02:00",
+                    "end_time": "2021-06-02T17:55:10+02:00",
+                    "next_token": "f/1234",
+                },
+                None,
+            ),
             ({"tail": "2", "stream": True, "stream_period": "6"}, None),
         ],
     )

--- a/cli/tests/pcluster/cli/test_get_cluster_log_events/TestGetClusterLogEventsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_get_cluster_log_events/TestGetClusterLogEventsCommand/test_helper/pcluster-help.txt
@@ -20,21 +20,24 @@ optional arguments:
                         AWS Region to use.
   --log-stream-name LOG_STREAM_NAME
                         Log stream name, as reported by 'pcluster list-
-                        cluster-logs' command
+                        cluster-logs' command.
   --start-time START_TIME
-                        Start time of interval of interest for log events,
-                        expressed as the number of milliseconds after Jan 1,
-                        1970 00:00:00 UTC.
-  --end-time END_TIME   End time of interval of interest for log events,
-                        expressed as the number of milliseconds after Jan 1,
-                        1970 00:00:00 UTC.
-  --head HEAD           Gets the first <head> lines of the log stream
-  --tail TAIL           Gets the last <tail> lines of the log stream
+                        Start time of interval of interest for log events, ISO
+                        8601 format: YYYY-MM-DDThh:mm:ssTZD (e.g.
+                        1984-09-15T19:20:30+01:00), time elements might be
+                        omitted.
+  --end-time END_TIME   End time of interval of interest for log events, ISO
+                        8601 format: YYYY-MM-DDThh:mm:ssTZD (e.g.
+                        1984-09-15T19:20:30+01:00), time elements might be
+                        omitted.
+  --head HEAD           Gets the first <head> lines of the log stream.
+  --tail TAIL           Gets the last <tail> lines of the log stream.
   --next-token NEXT_TOKEN
-                        Token for paginated requests
+                        Token for paginated requests.
   --stream              Gets the log stream and waits for additional output to
                         be produced. It can be used in conjunction with --tail
                         to start from the latest <tail> lines of the log
-                        stream
+                        stream. It doesn't work for CloudFormation Stack
+                        Events log stream.
   --stream-period STREAM_PERIOD
-                        Sets the streaming period. Default is 5 seconds
+                        Sets the streaming period. Default is 5 seconds.

--- a/cli/tests/pcluster/cli/test_list_cluster_logs.py
+++ b/cli/tests/pcluster/cli/test_list_cluster_logs.py
@@ -49,9 +49,12 @@ class TestListClusterLogsCommand:
         assert_that(out + err).contains(error_message)
 
     @pytest.mark.parametrize(
-        "args",
-        [{}, {"filters": "Name=private-dns-name,Values=ip-10-10-10-10", "next_token": "123"}],
-        ids=["required", "all"],
+        "args, ",
+        [
+            {},
+            {"filters": "Name=private-dns-name,Values=ip-10-10-10-10", "next_token": "123"},
+            {"filters": "Name=node-type,Values=HeadNode"},
+        ]
     )
     def test_execute(self, mocker, capsys, set_env, run_cli, args):
         mocked_result = {

--- a/cli/tests/pcluster/cli/test_list_cluster_logs.py
+++ b/cli/tests/pcluster/cli/test_list_cluster_logs.py
@@ -54,7 +54,7 @@ class TestListClusterLogsCommand:
             {},
             {"filters": "Name=private-dns-name,Values=ip-10-10-10-10", "next_token": "123"},
             {"filters": "Name=node-type,Values=HeadNode"},
-        ]
+        ],
     )
     def test_execute(self, mocker, capsys, set_env, run_cli, args):
         mocked_result = {
@@ -88,6 +88,13 @@ class TestListClusterLogsCommand:
             ],
             "nextToken": "123-456",
             "ResponseMetadata": {},
+            "stackEventsStream": [
+                {
+                    "Stack Events Stream": "cloudformation-stack-events",
+                    "Cluster Creation Time": "2021-06-04T10:23:20+00:00",
+                    "Last Update Time": "2021-06-04T10:23:20+00:00",
+                }
+            ],
         }
         list_logs_mock = mocker.patch("pcluster.cli.commands.cluster.Cluster.list_logs", return_value=mocked_result)
         set_env("AWS_DEFAULT_REGION", "us-east-1")
@@ -96,7 +103,9 @@ class TestListClusterLogsCommand:
         run_cli(command, expect_failure=False)
 
         out_err = capsys.readouterr()
-        expected_out = [
+        # cfn stack events are not displayed if next-token is passed
+        expected_out = [] if "next_token" in args else ["cloudformation-stack-events", "2021-06-04T10:23:20+00:00"]
+        expected_out += [
             "ip-10-0-0-102.i-0717e670ad2549e72.cfn-init",
             self._timestamp_to_date(1622802790248),
             self._timestamp_to_date(1622802893126),

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -41,7 +41,9 @@ class TestCluster:
                 )
             ),
         )
-        return Cluster(FAKE_NAME, stack=ClusterStack({"StackName": FAKE_NAME}))
+        return Cluster(
+            FAKE_NAME, stack=ClusterStack({"StackName": FAKE_NAME, "CreationTime": "2021-06-04 10:23:20.199000+00:00"})
+        )
 
     @pytest.mark.parametrize(
         "node_type, expected_response, expected_instances",
@@ -430,7 +432,7 @@ class TestCluster:
         "stack_exists, logging_enabled, client_error, expected_error",
         [
             (False, False, False, "Cluster .* does not exist"),
-            (True, False, False, "CloudWatch logging is not enabled"),
+            (True, False, False, ""),
             (True, True, True, "Unexpected error when retrieving"),
             (True, True, False, ""),
         ],
@@ -464,7 +466,8 @@ class TestCluster:
                 cluster.list_logs()
         else:
             cluster.list_logs()
-            describe_logs_mock.assert_called()
+            if logging_enabled:
+                describe_logs_mock.assert_called()
 
         # check preliminary steps
         stack_exists_mock.assert_called_with(cluster.stack_name)

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -188,11 +188,13 @@ class Cluster:
             logging.error("Failed listing cluster's logs with error:\n%s\nand output:\n%s", e.stderr, e.stdout)
             raise
 
-    def get_log_events(self, log_stream, head=None):
+    def get_log_events(self, log_stream, head=None, tail=None):
         """Run pcluster get-cluster-log-events and return the result."""
         cmd_args = ["pcluster", "get-cluster-log-events", self.name, "--log-stream-name", log_stream]
         if head:
             cmd_args += ["--head", str(head)]
+        if tail:
+            cmd_args += ["--tail", str(tail)]
         try:
             result = run_command(cmd_args, log_error=False)
             logging.info("Log events listed successfully")

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -128,6 +128,14 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, region, insta
         # check archive prefix and content
         with tarfile.open(output_file) as archive:
 
+            # check the cfn stack events file is present
+            stack_events_file_found = False
+            for file in archive:
+                if "cloudformation-stack-events" == file.name:
+                    stack_events_file_found = True
+                    break
+            assert_that(stack_events_file_found).is_true()
+
             # check there are the logs of all the instances
             for instance_id in set(instance_ids):
                 instance_found = False
@@ -154,10 +162,13 @@ def _test_pcluster_list_cluster_logs(cluster, instance_ids):
     logging.info("Testing that pcluster list-cluster-logs is working as expected")
     std_output = cluster.list_logs()
 
-    # check headers
-    assert_that(std_output).contains("Log Stream Name")
-    assert_that(std_output).contains("First Event")
-    assert_that(std_output).contains("Last Event")
+    # check cfn stack events headers and log stream name
+    for item in ["Stack Events Stream", "Cluster Creation Time", "Last Update Time", "cloudformation-stack-events"]:
+        assert_that(std_output).contains(item)
+
+    # check CW log streams headers
+    for item in ["Log Stream Name", "First Event", "Last Event"]:
+        assert_that(std_output).contains(item)
 
     # check there are the logs of all the instances
     for instance_id in set(instance_ids):
@@ -175,6 +186,10 @@ def _test_pcluster_list_cluster_logs(cluster, instance_ids):
 def _test_pcluster_get_cluster_log_events(cluster, cfn_init_log_stream):
     """Test pcluster get-cluster-log-events functionality."""
     logging.info("Testing that pcluster get-cluster-log-events is working as expected")
+    # Check cfn-init log stream
     std_output = cluster.get_log_events(cfn_init_log_stream, head=10)
-
     assert_that(std_output).contains("[DEBUG] CloudFormation client initialized with endpoint")
+
+    # Check CFN Stack events stream
+    std_output = cluster.get_log_events("cloudformation-stack-events")
+    assert_that(std_output).contains("CREATE_COMPLETE AWS::CloudFormation::Stack")

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -190,6 +190,10 @@ def _test_pcluster_get_cluster_log_events(cluster, cfn_init_log_stream):
     std_output = cluster.get_log_events(cfn_init_log_stream, head=10)
     assert_that(std_output).contains("[DEBUG] CloudFormation client initialized with endpoint")
 
-    # Check CFN Stack events stream
-    std_output = cluster.get_log_events("cloudformation-stack-events")
-    assert_that(std_output).contains("CREATE_COMPLETE AWS::CloudFormation::Stack")
+    # Check CFN Stack events stream with tail option
+    std_output = cluster.get_log_events("cloudformation-stack-events", tail=10)
+    assert_that(std_output).contains(f"CREATE_COMPLETE AWS::CloudFormation::Stack {cluster.name}")
+
+    # Check CFN Stack events stream with head option
+    std_output = cluster.get_log_events("cloudformation-stack-events", head=10)
+    assert_that(std_output).contains(f"CREATE_IN_PROGRESS AWS::CloudFormation::Stack {cluster.name} User Initiated")


### PR DESCRIPTION
## List logs
The command will show a "fake" stream name, that can be used by the get-cluster-log-events command.
If CW logging is not enabled the list-cluster-logs command will return this stream only.
```
$ pcluster list-cluster-logs test22
Stack Events Stream          Cluster Creation Time      Last Update Time 
cloudformation-stack-events  2021-06-04T10:23:20+00:00  2021-06-04T10:23:20+00:00

Log Stream Name                                      First Event                Last Event
ip-10-0-0-102.i-0717e670ad2549e72.cfn-init           2021-06-04T12:33:10+02:00  2021-06-04T12:34:53+02:00
ip-10-0-0-102.i-0717e670ad2549e72.chef-client        2021-06-04T12:33:57+02:00  2021-06-04T12:34:21+02:00
ip-10-0-0-102.i-0717e670ad2549e72.cloud-init         2021-06-04T12:33:57+02:00  2021-06-04T12:34:58+02:00

$ pcluster list-cluster-logs test-nocwlogs
Stack Events Stream          Cluster Creation Time      Last Update Time
cloudformation-stack-events  2021-06-21T09:53:05+00:00  2021-06-21T09:53:05+00:00

There are no cluster's logs saved in CloudWatch.
```

## Get cluster log events
Filters and stream options are not accepted when retrieving stack events stream content.
Head and tail options are accepted.
```
$ pcluster get-cluster-log-events test22 --log-stream-name cloudformation-stack-events
2021-06-04T10:35:09+00:00 CREATE_COMPLETE AWS::CloudFormation::Stack test22
2021-06-04T10:35:05+00:00 CREATE_COMPLETE AWS::CloudWatch::Dashboard CloudwatchDashboard88785441
2021-06-04T10:35:05+00:00 CREATE_IN_PROGRESS AWS::CloudWatch::Dashboard CloudwatchDashboard88785441 Resource creation Initiated
...
```

## Export logs
The CFN stack events are saved in a file and stored in the logs archive.
If CW logging is not enabled the export-cluster-logs command will create an archive with this file only.
The filters, start-time, end-time, buckets options and stream options don't impact the cloudformation-stack-events content.
```
$ pcluster export-cluster-logs test22 --filters Name=private-dns-name,Values=ip-10-0-0-102 --bucket bucketname --end-time 2021-06-07T15:12:06+02:00 --start-time 2021-06-04T12:34:33 --output test.tar.gz
Beginning export of logs for the cluster: test22
Starting export of logs from log group /aws/parallelcluster/test22-202106041223 to s3 bucket bucketname
Waiting for export task with task ID=d509567b-05f9-4414-a421-54777d1dcfb2 to finish...
Cluster's logs exported correctly to test.tar.gz.

$ tar -tf test.tar.gz
cloudformation-stack-events
test22-logs-1624025508.563728/
test22-logs-1624025508.563728/ip-10-0-0-102.i-0717e670ad2549e72.system-messages
test22-logs-1624025508.563728/ip-10-0-0-102.i-0717e670ad2549e72.slurmctld
test22-logs-1624025508.563728/ip-10-0-0-102.i-0717e670ad2549e72.clustermgtd
```
