### PR TITLE
3.0: Validation errors not required

### DIFF
--- a/api/client/src/docs/BuildImageResponseContent.md
+++ b/api/client/src/docs/BuildImageResponseContent.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **image** | [**ImageInfoSummary**](ImageInfoSummary.md) |  | 
-**validation_messages** | [**[ConfigValidationMessage]**](ConfigValidationMessage.md) | List of messages collected during image config validation whose level is lower than the validationFailureLevel set by the user | 
+**validation_messages** | [**[ConfigValidationMessage]**](ConfigValidationMessage.md) | List of messages collected during image config validation whose level is lower than the validationFailureLevel set by the user | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/client/src/docs/CreateClusterResponseContent.md
+++ b/api/client/src/docs/CreateClusterResponseContent.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **cluster** | [**ClusterInfoSummary**](ClusterInfoSummary.md) |  | 
-**validation_messages** | [**[ConfigValidationMessage]**](ConfigValidationMessage.md) | List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user | 
+**validation_messages** | [**[ConfigValidationMessage]**](ConfigValidationMessage.md) | List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/client/src/docs/UpdateClusterResponseContent.md
+++ b/api/client/src/docs/UpdateClusterResponseContent.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **cluster** | [**ClusterInfoSummary**](ClusterInfoSummary.md) |  | 
-**validation_messages** | [**[ConfigValidationMessage]**](ConfigValidationMessage.md) | List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user | 
 **change_set** | [**[Change]**](Change.md) | List of configuration changes requested by the update operation | 
+**validation_messages** | [**[ConfigValidationMessage]**](ConfigValidationMessage.md) | List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/client/src/pcluster_client/model/build_image_response_content.py
+++ b/api/client/src/pcluster_client/model/build_image_response_content.py
@@ -105,12 +105,11 @@ class BuildImageResponseContent(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, image, validation_messages, *args, **kwargs):  # noqa: E501
+    def __init__(self, image, *args, **kwargs):  # noqa: E501
         """BuildImageResponseContent - a model defined in OpenAPI
 
         Args:
             image (ImageInfoSummary):
-            validation_messages ([ConfigValidationMessage]): List of messages collected during image config validation whose level is lower than the validationFailureLevel set by the user
 
         Keyword Args:
             _check_type (bool): if True, values for parameters in openapi_types
@@ -143,6 +142,7 @@ class BuildImageResponseContent(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            validation_messages ([ConfigValidationMessage]): List of messages collected during image config validation whose level is lower than the validationFailureLevel set by the user. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -169,7 +169,6 @@ class BuildImageResponseContent(ModelNormal):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
         self.image = image
-        self.validation_messages = validation_messages
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/api/client/src/pcluster_client/model/create_cluster_response_content.py
+++ b/api/client/src/pcluster_client/model/create_cluster_response_content.py
@@ -105,12 +105,11 @@ class CreateClusterResponseContent(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, cluster, validation_messages, *args, **kwargs):  # noqa: E501
+    def __init__(self, cluster, *args, **kwargs):  # noqa: E501
         """CreateClusterResponseContent - a model defined in OpenAPI
 
         Args:
             cluster (ClusterInfoSummary):
-            validation_messages ([ConfigValidationMessage]): List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user
 
         Keyword Args:
             _check_type (bool): if True, values for parameters in openapi_types
@@ -143,6 +142,7 @@ class CreateClusterResponseContent(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            validation_messages ([ConfigValidationMessage]): List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -169,7 +169,6 @@ class CreateClusterResponseContent(ModelNormal):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
         self.cluster = cluster
-        self.validation_messages = validation_messages
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/api/client/src/pcluster_client/model/update_cluster_response_content.py
+++ b/api/client/src/pcluster_client/model/update_cluster_response_content.py
@@ -82,8 +82,8 @@ class UpdateClusterResponseContent(ModelNormal):
         lazy_import()
         return {
             'cluster': (ClusterInfoSummary,),  # noqa: E501
-            'validation_messages': ([ConfigValidationMessage],),  # noqa: E501
             'change_set': ([Change],),  # noqa: E501
+            'validation_messages': ([ConfigValidationMessage],),  # noqa: E501
         }
 
     @cached_property
@@ -93,8 +93,8 @@ class UpdateClusterResponseContent(ModelNormal):
 
     attribute_map = {
         'cluster': 'cluster',  # noqa: E501
-        'validation_messages': 'validationMessages',  # noqa: E501
         'change_set': 'changeSet',  # noqa: E501
+        'validation_messages': 'validationMessages',  # noqa: E501
     }
 
     _composed_schemas = {}
@@ -109,12 +109,11 @@ class UpdateClusterResponseContent(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, cluster, validation_messages, change_set, *args, **kwargs):  # noqa: E501
+    def __init__(self, cluster, change_set, *args, **kwargs):  # noqa: E501
         """UpdateClusterResponseContent - a model defined in OpenAPI
 
         Args:
             cluster (ClusterInfoSummary):
-            validation_messages ([ConfigValidationMessage]): List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user
             change_set ([Change]): List of configuration changes requested by the update operation
 
         Keyword Args:
@@ -148,6 +147,7 @@ class UpdateClusterResponseContent(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            validation_messages ([ConfigValidationMessage]): List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -174,7 +174,6 @@ class UpdateClusterResponseContent(ModelNormal):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
         self.cluster = cluster
-        self.validation_messages = validation_messages
         self.change_set = change_set
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \

--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -1132,7 +1132,6 @@ components:
           description: List of messages collected during image config validation whose level is lower than the validationFailureLevel set by the user
       required:
         - image
-        - validationMessages
     Change:
       type: object
       properties:
@@ -1318,7 +1317,6 @@ components:
           description: List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user
       required:
         - cluster
-        - validationMessages
     DeleteClusterResponseContent:
       type: object
       properties:
@@ -1715,7 +1713,6 @@ components:
       required:
         - changeSet
         - cluster
-        - validationMessages
     UpdateComputeFleetStatusRequestContent:
       type: object
       properties:

--- a/api/spec/smithy/model/operations/BuildImage.smithy
+++ b/api/spec/smithy/model/operations/BuildImage.smithy
@@ -41,7 +41,6 @@ structure BuildImageRequest {
 structure BuildImageResponse {
     @required
     image: ImageInfoSummary,
-    @required
     @documentation("List of messages collected during image config validation whose level is lower than the validationFailureLevel set by the user")
     validationMessages: ValidationMessages
 }

--- a/api/spec/smithy/model/operations/CreateCluster.smithy
+++ b/api/spec/smithy/model/operations/CreateCluster.smithy
@@ -41,7 +41,6 @@ structure CreateClusterRequest {
 structure CreateClusterResponse {
     @required
     cluster: ClusterInfoSummary,
-    @required
     @documentation("List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user")
     validationMessages: ValidationMessages
 }

--- a/api/spec/smithy/model/operations/UpdateCluster.smithy
+++ b/api/spec/smithy/model/operations/UpdateCluster.smithy
@@ -44,7 +44,6 @@ structure UpdateClusterRequest {
 structure UpdateClusterResponse {
     @required
     cluster: ClusterInfoSummary,
-    @required
     @documentation("List of messages collected during cluster config validation whose level is lower than the validationFailureLevel set by the user")
     validationMessages: ValidationMessages,
     @required

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -123,7 +123,7 @@ def create_cluster(
                 version=get_installed_version(),
                 cluster_status=cloud_formation_status_to_cluster_status(CloudFormationStatus.CREATE_IN_PROGRESS),
             ),
-            validation_messages=validation_results_to_config_validation_errors(ignored_validation_failures),
+            validation_messages=validation_results_to_config_validation_errors(ignored_validation_failures) or None,
         )
     except ConfigValidationError as e:
         raise _handle_config_validation_error(e)
@@ -349,7 +349,7 @@ def update_cluster(
                 version=cluster.stack.version,
                 cluster_status=cloud_formation_status_to_cluster_status(CloudFormationStatus.UPDATE_IN_PROGRESS),
             ),
-            validation_messages=validation_results_to_config_validation_errors(ignored_validation_failures),
+            validation_messages=validation_results_to_config_validation_errors(ignored_validation_failures) or None,
             change_set=change_set,
         )
     except ConfigValidationError as e:
@@ -373,13 +373,13 @@ def _handle_cluster_update_error(e):
     change_set, errors = _analyze_changes(e.update_changes)
     return UpdateClusterBadRequestException(
         UpdateClusterBadRequestExceptionResponseContent(
-            message=str(e), change_set=change_set, update_validation_errors=errors
+            message=str(e), change_set=change_set, update_validation_errors=errors or None
         )
     )
 
 
 def _handle_config_validation_error(e: ConfigValidationError) -> CreateClusterBadRequestException:
-    config_validation_messages = validation_results_to_config_validation_errors(e.validation_failures)
+    config_validation_messages = validation_results_to_config_validation_errors(e.validation_failures) or None
     return CreateClusterBadRequestException(
         CreateClusterBadRequestExceptionResponseContent(
             configuration_validation_errors=config_validation_messages, message="Invalid cluster configuration"

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -107,12 +107,12 @@ def build_image(
 
         return BuildImageResponseContent(
             image=_imagebuilder_stack_to_image_info_summary(imagebuilder.stack),
-            validation_messages=validation_results_to_config_validation_errors(suppressed_validation_failures),
+            validation_messages=validation_results_to_config_validation_errors(suppressed_validation_failures) or None,
         )
     except BadRequestImageBuilderActionError as e:
         errors = validation_results_to_config_validation_errors(e.validation_failures)
         raise BuildImageBadRequestException(
-            BuildImageBadRequestExceptionResponseContent(message=str(e), configuration_validation_errors=errors)
+            BuildImageBadRequestExceptionResponseContent(message=str(e), configuration_validation_errors=errors or None)
         )
 
 

--- a/cli/src/pcluster/api/models/build_image_response_content.py
+++ b/cli/src/pcluster/api/models/build_image_response_content.py
@@ -94,7 +94,4 @@ class BuildImageResponseContent(Model):
         :param validation_messages: The validation_messages of this BuildImageResponseContent.
         :type validation_messages: List[ConfigValidationMessage]
         """
-        if validation_messages is None:
-            raise ValueError("Invalid value for `validation_messages`, must not be `None`")
-
         self._validation_messages = validation_messages

--- a/cli/src/pcluster/api/models/create_cluster_response_content.py
+++ b/cli/src/pcluster/api/models/create_cluster_response_content.py
@@ -94,7 +94,4 @@ class CreateClusterResponseContent(Model):
         :param validation_messages: The validation_messages of this CreateClusterResponseContent.
         :type validation_messages: List[ConfigValidationMessage]
         """
-        if validation_messages is None:
-            raise ValueError("Invalid value for `validation_messages`, must not be `None`")
-
         self._validation_messages = validation_messages

--- a/cli/src/pcluster/api/models/update_cluster_response_content.py
+++ b/cli/src/pcluster/api/models/update_cluster_response_content.py
@@ -106,9 +106,6 @@ class UpdateClusterResponseContent(Model):
         :param validation_messages: The validation_messages of this UpdateClusterResponseContent.
         :type validation_messages: List[ConfigValidationMessage]
         """
-        if validation_messages is None:
-            raise ValueError("Invalid value for `validation_messages`, must not be `None`")
-
         self._validation_messages = validation_messages
 
     @property

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -1338,7 +1338,6 @@ components:
           type: array
       required:
       - image
-      - validationMessages
       title: BuildImageResponseContent
       type: object
     Change:
@@ -1609,7 +1608,6 @@ components:
           type: array
       required:
       - cluster
-      - validationMessages
       title: CreateClusterResponseContent
       type: object
     DeleteClusterResponseContent:
@@ -2277,7 +2275,6 @@ components:
       required:
       - changeSet
       - cluster
-      - validationMessages
       title: UpdateClusterResponseContent
       type: object
     UpdateComputeFleetStatusRequestContent:

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -119,7 +119,7 @@ class TestCreateCluster:
                     "name": "cluster",
                     "clusterConfiguration": BASE64_ENCODED_CONFIG,
                 },
-                [],
+                None,
                 ["type:type1", "type:type2"],
                 ValidationLevel.WARNING,
                 False,
@@ -152,8 +152,6 @@ class TestCreateCluster:
             rollback_on_failure,
         )
 
-        messages = [{"level": "WARNING", "message": "message", "type": "type"}] if errors else []
-
         expected_response = {
             "cluster": {
                 "cloudformationStackArn": "id",
@@ -163,8 +161,10 @@ class TestCreateCluster:
                 "region": create_cluster_request_content["region"],
                 "version": "3.0.0",
             },
-            "validationMessages": messages,
         }
+
+        if errors:
+            expected_response["validationMessages"] = [{"level": "WARNING", "message": "message", "type": "type"}]
 
         with soft_assertions():
             assert_that(response.status_code).is_equal_to(202)
@@ -1123,7 +1123,7 @@ class TestUpdateCluster:
                 {
                     "clusterConfiguration": BASE64_ENCODED_CONFIG,
                 },
-                [],
+                None,
                 ["type:type1", "type:type2"],
                 ValidationLevel.WARNING,
                 False,
@@ -1164,8 +1164,6 @@ class TestUpdateCluster:
             force_update,
         )
 
-        messages = [{"level": "WARNING", "message": "message", "type": "type"}] if errors else []
-
         expected_response = {
             "cluster": {
                 "cloudformationStackArn": stack_data["StackId"],
@@ -1175,11 +1173,13 @@ class TestUpdateCluster:
                 "region": "us-east-1",
                 "version": "3.0.0",
             },
-            "validationMessages": messages,
             "changeSet": [
                 {"parameter": "toplevel.subpath.param", "requestedValue": "newval", "currentValue": "oldval"}
             ],
         }
+
+        if errors:
+            expected_response["validationMessages"] = [{"level": "WARNING", "message": "message", "type": "type"}]
 
         with soft_assertions():
             assert_that(response.status_code).is_equal_to(202)


### PR DESCRIPTION
### Notes
Before, the list of validation errors in the CreateCluster, UpdateCluster and BuildImage API responses was required. This patch makes it optional, and only adds it to the response if it is non empty.

### Tests
Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
