### PR TITLE
3.0: Return empty list in case of CreateCluster with no validation failures

### DIFF
--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -123,7 +123,7 @@ def create_cluster(
                 version=get_installed_version(),
                 cluster_status=cloud_formation_status_to_cluster_status(CloudFormationStatus.CREATE_IN_PROGRESS),
             ),
-            validation_messages=validation_results_to_config_validation_errors(ignored_validation_failures) or None,
+            validation_messages=validation_results_to_config_validation_errors(ignored_validation_failures),
         )
     except ConfigValidationError as e:
         raise _handle_config_validation_error(e)


### PR DESCRIPTION
### Notes
In case of a CreateCluster with no validation failures, we return an empty list of validation messages as this is a required part of the API response. This patch aligns the CreateCluster to the behavior of the UpdateCluster and of the custom image APIs, adding a test for this case for the Create and Update Cluster APIs. If we later decide to instead make this field not required, I will make a separate PR adjusting the response for all the APIs.

### Tests
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
