### PR TITLE
3.0: Implement DeleteCluster API

### DIFF
--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -194,19 +194,6 @@ paths:
           schema:
             type: string
             description: AWS Region. Defaults to the region the API is deployed to.
-        - name: retainLogs
-          in: query
-          description: Retain cluster logs on delete. Defaults to True.
-          schema:
-            type: boolean
-            description: Retain cluster logs on delete. Defaults to True.
-            nullable: true
-        - name: clientToken
-          in: query
-          description: Idempotency token that can be set by the client so that retries for the same request are idempotent
-          schema:
-            type: string
-            description: Idempotency token that can be set by the client so that retries for the same request are idempotent
       responses:
         "202":
           description: DeleteCluster 202 response

--- a/api/spec/smithy/model/operations/DeleteCluster.smithy
+++ b/api/spec/smithy/model/operations/DeleteCluster.smithy
@@ -23,13 +23,6 @@ structure DeleteClusterRequest {
 
     @httpQuery("region")
     region: Region,
-    @httpQuery("retainLogs")
-    @documentation("Retain cluster logs on delete. Defaults to True.")
-    retainLogs: Boolean,
-    @idempotencyToken
-    @httpQuery("clientToken")
-    @documentation("Idempotency token that can be set by the client so that retries for the same request are idempotent")
-    clientToken: String,
 }
 
 structure DeleteClusterResponse {

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -127,6 +127,7 @@ def create_cluster(
 
 
 @configure_aws_region()
+@convert_errors()
 @http_success_status_code(202)
 def delete_cluster(cluster_name, region=None):
     """
@@ -167,8 +168,6 @@ def delete_cluster(cluster_name, region=None):
             "In case you have running instances belonging to a deleted cluster please use the DeleteClusterInstances "
             "API."
         )
-    except ClusterActionError as e:
-        raise InternalServiceException(f"Failed when deleting cluster due to: {e}.")
 
 
 @configure_aws_region()

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -16,6 +16,7 @@ from pcluster.api.controllers.common import (
     configure_aws_region,
     convert_errors,
     get_validator_suppressors,
+    http_success_status_code,
     read_config,
 )
 from pcluster.api.converters import (
@@ -60,6 +61,7 @@ LOGGER = logging.getLogger(__name__)
 
 @configure_aws_region(is_query_string_arg=False)
 @convert_errors()
+@http_success_status_code(202)
 def create_cluster(
     create_cluster_request_content: Dict,
     suppress_validators: List[str] = None,
@@ -125,7 +127,8 @@ def create_cluster(
 
 
 @configure_aws_region()
-def delete_cluster(cluster_name, region=None, retain_logs=None, client_token=None):
+@http_success_status_code(202)
+def delete_cluster(cluster_name, region=None):
     """
     Initiate the deletion of a cluster.
 
@@ -133,24 +136,39 @@ def delete_cluster(cluster_name, region=None, retain_logs=None, client_token=Non
     :type cluster_name: str
     :param region: AWS Region. Defaults to the region the API is deployed to.
     :type region: str
-    :param retain_logs: Retain cluster logs on delete. Defaults to True.
-    :type retain_logs: bool
-    :param client_token: Idempotency token that can be set by the client so that retries for the same request are
-    idempotent
-    :type client_token: str
 
     :rtype: DeleteClusterResponseContent
     """
-    return DeleteClusterResponseContent(
-        cluster=ClusterInfoSummary(
-            cluster_name="nameeee",
-            cloudformation_stack_status=CloudFormationStatus.CREATE_COMPLETE,
-            cloudformation_stack_arn="arn",
-            region="region",
-            version="3.0.0",
-            cluster_status=ClusterStatus.CREATE_COMPLETE,
+    try:
+        cluster = Cluster(cluster_name)
+
+        if not check_cluster_version(cluster):
+            raise BadRequestException(
+                f"cluster '{cluster_name}' belongs to an incompatible ParallelCluster major version."
+            )
+
+        if not cluster.status == CloudFormationStatus.DELETE_IN_PROGRESS:
+            # TODO: remove keep_logs logic from delete
+            cluster.delete(keep_logs=False)
+
+        return DeleteClusterResponseContent(
+            cluster=ClusterInfoSummary(
+                cluster_name=cluster_name,
+                cloudformation_stack_status=CloudFormationStatus.DELETE_IN_PROGRESS,
+                cloudformation_stack_arn=cluster.stack.id,
+                region=os.environ.get("AWS_DEFAULT_REGION"),
+                version=cluster.stack.version,
+                cluster_status=cloud_formation_status_to_cluster_status(CloudFormationStatus.DELETE_IN_PROGRESS),
+            )
         )
-    )
+    except StackNotFoundError:
+        raise NotFoundException(
+            f"cluster '{cluster_name}' does not exist or belongs to an incompatible ParallelCluster major version. "
+            "In case you have running instances belonging to a deleted cluster please use the DeleteClusterInstances "
+            "API."
+        )
+    except ClusterActionError as e:
+        raise InternalServiceException(f"Failed when deleting cluster due to: {e}.")
 
 
 @configure_aws_region()
@@ -170,11 +188,11 @@ def describe_cluster(cluster_name, region=None):
         cfn_stack = cluster.stack
     except StackNotFoundError:
         raise NotFoundException(
-            f"cluster {cluster_name} does not exist or belongs to an incompatible ParallelCluster major version."
+            f"cluster '{cluster_name}' does not exist or belongs to an incompatible ParallelCluster major version."
         )
 
     if not check_cluster_version(cluster):
-        raise BadRequestException(f"cluster {cluster_name} belongs to an incompatible ParallelCluster major version.")
+        raise BadRequestException(f"cluster '{cluster_name}' belongs to an incompatible ParallelCluster major version.")
 
     fleet_status = cluster.compute_fleet_status
     if fleet_status == ComputeFleetStatus.UNKNOWN:

--- a/cli/src/pcluster/api/controllers/common.py
+++ b/cli/src/pcluster/api/controllers/common.py
@@ -68,6 +68,26 @@ def configure_aws_region(is_query_string_arg: bool = True):
     return _decorator_validate_region
 
 
+def http_success_status_code(status_code: int = 200):
+    """
+    Set the status code for successful API responses.
+
+    It can be used as a decorator for API controller methods that need to return a status code different
+    from 200 for successful requests.
+
+    :param status_code: status code to return for successful requests
+    """
+
+    def _decorator_http_success_status_code(func):
+        @functools.wraps(func)
+        def _wrapper_http_success_status_code(*args, **kwargs):
+            return func(*args, **kwargs), status_code
+
+        return _wrapper_http_success_status_code
+
+    return _decorator_http_success_status_code
+
+
 def check_cluster_version(cluster):
     return cluster.stack.version and packaging.version.parse("4.0.0") > packaging.version.parse(
         cluster.stack.version

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -237,27 +237,6 @@ paths:
           description: AWS Region. Defaults to the region the API is deployed to.
           type: string
         style: form
-      - description: Retain cluster logs on delete. Defaults to True.
-        explode: true
-        in: query
-        name: retainLogs
-        required: false
-        schema:
-          description: Retain cluster logs on delete. Defaults to True.
-          nullable: true
-          type: boolean
-        style: form
-      - description: Idempotency token that can be set by the client so that retries
-          for the same request are idempotent
-        explode: true
-        in: query
-        name: clientToken
-        required: false
-        schema:
-          description: Idempotency token that can be set by the client so that retries
-            for the same request are idempotent
-          type: string
-        style: form
       responses:
         "202":
           content:
@@ -1376,8 +1355,8 @@ components:
           description: AWS Region. Defaults to the region the API is deployed to.
           type: string
       required:
-      - imageConfiguration
       - id
+      - imageConfiguration
       type: object
     BuildImageResponseContent:
       example:

--- a/cli/src/pcluster/api/pcluster_api.py
+++ b/cli/src/pcluster/api/pcluster_api.py
@@ -182,6 +182,7 @@ class PclusterApi:
     @staticmethod
     def delete_cluster(cluster_name: str, region: str, keep_logs: bool = True):
         """Delete cluster."""
+        cluster = None
         try:
             if region:
                 os.environ["AWS_DEFAULT_REGION"] = region
@@ -190,6 +191,8 @@ class PclusterApi:
             cluster.delete(keep_logs)
             return ClusterInfo(cluster.stack)
         except Exception as e:
+            if cluster:
+                cluster.terminate_nodes()
             return ApiFailure(str(e))
 
     @staticmethod

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -257,12 +257,10 @@ class TestCluster:
         mocker.patch("pcluster.aws.cfn.CfnClient.describe_stack")
         mocker.patch("pcluster.aws.cfn.CfnClient.delete_stack")
         persist_cloudwatch_log_groups_mock = mocker.patch.object(cluster, "_persist_cloudwatch_log_groups")
-        terminate_nodes_mock = mocker.patch.object(cluster, "_terminate_nodes")
 
         cluster.delete(keep_logs)
 
         assert_that(persist_cloudwatch_log_groups_mock.called).is_equal_to(persist_called)
-        assert_that(terminate_nodes_mock.call_count).is_equal_to(1 if terminate_instances_called else 0)
 
     @pytest.mark.parametrize(
         "template, expected_retain, fail_on_persist",


### PR DESCRIPTION
### Notes
This patch implements the DeleteCluster API

### Tests
1. Unit tests
2. Delete cluster:
```
curl --location --request DELETE '{{endpoint}}/v3/clusters/test-cluster-4?region=eu-west-1&retainLogs=false' \
--header 'Authorization: true'

{
    "cluster": {
        "cloudformationStackArn": {{stack arn}},
        "cloudformationStackStatus": "DELETE_IN_PROGRESS",
        "clusterName": "test-cluster-4",
        "clusterStatus": "DELETE_IN_PROGRESS",
        "region": "eu-west-1",
        "version": "3.0.0"
    }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
