### PR TITLE
3.0: HeadNode.Imds.Secured: default value and improvement to validation error messages

### DIFF
--- a/cli/src/pcluster/cli_commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli_commands/configure/easyconfig.py
@@ -135,8 +135,10 @@ def configure(args):  # noqa: C901
 
     if scheduler == "awsbatch":
         base_os = "alinux2"
+        head_node_imds_secured = False
     else:
         base_os = prompt_iterable("Operating System", get_supported_os_for_scheduler(scheduler))
+        head_node_imds_secured = True
 
     default_instance_type = AWSApi.instance().ec2.get_default_instance_type()
     head_node_instance_type = prompt(
@@ -224,6 +226,7 @@ def configure(args):  # noqa: C901
             "InstanceType": head_node_instance_type,
             "Networking": {"SubnetId": vpc_parameters["head_node_subnet_id"]},
             "Ssh": {"KeyName": key_name},
+            "Imds": {"Secured": head_node_imds_secured},
         },
         "Scheduling": {"Scheduler": scheduler, "Queues": queues},
     }

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -597,7 +597,7 @@ class Imds(Resource):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.secured = Resource.init_param(secured)
+        self.secured = Resource.init_param(secured, default=True)
 
 
 class ClusterIam(Resource):

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -34,7 +34,6 @@ from pcluster.constants import (
     OS_MAPPING,
     PCLUSTER_CLUSTER_NAME_TAG,
     PCLUSTER_NODE_TYPE_TAG,
-    SCHEDULERS_SUPPORTING_IMDS_SECURED,
 )
 from pcluster.models.s3_bucket import S3Bucket
 from pcluster.utils import get_installed_version
@@ -254,11 +253,6 @@ def add_lambda_cfn_role(scope, function_id: str, statements: List[iam.PolicyStat
             ),
         ],
     )
-
-
-def get_property_head_node_imds_secured(imds_secured, scheduler):
-    """Return the value for property imds secured."""
-    return imds_secured or (imds_secured is None and scheduler in SCHEDULERS_SUPPORTING_IMDS_SECURED)
 
 
 class PclusterLambdaConstruct(Construct):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -69,7 +69,6 @@ from pcluster.templates.cdk_builder_utils import (
     get_custom_tags,
     get_default_instance_tags,
     get_default_volume_tags,
-    get_property_head_node_imds_secured,
     get_retain_log_on_delete,
     get_shared_storage_ids_by_type,
     get_shared_storage_options_by_type,
@@ -1068,11 +1067,7 @@ class ClusterCdkStack(Stack):
                     "instance_types_data_s3_key": f"{self.bucket.artifact_directory}/configs/instance-types-data.json",
                     "custom_node_package": self.config.custom_node_package or "",
                     "custom_awsbatchcli_package": self.config.custom_aws_batch_cli_package or "",
-                    "head_node_imds_secured": "true"
-                    if get_property_head_node_imds_secured(
-                        self.config.head_node.imds.secured, self.config.scheduling.scheduler
-                    )
-                    else "false",
+                    "head_node_imds_secured": str(self.config.head_node.imds.secured).lower(),
                 },
                 "run_list": f"recipe[aws-parallelcluster::{self.config.scheduling.scheduler}_config]",
             },

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -797,6 +797,11 @@ class HeadNodeImdsValidator(Validator):
                 f"Cannot validate IMDS configuration with scheduler {scheduler}.",
                 FailureLevel.ERROR,
             )
+        elif imds_secured is None:
+            self._add_failure(
+                f"Cannot validate IMDS configuration with Imds.Secured {imds_secured}.",
+                FailureLevel.ERROR,
+            )
         elif imds_secured and scheduler not in SCHEDULERS_SUPPORTING_IMDS_SECURED:
             self._add_failure(
                 f"IMDS secured cannot be enabled in Head Node when using scheduler {scheduler}. "

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -794,18 +794,17 @@ class HeadNodeImdsValidator(Validator):
     def _validate(self, imds_secured: bool, scheduler: str):
         if scheduler is None:
             self._add_failure(
-                f"Cannot validate IMDS configuration with scheduler {scheduler}.",
+                "Cannot validate IMDS configuration if scheduler is not set.",
                 FailureLevel.ERROR,
             )
         elif imds_secured is None:
             self._add_failure(
-                f"Cannot validate IMDS configuration with Imds.Secured {imds_secured}.",
+                "Cannot validate IMDS configuration if IMDS Secured is not set.",
                 FailureLevel.ERROR,
             )
         elif imds_secured and scheduler not in SCHEDULERS_SUPPORTING_IMDS_SECURED:
             self._add_failure(
-                f"IMDS secured cannot be enabled in Head Node when using scheduler {scheduler}. "
-                f"Supported schedulers are: {','.join(SCHEDULERS_SUPPORTING_IMDS_SECURED)}",
+                f"IMDS Secured cannot be enabled when using scheduler {scheduler}. Please, disable IMDS Secured.",
                 FailureLevel.ERROR,
             )
 

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-45678912
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: true
 Scheduling:
   Scheduler: slurm
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: true
 Scheduling:
   Scheduler: slurm
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: false
 Scheduling:
   Scheduler: awsbatch
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: true
 Scheduling:
   Scheduler: slurm
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: true
 Scheduling:
   Scheduler: slurm
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: true
 Scheduling:
   Scheduler: slurm
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: false
 Scheduling:
   Scheduler: awsbatch
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: true
 Scheduling:
   Scheduler: slurm
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: true
 Scheduling:
   Scheduler: slurm
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: true
 Scheduling:
   Scheduler: slurm
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: false
 Scheduling:
   Scheduler: awsbatch
   Queues:

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_with_region_arg/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_with_region_arg/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: true
 Scheduling:
   Scheduler: slurm
   Queues:

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -751,10 +751,10 @@ def test_intel_hpc_os_validator(os, expected_message):
 @pytest.mark.parametrize(
     "imds_secured, scheduler, expected_message",
     [
-        (None, "slurm", None),
+        (None, "slurm", "Cannot validate IMDS configuration with Imds.Secured None."),
         (True, "slurm", None),
         (False, "slurm", None),
-        (None, "awsbatch", None),
+        (None, "awsbatch", "Cannot validate IMDS configuration with Imds.Secured None."),
         (False, "awsbatch", None),
         (
             True,

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -11,7 +11,7 @@
 import pytest
 
 from pcluster.aws.aws_resources import InstanceTypeInfo
-from pcluster.constants import PCLUSTER_NAME_MAX_LENGTH, SCHEDULERS_SUPPORTING_IMDS_SECURED
+from pcluster.constants import PCLUSTER_NAME_MAX_LENGTH
 from pcluster.validators.cluster_validators import (
     FSX_MESSAGES,
     FSX_SUPPORTED_ARCHITECTURES_OSES,
@@ -751,20 +751,19 @@ def test_intel_hpc_os_validator(os, expected_message):
 @pytest.mark.parametrize(
     "imds_secured, scheduler, expected_message",
     [
-        (None, "slurm", "Cannot validate IMDS configuration with Imds.Secured None."),
+        (None, "slurm", "Cannot validate IMDS configuration if IMDS Secured is not set."),
         (True, "slurm", None),
         (False, "slurm", None),
-        (None, "awsbatch", "Cannot validate IMDS configuration with Imds.Secured None."),
+        (None, "awsbatch", "Cannot validate IMDS configuration if IMDS Secured is not set."),
         (False, "awsbatch", None),
         (
             True,
             "awsbatch",
-            f"IMDS secured cannot be enabled in Head Node when using scheduler awsbatch. "
-            f"Supported schedulers are: {','.join(SCHEDULERS_SUPPORTING_IMDS_SECURED)}",
+            "IMDS Secured cannot be enabled when using scheduler awsbatch. Please, disable IMDS Secured.",
         ),
-        (None, None, "Cannot validate IMDS configuration with scheduler None."),
-        (True, None, "Cannot validate IMDS configuration with scheduler None."),
-        (False, None, "Cannot validate IMDS configuration with scheduler None."),
+        (None, None, "Cannot validate IMDS configuration if scheduler is not set."),
+        (True, None, "Cannot validate IMDS configuration if scheduler is not set."),
+        (False, None, "Cannot validate IMDS configuration if scheduler is not set."),
     ],
 )
 def test_head_node_imds_validator(imds_secured, scheduler, expected_message):

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -38,6 +38,7 @@ from conftest_markers import (
     check_marker_skip_list,
 )
 from conftest_tests_config import apply_cli_dimensions_filtering, parametrize_from_config, remove_disabled_tests
+from constants import SCHEDULERS_SUPPORTING_IMDS_SECURED
 from framework.tests_configuration.config_renderer import read_config_file
 from framework.tests_configuration.config_utils import get_all_regions
 from jinja2 import Environment, FileSystemLoader
@@ -519,6 +520,9 @@ def _get_default_template_values(vpc_stack, request):
     default_values = get_vpc_snakecase_value(vpc_stack)
     default_values.update({dimension: request.node.funcargs.get(dimension) for dimension in DIMENSIONS_MARKER_ARGS})
     default_values["key_name"] = request.config.getoption("key_name")
+
+    scheduler = request.node.funcargs.get("scheduler")
+    default_values["imds_secured"] = scheduler in SCHEDULERS_SUPPORTING_IMDS_SECURED
 
     return default_values
 

--- a/tests/integration-tests/constants.py
+++ b/tests/integration-tests/constants.py
@@ -15,3 +15,5 @@ OS_TO_ROOT_VOLUME_DEVICE = {
     "ubuntu1804": "/dev/sda1",
     "ubuntu2004": "/dev/sda1",
 }
+
+SCHEDULERS_SUPPORTING_IMDS_SECURED = ["slurm"]

--- a/tests/integration-tests/tests/arm_pl/test_arm_pl/test_arm_pl/pcluster.config.yaml
+++ b/tests/integration-tests/tests/arm_pl/test_arm_pl/test_arm_pl/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_install_args_quotes/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_install_args_quotes/pcluster.config.yaml
@@ -19,6 +19,8 @@ HeadNode:
     S3Access:
       - BucketName: {{ bucket_name }}
         EnableWriteAccess: false
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
@@ -12,6 +12,8 @@ HeadNode:
   CustomActions:
     OnNodeConfigured:
       Script: s3://{{ bucket_name }}/post_install.sh
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
@@ -7,6 +7,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
@@ -7,6 +7,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
@@ -10,6 +10,8 @@ HeadNode:
     Enabled: true
     Port: {{ dcv_port }}
     AllowedIps: {{ access_from }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
@@ -10,6 +10,8 @@ HeadNode:
     Enabled: true
     Port: {{ dcv_port }}
     AllowedIps: {{ access_from }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_hit_disable_hyperthreading/pcluster.config.yaml
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_hit_disable_hyperthreading/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/dns/test_dns/test_hit_no_cluster_dns_mpi/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dns/test_dns/test_hit_no_cluster_dns_mpi/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.yaml
@@ -7,6 +7,8 @@ HeadNode:
     {% if instance == "p4d.24xlarge" %}ElasticIp: true{% endif %}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.yaml
@@ -11,6 +11,8 @@ HeadNode:
       {% for policy in iam_policies %}
       - Policy: {{ policy }} # Todo: change it to arn instead of name
       {% endfor %}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
@@ -11,6 +11,8 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     InstanceRole: {{ ec2_iam_role }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
@@ -14,6 +14,8 @@ HeadNode:
       - BucketName: {{ bucket }}
         KeyName: read_and_write/
         EnableWriteAccess: true
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
@@ -9,6 +9,8 @@ HeadNode:
   LocalStorage:
     RootVolume:
       Size: 80
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -7,6 +7,8 @@ HeadNode:
     ElasticIp: true
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/nccl/test_nccl/test_nccl/pcluster.config.yaml
+++ b/tests/integration-tests/tests/nccl/test_nccl/test_nccl/pcluster.config.yaml
@@ -7,6 +7,8 @@ HeadNode:
     ElasticIp: true
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ private_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_existing_eip/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_existing_eip/pcluster.config.yaml
@@ -7,6 +7,8 @@ HeadNode:
     ElasticIp: {{ elastic_ip }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.yaml
@@ -9,6 +9,8 @@ HeadNode:
   Ssh:
     KeyName: {{ key_name }}
     AllowedIps: {{ ssh_from }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
@@ -8,6 +8,8 @@ HeadNode:
       - {{ vpc_security_group_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.yaml
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.yaml
@@ -7,6 +7,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
@@ -7,6 +7,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: False
 Scheduling:
   Scheduler: awsbatch
   Queues:

--- a/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
+++ b/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -12,6 +12,8 @@ HeadNode:
       VolumeType: gp3
       Iops: 3400
       Throughput: 135
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -8,6 +8,8 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     InstanceRole: {{ ec2_iam_role }} # TODO: change the role name in the test into role arn
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:
@@ -28,4 +30,3 @@ SharedStorage:
   - MountDir: {{ mount_dir }}
     StorageType: Ebs
     Name: ebs
-

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:
@@ -32,5 +34,3 @@ SharedStorage:
       Size: {{ volume_size }}
       VolumeType: gp2
       SnapshotId: {{ snapshot_id }}
-
-

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_efs/test_existing_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_existing_efs/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_existing_fsx/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_existing_fsx/pcluster.config.yaml
@@ -9,6 +9,8 @@ HeadNode:
   Iam:
     S3Access:
       - BucketName: {{ bucket_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
@@ -10,6 +10,8 @@ HeadNode:
     S3Access:
       - BucketName: {{ bucket_name }}
         EnableWriteAccess: False
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster_restore_fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster_restore_fsx.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
@@ -10,6 +10,8 @@ HeadNode:
     S3Access:
       - BucketName: {{ bucket_name }}
         EnableWriteAccess: False
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.yaml
@@ -6,6 +6,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
@@ -9,6 +9,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
   Queues:

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.yaml
@@ -11,6 +11,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: False
 Scheduling:
   Scheduler: awsbatch
   Queues:

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.yaml
@@ -11,6 +11,8 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  Imds:
+    Secured: False
 Scheduling:
   Scheduler: awsbatch
   Queues:


### PR DESCRIPTION
### Changes
1. Set default value for HeadNode.Imds.Secured in pcluster configure
2. Remove conditional default for configuration HeadNode.Imds.Secured
3. Add configuration guidelines to HeadNode IMDS validation error messages

### Tests
1. Manual tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
