### PR TITLE
3.0  Expose Route53 hosted zone setting in the cluster configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 3.0.0
 ------
+**ENHANCEMENTS**
+- Add possibility to use an existing Instance Profile for cluster creation and Imagebuilder.
+- Add possibility to use an existing Private Route53 Hosted Zone when using Slurm as scheduler.
 
 **CHANGES**
 

--- a/cli/src/pcluster/aws/aws_api.py
+++ b/cli/src/pcluster/aws/aws_api.py
@@ -20,6 +20,7 @@ from pcluster.aws.iam import IamClient
 from pcluster.aws.imagebuilder import ImageBuilderClient
 from pcluster.aws.kms import KmsClient
 from pcluster.aws.logs import LogsClient
+from pcluster.aws.route53 import Route53Client
 from pcluster.aws.s3 import S3Client
 from pcluster.aws.s3_resource import S3Resource
 from pcluster.aws.sts import StsClient
@@ -53,6 +54,7 @@ class AWSApi:
         self._iam = None
         self._ddb_resource = None
         self._logs = None
+        self._route53 = None
 
     @property
     def cfn(self):
@@ -144,6 +146,13 @@ class AWSApi:
         if not self._logs:
             self._logs = LogsClient()
         return self._logs
+
+    @property
+    def route53(self):
+        """STS client."""
+        if not self._route53:
+            self._route53 = Route53Client()
+        return self._route53
 
     @staticmethod
     def instance():

--- a/cli/src/pcluster/aws/aws_api.py
+++ b/cli/src/pcluster/aws/aws_api.py
@@ -149,7 +149,7 @@ class AWSApi:
 
     @property
     def route53(self):
-        """STS client."""
+        """Route53 client."""
         if not self._route53:
             self._route53 = Route53Client()
         return self._route53

--- a/cli/src/pcluster/aws/route53.py
+++ b/cli/src/pcluster/aws/route53.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from pcluster.aws.common import AWSClientError, AWSExceptionHandler, Boto3Client, Cache
+
+
+class Route53Client(Boto3Client):
+    """Route53 Boto3 client."""
+
+    def __init__(self):
+        super().__init__("route53")
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def get_hosted_zone(self, hosted_zone_id):
+        """
+        Return Domain name.
+
+        :param hosted_zone_id: Hosted zone Id
+        :return: hosted zone info
+        """
+        return self._client.get_hosted_zone(Id=hosted_zone_id)
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def get_domain_name(self, hosted_zone_id):
+        """Return the availability zone associated to the given subnet."""
+        hosted_zone_info = self.get_hosted_zone(hosted_zone_id)
+        if hosted_zone_info:
+            return hosted_zone_info.get("HostedZone").get("Name")
+        raise AWSClientError(function_name="get_domain_name", message=f"Hosted zone {hosted_zone_id} not found")

--- a/cli/src/pcluster/aws/route53.py
+++ b/cli/src/pcluster/aws/route53.py
@@ -30,9 +30,29 @@ class Route53Client(Boto3Client):
 
     @AWSExceptionHandler.handle_client_exception
     @Cache.cached
-    def get_domain_name(self, hosted_zone_id):
+    def get_hosted_zone_domain_name(self, hosted_zone_id):
         """Return the availability zone associated to the given subnet."""
         hosted_zone_info = self.get_hosted_zone(hosted_zone_id)
         if hosted_zone_info:
             return hosted_zone_info.get("HostedZone").get("Name")
-        raise AWSClientError(function_name="get_domain_name", message=f"Hosted zone {hosted_zone_id} not found")
+        raise AWSClientError(
+            function_name="get_hosted_zone_domain_name", message=f"Hosted zone {hosted_zone_id} not found"
+        )
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def get_vpc_ids(self, hosted_zone_id):
+        """Return list of vpc ids related to the hosted zone."""
+        hosted_zone_info = self.get_hosted_zone(hosted_zone_id)
+        if hosted_zone_info:
+            return [vpc.get("VPCId") for vpc in hosted_zone_info.get("VPCs")]
+        raise AWSClientError(function_name="get_vpc_ids", message=f"Hosted zone {hosted_zone_id} not found")
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def is_private_zone(self, hosted_zone_id):
+        """Return list of vpc ids related to the hosted zone."""
+        hosted_zone_info = self.get_hosted_zone(hosted_zone_id)
+        if hosted_zone_info:
+            return hosted_zone_info.get("HostedZone").get("Config").get("PrivateZone")
+        raise AWSClientError(function_name="is_private_zone", message=f"Hosted zone {hosted_zone_id} not found")

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1385,9 +1385,10 @@ class SlurmQueue(BaseQueue):
 class Dns(Resource):
     """Represent the DNS settings."""
 
-    def __init__(self, disable_managed_dns: bool = None):
+    def __init__(self, disable_managed_dns: bool = None, hosted_zone_id: str = None):
         super().__init__()
         self.disable_managed_dns = Resource.init_param(disable_managed_dns, default=False)
+        self.hosted_zone_id = Resource.init_param(hosted_zone_id)
 
 
 class SlurmSettings(Resource):

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -49,7 +49,6 @@ from pcluster.validators.cluster_validators import (
     CustomAmiTagValidator,
     DcvValidator,
     DisableSimultaneousMultithreadingArchitectureValidator,
-    DNSVPCValidator,
     DuplicateInstanceTypeValidator,
     DuplicateMountDirValidator,
     DuplicateNameValidator,
@@ -62,6 +61,7 @@ from pcluster.validators.cluster_validators import (
     FsxNetworkingValidator,
     HeadNodeImdsValidator,
     HeadNodeLaunchTemplateValidator,
+    HostedZoneValidator,
     InstanceArchitectureCompatibilityValidator,
     IntelHpcArchitectureValidator,
     IntelHpcOsValidator,
@@ -1442,7 +1442,10 @@ class SlurmClusterConfig(BaseClusterConfig):
         )
         if self.scheduling.settings and self.scheduling.settings.dns and self.scheduling.settings.dns.hosted_zone_id:
             self._register_validator(
-                DNSVPCValidator, hosted_zone_id=self.scheduling.settings.dns.hosted_zone_id, headnode_vpc=self.vpc_id
+                HostedZoneValidator,
+                hosted_zone_id=self.scheduling.settings.dns.hosted_zone_id,
+                cluster_vpc=self.vpc_id,
+                cluster_name=self.cluster_name,
             )
 
         for queue in self.scheduling.queues:

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -49,6 +49,7 @@ from pcluster.validators.cluster_validators import (
     CustomAmiTagValidator,
     DcvValidator,
     DisableSimultaneousMultithreadingArchitectureValidator,
+    DNSVPCValidator,
     DuplicateInstanceTypeValidator,
     DuplicateMountDirValidator,
     DuplicateNameValidator,
@@ -1439,6 +1440,10 @@ class SlurmClusterConfig(BaseClusterConfig):
         self._register_validator(
             HeadNodeImdsValidator, imds_secured=self.head_node.imds.secured, scheduler=self.scheduling.scheduler
         )
+        if self.scheduling.settings and self.scheduling.settings.dns and self.scheduling.settings.dns.hosted_zone_id:
+            self._register_validator(
+                DNSVPCValidator, hosted_zone_id=self.scheduling.settings.dns.hosted_zone_id, headnode_vpc=self.vpc_id
+            )
 
         for queue in self.scheduling.queues:
             self._register_validator(ComputeResourceLaunchTemplateValidator, queue=queue, ami_id=self.ami_id)

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -10,10 +10,6 @@
 # limitations under the License.
 
 PCLUSTER_NAME_MAX_LENGTH = 60
-HOST_NAME_MAX_LENGTH = 64
-# Max fqdn size is 255 characters, the first 64 are used for the hostname (e.g. queuename-st|dy-computeresourcename-N),
-# then we need to add an extra ., so we have 190 characters to be used for the clustername + domain-name.
-CLUSTER_NAME_AND_CUSTOM_DOMAIN_NAME_MAX_LENGTH = 255 - HOST_NAME_MAX_LENGTH - 1
 PCLUSTER_NAME_REGEX = r"^([a-zA-Z][a-zA-Z0-9-]{0,%d})$"
 PCLUSTER_ISSUES_LINK = "https://github.com/aws/aws-parallelcluster/issues"
 

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -10,6 +10,10 @@
 # limitations under the License.
 
 PCLUSTER_NAME_MAX_LENGTH = 60
+HOST_NAME_MAX_LENGTH = 64
+# Max fqdn size is 255 characters, the first 64 are used for the hostname (e.g. queuename-st|dy-computeresourcename-N),
+# then we need to add an extra ., so we have 190 characters to be used for the clustername + domain-name.
+CLUSTER_NAME_AND_CUSTOM_DOMAIN_NAME_MAX_LENGTH = 255 - HOST_NAME_MAX_LENGTH - 1
 PCLUSTER_NAME_REGEX = r"^([a-zA-Z][a-zA-Z0-9-]{0,%d})$"
 PCLUSTER_ISSUES_LINK = "https://github.com/aws/aws-parallelcluster/issues"
 

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/cleanup_resources.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/cleanup_resources.py
@@ -23,6 +23,8 @@ boto3_config = Config(retries={"max_attempts": 60})
 def _delete_dns_records(event):
     """Delete all DNS entries from the private Route53 hosted zone created within the cluster."""
     hosted_zone_id = event["ResourceProperties"]["ClusterHostedZone"]
+    domain_name = event["ResourceProperties"]["ClusterDNSDomain"]
+
     if not hosted_zone_id:
         logger.error("Hosted Zone ID is empty")
         raise Exception("Hosted Zone ID is empty")
@@ -34,7 +36,7 @@ def _delete_dns_records(event):
         completed_successfully = False
         while not completed_successfully:
             completed_successfully = True
-            for changes in _list_resource_record_sets_iterator(hosted_zone_id):
+            for changes in _list_resource_record_sets_iterator(hosted_zone_id, domain_name):
                 if changes:
                     try:
                         route53.change_resource_record_sets(
@@ -56,7 +58,7 @@ def _delete_dns_records(event):
         raise
 
 
-def _list_resource_record_sets_iterator(hosted_zone_id):
+def _list_resource_record_sets_iterator(hosted_zone_id, domain_name):
     route53 = boto3.client("route53", config=boto3_config)
     pagination_config = {"PageSize": 100}
 
@@ -64,7 +66,7 @@ def _list_resource_record_sets_iterator(hosted_zone_id):
     for page in paginator.paginate(HostedZoneId=hosted_zone_id, PaginationConfig=pagination_config):
         changes = []
         for record_set in page.get("ResourceRecordSets", []):
-            if record_set.get("Type") == "A":
+            if record_set.get("Type") == "A" and record_set.get("Name").endswith(domain_name):
                 changes.append({"Action": "DELETE", "ResourceRecordSet": record_set})
         yield changes
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1001,6 +1001,7 @@ class DnsSchema(BaseSchema):
     """Represent the schema of Dns Settings."""
 
     disable_managed_dns = fields.Bool(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    hosted_zone_id = fields.Str(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -101,12 +101,13 @@ class SlurmConstruct(Construct):
 
     def _add_parameters(self):
         if self._condition_custom_cluster_dns():
-            subdomain = self.stack_name
-            hosted_zone_id = self.config.scheduling.settings.dns.hosted_zone_id
-            domain_name = AWSApi.instance().route53.get_hosted_zone_domain_name(hosted_zone_id)
-            cluster_dns_domain = subdomain + "." + domain_name
+            domain_name = AWSApi.instance().route53.get_hosted_zone_domain_name(
+                self.config.scheduling.settings.dns.hosted_zone_id
+            )
         else:
-            cluster_dns_domain = f"{self.stack_name}.pcluster"
+            domain_name = "pcluster"
+        cluster_dns_domain = f"{self.stack_name}.{domain_name}"
+
         self.cluster_dns_domain = CfnParameter(
             self.stack_scope,
             "ClusterDNSDomain",

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -8,6 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+from collections import namedtuple
 
 from aws_cdk import aws_dynamodb as dynamodb
 from aws_cdk import aws_ec2 as ec2
@@ -17,6 +18,7 @@ from aws_cdk import aws_logs as logs
 from aws_cdk import aws_route53 as route53
 from aws_cdk.core import CfnCustomResource, CfnDeletionPolicy, CfnOutput, CfnParameter, CfnTag, Construct, Fn, Stack
 
+from pcluster.aws.aws_api import AWSApi
 from pcluster.config.cluster_config import CapacityType, SharedStorageType, SlurmClusterConfig
 from pcluster.constants import OS_MAPPING, PCLUSTER_CLUSTER_NAME_TAG, PCLUSTER_DYNAMODB_PREFIX, PCLUSTER_QUEUE_NAME_TAG
 from pcluster.models.s3_bucket import S3Bucket
@@ -36,6 +38,8 @@ from pcluster.templates.cdk_builder_utils import (
     get_user_data_content,
 )
 from pcluster.utils import join_shell_args
+
+CustomDns = namedtuple("CustomDns", ["ref", "name"])
 
 
 class SlurmConstruct(Construct):
@@ -351,12 +355,18 @@ class SlurmConstruct(Construct):
         self.dynamodb_table = table
 
     def _add_private_hosted_zone(self):
-        cluster_hosted_zone = route53.CfnHostedZone(
-            self.stack_scope,
-            "Route53HostedZone",
-            name=self.cluster_dns_domain.value_as_string,
-            vpcs=[route53.CfnHostedZone.VPCProperty(vpc_id=self.config.vpc_id, vpc_region=self._stack_region)],
-        )
+        if self._condition_custom_cluster_dns():
+            subdomain = self.stack_name
+            hosted_zone_id = self.config.scheduling.settings.dns.hosted_zone_id
+            domain_name = AWSApi.instance().route53.get_domain_name(hosted_zone_id)
+            cluster_hosted_zone = CustomDns(ref=hosted_zone_id, name=subdomain + domain_name)
+        else:
+            cluster_hosted_zone = route53.CfnHostedZone(
+                self.stack_scope,
+                "Route53HostedZone",
+                name=self.cluster_dns_domain.value_as_string,
+                vpcs=[route53.CfnHostedZone.VPCProperty(vpc_id=self.config.vpc_id, vpc_region=self._stack_region)],
+            )
 
         # If Headnode InstanceRole is created by ParallelCluster, add Route53 policy for InstanceRole
         head_node_role_info = self.instance_roles.get("HeadNode")
@@ -661,4 +671,11 @@ class SlurmConstruct(Construct):
             self.config.scheduling.settings
             and self.config.scheduling.settings.dns
             and self.config.scheduling.settings.dns.disable_managed_dns
+        )
+
+    def _condition_custom_cluster_dns(self):
+        return (
+            self.config.scheduling.settings
+            and self.config.scheduling.settings.dns
+            and self.config.scheduling.settings.dns.hosted_zone_id
         )

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -16,6 +16,7 @@ from pcluster.aws.common import AWSClientError
 from pcluster.cli_commands.dcv.utils import get_supported_dcv_os
 from pcluster.constants import (
     CIDR_ALL_IPS,
+    CLUSTER_NAME_AND_CUSTOM_DOMAIN_NAME_MAX_LENGTH,
     PCLUSTER_IMAGE_BUILD_STATUS_TAG,
     PCLUSTER_NAME_MAX_LENGTH,
     PCLUSTER_NAME_REGEX,
@@ -57,7 +58,7 @@ FSX_MESSAGES = {
 class ClusterNameValidator(Validator):
     """Cluster name validator."""
 
-    def _validate(self, name):
+    def _validate(self, name, config):
         if not re.match(PCLUSTER_NAME_REGEX % (PCLUSTER_NAME_MAX_LENGTH - 1), name):
             self._add_failure(
                 (
@@ -67,6 +68,26 @@ class ClusterNameValidator(Validator):
                 ),
                 FailureLevel.ERROR,
             )
+        if (
+            config.get("Scheduling")
+            and config.get("Scheduling").get("SlurmSettings")
+            and config.get("Scheduling").get("SlurmSettings").get("Dns")
+        ):
+
+            hosted_zone_id = config.get("Scheduling").get("SlurmSettings").get("Dns").get("HostedZoneId")
+            if hosted_zone_id:
+                domain_name = AWSApi.instance().route53.get_hosted_zone_domain_name(hosted_zone_id)
+                total_length = len(name) + len(domain_name)
+                if total_length > CLUSTER_NAME_AND_CUSTOM_DOMAIN_NAME_MAX_LENGTH:
+                    self._add_failure(
+                        (
+                            "Error: When specifying HostedZoneId, "
+                            f"the total length of cluster name {name} and domain name {domain_name} can not be "
+                            f"longer than {CLUSTER_NAME_AND_CUSTOM_DOMAIN_NAME_MAX_LENGTH} character, "
+                            f"current length is {total_length}"
+                        ),
+                        FailureLevel.ERROR,
+                    )
 
 
 class RegionValidator(Validator):
@@ -880,3 +901,17 @@ class ComputeResourceLaunchTemplateValidator(_LaunchTemplateValidator):
             NetworkInterfaces=network_interfaces,
             DryRun=True,
         )
+
+
+class DNSVPCValidator(Validator):
+    """Validate custom private domain in the same VPC as headnode."""
+
+    def _validate(self, hosted_zone_id, headnode_vpc):
+        if AWSApi.instance().route53.is_private_zone(hosted_zone_id):
+            vpc_ids = AWSApi.instance().route53.get_vpc_ids(hosted_zone_id)
+            if headnode_vpc not in vpc_ids:
+                self._add_failure(
+                    f"Private Route53 hosted zone need to be associated with the VPC of the cluster: {headnode_vpc} "
+                    f"The VPCs associated with hosted zone are {vpc_ids}.",
+                    FailureLevel.ERROR,
+                )

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -20,6 +20,7 @@ from pcluster.aws.iam import IamClient
 from pcluster.aws.imagebuilder import ImageBuilderClient
 from pcluster.aws.kms import KmsClient
 from pcluster.aws.logs import LogsClient
+from pcluster.aws.route53 import Route53Client
 from pcluster.aws.s3 import S3Client
 from pcluster.aws.s3_resource import S3Resource
 from pcluster.aws.sts import StsClient
@@ -87,6 +88,7 @@ class _DummyAWSApi(AWSApi):
         self._batch = _DummyBatchClient()
         self._logs = _DummyLogsClient()
         self._ddb_resource = _DummyDynamoResource()
+        self._route53 = _DummyRoute53Client()
 
 
 class _DummyCfnClient(CfnClient):
@@ -201,6 +203,12 @@ class _DummyBatchClient(IamClient):
 
 
 class _DummyLogsClient(LogsClient):
+    def __init__(self):
+        """Override Parent constructor. No real boto3 client is created."""
+        pass
+
+
+class _DummyRoute53Client(Route53Client):
     def __init__(self):
         """Override Parent constructor. No real boto3 client is created."""
         pass

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -48,7 +48,8 @@ Scheduling:
   SlurmSettings:
     ScaledownIdletime: 10
     Dns:
-      DisableManagedDns: true
+      DisableManagedDns: false
+      HostedZoneId: 12345ABC
   SlurmQueues:
     - Name: queue1
       CapacityType: ONDEMAND

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -20,7 +20,6 @@ from pcluster.validators.cluster_validators import (
     ComputeResourceSizeValidator,
     DcvValidator,
     DisableSimultaneousMultithreadingArchitectureValidator,
-    DNSVPCValidator,
     DuplicateInstanceTypeValidator,
     DuplicateMountDirValidator,
     EfaOsArchitectureValidator,
@@ -30,6 +29,7 @@ from pcluster.validators.cluster_validators import (
     FsxArchitectureOsValidator,
     FsxNetworkingValidator,
     HeadNodeImdsValidator,
+    HostedZoneValidator,
     InstanceArchitectureCompatibilityValidator,
     IntelHpcArchitectureValidator,
     IntelHpcOsValidator,
@@ -49,71 +49,27 @@ def boto3_stubber_path():
 
 
 @pytest.mark.parametrize(
-    "cluster_name, config_dict, should_trigger_name_error, should_trigger_dns_error, custom_dns",
+    "cluster_name, should_trigger_error",
     [
-        ("ThisClusterNameShouldBeRightSize-ContainAHyphen-AndANumber12", {}, False, False, False),
-        (
-            "ThisClusterNameShouldBeJustOneCharacterTooLongAndShouldntBeOk",
-            {"Scheduling": {"SlurmSettings": {}}},
-            True,
-            False,
-            False,
-        ),
-        ("2AClusterCanNotBeginByANumber", {"Scheduling": {"SlurmSettings": {"Dns": {}}}}, True, False, False),
-        ("ClusterCanNotContainUnderscores_LikeThis", {}, True, False, False),
-        ("ClusterCanNotContainSpaces LikeThis", {}, True, False, False),
-        (
-            "ThisClusterNameShouldBeRightSize-ContainAHyphen-AndANumber12",
-            {"Scheduling": {"SlurmSettings": {"Dns": {"HostedZoneId": "12345"}}}},
-            False,
-            False,
-            True,
-        ),
-        (
-            "ThisClusterNameShouldBeRightSize-ContainAHyphen-AndANumber12",
-            {"Scheduling": {"SlurmSettings": {"Dns": {"HostedZoneId": "1234"}}}},
-            False,
-            True,
-            True,
-        ),
+        ("ThisClusterNameShouldBeRightSize-ContainAHyphen-AndANumber12", False),
+        ("ThisClusterNameShouldBeJustOneCharacterTooLongAndShouldntBeOk", True),
+        ("2AClusterCanNotBeginByANumber", True),
+        ("ClusterCanNotContainUnderscores_LikeThis", True),
+        ("ClusterCanNotContainSpaces LikeThis", True),
     ],
 )
-def test_cluster_name_validator(
-    mocker, cluster_name, config_dict, should_trigger_name_error, should_trigger_dns_error, custom_dns
-):
-    if should_trigger_dns_error:
-        get_hosted_zone_info = {
-            "HostedZone": {
-                "Name": "a_long_name_together_with_stackname_longer_than_190_"
-                "characters_0123456789_0123456789_0123456789_0123456789_"
-                "0123456789_0123456789_0123456789_0123456789_0123456789_"
-                "0123456789.com"
-            }
-        }
-    else:
-        get_hosted_zone_info = {"HostedZone": {"Name": "shortname.com"}}
-
-    mock_aws_api(mocker)
-    get_domain_name = mocker.patch(
-        "pcluster.aws.route53.Route53Client.get_hosted_zone", return_value=get_hosted_zone_info
-    )
-
-    expected_message = None
-    if should_trigger_name_error:
-        expected_message = (
+def test_cluster_name_validator(cluster_name, should_trigger_error):
+    expected_message = (
+        (
             "Error: The cluster name can contain only alphanumeric characters (case-sensitive) and hyphens. "
             "It must start with an alphabetic character and can't be longer "
             f"than {PCLUSTER_NAME_MAX_LENGTH} characters."
         )
-    if should_trigger_dns_error:
-        expected_message = "Error: When specifying HostedZoneId"
-
-    actual_failures = ClusterNameValidator().execute(cluster_name, config_dict)
+        if should_trigger_error
+        else None
+    )
+    actual_failures = ClusterNameValidator().execute(cluster_name)
     assert_failure_messages(actual_failures, expected_message)
-    if custom_dns:
-        get_domain_name.assert_called_once()
-    else:
-        get_domain_name.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -813,27 +769,53 @@ def test_head_node_imds_validator(imds_secured, scheduler, expected_message):
 
 
 @pytest.mark.parametrize(
-    "vpcs, is_private_zone, expected_message",
+    "vpcs, is_private_zone, domain_name, expected_message",
     [
-        (None, False, None),  # Public hosted zone
         (
-            [{"VPCRegiion": "us-east-1", "VPCId": "vpc-123"}, {"VPCRegiion": "us-east-1", "VPCId": "vpc-456"}],
-            True,
             None,
-        ),  # Private hosted zone associated with cluster VPC
+            False,
+            "domain.com",
+            "Hosted zone 12345Z cannot be used",
+        ),
         (
-            [{"VPCRegiion": "us-east-1", "VPCId": "vpc-456"}],
+            [{"VPCRegion": "us-east-1", "VPCId": "vpc-123"}, {"VPCRegion": "us-east-1", "VPCId": "vpc-456"}],
             True,
-            "Private Route53 hosted zone need to be associated with the VPC of the cluster",
+            "domain.com",
+            None,
+        ),
+        (
+            [{"VPCRegion": "us-east-1", "VPCId": "vpc-456"}],
+            True,
+            "domain.com",
+            "Private Route53 hosted zone 12345Z need to be associated with the VPC of the cluster",
+        ),
+        (
+            [{"VPCRegion": "us-east-1", "VPCId": "vpc-123"}, {"VPCRegion": "us-east-1", "VPCId": "vpc-456"}],
+            True,
+            "a_long_name_together_with_stackname_longer_than_190_"
+            "characters_0123456789_0123456789_0123456789_0123456789_"
+            "0123456789_0123456789_0123456789_0123456789_0123456789_"
+            "0123456789.com",
+            "Error: When specifying HostedZoneId, ",
         ),
     ],
+    ids=[
+        "Public hosted zone",
+        "Private hosted zone associated with cluster VPC",
+        "Private hosted zone not associated with cluster VPC",
+        "Hosted zone name and cluster name exceeds lengths",
+    ],
 )
-def test_dns_vpc_validator(mocker, vpcs, is_private_zone, expected_message):
+def test_hosted_zone_validator(mocker, vpcs, is_private_zone, domain_name, expected_message):
     get_hosted_zone_info = {
-        "HostedZone": {"Name": "domain.com", "Config": {"PrivateZone": is_private_zone}},
+        "HostedZone": {"Name": domain_name, "Config": {"PrivateZone": is_private_zone}},
         "VPCs": vpcs,
     }
     mock_aws_api(mocker)
     mocker.patch("pcluster.aws.route53.Route53Client.get_hosted_zone", return_value=get_hosted_zone_info)
-    actual_failures = DNSVPCValidator().execute(hosted_zone_id="12345Z", headnode_vpc="vpc-123")
+    actual_failures = HostedZoneValidator().execute(
+        hosted_zone_id="12345Z",
+        cluster_vpc="vpc-123",
+        cluster_name="ThisClusterNameShouldBeRightSize-ContainAHyphen-AndANumber12",
+    )
     assert_failure_messages(actual_failures, expected_message)

--- a/tests/integration-tests/tests/dns/test_dns/test_existing_hosted_zone/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dns/test_dns/test_existing_hosted_zone/pcluster.config.yaml
@@ -1,0 +1,27 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    Dns:
+      HostedZoneId: {{ existing_hosted_zone }}
+  SlurmQueues:
+    - Name: ondemand
+      CapacityType: ONDEMAND
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: ondemand-1
+          InstanceType: {{ instance }}
+          MinCount: {{ queue_size }}
+SharedStorage:
+  - MountDir: /shared
+    Name: name1
+    StorageType: Ebs


### PR DESCRIPTION
* Exposed HostedZoneId in Slurm Settings, automatically retrieve domain name with `HostedZoneId`
* Add custer name as subdomain, 
* Add validator to verify that the total length of cluster name and domain name is not longer than 190 characters
* Add validator to validate custom hosted zone is associated with VPC of the cluster if hosted zone is a private hosted zone
* Add validator to verify if hostedzone is  public hosted zone
* Add logic to clean up records when deleting the cluster
* Manually tests done:
    * Custom private hosted zone in the same vpc as ParallelCluster 
        * Test running regular job --succeeded
        * mpi job --succeeded
        * ssh with hostename --succeeded
    * Custom private hosted zone in different vpc with ParallelCluster 
        * Test running regular job --succeed 
        * mpi job  --failed 
        * ssh with hostname --failed 
        * After adding the same VPC as cluster, ssh with hostname succeeded
    * Custom public hosted zone
      * Test running regular job --succeeded 
      * mpi job --failed 
      * ssh with hostname --failed 
* Integration test
    * Test_exsiting_hosted_zone with slurm and alinux2
