### PR TITLE
3.0: Add value of update key when updating a list element

### DIFF
--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -150,7 +150,7 @@ class ConfigPatch:
 
         If update_key is not set we're considering Name as identifier.
         """
-        update_key = field_obj.metadata.get("update_key", "Name")
+        update_key = field_obj.metadata.get("update_key")
 
         # Compare items in the list by searching the right item to compare through update_key value
         # First, compare all sections from target vs base config and mark visited base sections.
@@ -184,29 +184,16 @@ class ConfigPatch:
         for base_nested_section in base_section.get(data_key, []):
             if not base_nested_section.get("visited", False):
                 update_key_value = base_nested_section.get(update_key)
-                target_nested_section = next(
-                    (
-                        nested_section
-                        for nested_section in target_section.get(data_key, [])
-                        if nested_section.get(update_key) == update_key_value
-                    ),
-                    None,
-                )
-                if base_nested_section and target_nested_section:
-                    nested_path = copy.deepcopy(param_path)
-                    nested_path.append(data_key)
-                    self._compare_section(base_nested_section, target_nested_section, field_obj.schema, nested_path)
-                else:
-                    self.changes.append(
-                        Change(
-                            param_path,
-                            data_key,
-                            base_nested_section,
-                            None,
-                            change_update_policy,
-                            is_list=True,
-                        )
+                self.changes.append(
+                    Change(
+                        param_path,
+                        data_key,
+                        base_nested_section,
+                        None,
+                        change_update_policy,
+                        is_list=True,
                     )
+                )
 
     @property
     def update_policy_level(self):

--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -166,7 +166,7 @@ class ConfigPatch:
             )
             if base_nested_section:
                 nested_path = copy.deepcopy(param_path)
-                nested_path.append(data_key)
+                nested_path.append(f"{data_key}[{update_key_value}]")
                 self._compare_section(base_nested_section, target_nested_section, field_obj.schema, nested_path)
                 base_nested_section["visited"] = True
             else:

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -27,6 +27,7 @@ from pcluster.config.imagebuilder_config import (
     ImagebuilderDevSettings,
     Volume,
 )
+from pcluster.config.update_policy import UpdatePolicy
 from pcluster.constants import PCLUSTER_IMAGE_NAME_REGEX
 from pcluster.imagebuilder_utils import AMI_NAME_REQUIRED_SUBSTRING
 from pcluster.schemas.common_schema import (
@@ -134,7 +135,11 @@ class IamSchema(BaseSchema):
 
     instance_role = fields.Str(validate=validate.Regexp("^arn:.*:(role|instance-profile)/"))
     cleanup_lambda_role = fields.Str(validate=validate.Regexp("^arn:.*:role/"))
-    additional_iam_policies = fields.Nested(AdditionalIamPolicySchema, many=True)
+    additional_iam_policies = fields.Nested(
+        AdditionalIamPolicySchema,
+        many=True,
+        metadata={"update_policy": UpdatePolicy.SUPPORTED, "update_key": "Policy"},
+    )
 
     @validates_schema
     def no_coexist_role_policies(self, data, **kwargs):

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -80,7 +80,7 @@ def _compare_changes(changes, expected_changes):
 @pytest.mark.parametrize(
     "change_path, template_rendering_key, param_key, src_param_value, dst_param_value, change_update_policy, is_list",
     [
-        (
+        pytest.param(
             ["HeadNode", "Networking"],
             "head_node_subnet_id",
             "SubnetId",
@@ -88,8 +88,9 @@ def _compare_changes(changes, expected_changes):
             "subnet-1234567a",
             UpdatePolicy.UNSUPPORTED,
             False,
+            id="change subnet id",
         ),
-        (
+        pytest.param(
             ["HeadNode", "Networking"],
             "additional_sg",
             "AdditionalSecurityGroups",
@@ -97,24 +98,27 @@ def _compare_changes(changes, expected_changes):
             "sg-1234567a",
             UpdatePolicy.SUPPORTED,
             True,
+            id="change additional security group",
         ),
-        (
-            ["Scheduling", "Slurm", "Queues", "ComputeResources"],
+        pytest.param(
+            ["Scheduling", "Slurm", "Queues[queue1]", "ComputeResources[compute-resource1]"],
             "max_count",
             "MaxCount",
             0,
             1,
             UpdatePolicy.MAX_COUNT,
             False,
+            id="change compute resources max count",
         ),
-        (
-            ["Scheduling", "Slurm", "Queues", "ComputeResources"],
+        pytest.param(
+            ["Scheduling", "Slurm", "Queues[queue1]", "ComputeResources[compute-resource1]"],
             "compute_instance_type",
             "InstanceType",
             "t2.micro",
             "c4.xlarge",
             UpdatePolicy.COMPUTE_FLEET_STOP,
             False,
+            id="change compute resources instance type",
         ),
     ],
 )
@@ -188,7 +192,7 @@ def test_multiple_param_changes(pcluster_config_reader, test_datadir):
             is_list=False,
         ),
         Change(
-            ["Scheduling", "Slurm", "Queues", "Networking"],
+            ["Scheduling", "Slurm", "Queues[queue1]", "Networking"],
             "SubnetIds",
             ["subnet-12345678"],
             ["subnet-1234567a"],
@@ -240,9 +244,9 @@ def _test_less_target_sections(base_conf, target_conf):
                 ),
                 is_list=True,
             ),
-            Change(["SharedStorage"], "MountDir", "vol2", "vol1", UpdatePolicy.UNSUPPORTED, is_list=False),
-            Change(["SharedStorage", "Ebs"], "Iops", None, 20, UpdatePolicy.SUPPORTED, is_list=False),
-            Change(["SharedStorage", "Ebs"], "VolumeType", "gp3", "gp2", UpdatePolicy.UNSUPPORTED, is_list=False),
+            Change(["SharedStorage[ebs2]"], "MountDir", "vol2", "vol1", UpdatePolicy.UNSUPPORTED, is_list=False),
+            Change(["SharedStorage[ebs2]", "Ebs"], "Iops", None, 20, UpdatePolicy.SUPPORTED, is_list=False),
+            Change(["SharedStorage[ebs2]", "Ebs"], "VolumeType", "gp3", "gp2", UpdatePolicy.UNSUPPORTED, is_list=False),
         ],
         UpdatePolicy.UNSUPPORTED,
     )
@@ -287,9 +291,9 @@ def _test_more_target_sections(base_conf, target_conf):
                 ),
                 is_list=True,
             ),
-            Change(["SharedStorage"], "MountDir", "vol2", "vol1", UpdatePolicy.UNSUPPORTED, is_list=False),
-            Change(["SharedStorage", "Ebs"], "Iops", None, 20, UpdatePolicy.SUPPORTED, is_list=False),
-            Change(["SharedStorage", "Ebs"], "VolumeType", "gp3", "gp2", UpdatePolicy.UNSUPPORTED, is_list=False),
+            Change(["SharedStorage[ebs2]"], "MountDir", "vol2", "vol1", UpdatePolicy.UNSUPPORTED, is_list=False),
+            Change(["SharedStorage[ebs2]", "Ebs"], "Iops", None, 20, UpdatePolicy.SUPPORTED, is_list=False),
+            Change(["SharedStorage[ebs2]", "Ebs"], "VolumeType", "gp3", "gp2", UpdatePolicy.UNSUPPORTED, is_list=False),
         ],
         UpdatePolicy.UNSUPPORTED,
     )
@@ -303,7 +307,11 @@ def _test_incompatible_ebs_sections(base_conf, target_conf):
     _check_patch(
         base_conf,
         target_conf,
-        [Change(["SharedStorage"], "MountDir", "vol1", "new_value", UpdatePolicy(UpdatePolicy.UNSUPPORTED), False)],
+        [
+            Change(
+                ["SharedStorage[ebs1]"], "MountDir", "vol1", "new_value", UpdatePolicy(UpdatePolicy.UNSUPPORTED), False
+            )
+        ],
         UpdatePolicy.UNSUPPORTED,
     )
 

--- a/cli/tests/pcluster/schemas/test_schemas.py
+++ b/cli/tests/pcluster/schemas/test_schemas.py
@@ -1,0 +1,53 @@
+import inspect
+
+from assertpy import assert_that, soft_assertions
+from marshmallow import Schema
+
+import pcluster.schemas.cluster_schema
+import pcluster.schemas.common_schema
+import pcluster.schemas.imagebuilder_schema
+
+
+def _validate_list_has_update_key(section):
+    """Validate that the schema's lists have an update_key defined."""
+    for _, field_obj in section.declared_fields.items():
+        is_list = hasattr(field_obj, "many") and field_obj.many
+        if is_list:
+            update_key = field_obj.metadata.get("update_key", None)
+            assert_that(update_key).is_not_none()
+
+
+def _is_schema(module):
+    """Get the Schema subclasses defined in the module.
+
+    :param module: the module where the schemas are defined
+    """
+
+    def predicate(class_object):
+        return (
+            inspect.isclass(class_object)
+            and class_object.__module__ == module.__name__
+            and issubclass(class_object, Schema)
+        )
+
+    return predicate
+
+
+def _validate_module_schemas(module):
+    """Validate the schema subclasses defined in the module.
+
+    This validator checks that if the schema has list field, it has an update_key defined. Note that since we check
+    every schema in the module, we don't just need to check the lists at the top level (if there are nested fields,
+    the check on the list will be done when the field's schema is validated.
+
+    :param module: the module with the schemas to validate
+    """
+    for _, class_object in inspect.getmembers(module, _is_schema(module)):
+        _validate_list_has_update_key(class_object())
+
+
+def test_schemas():
+    with soft_assertions():
+        _validate_module_schemas(pcluster.schemas.cluster_schema)
+        _validate_module_schemas(pcluster.schemas.imagebuilder_schema)
+        _validate_module_schemas(pcluster.schemas.common_schema)


### PR DESCRIPTION
### Notes
When computing a change, if we are updating a list element we want to embed the value of the element's update key in the path. For example, when modifying the EnableWriteAccess of a bucket in an S3 access policy, currently we would have:

**path: [..., S3Access, BucketName], param: EnableWriteAccess**

while with this patch we wolud have:

**path: [..., S3Access, BucketName[bucket2]], param: EnableWriteAccess**

Note that the BucketName in this case is the update key, which means that if we change the BucketName itself, we would continue to have something like the following instead:

**path: [..., S3Access], param: BucketName, old: bucket2, new: None**
**path: [..., S3Access], param: BucketName, old: None, new bucket3**

### Tests
Fixed and run unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
