### PR TITLE
3.0: Avoid explicit reference to local CFN template in API infrastructure integration tests

### DIFF
--- a/tests/integration-tests/tests/api_infrastructure/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/api_infrastructure/test_api_infrastructure.py
@@ -9,7 +9,6 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
-import os
 import re
 
 import boto3
@@ -19,31 +18,14 @@ import requests
 from assertpy import assert_that, soft_assertions
 
 
-@pytest.mark.skip_regions(["cn-north-1", "cn-northwest-1"])  # TODO No Lambda container support in China regions
-def test_api_infrastructure_with_default_parameters(
-    region, api_definition_s3_uri, public_ecr_image_uri, parameterized_cfn_stacks_factory
-):
+@pytest.mark.skip_regions(["cn-north-1", "cn-northwest-1"])  # No Lambda container support in China regions
+def test_api_infrastructure_with_default_parameters(region, api_server_factory):
     """Test that creating the API Infrastructure stack with the defaults correctly sets up the Lambda and APIGateway API
 
     :param region: the region where the stack is run
-    :api_definition_s3_uri: a fixture, the S3 URI of the API definition
-    :public_ecr_image_uri: a fixture, the URI of the published Lambda Docker image
-    :api_infrastructure_stack_factory: a fixture, the factory used to create the regional API Infrastructure stack
+    :api_server_factory: factory for deploying API servers on-demand to each region
     """
-    parameters = [
-        {"ParameterKey": "ApiDefinitionS3Uri", "ParameterValue": api_definition_s3_uri},
-        {"ParameterKey": "PublicEcrImageUri", "ParameterValue": public_ecr_image_uri},
-    ]
-    capabilities = ["CAPABILITY_AUTO_EXPAND", "CAPABILITY_IAM"]
-    template_path = os.path.join("..", "..", "api", "infrastructure", "parallelcluster-api.yaml")
-    stack_prefix = "integ-tests-api-infrastructure"
-    stack = parameterized_cfn_stacks_factory(
-        region=region,
-        template_path=template_path,
-        stack_prefix=stack_prefix,
-        parameters=parameters,
-        capabilities=capabilities,
-    )
+    stack = api_server_factory(region)
 
     lambda_client = boto3.client("lambda", region_name=region)
     apigateway_client = boto3.client("apigateway", region_name=region)

--- a/tests/integration-tests/tests/api_infrastructure/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/api_infrastructure/test_api_infrastructure.py
@@ -9,6 +9,7 @@
 # or in the "LICENSE.txt" file accompanying this file.
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
+import logging
 import re
 
 import boto3
@@ -16,6 +17,8 @@ import botocore
 import pytest
 import requests
 from assertpy import assert_that, soft_assertions
+
+LOGGER = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_regions(["cn-north-1", "cn-northwest-1"])  # No Lambda container support in China regions
@@ -100,6 +103,7 @@ def _assert_can_call_list_clusters(region, api_url):
     botocore.auth.SigV4Auth(session.get_credentials(), "execute-api", region).add_auth(request)
     prepared_request = request.prepare()
     response = requests.get(prepared_request.url, headers=prepared_request.headers, timeout=10)
+    LOGGER.info(response.json())
     assert_that(response.status_code).is_equal_to(requests.codes.ok)
 
 

--- a/tests/integration-tests/tests/api_infrastructure/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/api_infrastructure/test_api_infrastructure.py
@@ -64,7 +64,7 @@ def _assert_parallelcluster_lambda(client, lambda_name, lambda_arn, lambda_image
     lambda_configuration = lambda_resource["Configuration"]
     assert_that(lambda_configuration["FunctionArn"]).is_equal_to(lambda_arn)
     assert_that(lambda_configuration["Timeout"]).is_equal_to(30)
-    assert_that(lambda_configuration["MemorySize"]).is_equal_to(256)
+    assert_that(lambda_configuration["MemorySize"]).is_equal_to(512)
     assert_that(lambda_configuration["TracingConfig"]["Mode"]).is_equal_to("Active")
     assert_that(lambda_resource["Tags"]).contains("parallelcluster:version")
     assert_that(lambda_resource["Code"]["ImageUri"]).is_equal_to(lambda_image_uri)


### PR DESCRIPTION
### Notes
Before, the ParallelCluster API infrastructure integration test referenced a local CloudFormation template to create the stack to set up the ParallelCluster API infrastructure. This patch uses the `apy_server_factory` fixture that we also use to instantiate the `api_client` in the other API tests to create the infrastructure, instead of explicitly referencing a local template file.

### Tests
Successfully run integration test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
