### PR TITLE
3.0: Handle differences between AWS Batch and Slurm in API tests

### DIFF
--- a/tests/integration-tests/tests/api/test_api/test_cluster_awsbatch/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/api/test_api/test_cluster_awsbatch/pcluster.config.update.yaml
@@ -25,7 +25,6 @@ Scheduling:
         - Name: compute-resource-0
           InstanceTypes:
             - {{ instance }}
-          MinvCpus: 8
+          MinvCpus: {{ vcpus }}
           MaxvCpus: 16
           DesiredvCpus: 12
-          SpotBidPercentage: 70

--- a/tests/integration-tests/tests/api/test_api/test_cluster_awsbatch/pcluster.config.yaml
+++ b/tests/integration-tests/tests/api/test_api/test_cluster_awsbatch/pcluster.config.yaml
@@ -25,7 +25,6 @@ Scheduling:
         - Name: compute-resource-0
           InstanceTypes:
             - {{ instance }}
-          MinvCpus: 4
-          MaxvCpus: 12
-          DesiredvCpus: 8
-          SpotBidPercentage: 35
+          MinvCpus: {{ vcpus }}
+          MaxvCpus: {{ vcpus }}
+          DesiredvCpus: {{ vcpus }}

--- a/tests/integration-tests/tests/api/test_api/test_cluster_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/api/test_api/test_cluster_slurm/pcluster.config.update.yaml
@@ -1,10 +1,5 @@
 Image:
   Os: {{ os }}
-Tags:
-  - Key: key
-    Value: value3
-  - Key: key2
-    Value: value2
 HeadNode:
   InstanceType: {{ instance }}
   Networking:
@@ -12,64 +7,24 @@ HeadNode:
   Ssh:
     KeyName: {{ key_name }}
 Scheduling:
-  Scheduler: slurm
+  Scheduler: {{ scheduler }}
   SlurmSettings:
     ScaledownIdletime: 30
   SlurmQueues:
-    - Name: queue1
-      ComputeSettings:
-        LocalStorage:
-          RootVolume:
-            Size: 40
-      CapacityType: ONDEMAND
+    - Name: ondemand1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
       ComputeResources:
-        - Name: queue1-i1
-          InstanceType: c5.xlarge
+        - Name: compute-resource-12
+          InstanceType: {{ instance }}
           MinCount: 1
-          MaxCount: 3
-        - Name: queue1-i2
-          InstanceType: t2.micro
-          MinCount: 0
+          MaxCount: 2
+    - Name: ondemand2
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
-    - Name: queue2
-      ComputeSettings:
-        LocalStorage:
-          RootVolume:
-            Size: 40
       ComputeResources:
-        - Name: queue2-i1
-          Efa:
-            Enabled: true
-          InstanceType: c5n.18xlarge
-      Networking:
-        SubnetIds:
-          - {{ private_subnet_id }}
-SharedStorage:
-  - MountDir: shared
-    Name: ebs
-    StorageType: Ebs
-    EbsSettings:
-      VolumeType: io2
-  - MountDir: efs
-    Name: efs
-    StorageType: Efs
-  - MountDir: raid
-    StorageType: Ebs
-    Name: raid
-    EbsSettings:
-      VolumeType: io2
-      Raid:
-        Type: 0
-        NumberOfVolumes: 2
-  - MountDir: fsx
-    Name: fsx
-    StorageType: FsxLustre
-    FsxLustreSettings:
-      StorageCapacity: 3600
-Monitoring:
-  DetailedMonitoring: false
-  Logs:
-    CloudWatch:
-      Enabled: true
+        - Name: compute-resource-12
+          InstanceType: {{ instance }}
+          MinCount: 1

--- a/tests/integration-tests/tests/api/test_api/test_cluster_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/api/test_api/test_cluster_slurm/pcluster.config.yaml
@@ -1,10 +1,5 @@
 Image:
   Os: {{ os }}
-Tags:
-  - Key: key
-    Value: value3
-  - Key: key2
-    Value: value2
 HeadNode:
   InstanceType: {{ instance }}
   Networking:
@@ -12,64 +7,24 @@ HeadNode:
   Ssh:
     KeyName: {{ key_name }}
 Scheduling:
-  Scheduler: slurm
+  Scheduler: {{ scheduler }}
   SlurmSettings:
     ScaledownIdletime: 30
   SlurmQueues:
-    - Name: queue1
-      ComputeSettings:
-        LocalStorage:
-          RootVolume:
-            Size: 40
-      CapacityType: ONDEMAND
+    - Name: ondemand1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
       ComputeResources:
-        - Name: queue1-i1
-          InstanceType: c5.xlarge
+        - Name: compute-resource-12
+          InstanceType: {{ instance }}
           MinCount: 1
-          MaxCount: 2
-        - Name: queue1-i2
-          InstanceType: t2.micro
-          MinCount: 0
+          MaxCount: 1
+    - Name: ondemand2
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
-    - Name: queue2
-      ComputeSettings:
-        LocalStorage:
-          RootVolume:
-            Size: 40
       ComputeResources:
-        - Name: queue2-i1
-          Efa:
-            Enabled: true
-          InstanceType: c5n.18xlarge
-      Networking:
-        SubnetIds:
-          - {{ private_subnet_id }}
-SharedStorage:
-  - MountDir: shared
-    Name: ebs
-    StorageType: Ebs
-    EbsSettings:
-      VolumeType: io2
-  - MountDir: efs
-    Name: efs
-    StorageType: Efs
-  - MountDir: raid
-    StorageType: Ebs
-    Name: raid
-    EbsSettings:
-      VolumeType: io2
-      Raid:
-        Type: 0
-        NumberOfVolumes: 2
-  - MountDir: fsx
-    Name: fsx
-    StorageType: FsxLustre
-    FsxLustreSettings:
-      StorageCapacity: 3600
-Monitoring:
-  DetailedMonitoring: false
-  Logs:
-    CloudWatch:
-      Enabled: true
+        - Name: compute-resource-12
+          InstanceType: {{ instance }}
+          MinCount: 1


### PR DESCRIPTION
### Notes
When Slurm clusters are created, the instances are ready as soon as the stack creation is completed. With AWS Batch this is not true, so we add a step to wait until the desired number of instances are present in the cluster. Furthermore, the queue name for AWS Batch clusters is not populated (not that we can specify only one queue), and so this patch handles also that corner case when creating the compute_node_map.

### Tests
Run API integration tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
