### PR TITLE
Add support for FSx DataCompressionType option

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -258,6 +258,7 @@ class SharedFsx(Resource):
         name: str,
         storage_capacity: int = None,
         deployment_type: str = None,
+        data_compression_type: str = None,
         export_path: str = None,
         import_path: str = None,
         imported_file_chunk_size: int = None,
@@ -280,6 +281,7 @@ class SharedFsx(Resource):
         self.storage_capacity = Resource.init_param(storage_capacity)
         self.fsx_storage_type = Resource.init_param(fsx_storage_type)
         self.deployment_type = Resource.init_param(deployment_type)
+        self.data_compression_type = Resource.init_param(data_compression_type)
         self.export_path = Resource.init_param(export_path)
         self.import_path = Resource.init_param(import_path)
         self.imported_file_chunk_size = Resource.init_param(imported_file_chunk_size)

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -336,6 +336,9 @@ class FsxLustreSettingsSchema(BaseSchema):
     drive_cache_type = fields.Str(
         validate=validate.OneOf(["READ"]), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
     )
+    data_compression_type = fields.Str(
+        validate=validate.OneOf(["LZ4"]), metadata={"update_policy": UpdatePolicy.SUPPORTED}
+    )
     fsx_storage_type = fields.Str(
         data_key="StorageType",
         validate=validate.OneOf(["HDD", "SSD"]),

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -622,6 +622,7 @@ class ClusterCdkStack(Stack):
                 storage_capacity=shared_fsx.storage_capacity,
                 lustre_configuration=fsx.CfnFileSystem.LustreConfigurationProperty(
                     deployment_type=shared_fsx.deployment_type,
+                    data_compression_type=shared_fsx.data_compression_type,
                     imported_file_chunk_size=shared_fsx.imported_file_chunk_size,
                     export_path=shared_fsx.export_path,
                     import_path=shared_fsx.import_path,

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_awsbatch/awsbatch.full.yaml
@@ -96,6 +96,7 @@ SharedStorage:
     FsxLustreSettings:
       StorageCapacity: 3600  # 3600
       DeploymentType: SCRATCH_1  # PERSISTENT_1 | SCRATCH_1 | SCRATCH_2
+      DataCompressionType: LZ4
       ImportedFileChunkSize: 10  # 1024
       ExportPath: String  # s3://bucket/folder
       ImportPath: String  # s3://bucket

--- a/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
+++ b/cli/tests/pcluster/schemas/test_cluster_schema/test_cluster_schema_slurm/slurm.full.yaml
@@ -143,6 +143,7 @@ SharedStorage:
       StorageCapacity: 3600
       DeploymentType: PERSISTENT_1  # PERSISTENT_1 | SCRATCH_1 | SCRATCH_2
       ImportedFileChunkSize: 1024
+      DataCompressionType: LZ4
       ExportPath: String  # s3://bucket/folder
       ImportPath: String  # s3://bucket
       WeeklyMaintenanceStartTime: "1:00:00"

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -471,6 +471,9 @@ def test_efs_throughput_mode_provisioned_throughput_validator(section_dict, expe
         ({"StorageType": "INVALID_VALUE"}, "Must be one of"),
         ({"DriveCacheType": "READ"}, None),
         ({"DriveCacheType": "INVALID_VALUE"}, "Must be one of"),
+        ({"DataCompressionType": None}, None),
+        ({"DataCompressionType": "LZ4"}, None),
+        ({"DataCompressionType": "INVALID_VALUE"}, "Must be one of"),
         ({"invalid_key": "fake_value"}, "Unknown field"),
     ],
 )

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
@@ -50,6 +50,9 @@ SharedStorage:
       {% if drive_cache_type %}
       DriveCacheType: {{ drive_cache_type }}
       {% endif %}
+      {% if data_compression_type %}
+      DataCompressionType: {{ data_compression_type }}
+      {% endif %}
       {% if storage_type %}
       StorageType: {{ storage_type }}
       {% endif %}


### PR DESCRIPTION
* Add support for new DataCompressionType Lustre configuration option.
* Add new `DataCompressionType` parameter in `FsxLustreSettings` section. Supported value is `LZ4`. Default is not specified and not enabled. To disable the feature, do not specify the parameter.
* Add new unit test and integration tests for the feature.

Cherry pick of: https://github.com/aws/aws-parallelcluster/commit/026dabba71380cfc903ec244d529b07d393e8825

