### PR TITLE
3.0: Implement UpdateCluster API

### DIFF
--- a/cli/src/pcluster/api/controllers/common.py
+++ b/cli/src/pcluster/api/controllers/common.py
@@ -30,7 +30,9 @@ from pcluster.api.errors import (
 from pcluster.aws.common import BadRequestError, LimitExceededError
 from pcluster.config.common import AllValidatorsSuppressor, TypeMatchValidatorsSuppressor, ValidatorSuppressor
 from pcluster.constants import SUPPORTED_REGIONS
+from pcluster.models.cluster import Cluster
 from pcluster.models.common import BadRequest, Conflict, LimitExceeded
+from pcluster.utils import get_installed_version
 
 LOGGER = logging.getLogger(__name__)
 
@@ -88,10 +90,18 @@ def http_success_status_code(status_code: int = 200):
     return _decorator_http_success_status_code
 
 
-def check_cluster_version(cluster):
-    return cluster.stack.version and packaging.version.parse("4.0.0") > packaging.version.parse(
-        cluster.stack.version
-    ) >= packaging.version.parse("3.0.0")
+def check_cluster_version(cluster: Cluster, exact_match: bool = False) -> bool:
+    if not cluster.stack.version:
+        return False
+
+    if exact_match:
+        return packaging.version.parse(cluster.stack.version) == packaging.version.parse(get_installed_version())
+    else:
+        return (
+            packaging.version.parse("4.0.0")
+            > packaging.version.parse(cluster.stack.version)
+            >= packaging.version.parse("3.0.0")
+        )
 
 
 def read_config(base64_encoded_config: str) -> str:

--- a/cli/src/pcluster/aws/common.py
+++ b/cli/src/pcluster/aws/common.py
@@ -98,6 +98,8 @@ class AWSExceptionHandler:
 
                 if error_code in AWSClientError.ErrorCode.throttling_error_codes():
                     error = LimitExceededError(func.__name__, message, error_code)
+                elif error_code == AWSClientError.ErrorCode.VALIDATION_ERROR:
+                    error = BadRequestError(func.__name__, message, error_code)
                 else:
                     error = AWSClientError(func.__name__, message, error_code)
             LOGGER.error("Encountered error when performing boto3 call in %s: %s", error.function_name, error.message)

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -55,7 +55,7 @@ def parse_config(config):
         return config_dict
     except Exception as e:
         LOGGER.error("Failed when parsing the configuration due to invalid YAML document: %s", e)
-        raise BadRequest("configuration must be a valid YAML document")
+        raise BadRequest("Configuration must be a valid YAML document")
 
 
 class FiltersParserError(Exception):

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -109,9 +109,9 @@ class CustomAmiTagValidator(Validator):
         if PCLUSTER_VERSION_TAG not in tags_dict:
             self._add_failure(
                 (
-                    "The custom AMI may not have been created by pcluster."
-                    "You can ignore this warning if the AMI is shared or copied from another pcluster AMI."
-                    "If the AMI is indeed not created by pcluster, cluster creation will fail."
+                    "The custom AMI may not have been created by pcluster. "
+                    "You can ignore this warning if the AMI is shared or copied from another pcluster AMI. "
+                    "If the AMI is indeed not created by pcluster, cluster creation will fail. "
                     "If the cluster creation fails, please goto"
                     "https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting.html"
                     "#troubleshooting-stack-creation-failures for troubleshooting."

--- a/cli/tests/pcluster/models/test_imagebuilder.py
+++ b/cli/tests/pcluster/models/test_imagebuilder.py
@@ -360,8 +360,8 @@ def test_delete_with_cfn_error(mocker, error, returned_error):
     "config, expected_result, expected_error_message",
     [
         (None, None, None),
-        ("notAYamldict", None, "configuration must be a valid YAML document"),
-        ("malformed\n\nyaml", None, "configuration must be a valid YAML document"),
+        ("notAYamldict", None, "Configuration must be a valid YAML document"),
+        ("malformed\n\nyaml", None, "Configuration must be a valid YAML document"),
         (
             "Build:\n  InstanceType: instanceType\n  ParentImage: arn:parentImage",
             ImageBuilderConfig(build=Build(instance_type="instanceType", parent_image="arn:parentImage")),

--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -114,7 +114,7 @@ def test_iam_policies(region, scheduler, pcluster_config_reader, clusters_factor
 
 def _test_s3_access(remote_command_executor, region):
     logging.info("Testing S3 Access")
-    result = remote_command_executor.run_remote_command(f"AWS_DEFAULT_REGION={region} sudo aws s3 ls").stdout
+    result = remote_command_executor.run_remote_command(f"AWS_DEFAULT_REGION={region} aws s3 ls").stdout
     # An error occurred (AccessDenied) when calling the ListBuckets operation: Access Denied
     assert_that(result).does_not_contain("AccessDenied")
 

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
@@ -33,7 +33,7 @@ def test_multiple_nics(scheduler, region, pcluster_config_reader, clusters_facto
 
 def _get_private_ip_addresses(instance_id, region, remote_command_executor):
     result = remote_command_executor.run_remote_command(
-        "sudo aws ec2 describe-instances --instance-id {0} --region {1} "
+        "aws ec2 describe-instances --instance-id {0} --region {1} "
         '--query "Reservations[0].Instances[0].NetworkInterfaces[*].PrivateIpAddresses[*].PrivateIpAddress" '
         "--output text".format(instance_id, region)
     )

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -444,7 +444,7 @@ def _test_export_path(remote_command_executor, mount_dir, bucket_name, region):
         "sudo lfs hsm_archive {mount_dir}/file_to_export && sleep 5".format(mount_dir=mount_dir)
     )
     remote_command_executor.run_remote_command(
-        "sudo aws s3 cp --region {region} s3://{bucket_name}/export_dir/file_to_export ./file_to_export".format(
+        "aws s3 cp --region {region} s3://{bucket_name}/export_dir/file_to_export ./file_to_export".format(
             region=region, bucket_name=bucket_name
         )
     )
@@ -518,7 +518,7 @@ def _test_data_repository_task(remote_command_executor, mount_dir, bucket_name, 
     assert_that(task.get("Lifecycle")).is_equal_to("SUCCEEDED")
 
     remote_command_executor.run_remote_command(
-        "sudo aws s3 cp --region {region} s3://{bucket_name}/export_dir/file_to_export ./file_to_export".format(
+        "aws s3 cp --region {region} s3://{bucket_name}/export_dir/file_to_export ./file_to_export".format(
             region=region, bucket_name=bucket_name
         )
     )


### PR DESCRIPTION
### Notes
This patch implements the UpdateCluster API by calling the methods exposed by the Cluster business object. Things to note:

1. We throw a BadRequest execption in case of an empty change set, unless the caller specified force=True. Note that this change set does not take into account changes to parameters with print_succeded = False.  As far as we can tell at the moment this can happen only for SUCCEDED check result with policies IGNORED or READ_ONLY_RESOURCE_BUCKET. In the future we plan to make these be UNSUPPORTED.
2. The validation of the patch happens after the validation of the configuration. We do not return suppressed validation configuration errors in the BadRequest caused by a failed during patch validation, as we do not want to confuse the customer (i.e. the BadRequest was not caused by the configuration validation erros they suppressed). We do return the suppressed configuration validation errors in the response in the case of a successful request.

### Tests
1. Unit tests
2. Update cluster:
```
{
    "changeSet": [
        {
            "currentValue": "t2.micro",
            "parameter": "HeadNode.InstanceType",
            "requestedValue": "t2.small"
        }
    ],
    "cluster": {
        "cloudformationStackArn": "arn:aws:cloudformation:eu-west-1:395964158899:stack/test-cluster-1/f27a4e20-d2b4-11eb-957d-0a3927392745",
        "cloudformationStackStatus": "UPDATE_IN_PROGRESS",
        "clusterName": "test-cluster-1",
        "clusterStatus": "UPDATE_IN_PROGRESS",
        "region": "eu-west-1",
        "version": "3.0.0"
    },
    "validationMessages": [
        {
            "level": "WARNING",
            "message": "The custom AMI may not have been created by pcluster. You can ignore this warning if the AMI is shared or copied from another pcluster AMI. If the AMI is indeed not created by pcluster, cluster creation will fail. If the cluster creation fails, please gotohttps://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting.html#troubleshooting-stack-creation-failures for troubleshooting.",
            "type": "CustomAmiTagValidator"
        }
    ]
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
