### PR TITLE
Revert "Temporarily disable centos8 intel_hpc test"

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -261,7 +261,7 @@ intel_hpc:
     dimensions:
       - regions: ["us-east-1"]
         instances: ["c5n.18xlarge"]
-        oss: ["centos7"]
+        oss: ["centos7", "centos8"]
         schedulers: ["slurm"]
 networking:
   test_cluster_networking.py::test_cluster_in_private_subnet:


### PR DESCRIPTION
This reverts commit bf570f1f7dce394bcdac7ab2a5132f01d8737b83.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
