### PR TITLE
3.0: Remove the ClientToken param from all APIs

### DIFF
--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -114,12 +114,6 @@ paths:
             type: boolean
             description: When set it automatically initiates a cluster stack rollback on failures. Defaults to true.
             nullable: true
-        - name: clientToken
-          in: query
-          description: Idempotency token that can be set by the client so that retries for the same request are idempotent
-          schema:
-            type: string
-            description: Idempotency token that can be set by the client so that retries for the same request are idempotent
       responses:
         "202":
           description: CreateCluster 202 response
@@ -364,12 +358,6 @@ paths:
             type: boolean
             description: Force update by ignoring the update validation errors.
             nullable: true
-        - name: clientToken
-          in: query
-          description: Idempotency token that can be set by the client so that retries for the same request are idempotent
-          schema:
-            type: string
-            description: Idempotency token that can be set by the client so that retries for the same request are idempotent
       responses:
         "202":
           description: UpdateCluster 202 response
@@ -823,12 +811,6 @@ paths:
             type: boolean
             description: When set it automatically initiates an image stack rollback on failures. Defaults to true.
             nullable: true
-        - name: clientToken
-          in: query
-          description: Idempotency token that can be set by the client so that retries for the same request are idempotent
-          schema:
-            type: string
-            description: Idempotency token that can be set by the client so that retries for the same request are idempotent
       responses:
         "202":
           description: BuildImage 202 response
@@ -903,12 +885,6 @@ paths:
           schema:
             type: string
             description: AWS Region. Defaults to the region the API is deployed to.
-        - name: clientToken
-          in: query
-          description: Idempotency token that can be set by the client so that retries for the same request are idempotent
-          schema:
-            type: string
-            description: Idempotency token that can be set by the client so that retries for the same request are idempotent
         - name: force
           in: query
           description: Force deletion in case there are instances using the AMI or in case the AMI is shared

--- a/api/spec/smithy/model/operations/BuildImage.smithy
+++ b/api/spec/smithy/model/operations/BuildImage.smithy
@@ -30,10 +30,6 @@ structure BuildImageRequest {
     @httpQuery("rollbackOnFailure")
     @documentation("When set it automatically initiates an image stack rollback on failures. Defaults to true.")
     rollbackOnFailure: Boolean,
-    @idempotencyToken
-    @httpQuery("clientToken")
-    @documentation("Idempotency token that can be set by the client so that retries for the same request are idempotent")
-    clientToken: String,
 
     @required
     id: ImageId,

--- a/api/spec/smithy/model/operations/CreateCluster.smithy
+++ b/api/spec/smithy/model/operations/CreateCluster.smithy
@@ -30,10 +30,6 @@ structure CreateClusterRequest {
     @httpQuery("rollbackOnFailure")
     @documentation("When set it automatically initiates a cluster stack rollback on failures. Defaults to true.")
     rollbackOnFailure: Boolean,
-    @idempotencyToken
-    @httpQuery("clientToken")
-    @documentation("Idempotency token that can be set by the client so that retries for the same request are idempotent")
-    clientToken: String,
 
     @required
     name: ClusterName,

--- a/api/spec/smithy/model/operations/DeleteImage.smithy
+++ b/api/spec/smithy/model/operations/DeleteImage.smithy
@@ -23,10 +23,6 @@ structure DeleteImageRequest {
 
     @httpQuery("region")
     region: Region,
-    @idempotencyToken
-    @httpQuery("clientToken")
-    @documentation("Idempotency token that can be set by the client so that retries for the same request are idempotent")
-    clientToken: String,
     @httpQuery("force")
     @documentation("Force deletion in case there are instances using the AMI or in case the AMI is shared")
     force: Boolean,

--- a/api/spec/smithy/model/operations/UpdateCluster.smithy
+++ b/api/spec/smithy/model/operations/UpdateCluster.smithy
@@ -36,10 +36,6 @@ structure UpdateClusterRequest {
     @httpQuery("forceUpdate")
     @documentation("Force update by ignoring the update validation errors.")
     forceUpdate: Boolean,
-    @idempotencyToken
-    @httpQuery("clientToken")
-    @documentation("Idempotency token that can be set by the client so that retries for the same request are idempotent")
-    clientToken: String,
 
     @required
     clusterConfiguration: ClusterConfigurationData,

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -78,7 +78,6 @@ def create_cluster(
     validation_failure_level: str = None,
     dryrun: bool = None,
     rollback_on_failure: bool = None,
-    client_token: str = None,
 ) -> CreateClusterResponseContent:
     """
     Create a ParallelCluster managed cluster in a given region.
@@ -92,18 +91,12 @@ def create_cluster(
     configuration. Response code: 200
     :param rollback_on_failure: When set it automatically initiates a cluster stack rollback on failures.
     Defaults to true.
-    :param client_token: Idempotency token that can be set by the client so that retries for the same request are
-    idempotent
     """
     # Set defaults
     rollback_on_failure = rollback_on_failure or True
     validation_failure_level = validation_failure_level or ValidationLevel.ERROR
     dryrun = dryrun or False
     create_cluster_request_content = CreateClusterRequestContent.from_dict(create_cluster_request_content)
-
-    # Validate inputs
-    if client_token:
-        raise BadRequestException("clientToken is currently not supported for this operation")
     cluster_config = read_config(create_cluster_request_content.cluster_configuration)
 
     try:
@@ -290,7 +283,6 @@ def update_cluster(
     region=None,
     dryrun=None,
     force_update=None,
-    client_token=None,
 ):
     """
     Update cluster.
@@ -311,9 +303,6 @@ def update_cluster(
     :type dryrun: bool
     :param force_update: Force update by ignoring the update validation errors.
     :type force_update: bool
-    :param client_token: Idempotency token that can be set by the client so that retries for the same request are
-    idempotent
-    :type client_token: str
 
     :rtype: UpdateClusterResponseContent
     """
@@ -322,10 +311,6 @@ def update_cluster(
     dryrun = dryrun or False
     force_update = force_update or False
     update_cluster_request_content = UpdateClusterRequestContent.from_dict(update_cluster_request_content)
-
-    # Validate inputs
-    if client_token:
-        raise BadRequestException("clientToken is currently not supported for this operation")
     cluster_config = read_config(update_cluster_request_content.cluster_configuration)
 
     try:

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -60,7 +60,6 @@ def build_image(
     validation_failure_level=None,
     dryrun=None,
     rollback_on_failure=None,
-    client_token=None,
 ):
     """
     Create a custom ParallelCluster image in a given region.
@@ -78,20 +77,9 @@ def build_image(
     :param rollback_on_failure: When set it automatically initiates an image stack rollback on failures.
     Defaults to true.
     :type rollback_on_failure: bool
-    :param client_token: Idempotency token that can be set by the client so that retries for the same request are
-    idempotent
-    :type client_token: str
 
     :rtype: BuildImageResponseContent
     """
-    if client_token:
-        raise BuildImageBadRequestException(
-            BuildImageBadRequestExceptionResponseContent(
-                message="clientToken is currently not supported for this operation",
-                configuration_validation_errors=[],
-            )
-        )
-
     rollback_on_failure = rollback_on_failure or False
     disable_rollback = not rollback_on_failure
     validation_failure_level = validation_failure_level or FailureLevel.ERROR
@@ -131,7 +119,7 @@ def build_image(
 @configure_aws_region()
 @http_success_status_code(202)
 @convert_errors()
-def delete_image(image_id, region=None, client_token=None, force=None):
+def delete_image(image_id, region=None, force=None):
     """
     Initiate the deletion of the custom ParallelCluster image.
 
@@ -139,17 +127,11 @@ def delete_image(image_id, region=None, client_token=None, force=None):
     :type image_id: str
     :param region: AWS Region. Defaults to the region the API is deployed to.
     :type region: str
-    :param client_token: Idempotency token that can be set by the client so that retries for the same request are
-    idempotent
-    :type client_token: str
     :param force: Force deletion in case there are instances using the AMI or in case the AMI is shared
     :type force: bool
 
     :rtype: DeleteImageResponseContent
     """
-    if client_token:
-        raise BadRequestException("clientToken is currently not supported for this operation")
-
     force = force or False
     imagebuilder = ImageBuilder(image_id=image_id)
     image, stack = _get_underlying_image_or_stack(imagebuilder)

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -139,17 +139,6 @@ paths:
           nullable: true
           type: boolean
         style: form
-      - description: Idempotency token that can be set by the client so that retries
-          for the same request are idempotent
-        explode: true
-        in: query
-        name: clientToken
-        required: false
-        schema:
-          description: Idempotency token that can be set by the client so that retries
-            for the same request are idempotent
-          type: string
-        style: form
       requestBody:
         content:
           application/json:
@@ -429,17 +418,6 @@ paths:
           description: Force update by ignoring the update validation errors.
           nullable: true
           type: boolean
-        style: form
-      - description: Idempotency token that can be set by the client so that retries
-          for the same request are idempotent
-        explode: true
-        in: query
-        name: clientToken
-        required: false
-        schema:
-          description: Idempotency token that can be set by the client so that retries
-            for the same request are idempotent
-          type: string
         style: form
       requestBody:
         content:
@@ -963,17 +941,6 @@ paths:
           nullable: true
           type: boolean
         style: form
-      - description: Idempotency token that can be set by the client so that retries
-          for the same request are idempotent
-        explode: true
-        in: query
-        name: clientToken
-        required: false
-        schema:
-          description: Idempotency token that can be set by the client so that retries
-            for the same request are idempotent
-          type: string
-        style: form
       requestBody:
         content:
           application/json:
@@ -1059,17 +1026,6 @@ paths:
         required: false
         schema:
           description: AWS Region. Defaults to the region the API is deployed to.
-          type: string
-        style: form
-      - description: Idempotency token that can be set by the client so that retries
-          for the same request are idempotent
-        explode: true
-        in: query
-        name: clientToken
-        required: false
-        schema:
-          description: Idempotency token that can be set by the client so that retries
-            for the same request are idempotent
           type: string
         style: form
       - description: Force deletion in case there are instances using the AMI or in

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -64,7 +64,6 @@ class TestCreateCluster:
         validation_failure_level=None,
         dryrun=None,
         rollback_on_failure=None,
-        client_token=None,
     ):
         query_string = []
         if suppress_validators:
@@ -75,8 +74,6 @@ class TestCreateCluster:
             query_string.append(("dryrun", dryrun))
         if rollback_on_failure is not None:
             query_string.append(("rollbackOnFailure", rollback_on_failure))
-        if client_token:
-            query_string.append(("clientToken", client_token))
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -190,13 +187,12 @@ class TestCreateCluster:
 
     @pytest.mark.parametrize(
         "create_cluster_request_content, suppress_validators, validation_failure_level, dryrun, rollback_on_failure, "
-        "client_token, expected_response",
+        "expected_response",
         [
-            (None, None, None, None, None, None, {"message": "Bad Request: request body is required"}),
-            ({}, None, None, None, None, None, {"message": "Bad Request: request body is required"}),
+            (None, None, None, None, None, {"message": "Bad Request: request body is required"}),
+            ({}, None, None, None, None, {"message": "Bad Request: request body is required"}),
             (
                 {"region": "us-east-1", "name": "cluster"},
-                None,
                 None,
                 None,
                 None,
@@ -209,12 +205,10 @@ class TestCreateCluster:
                 None,
                 None,
                 None,
-                None,
                 {"message": "Bad Request: invalid or unsupported region 'invalid'"},
             ),
             (
                 {"clusterConfiguration": "config", "region": "us-east-1"},
-                None,
                 None,
                 None,
                 None,
@@ -227,13 +221,11 @@ class TestCreateCluster:
                 None,
                 None,
                 None,
-                None,
                 {"message": "Bad Request: 'ALLL' does not match '^(ALL|type:[A-Za-z0-9]+)$'"},
             ),
             (
                 {"clusterConfiguration": "config", "name": "cluster", "region": "us-east-1"},
                 ["type:"],
-                None,
                 None,
                 None,
                 None,
@@ -245,7 +237,6 @@ class TestCreateCluster:
                 "CRITICAL",
                 None,
                 None,
-                None,
                 {"message": "Bad Request: 'CRITICAL' is not one of ['INFO', 'WARNING', 'ERROR']"},
             ),
             (
@@ -253,7 +244,6 @@ class TestCreateCluster:
                 None,
                 None,
                 "NO",
-                None,
                 None,
                 {"message": "Bad Request: Wrong type, expected 'boolean' for query parameter 'dryrun'"},
             ),
@@ -263,12 +253,10 @@ class TestCreateCluster:
                 None,
                 None,
                 "NO",
-                None,
                 {"message": "Bad Request: Wrong type, expected 'boolean' for query parameter 'rollbackOnFailure'"},
             ),
             (
                 {"clusterConfiguration": "config", "name": "cluster", "region": "us-east-1"},
-                None,
                 None,
                 None,
                 None,
@@ -281,7 +269,6 @@ class TestCreateCluster:
                 None,
                 None,
                 None,
-                None,
                 {"message": "Bad Request: Configuration must be a valid YAML document"},
             ),
             (
@@ -290,7 +277,6 @@ class TestCreateCluster:
                     "name": "cluster",
                     "region": "us-east-1",
                 },
-                None,
                 None,
                 None,
                 None,
@@ -314,17 +300,7 @@ class TestCreateCluster:
                 None,
                 None,
                 None,
-                None,
                 {"message": "Bad Request: configuration is required and cannot be empty"},
-            ),
-            (
-                {"clusterConfiguration": "", "name": "cluster", "region": "us-east-1"},
-                None,
-                None,
-                None,
-                None,
-                "token",
-                {"message": "Bad Request: clientToken is currently not supported for this operation"},
             ),
         ],
         ids=[
@@ -342,7 +318,6 @@ class TestCreateCluster:
             "invalid_config_format",
             "invalid_config_schema",
             "empty_config",
-            "client_token",
         ],
     )
     def test_malformed_request(
@@ -354,7 +329,6 @@ class TestCreateCluster:
         validation_failure_level,
         dryrun,
         rollback_on_failure,
-        client_token,
         expected_response,
     ):
         mocker.patch("pcluster.aws.cfn.CfnClient.stack_exists", return_value=False)
@@ -366,7 +340,6 @@ class TestCreateCluster:
             validation_failure_level,
             dryrun,
             rollback_on_failure,
-            client_token,
         )
 
         with soft_assertions():

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -249,13 +249,11 @@ class TestDeleteImage:
     url = "/v3/images/custom/{image_name}"
     method = "DELETE"
 
-    def _send_test_request(self, client, image_name, region="us-east-1", force=True, client_token=None):
+    def _send_test_request(self, client, image_name, region="us-east-1", force=True):
         query_string = [
             ("force", force),
             ("region", region),
         ]
-        if client_token:
-            query_string.append(("clientToken", client_token))
         headers = {
             "Accept": "application/json",
         }
@@ -410,14 +408,6 @@ class TestDeleteImage:
             assert_that(response.status_code).is_equal_to(500)
             assert_that(response.get_json()).is_equal_to(expected_error)
 
-    def test_that_call_with_client_token_throws_bad_request(self, client):
-        expected_error = {"message": "Bad Request: clientToken is currently not supported for this operation"}
-        response = self._send_test_request(client, "image1", client_token="clientToken")
-
-        with soft_assertions():
-            assert_that(response.status_code).is_equal_to(400)
-            assert_that(response.get_json()).is_equal_to(expected_error)
-
 
 class TestBuildImage:
     url = "/v3/images/custom"
@@ -434,7 +424,7 @@ class TestBuildImage:
         "ZWxjbHVzdGVyL3RhcmJhbGwvZDVjMmExZWMyNjdhODY1Y2ZmM2NmMzUwYWYzMGQ0NGU2OGYwZWYxOA===="
     )
 
-    def _send_test_request(self, client, dryrun=False, client_token=None, suppress_validators=None):
+    def _send_test_request(self, client, dryrun=False, suppress_validators=None):
         build_image_request_content = {
             "imageConfiguration": self.encoded_config,
             "id": "imageid",
@@ -445,9 +435,6 @@ class TestBuildImage:
             ("dryrun", dryrun),
             ("rollbackOnFailure", True),
         ]
-
-        if client_token:
-            query_string.append(("clientToken", client_token))
 
         if suppress_validators:
             query_string.extend([("suppressValidators", validator) for validator in suppress_validators])
@@ -572,17 +559,6 @@ class TestBuildImage:
 
         with soft_assertions():
             assert_that(response.status_code).is_equal_to(error_code)
-            assert_that(response.get_json()).is_equal_to(expected_error)
-
-    def test_that_call_with_client_token_throws_bad_request(self, client):
-        expected_error = {
-            "configurationValidationErrors": [],
-            "message": "clientToken is currently not supported for this operation",
-        }
-        response = self._send_test_request(client, client_token="clientToken")
-
-        with soft_assertions():
-            assert_that(response.status_code).is_equal_to(400)
             assert_that(response.get_json()).is_equal_to(expected_error)
 
 


### PR DESCRIPTION
### Notes
Remove the ClientToken parameter from all APIs.

### Tests
Fixed and run unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
