### PR TITLE
Move ClusterNameValidator into config validation logic

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -43,6 +43,7 @@ from pcluster.validators.awsbatch_validators import (
 )
 from pcluster.validators.cluster_validators import (
     ArchitectureOsValidator,
+    ClusterNameValidator,
     ComputeResourceLaunchTemplateValidator,
     ComputeResourceSizeValidator,
     CustomAmiTagValidator,
@@ -870,6 +871,7 @@ class BaseClusterConfig(Resource):
 
     def __init__(
         self,
+        cluster_name: str,
         image: Image,
         head_node: HeadNode,
         shared_storage: List[Resource] = None,
@@ -883,6 +885,7 @@ class BaseClusterConfig(Resource):
     ):
         super().__init__()
         self.__region = None
+        self.cluster_name = cluster_name
         self.image = image
         self.head_node = head_node
         self.shared_storage = shared_storage
@@ -901,6 +904,7 @@ class BaseClusterConfig(Resource):
 
     def _register_validators(self):
         self._register_validator(RegionValidator, region=self.region)
+        self._register_validator(ClusterNameValidator, name=self.cluster_name)
         self._register_validator(ArchitectureOsValidator, os=self.image.os, architecture=self.head_node.architecture)
         if self.ami_id:
             self._register_validator(
@@ -1191,8 +1195,8 @@ class AwsBatchScheduling(Resource):
 class AwsBatchClusterConfig(BaseClusterConfig):
     """Represent the full AwsBatch Cluster configuration."""
 
-    def __init__(self, scheduling: AwsBatchScheduling, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, cluster_name: str, scheduling: AwsBatchScheduling, **kwargs):
+        super().__init__(cluster_name, **kwargs)
         self.scheduling = scheduling
 
     def _register_validators(self):
@@ -1406,8 +1410,8 @@ class SlurmScheduling(Resource):
 class SlurmClusterConfig(BaseClusterConfig):
     """Represent the full Slurm Cluster configuration."""
 
-    def __init__(self, scheduling: SlurmScheduling, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, cluster_name: str, scheduling: SlurmScheduling, **kwargs):
+        super().__init__(cluster_name, **kwargs)
         self.scheduling = scheduling
 
     def get_instance_types_data(self):

--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -67,7 +67,7 @@ class ConfigPatch:
         self.base_config = copy.deepcopy(base_config)
         self.target_config = copy.deepcopy(target_config)
 
-        self.cluster_schema = ClusterSchema()
+        self.cluster_schema = ClusterSchema(cluster_name=cluster.name)
         self.changes = []
         self._compare()
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1129,6 +1129,10 @@ class ClusterSchema(BaseSchema):
     additional_resources = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     dev_settings = fields.Nested(ClusterDevSettingsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
+    def __init__(self, cluster_name: str):
+        super().__init__()
+        self.cluster_name = cluster_name
+
     @validates("tags")
     def validate_tags(self, tags):
         """Validate tags."""
@@ -1139,11 +1143,11 @@ class ClusterSchema(BaseSchema):
         """Generate cluster according to the scheduler. Save original configuration."""
         scheduler = data.get("scheduling").scheduler
         if scheduler == "slurm":
-            cluster = SlurmClusterConfig(**data)
+            cluster = SlurmClusterConfig(cluster_name=self.cluster_name, **data)
         elif scheduler == "awsbatch":
-            cluster = AwsBatchClusterConfig(**data)
+            cluster = AwsBatchClusterConfig(cluster_name=self.cluster_name, **data)
         else:  # scheduler == "custom":
-            cluster = BaseClusterConfig(**data)  # FIXME Must be ByosCluster
+            cluster = BaseClusterConfig(cluster_name=self.cluster_name, **data)  # FIXME Must be ByosCluster
 
         cluster.source_config = original_data
         return cluster

--- a/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure.py
+++ b/cli/tests/pcluster/cli_commands/configure/test_pcluster_configure.py
@@ -336,7 +336,7 @@ def _assert_configurations_are_equal(path_config_expected, path_config_after_inp
     with open(path_config_after_input) as after_input_conf_file:
         after_input_content = yaml.safe_load(after_input_conf_file)
         copy_after_input_content = deepcopy(after_input_content)
-        ClusterSchema().load(
+        ClusterSchema(cluster_name="clustername").load(
             copy_after_input_content
         )  # Test if the generated yaml can be corrected loaded by Marshmallow.
     with open(path_config_expected) as expected_conf_file:

--- a/cli/tests/pcluster/config/dummy_cluster_config.py
+++ b/cli/tests/pcluster/config/dummy_cluster_config.py
@@ -43,7 +43,7 @@ class _DummySlurmClusterConfig(SlurmClusterConfig):
     """Generate dummy Slurm cluster config."""
 
     def __init__(self, scheduling: SlurmScheduling, **kwargs):
-        super().__init__(scheduling, **kwargs)
+        super().__init__("clustername", scheduling, **kwargs)
 
     @property
     def region(self):
@@ -62,7 +62,7 @@ class _DummyAwsBatchClusterConfig(AwsBatchClusterConfig):
     """Generate dummy Slurm cluster config."""
 
     def __init__(self, scheduling: AwsBatchScheduling, **kwargs):
-        super().__init__(scheduling, **kwargs)
+        super().__init__("clustername", scheduling, **kwargs)
 
     @property
     def region(self):

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -30,7 +30,11 @@ def instance_type_info_mock(aws_api_mock):
 class TestBaseClusterConfig:
     @pytest.fixture()
     def base_cluster_config(self):
-        return BaseClusterConfig(image=Image("alinux2"), head_node=HeadNode("c5.xlarge", HeadNodeNetworking("subnet")))
+        return BaseClusterConfig(
+            cluster_name="clustername",
+            image=Image("alinux2"),
+            head_node=HeadNode("c5.xlarge", HeadNodeNetworking("subnet")),
+        )
 
     @pytest.mark.parametrize(
         "custom_ami, ami_filters",

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -177,7 +177,7 @@ def test_single_param_change(
 
 
 def _load_config(config_file):
-    return ClusterSchema().load(load_yaml_dict(config_file))
+    return ClusterSchema(cluster_name="clustername").load(load_yaml_dict(config_file))
 
 
 def test_multiple_param_changes(mocker, pcluster_config_reader, test_datadir):

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -30,11 +30,11 @@ def _check_cluster_schema(test_datadir, config_file_name):
     input_yaml = load_yaml_dict(test_datadir / config_file_name)
     print(input_yaml)
     copy_input_yaml = deepcopy(input_yaml)
-    cluster = ClusterSchema().load(copy_input_yaml)
+    cluster = ClusterSchema(cluster_name="clustername").load(copy_input_yaml)
     print(cluster)
 
     # Re-create Yaml file from model and compare content
-    cluster_schema = ClusterSchema()
+    cluster_schema = ClusterSchema(cluster_name="clustername")
     cluster_schema.context = {"delete_defaults_when_dump": True}
     output_json = cluster_schema.dump(cluster)
     assert_that(json.dumps(input_yaml, sort_keys=True)).is_equal_to(json.dumps(output_json, sort_keys=True))

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -557,7 +557,9 @@ def test_subnet_id_validator(subnet_id, expected_message):
     ],
 )
 def test_tags_validator(key, expected_message):
-    _validate_and_assert_error(ClusterSchema(), {"Tags": [{"Key": key, "Value": "test_value"}]}, expected_message)
+    _validate_and_assert_error(
+        ClusterSchema(cluster_name="clustername"), {"Tags": [{"Key": key, "Value": "test_value"}]}, expected_message
+    )
 
 
 def _validate_and_assert_error(schema, section_dict, expected_message, partial=True):

--- a/cli/tests/pcluster/schemas/test_schemas.py
+++ b/cli/tests/pcluster/schemas/test_schemas.py
@@ -42,8 +42,12 @@ def _validate_module_schemas(module):
 
     :param module: the module with the schemas to validate
     """
-    for _, class_object in inspect.getmembers(module, _is_schema(module)):
-        _validate_list_has_update_key(class_object())
+    for _, schema_class in inspect.getmembers(module, _is_schema(module)):
+        if issubclass(schema_class, pcluster.schemas.cluster_schema.ClusterSchema):
+            schema_instance = schema_class(cluster_name="clustername")
+        else:
+            schema_instance = schema_class()
+        _validate_list_has_update_key(schema_instance)
 
 
 def test_schemas():

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -30,9 +30,7 @@ def test_slurm_cluster_builder(mocker):
     mock_bucket(mocker)
 
     generated_template = CDKTemplateBuilder().build_cluster_template(
-        cluster_config=dummy_slurm_cluster_config(mocker),
-        bucket=dummy_cluster_bucket(),
-        stack_name="parallelcluster-dummyname",
+        cluster_config=dummy_slurm_cluster_config(mocker), bucket=dummy_cluster_bucket(), stack_name="clustername"
     )
     print(yaml.dump(generated_template))
     # TODO assert content of the template by matching expected template
@@ -44,9 +42,7 @@ def test_awsbatch_cluster_builder(mocker):
     mock_bucket(mocker)
 
     generated_template = CDKTemplateBuilder().build_cluster_template(
-        cluster_config=dummy_awsbatch_cluster_config(mocker),
-        bucket=dummy_cluster_bucket(),
-        stack_name="parallelcluster-dummyname",
+        cluster_config=dummy_awsbatch_cluster_config(mocker), bucket=dummy_cluster_bucket(), stack_name="clustername"
     )
     print(yaml.dump(generated_template))
     # TODO assert content of the template by matching expected template
@@ -67,12 +63,10 @@ def test_head_node_dna_json(mocker, test_datadir, config_file_name, expected_hea
 
     input_yaml = load_yaml_dict(test_datadir / config_file_name)
 
-    cluster_config = ClusterSchema().load(input_yaml)
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
 
     generated_template = CDKTemplateBuilder().build_cluster_template(
-        cluster_config=cluster_config,
-        bucket=dummy_cluster_bucket(),
-        stack_name="parallelcluster-dummyname",
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
     )
 
     generated_head_node_dna_json = json.loads(

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
@@ -26,7 +26,7 @@
     "head_node_imds_secured": "false",
     "hosted_zone": "",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",
-    "log_group_name": "/aws/parallelcluster/parallelcluster-dummyname-202101010101",
+    "log_group_name": "/aws/parallelcluster/clustername-202101010101",
     "node_type": "HeadNode",
     "postinstall": "NONE",
     "postinstall_args": "NONE",
@@ -37,7 +37,7 @@
     "raid_vol_ids": "NONE",
     "region": "{'Ref': 'AWS::Region'}",
     "scheduler": "awsbatch",
-    "stack_name": "parallelcluster-dummyname",
+    "stack_name": "clustername",
     "volume": "NONE"
   },
   "run_list": "recipe[aws-parallelcluster::awsbatch_config]"

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
@@ -26,7 +26,7 @@
     "head_node_imds_secured": "false",
     "hosted_zone": "{'Ref': 'Route53HostedZone'}",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",
-    "log_group_name": "/aws/parallelcluster/parallelcluster-dummyname-202101010101",
+    "log_group_name": "/aws/parallelcluster/clustername-202101010101",
     "node_type": "HeadNode",
     "postinstall": "NONE",
     "postinstall_args": "NONE",
@@ -37,7 +37,7 @@
     "raid_vol_ids": "NONE",
     "region": "{'Ref': 'AWS::Region'}",
     "scheduler": "slurm",
-    "stack_name": "parallelcluster-dummyname",
+    "stack_name": "clustername",
     "volume": "NONE"
   },
   "run_list": "recipe[aws-parallelcluster::slurm_config]"

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
@@ -26,7 +26,7 @@
     "head_node_imds_secured": "true",
     "hosted_zone": "{'Ref': 'Route53HostedZone'}",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",
-    "log_group_name": "/aws/parallelcluster/parallelcluster-dummyname-202101010101",
+    "log_group_name": "/aws/parallelcluster/clustername-202101010101",
     "node_type": "HeadNode",
     "postinstall": "NONE",
     "postinstall_args": "NONE",
@@ -37,7 +37,7 @@
     "raid_vol_ids": "NONE",
     "region": "{'Ref': 'AWS::Region'}",
     "scheduler": "slurm",
-    "stack_name": "parallelcluster-dummyname",
+    "stack_name": "clustername",
     "volume": "NONE"
   },
   "run_list": "recipe[aws-parallelcluster::slurm_config]"

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -42,10 +42,10 @@ def test_cw_dashboard_builder(mocker, test_datadir, config_file_name):
     mock_bucket(mocker)
 
     input_yaml = load_yaml_dict(test_datadir / config_file_name)
-    cluster_config = ClusterSchema().load(input_yaml)
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
     print(cluster_config)
     generated_template = CDKTemplateBuilder().build_cluster_template(
-        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="parallelcluster-dummyname"
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
     )
     output_yaml = yaml.dump(generated_template, width=float("inf"))
     print(output_yaml)

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -54,7 +54,7 @@ def _mock_all_validators(mocker, mockers):
 
 def _load_and_validate(config_path):
     input_yaml = load_yaml_dict(config_path)
-    cluster = ClusterSchema().load(input_yaml)
+    cluster = ClusterSchema(cluster_name="clustername").load(input_yaml)
     failures = cluster.validate()
     assert_that(failures).is_empty()
 


### PR DESCRIPTION
This permits to use validator_suppressors logic to skip ClusterNameValidator and permits to have the cluster_name available in the config class to be used for other validators (e.g. dns domain + cluster name total length).

`cluster_name` is now a mandatory parameter for the ClusterSchema initialization.

## Test

Before:
```
($ pcluster create -c cluster-config.yaml test-clusteré£ --suppress-validators
Beginning cluster creation for cluster: test-clusteré£
...
Validating cluster configuration...
ERROR: Cluster creation failed. Configuration is invalid.
Validation failures:
ERROR: Error: The cluster name can contain only alphanumeric characters (case-sensitive) and hyphens. It must start with an alphabetic character and can't be longer than 60 characters.
```

After:
```
$ pcluster create -c cluster-config.yaml test-clusteré£ --suppress-validators
Beginning cluster creation for cluster: test-clusteré£
...
Validating cluster configuration...
Validation succeeded.
...
``` 
