### PR TITLE
3.0: Add to integ tests requirements: cfn_flip

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -2,11 +2,12 @@ argparse
 assertpy
 aws-parallelcluster
 boto3
+cfn_flip
 fabric
 jinja2
 junitparser
-pykwalify
 pexpect
+pykwalify
 pytest
 pytest-datadir
 pytest-html
@@ -14,7 +15,7 @@ pytest-rerunfailures
 pytest-sugar
 pytest-xdist
 PyYAML
+requests
 retrying
 troposphere
 untangle
-requests


### PR DESCRIPTION
### Changes
1. Add to integ tests requirements: cfn_flip. Without this change, all the integration tests using troposphere fail with a module not found error.

### Tests
1. Integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
