### PR TITLE
Add tag Name to shared storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ CHANGELOG
 - Implement scaling protection mechanism with Slurm scheduler: compute fleet is automatically set to 'PROTECTED' state
   in case recurrent failures are encountered when provisioning nodes.
 - Upgrade Slurm to version 20.11.8.
+- Add tag 'Name' to every shared storage with the value specified in the shared storage name config.
 
 2.11.0
 ------

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -70,6 +70,7 @@ from pcluster.validators.cluster_validators import (
     OverlappingMountDirValidator,
     RegionValidator,
     SchedulerOsValidator,
+    SharedStorageNameValidator,
 )
 from pcluster.validators.ebs_validators import (
     EbsVolumeIopsValidator,
@@ -974,6 +975,10 @@ class BaseClusterConfig(Resource):
                 resource_name="Shared Storage",
             )
             for storage in self.shared_storage:
+                self._register_validator(
+                    SharedStorageNameValidator,
+                    name=storage.name,
+                )
                 if isinstance(storage, SharedFsx):
                     storage_count["fsx"] += 1
                     if storage.file_system_id:

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -110,6 +110,8 @@ PCLUSTER_S3_ARTIFACTS_DICT = {
     "scheduler_resources_name": "scheduler_resources.zip",
 }
 
+PCLUSTER_TAG_VALUE_REGEX = r"^([\w\+\-\=\.\_\:\@/]{0,256})$"
+
 IMAGEBUILDER_RESOURCE_NAME_PREFIX = "ParallelClusterImage"
 
 IAM_ROLE_PATH = "/parallelcluster/"

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -30,6 +30,7 @@ from aws_cdk.core import (
     CfnParameter,
     CfnResourceSignal,
     CfnStack,
+    CfnTag,
     Construct,
     CustomResource,
     Fn,
@@ -654,6 +655,7 @@ class ClusterCdkStack(Stack):
                 storage_type=shared_fsx.fsx_storage_type,
                 subnet_ids=self.config.compute_subnet_ids,
                 security_group_ids=self._get_compute_security_groups(),
+                tags=[CfnTag(key="Name", value=shared_fsx.name)],
             )
             fsx_id = fsx_resource.ref
             # Get MountName for new filesystem
@@ -709,6 +711,7 @@ class ClusterCdkStack(Stack):
                 provisioned_throughput_in_mibps=shared_efs.provisioned_throughput,
                 throughput_mode=shared_efs.throughput_mode,
             )
+            efs_resource.tags.set_tag(key="Name", value=shared_efs.name)
             efs_id = efs_resource.ref
 
         checked_availability_zones = []
@@ -824,6 +827,7 @@ class ClusterCdkStack(Stack):
             size=shared_ebs.size,
             snapshot_id=shared_ebs.snapshot_id,
             volume_type=shared_ebs.volume_type,
+            tags=[CfnTag(key="Name", value=shared_ebs.name)],
         )
         volume.cfn_options.deletion_policy = convert_deletion_policy(shared_ebs.deletion_policy)
         return volume.ref

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -19,6 +19,7 @@ from pcluster.constants import (
     PCLUSTER_IMAGE_BUILD_STATUS_TAG,
     PCLUSTER_NAME_MAX_LENGTH,
     PCLUSTER_NAME_REGEX,
+    PCLUSTER_TAG_VALUE_REGEX,
     PCLUSTER_VERSION_TAG,
     SCHEDULERS_SUPPORTING_IMDS_SECURED,
     SUPPORTED_OSES,
@@ -602,6 +603,27 @@ class EfsIdValidator(Validator):  # TODO add tests
                     ),
                     FailureLevel.WARNING,
                 )
+
+
+class SharedStorageNameValidator(Validator):
+    """
+    Shared storage name validator.
+
+    Validate if the provided name for the shared storage complies with the acceptable pattern.
+    Since the storage name is used as a tag, the provided name must comply with the tag pattern.
+    """
+
+    def _validate(self, name: str):
+        if not re.match(PCLUSTER_TAG_VALUE_REGEX, name):
+            self._add_failure(
+                (
+                    f"Error: The shared storage name {name} is not valid. "
+                    "Allowed characters are letters, numbers and white spaces that can be represented in UTF-8 "
+                    "and the following characters: '+' '-' '=' '.' '_' ':' '/', "
+                    f"and it can't be longer than 256 characters."
+                ),
+                FailureLevel.ERROR,
+            )
 
 
 # --------------- Third party software validators --------------- #


### PR DESCRIPTION
### Changes
1. Add tag Name to shared storage, using the value specified in the shared storage name config. Since the name is used as a tag value, it must comply with the standard AWS tag regular expression.

This change will be reflected in integration tests during a dedicated activity on integration testing covering shared storage.


### Tests
1. Manual tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
