### PR TITLE
3.0: Add GitHub action to generate API client

### DIFF
--- a/.github/workflows/openapi_generator.yml
+++ b/.github/workflows/openapi_generator.yml
@@ -22,10 +22,15 @@ jobs:
           sudo npm install -g redoc-cli
           sudo snap install yq
       - working-directory: api
-        run: ./gradlew buildSmithyModel openApiValidate redoc
+        run: ./gradlew buildSmithyModel openApiValidate redoc generatePythonClient
       - uses: EndBug/add-and-commit@v7
         with:
           add: 'api/spec/openapi'
           message: 'Generate OpenAPI model'
+          signoff: true
+      - uses: EndBug/add-and-commit@v7
+        with:
+          add: 'api/client/src'
+          message: 'Generate API Client'
           signoff: true
 

--- a/api/client/src/docs/ClusterOperationsApi.md
+++ b/api/client/src/docs/ClusterOperationsApi.md
@@ -67,7 +67,6 @@ with pcluster.api.client.ApiClient(configuration) as api_client:
     validation_failure_level = ValidationLevel("INFO") # ValidationLevel | Min validation level that will cause the creation to fail. Defaults to 'ERROR'. (optional)
     dryrun = True # bool, none_type | Only perform request validation without creating any resource. It can be used to validate the cluster configuration. Response code: 200 (optional)
     rollback_on_failure = True # bool, none_type | When set it automatically initiates a cluster stack rollback on failures. Defaults to true. (optional)
-    client_token = "clientToken_example" # str | Idempotency token that can be set by the client so that retries for the same request are idempotent (optional)
 
     # example passing only required values which don't have defaults set
     try:
@@ -79,7 +78,7 @@ with pcluster.api.client.ApiClient(configuration) as api_client:
     # example passing only required values which don't have defaults set
     # and optional values
     try:
-        api_response = api_instance.create_cluster(create_cluster_request_content, suppress_validators=suppress_validators, validation_failure_level=validation_failure_level, dryrun=dryrun, rollback_on_failure=rollback_on_failure, client_token=client_token)
+        api_response = api_instance.create_cluster(create_cluster_request_content, suppress_validators=suppress_validators, validation_failure_level=validation_failure_level, dryrun=dryrun, rollback_on_failure=rollback_on_failure)
         pprint(api_response)
     except pcluster.api.client.ApiException as e:
         print("Exception when calling ClusterOperationsApi->create_cluster: %s\n" % e)
@@ -95,7 +94,6 @@ Name | Type | Description  | Notes
  **validation_failure_level** | **ValidationLevel**| Min validation level that will cause the creation to fail. Defaults to &#39;ERROR&#39;. | [optional]
  **dryrun** | **bool, none_type**| Only perform request validation without creating any resource. It can be used to validate the cluster configuration. Response code: 200 | [optional]
  **rollback_on_failure** | **bool, none_type**| When set it automatically initiates a cluster stack rollback on failures. Defaults to true. | [optional]
- **client_token** | **str**| Idempotency token that can be set by the client so that retries for the same request are idempotent | [optional]
 
 ### Return type
 
@@ -460,7 +458,6 @@ with pcluster.api.client.ApiClient(configuration) as api_client:
     region = "region_example" # str | AWS Region. Defaults to the region the API is deployed to. (optional)
     dryrun = True # bool, none_type | Only perform request validation without creating any resource. It can be used to validate the cluster configuration and update requirements. Response code: 200 (optional)
     force_update = True # bool, none_type | Force update by ignoring the update validation errors. (optional)
-    client_token = "clientToken_example" # str | Idempotency token that can be set by the client so that retries for the same request are idempotent (optional)
 
     # example passing only required values which don't have defaults set
     try:
@@ -472,7 +469,7 @@ with pcluster.api.client.ApiClient(configuration) as api_client:
     # example passing only required values which don't have defaults set
     # and optional values
     try:
-        api_response = api_instance.update_cluster(cluster_name, update_cluster_request_content, suppress_validators=suppress_validators, validation_failure_level=validation_failure_level, region=region, dryrun=dryrun, force_update=force_update, client_token=client_token)
+        api_response = api_instance.update_cluster(cluster_name, update_cluster_request_content, suppress_validators=suppress_validators, validation_failure_level=validation_failure_level, region=region, dryrun=dryrun, force_update=force_update)
         pprint(api_response)
     except pcluster.api.client.ApiException as e:
         print("Exception when calling ClusterOperationsApi->update_cluster: %s\n" % e)
@@ -490,7 +487,6 @@ Name | Type | Description  | Notes
  **region** | **str**| AWS Region. Defaults to the region the API is deployed to. | [optional]
  **dryrun** | **bool, none_type**| Only perform request validation without creating any resource. It can be used to validate the cluster configuration and update requirements. Response code: 200 | [optional]
  **force_update** | **bool, none_type**| Force update by ignoring the update validation errors. | [optional]
- **client_token** | **str**| Idempotency token that can be set by the client so that retries for the same request are idempotent | [optional]
 
 ### Return type
 

--- a/api/client/src/docs/ImageOperationsApi.md
+++ b/api/client/src/docs/ImageOperationsApi.md
@@ -67,7 +67,6 @@ with pcluster.api.client.ApiClient(configuration) as api_client:
     validation_failure_level = ValidationLevel("INFO") # ValidationLevel | Min validation level that will cause the creation to fail. Defaults to 'error'. (optional)
     dryrun = True # bool, none_type | Only perform request validation without creating any resource. It can be used to validate the image configuration. Response code: 200 (optional)
     rollback_on_failure = True # bool, none_type | When set it automatically initiates an image stack rollback on failures. Defaults to true. (optional)
-    client_token = "clientToken_example" # str | Idempotency token that can be set by the client so that retries for the same request are idempotent (optional)
 
     # example passing only required values which don't have defaults set
     try:
@@ -79,7 +78,7 @@ with pcluster.api.client.ApiClient(configuration) as api_client:
     # example passing only required values which don't have defaults set
     # and optional values
     try:
-        api_response = api_instance.build_image(build_image_request_content, suppress_validators=suppress_validators, validation_failure_level=validation_failure_level, dryrun=dryrun, rollback_on_failure=rollback_on_failure, client_token=client_token)
+        api_response = api_instance.build_image(build_image_request_content, suppress_validators=suppress_validators, validation_failure_level=validation_failure_level, dryrun=dryrun, rollback_on_failure=rollback_on_failure)
         pprint(api_response)
     except pcluster.api.client.ApiException as e:
         print("Exception when calling ImageOperationsApi->build_image: %s\n" % e)
@@ -95,7 +94,6 @@ Name | Type | Description  | Notes
  **validation_failure_level** | **ValidationLevel**| Min validation level that will cause the creation to fail. Defaults to &#39;error&#39;. | [optional]
  **dryrun** | **bool, none_type**| Only perform request validation without creating any resource. It can be used to validate the image configuration. Response code: 200 | [optional]
  **rollback_on_failure** | **bool, none_type**| When set it automatically initiates an image stack rollback on failures. Defaults to true. | [optional]
- **client_token** | **str**| Idempotency token that can be set by the client so that retries for the same request are idempotent | [optional]
 
 ### Return type
 
@@ -168,7 +166,6 @@ with pcluster.api.client.ApiClient(configuration) as api_client:
     api_instance = image_operations_api.ImageOperationsApi(api_client)
     image_id = "AqWzy" # str | Id of the image
     region = "region_example" # str | AWS Region. Defaults to the region the API is deployed to. (optional)
-    client_token = "clientToken_example" # str | Idempotency token that can be set by the client so that retries for the same request are idempotent (optional)
     force = True # bool, none_type | Force deletion in case there are instances using the AMI or in case the AMI is shared (optional)
 
     # example passing only required values which don't have defaults set
@@ -181,7 +178,7 @@ with pcluster.api.client.ApiClient(configuration) as api_client:
     # example passing only required values which don't have defaults set
     # and optional values
     try:
-        api_response = api_instance.delete_image(image_id, region=region, client_token=client_token, force=force)
+        api_response = api_instance.delete_image(image_id, region=region, force=force)
         pprint(api_response)
     except pcluster.api.client.ApiException as e:
         print("Exception when calling ImageOperationsApi->delete_image: %s\n" % e)
@@ -194,7 +191,6 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **image_id** | **str**| Id of the image |
  **region** | **str**| AWS Region. Defaults to the region the API is deployed to. | [optional]
- **client_token** | **str**| Idempotency token that can be set by the client so that retries for the same request are idempotent | [optional]
  **force** | **bool, none_type**| Force deletion in case there are instances using the AMI or in case the AMI is shared | [optional]
 
 ### Return type

--- a/api/client/src/pcluster/api/client/api/cluster_operations_api.py
+++ b/api/client/src/pcluster/api/client/api/cluster_operations_api.py
@@ -75,7 +75,6 @@ class ClusterOperationsApi(object):
                 validation_failure_level (ValidationLevel): Min validation level that will cause the creation to fail. Defaults to 'ERROR'.. [optional]
                 dryrun (bool, none_type): Only perform request validation without creating any resource. It can be used to validate the cluster configuration. Response code: 200. [optional]
                 rollback_on_failure (bool, none_type): When set it automatically initiates a cluster stack rollback on failures. Defaults to true.. [optional]
-                client_token (str): Idempotency token that can be set by the client so that retries for the same request are idempotent. [optional]
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -142,7 +141,6 @@ class ClusterOperationsApi(object):
                     'validation_failure_level',
                     'dryrun',
                     'rollback_on_failure',
-                    'client_token',
                 ],
                 'required': [
                     'create_cluster_request_content',
@@ -176,15 +174,12 @@ class ClusterOperationsApi(object):
                         (bool, none_type,),
                     'rollback_on_failure':
                         (bool, none_type,),
-                    'client_token':
-                        (str,),
                 },
                 'attribute_map': {
                     'suppress_validators': 'suppressValidators',
                     'validation_failure_level': 'validationFailureLevel',
                     'dryrun': 'dryrun',
                     'rollback_on_failure': 'rollbackOnFailure',
-                    'client_token': 'clientToken',
                 },
                 'location_map': {
                     'create_cluster_request_content': 'body',
@@ -192,7 +187,6 @@ class ClusterOperationsApi(object):
                     'validation_failure_level': 'query',
                     'dryrun': 'query',
                     'rollback_on_failure': 'query',
-                    'client_token': 'query',
                 },
                 'collection_format_map': {
                     'suppress_validators': 'multi',
@@ -630,7 +624,6 @@ class ClusterOperationsApi(object):
                 region (str): AWS Region. Defaults to the region the API is deployed to.. [optional]
                 dryrun (bool, none_type): Only perform request validation without creating any resource. It can be used to validate the cluster configuration and update requirements. Response code: 200. [optional]
                 force_update (bool, none_type): Force update by ignoring the update validation errors.. [optional]
-                client_token (str): Idempotency token that can be set by the client so that retries for the same request are idempotent. [optional]
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -701,7 +694,6 @@ class ClusterOperationsApi(object):
                     'region',
                     'dryrun',
                     'force_update',
-                    'client_token',
                 ],
                 'required': [
                     'cluster_name',
@@ -748,8 +740,6 @@ class ClusterOperationsApi(object):
                         (bool, none_type,),
                     'force_update':
                         (bool, none_type,),
-                    'client_token':
-                        (str,),
                 },
                 'attribute_map': {
                     'cluster_name': 'clusterName',
@@ -758,7 +748,6 @@ class ClusterOperationsApi(object):
                     'region': 'region',
                     'dryrun': 'dryrun',
                     'force_update': 'forceUpdate',
-                    'client_token': 'clientToken',
                 },
                 'location_map': {
                     'cluster_name': 'path',
@@ -768,7 +757,6 @@ class ClusterOperationsApi(object):
                     'region': 'query',
                     'dryrun': 'query',
                     'force_update': 'query',
-                    'client_token': 'query',
                 },
                 'collection_format_map': {
                     'suppress_validators': 'multi',

--- a/api/client/src/pcluster/api/client/api/image_operations_api.py
+++ b/api/client/src/pcluster/api/client/api/image_operations_api.py
@@ -73,7 +73,6 @@ class ImageOperationsApi(object):
                 validation_failure_level (ValidationLevel): Min validation level that will cause the creation to fail. Defaults to 'error'.. [optional]
                 dryrun (bool, none_type): Only perform request validation without creating any resource. It can be used to validate the image configuration. Response code: 200. [optional]
                 rollback_on_failure (bool, none_type): When set it automatically initiates an image stack rollback on failures. Defaults to true.. [optional]
-                client_token (str): Idempotency token that can be set by the client so that retries for the same request are idempotent. [optional]
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -140,7 +139,6 @@ class ImageOperationsApi(object):
                     'validation_failure_level',
                     'dryrun',
                     'rollback_on_failure',
-                    'client_token',
                 ],
                 'required': [
                     'build_image_request_content',
@@ -174,15 +172,12 @@ class ImageOperationsApi(object):
                         (bool, none_type,),
                     'rollback_on_failure':
                         (bool, none_type,),
-                    'client_token':
-                        (str,),
                 },
                 'attribute_map': {
                     'suppress_validators': 'suppressValidators',
                     'validation_failure_level': 'validationFailureLevel',
                     'dryrun': 'dryrun',
                     'rollback_on_failure': 'rollbackOnFailure',
-                    'client_token': 'clientToken',
                 },
                 'location_map': {
                     'build_image_request_content': 'body',
@@ -190,7 +185,6 @@ class ImageOperationsApi(object):
                     'validation_failure_level': 'query',
                     'dryrun': 'query',
                     'rollback_on_failure': 'query',
-                    'client_token': 'query',
                 },
                 'collection_format_map': {
                     'suppress_validators': 'multi',
@@ -227,7 +221,6 @@ class ImageOperationsApi(object):
 
             Keyword Args:
                 region (str): AWS Region. Defaults to the region the API is deployed to.. [optional]
-                client_token (str): Idempotency token that can be set by the client so that retries for the same request are idempotent. [optional]
                 force (bool, none_type): Force deletion in case there are instances using the AMI or in case the AMI is shared. [optional]
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
@@ -292,7 +285,6 @@ class ImageOperationsApi(object):
                 'all': [
                     'image_id',
                     'region',
-                    'client_token',
                     'force',
                 ],
                 'required': [
@@ -324,21 +316,17 @@ class ImageOperationsApi(object):
                         (str,),
                     'region':
                         (str,),
-                    'client_token':
-                        (str,),
                     'force':
                         (bool, none_type,),
                 },
                 'attribute_map': {
                     'image_id': 'imageId',
                     'region': 'region',
-                    'client_token': 'clientToken',
                     'force': 'force',
                 },
                 'location_map': {
                     'image_id': 'path',
                     'region': 'query',
-                    'client_token': 'query',
                     'force': 'query',
                 },
                 'collection_format_map': {


### PR DESCRIPTION
Update the existing openapi_generator workflow so that the API client is generated automatically when the API model is updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
