### PR TITLE
3.0: Add integration test covering IMDS access preserved on instance reboot

### DIFF
--- a/api/client/src/pcluster_client/sigv4_auth.py
+++ b/api/client/src/pcluster_client/sigv4_auth.py
@@ -26,10 +26,9 @@ def sigv4_auth(method, host, path, querys, body, headers):
     url = f"{host}{path}?{request_parameters}"
 
     session = botocore.session.Session()
-    data = json.dumps(body) if body else None
     request = botocore.awsrequest.AWSRequest(method=method,
                                              url=url,
-                                             data=data)
+                                             data=json.dumps(body))
     botocore.auth.SigV4Auth(session.get_credentials(),
                             "execute-api", region).add_auth(request)
     prepared_request = request.prepare()

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -373,7 +373,7 @@ def pcluster_config_reader(test_datadir, vpc_stack, request, region):
         default_values = _get_default_template_values(vpc_stack, request)
         file_loader = FileSystemLoader(str(test_datadir))
         env = Environment(loader=file_loader)
-        rendered_template = env.get_template(config_file).render(**{**kwargs, **default_values})
+        rendered_template = env.get_template(config_file).render(**{**default_values, **kwargs})
         config_file_path.write_text(rendered_template)
         if not config_file.endswith("image.config.yaml"):
             inject_additional_config_settings(config_file_path, request, region)

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -16,7 +16,7 @@ from assertpy import assert_that, soft_assertions
 from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
 from time_utils import minutes, seconds
-from utils import get_compute_nodes_count, get_compute_nodes_instance_ids, get_username_for_os
+from utils import get_compute_nodes_count, get_compute_nodes_instance_ids
 
 from tests.common.scaling_common import get_compute_nodes_allocation
 
@@ -141,10 +141,11 @@ def assert_head_node_is_running(region, cluster):
     assert_that(head_node_state).is_equal_to("running")
 
 
-def assert_aws_identity_access_is_correct(cluster, users_allow_list):
+def assert_aws_identity_access_is_correct(cluster, users_allow_list, remote_command_executor=None):
     logging.info("Asserting access to AWS caller identity is correct")
-    username = get_username_for_os(cluster.os)
-    remote_command_executor = RemoteCommandExecutor(cluster, username=username)
+
+    if not remote_command_executor:
+        remote_command_executor = RemoteCommandExecutor(cluster)
 
     for user, allowed in users_allow_list.items():
         logging.info(f"Asserting access to AWS caller identity is {'allowed' if allowed else 'denied'} for user {user}")


### PR DESCRIPTION
### Changes
1. Add integration test covering IMDS access preserved on instance reboot
2. Fixed a bug into pcluster_config_reader: default values were overwritten to custom values, which is a wrong behavior

Note: this PR requires [PR](https://github.com/aws/aws-parallelcluster-cookbook/pull/1010) to be merged first.

### Tests
1. Integration tests (pending)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.