### PR TITLE
Make pcluster configure set the Ebs shared storage for the home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ CHANGELOG
 - Implement scaling protection mechanism with Slurm scheduler: compute fleet is automatically set to 'PROTECTED' state
   in case recurrent failures are encountered when provisioning nodes.
 - Upgrade Slurm to version 20.11.8.
+- Make pcluster configure set the default Ebs shared storage for the home directory.
 
 2.11.0
 ------

--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -231,6 +231,7 @@ def configure(args):  # noqa: C901
             "Imds": {"Secured": head_node_imds_secured},
         },
         "Scheduling": {"Scheduler": scheduler, f"{scheduler_prefix}Queues": queues},
+        "SharedStorage": [{"MountDir": "/home", "Name": "home-directory", "StorageType": "Ebs"}],
     }
 
     _write_configuration_file(config_file_path, result)

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.yaml
@@ -20,3 +20,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-45678912
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -20,3 +20,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-23456789
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/pcluster.config.yaml
@@ -22,3 +22,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-23456789
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/pcluster.config.yaml
@@ -20,3 +20,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-12345678
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -20,3 +20,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-23456789
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.yaml
@@ -20,3 +20,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-23456789
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.yaml
@@ -22,3 +22,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-23456789
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -20,3 +20,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-23456789
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.yaml
@@ -20,3 +20,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-23456789
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.yaml
@@ -20,3 +20,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-12345678
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.yaml
@@ -22,3 +22,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-23456789
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/pcluster.config.yaml
@@ -20,3 +20,7 @@ Scheduling:
       Networking:
         SubnetIds:
           - subnet-23456789
+SharedStorage:
+  - MountDir: /home
+    Name: home-directory
+    StorageType: Ebs


### PR DESCRIPTION
### Changes
1. pcluster configure sets by default the home directory placed in an Ebs volume.

```
SharedStorage:
  - MountDir: /home
    Name: home-directory
    StorageType: Ebs
```

**CANNOT BE MERGED UNTIL THE SUPPORT FOR THE EXTERNAL HOME DIRECTORY WEILL BE COMPLETED**

### Tests
1. Manual test
2. Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
