### PR TITLE
3.0: Add integration tests for custom image APIs

### DIFF
--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -39,6 +39,7 @@ from pcluster.api.models import (
     ImageInfoSummary,
     ImageStatusFilteringOption,
     ListImagesResponseContent,
+    Tag,
     ValidationLevel,
 )
 from pcluster.api.models.delete_image_response_content import DeleteImageResponseContent
@@ -200,7 +201,7 @@ def _image_to_describe_image_response(imagebuilder):
             ami_name=imagebuilder.image.name,
             ami_id=imagebuilder.image.id,
             state=imagebuilder.image.state.upper(),
-            tags=imagebuilder.image.tags,
+            tags=[Tag(key=tag["Key"], value=tag["Value"]) for tag in imagebuilder.image.tags],
             architecture=imagebuilder.image.architecture,
             description=imagebuilder.image.description,
         ),

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -756,9 +756,9 @@ class TestDescribeImage:
                 "state": Ec2AmiState.AVAILABLE,
                 "description": "description",
                 "tags": [
-                    {"Key": "parallelcluster:image_id", "Value": "image1"},
-                    {"Key": "parallelcluster:version", "Value": "3.0.0"},
-                    {"Key": "parallelcluster:build_config", "Value": "test_url"},
+                    {"key": "parallelcluster:image_id", "value": "image1"},
+                    {"key": "parallelcluster:version", "value": "3.0.0"},
+                    {"key": "parallelcluster:build_config", "value": "test_url"},
                 ],
             },
             "imageBuildStatus": ImageBuildStatus.BUILD_COMPLETE,

--- a/tests/integration-tests/tests/api/test_api_client/test_custom_image/image.config.yaml
+++ b/tests/integration-tests/tests/api/test_api_client/test_custom_image/image.config.yaml
@@ -1,0 +1,4 @@
+Build:
+  InstanceType: {{ instance }}
+  ParentImage: {{ parent_image }}
+  UpdateOsAndReboot: true


### PR DESCRIPTION
### Notes
This patch adds integration tests for the custom image APIs.

The workflow is as follows:
* `BuildImage`
* `DescribeImage` after waiting for the CFN stack to be deleted
* `ListImages` of available images
* `DeleteImage` and check that describe does not find it

The patch also adds a separate test for the `DescribeOfficialImages`.

### Tests
Successfully run the integration test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
