### PR TITLE
Fix runtime bake package installation issue on CentOS7

### DIFF
--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -417,7 +417,7 @@ Resources:
                   dnf -y groupinstall development && dnf -y install curl wget jq python3-pip
                   pip3 install awscli --upgrade --user
                 elif [ "${!yum}" == "0" ]; then
-                  yum -y groupinstall development && yum -y install curl wget jq awscli python3-pip
+                  yum -y groupinstall development && yum -y install epel-release && yum -y --setopt=skip_missing_names_on_install=False install curl wget jq awscli python3-pip
                 fi
                 if [ "${!apt}" == "0" ]; then
                   apt-cache search build-essential; apt-get clean; apt update -y; apt-get -y install build-essential curl wget jq python-setuptools awscli python3-pip

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -529,7 +529,7 @@ Resources:
                   dnf -y groupinstall development && dnf -y install curl wget jq python3-pip
                   pip3 install awscli --upgrade --user
                 elif [ "${!yum}" == "0" ]; then
-                  yum -y groupinstall development && yum -y install curl wget jq awscli python3-pip
+                  yum -y groupinstall development && yum -y install epel-release && yum -y --setopt=skip_missing_names_on_install=False install curl wget jq awscli python3-pip
                 fi
                 if [ "${!apt}" == "0" ]; then
                   apt-cache search build-essential; apt-get clean; apt update -y; apt-get -y install build-essential curl wget jq python-setuptools awscli python3-pip

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -485,7 +485,7 @@ Resources:
                   dnf -y groupinstall development && dnf -y install curl wget jq python3-pip
                   pip3 install awscli --upgrade --user
                 elif [ "${!yum}" == "0" ]; then
-                  yum -y groupinstall development && yum -y install curl wget jq awscli python3-pip
+                  yum -y groupinstall development && yum -y install epel-release && yum -y --setopt=skip_missing_names_on_install=False install curl wget jq awscli python3-pip
                 fi
                 if [ "${!apt}" == "0" ]; then
                   apt-cache search build-essential; apt-get clean; apt update -y; apt-get -y install build-essential curl wget jq python-setuptools awscli python3-pip


### PR DESCRIPTION
* Runtime bake path was failing to install `jq` silently on CentOS7
* Add `--setopt=skip_missing_names_on_install=False` so that yum will `exit 1` if package name is missing: https://bugzilla.redhat.com/show_bug.cgi?id=1274211
* Fix package installation by installing `epel-release` before `jq`
* CentOS 8 does not have this issue; `dnf` will `exit 1` if there is a missing package

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
