### PR TITLE
integ-tests: test cluster CLI commands

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -56,7 +56,7 @@ class Cluster:
         self.__cfn_parameters = None
         self.__cfn_outputs = None
         self.__cfn_resources = None
-        self.cfn_stack_arn = None
+        self.__cfn_stack_arn = None
 
     def __repr__(self):
         attrs = ", ".join(["{key}={value}".format(key=key, value=repr(value)) for key, value in self.__dict__.items()])
@@ -69,10 +69,14 @@ class Cluster:
         """
         self.create_complete = True
 
-    def update(self, config_file, force=True):
+    def update(self, config_file, force=True, extra_args=None, raise_on_error=True, wait=True, log_error=True):
         """
         Update a cluster with an already updated config.
         :param force: if to use --force flag when update
+        :param extra_args: list of strings; extra args to pass to `pcluster update-cluster`
+        :param raise_on_error: raise exception if cluster creation fails
+        :param wait: wait for update completion
+        :param log_error: log error when error occurs. This can be set to False when error is expected
         """
         # update the cluster
         logging.info("Updating cluster {0} with config {1}".format(self.name, config_file))
@@ -83,17 +87,22 @@ class Cluster:
             config_file,
             "--cluster-name",
             self.name,
-            "--wait",
         ]
+        if wait:
+            command.append("--wait")
         if force:
             command.extend(["--force-update", "true"])
-        result = run_command(command)
-        logging.info("update-cluster --wait response: %s", result.stdout)
+        if extra_args:
+            command.extend(extra_args)
+        result = run_command(command, raise_on_error=raise_on_error, log_error=log_error)
+        logging.info("update-cluster response: %s", result.stdout)
         response = json.loads(result.stdout)
         if response.get("cloudFormationStackStatus") != "UPDATE_COMPLETE":
             error = f"Cluster update failed for {self.name}"
-            logging.error(error)
-            raise Exception(error)
+            if log_error:
+                logging.error(error)
+            if raise_on_error:
+                raise Exception(error)
         logging.info("Cluster {0} updated successfully".format(self.name))
         # Only update config file attribute if update is successful
         self.config_file = config_file
@@ -103,7 +112,7 @@ class Cluster:
         # reset cached properties
         self._reset_cached_properties()
 
-        return result
+        return response
 
     def delete(self, delete_logs=False):
         """Delete this cluster."""
@@ -129,6 +138,7 @@ class Cluster:
         else:
             logging.warning("CloudWatch logs for cluster %s are preserved due to failure.", self.name)
         try:
+            self.cfn_stack_arn  # Cache cfn_stack_arn attribute before stack deletion
             result = run_command(cmd_args, log_error=False)
             if "DELETE_FAILED" in result.stdout:
                 error = "Cluster deletion failed for {0} with output: {1}".format(self.name, result.stdout)
@@ -187,25 +197,38 @@ class Cluster:
             logging.error("Failed when getting cluster status with error:\n%s\nand output:\n%s", e.stderr, e.stdout)
             raise
 
-    def instances(self, desired_instance_role=None):
-        """Run pcluster instances and return the result."""
-        if desired_instance_role:
-            if desired_instance_role == "HeadNode":
-                desired_instance_role = "HEAD"
-            elif desired_instance_role == "Compute":
-                desired_instance_role = "COMPUTE"
+    def describe_compute_fleet(self):
+        """Run pcluster describe-compute-fleet and return the result."""
+        cmd_args = ["pcluster", "describe-compute-fleet", "--cluster-name", self.name]
+        try:
+            result = run_command(cmd_args, log_error=False)
+            response = json.loads(result.stdout)
+            logging.info("Describe cluster %s compute fleet successfully", self.name)
+            return response
+        except subprocess.CalledProcessError as e:
+            logging.error(
+                "Failed when getting cluster compute fleet with error:\n%s\nand output:\n%s", e.stderr, e.stdout
+            )
+            raise
+
+    def get_cluster_instance_ids(self, node_type=None, queue_name=None):
+        """Run pcluster describe-cluster-instances and collect instance ids."""
+        cmd_args = ["pcluster", "describe-cluster-instances", "--cluster-name", self.name]
+        if node_type:
+            if node_type == "HeadNode":
+                node_type = "HEAD"
+            elif node_type == "Compute":
+                node_type = "COMPUTE"
             else:
                 raise ValueError
-        cmd_args = ["pcluster", "describe-cluster-instances", "--cluster-name", self.name]
+            cmd_args.extend(["--node-type", node_type])
+        if queue_name:
+            cmd_args.extend(["--queue-name", queue_name])
         try:
             result = run_command(cmd_args, log_error=False)
             response = json.loads(result.stdout)
             logging.info("Get cluster {0} instances successfully".format(self.name))
-            cluster_instances = []
-            for instance in response["instances"]:
-                if not desired_instance_role or desired_instance_role == instance["nodeType"]:
-                    cluster_instances.append(instance["instanceId"])
-            return cluster_instances
+            return [instance["instanceId"] for instance in response["instances"]]
         except subprocess.CalledProcessError as e:
             logging.error("Failed when getting cluster instances with error:\n%s\nand output:\n%s", e.stderr, e.stdout)
             raise
@@ -301,6 +324,15 @@ class Cluster:
             self.__cfn_resources = retrieve_cfn_resources(self.cfn_name, self.region)
         return self.__cfn_resources
 
+    @property
+    def cfn_stack_arn(self):
+        """Return CloudFormation stack ARN."""
+        if not self.__cfn_stack_arn:
+            self.__cfn_stack_arn = boto3.client("cloudformation").describe_stacks(StackName=self.name)["Stacks"][0][
+                "StackId"
+            ]
+        return self.__cfn_stack_arn
+
     def _reset_cached_properties(self):
         """Discard cached data."""
         self.__cfn_parameters = None
@@ -334,12 +366,14 @@ class ClustersFactory:
         self.__created_clusters = {}
         self._delete_logs_on_success = delete_logs_on_success
 
-    def create_cluster(self, cluster, extra_args=None, raise_on_error=True):
+    def create_cluster(self, cluster, extra_args=None, raise_on_error=True, wait=True, log_error=True):
         """
         Create a cluster with a given config.
         :param cluster: cluster to create.
         :param extra_args: list of strings; extra args to pass to `pcluster create`
         :param raise_on_error: raise exception if cluster creation fails
+        :param wait: wait for creation completion
+        :param log_error: log error when error occurs. This can be set to False when error is expected
         """
         name = cluster.name
         config = cluster.config_file
@@ -358,31 +392,30 @@ class ClustersFactory:
             config,
             "--cluster-name",
             name,
-            "--wait",
         ]
+        if wait:
+            create_cmd_args.append("--wait")
         if extra_args:
             create_cmd_args.extend(extra_args)
-        result = run_command(
-            create_cmd_args,
-            timeout=7200,
-            raise_on_error=raise_on_error,
-        )
+        result = run_command(create_cmd_args, timeout=7200, raise_on_error=raise_on_error, log_error=log_error)
         logging.info("create-cluster response: %s", result.stdout)
         response = json.loads(result.stdout)
-        cluster.cfn_stack_arn = response["cloudformationStackArn"]
-        if response.get("cloudFormationStackStatus") != "CREATE_COMPLETE":
-            error = f"Cluster creation failed for {name}"
-            logging.error(error)
-            if raise_on_error:
-                raise Exception(error)
+        if wait:
+            if response.get("cloudFormationStackStatus") != "CREATE_COMPLETE":
+                error = f"Cluster creation failed for {name}"
+                logging.error(error)
+                if raise_on_error:
+                    raise Exception(error)
+            else:
+                logging.info("Cluster {0} created successfully".format(name))
+                cluster.mark_as_created()
+            # FIXME: temporary workaround since in certain circumstances the cluster isn't ready for
+            # job submission right after creation. We need to investigate this further.
+            logging.info("Sleeping for 30 seconds in case cluster is not ready yet")
+            time.sleep(30)
         else:
-            logging.info("Cluster {0} created successfully".format(name))
-            cluster.mark_as_created()
-
-        # FIXME: temporary workaround since in certain circumstances the cluster isn't ready for
-        # job submission right after creation. We need to investigate this further.
-        logging.info("Sleeping for 30 seconds in case cluster is not ready yet")
-        time.sleep(30)
+            logging.info("Cluster {0} creation started successfully".format(name))
+        return response
 
     def destroy_cluster(self, name, test_passed):
         """Destroy a created cluster."""

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -294,7 +294,7 @@ def clusters_factory(request, region):
     """
     factory = ClustersFactory(delete_logs_on_success=request.config.getoption("delete_logs_on_success"))
 
-    def _cluster_factory(cluster_config, extra_args=None, raise_on_error=True):
+    def _cluster_factory(cluster_config, extra_args=None, raise_on_error=True, wait=True, log_error=True):
         cluster_config = _write_config_to_outdir(request, cluster_config, "clusters_configs")
         cluster = Cluster(
             name=request.config.getoption("cluster")
@@ -309,7 +309,9 @@ def clusters_factory(request, region):
             region=region,
         )
         if not request.config.getoption("cluster"):
-            factory.create_cluster(cluster, extra_args=extra_args, raise_on_error=raise_on_error)
+            cluster.creation_response = factory.create_cluster(
+                cluster, extra_args=extra_args, raise_on_error=raise_on_error, wait=wait, log_error=log_error
+            )
         return cluster
 
     yield _cluster_factory

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import json
 import logging
+import re
 import tarfile
 import tempfile
 
@@ -19,43 +20,263 @@ import botocore
 import pytest
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
-from utils import check_status, get_cluster_nodes_instance_ids
+from utils import check_status, get_cluster_nodes_instance_ids, run_command
 
 from tests.common.assertions import assert_no_errors_in_logs, wait_for_num_instances_in_cluster
+from tests.common.utils import get_installed_parallelcluster_version, retrieve_latest_ami
 
 
 @pytest.mark.regions(["us-east-2"])
 @pytest.mark.instances(["c5.xlarge"])
 @pytest.mark.schedulers(["slurm"])
 @pytest.mark.oss(["ubuntu1804"])
-@pytest.mark.usefixtures("region", "os", "instance")
-def test_slurm_cli_commands(scheduler, region, pcluster_config_reader, clusters_factory, s3_bucket_factory):
+@pytest.mark.usefixtures("region", "instance")
+def test_slurm_cli_commands(
+    request, scheduler, region, os, pcluster_config_reader, clusters_factory, s3_bucket_factory
+):
     """Test pcluster cli commands are working."""
     # Use long scale down idle time so we know nodes are terminated by pcluster stop
     cluster_config = pcluster_config_reader(scaledown_idletime=60)
-    cluster = clusters_factory(cluster_config)
+    # Generate configuration with warnings and errors
+    custom_ami = retrieve_latest_ami(
+        region, os, ami_type="official", architecture="x86_64"
+    )  # Using custom AMI not tagged by pcluser will generate a warning
+    cluster_config_with_warning = pcluster_config_reader(
+        config_file="pcluster.config.with.warnings.yaml", custom_ami=custom_ami
+    )
+    cluster = _test_create_cluster(clusters_factory, cluster_config, cluster_config_with_warning, request)
     remote_command_executor = RemoteCommandExecutor(cluster)
+    _test_list_cluster(cluster.name, "CREATE_COMPLETE")
+    _test_create_or_update_with_warnings(str(cluster_config_with_warning), cluster=cluster)
 
-    instance_ids = _test_pcluster_instances_and_status(cluster, region, compute_fleet_status="RUNNING")
-    _test_pcluster_stop_and_start(cluster, region, expected_num_nodes=2)
+    instance_ids = _test_describe_instances(cluster, region)
+    check_status(cluster, "CREATE_COMPLETE", "running", "RUNNING")
+    _test_describe_instances(cluster, region, node_type="HeadNode")
+    _test_describe_instances(cluster, region, node_type="Compute")
+    _test_describe_instances(cluster, region, queue_name="ondemand1")
+    _test_pcluster_compute_fleet(cluster, region, expected_num_nodes=2)
     _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, region, instance_ids)
     cfn_init_log_stream = _test_pcluster_list_cluster_logs(cluster, instance_ids)
     _test_pcluster_get_cluster_log_events(cluster, cfn_init_log_stream)
     assert_no_errors_in_logs(remote_command_executor, scheduler)
 
 
-def _test_pcluster_instances_and_status(cluster, region, compute_fleet_status=None):
-    """Test pcluster status and pcluster instances functionalities."""
-    logging.info("Testing that pcluster status and pcluster instances output are expected")
-    cluster_instances_from_ec2 = get_cluster_nodes_instance_ids(cluster.cfn_name, region)
-    cluster_instances_from_cli = cluster.instances()
+def _test_create_cluster(clusters_factory, cluster_config, cluster_config_with_warning, request):
+    if not request.config.getoption("cluster"):
+        # Test below is not compatible with `--cluster` flag. Therefore, skip it if the flag is provided.
+        _test_create_or_update_with_warnings(cluster_config_with_warning, clusters_factory)
+
+    cluster = clusters_factory(cluster_config, wait=False)
+    if not request.config.getoption("cluster"):
+        expected_creation_response = {
+            "cluster": {
+                "clusterName": cluster.name,
+                "cloudformationStackStatus": "CREATE_IN_PROGRESS",
+                "cloudformationStackArn": cluster.cfn_stack_arn,
+                "region": cluster.region,
+                "version": get_installed_parallelcluster_version(),
+                "clusterStatus": "CREATE_IN_PROGRESS",
+            }
+        }
+        assert_that(cluster.creation_response).is_equal_to(expected_creation_response)
+        _test_list_cluster(cluster.name, "CREATE_IN_PROGRESS")
+        logging.info("Waiting for CloudFormation stack creation completion")
+        cloud_formation = boto3.client("cloudformation")
+        waiter = cloud_formation.get_waiter("stack_create_complete")
+        waiter.wait(StackName=cluster.name)
+    return cluster
+
+
+def _test_create_or_update_with_warnings(cluster_config_with_warning, clusters_factory=None, cluster=None):
+    """
+    Test create-cluster or update-cluster with a erroneous configuration file.
+
+    If clusters_factory is not None, this function tests create-cluster.
+    Otherwise cluster has to be provided and this function tests update-cluster.
+    """
+    # clusters_factory and cluster are mutually exclusive but one of them has to be provided
+    assert_that(clusters_factory or cluster).is_not_none()
+    logging.info("Testing cluster creation/update on a configuration file with 1 error and 2 warnings.")
+    custom_ami_tag_warning = {
+        "level": "WARNING",
+        "type": "CustomAmiTagValidator",
+        "message": "The custom AMI may not.*been created by pcluster",
+    }
+    name_error = {
+        "level": "ERROR",
+        "type": "NameValidator",
+        "message": "Name must begin with a letter and only contain lowercase letters, digits and hyphens.",
+    }
+    key_pair_warning = {
+        "level": "WARNING",
+        "type": "KeyPairValidator",
+        "message": ".*you do not specify a key pair.*",
+    }
+
+    test_cases = []
+
+    def construct_validation_error_expected_response(configuration_validation_errors):
+        return {
+            "configurationValidationErrors": configuration_validation_errors,
+            "message": "Invalid cluster configuration",
+        }
+
+    expected_response = construct_validation_error_expected_response(
+        [custom_ami_tag_warning, key_pair_warning, name_error]
+    )
+    test_cases.extend(
+        [
+            (expected_response, ["--validation-failure-level", "WARNING"]),
+            (expected_response, ["--validation-failure-level", "WARNING", "--dryrun", "true"]),
+            # Test default --validation-failure-level shows errors and warnings
+            (expected_response, None),
+        ]
+    )
+
+    # Test suppressing a error and a warning
+    expected_response = construct_validation_error_expected_response([key_pair_warning])
+    test_cases.append(
+        (
+            expected_response,
+            [
+                "--validation-failure-level",
+                "WARNING",
+                "--dryrun",
+                "true",
+                "--suppress-validators",
+                "type:CustomAmiTagValidator",
+                "type:NameValidator",
+            ],
+        )
+    )
+
+    # Test dry run with successful validations
+    # Test default --validation-failure-level does not fail on warnings
+    expected_response = {"message": "Request would have succeeded, but DryRun flag is set."}
+    test_cases.extend(
+        [
+            (expected_response, ["--dryrun", "true", "--suppress-validators", "type:NameValidator"]),
+            (
+                expected_response,
+                [
+                    "--validation-failure-level",
+                    "WARNING",
+                    "--dryrun",
+                    "true",
+                    "--suppress-validators",
+                    "type:CustomAmiTagValidator",
+                    "type:NameValidator",
+                    "type:KeyPairValidator",
+                ],
+            ),
+            # Test suppressing all validators
+            (
+                expected_response,
+                ["--validation-failure-level", "WARNING", "--dryrun", "true", "--suppress-validators", "ALL"],
+            ),
+        ]
+    )
+    for test_case in test_cases:
+        _check_response(
+            cluster_config_with_warning,
+            test_case[0],
+            extra_args=test_case[1],
+            clusters_factory=clusters_factory,
+            cluster=cluster,
+        )
+
+
+def _create_cluster_with_warnings(clusters_factory, cluster_config, extra_args=None):
+    """
+    Create cluster with warnings expected.
+
+    Set log_error=False and raise_on_error=False if error is expected.
+    Therefore, the test log won't be flooded with errors.
+    """
+    return clusters_factory(
+        cluster_config, extra_args=extra_args, raise_on_error=False, wait=False, log_error=False
+    ).creation_response
+
+
+def _check_response(cluster_config, expected_response, clusters_factory=None, cluster=None, extra_args=None):
+    if clusters_factory:
+        actual_response = _create_cluster_with_warnings(
+            clusters_factory,
+            cluster_config,
+            extra_args=extra_args,
+        )
+    else:
+        actual_response = cluster.update(
+            cluster_config, extra_args=extra_args, wait=False, log_error=False, raise_on_error=False
+        )
+    expected_validation_errors = expected_response.get("configurationValidationErrors")
+    if expected_validation_errors:
+        # If validation error is expected. The code below checks for the validation error without enforcing the order
+        # of errors and warnings and use Regex to match the error message
+        actual_validation_errors = actual_response["configurationValidationErrors"]
+        assert_that(actual_validation_errors).is_length(len(expected_validation_errors))
+        for actual_error in actual_validation_errors:
+            for expected_error in expected_validation_errors:
+                if actual_error["type"] == expected_error["type"]:
+                    # Either check the regex of expected_message match actual failure or check the
+                    # whole strings are equal. This is to deal with strings having regex symbols (e.g. "[") inside
+                    assert_that(
+                        re.search(expected_error["message"], actual_error["message"])
+                        or expected_error["message"] == actual_error["message"]
+                    )
+                    assert_that(actual_error["level"]).is_equal_to(expected_error["level"])
+    else:
+        # Otherwise, assert the actual response is exactly as expected
+        assert_that(actual_response).is_equal_to(expected_response)
+
+
+def _test_list_cluster(cluster_name, expected_status):
+    # Test the command response contains the cluster_name and expected_status.
+    # ToDo: design test for this command to check stacks inside a region.
+    #  It is hard because the test will be dependent on other tests
+    logging.info("Testing list clusters")
+    cmd_args = ["pcluster", "list-clusters"]
+    found_cluster = _find_cluster_with_pagination(cmd_args, cluster_name)
+    assert_that(found_cluster).is_not_none()
+    assert_that(found_cluster["cloudformationStackStatus"]).is_equal_to(expected_status)
+
+    logging.info("Testing list clusters with status filter")
+    cmd_args.extend(["--cluster-status", expected_status])
+    found_cluster = _find_cluster_with_pagination(cmd_args, cluster_name)
+    assert_that(found_cluster).is_not_none()
+    assert_that(found_cluster["cloudformationStackStatus"]).is_equal_to(expected_status)
+
+
+def _find_cluster_with_pagination(cmd_args, cluster_name):
+    result = run_command(cmd_args)
+    response = json.loads(result.stdout)
+    found_cluster = _find_cluster_in_list(cluster_name, response["items"])
+    while response.get("nextToken") and found_cluster is None:
+        cmd_args_with_next_token = cmd_args + ["--next-token", response["nextToken"]]
+        result = run_command(cmd_args_with_next_token)
+        response = json.loads(result.stdout)
+        found_cluster = _find_cluster_in_list(cluster_name, response["items"])
+    return found_cluster
+
+
+def _find_cluster_in_list(cluster_name, cluster_list):
+    for cluster in cluster_list:
+        if cluster_name == cluster["clusterName"]:
+            return cluster
+
+
+def _test_describe_instances(cluster, region, node_type=None, queue_name=None):
+    logging.info("Testing the result from describe-cluster-instances is the same as calling boto3 directly.")
+    cluster_instances_from_ec2 = get_cluster_nodes_instance_ids(
+        cluster.cfn_name, region, node_type=node_type, queue_name=queue_name
+    )
+    cluster_instances_from_cli = cluster.get_cluster_instance_ids(node_type=node_type, queue_name=queue_name)
     assert_that(set(cluster_instances_from_cli)).is_equal_to(set(cluster_instances_from_ec2))
-    check_status(cluster, "CREATE_COMPLETE", "running", compute_fleet_status)
     return cluster_instances_from_cli
 
 
-def _test_pcluster_stop_and_start(cluster, region, expected_num_nodes):
-    """Test pcluster start and stop functionality."""
+def _test_pcluster_compute_fleet(cluster, region, expected_num_nodes):
+    """Test pcluster compute fleet commands."""
     logging.info("Testing pcluster stop functionalities")
     cluster.stop()
     # Sample pcluster stop output:
@@ -64,7 +285,10 @@ def _test_pcluster_stop_and_start(cluster, region, expected_num_nodes):
     # Please run 'pcluster status' if you need to check compute fleet status
 
     wait_for_num_instances_in_cluster(cluster.cfn_name, region, desired=0)
-    _test_pcluster_instances_and_status(cluster, region, compute_fleet_status="STOPPED")
+    _test_describe_instances(cluster, region)
+    compute_fleet = cluster.describe_compute_fleet()
+    assert_that(compute_fleet["status"]).is_equal_to("STOPPED")
+    last_stop_time = compute_fleet["lastStatusUpdatedTime"]
 
     logging.info("Testing pcluster start functionalities")
     # Do a complicated sequence of start and stop and see if commands will still work
@@ -72,8 +296,13 @@ def _test_pcluster_stop_and_start(cluster, region, expected_num_nodes):
     cluster.stop()
     cluster.stop()
     cluster.start()
+    compute_fleet = cluster.describe_compute_fleet()
+    last_start_time = compute_fleet["lastStatusUpdatedTime"]
+    logging.info("Checking last status update time is updated")
+    assert_that(last_stop_time < last_start_time)
     wait_for_num_instances_in_cluster(cluster.cfn_name, region, desired=expected_num_nodes)
-    _test_pcluster_instances_and_status(cluster, region, compute_fleet_status="RUNNING")
+    _test_describe_instances(cluster, region)
+    check_status(cluster, "CREATE_COMPLETE", "running", "RUNNING")
 
 
 def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster, region, instance_ids):

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.with.warnings.yaml
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.with.warnings.yaml
@@ -1,0 +1,32 @@
+Image:
+  Os: {{ os }}
+  CustomAmi: {{ custom_ami}}  # If an AMI without proper tags is provided, it will generate an warning
+HeadNode:  # Head Node section without a KeyName will generate an warning
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: ondemand1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: invalid_underscore_name  # Name with underscore will generate an error
+          InstanceType: c5.large
+        - Name: compute-resource-12
+          InstanceType: {{ instance }}
+          MinCount: 1
+    - Name: ondemand2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: compute-resource-21
+          InstanceType: c5.large
+        - Name: compute-resource-12
+          InstanceType: {{ instance }}
+          MinCount: 1

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
@@ -31,7 +31,7 @@ def test_intel_hpc(region, scheduler, instance, os, pcluster_config_reader, clus
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
-    _test_intel_instance_tags(cluster.instances(), region)
+    _test_intel_instance_tags(cluster.get_cluster_instance_ids(), region)
     _test_intel_clck(remote_command_executor, scheduler_commands, test_datadir, os)
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -268,7 +268,7 @@ def _test_root_volume_encryption(cluster, os, region, scheduler, encrypted):
     logging.info("Testing root volume encryption.")
     if scheduler == "slurm":
         # If the scheduler is slurm, root volumes both on head and compute can be encrypted
-        instance_ids = cluster.instances()
+        instance_ids = cluster.get_cluster_instance_ids()
         for instance in instance_ids:
             root_volume_id = utils.get_root_volume_id(instance, region, os)
             _test_ebs_encrypted_with_kms(root_volume_id, region, encrypted=encrypted)
@@ -290,7 +290,7 @@ def _assert_root_volume_configuration(cluster, os, region, scheduler):
         _assert_volume_configuration(expected_settings, root_volume_id, region)
     if scheduler == "slurm":
         # Only if the scheduler is slurm, root volumes both on compute can be configured
-        instance_ids = cluster.instances()
+        instance_ids = cluster.get_cluster_instance_ids()
         for instance in instance_ids:
             if instance == head_node:
                 # head node is already checked

--- a/tests/integration-tests/tests/tags/test_tag_propagation.py
+++ b/tests/integration-tests/tests/tags/test_tag_propagation.py
@@ -168,7 +168,7 @@ def get_head_node_tags(cluster):
 
 def get_compute_node_root_volume_tags(cluster, os):
     """Return the given cluster's compute node's root volume's tags."""
-    compute_nodes = cluster.instances(desired_instance_role="Compute")
+    compute_nodes = cluster.get_cluster_instance_ids(node_type="Compute")
     assert_that(compute_nodes).is_length(1)
     root_volume_id = get_root_volume_id(compute_nodes[0], cluster.region, os)
     return get_tags_for_volume(root_volume_id, cluster.region)
@@ -176,7 +176,7 @@ def get_compute_node_root_volume_tags(cluster, os):
 
 def get_compute_node_tags(cluster):
     """Return the given cluster's compute node's tags."""
-    compute_nodes = cluster.instances(desired_instance_role="Compute")
+    compute_nodes = cluster.get_cluster_instance_ids(node_type="Compute")
     assert_that(compute_nodes).is_length(1)
     return get_ec2_instance_tags(compute_nodes[0], cluster.region)
 

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -193,11 +193,15 @@ def get_compute_nodes_instance_ids(stack_name, region, instance_types=None):
     return get_cluster_nodes_instance_ids(stack_name, region, instance_types, node_type="Compute")
 
 
-def get_cluster_nodes_instance_ids(stack_name, region, instance_types=None, node_type=None):
+def get_cluster_nodes_instance_ids(stack_name, region, instance_types=None, node_type=None, queue_name=None):
     """Return a list of cluster Instances Id's."""
     try:
         instances = _describe_cluster_instances(
-            stack_name, region, filter_by_node_type=node_type, filter_by_instance_types=instance_types
+            stack_name,
+            region,
+            filter_by_node_type=node_type,
+            filter_by_instance_types=instance_types,
+            filter_by_queue_name=queue_name,
         )
         instance_ids = []
         for instance in instances:
@@ -209,7 +213,12 @@ def get_cluster_nodes_instance_ids(stack_name, region, instance_types=None, node
 
 
 def _describe_cluster_instances(
-    stack_name, region, filter_by_node_type=None, filter_by_name=None, filter_by_instance_types=None
+    stack_name,
+    region,
+    filter_by_node_type=None,
+    filter_by_name=None,
+    filter_by_instance_types=None,
+    filter_by_queue_name=None,
 ):
     ec2 = boto3.client("ec2", region_name=region)
     filters = [
@@ -218,6 +227,8 @@ def _describe_cluster_instances(
     ]
     if filter_by_node_type:
         filters.append({"Name": "tag:parallelcluster:node-type", "Values": [filter_by_node_type]})
+    if filter_by_queue_name:
+        filters.append({"Name": "tag:parallelcluster:queue-name", "Values": [filter_by_queue_name]})
     if filter_by_name:
         filters.append({"Name": "tag:Name", "Values": [filter_by_name]})
     if filter_by_instance_types:


### PR DESCRIPTION
* Test `create-cluster` (`--dryrun`, `--suppress-validators`, `--validation-failure-level`, error response, successful response).

* Test `update-cluster` (`--dryrun`, `--suppress-validators`, `--validation-failure-level`, error response). The successful case of `update-cluster` is tested in `test_update_slurm` and `test_update_awsbatch`

* Add wait (default is True) parameter on tests. Therefore we can test the response with `wait==False`. (Note that when `wait==True`, the response is always from describe-cluster, so we need to set it to `False` if we want to test the response for create/update/delete

* Split `_test_pcluster_instances_and_status` to `_test_describe_instances` and `_test_pcluster_compute_fleet` to make testing function names to be consistent with the commands under testing

* Other minor renaming

* Fix retrieval of `cfn_stack_arn` in `class Cluster`: Previous code could not retrieve the arn if stack creation failed. The `cfn_stack_arn` is used to clean up resources according to stack-id tag

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
