### PR TITLE
Temporarily disable centos8 intel_hpc test

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -261,7 +261,7 @@ intel_hpc:
     dimensions:
       - regions: ["us-east-1"]
         instances: ["c5n.18xlarge"]
-        oss: ["centos7", "centos8"]
+        oss: ["centos7"]
         schedulers: ["slurm"]
 networking:
   test_cluster_networking.py::test_cluster_in_private_subnet:


### PR DESCRIPTION
* Disabling test for now due to known issue with intel cluster checker

Signed-off-by: Rex <shuningc@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
