### PR TITLE
3.0: Remove schema manipulation for Scheduling and SharedStorage sections to fix regression on update checks

### DIFF
--- a/cli/src/pcluster/cli_commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli_commands/configure/easyconfig.py
@@ -220,6 +220,8 @@ def configure(args):  # noqa: C901
     # Here is the end of prompt. Code below assembles config and write to file
     for queue in queues:
         queue["Networking"] = {"SubnetIds": [vpc_parameters["compute_subnet_id"]]}
+
+    scheduler_prefix = "AwsBatch" if scheduler == "awsbatch" else scheduler.capitalize()
     result = {
         "Image": {"Os": base_os},
         "HeadNode": {
@@ -228,7 +230,7 @@ def configure(args):  # noqa: C901
             "Ssh": {"KeyName": key_name},
             "Imds": {"Secured": head_node_imds_secured},
         },
-        "Scheduling": {"Scheduler": scheduler, "Queues": queues},
+        "Scheduling": {"Scheduler": scheduler, f"{scheduler_prefix}Queues": queues},
     }
 
     _write_configuration_file(config_file_path, result)

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -140,7 +140,7 @@ UpdatePolicy.AWSBATCH_CE_MAX_RESIZE = UpdatePolicy(
     ),
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
     condition_checker=lambda change, patch: patch.cluster.get_running_capacity()
-    <= patch.target_config["Scheduling"]["Queues"][0]["ComputeResources"][0]["MaxvCpus"],
+    <= patch.target_config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["MaxvCpus"],
 )
 
 # Checks resize of max_count

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -393,7 +393,6 @@ class Cluster:
             LOGGER.info("Validation succeeded.")
         except ValidationError as e:
             # syntactic failure
-            ClusterSchema.process_validation_message(e)
             validation_failures = [
                 ValidationResult(
                     str(sorted(e.messages.items())), FailureLevel.ERROR, validator_type="ConfigSchemaValidator"

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -86,11 +86,8 @@ class BaseSchema(Schema):
         if kwargs.get("partial"):
             # If the schema is to be loaded partially, do not check existence constrain.
             return True
-        if one_required:
-            result = len([data.get(field_name) for field_name in field_list if data.get(field_name)]) != 1
-        else:
-            result = len([data.get(field_name) for field_name in field_list if data.get(field_name)]) > 1
-        return result
+        num_of_fields = len([data.get(field_name) for field_name in field_list if data.get(field_name)])
+        return num_of_fields != 1 if one_required else num_of_fields > 1
 
     @pre_dump
     def prepare_objects(self, data, **kwargs):
@@ -118,7 +115,7 @@ class BaseSchema(Schema):
     def remove_none_values(self, data, **kwargs):
         """Remove None values before creating the Yaml format."""
         if self.context.get("delete_defaults_when_dump"):
-            return {key: value for key, value in data.items() if value is not None and value != []}
+            return {key: value for key, value in data.items() if value not in (None, [], {})}
         return data
 
 

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-t2micro

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-t2micro

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: false
 Scheduling:
   Scheduler: awsbatch
-  Queues:
+  AwsBatchQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-optimal

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-t2micro

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-t2micro

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-t2micro

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: false
 Scheduling:
   Scheduler: awsbatch
-  Queues:
+  AwsBatchQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-optimal

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-t2micro

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-t2micro

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-t2micro

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: false
 Scheduling:
   Scheduler: awsbatch
-  Queues:
+  AwsBatchQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-optimal

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_with_region_arg/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure/test_with_region_arg/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: myqueue
       ComputeResources:
         - Name: myqueue-t2micro

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -101,6 +101,16 @@ def _compare_changes(changes, expected_changes):
             id="change additional security group",
         ),
         pytest.param(
+            ["SharedStorage[ebs1]", "EbsSettings"],
+            "ebs_encrypted",
+            "Encrypted",
+            True,
+            False,
+            UpdatePolicy.UNSUPPORTED,
+            False,
+            id="change ebs settings encrypted",
+        ),
+        pytest.param(
             ["Scheduling", "Slurm", "Queues[queue1]", "ComputeResources[compute-resource1]"],
             "max_count",
             "MaxCount",
@@ -246,7 +256,14 @@ def _test_less_target_sections(base_conf, target_conf):
             ),
             Change(["SharedStorage[ebs2]"], "MountDir", "vol2", "vol1", UpdatePolicy.UNSUPPORTED, is_list=False),
             Change(["SharedStorage[ebs2]", "Ebs"], "Iops", None, 20, UpdatePolicy.SUPPORTED, is_list=False),
-            Change(["SharedStorage[ebs2]", "Ebs"], "VolumeType", "gp3", "gp2", UpdatePolicy.UNSUPPORTED, is_list=False),
+            Change(
+                ["SharedStorage[ebs2]", "Ebs"],
+                "VolumeType",
+                "gp3",
+                "gp2",
+                UpdatePolicy.UNSUPPORTED,
+                is_list=False,
+            ),
         ],
         UpdatePolicy.UNSUPPORTED,
     )
@@ -293,7 +310,14 @@ def _test_more_target_sections(base_conf, target_conf):
             ),
             Change(["SharedStorage[ebs2]"], "MountDir", "vol2", "vol1", UpdatePolicy.UNSUPPORTED, is_list=False),
             Change(["SharedStorage[ebs2]", "Ebs"], "Iops", None, 20, UpdatePolicy.SUPPORTED, is_list=False),
-            Change(["SharedStorage[ebs2]", "Ebs"], "VolumeType", "gp3", "gp2", UpdatePolicy.UNSUPPORTED, is_list=False),
+            Change(
+                ["SharedStorage[ebs2]", "Ebs"],
+                "VolumeType",
+                "gp3",
+                "gp2",
+                UpdatePolicy.UNSUPPORTED,
+                is_list=False,
+            ),
         ],
         UpdatePolicy.UNSUPPORTED,
     )

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -16,7 +16,9 @@ from assertpy import assert_that
 
 from pcluster.config.config_patch import Change, ConfigPatch
 from pcluster.config.update_policy import UpdatePolicy
+from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.utils import load_yaml_dict
+from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.test_utils import dummy_cluster
 
 default_cluster_params = {
@@ -25,6 +27,8 @@ default_cluster_params = {
     "additional_sg": "sg-12345678",
     "max_count": 10,
     "compute_instance_type": "t2.micro",
+    "shared_dir": "mountdir1",
+    "ebs_encrypted": True,
 }
 
 
@@ -111,17 +115,17 @@ def _compare_changes(changes, expected_changes):
             id="change ebs settings encrypted",
         ),
         pytest.param(
-            ["Scheduling", "Slurm", "Queues[queue1]", "ComputeResources[compute-resource1]"],
+            ["Scheduling", "SlurmQueues[queue1]", "ComputeResources[compute-resource1]"],
             "max_count",
             "MaxCount",
-            0,
             1,
+            2,
             UpdatePolicy.MAX_COUNT,
             False,
             id="change compute resources max count",
         ),
         pytest.param(
-            ["Scheduling", "Slurm", "Queues[queue1]", "ComputeResources[compute-resource1]"],
+            ["Scheduling", "SlurmQueues[queue1]", "ComputeResources[compute-resource1]"],
             "compute_instance_type",
             "InstanceType",
             "t2.micro",
@@ -133,6 +137,7 @@ def _compare_changes(changes, expected_changes):
     ],
 )
 def test_single_param_change(
+    mocker,
     test_datadir,
     pcluster_config_reader,
     change_path,
@@ -143,6 +148,7 @@ def test_single_param_change(
     change_update_policy,
     is_list,
 ):
+    mock_aws_api(mocker)
     dst_config_file = "pcluster.config.dst.yaml"
     _duplicate_config_file(dst_config_file, test_datadir)
 
@@ -151,13 +157,13 @@ def test_single_param_change(
     src_dict[template_rendering_key] = src_param_value
 
     src_config_file = pcluster_config_reader(**src_dict)
-    src_conf = load_yaml_dict(src_config_file)
+    src_conf = _load_config(src_config_file)
 
     dst_dict = {}
     dst_dict.update(default_cluster_params)
     dst_dict[template_rendering_key] = dst_param_value
     dst_config_file = pcluster_config_reader(dst_config_file, **dst_dict)
-    dst_conf = load_yaml_dict(dst_config_file)
+    dst_conf = _load_config(dst_config_file)
 
     if is_list:
         expected_change = Change(
@@ -167,10 +173,15 @@ def test_single_param_change(
         expected_change = Change(
             change_path, param_key, src_param_value, dst_param_value, change_update_policy, is_list=False
         )
-    _check_patch(src_conf, dst_conf, [expected_change], change_update_policy)
+    _check_patch(src_conf.source_config, dst_conf.source_config, [expected_change], change_update_policy)
 
 
-def test_multiple_param_changes(pcluster_config_reader, test_datadir):
+def _load_config(config_file):
+    return ClusterSchema().load(load_yaml_dict(config_file))
+
+
+def test_multiple_param_changes(mocker, pcluster_config_reader, test_datadir):
+    mock_aws_api(mocker)
     dst_config_file = "pcluster.config.dst.yaml"
     _duplicate_config_file(dst_config_file, test_datadir)
 
@@ -181,7 +192,7 @@ def test_multiple_param_changes(pcluster_config_reader, test_datadir):
     src_dict["additional_sg"] = "sg-12345678"
 
     src_config_file = pcluster_config_reader(**src_dict)
-    src_conf = load_yaml_dict(src_config_file)
+    src_conf = _load_config(src_config_file)
 
     dst_dict = {}
     dst_dict.update(default_cluster_params)
@@ -190,7 +201,7 @@ def test_multiple_param_changes(pcluster_config_reader, test_datadir):
     dst_dict["additional_sg"] = "sg-1234567a"
 
     dst_config_file = pcluster_config_reader(dst_config_file, **dst_dict)
-    dst_conf = load_yaml_dict(dst_config_file)
+    dst_conf = _load_config(dst_config_file)
 
     expected_changes = [
         Change(
@@ -202,7 +213,7 @@ def test_multiple_param_changes(pcluster_config_reader, test_datadir):
             is_list=False,
         ),
         Change(
-            ["Scheduling", "Slurm", "Queues[queue1]", "Networking"],
+            ["Scheduling", "SlurmQueues[queue1]", "Networking"],
             "SubnetIds",
             ["subnet-12345678"],
             ["subnet-1234567a"],
@@ -219,7 +230,7 @@ def test_multiple_param_changes(pcluster_config_reader, test_datadir):
         ),
     ]
 
-    _check_patch(src_conf, dst_conf, expected_changes, UpdatePolicy.UNSUPPORTED)
+    _check_patch(src_conf.source_config, dst_conf.source_config, expected_changes, UpdatePolicy.UNSUPPORTED)
 
 
 def _test_equal_configs(base_conf, target_conf):
@@ -235,8 +246,8 @@ def _test_less_target_sections(base_conf, target_conf):
 
     # update some values in the target config for the remaining ebs
     target_conf["SharedStorage"][0]["MountDir"] = "vol1"
-    target_conf["SharedStorage"][0]["Ebs"]["Iops"] = 20
-    target_conf["SharedStorage"][0]["Ebs"]["VolumeType"] = "gp2"
+    target_conf["SharedStorage"][0]["EbsSettings"]["Iops"] = 20
+    target_conf["SharedStorage"][0]["EbsSettings"]["VolumeType"] = "gp2"
 
     # The patch must show multiple differences: one for EBS settings and one for missing ebs section in target conf
     _check_patch(
@@ -255,9 +266,9 @@ def _test_less_target_sections(base_conf, target_conf):
                 is_list=True,
             ),
             Change(["SharedStorage[ebs2]"], "MountDir", "vol2", "vol1", UpdatePolicy.UNSUPPORTED, is_list=False),
-            Change(["SharedStorage[ebs2]", "Ebs"], "Iops", None, 20, UpdatePolicy.SUPPORTED, is_list=False),
+            Change(["SharedStorage[ebs2]", "EbsSettings"], "Iops", None, 20, UpdatePolicy.SUPPORTED, is_list=False),
             Change(
-                ["SharedStorage[ebs2]", "Ebs"],
+                ["SharedStorage[ebs2]", "EbsSettings"],
                 "VolumeType",
                 "gp3",
                 "gp2",
@@ -289,8 +300,8 @@ def _test_more_target_sections(base_conf, target_conf):
     # update some values in the target config for the remaining ebs
     target_storage = _get_storage_by_name(target_conf, "ebs2")
     target_storage["MountDir"] = "vol1"
-    target_storage["Ebs"]["Iops"] = 20
-    target_storage["Ebs"]["VolumeType"] = "gp2"
+    target_storage["EbsSettings"]["Iops"] = 20
+    target_storage["EbsSettings"]["VolumeType"] = "gp2"
 
     # The patch must show multiple differences: changes for EBS settings and one for missing ebs section in base conf
     _check_patch(
@@ -309,9 +320,9 @@ def _test_more_target_sections(base_conf, target_conf):
                 is_list=True,
             ),
             Change(["SharedStorage[ebs2]"], "MountDir", "vol2", "vol1", UpdatePolicy.UNSUPPORTED, is_list=False),
-            Change(["SharedStorage[ebs2]", "Ebs"], "Iops", None, 20, UpdatePolicy.SUPPORTED, is_list=False),
+            Change(["SharedStorage[ebs2]", "EbsSettings"], "Iops", None, 20, UpdatePolicy.SUPPORTED, is_list=False),
             Change(
-                ["SharedStorage[ebs2]", "Ebs"],
+                ["SharedStorage[ebs2]", "EbsSettings"],
                 "VolumeType",
                 "gp3",
                 "gp2",
@@ -391,7 +402,8 @@ def _test_different_names(base_conf, target_conf):
         _test_different_names,
     ],
 )
-def test_adaptation(test_datadir, pcluster_config_reader, test):
+def test_adaptation(mocker, test_datadir, pcluster_config_reader, test):
+    mock_aws_api(mocker)
     base_config_file_name = "pcluster.config.base.yaml"
     _duplicate_config_file(base_config_file_name, test_datadir)
     target_config_file_name = "pcluster.config.dst.yaml"
@@ -400,10 +412,10 @@ def test_adaptation(test_datadir, pcluster_config_reader, test):
     base_config_file = pcluster_config_reader(base_config_file_name, **default_cluster_params)
     target_config_file = pcluster_config_reader(target_config_file_name, **default_cluster_params)
 
-    base_conf = load_yaml_dict(base_config_file)
-    target_conf = load_yaml_dict(target_config_file)
+    base_conf = _load_config(base_config_file)
+    target_conf = _load_config(target_config_file)
 
-    test(base_conf, target_conf)
+    test(base_conf.source_config, target_conf.source_config)
 
 
 @pytest.mark.parametrize(
@@ -424,12 +436,14 @@ def test_adaptation(test_datadir, pcluster_config_reader, test):
     ],
 )
 def test_patch_check_cluster_resource_bucket(
+    mocker,
     old_bucket_name,
     new_bucket_name,
     expected_error_row,
     test_datadir,
     pcluster_config_reader,
 ):
+    mock_aws_api(mocker)
     expected_message_rows = [
         ["param_path", "parameter", "old value", "new value", "check", "reason", "action_needed"],
         # ec2_iam_role is to make sure other parameters are not affected by cluster_resource_bucket custom logic
@@ -452,15 +466,17 @@ def test_patch_check_cluster_resource_bucket(
         ]
         expected_message_rows.append(error_message_row)
     src_dict = {"cluster_resource_bucket": old_bucket_name, "ec2_iam_role": "some_old_role"}
+    src_dict.update(default_cluster_params)
     dst_dict = {"cluster_resource_bucket": new_bucket_name, "ec2_iam_role": "some_new_role"}
+    dst_dict.update(default_cluster_params)
     dst_config_file = "pcluster.config.dst.yaml"
     _duplicate_config_file(dst_config_file, test_datadir)
 
     src_config_file = pcluster_config_reader(**src_dict)
-    src_conf = load_yaml_dict(src_config_file)
+    src_conf = _load_config(src_config_file)
     dst_config_file = pcluster_config_reader(dst_config_file, **dst_dict)
-    dst_conf = load_yaml_dict(dst_config_file)
-    patch = ConfigPatch(dummy_cluster(), base_config=src_conf, target_config=dst_conf)
+    dst_conf = _load_config(dst_config_file)
+    patch = ConfigPatch(dummy_cluster(), base_config=src_conf.source_config, target_config=dst_conf.source_config)
 
     patch_allowed, rows = patch.check()
     assert_that(len(rows)).is_equal_to(len(expected_message_rows))

--- a/cli/tests/pcluster/config/test_config_patch/test_adaptation/pcluster.config.yaml
+++ b/cli/tests/pcluster/config/test_config_patch/test_adaptation/pcluster.config.yaml
@@ -9,21 +9,23 @@ HeadNode:
   Ssh:
     KeyName: test-key
 Scheduling:
-  Slurm:
-    Queues:
-      - Name: queue1
-        Networking:
-          SubnetIds:
-            - {{compute_subnet_id}}
-        ComputeResources:
-          - Name: compute-resource1
-            InstanceType: c5.2xlarge
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - {{compute_subnet_id}}
+      ComputeResources:
+        - Name: compute-resource1
+          InstanceType: c5.2xlarge
 SharedStorage:
   - MountDir: vol1
     Name: ebs1
-    Ebs:
+    StorageType: Ebs
+    EbsSettings:
       VolumeType: gp3
   - MountDir: vol2
     Name: ebs2
-    Ebs:
+    StorageType: Ebs
+    EbsSettings:
       VolumeType: gp3

--- a/cli/tests/pcluster/config/test_config_patch/test_multiple_param_changes/pcluster.config.yaml
+++ b/cli/tests/pcluster/config/test_config_patch/test_multiple_param_changes/pcluster.config.yaml
@@ -9,17 +9,18 @@ HeadNode:
   Ssh:
     KeyName: test-key
 Scheduling:
-  Slurm:
-    Queues:
-      - Name: queue1
-        Networking:
-          SubnetIds:
-            - {{compute_subnet_id}}
-        ComputeResources:
-          - Name: compute-resource1
-            InstanceType: c5.2xlarge
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - {{compute_subnet_id}}
+      ComputeResources:
+        - Name: compute-resource1
+          InstanceType: c5.2xlarge
 SharedStorage:
   - MountDir: {{shared_dir}}
     Name: ebs1
-    Ebs:
+    StorageType: Ebs
+    EbsSettings:
       VolumeType: gp2

--- a/cli/tests/pcluster/config/test_config_patch/test_patch_check_cluster_resource_bucket/pcluster.config.yaml
+++ b/cli/tests/pcluster/config/test_config_patch/test_patch_check_cluster_resource_bucket/pcluster.config.yaml
@@ -11,19 +11,20 @@ HeadNode:
   Iam:
     InstanceRole: {{ ec2_iam_role }}
 Scheduling:
-  Slurm:
-    Queues:
-      - Name: queue1
-        Networking:
-          SubnetIds:
-            - {{compute_subnet_id}}
-        ComputeResources:
-          - Name: compute-resource1
-            InstanceType: c5.2xlarge
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - {{compute_subnet_id}}
+      ComputeResources:
+        - Name: compute-resource1
+          InstanceType: c5.2xlarge
 SharedStorage:
   - MountDir: {{shared_dir}}
     Name: ebs1
-    Ebs:
+    StorageType: Ebs
+    EbsSettings:
       VolumeType: gp2
 {% if cluster_resource_bucket %}
 CustomS3Bucket: {{ cluster_resource_bucket }}

--- a/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.yaml
+++ b/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.yaml
@@ -9,19 +9,21 @@ HeadNode:
   Ssh:
     KeyName: test-key
 Scheduling:
-  Slurm:
-    Queues:
-      - Name: queue1
-        Networking:
-          SubnetIds:
-            - {{compute_subnet_id}}
-        ComputeResources:
-          - Name: compute-resource1
-            InstanceType: {{compute_instance_type}}
-            MinCount: 1
-            MaxCount: {{max_count}}
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - {{compute_subnet_id}}
+      ComputeResources:
+        - Name: compute-resource1
+          InstanceType: {{compute_instance_type}}
+          MinCount: 1
+          MaxCount: {{max_count}}
 SharedStorage:
   - MountDir: vol1
     Name: ebs1
-    Ebs:
+    StorageType: Ebs
+    EbsSettings:
       VolumeType: gp2
+      Encrypted: {{ebs_encrypted}}

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -583,7 +583,7 @@ HeadNode:
     KeyName: ermann-dub-ef
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
   - Name: queue2
     ComputeResources:
     - Name: queue1-t2micro

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -40,7 +40,7 @@ HeadNode:
     AllowedIps: 0.0.0.0/0  # 0.0.0.0/0
 Scheduling:
   Scheduler: awsbatch
-  Queues:
+  AwsBatchQueues:
     - Name: String  # queue
       CapacityType: ONDEMAND  # ONDEMAND | SPOT
       Networking:

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.simple.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.simple.yaml
@@ -8,7 +8,7 @@ HeadNode:
     SubnetId: subnet-12345678
 Scheduling:
   Scheduler: awsbatch
-  Queues:
+  AwsBatchQueues:
     - Name: queue1
       Networking:
         SubnetIds:
@@ -21,19 +21,8 @@ Scheduling:
             - c4
           MaxvCpus: 10
 SharedStorage:
-  - MountDir: /shared
-    Name: ebs1
-    StorageType: Ebs
-    EbsSettings:
-      VolumeType: gp2  # gp2 | gp3 | io1 | io2 | sc1 | st1 | standard
-      Iops: 100
-      Size: 150
-      Encrypted: True
-      KmsKeyId: String
-      SnapshotId: snap-12345678
-      VolumeId: vol-12345678
   - MountDir: /shared2
-    Name: ebs1
+    Name: ebs2
     StorageType: Ebs
   - MountDir: /shared3
     Name: efs

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -54,7 +54,7 @@ Scheduling:
     ScaledownIdletime: 10
     Dns:
       DisableManagedDns: true
-  Queues:
+  SlurmQueues:
     - Name: queue1
       CapacityType: ONDEMAND
       Networking:

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.required.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.required.yaml
@@ -8,7 +8,7 @@ HeadNode:
     KeyName: ec2-key-name
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: queue1
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -19,9 +19,9 @@ from pcluster.schemas.cluster_schema import (
     CloudWatchLogsSchema,
     ClusterSchema,
     DcvSchema,
-    EbsSchema,
-    EfsSchema,
-    FsxSchema,
+    EbsSettingsSchema,
+    EfsSettingsSchema,
+    FsxLustreSettingsSchema,
     HeadNodeEphemeralVolumeSchema,
     HeadNodeNetworkingSchema,
     HeadNodeRootVolumeSchema,
@@ -293,7 +293,7 @@ def test_cidr_validator(section_dict, expected_message):
 )
 def test_ebs_validator(section_dict, expected_message):
     """Verify that cw_log behaves as expected when parsed in a config file."""
-    _validate_and_assert_error(EbsSchema(), section_dict, expected_message)
+    _validate_and_assert_error(EbsSettingsSchema(), section_dict, expected_message)
 
 
 @pytest.mark.parametrize(
@@ -332,7 +332,7 @@ def test_ebs_validator(section_dict, expected_message):
 )
 def test_efs_validator(section_dict, expected_message):
     """Verify that cw_log behaves as expected when parsed in a config file."""
-    _validate_and_assert_error(EfsSchema(), section_dict, expected_message)
+    _validate_and_assert_error(EfsSettingsSchema(), section_dict, expected_message)
 
 
 @pytest.mark.parametrize(
@@ -350,7 +350,7 @@ def test_efs_validator(section_dict, expected_message):
     ],
 )
 def test_efs_throughput_mode_provisioned_throughput_validator(section_dict, expected_message):
-    _validate_and_assert_error(EfsSchema(), section_dict, expected_message, partial=False)
+    _validate_and_assert_error(EfsSettingsSchema(), section_dict, expected_message, partial=False)
 
 
 @pytest.mark.parametrize(
@@ -474,7 +474,7 @@ def test_efs_throughput_mode_provisioned_throughput_validator(section_dict, expe
     ],
 )
 def test_fsx_validator(section_dict, expected_message):
-    _validate_and_assert_error(FsxSchema(), section_dict, expected_message)
+    _validate_and_assert_error(FsxLustreSettingsSchema(), section_dict, expected_message)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: False
 Scheduling:
   Scheduler: awsbatch
-  Queues:
+  AwsBatchQueues:
     - Name: queue1
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: False
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: queue1
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: True
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: queue1
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.batch.no_headnode_log.yaml
@@ -8,7 +8,7 @@ HeadNode:
     SubnetId: subnet-12345678
 Scheduling:
   Scheduler: awsbatch
-  Queues:
+  AwsBatchQueues:
     - Name: queue1
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.slurm.conditional_vol.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.slurm.conditional_vol.yaml
@@ -12,7 +12,7 @@ HeadNode:
     AllowedIps: 0.0.0.0/0
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: queue1
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos7.slurm.full.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos7.slurm.full.yaml
@@ -12,7 +12,7 @@ HeadNode:
     AllowedIps: 0.0.0.0/0
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: queue1
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/ubuntu18.slurm.no_dashboard.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/ubuntu18.slurm.no_dashboard.yaml
@@ -12,7 +12,7 @@ HeadNode:
     AllowedIps: 0.0.0.0/0
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: queue1
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/ubuntu18.slurm.simple.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/ubuntu18.slurm.simple.yaml
@@ -8,7 +8,7 @@ HeadNode:
     KeyName: ec2-key-name
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: queue1
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -49,7 +49,7 @@ Scheduling:
     ScaledownIdletime: 10
     Dns:
       DisableManagedDns: true
-  Queues:
+  SlurmQueues:
     - Name: queue1
       CapacityType: ONDEMAND
       Networking:

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_2.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_2.yaml
@@ -9,7 +9,7 @@ HeadNode:
     AllowedIps: 1.2.3.4/32
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: queue1
       CapacityType: ONDEMAND
       Networking:

--- a/cli/tests/pcluster/validators/test_all_validators/test_validators_are_called_with_correct_argument/slurm.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_validators_are_called_with_correct_argument/slurm.yaml
@@ -9,7 +9,7 @@ HeadNode:
     KeyName: ec2-key-name
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: queue1
       Networking:
         SubnetIds:

--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -603,7 +603,7 @@ HeadNode:
     KeyName: {{ key_name }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  <scheduler-specific>Queues:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0
@@ -681,7 +681,7 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   ...
 Scheduling:
-  Queues:
+  <scheduler-specific>Queues:
     - Name: queue-0
       Networking:
         SubnetIds:

--- a/tests/integration-tests/benchmarks/test_scaling_performance/test_scaling_performance/pcluster.config.yaml
+++ b/tests/integration-tests/benchmarks/test_scaling_performance/test_scaling_performance/pcluster.config.yaml
@@ -10,7 +10,7 @@ Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:
     ScaledownIdletime: {{ scaledown_idletime }}
-  Queues:
+  SlurmQueues:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/benchmarks/test_scheduler_performance/test_scheduler_performance/pcluster.config.yaml
+++ b/tests/integration-tests/benchmarks/test_scheduler_performance/test_scheduler_performance/pcluster.config.yaml
@@ -10,7 +10,7 @@ Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:
     ScaledownIdletime: {{ scaledown_idletime }}
-  Queues:
+  SlurmQueues:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -465,8 +465,9 @@ def inject_additional_config_settings(cluster_config, request, region):  # noqa 
                 )
                 _add_policy_for_pre_post_install(config_content["HeadNode"], option, request, region)
 
-            if config_content["Scheduling"]["Scheduler"] != "awsbatch":
-                for queue in config_content["Scheduling"]["Queues"]:
+            scheduler = config_content["Scheduling"]["Scheduler"]
+            if scheduler != "awsbatch":
+                for queue in config_content["Scheduling"][f"{scheduler.capitalize()}Queues"]:
                     if not dict_has_nested_key(queue, ("CustomActions", config_param)):
                         dict_add_nested_key(
                             queue, request.config.getoption(option), ("CustomActions", config_param, "Script")

--- a/tests/integration-tests/tests/arm_pl/test_arm_pl/test_arm_pl/pcluster.config.yaml
+++ b/tests/integration-tests/tests/arm_pl/test_arm_pl/test_arm_pl/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_install_args_quotes/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_install_args_quotes/pcluster.config.yaml
@@ -23,7 +23,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       CustomActions:
         OnNodeStart:

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
@@ -18,7 +18,7 @@ Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:
     ScaledownIdletime: 10
-  Queues:
+  SlurmQueues:
     - Name: compute
       CustomActions:
         OnNodeConfigured:

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:
     ScaledownIdletime: {{ scaledown_idletime }}
-  Queues:
+  SlurmQueues:
     - Name: ondemand1
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: compute
       ComputeResources:
         - Name: compute-i1

--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -192,20 +192,35 @@ def assert_config_contains_expected_values(
         {"parameter_path": ["HeadNode", "InstanceType"], "expected_value": instance},
         {"parameter_path": ["HeadNode", "Networking", "SubnetId"], "expected_value": headnode_subnet_id},
         {
-            "parameter_path": ["Scheduling", "Queues", 0, "Networking", "SubnetIds", 0],
+            "parameter_path": [
+                "Scheduling",
+                "AwsBatchQueues" if scheduler == "awsbatch" else "SlurmQueues",
+                0,
+                "Networking",
+                "SubnetIds",
+                0,
+            ],
             "expected_value": compute_subnet_id,
         },
     ]
 
-    compute_resource_path = ["Scheduling", "Queues", 0, "ComputeResources", 0]
     if scheduler == "slurm":
         param_validators += [
-            {"parameter_path": compute_resource_path + ["InstanceType"], "expected_value": instance},
-            {"parameter_path": compute_resource_path + ["MinCount"], "expected_value": 0},
+            {
+                "parameter_path": ["Scheduling", "SlurmQueues", 0, "ComputeResources", 0, "InstanceType"],
+                "expected_value": instance,
+            },
+            {
+                "parameter_path": ["Scheduling", "SlurmQueues", 0, "ComputeResources", 0, "MinCount"],
+                "expected_value": 0,
+            },
         ]
     elif scheduler == "awsbatch":
         param_validators += [
-            {"parameter_path": compute_resource_path + ["MinvCpus"], "expected_value": 1},
+            {
+                "parameter_path": ["Scheduling", "AwsBatchQueues", 0, "ComputeResources", 0, "MinvCpus"],
+                "expected_value": 1,
+            },
         ]
 
     for validator in param_validators:

--- a/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
@@ -11,7 +11,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: compute
       ComputeResources:
         - Name: compute-i1

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
@@ -11,7 +11,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: compute
       ComputeResources:
         - Name: compute-i1

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
@@ -11,7 +11,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: compute
       ComputeResources:
         - Name: compute-i1

--- a/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue1
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
@@ -14,7 +14,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
@@ -14,7 +14,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_hit_disable_hyperthreading/pcluster.config.yaml
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_hit_disable_hyperthreading/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: ht-disabled
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/dns/test_dns/test_hit_no_cluster_dns_mpi/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dns/test_dns/test_hit_no_cluster_dns_mpi/pcluster.config.yaml
@@ -14,7 +14,7 @@ Scheduling:
     ScaledownIdletime: {{ scaledown_idletime }}
     Dns:
       DisableManagedDns: true
-  Queues:
+  SlurmQueues:
     - Name: default-queue
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.yaml
@@ -11,7 +11,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: efa-enabled
       Networking:
         PlacementGroup:

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.yaml
@@ -15,7 +15,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       {% if scheduler != "awsbatch" %}
       Iam:

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
@@ -15,7 +15,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       {% if scheduler != "awsbatch" %}
       Iam:

--- a/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
@@ -18,7 +18,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
@@ -13,7 +13,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeSettings:
         LocalStorage:

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -11,7 +11,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/nccl/test_nccl/test_nccl/pcluster.config.yaml
+++ b/tests/integration-tests/tests/nccl/test_nccl/test_nccl/pcluster.config.yaml
@@ -11,7 +11,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: ondemand1
       ComputeResources:
         - Name: ondemand-i1

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_existing_eip/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_existing_eip/pcluster.config.yaml
@@ -11,7 +11,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: dynamic
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.yaml
@@ -13,7 +13,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
@@ -12,7 +12,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.yaml
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.yaml
@@ -11,7 +11,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
@@ -11,7 +11,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       CapacityType: ONDEMAND
       ComputeResources:

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:
     ScaledownIdletime: {{ scaledown_idletime }}
-  Queues:
+  SlurmQueues:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
   Scheduler: {{ scheduler }}
   SlurmSettings:
     ScaledownIdletime: {{ scaledown_idletime }}
-  Queues:
+  SlurmQueues:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/schedulers/test_awsbatch.py
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch.py
@@ -38,8 +38,8 @@ def test_awsbatch(pcluster_config_reader, clusters_factory, test_datadir, caplog
     _assert_compute_instance_type_validation_successful(caplog)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
-    min_vcpus = cluster.config["Scheduling"]["Queues"][0]["ComputeResources"][0]["MinvCpus"]
-    max_vcpus = cluster.config["Scheduling"]["Queues"][0]["ComputeResources"][0]["MaxvCpus"]
+    min_vcpus = cluster.config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["MinvCpus"]
+    max_vcpus = cluster.config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["MaxvCpus"]
     assert_that(get_batch_ce_min_size(cluster.cfn_name, region)).is_equal_to(int(min_vcpus))
     assert_that(get_batch_ce_max_size(cluster.cfn_name, region)).is_equal_to(int(max_vcpus))
 

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: False
 Scheduling:
   Scheduler: awsbatch
-  Queues:
+  AwsBatchQueues:
     - Name: ondemand1
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_error_handling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_error_handling/pcluster.config.yaml
@@ -10,7 +10,7 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     ScaledownIdletime: {{ scaledown_idletime }}
-  Queues:
+  SlurmQueues:
     - Name: ondemand1
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.yaml
@@ -10,7 +10,7 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     ScaledownIdletime: {{ scaledown_idletime }}
-  Queues:
+  SlurmQueues:
     - Name: ondemand
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_pmix/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_pmix/pcluster.config.yaml
@@ -8,7 +8,7 @@ HeadNode:
     KeyName: {{ key_name }}
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: ondemand
       CapacityType: ONDEMAND
       Networking:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
@@ -13,7 +13,7 @@ HeadNode:
         EnableWriteAccess: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: broken
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
@@ -13,7 +13,7 @@ HeadNode:
         EnableWriteAccess: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: broken
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
@@ -13,7 +13,7 @@ HeadNode:
         EnableWriteAccess: true
 Scheduling:
   Scheduler: slurm
-  Queues:
+  SlurmQueues:
     - Name: broken
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_scaling/pcluster.config.yaml
@@ -10,7 +10,7 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     ScaledownIdletime: {{ scaledown_idletime }}
-  Queues:
+  SlurmQueues:
     - Name: ondemand1
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
+++ b/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: compute
       CapacityType: SPOT
       ComputeResources:

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -297,10 +297,10 @@ def _assert_root_volume_configuration(cluster, os, region, scheduler):
                 continue
             root_volume_id = utils.get_root_volume_id(instance, region, os)
             if utils.dict_has_nested_key(
-                cluster.config, ("Scheduling", "Queues", 0, "ComputeSettings", "LocalStorage", "RootVolume")
+                cluster.config, ("Scheduling", "SlurmQueues", 0, "ComputeSettings", "LocalStorage", "RootVolume")
             ):
                 logging.info("Checking compute node root volume settings")
-                expected_settings = cluster.config["Scheduling"]["Queues"][0]["ComputeSettings"]["LocalStorage"][
+                expected_settings = cluster.config["Scheduling"]["SlurmQueues"][0]["ComputeSettings"]["LocalStorage"][
                     "RootVolume"
                 ]
                 _assert_volume_configuration(expected_settings, root_volume_id, region)

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -16,7 +16,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       {% if scheduler == "slurm" %}
       ComputeSettings:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -12,7 +12,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_efs/test_existing_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_existing_efs/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_existing_fsx/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_existing_fsx/pcluster.config.yaml
@@ -13,7 +13,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       Iam:
         S3Access:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
@@ -14,7 +14,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       Iam:
         S3Access:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster_restore_fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster_restore_fsx.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
@@ -14,7 +14,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
@@ -13,7 +13,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 Scheduling:
   Scheduler: {{ scheduler }}
-  Queues:
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -414,9 +414,13 @@ def test_update_awsbatch(region, pcluster_config_reader, clusters_factory, test_
 
 def _verify_initialization(region, cluster, config):
     # Verify initial settings
-    _test_max_vcpus(region, cluster.cfn_name, config["Scheduling"]["Queues"][0]["ComputeResources"][0]["MaxvCpus"])
-    _test_min_vcpus(region, cluster.cfn_name, config["Scheduling"]["Queues"][0]["ComputeResources"][0]["MinvCpus"])
-    spot_bid_percentage = config["Scheduling"]["Queues"][0]["ComputeResources"][0]["SpotBidPercentage"]
+    _test_max_vcpus(
+        region, cluster.cfn_name, config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["MaxvCpus"]
+    )
+    _test_min_vcpus(
+        region, cluster.cfn_name, config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["MinvCpus"]
+    )
+    spot_bid_percentage = config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["SpotBidPercentage"]
     assert_that(get_batch_spot_bid_percentage(cluster.cfn_name, region)).is_equal_to(spot_bid_percentage)
 
 

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.yaml
@@ -15,7 +15,7 @@ HeadNode:
     Secured: False
 Scheduling:
   Scheduler: awsbatch
-  Queues:
+  AwsBatchQueues:
     - Name: queue-0
       CapacityType: SPOT
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.yaml
@@ -15,7 +15,7 @@ HeadNode:
     Secured: False
 Scheduling:
   Scheduler: awsbatch
-  Queues:
+  AwsBatchQueues:
     - Name: queue-0
       CapacityType: SPOT
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -22,7 +22,7 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     ScaledownIdletime: 30
-  Queues:
+  SlurmQueues:
     - Name: queue1
       ComputeSettings:
         LocalStorage:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -16,7 +16,7 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     ScaledownIdletime: 30
-  Queues:
+  SlurmQueues:
     - Name: queue1
       ComputeSettings:
         LocalStorage:


### PR DESCRIPTION
# Remove schema manipulation for Scheduling section to fix regression on update checks

We needed a way to differentiate Slurm queues schema from Awsbatch queues schema
and we were using an internal manipulation with pre_load to create internal fields
to be used to validate the different schemas.

It was causing problem during the check of the changes during an update
because we were cycling for all the schema variables and these internally created
fields were not present in the schema.
This bug was not discovered by config_patch tests because we were using the old
schema with `Scheduling > Slurm` structure rather than the current schema on
which "slurm" is not a subfolder but just an attribute of `Scheduling > Scheduler:Slurm`

Now instead of doing pre_load, post_dump actions to create internal fields
to differentiate the scheduling schemas are accepting both SlurmQueues and AwsBatchQueues
with different schemas and just differentiate the initialization according to the scheduler.

This is aligned with Slurm/AwsBatchSettings or Efs/Ebs/FsxLustreSettings,
this simplify validation because we don't need to post-process failures from marshmallow
to restore the right section name used by the customer.

## Tests
* Fixed unit tests for config_patch by using schema load and being sure we're using an accepted schema
* Added unit test for a change in the EbsSettings fields
* Updated configuration files in unit tests expected outputs and integration tests
* Added multiple unit tests for SchedulingSchema and SharedStorageSchema
* Updated integration tests configuration files

# Remove schema manipulation for SharedStorageSchema sections to fix regression on update checks

We needed a way to differentiate different storage schemas
and we were using an internal manipulation with pre_load to create internal fields
to be used to validate the different schemas.

It was causing problem during the check of the changes in the update
because we were cycling for all the schema variables and these internally created
fields were not present in the schema.

This bug was not discovered by config_patch tests because we were using the old
schema with `SharedStorage > Ebs` structure rather than the current schema on
which "Ebs" is not a subfolder but just an attribute of `SharedStorage > StorageType:Ebs`

In this case we don't really need pre_load, post_dump actions to create internal fields
to differentiate the storage schemas. We can simply accept both Settings fields
with different schemas and just differentiate the initialization according to the storage type.

Added unit tests for the new validators.