### PR TITLE
Fix build image deletion role

### DIFF
--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -650,7 +650,7 @@ class ImageBuilderCdkStack(Stack):
                         resource="role",
                         region="",
                         resource_name="{0}/{1}".format(
-                            IMAGEBUILDER_RESOURCE_NAME_PREFIX,
+                            IAM_ROLE_PATH.strip("/"),
                             self._build_resource_name(IMAGEBUILDER_RESOURCE_NAME_PREFIX + "Cleanup"),
                         ),
                     )
@@ -694,7 +694,7 @@ class ImageBuilderCdkStack(Stack):
                         resource="instance-profile",
                         region="",
                         resource_name="{0}/{1}".format(
-                            IMAGEBUILDER_RESOURCE_NAME_PREFIX,
+                            IAM_ROLE_PATH.strip("/"),
                             self._build_resource_name(IMAGEBUILDER_RESOURCE_NAME_PREFIX),
                         ),
                     )
@@ -710,7 +710,7 @@ class ImageBuilderCdkStack(Stack):
                         resource="role",
                         region="",
                         resource_name="{0}/{1}".format(
-                            IMAGEBUILDER_RESOURCE_NAME_PREFIX,
+                            IAM_ROLE_PATH.strip("/"),
                             self._build_resource_name(IMAGEBUILDER_RESOURCE_NAME_PREFIX),
                         ),
                     )
@@ -888,7 +888,7 @@ class ImageBuilderCdkStack(Stack):
                         region="",
                         resource="role",
                         resource_name="{0}/{1}".format(
-                            IMAGEBUILDER_RESOURCE_NAME_PREFIX,
+                            IAM_ROLE_PATH.strip("/"),
                             self._build_resource_name(IMAGEBUILDER_RESOURCE_NAME_PREFIX),
                         ),
                     )
@@ -917,7 +917,7 @@ class ImageBuilderCdkStack(Stack):
                         region="",
                         resource="instance-profile",
                         resource_name="{0}/{1}".format(
-                            IMAGEBUILDER_RESOURCE_NAME_PREFIX,
+                            IAM_ROLE_PATH.strip("/"),
                             self._build_resource_name(IMAGEBUILDER_RESOURCE_NAME_PREFIX),
                         ),
                     )

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -1103,7 +1103,7 @@ def test_imagebuilder_instance_role(
                                                     {"Ref": "AWS::Partition"},
                                                     ":iam::",
                                                     {"Ref": "AWS::AccountId"},
-                                                    ":role/ParallelClusterImage/ParallelClusterImage-",
+                                                    ":role/parallelcluster/ParallelClusterImage-",
                                                     {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
                                                 ],
                                             ]
@@ -1120,7 +1120,7 @@ def test_imagebuilder_instance_role(
                                                     {"Ref": "AWS::Partition"},
                                                     ":iam::",
                                                     {"Ref": "AWS::AccountId"},
-                                                    ":instance-profile/ParallelClusterImage/ParallelClusterImage-",
+                                                    ":instance-profile/parallelcluster/ParallelClusterImage-",
                                                     {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
                                                 ],
                                             ]
@@ -1391,7 +1391,7 @@ def test_imagebuilder_instance_role(
                                                     {"Ref": "AWS::Partition"},
                                                     ":iam::",
                                                     {"Ref": "AWS::AccountId"},
-                                                    ":role/ParallelClusterImage/" "ParallelClusterImageCleanup-",
+                                                    ":role/parallelcluster/" "ParallelClusterImageCleanup-",
                                                     {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
                                                 ],
                                             ]
@@ -1447,7 +1447,7 @@ def test_imagebuilder_instance_role(
                                                     {"Ref": "AWS::Partition"},
                                                     ":iam::",
                                                     {"Ref": "AWS::AccountId"},
-                                                    ":instance-profile/ParallelClusterImage/ParallelClusterImage-",
+                                                    ":instance-profile/parallelcluster/ParallelClusterImage-",
                                                     {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
                                                 ],
                                             ]
@@ -1464,7 +1464,7 @@ def test_imagebuilder_instance_role(
                                                     {"Ref": "AWS::Partition"},
                                                     ":iam::",
                                                     {"Ref": "AWS::AccountId"},
-                                                    ":role/ParallelClusterImage/ParallelClusterImage-",
+                                                    ":role/parallelcluster/ParallelClusterImage-",
                                                     {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
                                                 ],
                                             ]


### PR DESCRIPTION
The path of roles and instance profile was changed to "/parallelcluster/"

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
