### PR TITLE
3.0: Do not convert generic Exceptions at the API controller level.

### DIFF
--- a/cli/src/pcluster/api/controllers/common.py
+++ b/cli/src/pcluster/api/controllers/common.py
@@ -20,13 +20,7 @@ from typing import List, Optional, Set
 from flask import request
 from pkg_resources import packaging
 
-from pcluster.api.errors import (
-    BadRequestException,
-    ConflictException,
-    InternalServiceException,
-    LimitExceededException,
-    ParallelClusterApiException,
-)
+from pcluster.api.errors import BadRequestException, ConflictException, LimitExceededException
 from pcluster.aws.common import BadRequestError, LimitExceededError
 from pcluster.config.common import AllValidatorsSuppressor, TypeMatchValidatorsSuppressor, ValidatorSuppressor
 from pcluster.constants import SUPPORTED_REGIONS
@@ -129,17 +123,15 @@ def convert_errors():
         def wrapper(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
-            except ParallelClusterApiException as e:
-                error = e
             except (LimitExceeded, LimitExceededError) as e:
-                error = LimitExceededException(str(e))
+                raise LimitExceededException(str(e))
             except (BadRequest, BadRequestError) as e:
-                error = BadRequestException(str(e))
+                raise BadRequestException(str(e))
             except Conflict as e:
-                error = ConflictException(str(e))
+                raise ConflictException(str(e))
             except Exception as e:
-                error = InternalServiceException(str(e))
-            raise error
+                # ParallelClusterApiException is among the exceptions we might raise here
+                raise e
 
         return wrapper
 

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -392,6 +392,11 @@ class TestCreateCluster:
         expected_response = {"message": "error message"}
         if error_type == BadRequestClusterActionError:
             expected_response["message"] = "Bad Request: " + expected_response["message"]
+        elif error_type == ClusterActionError:
+            expected_response = {
+                "message": "Unexpected fatal exception. Please look at the application logs for"
+                " details on the encountered failure."
+            }
 
         with soft_assertions():
             assert_that(response.status_code).is_equal_to(error_code)
@@ -548,6 +553,11 @@ class TestDeleteCluster:
         expected_response = {"message": "error message"}
         if error_type == BadRequestClusterActionError:
             expected_response["message"] = "Bad Request: " + expected_response["message"]
+        elif error_type == ClusterActionError:
+            expected_response = {
+                "message": "Unexpected fatal exception. Please look at the application logs for"
+                " details on the encountered failure."
+            }
 
         with soft_assertions():
             assert_that(response.status_code).is_equal_to(error_code)
@@ -1703,6 +1713,11 @@ class TestUpdateCluster:
         expected_response = {"message": "error message"}
         if error_type == BadRequestClusterActionError:
             expected_response["message"] = "Bad Request: " + expected_response["message"]
+        elif error_type == ClusterActionError:
+            expected_response = {
+                "message": "Unexpected fatal exception. Please look at the application logs for"
+                " details on the encountered failure."
+            }
         elif error_type == ClusterUpdateError:
             expected_response["changeSet"] = [
                 {"parameter": "toplevel.subpath.param", "requestedValue": "newval", "currentValue": "oldval"},

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -238,6 +238,8 @@ class TestListImages:
         expected_error = {"message": "test error"}
         if error == BadRequestError:
             expected_error["message"] = "Bad Request: " + expected_error["message"]
+        elif error == AWSClientError:
+            expected_error = {"message": "Failed when calling AWS service in get_images: test error"}
         response = self._send_test_request(client, ImageStatusFilteringOption.AVAILABLE)
 
         with soft_assertions():
@@ -401,7 +403,10 @@ class TestDeleteImage:
         image = _create_image_info("image1")
         mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", return_value=image)
         mocker.patch("pcluster.models.imagebuilder.ImageBuilder.delete", side_effect=Exception("test error"))
-        expected_error = {"message": "test error"}
+        expected_error = {
+            "message": "Unexpected fatal exception. Please look at the application "
+            "logs for details on the encountered failure."
+        }
         response = self._send_test_request(client, "image1")
 
         with soft_assertions():
@@ -705,6 +710,8 @@ class TestDescribeOfficialImages:
         expected_error = {"message": "test error"}
         if error == BadRequestError:
             expected_error["message"] = "Bad Request: " + expected_error["message"]
+        elif error == AWSClientError:
+            expected_error = {"message": "Failed when calling AWS service in get_official_images: test error"}
         response = self._send_test_request(client)
 
         with soft_assertions():
@@ -848,6 +855,11 @@ class TestDescribeImage:
             expected_error = {"message": "No image or stack associated to parallelcluster image id image1."}
         elif error == BadRequestError:
             expected_error = {"message": "Bad Request: Unable to get image image1, due to test error."}
+        elif error == AWSClientError:
+            expected_error = {
+                "message": "Unexpected fatal exception. Please look at the application "
+                "logs for details on the encountered failure."
+            }
         else:
             expected_error = {"message": "Unable to get image image1, due to test error."}
 


### PR DESCRIPTION
### Notes
We want to avoid to show generic exceptions' messages in the error returned to the customer. This patch makes the decorator in the controllers simply raise the generic exceptions and we then rely on the conversion in the flask app that produces a error with a generic message, telling the customer to look at the logs for more details.

### Tests
Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
