### PR TITLE
3.0: Remove update metadata from imagebuilder_schema schemas

### DIFF
--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -27,7 +27,6 @@ from pcluster.config.imagebuilder_config import (
     ImagebuilderDevSettings,
     Volume,
 )
-from pcluster.config.update_policy import UpdatePolicy
 from pcluster.constants import PCLUSTER_IMAGE_NAME_REGEX
 from pcluster.imagebuilder_utils import AMI_NAME_REQUIRED_SUBSTRING
 from pcluster.schemas.common_schema import (
@@ -135,11 +134,7 @@ class IamSchema(BaseSchema):
 
     instance_role = fields.Str(validate=validate.Regexp("^arn:.*:(role|instance-profile)/"))
     cleanup_lambda_role = fields.Str(validate=validate.Regexp("^arn:.*:role/"))
-    additional_iam_policies = fields.Nested(
-        AdditionalIamPolicySchema,
-        many=True,
-        metadata={"update_policy": UpdatePolicy.SUPPORTED, "update_key": "Policy"},
-    )
+    additional_iam_policies = fields.Nested(AdditionalIamPolicySchema, many=True)
 
     @validates_schema
     def no_coexist_role_policies(self, data, **kwargs):

--- a/cli/tests/pcluster/schemas/test_schemas.py
+++ b/cli/tests/pcluster/schemas/test_schemas.py
@@ -49,5 +49,4 @@ def _validate_module_schemas(module):
 def test_schemas():
     with soft_assertions():
         _validate_module_schemas(pcluster.schemas.cluster_schema)
-        _validate_module_schemas(pcluster.schemas.imagebuilder_schema)
         _validate_module_schemas(pcluster.schemas.common_schema)


### PR DESCRIPTION
### Notes
The schemas in imagebuilder_schema are not used during an update. This patch removes the update metadata from the schemas in that file, and does not test the schemas in that file for the presence of an update key on lists.

### Tests
Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
