### PR TITLE
3.0: Revert "Add GitHub action to generate API client"

### DIFF
--- a/.github/workflows/openapi_generator.yml
+++ b/.github/workflows/openapi_generator.yml
@@ -22,15 +22,10 @@ jobs:
           sudo npm install -g redoc-cli
           sudo snap install yq
       - working-directory: api
-        run: ./gradlew buildSmithyModel openApiValidate redoc generatePythonClient
+        run: ./gradlew buildSmithyModel openApiValidate redoc
       - uses: EndBug/add-and-commit@v7
         with:
           add: 'api/spec/openapi'
           message: 'Generate OpenAPI model'
-          signoff: true
-      - uses: EndBug/add-and-commit@v7
-        with:
-          add: 'api/client/src'
-          message: 'Generate API Client'
           signoff: true
 


### PR DESCRIPTION
This reverts commit e72d1f84c31cf68631f14dd3bbbf3f99326e3f8c.

The above commit makes GH actions to be stuck.
We must investigate the root cause, but a revert is necessary to unblock the PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
