### PR TITLE
3.0: Add integration tests covering the integration between pcluster multi-user with opsworks and active directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.xml
 assets/
 report.html
 tests_outputs/
+pytest.log

--- a/tests/integration-tests/configs/pcluster3.yaml
+++ b/tests/integration-tests/configs/pcluster3.yaml
@@ -50,6 +50,17 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
+  multi-user:
+    test_multi_user.py::test_create_multi_user_with_active_directory:
+      dimensions:
+        - regions: [ "us-east-1" ]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: [ "alinux2" ]
+    test_multi_user.py::test_create_multi_user_with_opsworks:
+      dimensions:
+        - regions: [ "eu-west-1" ]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: [ "alinux2" ]
   schedulers:
     test_awsbatch.py::test_awsbatch:
       dimensions:

--- a/tests/integration-tests/configs/pcluster3.yaml
+++ b/tests/integration-tests/configs/pcluster3.yaml
@@ -56,11 +56,13 @@ test-suites:
         - regions: [ "us-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [ "alinux2" ]
+          schedulers: ["slurm"]
     test_multi_user.py::test_create_multi_user_with_opsworks:
       dimensions:
         - regions: [ "eu-west-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: [ "alinux2" ]
+          schedulers: ["slurm"]
   schedulers:
     test_awsbatch.py::test_awsbatch:
       dimensions:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1047,6 +1047,13 @@ def opsworks_stack_factory(region):
     yield create_stack
 
     for stack_id in stacks:
+        logging.info(f"Retrieving registered instances from opsworks stack: {stack_id}")
+        result = opsworks.describe_instances(StackId=stack_id)
+        instances = [instance["Ec2InstanceId"] for instance in result["Instances"]]
+        for instance in instances:
+            logging.info(f"Deregistering instance #{instance} from opsworks stack: {stack_id}")
+            opsworks.deregister_instance(InstanceId=instance)
+            logging.info(f"Deregistered instance #{instance} from opsworks stack: {stack_id}")
         logging.info(f"Deleting opsworks stack: {stack_id}")
         opsworks.delete_stack(StackId=stack_id)
 

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1049,7 +1049,7 @@ def opsworks_stack_factory(region):
     for stack_id in stacks:
         logging.info(f"Retrieving registered instances from opsworks stack: {stack_id}")
         result = opsworks.describe_instances(StackId=stack_id)
-        instances = [instance["Ec2InstanceId"] for instance in result["Instances"]]
+        instances = [instance["InstanceId"] for instance in result["Instances"]]
         logging.info(f"Retrieved registered instances from opsworks stack {stack_id}: {instances}")
         for instance in instances:
             logging.info(f"Deregistering instance {instance} from opsworks stack: {stack_id}")

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1050,10 +1050,11 @@ def opsworks_stack_factory(region):
         logging.info(f"Retrieving registered instances from opsworks stack: {stack_id}")
         result = opsworks.describe_instances(StackId=stack_id)
         instances = [instance["Ec2InstanceId"] for instance in result["Instances"]]
+        logging.info(f"Retrieved registered instances from opsworks stack {stack_id}: {instances}")
         for instance in instances:
-            logging.info(f"Deregistering instance #{instance} from opsworks stack: {stack_id}")
+            logging.info(f"Deregistering instance {instance} from opsworks stack: {stack_id}")
             opsworks.deregister_instance(InstanceId=instance)
-            logging.info(f"Deregistered instance #{instance} from opsworks stack: {stack_id}")
+            logging.info(f"Deregistered instance {instance} from opsworks stack: {stack_id}")
         logging.info(f"Deleting opsworks stack: {stack_id}")
         opsworks.delete_stack(StackId=stack_id)
 

--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -5,8 +5,9 @@ boto3
 fabric
 jinja2
 junitparser
-pykwalify
 pexpect
+pycryptodome
+pykwalify
 pytest
 pytest-datadir
 pytest-html
@@ -14,7 +15,7 @@ pytest-rerunfailures
 pytest-sugar
 pytest-xdist
 PyYAML
+requests
 retrying
 troposphere
 untangle
-requests

--- a/tests/integration-tests/tests/multi-user/__init__.py
+++ b/tests/integration-tests/tests/multi-user/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.

--- a/tests/integration-tests/tests/multi-user/test_multi_user.py
+++ b/tests/integration-tests/tests/multi-user/test_multi_user.py
@@ -149,6 +149,8 @@ def test_create_multi_user_with_opsworks(
 ):
     """Test the creation of a cluster whose users are managed with OpsWorks."""
 
+    logging.info("TROUBLESHOOTING log")
+
     # Create IAM resources required by OpsWorks stack
     opsworks_service_role_policy_arn = create_policy_from_file(
         policy_factory, f"{test_datadir}/opsworks_service_role_policy.json"

--- a/tests/integration-tests/tests/multi-user/test_multi_user.py
+++ b/tests/integration-tests/tests/multi-user/test_multi_user.py
@@ -202,9 +202,6 @@ def test_create_multi_user_with_opsworks(
     # TODO add assertions about ssh access and job submission
     # assert_ssh_login(cluster=cluster, username=ssh_user_name, ssh_key=private_key_path)
 
-    # Need to delete the cluster before deleting OpsWorks stack
-    # cluster.delete()
-
 
 def _get_head_node_instance(cluster):
     return (

--- a/tests/integration-tests/tests/multi-user/test_multi_user.py
+++ b/tests/integration-tests/tests/multi-user/test_multi_user.py
@@ -204,7 +204,7 @@ def test_create_multi_user_with_opsworks(
     # assert_ssh_login(cluster=cluster, username=ssh_user_name, ssh_key=private_key_path)
 
     # Need to delete the cluster before deleting OpsWorks stack
-    cluster.delete()
+    # cluster.delete()
 
 
 def _get_head_node_instance(cluster):

--- a/tests/integration-tests/tests/multi-user/test_multi_user.py
+++ b/tests/integration-tests/tests/multi-user/test_multi_user.py
@@ -192,11 +192,12 @@ def test_create_multi_user_with_opsworks(
     user_arn, user_name = user_factory()
     _, ssh_user_name = opsworks_user_profile_factory(user_arn, user_name, public_key)
 
-    logging.info("Waiting for opsworks stack to import users")
+    logging.info("Sleeping 120 seconds to give opsworks time to import new user")
     time.sleep(120)  # TODO: implement a waiter here
 
     assert_aws_identity_access_is_correct(
-        cluster=cluster, users_allow_list={"root": True, "pcluster-admin": True, "slurm": False, ssh_user_name: False}
+        cluster=cluster,
+        users_allow_list={"root": True, "pcluster-admin": True, "aws": True, "slurm": False, ssh_user_name: False},
     )
 
     # TODO add assertions about ssh access and job submission

--- a/tests/integration-tests/tests/multi-user/test_multi_user.py
+++ b/tests/integration-tests/tests/multi-user/test_multi_user.py
@@ -149,8 +149,6 @@ def test_create_multi_user_with_opsworks(
 ):
     """Test the creation of a cluster whose users are managed with OpsWorks."""
 
-    logging.info("TROUBLESHOOTING log")
-
     # Create IAM resources required by OpsWorks stack
     opsworks_service_role_policy_arn = create_policy_from_file(
         policy_factory, f"{test_datadir}/opsworks_service_role_policy.json"

--- a/tests/integration-tests/tests/multi-user/test_multi_user.py
+++ b/tests/integration-tests/tests/multi-user/test_multi_user.py
@@ -1,0 +1,321 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import io
+import logging
+import os
+import time
+from zipfile import ZipFile
+
+import boto3
+import pytest
+from assertpy import assert_that
+from Crypto.PublicKey import RSA
+from remote_command_executor import RemoteCommandExecutor
+from utils import get_username_for_os
+
+from tests.common.utils import retrieve_latest_ami
+
+
+@pytest.mark.dimensions("eu-west-1", "c5.xlarge", "*", "*")
+@pytest.mark.usefixtures("instance", "scheduler")
+def test_create_multi_user_with_active_directory(
+    region,
+    os,
+    pcluster_config_reader,
+    s3_bucket_factory,
+    clusters_factory,
+    architecture,
+    vpc_stack,
+    test_datadir,
+    policy_factory,
+    role_factory,
+    ssm_parameter_factory,
+    dhcp_options_set_factory,
+    active_directory_factory,
+    lambda_function_factory,
+):
+    """Test the creation of a cluster whose users are managed by Active Directory."""
+
+    # Create SimpleAD
+    vpc_id = vpc_stack.cfn_outputs["VpcId"]
+    public_subnet_id = vpc_stack.cfn_outputs["PublicSubnetId"]
+    private_subnet_id = vpc_stack.cfn_outputs["PrivateAdditionalCidrSubnetId"]
+    directory_id, directory_name, directory_password = active_directory_factory(
+        vpc_id, public_subnet_id, private_subnet_id
+    )
+
+    response = wait_directory_to_be_active(region, directory_id)
+    dns_ip_addresses = response["DirectoryDescriptions"][0]["DnsIpAddrs"]
+
+    # Configure DHCP Option Set for VPC
+    dhcp_options_set_factory(
+        vpc_id=vpc_id,
+        dhcp_configurations=[
+            {"Key": "domain-name", "Values": [directory_name]},
+            {"Key": "domain-name-servers", "Values": dns_ip_addresses},
+        ],
+    )
+
+    # SSM Parameters
+    domain_name_parameter = ssm_parameter_factory(value=directory_name, type="String")
+    domain_password_parameter = ssm_parameter_factory(value=directory_password, type="SecureString")
+
+    # IAM Policy for the head node to interact with Active Directory
+    active_directory_policy_arn = create_policy_from_file(
+        policy_factory, f"{test_datadir}/active_directory_policy.json"
+    )
+
+    # IAM Policy for the Lambda execution role
+    get_join_credentials_policy_arn = create_policy_from_file(
+        policy_factory, f"{test_datadir}/get_join_credentials_policy.json"
+    )
+
+    # IAM role for the Lambda execution role
+    lambda_execution_role_name, lambda_execution_role_arn = role_factory(
+        trusted_service="lambda",
+        policies=["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", get_join_credentials_policy_arn],
+    )
+
+    # Create resource bucket and upload resources
+    bucket_name = s3_bucket_factory()
+    bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+    bucket.upload_file(str(test_datadir / "pre_install.sh"), "pre_install.sh")
+    bucket.upload_file(str(test_datadir / "post_install.sh"), "post_install.sh")
+
+    # Create Lambda
+    _, function_name = lambda_function_factory(
+        Runtime="python2.7",
+        Role=lambda_execution_role_arn,
+        Handler="lambda_handler",
+        Code={"ZipFile": make_zip_file_bytes(path=str(test_datadir / "join_domain_lambda"))},
+        Timeout=30,
+        MemorySize=128,
+        Publish=True,
+        Environment={
+            "Variables": {
+                "DOMAIN_NAME_PARAMETER": domain_name_parameter,
+                "DOMAIN_PASSWORD_PARAMETER": domain_password_parameter,
+            }
+        },
+    )
+
+    # Create cluster
+    custom_ami = retrieve_latest_ami(region, os, ami_type="pcluster", architecture=architecture)
+    cluster_config = pcluster_config_reader(
+        custom_ami=custom_ami,
+        bucket_name=bucket_name,
+        active_directory_policy_arn=active_directory_policy_arn,
+        lambda_function_name=function_name,
+    )
+    cluster = clusters_factory(cluster_config, raise_on_error=False)
+
+    _assert_head_node_is_running(region, cluster)
+
+    active_directory_admin_user = "administrator"
+    assert_aws_identity_access_is_correct(
+        cluster=cluster, users_allow_list={"root": True, "pcluster-admin": True, active_directory_admin_user: False}
+    )
+
+    # TODO add assertions about ssh access and job submission
+    # assert_ssh_login(cluster=cluster, username=active_directory_admin_user, ssh_key=private_key_path)
+
+
+@pytest.mark.dimensions("us-east-1", "c5.xlarge", "*", "*")
+@pytest.mark.usefixtures("instance", "scheduler")
+def test_create_multi_user_with_opsworks(
+    region,
+    os,
+    pcluster_config_reader,
+    s3_bucket_factory,
+    clusters_factory,
+    architecture,
+    vpc_stack,
+    test_datadir,
+    policy_factory,
+    role_factory,
+    instance_profile_factory,
+    user_factory,
+    opsworks_stack_factory,
+    opsworks_user_profile_factory,
+):
+    """Test the creation of a cluster whose users are managed with OpsWorks."""
+
+    # Create IAM resources required by OpsWorks stack
+    opsworks_service_role_policy_arn = create_policy_from_file(
+        policy_factory, f"{test_datadir}/opsworks_service_role_policy.json"
+    )
+    _, opsworks_service_role_arn = role_factory(trusted_service="opsworks", policies=[opsworks_service_role_policy_arn])
+    opsworks_instance_profile_arn = instance_profile_factory()
+
+    # Create OpsWorks stack
+    vpc_id = vpc_stack.cfn_outputs["VpcId"]
+    subnet_id = vpc_stack.cfn_outputs["PublicSubnetId"]
+    opsworks_stack_id = opsworks_stack_factory(
+        vpc_id, subnet_id, opsworks_service_role_arn, opsworks_instance_profile_arn
+    )
+
+    # Create resource bucket and upload scripts
+    bucket_name = s3_bucket_factory()
+    bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+    bucket.upload_file(str(test_datadir / "post_install.sh"), "post_install.sh")
+
+    # Create cluster
+    custom_ami = retrieve_latest_ami(region, os, ami_type="pcluster", architecture=architecture)
+    cluster_config = pcluster_config_reader(
+        custom_ami=custom_ami, bucket_name=bucket_name, opsworks_stack_id=opsworks_stack_id
+    )
+    cluster = clusters_factory(cluster_config, raise_on_error=False)
+
+    _assert_head_node_is_running(region, cluster)
+
+    # The opsworks-agent process is run as aws user, so it requires the access to IMDS
+    configure_imds_access(cluster, {"aws": True})
+
+    # Create new user credentials
+    key = RSA.generate(2048)
+    private_key = key.export_key()
+    private_key_path = f"{test_datadir}/private.key"
+    with (open(private_key_path, "wb")) as file:
+        file.write(private_key)
+    public_key = key.publickey().export_key().decode("utf-8")
+
+    # Create new user
+    user_arn, user_name = user_factory()
+    _, ssh_user_name = opsworks_user_profile_factory(user_arn, user_name, public_key)
+
+    time.sleep(120)  # TODO: implement a waiter here
+
+    assert_aws_identity_access_is_correct(
+        cluster=cluster, users_allow_list={"root": True, "pcluster-admin": True, ssh_user_name: False}
+    )
+
+    # TODO add assertions about ssh access and job submission
+    # assert_ssh_login(cluster=cluster, username=ssh_user_name, ssh_key=private_key_path)
+
+    # Need to delete the cluster before deleting OpsWorks stack
+    cluster.delete()
+
+
+def _get_head_node_instance(cluster):
+    return (
+        boto3.client("ec2", region_name=cluster.region)
+        .describe_instances(Filters=[{"Name": "ip-address", "Values": [cluster.head_node_ip]}])
+        .get("Reservations")[0]
+        .get("Instances")[0]
+        .get("InstanceId")
+    )
+
+
+def configure_imds_access(cluster, users_allow_list):
+    username = get_username_for_os(cluster.os)
+    remote_command_executor = RemoteCommandExecutor(cluster, username=username)
+
+    for user, allowed in users_allow_list.items():
+        logging.info(f"{'Allowing' if allowed else 'Denying'} access to IMDS for user {user}")
+        command = f"sudo /opt/parallelcluster/scripts/imds/imds-access.sh --{'allow' if allowed else 'deny'} {user}"
+        result = remote_command_executor.run_remote_command(command)
+        logging.info(f"result.stdout {result.stdout}")
+        logging.info(f"result.stderr {result.stderr}")
+        logging.info(f"result.failed {result.failed}")
+
+
+def assert_os_users_existence(cluster, users_existence):
+    logging.info("Asserting OS users existence is correct")
+    username = get_username_for_os(cluster.os)
+    remote_command_executor = RemoteCommandExecutor(cluster, username=username)
+
+    for user, exists in users_existence.items():
+        logging.info(f"Asserting OS user {user} {'exists' if exists else 'does not exist'}")
+        command = f"sudo id {user}"
+        result = remote_command_executor.run_remote_command(command, raise_on_error=False)
+        logging.info(f"result.stdout {result.stdout}")
+        logging.info(f"result.stderr {result.stderr}")
+        logging.info(f"result.failed {result.failed}")
+        assert_that(result.failed).is_equal_to(not exists)
+
+
+def assert_aws_identity_access_is_correct(cluster, users_allow_list):
+    logging.info("Asserting access to AWS caller identity is correct")
+    username = get_username_for_os(cluster.os)
+    remote_command_executor = RemoteCommandExecutor(cluster, username=username)
+
+    for user, allowed in users_allow_list.items():
+        logging.info(f"Asserting access to AWS caller identity is {'allowed' if allowed else 'denied'} for user {user}")
+        command = f"sudo -u {user} aws sts get-caller-identity"
+        result = remote_command_executor.run_remote_command(command, raise_on_error=False)
+        logging.info(f"result.stdout {result.stdout}")
+        logging.info(f"result.stderr {result.stderr}")
+        logging.info(f"result.failed {result.failed}")
+        assert_that(result.failed).is_equal_to(not allowed)
+
+
+def assert_ssh_login(cluster, username, ssh_key):
+    remote_command_executor = RemoteCommandExecutor(cluster, username=username, ssh_key=ssh_key)
+    command = "echo Hello"
+    result = remote_command_executor.run_remote_command(command, raise_on_error=False)
+    logging.info(f"result.stdout {result.stdout}")
+    logging.info(f"result.stderr {result.stderr}")
+    logging.info(f"result.failed {result.failed}")
+    assert_that(result.failed).is_equal_to(False)
+
+
+def wait_directory_to_be_active(region, directory_id):
+    ds = boto3.client("ds", region_name=region)
+
+    wait_time_seconds = 60
+    attempts = 0
+    max_attempts = 5
+    while attempts < max_attempts:
+        ds_response = ds.describe_directories(DirectoryIds=[directory_id])
+        directory_stage = ds_response["DirectoryDescriptions"][0]["Stage"]
+        if directory_stage == "Active":
+            return ds_response
+        time.sleep(wait_time_seconds)
+    raise Exception(
+        f"Active Directory {directory_id} did not reach status Active "
+        f"within the expected time span ({wait_time_seconds*max_attempts} seconds)"
+    )
+
+
+def _assert_head_node_is_running(region, cluster):
+    logging.info("Asserting the head node is running")
+    head_node_state = (
+        boto3.client("ec2", region_name=region)
+        .describe_instances(Filters=[{"Name": "ip-address", "Values": [cluster.head_node_ip]}])
+        .get("Reservations")[0]
+        .get("Instances")[0]
+        .get("State")
+        .get("Name")
+    )
+    assert_that(head_node_state).is_equal_to("running")
+
+
+def create_policy_from_file(policy_factory, file_path):
+    with (open(file_path, "r")) as file:
+        policy_document = file.read()
+    return policy_factory(policy_document)
+
+
+def files_to_zip(path):
+    for root, _, files in os.walk(path):
+        for f in files:
+            full_path = os.path.join(root, f)
+            archive_name = full_path[len(path) + len(os.sep) :]
+            yield full_path, archive_name
+
+
+def make_zip_file_bytes(path):
+    buf = io.BytesIO()
+    with ZipFile(buf, "w") as z:
+        for full_path, archive_name in files_to_zip(path=path):
+            z.write(full_path, archive_name)
+    return buf.getvalue()

--- a/tests/integration-tests/tests/multi-user/test_multi_user.py
+++ b/tests/integration-tests/tests/multi-user/test_multi_user.py
@@ -194,10 +194,11 @@ def test_create_multi_user_with_opsworks(
     user_arn, user_name = user_factory()
     _, ssh_user_name = opsworks_user_profile_factory(user_arn, user_name, public_key)
 
+    logging.info("Waiting for opsworks stack to import users")
     time.sleep(120)  # TODO: implement a waiter here
 
     assert_aws_identity_access_is_correct(
-        cluster=cluster, users_allow_list={"root": True, "pcluster-admin": True, ssh_user_name: False}
+        cluster=cluster, users_allow_list={"root": True, "pcluster-admin": True, "slurm": False, ssh_user_name: False}
     )
 
     # TODO add assertions about ssh access and job submission

--- a/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/active_directory_policy.json
+++ b/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/active_directory_policy.json
@@ -1,0 +1,140 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "ec2:DescribeVolumes",
+        "ec2:AttachVolume",
+        "ec2:DescribeInstanceAttribute",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstances",
+        "ec2:DescribeRegions"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "dynamodb:ListTables"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "sqs:SendMessage",
+        "sqs:ReceiveMessage",
+        "sqs:ChangeMessageVisibility",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueUrl"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:sqs:*:*:parallelcluster-*"
+    },
+    {
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:TerminateInstanceInAutoScalingGroup",
+        "autoscaling:SetDesiredCapacity",
+        "autoscaling:DescribeTags",
+        "autoScaling:UpdateAutoScalingGroup",
+        "autoscaling:SetInstanceHealth"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackResource"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:cloudformation:*:*:stack/parallelcluster-*/*"
+    },
+    {
+      "Action": [
+        "dynamodb:PutItem",
+        "dynamodb:Query",
+        "dynamodb:GetItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:DescribeTable"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:dynamodb:*:*:table/parallelcluster-*"
+    },
+    {
+      "Action": "s3:GetObject",
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::parallelcluster*/*"
+    },
+    {
+      "Action": [
+        "cloudformation:DescribeStacks"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:cloudformation:*:*:stack/*"
+    },
+    {
+      "Action": [
+        "sqs:ListQueues"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "ssm:DescribeAssociation",
+        "ssm:GetDeployablePatchSnapshotForInstance",
+        "ssm:GetDocument",
+        "ssm:DescribeDocument",
+        "ssm:GetManifest",
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:ListAssociations",
+        "ssm:ListInstanceAssociations",
+        "ssm:PutInventory",
+        "ssm:PutComplianceItems",
+        "ssm:PutConfigurePackageResult",
+        "ssm:UpdateAssociationStatus",
+        "ssm:UpdateInstanceAssociationStatus",
+        "ssm:UpdateInstanceInformation"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "ec2messages:AcknowledgeMessage",
+        "ec2messages:DeleteMessage",
+        "ec2messages:FailMessage",
+        "ec2messages:GetEndpoint",
+        "ec2messages:GetMessages",
+        "ec2messages:SendReply"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": "lambda:InvokeFunction",
+      "Effect": "Allow",
+      "Resource": "arn:aws:lambda:*:*:function:*"
+    },
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/get_join_credentials_policy.json
+++ b/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/get_join_credentials_policy.json
@@ -1,0 +1,33 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "ssm:GetParameter"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:ssm:*:*:parameter/*"
+      ]
+    },
+    {
+      "Action": [
+        "ssm:SendCommand"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ssm:*::document/AWS-RunShellScript"
+      ]
+    },
+    {
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:kms:*:*:key/*"
+      ]
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/join_domain_lambda/join-domain-lambda.py
+++ b/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/join_domain_lambda/join-domain-lambda.py
@@ -1,0 +1,30 @@
+import json
+import os
+
+import boto3
+
+
+def lambda_handler(event, context):
+    json_message = json.dumps(event)
+    message = json.loads(json_message)
+    instance_id = message["instance"]
+    ssm_client = boto3.client("ssm")
+    domain_name = ssm_client.get_parameter(Name=os.environ["DOMAIN_NAME_PARAMETER"])
+    domain_name_value = domain_name["Parameter"]["Value"]
+    domain_password = ssm_client.get_parameter(Name=os.environ["DOMAIN_PASSWORD_PARAMETER"], WithDecryption=True)
+    domain_password_value = domain_password["Parameter"]["Value"]
+    ssm_client.send_command(
+        InstanceIds=["%s" % instance_id],
+        DocumentName="AWS-RunShellScript",
+        Parameters={
+            "commands": [
+                'echo "%s" | realm join -U Administrator@%s %s --verbose'
+                % (domain_password_value, domain_name_value, domain_name_value),
+                "rm -rf /var/lib/amazon/ssm/i-*/document/orchestration/*",
+            ]
+        },
+    )
+    return {
+        "statusCode": 200,
+        "body": json.dumps("Command Executed with credentials: %s %s" % (domain_name_value, domain_password_value)),
+    }

--- a/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/pcluster.config.yaml
@@ -1,0 +1,46 @@
+Image:
+  Os: {{ os }}
+  CustomAmi: {{ custom_ami }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+      - Policy: {{ active_directory_policy_arn }}
+  CustomActions:
+    OnNodeStart:
+      Script: s3://{{ bucket_name }}/pre_install.sh
+      Args:
+        - {{ lambda_function_name }}
+    OnNodeConfigured:
+      Script: s3://{{ bucket_name }}/post_install.sh
+
+Scheduling:
+  Scheduler: {{ scheduler }}
+  Queues:
+    - Name: compute
+      ComputeResources:
+        - Name: compute-i1
+          InstanceType: {{ instance }}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+          - Policy: arn:aws:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+          - Policy: {{ active_directory_policy_arn }}
+      CustomActions:
+        OnNodeStart:
+          Script: s3://{{ bucket_name }}/pre_install.sh
+          Args:
+            - {{ lambda_function_name }}
+        OnNodeConfigured:
+          Script: s3://{{ bucket_name }}/post_install.sh

--- a/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/post_install.sh
+++ b/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/post_install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sed -i 's/PasswordAuthentication no//g' /etc/ssh/sshd_config
+echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
+sleep 1
+service sshd restart

--- a/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/pre_install.sh
+++ b/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_active_directory/pre_install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Install the required packages
+yum -y install sssd realmd krb5-workstation samba-common-tools
+instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+region=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//')
+# Lambda function to join the linux system in the domain
+function_name=$2
+aws --region ${region} lambda invoke --function-name $function_name /tmp/out --payload '{"instance": "'${instance_id}'"}' --log-type None
+output=""
+while [ -z "$output" ]
+do
+  sleep 5
+  output=$(realm list)
+done
+#This line allows the users to login without the domain name
+sed -i 's/use_fully_qualified_names = True/use_fully_qualified_names = False/g' /etc/sssd/sssd.conf
+#This line configure sssd to create the home directories in the shared folder
+mkdir -p /shared/home/
+sed -i '/fallback_homedir/c\fallback_homedir = /home/%u' /etc/sssd/sssd.conf
+sleep 1
+service sssd restart

--- a/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_opsworks/opsworks_service_role_policy.json
+++ b/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_opsworks/opsworks_service_role_policy.json
@@ -1,0 +1,20 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:DescribeAlarms",
+        "ec2:*",
+        "ecs:*",
+        "elasticloadbalancing:*",
+        "iam:PassRole",
+        "rds:*"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ]
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_opsworks/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_opsworks/pcluster.config.yaml
@@ -1,0 +1,31 @@
+Image:
+  Os: {{ os }}
+  CustomAmi: {{ custom_ami }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - Policy: arn:aws:iam::aws:policy/AWSOpsWorksInstanceRegistration
+      - Policy: arn:aws:iam::aws:policy/AWSOpsWorksRegisterCLI_EC2
+  CustomActions:
+    OnNodeConfigured:
+      Script: s3://{{ bucket_name }}/post_install.sh
+      Args:
+        - {{ opsworks_stack_id }}
+
+Scheduling:
+  Scheduler: {{ scheduler }}
+  Queues:
+    - Name: compute
+      ComputeResources:
+        - Name: compute-i1
+          InstanceType: {{ instance }}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_opsworks/post_install.sh
+++ b/tests/integration-tests/tests/multi-user/test_multi_user/test_create_multi_user_with_opsworks/post_install.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+exec > >(tee /var/log/post-install.log|logger -t post-inst -s 2>/dev/console) 2>&1
+
+### Utility functions
+
+register_opsworks_client() {
+    source /etc/parallelcluster/cfnconfig
+    aws opsworks register --use-instance-profile \
+                          --infrastructure-class ec2 \
+                          --region $region \
+                          --stack-id $opsworks_stack_id \
+                          --local
+}
+
+configure_opsworks_deregistration() {
+    cat <<-'EOF' > /root/deregister_instances.sh
+#!/bin/bash
+
+dereg_log="/var/log/opsworks-deregister.log"
+
+exec > >(tee -a $dereg_log|logger -t owdereg) 2>&1
+
+export aws_bin="/opt/parallelcluster/pyenv/versions/3.6.9/envs/cookbook_virtualenv/bin/aws"
+
+source /etc/parallelcluster/cfnconfig
+
+export opsworks_stack_id=$postinstall_args
+
+stack_members=$($aws_bin opsworks --region $region describe-instances --stack-id $opsworks_stack_id | jq -r ."Instances[] | [.Ec2InstanceId, .InstanceId] | @csv")
+
+echo "`date`: OpsWorks deregistration cycle started." >> $dereg_log
+
+for instance in $stack_members; do
+  ec2_id=$(echo $instance | awk -F',' '{print $1}' | tr -d '"')
+  opsworks_id=$(echo $instance | awk -F',' '{print $2}' | tr -d '"')
+  echo "Checking instance: $ec2_id"
+  ec2_state=$($aws_bin ec2 describe-instances --instance-id $ec2_id --region $region | jq -r ".Reservations[].Instances[].State.Name")
+  echo "Instance $ec2_id is in state \"$ec2_state\""
+  if [ "$ec2_state" = "terminated" ]; then
+    echo "Instance $ec2_id will be deregistered from OpsWorks"
+    aws opsworks deregister-instance --instance-id $opsworks_id --region $region
+  else
+    echo "Instance $ec2_id still in use or transitioning state - not deregistering."
+  fi
+done
+
+echo "`date`: OpsWorks deregistration cycle completed." >> $dereg_log
+EOF
+
+chmod +x /root/deregister_instances.sh
+
+echo "*  *  *  *  * root /root/deregister_instances.sh" >> /etc/crontab
+}
+
+### Main body
+
+# Load environment variables from ParallelCluster
+source /etc/parallelcluster/cfnconfig
+
+# Obtain the OpsWorks stack ID from the pcluster "post_install_args" parameter
+export opsworks_stack_id=$postinstall_args
+
+# If the script is being executed on the controller, set up a cron job to run OpsWorks deregistration
+if [ $node_type  == 'HeadNode' ]; then
+    configure_opsworks_deregistration
+fi
+
+# For both controller and compute nodes, register the OpsWorks client
+register_opsworks_client


### PR DESCRIPTION
### Changes
1. Add integration tests covering the integration between pcluster multi-user with opsworks and active directory
1. Add to gitignore: pytest.log

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
