### PR TITLE
3.0: Improve assert condition to consider folder name too

### DIFF
--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -131,7 +131,7 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, region, insta
             # check the cfn stack events file is present
             stack_events_file_found = False
             for file in archive:
-                if f"{cluster.name}-cfn-events" == file.name:
+                if f"{cluster.name}-cfn-events" in file.name:
                     stack_events_file_found = True
                     break
             assert_that(stack_events_file_found).is_true()


### PR DESCRIPTION
In the https://github.com/aws/aws-parallelcluster/pull/2863 we introduced a root folder in the archive so in the assert we cannot use an equality test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
