### PR TITLE
[API] Align timestamp formats.

### DIFF
--- a/cli/src/pcluster/api/controllers/cluster_compute_fleet_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_compute_fleet_controller.py
@@ -18,6 +18,7 @@ from pcluster.api.models import (
 )
 from pcluster.aws.common import StackNotFoundError
 from pcluster.models.cluster import Cluster
+from pcluster.utils import to_iso_time
 
 
 @configure_aws_region()
@@ -41,7 +42,7 @@ def describe_compute_fleet(cluster_name, region=None):
             )
         status, last_status_updated_time = cluster.compute_fleet_status_with_last_updated_time
         return DescribeComputeFleetResponseContent(
-            last_status_updated_time=last_status_updated_time, status=status.value
+            last_status_updated_time=to_iso_time(last_status_updated_time), status=status.value
         )
     except StackNotFoundError:
         raise NotFoundException(
@@ -96,6 +97,7 @@ def update_compute_fleet(update_compute_fleet_request_content, cluster_name, reg
                         " `ENABLED` or `DISABLED` for AWS Batch clusters."
                     )
         status, last_status_updated_time = cluster.compute_fleet_status_with_last_updated_time
+        last_status_updated_time = to_iso_time(last_status_updated_time)
         return UpdateComputeFleetResponseContent(last_status_updated_time=last_status_updated_time, status=status.value)
     except StackNotFoundError:
         raise NotFoundException(

--- a/cli/src/pcluster/api/controllers/cluster_instances_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_instances_controller.py
@@ -18,6 +18,7 @@ from pcluster.api.models import ClusterInstance, DescribeClusterInstancesRespons
 from pcluster.api.models import NodeType as ApiNodeType
 from pcluster.aws.common import StackNotFoundError
 from pcluster.models.cluster import Cluster, NodeType
+from pcluster.utils import to_iso_time
 
 # pylint: disable=W0613
 
@@ -84,7 +85,7 @@ def describe_cluster_instances(cluster_name, region=None, next_token=None, node_
         ec2_instances.append(
             ClusterInstance(
                 instance_id=instance.id,
-                launch_time=instance.launch_time,
+                launch_time=to_iso_time(instance.launch_time),
                 public_ip_address=instance.public_ip,
                 instance_type=instance.instance_type,
                 state=instance.state,

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -60,7 +60,7 @@ from pcluster.models.cluster import (
     NotFoundClusterActionError,
 )
 from pcluster.models.cluster_resources import ClusterStack
-from pcluster.utils import get_installed_version
+from pcluster.utils import get_installed_version, to_iso_time
 from pcluster.validators.common import FailureLevel
 
 LOGGER = logging.getLogger(__name__)
@@ -214,7 +214,7 @@ def describe_cluster(cluster_name, region=None):
         LOGGER.error(e)
 
     response = DescribeClusterResponseContent(
-        creation_time=cfn_stack.creation_time,
+        creation_time=to_iso_time(cfn_stack.creation_time),
         version=cfn_stack.version,
         cluster_configuration=ClusterConfigurationStructure(url=config_url),
         tags=[Tag(value=tag.get("Value"), key=tag.get("Key")) for tag in cfn_stack.tags],
@@ -222,7 +222,7 @@ def describe_cluster(cluster_name, region=None):
         cluster_name=cluster_name,
         compute_fleet_status=fleet_status.value,
         cloudformation_stack_arn=cfn_stack.id,
-        last_updated_time=cfn_stack.last_updated_time,
+        last_updated_time=to_iso_time(cfn_stack.last_updated_time),
         region=os.environ.get("AWS_DEFAULT_REGION"),
         cluster_status=cloud_formation_status_to_cluster_status(cfn_stack.status),
     )
@@ -231,7 +231,7 @@ def describe_cluster(cluster_name, region=None):
         head_node = cluster.head_node_instance
         response.headnode = EC2Instance(
             instance_id=head_node.id,
-            launch_time=head_node.launch_time,
+            launch_time=to_iso_time(head_node.launch_time),
             public_ip_address=head_node.public_ip,
             instance_type=head_node.instance_type,
             state=InstanceState.from_dict(head_node.state),

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -49,7 +49,7 @@ from pcluster.aws.ec2 import Ec2Client
 from pcluster.constants import SUPPORTED_ARCHITECTURES, SUPPORTED_OSES
 from pcluster.models.imagebuilder import BadRequestImageBuilderActionError, ImageBuilder, NonExistingImageError
 from pcluster.models.imagebuilder_resources import ImageBuilderStack, NonExistingStackError
-from pcluster.utils import get_installed_version
+from pcluster.utils import get_installed_version, to_iso_time
 from pcluster.validators.common import FailureLevel
 
 LOGGER = logging.getLogger(__name__)
@@ -205,7 +205,7 @@ def describe_image(image_id, region=None):
 
 def _image_to_describe_image_response(imagebuilder):
     return DescribeImageResponseContent(
-        creation_time=imagebuilder.image.creation_date,
+        creation_time=to_iso_time(imagebuilder.image.creation_date),
         image_configuration=ImageConfigurationStructure(url=imagebuilder.config_url),
         image_id=imagebuilder.image_id,
         image_build_status=ImageBuildStatus.BUILD_COMPLETE,
@@ -234,7 +234,7 @@ def _stack_to_describe_image_response(imagebuilder):
         cloudformation_stack_status=imagebuilder.stack.status,
         cloudformation_stack_status_reason=imagebuilder.stack.status_reason,
         cloudformation_stack_arn=imagebuilder.stack.id,
-        cloudformation_stack_creation_time=imagebuilder.stack.creation_time,
+        cloudformation_stack_creation_time=to_iso_time(imagebuilder.stack.creation_time),
         cloudformation_stack_tags=imagebuilder.stack.tags,
         region=os_lib.environ.get("AWS_DEFAULT_REGION"),
         version=imagebuilder.stack.version,

--- a/cli/src/pcluster/api/pcluster_api.py
+++ b/cli/src/pcluster/api/pcluster_api.py
@@ -30,7 +30,7 @@ from pcluster.models.cluster_resources import ClusterInstance
 from pcluster.models.compute_fleet_status_manager import ComputeFleetStatus
 from pcluster.models.imagebuilder import ImageBuilder, ImageBuilderActionError, NonExistingImageError
 from pcluster.models.imagebuilder_resources import ImageBuilderStack, NonExistingStackError
-from pcluster.utils import get_installed_version
+from pcluster.utils import get_installed_version, to_iso_time
 from pcluster.validators.common import FailureLevel
 
 LOGGER = logging.getLogger(__name__)
@@ -69,7 +69,7 @@ class ClusterInstanceInfo:
     """Minimal representation of an instance of a cluster."""
 
     def __init__(self, instance: ClusterInstance):
-        self.launch_time = instance.launch_time
+        self.launch_time = to_iso_time(instance.launch_time)
         self.instance_id = instance.id
         self.public_ip_address = instance.public_ip
         self.private_ip_address = instance.private_ip
@@ -105,7 +105,7 @@ class ImageBuilderStackInfo(ImageBuilderInfo):
         self.stack_arn = imagebuilder.stack.id
         self.tags = imagebuilder.stack.tags
         self.version = imagebuilder.stack.version
-        self.creation_time = imagebuilder.stack.creation_time
+        self.creation_time = to_iso_time(imagebuilder.stack.creation_time)
         self.build_log = imagebuilder.stack.build_log
 
         # build image process status by stack status mapping
@@ -128,7 +128,7 @@ class ImageBuilderImageInfo(ImageBuilderInfo):
         self.image_architecture = imagebuilder.image.architecture
         self.image_tags = imagebuilder.image.tags
         self.imagebuild_status = "BUILD_COMPLETE"
-        self.creation_time = imagebuilder.image.creation_date
+        self.creation_time = to_iso_time(imagebuilder.image.creation_date)
         self.build_log = imagebuilder.image.build_log
         self.version = imagebuilder.image.version
 

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -8,6 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
 import itertools
 import json
 import logging
@@ -19,12 +20,12 @@ import sys
 import time
 import urllib.request
 import zipfile
-from datetime import datetime
 from io import BytesIO
 from shlex import quote
 from typing import NoReturn
 from urllib.parse import urlparse
 
+import dateutil.parser
 import pkg_resources
 import yaml
 from dateutil import tz
@@ -121,6 +122,25 @@ def camelcase(snake_case_word):
     """Convert the given snake case word into a camel case one."""
     parts = iter(snake_case_word.split("_"))
     return "".join(word.title() for word in parts)
+
+
+def to_iso_time(time_in):
+    """
+    Convert a given string or datetime into ISO 8601 format with milliseconds.
+
+    :param time_in: Time in a format that may be parsed
+    :return time in ISO 8601 UTC format with ms (e.g. 2021-07-15T01:22:02.655Z)
+    """
+    if time_in:
+        if isinstance(time_in, str):
+            time_ = dateutil.parser.parse(time_in)
+        elif isinstance(time_in, datetime.date):
+            time_ = time_in.replace(tzinfo=datetime.timezone.utc)
+        else:
+            raise TypeError("to_iso_time object must be 'str' or 'datetime'.")
+        return time_.isoformat(timespec="milliseconds")[:-6] + "Z"
+    else:
+        return time_in
 
 
 def to_kebab_case(input):
@@ -298,7 +318,8 @@ def timestamp_to_isoformat(timestamp, timezone=None):
     if not timezone:
         timezone = tz.tzlocal()
     # Forcing microsecond to 0 to avoid having them displayed.
-    return datetime.fromtimestamp(timestamp / 1000, tz=timezone).isoformat(timespec="seconds")
+    time_ = datetime.datetime.fromtimestamp(timestamp / 1000, tz=timezone)
+    return time_.isoformat(timespec="seconds")
 
 
 def isoformat_to_epoch(time_isoformat):

--- a/cli/tests/pcluster/api/controllers/test_cluster_compute_fleet_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_compute_fleet_controller.py
@@ -12,6 +12,7 @@ import pytest
 from assertpy import assert_that, soft_assertions
 
 from pcluster.aws.common import AWSClientError, StackNotFoundError
+from pcluster.utils import to_iso_time
 
 
 def cfn_describe_stack_mock_response(scheduler, stack_status="CREATE_COMPLETE"):
@@ -86,7 +87,7 @@ class TestUpdateComputeFleetStatus:
             assert_that(response.status_code).is_equal_to(200)
             expected_response = {"status": status}
             if last_status_updated_time:
-                expected_response["lastStatusUpdatedTime"] = last_status_updated_time
+                expected_response["lastStatusUpdatedTime"] = to_iso_time(last_status_updated_time)
             assert_that(response.get_json()).is_equal_to(expected_response)
 
     @pytest.mark.parametrize(
@@ -300,7 +301,7 @@ class TestDescribeComputeFleet:
             assert_that(response.status_code).is_equal_to(200)
             expected_response = {"status": status}
             if last_status_updated_time:
-                expected_response["lastStatusUpdatedTime"] = last_status_updated_time
+                expected_response["lastStatusUpdatedTime"] = to_iso_time(last_status_updated_time)
             assert_that(response.get_json()).is_equal_to(expected_response)
 
     def test_slurm_dynamo_table_not_exist(self, mocker, client):

--- a/cli/tests/pcluster/api/controllers/test_cluster_instances_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_instances_controller.py
@@ -10,6 +10,7 @@ from assertpy import assert_that, soft_assertions
 
 from pcluster.api.models import NodeType
 from pcluster.aws.common import StackNotFoundError
+from pcluster.utils import to_iso_time
 
 
 def cfn_describe_instances_mock_response(
@@ -44,7 +45,7 @@ def describe_cluster_instances_mock_response(instances):
         response = {
             "instanceId": "i-0a9342a0000000000",
             "instanceType": "t2.micro",
-            "launchTime": "2021-04-30T00:00:00+00:00",
+            "launchTime": to_iso_time("2021-04-30T00:00:00+00:00"),
             "nodeType": node_type,
             "privateIpAddress": "10.0.0.79",
             "publicIpAddress": "1.2.3.4",

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -26,6 +26,7 @@ from pcluster.models.cluster import (
     LimitExceededClusterActionError,
 )
 from pcluster.models.compute_fleet_status_manager import ComputeFleetStatus
+from pcluster.utils import to_iso_time
 from pcluster.validators.common import FailureLevel, ValidationResult
 
 
@@ -588,8 +589,8 @@ class TestDescribeCluster:
                     "clusterName": "clustername",
                     "clusterStatus": "CREATE_COMPLETE",
                     "computeFleetStatus": "RUNNING",
-                    "creationTime": "2021-04-30 00:00:00",
-                    "lastUpdatedTime": "2021-04-30 00:00:00",
+                    "creationTime": to_iso_time("2021-04-30 00:00:00"),
+                    "lastUpdatedTime": to_iso_time("2021-04-30 00:00:00"),
                     "region": "us-east-1",
                     "tags": [
                         {"key": "parallelcluster:version", "value": "3.0.0"},
@@ -603,7 +604,7 @@ class TestDescribeCluster:
                     "headnode": {
                         "instanceId": "i-020c2ec1b6d550000",
                         "instanceType": "t2.micro",
-                        "launchTime": "2021-05-10T13:55:48Z",
+                        "launchTime": to_iso_time("2021-05-10T13:55:48Z"),
                         "privateIpAddress": "192.168.61.109",
                         "publicIpAddress": "34.251.236.164",
                         "state": "running",
@@ -621,8 +622,8 @@ class TestDescribeCluster:
                     "clusterName": "clustername",
                     "clusterStatus": "CREATE_COMPLETE",
                     "computeFleetStatus": "RUNNING",
-                    "creationTime": "2021-04-30 00:00:00",
-                    "lastUpdatedTime": "2021-04-30 00:00:00",
+                    "creationTime": to_iso_time("2021-04-30 00:00:00"),
+                    "lastUpdatedTime": to_iso_time("2021-04-30 00:00:00"),
                     "region": "us-east-1",
                     "tags": [
                         {"key": "parallelcluster:version", "value": "3.0.0"},
@@ -646,8 +647,8 @@ class TestDescribeCluster:
                     "clusterName": "clustername",
                     "clusterStatus": "CREATE_COMPLETE",
                     "computeFleetStatus": "RUNNING",
-                    "creationTime": "2021-04-30 00:00:00",
-                    "lastUpdatedTime": "2021-04-30 00:00:00",
+                    "creationTime": to_iso_time("2021-04-30 00:00:00"),
+                    "lastUpdatedTime": to_iso_time("2021-04-30 00:00:00"),
                     "region": "us-east-1",
                     "tags": [
                         {"key": "parallelcluster:version", "value": "3.0.0"},
@@ -673,8 +674,8 @@ class TestDescribeCluster:
                     "clusterName": "clustername",
                     "clusterStatus": "CREATE_FAILED",
                     "computeFleetStatus": "RUNNING",
-                    "creationTime": "2021-04-30 00:00:00",
-                    "lastUpdatedTime": "2021-05-30 00:00:00",
+                    "creationTime": to_iso_time("2021-04-30 00:00:00"),
+                    "lastUpdatedTime": to_iso_time("2021-05-30 00:00:00"),
                     "region": "us-east-1",
                     "tags": [
                         {"key": "parallelcluster:version", "value": "3.0.0"},
@@ -704,8 +705,8 @@ class TestDescribeCluster:
                     "clusterName": "clustername",
                     "clusterStatus": "CREATE_COMPLETE",
                     "computeFleetStatus": "RUNNING",
-                    "creationTime": "2021-04-30 00:00:00",
-                    "lastUpdatedTime": "2021-04-30 00:00:00",
+                    "creationTime": to_iso_time("2021-04-30 00:00:00"),
+                    "lastUpdatedTime": to_iso_time("2021-04-30 00:00:00"),
                     "region": "us-east-1",
                     "tags": [
                         {"key": "parallelcluster:version", "value": "3.0.0"},
@@ -719,7 +720,7 @@ class TestDescribeCluster:
                     "headnode": {
                         "instanceId": "i-020c2ec1b6d550000",
                         "instanceType": "t2.micro",
-                        "launchTime": "2021-05-10T13:55:48Z",
+                        "launchTime": to_iso_time("2021-05-10T13:55:48Z"),
                         "privateIpAddress": "192.168.61.109",
                         "state": "running",
                     },

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -36,7 +36,7 @@ from pcluster.models.imagebuilder import (
     LimitExceededImageError,
 )
 from pcluster.models.imagebuilder_resources import BadRequestStackError, LimitExceededStackError
-from pcluster.utils import get_installed_version
+from pcluster.utils import get_installed_version, to_iso_time
 from pcluster.validators.common import FailureLevel, ValidationResult
 
 
@@ -747,7 +747,7 @@ class TestDescribeImage:
         )
 
         expected_response = {
-            "creationTime": "2021-04-12T00:00:00Z",
+            "creationTime": to_iso_time("2021-04-12T00:00:00Z"),
             "ec2AmiInfo": {
                 "amiId": "image1",
                 "amiName": "image1",
@@ -790,7 +790,7 @@ class TestDescribeImage:
             "cloudformationStackStatus": CloudFormationStackStatus.CREATE_IN_PROGRESS,
             "cloudformationStackArn": "arn:image1",
             "imageBuildLogsArn": "arn:image1:build_log",
-            "cloudformationStackCreationTime": "2021-04-12 00:00:00",
+            "cloudformationStackCreationTime": to_iso_time("2021-04-12 00:00:00"),
             "cloudformationStackTags": [
                 {"Key": "parallelcluster:image_id", "Value": "image1"},
                 {"Key": "parallelcluster:version", "Value": "3.0.0"},
@@ -828,7 +828,7 @@ class TestDescribeImage:
         expected_response = {
             "cloudformationStackArn": "arn:image1",
             "imageBuildLogsArn": "arn:image1:build_log",
-            "cloudformationStackCreationTime": "2021-04-12 00:00:00",
+            "cloudformationStackCreationTime": to_iso_time("2021-04-12 00:00:00"),
             "cloudformationStackTags": [
                 {"Key": "parallelcluster:image_id", "Value": "image1"},
                 {"Key": "parallelcluster:version", "Value": "3.0.0"},


### PR DESCRIPTION
**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*
PCLUSTER-3680

*Description of changes:*
Make all api responses return timestamp in ISO 8601 format with milliseconds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
