### PR TITLE
[3.0] Delete SNS Subscription during CloudFormation delete

### DIFF
--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -247,7 +247,7 @@ class ImageBuilderCdkStack(Stack):
         )
         resource_dependency_list.extend([lambda_cleanup, permission, lambda_log])
 
-        resource_dependency_list.append(self._add_sns_topic(lambda_cleanup, build_tags_list))
+        resource_dependency_list.extend(self._add_sns_topic_and_subscription(lambda_cleanup, build_tags_list))
 
         if lambda_cleanup_execution_role:
             for resource in resource_dependency_list:
@@ -714,7 +714,7 @@ class ImageBuilderCdkStack(Stack):
 
             self._add_resource_delete_policy(
                 policy_statements,
-                ["SNS:GetTopicAttributes", "SNS:DeleteTopic"],
+                ["SNS:GetTopicAttributes", "SNS:DeleteTopic", "SNS:Unsubscribe"],
                 [
                     self.format_arn(
                         service="sns",
@@ -787,17 +787,24 @@ class ImageBuilderCdkStack(Stack):
 
         return lambda_cleanup, permission, lambda_cleanup_execution_role, lambda_log
 
-    def _add_sns_topic(self, lambda_cleanup, build_tags):
+    def _add_sns_topic_and_subscription(self, lambda_cleanup, build_tags):
         # SNSTopic
-        subscription = sns.CfnTopic.SubscriptionProperty(endpoint=lambda_cleanup.attr_arn, protocol="lambda")
         sns_topic_resource = sns.CfnTopic(
             self,
             "BuildNotificationTopic",
-            subscription=[subscription],
             topic_name=self._build_resource_name(IMAGEBUILDER_RESOURCE_NAME_PREFIX),
             tags=build_tags,
         )
-        return sns_topic_resource
+        # SNSSubscription
+        sns_subscription_resource = sns.CfnSubscription(
+            self,
+            "BuildNotificationSubscription",
+            protocol="lambda",
+            topic_arn=sns_topic_resource.ref,
+            endpoint=lambda_cleanup.attr_arn,
+        )
+
+        return sns_subscription_resource, sns_topic_resource
 
     def _add_default_instance_role(self, cleanup_policy_statements, build_tags):
         """Set default instance role in imagebuilder cfn template."""

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -73,6 +73,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ImageRecipe": {},
                     "ParallelClusterImage": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -120,6 +121,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ImageRecipe": {},
                     "ParallelClusterImage": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -170,6 +172,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ImageRecipe": {},
                     "ParallelClusterImage": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -217,6 +220,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ParallelClusterValidateComponent": {},
                     "ParallelClusterTestComponent": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -265,6 +269,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ParallelClusterValidateComponent": {},
                     "ParallelClusterTestComponent": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -315,6 +320,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ParallelClusterValidateComponent": {},
                     "ParallelClusterTestComponent": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunction": {},
                     "DeleteStackFunctionPermission": {},
@@ -361,6 +367,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ImageRecipe": {},
                     "ParallelClusterImage": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -411,6 +418,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ParallelClusterValidateComponent": {},
                     "ParallelClusterTestComponent": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -459,6 +467,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ParallelClusterValidateComponent": {},
                     "ParallelClusterTestComponent": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -515,6 +524,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ParallelClusterValidateComponent": {},
                     "ParallelClusterTestComponent": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -564,6 +574,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ImageRecipe": {},
                     "ParallelClusterImage": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -612,6 +623,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ImageRecipe": {},
                     "ParallelClusterImage": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -660,6 +672,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_imagebuilder_bucket, moc
                     "ImageRecipe": {},
                     "ParallelClusterImage": {},
                     "BuildNotificationTopic": {},
+                    "BuildNotificationSubscription": {},
                     "DistributionConfiguration": {},
                     "DeleteStackFunctionExecutionRole": {},
                     "DeleteStackFunction": {},
@@ -1458,7 +1471,11 @@ def test_imagebuilder_instance_role(
                                         },
                                     },
                                     {
-                                        "Action": ["SNS:GetTopicAttributes", "SNS:DeleteTopic"],
+                                        "Action": [
+                                            "SNS:GetTopicAttributes",
+                                            "SNS:DeleteTopic",
+                                            "SNS:Unsubscribe",
+                                        ],
                                         "Effect": "Allow",
                                         "Resource": {
                                             "Fn::Join": [
@@ -2104,8 +2121,10 @@ def test_imagebuilder_build_tags(mocker, resource, response, expected_imagebuild
             resource_name == "InstanceProfile"
             or resource_name == "DeleteStackFunctionPermission"
             or resource_name == "DeleteStackFunctionLog"
+            or resource_name == "BuildNotificationSubscription"
         ):
-            # InstanceProfile, DeleteStackFunctionPermission and DeleteStackFunctionLog have no tags
+            # InstanceProfile, DeleteStackFunctionPermission,
+            # DeleteStackFunctionLog and BuildNotificationSubscription have no tags
             continue
         elif (
             resource_name == "InstanceRole"


### PR DESCRIPTION
Explicitly declare SNS Subscription resource separately from SNS topic, to be able to delete it during CloudFormation delete.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
