### PR TITLE
3.0: Replace pcluster user with pcluster-admin user in integ tests

### DIFF
--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -82,11 +82,11 @@ def test_create_wrong_pcluster_version(
     [
         (
             True,
-            {"root": True, "pcluster": True, "slurm": False},
+            {"root": True, "pcluster-admin": True, "slurm": False},
         ),
         (
             False,
-            {"root": True, "pcluster": True, "slurm": True},
+            {"root": True, "pcluster-admin": True, "slurm": True},
         ),
     ],
 )


### PR DESCRIPTION
### Changes
1. Replace pcluster user with pcluster-admin user in integ tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
