### PR TITLE
[3.0] Support restart/reboot for instance store (ephemeral drives) setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ CHANGELOG
 - Add prompt for availability zone in pcluster configure automated subnets creation.
 - Add configuration HeadNode.Imds.Secured to enable/disable restricted access to IMDS.
 - Use different permissions in instance roles based on the scheduler and the node's role in the cluster.
+- Support restart/reboot for instance type with instance store (ephemeral drives).
+- Remove instance store software encryption option (encrypted_ephemeral).
 - Implement scaling protection mechanism with Slurm scheduler: compute fleet is automatically set to 'PROTECTED' state
   in case recurrent failures are encountered when provisioning nodes.
 - Upgrade Slurm to version 20.11.8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ CHANGELOG
 ------
 **ENHANCEMENTS**
 - Add possibility to use an existing Instance Profile for cluster creation and Imagebuilder.
+- Support restart/reboot for instance type with instance store (ephemeral drives).  
 - Add possibility to use an existing Private Route53 Hosted Zone when using Slurm as scheduler.
 
 **CHANGES**
-
 - Drop support for SGE and Torque schedulers.
 - Drop support for CentOS8.
 - Change format and syntax of the configuration file to be used to create the cluster, from ini to YAML.
@@ -65,7 +65,6 @@ CHANGELOG
 - Add prompt for availability zone in pcluster configure automated subnets creation.
 - Add configuration HeadNode.Imds.Secured to enable/disable restricted access to IMDS.
 - Use different permissions in instance roles based on the scheduler and the node's role in the cluster.
-- Support restart/reboot for instance type with instance store (ephemeral drives).
 - Remove instance store software encryption option (encrypted_ephemeral).
 - Implement scaling protection mechanism with Slurm scheduler: compute fleet is automatically set to 'PROTECTED' state
   in case recurrent failures are encountered when provisioning nodes.

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -85,14 +85,6 @@ class Ec2Client(Boto3Client):
         raise AWSClientError(function_name="describe_subnets", message=f"Subnet {subnet_id} not found")
 
     @AWSExceptionHandler.handle_client_exception
-    def get_subnet_auto_assign_public_ip(self, subnet_id):
-        """Return auto assign public ip setting of the given subnet."""
-        subnets = self.describe_subnets([subnet_id])
-        if subnets:
-            return subnets[0].get("MapPublicIpOnLaunch")
-        raise AWSClientError(function_name="describe_subnets", message=f"Subnet {subnet_id} not found")
-
-    @AWSExceptionHandler.handle_client_exception
     def describe_image(self, ami_id):
         """Describe image by image id, return an object of ImageInfo."""
         result = self._client.describe_images(ImageIds=[ami_id])

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -174,9 +174,8 @@ class Raid(Resource):
 class EphemeralVolume(Resource):
     """Represent the Ephemeral Volume resource."""
 
-    def __init__(self, encrypted: bool = None, mount_dir: str = None):
+    def __init__(self, mount_dir: str = None):
         super().__init__()
-        self.encrypted = Resource.init_param(encrypted, default=False)
         self.mount_dir = Resource.init_param(mount_dir, default="/scratch")
 
 

--- a/cli/src/pcluster/models/cluster_resources.py
+++ b/cli/src/pcluster/models/cluster_resources.py
@@ -50,11 +50,6 @@ class ClusterStack(StackInfo):
         return self._get_param("ClusterUser")
 
     @property
-    def head_node_ip(self):
-        """Return the IP to be used to connect to the head node, public or private."""
-        return self._get_output("HeadNodePublicIP") or self._get_output("HeadNodePrivateIP")
-
-    @property
     def scheduler(self):
         """Return the scheduler used in the cluster."""
         return self._get_param("Scheduler")

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -65,7 +65,6 @@ write_files:
           "fsx_options": "${FSXOptions}",
           "scheduler": "${Scheduler}",
           "disable_hyperthreading_manually": "${DisableHyperThreadingManually}",
-          "encrypted_ephemeral": "${EncryptedEphemeral}",
           "ephemeral_dir": "${EphemeralDir}",
           "ebs_shared_dirs": "${EbsSharedDirs}",
           "proxy": "${ProxyServer}",

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -211,7 +211,6 @@ class EbsSettingsSchema(BaseSchema):
 class HeadNodeEphemeralVolumeSchema(BaseSchema):
     """Represent the schema of ephemeral volume.It is a child of storage schema."""
 
-    encrypted = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     mount_dir = fields.Str(
         validate=get_field_validator("file_path"), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
     )
@@ -225,7 +224,6 @@ class HeadNodeEphemeralVolumeSchema(BaseSchema):
 class QueueEphemeralVolumeSchema(BaseSchema):
     """Represent the schema of ephemeral volume.It is a child of storage schema."""
 
-    encrypted = fields.Bool(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
     mount_dir = fields.Str(
         validate=get_field_validator("file_path"), metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP}
     )

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -938,11 +938,6 @@ class ClusterCdkStack(Stack):
                     ),
                     "volume": get_shared_storage_ids_by_type(self.shared_storage_mappings, SharedStorageType.EBS),
                     "scheduler": self.config.scheduling.scheduler,
-                    "encrypted_ephemeral": "true"
-                    if head_node.local_storage
-                    and head_node.local_storage.ephemeral_volume
-                    and head_node.local_storage.ephemeral_volume.encrypted
-                    else "NONE",
                     "ephemeral_dir": head_node.local_storage.ephemeral_volume.mount_dir
                     if head_node.local_storage and head_node.local_storage.ephemeral_volume
                     else "/scratch",

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1160,13 +1160,6 @@ class ClusterCdkStack(Stack):
     def _condition_is_batch(self):
         return self.config.scheduling.scheduler == "awsbatch"
 
-    def _condition_head_node_has_public_ip(self):
-        head_node_networking = self.config.head_node.networking
-        assign_public_ip = head_node_networking.assign_public_ip
-        if assign_public_ip is None:
-            assign_public_ip = AWSApi.instance().ec2.get_subnet_auto_assign_public_ip(head_node_networking.subnet_id)
-        return assign_public_ip
-
     # -- Outputs ----------------------------------------------------------------------------------------------------- #
 
     def _add_outputs(self):
@@ -1199,11 +1192,3 @@ class ClusterCdkStack(Stack):
             description="Private DNS name of the head node",
             value=self.head_node_instance.attr_private_dns_name,
         )
-
-        if self._condition_head_node_has_public_ip():
-            CfnOutput(
-                self,
-                "HeadNodePublicIP",
-                description="Public IP Address of the head node",
-                value=self.head_node_instance.attr_public_ip,
-            )

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -618,12 +618,6 @@ class SlurmConstruct(Construct):
                                     self.shared_storage_options, SharedStorageType.FSX
                                 ),
                                 "Scheduler": self.config.scheduling.scheduler,
-                                "EncryptedEphemeral": "true"
-                                if queue.compute_settings
-                                and queue.compute_settings.local_storage
-                                and queue.compute_settings.local_storage.ephemeral_volume
-                                and queue.compute_settings.local_storage.ephemeral_volume.encrypted
-                                else "NONE",
                                 "EphemeralDir": queue.compute_settings.local_storage.ephemeral_volume.mount_dir
                                 if queue.compute_settings
                                 and queue.compute_settings.local_storage

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -33,7 +33,6 @@ HeadNode:
       Encrypted: true
       DeleteOnTermination: true
     EphemeralVolume:
-      Encrypted: true
       MountDir: /scratch
   Dcv:
     Enabled: true

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -24,7 +24,6 @@ HeadNode:
       Iops: 100
       DeleteOnTermination: true
     EphemeralVolume:
-      Encrypted: true
       MountDir: /test
   Dcv:
     Enabled: true
@@ -92,7 +91,6 @@ Scheduling:
             VolumeType: gp2
             Iops: 100
           EphemeralVolume:
-            Encrypted: true
             MountDir: /scratch
       Networking:
         SubnetIds:

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
@@ -17,7 +17,6 @@
     "efs_fs_id": "NONE",
     "efs_shared_dir": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     "enable_intel_hpc_platform": "false",
-    "encrypted_ephemeral": "NONE",
     "ephemeral_dir": "/scratch",
     "fsx_dns_name": "",
     "fsx_fs_id": "NONE",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
@@ -17,7 +17,6 @@
     "efs_fs_id": "NONE",
     "efs_shared_dir": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     "enable_intel_hpc_platform": "false",
-    "encrypted_ephemeral": "NONE",
     "ephemeral_dir": "/scratch",
     "fsx_dns_name": "",
     "fsx_fs_id": "NONE",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
@@ -17,7 +17,6 @@
     "efs_fs_id": "NONE",
     "efs_shared_dir": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     "enable_intel_hpc_platform": "false",
-    "encrypted_ephemeral": "NONE",
     "ephemeral_dir": "/scratch",
     "fsx_dns_name": "",
     "fsx_fs_id": "NONE",

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -21,7 +21,6 @@ HeadNode:
       Size: 40
       Encrypted: true
     EphemeralVolume:
-      Encrypted: true
       MountDir: /test
   Dcv:
     Enabled: true
@@ -85,7 +84,6 @@ Scheduling:
             Size:  35
             Encrypted:  true
           EphemeralVolume:
-            Encrypted: true
             MountDir: /scratch
       Networking:
         SubnetIds:

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -257,19 +257,14 @@ class Cluster:
     @property
     def head_node_ip(self):
         """Return the public ip of the cluster head node."""
-        if "HeadNodePublicIP" in self.cfn_outputs:
-            return self.cfn_outputs["HeadNodePublicIP"]
-        else:
-            ec2 = boto3.client("ec2", region_name=self.region)
-            filters = [
-                {"Name": "tag:parallelcluster:cluster-name", "Values": [self.cfn_name]},
-                {"Name": "instance-state-name", "Values": ["running"]},
-                {"Name": "tag:parallelcluster:node-type", "Values": ["HeadNode"]},
-            ]
-            instance = ec2.describe_instances(Filters=filters).get("Reservations")[0].get("Instances")[0]
-            return (
-                instance.get("PublicIpAddress") if instance.get("PublicIpAddress") else instance.get("PrivateIpAddress")
-            )
+        ec2 = boto3.client("ec2", region_name=self.region)
+        filters = [
+            {"Name": "tag:parallelcluster:cluster-name", "Values": [self.cfn_name]},
+            {"Name": "instance-state-name", "Values": ["running"]},
+            {"Name": "tag:parallelcluster:node-type", "Values": ["HeadNode"]},
+        ]
+        instance = ec2.describe_instances(Filters=filters).get("Reservations")[0].get("Instances")[0]
+        return instance.get("PublicIpAddress") if instance.get("PublicIpAddress") else instance.get("PrivateIpAddress")
 
     @property
     def os(self):

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -489,7 +489,7 @@ storage:
       - regions: ["us-east-1"]
         instances: ["m5d.xlarge", "h1.2xlarge"]
         oss: ["alinux2"]
-        schedulers: ["slurm"]
+        schedulers: ["awsbatch"]
 tags:
   test_tag_propagation.py::test_tag_propagation:
     dimensions:

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -483,6 +483,13 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm"]
+  # Ephemeral test requires instance type with instance store
+  test_ephemeral.py::test_head_node_stop:
+    dimensions:
+      - regions: ["us-east-1"]
+        instances: ["m5d.xlarge", "h1.2xlarge"]
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
 tags:
   test_tag_propagation.py::test_tag_propagation:
     dimensions:

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -28,10 +28,11 @@ class RemoteCommandExecutor:
     """Execute remote commands on the cluster head node."""
 
     def __init__(self, cluster, username=None, bastion=None):
+        head_node_ip = cluster.head_node_ip
         if not username:
             username = get_username_for_os(cluster.os)
         connection_kwargs = {
-            "host": cluster.head_node_ip,
+            "host": head_node_ip,
             "user": username,
             "forward_agent": False,
             "connect_kwargs": {"key_filename": [cluster.ssh_key]},
@@ -42,7 +43,7 @@ class RemoteCommandExecutor:
                 "ssh -tt -i {key_path} -o StrictHostKeyChecking=no "
                 '-o ProxyCommand="ssh -tt -o StrictHostKeyChecking=no -W %h:%p -A {bastion}" '
                 "-A {user}@{head_node} hostname".format(
-                    key_path=cluster.ssh_key, bastion=bastion, user=username, head_node=cluster.head_node_ip
+                    key_path=cluster.ssh_key, bastion=bastion, user=username, head_node=head_node_ip
                 ),
                 timeout=30,
                 shell=True,
@@ -50,7 +51,7 @@ class RemoteCommandExecutor:
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
         self.__connection = Connection(**connection_kwargs)
-        self.__user_at_hostname = "{0}@{1}".format(username, cluster.head_node_ip)
+        self.__user_at_hostname = "{0}@{1}".format(username, head_node_ip)
 
     def __del__(self):
         try:

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -159,6 +159,19 @@ def generate_random_string():
     return "".join(random.choice(string.ascii_lowercase + string.digits) for _ in range(16))  # nosec
 
 
+def restart_head_node(cluster):
+    # stop/start headnode
+    logging.info(f"Restarting head node for cluster: {cluster.name}")
+    head_node_instance = cluster.instances(desired_instance_role="HeadNode")
+    ec2_client = boto3.client("ec2", region_name=cluster.region)
+    ec2_client.stop_instances(InstanceIds=head_node_instance)
+    ec2_client.get_waiter("instance_stopped").wait(InstanceIds=head_node_instance)
+    ec2_client.start_instances(InstanceIds=head_node_instance)
+    ec2_client.get_waiter("instance_status_ok").wait(InstanceIds=head_node_instance)
+    time.sleep(120)  # Wait time is required for the head node to complete the reboot
+    logging.info(f"Restarted head node for cluster: {cluster.name}")
+
+
 def reboot_head_node(cluster, remote_command_executor=None):
     logging.info(f"Rebooting head node for cluster: {cluster.name}")
     if not remote_command_executor:

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -188,5 +188,5 @@ def reboot_head_node(cluster, remote_command_executor=None):
 def wait_head_node_running(cluster):
     logging.info(f"Waiting for head node to be running for cluster: {cluster.name}")
     boto3.client("ec2", region_name=cluster.region).get_waiter("instance_running").wait(
-        Filters=[{"Name": "ip-address", "Values": [cluster.head_node_ip]}], WaiterConfig={"Delay": 60, "MaxAttempts": 5}
+        InstanceIds=cluster.instances(desired_instance_role="HeadNode"), WaiterConfig={"Delay": 60, "MaxAttempts": 5}
     )

--- a/tests/integration-tests/tests/storage/test_ephemeral.py
+++ b/tests/integration-tests/tests/storage/test_ephemeral.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.

--- a/tests/integration-tests/tests/storage/test_ephemeral.py
+++ b/tests/integration-tests/tests/storage/test_ephemeral.py
@@ -1,0 +1,75 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+
+import pytest
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+
+from tests.common.utils import reboot_head_node, restart_head_node
+
+
+@pytest.mark.usefixtures("instance")
+def test_head_node_stop(scheduler, pcluster_config_reader, clusters_factory, region, os):
+    head_ephemeral_mount = "/scratch_head"
+    compute_ephemeral_mount = "/scratch_compute"
+    folder = "myFolder"
+    filename = "myFile"
+    cluster_config = pcluster_config_reader(
+        head_ephemeral_mount=head_ephemeral_mount, compute_ephemeral_mount=compute_ephemeral_mount
+    )
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    _test_head_ephemeral_setup(remote_command_executor, head_ephemeral_mount, folder, filename)
+
+    # reboot headnode (instance store is preserved)
+    reboot_head_node(cluster, remote_command_executor)
+    _test_head_ephemeral_preserved(remote_command_executor, head_ephemeral_mount, folder, filename)
+
+    # stop/start headnode (instance store is recreated)
+    restart_head_node(cluster)
+    # RemoteCommandExecutor needs to be re-initialized because HeadNode changed public IP
+    new_remote_command_executor = RemoteCommandExecutor(cluster)
+    _test_head_ephemeral_recreated(new_remote_command_executor, head_ephemeral_mount, folder, filename)
+
+
+def _test_head_ephemeral_setup(remote_command_executor, head_ephemeral_mount, folder, filename):
+    logging.info(f"Testing ephemeral {head_ephemeral_mount} is correctly setup on creation")
+    _create_file_and_folder(filename, folder, head_ephemeral_mount, remote_command_executor)
+    _check_file_exists(filename, folder, head_ephemeral_mount, remote_command_executor)
+
+
+def _test_head_ephemeral_preserved(remote_command_executor, head_ephemeral_mount, folder, filename):
+    logging.info(f"Testing ephemeral {head_ephemeral_mount} is correctly preserved on reboot")
+    _check_file_exists(filename, folder, head_ephemeral_mount, remote_command_executor)
+
+
+def _test_head_ephemeral_recreated(remote_command_executor, head_ephemeral_mount, folder, filename):
+    logging.info(f"Testing ephemeral {head_ephemeral_mount} is correctly recreated on restart")
+    _check_folder_does_not_exists(folder, head_ephemeral_mount, remote_command_executor)
+
+
+def _check_file_exists(filename, folder, head_ephemeral_mount, remote_command_executor):
+    result = remote_command_executor.run_remote_command(f"ls {head_ephemeral_mount}/{folder}/")
+    assert_that(result.stdout).contains(filename)
+
+
+def _check_folder_does_not_exists(folder, head_ephemeral_mount, remote_command_executor):
+    result = remote_command_executor.run_remote_command(f"ls {head_ephemeral_mount}/")
+    assert_that(result.stdout).does_not_contain(folder)
+
+
+def _create_file_and_folder(filename, folder, head_ephemeral_mount, remote_command_executor):
+    remote_command_executor.run_remote_command(
+        f"mkdir {head_ephemeral_mount}/{folder} && touch {head_ephemeral_mount}/{folder}/{filename}"
+    )

--- a/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
@@ -1,0 +1,35 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+  LocalStorage:
+    EphemeralVolume:
+      MountDir: {{ head_ephemeral_mount }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+Scheduling:
+  Scheduler: {{ scheduler }}
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
+    - Name: queue-0
+      ComputeResources:
+        - Name: compute-resource-0
+          {% if scheduler == "awsbatch" %}
+          InstanceTypes:
+            - {{ instance }}
+          {% else %}
+          InstanceType: {{ instance }}
+          {% endif %}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeSettings:
+        LocalStorage:
+          EphemeralVolume:
+            MountDir: {{ compute_ephemeral_mount }}

--- a/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
@@ -29,7 +29,3 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
-      ComputeSettings:
-        LocalStorage:
-          EphemeralVolume:
-            MountDir: {{ compute_ephemeral_mount }}


### PR DESCRIPTION
* Add new integ tests to check instance store is correctly configured.
    * Tested with config
```
    {%- import 'common.jinja2' as common -%}
    ---
    test-suites:
      storage:
        test_ephemeral.py::test_head_node_stop:
          dimensions:
            - regions: ["us-east-1"]
              instances: ["m5d.xlarge", "h1.2xlarge"]
              oss: ["alinux2"]
              schedulers: ["slurm"]
```

* Remove instance store software encryption option

* Remove HeadNodePublicIP from CFN output
  * Since Head Node now supports restart (stop and then start), its public IP can change and IP value cannot be statically stored in CFN output anymore.

This is related to https://github.com/aws/aws-parallelcluster-cookbook/pull/1013

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
