### PR TITLE
Install kernel-devel on OS update

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -103,8 +103,10 @@ phases:
               if [[ ${!PLATFORM} == RHEL ]]; then
                 if [[ ${!OS} == centos8 ]]; then
                   dnf -y update && dnf -y remove $(dnf repoquery --installonly --latest-limit=-2 -q)
+                  dnf -y install kernel-devel
                 else
                   yum -y update && package-cleanup -y --oldkernels --count=1
+                  yum -y install kernel-devel
                 fi
               elif [[ ${!PLATFORM} == DEBIAN ]]; then
                 while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done


### PR DESCRIPTION
Install kernel-devel during OS update, so that headers are aligned with new kernel
This was already done for the Ubuntu branch through `apt-get -y install linux-aws`

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
