### PR TITLE
3.0 Decorate build/delete image controllers to return 202 response

### DIFF
--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -9,7 +9,13 @@
 # pylint: disable=W0613
 import os as os_lib
 
-from pcluster.api.controllers.common import configure_aws_region, convert_errors, get_validator_suppressors, read_config
+from pcluster.api.controllers.common import (
+    configure_aws_region,
+    convert_errors,
+    get_validator_suppressors,
+    http_success_status_code,
+    read_config,
+)
 from pcluster.api.converters import (
     cloud_formation_status_to_image_status,
     validation_results_to_config_validation_errors,
@@ -46,6 +52,7 @@ from pcluster.validators.common import FailureLevel
 
 
 @configure_aws_region(is_query_string_arg=False)
+@http_success_status_code(202)
 @convert_errors()
 def build_image(
     build_image_request_content,
@@ -112,7 +119,7 @@ def build_image(
 
         return BuildImageResponseContent(
             image=_imagebuilder_stack_to_image_info_summary(imagebuilder.stack),
-            validation_messages=validation_results_to_config_validation_errors(suppressed_validation_failures) or None,
+            validation_messages=validation_results_to_config_validation_errors(suppressed_validation_failures),
         )
     except BadRequestImageBuilderActionError as e:
         errors = validation_results_to_config_validation_errors(e.validation_failures)
@@ -122,6 +129,7 @@ def build_image(
 
 
 @configure_aws_region()
+@http_success_status_code(202)
 @convert_errors()
 def delete_image(image_id, region=None, client_token=None, force=None):
     """

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -285,7 +285,7 @@ class TestDeleteImage:
         response = self._send_test_request(client, image_id, region, force)
 
         with soft_assertions():
-            assert_that(response.status_code).is_equal_to(200)
+            assert_that(response.status_code).is_equal_to(202)
             assert_that(response.get_json()).is_equal_to(expected_response)
 
     def test_delete_available_ec2_image_with_stack_yet_to_be_removed_succeeds(self, mocker, client):
@@ -492,18 +492,16 @@ class TestBuildImage:
                 "imageId": "image1",
                 "region": "eu-west-1",
                 "version": "3.0.0",
-            }
+            },
+            "validationMessages": [{"level": "INFO", "type": "type1", "message": "suppressed failure"}]
+            if suppressed_validation_errors
+            else [],
         }
-
-        if suppressed_validation_errors:
-            expected_response["validationMessages"] = [
-                {"level": "INFO", "type": "type1", "message": "suppressed failure"}
-            ]
 
         response = self._send_test_request(client, dryrun=False, suppress_validators=suppress_validators)
 
         with soft_assertions():
-            assert_that(response.status_code).is_equal_to(200)
+            assert_that(response.status_code).is_equal_to(202)
             assert_that(response.get_json()).is_equal_to(expected_response)
 
         mocked_call.assert_called_once()


### PR DESCRIPTION
### Notes
Return 202 for Custom Image APIs that return immediately (build/delete image).

### Test
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
