### PR TITLE
Reduce and move p4d.24xlarge integ tests

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -213,9 +213,9 @@ efa:
         instances: ["c5n.18xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
-      - regions: ["us-east-1"]
+      - regions: ["eu-west-1"]
         instances: ["p4d.24xlarge"]
-        oss: ["alinux2", "centos8", "ubuntu2004"]
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
       - regions: ["us-west-2"]
         instances: ["c6gn.16xlarge"]
@@ -233,10 +233,6 @@ efa:
         # Torque is not supported by OpenMPI distributed with EFA
         # Slurm test is to verify EFA works correctly when using the SIT model in the config file
         schedulers: ["sge", "slurm"]
-      - regions: ["us-west-2"]
-        instances: ["p4d.24xlarge"]
-        oss: ["ubuntu1804", "centos7"]
-        schedulers: ["sge"]
 iam:
   test_iam.py::test_iam_policies:
     dimensions:
@@ -600,17 +596,6 @@ update:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["sge"]
-multiple_nics:
-  test_multiple_nics.py::test_multiple_nics:
-    dimensions:
-      - regions: ["us-east-1"]
-        instances: ["p4d.24xlarge"]
-        oss: ["alinux2", "centos8"]
-        schedulers: ["slurm"]
-      - regions: ["us-west-2"]
-        instances: ["p4d.24xlarge"]
-        oss: ["ubuntu1804", "centos7", "ubuntu2004"]
-        schedulers: ["slurm"]
 resource_bucket:
   test_resource_bucket.py::test_resource_bucket:
     dimensions:
@@ -621,7 +606,7 @@ resource_bucket:
 nccl:
   test_nccl.py::test_nccl:
     dimensions:
-      - regions: ["us-east-1"]
+      - regions: ["eu-west-1"]
         instances: ["p4d.24xlarge"]
-        oss: ["ubuntu1804", "ubuntu2004"]
+        oss: ["ubuntu1804"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -83,3 +83,14 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: {{ common.OSS_GOVCLOUD_ARM }}
           schedulers: ["slurm"]
+  multiple_nics:
+    test_multiple_nics.py::test_multiple_nics:
+      dimensions:
+        - regions: ["us-east-1"]
+          instances: ["p4d.24xlarge"]
+          oss: ["alinux2", "centos8"]
+          schedulers: ["slurm"]
+        - regions: ["us-west-2"]
+          instances: ["p4d.24xlarge"]
+          oss: ["ubuntu1804", "centos7", "ubuntu2004"]
+          schedulers: ["slurm"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -512,7 +512,8 @@ AVAILABILITY_ZONE_OVERRIDES = {
     # NAT Gateway not available in sae1-az2
     "sa-east-1": ["sae1-az1", "sae1-az3"],
     # m6g.xlarge instances not available in euw1-az3
-    "eu-west-1": ["euw1-az1", "euw1-az2"],
+    # p4d.24xlarge instances only available in euw1-az2
+    "eu-west-1": ["euw1-az2"],
     # io2 EBS volumes not available in cac1-az4
     "ca-central-1": ["cac1-az1", "cac1-az2"],
     # instance can only be launch in placement group in eun1-az2


### PR DESCRIPTION
This commit does the following two things:
* Reduces the number of p4d.24xlarge tests that are run as part of the
  nightly integration tests against the latest released version.
* Moves the remaining p4d.24xlarge tests to the eu-west-1 region (where
  tests are now only run in the euw1-az2 AZ).

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
