### PR TITLE
3.0: Remove old assert, bucket prefix is no longer used as archive subfolder

### DIFF
--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -142,8 +142,6 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, region, insta
                 for file in archive:
                     if instance_id in file.name:
                         instance_found = True
-                        # check bucket prefix
-                        assert_that(file.name).contains(bucket_prefix)
                         break
                 assert_that(instance_found).is_true()
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
