### PR TITLE
3.0: Fix method name: terminate_nodes

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -488,7 +488,7 @@ class Cluster:
         except StackNotFoundError:
             raise
         except Exception as e:
-            self._terminate_nodes()
+            self.terminate_nodes()
             raise _cluster_error_mapper(e, f"Cluster {self.name} did not delete successfully. {e}")
 
     def _persist_cloudwatch_log_groups(self):


### PR DESCRIPTION
### Changes
1. Fix method name: terminate_nodes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
