### PR TITLE
Default to DEFAULT_MAX_COUNT in UpdatePolicy.MAX_COUNT condition checker

### DIFF
--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -10,6 +10,8 @@
 # limitations under the License.
 from enum import Enum
 
+from pcluster.constants import DEFAULT_MAX_COUNT
+
 
 class UpdatePolicy:
     """Describes the policy that rules the update of a configuration parameter."""
@@ -149,7 +151,8 @@ UpdatePolicy.MAX_COUNT = UpdatePolicy(
     fail_reason=lambda change, patch: "Shrinking a queue requires the compute fleet to be stopped first",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
     condition_checker=lambda change, patch: not patch.cluster.has_running_capacity()
-    or change.new_value >= change.old_value,
+    or (change.new_value if change.new_value is not None else DEFAULT_MAX_COUNT)
+    >= (change.old_value if change.old_value is not None else DEFAULT_MAX_COUNT),
 )
 
 # Update supported only with all compute nodes down

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -17,7 +17,16 @@ from tests.pcluster.test_utils import dummy_cluster
 
 @pytest.mark.parametrize(
     "is_fleet_stopped, old_max, new_max, expected_result",
-    [(True, 10, 11, True), (True, 10, 9, True), (False, 10, 9, False), (False, 10, 11, True)],
+    [
+        pytest.param(True, 10, 9, True, id="stopped fleet and new_max < old_max"),
+        pytest.param(True, 10, 11, True, id="stopped fleet new_max > old_max"),
+        pytest.param(False, 10, 9, False, id="running fleet and new_max < old_max"),
+        pytest.param(False, 10, 11, True, id="running fleet and new_max > old_max"),
+        pytest.param(False, None, 0, False, id="running fleet and new_max < DEFAULT_MAX_COUNT"),
+        pytest.param(False, None, 11, True, id="running fleet and new_max > DEFAULT_MAX_COUNT"),
+        pytest.param(False, 11, None, False, id="running fleet and DEFAULT_MAX_COUNT < old_max"),
+        pytest.param(False, 0, None, True, id="running fleet and DEFAULT_MAX_COUNT > old_max"),
+    ],
 )
 def test_max_count_policy(mocker, is_fleet_stopped, old_max, new_max, expected_result):
     cluster = dummy_cluster()


### PR DESCRIPTION
### Notes
In the `UpdatePolicy.MAX_COUNT` condition checker we want to check that either the fleet is stopped, or the new max count is bigger or equal to the old one (because shrinking queues requires stopping the compute fleet). If the old configuration and/or the new one do not specify a max count, we default to `DEFAULT_MAX_COUNT` in the condition checker.

### Tests
Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
