### PR TITLE
Cfn stack to create roles for pcluster image

### DIFF
--- a/tests/iam_policies/pcluster-image-roles-cfn.yaml
+++ b/tests/iam_policies/pcluster-image-roles-cfn.yaml
@@ -1,0 +1,650 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  PClusterBuildImageManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy to execute pcluster build-image command without IAM permission
+      # Groups:
+      #   - String
+      # ManagedPolicyName:
+      Path: /parallelcluster/
+      # Roles:
+      # Users:
+      #   - String
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EC2
+            Effect: Allow
+            Action:
+              - ec2:DescribeImages
+              - ec2:DescribeInstanceTypeOfferings
+              - ec2:DescribeInstanceTypes
+            Resource: '*'
+          - Sid: IAM
+            Effect: Allow
+            Action:
+              - iam:CreateInstanceProfile
+              - iam:GetRole
+              - iam:GetRolePolicy
+              - iam:GetInstanceProfile
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+          - Sid: IAMPassRole
+            Effect: Allow
+            Action:
+              - iam:PassRole
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+            Condition:
+              StringEquals:
+                iam:PassedToService:
+                  - lambda.amazonaws.com
+                  - !Sub 'ec2.${AWS::URLSuffix}'
+          - Sid: CloudWatch
+            Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*'
+          - Sid: CloudFormation
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+              - cloudformation:CreateStack
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*'
+          - Sid: Lambda
+            Effect: Allow
+            Action:
+              - lambda:CreateFunction
+              - lambda:GetFunction
+              - lambda:AddPermission
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterImage-*'
+          - Sid: ImageBuilder
+            Effect: Allow
+            Action:
+              - imagebuilder:CreateImage
+              - imagebuilder:TagResource
+              - imagebuilder:GetImage
+              - imagebuilder:GetImageRecipe
+              - imagebuilder:CreateImageRecipe
+              - imagebuilder:GetComponent
+              - imagebuilder:CreateComponent
+              - imagebuilder:GetInfrastructureConfiguration
+              - imagebuilder:CreateDistributionConfiguration
+              - imagebuilder:GetDistributionConfiguration
+              - imagebuilder:CreateInfrastructureConfiguration
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image-recipe/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:component/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:infrastructure-configuration/parallelclusterimage-*'
+          - Sid: S3Bucket
+            Effect: Allow
+            Action:
+              - s3:CreateBucket
+              - s3:ListBucket
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*'
+          - Sid: SNS
+            Effect: Allow
+            Action:
+              - sns:GetTopicAttributes
+              - sns:TagResource
+              - sns:CreateTopic
+              - sns:Subscribe
+              - sns:Publish
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:ParallelClusterImage-*'
+          - Sid: S3Objects
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*/*'
+          - Sid: ImageBuilderGetImage
+            Effect: Allow
+            Action:
+              - imagebuilder:GetImage
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:*:image/*'
+  PClusterBuildImageWithIamManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy to execute pcluster build-image command with IAM permission
+      # Groups:
+      #   - String
+      # ManagedPolicyName:
+      Path: /parallelcluster/
+      # Roles:
+      # Users:
+      #   - String
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EC2
+            Effect: Allow
+            Action:
+              - ec2:DescribeImages
+              - ec2:DescribeInstanceTypeOfferings
+              - ec2:DescribeInstanceTypes
+            Resource: '*'
+          - Sid: IAM
+            Effect: Allow
+            Action:
+              - iam:CreateInstanceProfile
+              - iam:TagRole
+              - iam:AddRoleToInstanceProfile"
+              - iam:GetRole
+              - iam:GetRolePolicy
+              - iam:GetInstanceProfile
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+          - Sid: IAMPutRolePolicy
+            Effect: Allow
+            Action:
+              - iam:PutRolePolicy
+              - iam:CreateRole
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+            Condition:
+              StringEquals:
+                iam:PermissionsBoundary:
+                  - arn-boundary
+          - Sid: IAMPassRole
+            Effect: Allow
+            Action:
+              - iam:PassRole
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+            Condition:
+              StringEquals:
+                iam:PassedToService:
+                  - lambda.amazonaws.com
+                  - !Sub 'ec2.${AWS::URLSuffix}'
+          - Sid: IAMAttachRolePolicy
+            Effect: Allow
+            Action:
+              - iam:AttachRolePolicy
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+            Condition:
+              ArnEquals:
+                iam:PolicyARN:
+                  - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+                  - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+                  - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+          - Sid: CloudWatch
+            Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*'
+          - Sid: CloudFormation
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+              - cloudformation:CreateStack
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*'
+          - Sid: Lambda
+            Effect: Allow
+            Action:
+              - lambda:CreateFunction
+              - lambda:GetFunction
+              - lambda:AddPermission
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterImage-*'
+          - Sid: ImageBuilder
+            Effect: Allow
+            Action:
+              - imagebuilder:CreateImage
+              - imagebuilder:TagResource
+              - imagebuilder:GetImage
+              - imagebuilder:GetImageRecipe
+              - imagebuilder:CreateImageRecipe
+              - imagebuilder:GetComponent
+              - imagebuilder:CreateComponent
+              - imagebuilder:GetInfrastructureConfiguration
+              - imagebuilder:CreateDistributionConfiguration
+              - imagebuilder:GetDistributionConfiguration
+              - imagebuilder:CreateInfrastructureConfiguration
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image-recipe/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:component/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:infrastructure-configuration/parallelclusterimage-*'
+          - Sid: S3Bucket
+            Effect: Allow
+            Action:
+              - s3:CreateBucket
+              - s3:ListBucket
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*'
+          - Sid: SNS
+            Effect: Allow
+            Action:
+              - sns:GetTopicAttributes
+              - sns:TagResource
+              - sns:CreateTopic
+              - sns:Subscribe
+              - sns:Publish
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:ParallelClusterImage-*'
+          - Sid: S3Objects
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*/*'
+          - Sid: ImageBuilderGetImage
+            Effect: Allow
+            Action:
+              - imagebuilder:GetImage
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:*:image/*'
+  PClusterDeleteImageManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy to execute pcluster delete-image command without IAM permission
+      # Groups:
+      #   - String
+      # ManagedPolicyName:
+      Path: /parallelcluster/
+      # Roles:
+      # Users:
+      #   - String
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EC2
+            Effect: Allow
+            Action:
+              - ec2:DeregisterImage
+              - ec2:DescribeImages
+              - ec2:DeleteSnapshot
+            Resource: '*'
+          - Sid: IAM
+            Effect: Allow
+            Action:
+              - iam:RemoveRoleFromInstanceProfile
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+          - Sid: ImageBuilder
+            Effect: Allow
+            Action:
+              - imagebuilder:DeleteImage
+              - imagebuilder:DeleteComponent
+              - imagebuilder:DeleteImageRecipe
+              - imagebuilder:DeleteInfrastructureConfiguration
+              - imagebuilder:DeleteDistributionConfiguration
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image-recipe/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:component/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:infrastructure-configuration/parallelclusterimage-*'
+          - Sid: CloudFormation
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+              - cloudformation:DeleteStack
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*'
+          - Sid: Lambda
+            Effect: Allow
+            Action:
+              - lambda:RemovePermission
+              - lambda:DeleteFunction
+              - lambda:AddPermission
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterImage-*'
+          - Sid: SNS
+            Effect: Allow
+            Action:
+              - SNS:DeleteTopic
+              - SNS:Unsubscribe
+              - SNS:GetTopicAttributes
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:ParallelClusterImage-*'
+          - Sid: S3Bucket
+            Effect: Allow
+            Action:
+              - s3:ListBucket
+              - s3:ListBucketVersions
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*'
+          - Sid: S3Objects
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+              - s3:GetObjectVersion
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*/*'
+          - Sid: CloudWatch
+            Effect: Allow
+            Action:
+              - logs:DeleteLogGroup
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/imagebuilder/ParallelClusterImage-*'
+              - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*'
+  PClusterDeleteImageWithIamManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy to execute pcluster delete-image command with IAM permission
+      # Groups:
+      #   - String
+      # ManagedPolicyName:
+      Path: /parallelcluster/
+      # Roles:
+      # Users:
+      #   - String
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EC2
+            Effect: Allow
+            Action:
+              - ec2:DeregisterImage
+              - ec2:DescribeImages
+              - ec2:DeleteSnapshot
+            Resource: '*'
+          - Sid: IAM
+            Effect: Allow
+            Action:
+              - iam:DeleteInstanceProfile
+              - iam:RemoveRoleFromInstanceProfile
+              - iam:DeleteRole
+              - iam:DetachRolePolicy
+              - iam:DeleteRolePolicy
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+          - Sid: ImageBuilder
+            Effect: Allow
+            Action:
+              - imagebuilder:DeleteImage
+              - imagebuilder:DeleteComponent
+              - imagebuilder:DeleteImageRecipe
+              - imagebuilder:DeleteInfrastructureConfiguration
+              - imagebuilder:DeleteDistributionConfiguration
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image-recipe/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:component/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:infrastructure-configuration/parallelclusterimage-*'
+          - Sid: CloudFormation
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+              - cloudformation:DeleteStack
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*'
+          - Sid: Lambda
+            Effect: Allow
+            Action:
+              - lambda:RemovePermission
+              - lambda:DeleteFunction
+              - lambda:AddPermission
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterImage-*'
+          - Sid: SNS
+            Effect: Allow
+            Action:
+              - SNS:DeleteTopic
+              - SNS:Unsubscribe
+              - SNS:GetTopicAttributes
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:ParallelClusterImage-*'
+          - Sid: S3Bucket
+            Effect: Allow
+            Action:
+              - s3:ListBucket
+              - s3:ListBucketVersions
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*'
+          - Sid: S3Objects
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+              - s3:GetObjectVersion
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*/*'
+          - Sid: CloudWatch
+            Effect: Allow
+            Action:
+              - logs:DeleteLogGroup
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/imagebuilder/ParallelClusterImage-*'
+              - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*'
+  PClusterListImagesManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy to execute pcluster list-images command
+      # Groups:
+      #   - String
+      # ManagedPolicyName:
+      Path: /parallelcluster/
+      # Roles:
+      # Users:
+      #   - String
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EC2
+            Effect: Allow
+            Action:
+              - ec2:DescribeImages
+            Resource: '*'
+          - Sid: CloudFormation
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+            Resource:
+              - '*'
+  PClusterDescribeImageManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy to execute pcluster describe-image command
+      # Groups:
+      #   - String
+      # ManagedPolicyName:
+      Path: /parallelcluster/
+      # Roles:
+      # Users:
+      #   - String
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EC2
+            Effect: Allow
+            Action:
+              - ec2:DescribeImages
+            Resource: '*'
+          - Sid: CloudFormation
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*'
+  PClusterImageCommandsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              AWS:
+                - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
+      Description: Role to execute pcluster image commands (build/delete/list/describe) without IAM permission
+      ManagedPolicyArns:
+        - !Ref PClusterBuildImageManagedPolicy
+        - !Ref PClusterDeleteImageManagedPolicy
+        - !Ref PClusterListImagesManagedPolicy
+        - !Ref PClusterDescribeImageManagedPolicy
+      # MaxSessionDuration: Integer
+      Path: /parallelcluster/
+      # PermissionsBoundary: String
+      RoleName: pcluster-image-commands
+      # Tags:
+      #   - Tag
+      # Policies:
+  PClusterImageCommandsRoleWithIam:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              AWS:
+                - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
+      Description: Role to execute pcluster image commands (build/delete/list/describe) with IAM permission
+      ManagedPolicyArns:
+        - !Ref PClusterBuildImageWithIamManagedPolicy
+        - !Ref PClusterDeleteImageWithIamManagedPolicy
+        - !Ref PClusterListImagesManagedPolicy
+        - !Ref PClusterDescribeImageManagedPolicy
+      # MaxSessionDuration: Integer
+      Path: /parallelcluster/
+      # PermissionsBoundary: String
+      RoleName: pcluster-image-commands-with-iam
+      # Tags:
+      #   - Tag
+      # Policies:
+  PClusterBuildImageLambdaCleanupRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Description: Role to be attached to the PCluster lambda cleanup function for building image
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      # MaxSessionDuration: Integer
+      Path: /parallelcluster/
+      # PermissionsBoundary: String
+      RoleName: PClusterBuildImageLambdaCleanupRole
+      # Tags:
+      #   - Tag
+      Policies:
+        - PolicyName: LambdaCleanupPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                  - iam:DetachRolePolicy
+                  - iam:DeleteRole
+                  - iam:DeleteRolePolicy
+                Resource: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+                Effect: Allow
+              - Action:
+                  - iam:DeleteInstanceProfile
+                  - iam:RemoveRoleFromInstanceProfile
+                Resource: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+                Effect: Allow
+              - Action: imagebuilder:DeleteInfrastructureConfiguration
+                Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:infrastructure-configuration/parallelclusterimage-*'
+                Effect: Allow
+              - Action:
+                  - imagebuilder:DeleteComponent
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:component/parallelclusterimage-*/*'
+                Effect: Allow
+              - Action: imagebuilder:DeleteImageRecipe
+                Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image-recipe/parallelclusterimage-*/*'
+                Effect: Allow
+              - Action: imagebuilder:DeleteDistributionConfiguration
+                Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
+                Effect: Allow
+              - Action: imagebuilder:DeleteImage
+                Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/parallelclusterimage-*/*'
+                Effect: Allow
+              - Action: cloudformation:DeleteStack
+                Resource: !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*/*'
+                Effect: Allow
+              - Action: ec2:CreateTags
+                Resource: !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}::image/*'
+                Effect: Allow
+              - Action: tag:TagResources
+                Resource: '*'
+                Effect: Allow
+              - Action:
+                  - lambda:DeleteFunction
+                  - lambda:RemovePermission
+                Resource: !Sub 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterImage-*'
+                Effect: Allow
+              - Action: logs:DeleteLogGroup
+                Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*:*'
+                Effect: Allow
+              - Action:
+                  - SNS:GetTopicAttributes
+                  - SNS:DeleteTopic
+                  - SNS:GetSubscriptionAttributes
+                  - SNS:Unsubscribe
+                Resource: !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:ParallelClusterImage-*'
+                Effect: Allow
+  PClusterBuildImageInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /parallelcluster/
+      Roles:
+        - !Ref PClusterBuildImageInstanceRole
+  PClusterBuildImageInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - !Sub 'ec2.${AWS::URLSuffix}'
+            Action:
+              - 'sts:AssumeRole'
+      Description: Role to be attached to the PCluster building image
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+      # MaxSessionDuration: Integer
+      Path: /parallelcluster/
+      # PermissionsBoundary: String
+      RoleName: PClusterBuildImageInstanceRole
+      # Tags:
+      #   - Tag
+      Policies:
+        - PolicyName: InstanceRoleInlinePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                  - ec2:CreateTags
+                  - ec2:ModifyImageAttribute
+                Resource: !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}::image/*'
+                Effect: Allow


### PR DESCRIPTION
This is a Cfn stack helper to create roles to be used for the image commands (build/delete/list/describe):
* pcluster-image-commands: role to execute pcluster image commands (build/delete/list/describe) without IAM permission
* pcluster-image-commands-with-iam: role to execute pcluster image commands (build/delete/list/describe) with IAM permission
* PClusterBuildImageLambdaCleanupRole: lambda role to be passed to configuration property Build/Iam/CleanupLambdaRole
* PClusterBuildImageInstanceRole - instance role to be passed to configuration property Build/Iam/InstanceRole. An instance profile will be autogenerated
  * or alternatively PClusterBuildImageInstanceProfile - instance profile to be passed to configuration property Build/Iam/InstanceProfile
  
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
