### PR TITLE
Fix rollbackOnFailure in CreateCluster and BuildImage APIs

### DIFF
--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -91,9 +91,9 @@ def create_cluster(
     Defaults to true.
     """
     # Set defaults
-    rollback_on_failure = rollback_on_failure or True
+    rollback_on_failure = rollback_on_failure in {True, None}
     validation_failure_level = validation_failure_level or ValidationLevel.ERROR
-    dryrun = dryrun or False
+    dryrun = dryrun is True
     create_cluster_request_content = CreateClusterRequestContent.from_dict(create_cluster_request_content)
     cluster_config = read_config(create_cluster_request_content.cluster_configuration)
 
@@ -306,8 +306,8 @@ def update_cluster(
     """
     # Set defaults
     validation_failure_level = validation_failure_level or ValidationLevel.ERROR
-    dryrun = dryrun or False
-    force_update = force_update or False
+    dryrun = dryrun is True
+    force_update = force_update is True
     update_cluster_request_content = UpdateClusterRequestContent.from_dict(update_cluster_request_content)
     cluster_config = read_config(update_cluster_request_content.cluster_configuration)
 

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -81,7 +81,7 @@ def build_image(
 
     :rtype: BuildImageResponseContent
     """
-    rollback_on_failure = rollback_on_failure or False
+    rollback_on_failure = rollback_on_failure in {True, None}
     disable_rollback = not rollback_on_failure
     validation_failure_level = validation_failure_level or ValidationLevel.ERROR
     dryrun = dryrun or False

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -122,7 +122,7 @@ class TestCreateCluster:
                 None,
                 ["type:type1", "type:type2"],
                 ValidationLevel.WARNING,
-                False,
+                True,
                 id="test with no errors",
             ),
         ],
@@ -170,7 +170,7 @@ class TestCreateCluster:
             assert_that(response.status_code).is_equal_to(202)
             assert_that(response.get_json()).is_equal_to(expected_response)
         cluster_create_mock.assert_called_with(
-            disable_rollback=not (rollback_on_failure or True),
+            disable_rollback=rollback_on_failure is False,
             validator_suppressors=mocker.ANY,
             validation_failure_level=FailureLevel[validation_failure_level or ValidationLevel.ERROR],
         )


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
