### PR TITLE
3.0: Add ROLLBACK_FAILED to failure states

### DIFF
--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -333,6 +333,9 @@ def _image_status_to_cloudformation_status(image_status):
         ImageStatusFilteringOption.FAILED: {
             CloudFormationStackStatus.CREATE_FAILED,
             CloudFormationStackStatus.DELETE_FAILED,
+            CloudFormationStackStatus.ROLLBACK_FAILED,
+            CloudFormationStackStatus.ROLLBACK_COMPLETE,
+            CloudFormationStackStatus.ROLLBACK_IN_PROGRESS,
         },
     }
     return mapping.get(image_status, set())

--- a/cli/src/pcluster/api/converters.py
+++ b/cli/src/pcluster/api/converters.py
@@ -33,7 +33,7 @@ def cloud_formation_status_to_image_status(cfn_status):
         CloudFormationStackStatus.CREATE_IN_PROGRESS: ImageBuildStatus.BUILD_IN_PROGRESS,
         CloudFormationStackStatus.CREATE_FAILED: ImageBuildStatus.BUILD_FAILED,
         CloudFormationStackStatus.CREATE_COMPLETE: ImageBuildStatus.BUILD_COMPLETE,
-        CloudFormationStackStatus.ROLLBACK_IN_PROGRESS: ImageBuildStatus.BUILD_IN_PROGRESS,
+        CloudFormationStackStatus.ROLLBACK_IN_PROGRESS: ImageBuildStatus.BUILD_FAILED,
         CloudFormationStackStatus.ROLLBACK_FAILED: ImageBuildStatus.BUILD_FAILED,
         CloudFormationStackStatus.ROLLBACK_COMPLETE: ImageBuildStatus.BUILD_FAILED,
         CloudFormationStackStatus.DELETE_IN_PROGRESS: ImageBuildStatus.DELETE_IN_PROGRESS,

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -75,7 +75,6 @@ from pcluster.validators.common import FailureLevel
 ImageBuilderStatusMapping = {
     "BUILD_IN_PROGRESS": [
         "CREATE_IN_PROGRESS",
-        "ROLLBACK_IN_PROGRESS",
         "UPDATE_IN_PROGRESS",
         "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
         "UPDATE_ROLLBACK_IN_PROGRESS",
@@ -85,6 +84,7 @@ ImageBuilderStatusMapping = {
         "IMPORT_ROLLBACK_IN_PROGRESS",
     ],
     "BUILD_FAILED": [
+        "ROLLBACK_IN_PROGRESS",
         "CREATE_FAILED",
         "ROLLBACK_FAILED",
         "ROLLBACK_COMPLETE",

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -168,6 +168,9 @@ class TestListImages:
             _create_stack("image4", CloudFormationStackStatus.DELETE_IN_PROGRESS),
             _create_stack("image5", CloudFormationStackStatus.DELETE_FAILED),
             _create_stack("image6", CloudFormationStackStatus.CREATE_FAILED),
+            _create_stack("image7", CloudFormationStackStatus.ROLLBACK_FAILED),
+            _create_stack("image8", CloudFormationStackStatus.ROLLBACK_COMPLETE),
+            _create_stack("image9", CloudFormationStackStatus.ROLLBACK_IN_PROGRESS),
         ]
         mocker.patch("pcluster.aws.cfn.CfnClient.get_imagebuilder_stacks", return_value=(describe_result, "nextPage"))
 
@@ -188,6 +191,30 @@ class TestListImages:
                     "imageBuildStatus": ImageBuildStatus.BUILD_FAILED,
                     "cloudformationStackStatus": CloudFormationStackStatus.CREATE_FAILED,
                     "cloudformationStackArn": "arn:image6",
+                    "region": "us-east-1",
+                    "version": "3.0.0",
+                },
+                {
+                    "imageId": "image7",
+                    "imageBuildStatus": ImageBuildStatus.BUILD_FAILED,
+                    "cloudformationStackStatus": CloudFormationStackStatus.ROLLBACK_FAILED,
+                    "cloudformationStackArn": "arn:image7",
+                    "region": "us-east-1",
+                    "version": "3.0.0",
+                },
+                {
+                    "imageId": "image8",
+                    "imageBuildStatus": ImageBuildStatus.BUILD_FAILED,
+                    "cloudformationStackStatus": CloudFormationStackStatus.ROLLBACK_COMPLETE,
+                    "cloudformationStackArn": "arn:image8",
+                    "region": "us-east-1",
+                    "version": "3.0.0",
+                },
+                {
+                    "imageId": "image9",
+                    "imageBuildStatus": ImageBuildStatus.BUILD_FAILED,
+                    "cloudformationStackStatus": CloudFormationStackStatus.ROLLBACK_IN_PROGRESS,
+                    "cloudformationStackArn": "arn:image9",
                     "region": "us-east-1",
                     "version": "3.0.0",
                 },


### PR DESCRIPTION
### Notes
This patch adds ROLLBACK_FAILED to the failures states for a `build_image`, so that those images appear in the `list_images` call result.

### Tests
Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
