### PR TITLE
3.0: Add depends on to ensure deletion cleanup order

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1238,6 +1238,8 @@ class ClusterCdkStack(Stack):
                 version=head_node_launch_template.attr_latest_version_number,
             ),
         )
+        if isinstance(self.scheduler_resources, SlurmConstruct):
+            head_node_instance.add_depends_on(self.scheduler_resources.terminate_compute_fleet_custom_resource)
         head_node_instance.cfn_options.creation_policy = CfnCreationPolicy(
             resource_signal=CfnResourceSignal(count=1, timeout="PT30M")
         )


### PR DESCRIPTION
The deletion order constrain is:
1. Delete Head node
2. Clean terminate compute fleet custom resource
3. Clean up hosted zones

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
