### PR TITLE
3.0: Default to disabling rollback on failure for build_image

### DIFF
--- a/api/client/src/docs/ImageOperationsApi.md
+++ b/api/client/src/docs/ImageOperationsApi.md
@@ -65,7 +65,7 @@ with pcluster_client.ApiClient(configuration) as api_client:
     ] # [str] | Identifies one or more config validators to suppress. Format: (ALL|type:[A-Za-z0-9]+) (optional)
     validation_failure_level = ValidationLevel("INFO") # ValidationLevel | Min validation level that will cause the creation to fail. (Defaults to 'ERROR'.) (optional)
     dryrun = True # bool, none_type | Only perform request validation without creating any resource. It can be used to validate the image configuration. (Defaults to 'false'.) (optional)
-    rollback_on_failure = True # bool, none_type | When set, will automatically initiate an image stack rollback on failure. (Defaults to 'true'.) (optional)
+    rollback_on_failure = True # bool, none_type | When set, will automatically initiate an image stack rollback on failure. (Defaults to 'false'.) (optional)
     region = "region_example" # str | AWS Region that the operation corresponds to. (optional)
 
     # example passing only required values which don't have defaults set
@@ -93,7 +93,7 @@ Name | Type | Description  | Notes
  **suppress_validators** | **[str]**| Identifies one or more config validators to suppress. Format: (ALL|type:[A-Za-z0-9]+) | [optional]
  **validation_failure_level** | **ValidationLevel**| Min validation level that will cause the creation to fail. (Defaults to &#39;ERROR&#39;.) | [optional]
  **dryrun** | **bool, none_type**| Only perform request validation without creating any resource. It can be used to validate the image configuration. (Defaults to &#39;false&#39;.) | [optional]
- **rollback_on_failure** | **bool, none_type**| When set, will automatically initiate an image stack rollback on failure. (Defaults to &#39;true&#39;.) | [optional]
+ **rollback_on_failure** | **bool, none_type**| When set, will automatically initiate an image stack rollback on failure. (Defaults to &#39;false&#39;.) | [optional]
  **region** | **str**| AWS Region that the operation corresponds to. | [optional]
 
 ### Return type

--- a/api/client/src/pcluster_client/api/image_operations_api.py
+++ b/api/client/src/pcluster_client/api/image_operations_api.py
@@ -72,7 +72,7 @@ class ImageOperationsApi(object):
                 suppress_validators ([str]): Identifies one or more config validators to suppress. Format: (ALL|type:[A-Za-z0-9]+). [optional]
                 validation_failure_level (ValidationLevel): Min validation level that will cause the creation to fail. (Defaults to 'ERROR'.). [optional]
                 dryrun (bool, none_type): Only perform request validation without creating any resource. It can be used to validate the image configuration. (Defaults to 'false'.). [optional]
-                rollback_on_failure (bool, none_type): When set, will automatically initiate an image stack rollback on failure. (Defaults to 'true'.). [optional]
+                rollback_on_failure (bool, none_type): When set, will automatically initiate an image stack rollback on failure. (Defaults to 'false'.). [optional]
                 region (str): AWS Region that the operation corresponds to.. [optional]
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.

--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -797,10 +797,10 @@ paths:
             nullable: true
         - name: rollbackOnFailure
           in: query
-          description: When set, will automatically initiate an image stack rollback on failure. (Defaults to 'true'.)
+          description: When set, will automatically initiate an image stack rollback on failure. (Defaults to 'false'.)
           schema:
             type: boolean
-            description: When set, will automatically initiate an image stack rollback on failure. (Defaults to 'true'.)
+            description: When set, will automatically initiate an image stack rollback on failure. (Defaults to 'false'.)
             nullable: true
         - name: region
           in: query

--- a/api/spec/smithy/model/operations/BuildImage.smithy
+++ b/api/spec/smithy/model/operations/BuildImage.smithy
@@ -28,7 +28,7 @@ structure BuildImageRequest {
     @documentation("Only perform request validation without creating any resource. It can be used to validate the image configuration. (Defaults to 'false'.)")
     dryrun: Boolean,
     @httpQuery("rollbackOnFailure")
-    @documentation("When set, will automatically initiate an image stack rollback on failure. (Defaults to 'true'.)")
+    @documentation("When set, will automatically initiate an image stack rollback on failure. (Defaults to 'false'.)")
     rollbackOnFailure: Boolean,
     @httpQuery("region")
     region: Region,

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -82,14 +82,14 @@ def build_image(
     (Defaults to &#39;false&#39;.)
     :type dryrun: bool
     :param rollback_on_failure: When set, will automatically initiate an image stack rollback on failure.
-    (Defaults to &#39;true&#39;.)
+    (Defaults to &#39;false&#39;.)
     :type rollback_on_failure: bool
     :param region: AWS Region that the operation corresponds to.
     :type region: str
 
     :rtype: BuildImageResponseContent
     """
-    rollback_on_failure = rollback_on_failure in {True, None}
+    rollback_on_failure = rollback_on_failure if rollback_on_failure is not None else False
     disable_rollback = not rollback_on_failure
     validation_failure_level = validation_failure_level or ValidationLevel.ERROR
     dryrun = dryrun or False

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -921,14 +921,14 @@ paths:
           type: boolean
         style: form
       - description: "When set, will automatically initiate an image stack rollback\
-          \ on failure. (Defaults to 'true'.)"
+          \ on failure. (Defaults to 'false'.)"
         explode: true
         in: query
         name: rollbackOnFailure
         required: false
         schema:
           description: "When set, will automatically initiate an image stack rollback\
-            \ on failure. (Defaults to 'true'.)"
+            \ on failure. (Defaults to 'false'.)"
           nullable: true
           type: boolean
         style: form

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -529,7 +529,7 @@ class TestBuildImage:
             assert_that(response.get_json()).is_equal_to(expected_response)
 
         mocked_call.assert_called_with(
-            disable_rollback=rollback_on_failure is False,
+            disable_rollback=not rollback_on_failure if rollback_on_failure is not None else True,
             validator_suppressors=mocker.ANY,
             validation_failure_level=FailureLevel[ValidationLevel.INFO],
         )

--- a/cli/tests/pcluster/cli/test_build_image/TestBuildImageCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_build_image/TestBuildImageCommand/test_helper/pcluster-help.txt
@@ -22,7 +22,7 @@ optional arguments:
                         configuration. (Defaults to 'false'.)
   --rollback-on-failure ROLLBACK_ON_FAILURE
                         When set, will automatically initiate an image stack
-                        rollback on failure. (Defaults to 'true'.)
+                        rollback on failure. (Defaults to 'false'.)
   --region REGION       AWS Region that the operation corresponds to.
   --image-configuration IMAGE_CONFIGURATION
                         Image configuration as a YAML document


### PR DESCRIPTION
### Notes
Disable rollback on failure on `build-image` by default.

### Tests
Unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
