### PR TITLE
3.0: Fix CFN logs interpolation

### DIFF
--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -189,7 +189,7 @@ def _log_cfn_event(event, indent):
     """Log failed CFN events."""
     from pcluster.aws.aws_api import AWSApi  # pylint: disable=import-outside-toplevel
 
-    print("%s- %s", " " * indent, AWSApi.instance().cfn.format_event(event))
+    print("{}- {}".format(" " * indent, AWSApi.instance().cfn.format_event(event)))
 
 
 def get_templates_bucket_path():


### PR DESCRIPTION
### Changes
1. Fix CFN logs interpolation

### Tests
Before fix:
```
Cluster creation failed. Failed events:
%s- %s    2021-06-29T13:40:51+00:00 CREATE_FAILED AWS::CloudFormation::Stack pc3-dub-imds-failure-fail The following resource(s) failed to create: [HeadNode]. 
%s- %s    2021-06-29T13:40:50+00:00 CREATE_FAILED AWS::EC2::Instance HeadNode Received FAILURE signal with UniqueId i-0c0ecd5ec00c77401
```

After fix:
```
Cluster creation failed. Failed events:
  - 2021-06-29T14:07:48+00:00 CREATE_FAILED AWS::CloudFormation::Stack pc3-dub-imds-failure-fail-3 The following resource(s) failed to create: [HeadNode]. 
  - 2021-06-29T14:07:46+00:00 CREATE_FAILED AWS::EC2::Instance HeadNode Received FAILURE signal with UniqueId i-0ab2cbf39cfa69457
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
