### PR TITLE
[CLI/get-image-log-events] fix type on limit parameter.

### DIFF
--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -1636,7 +1636,7 @@ paths:
             \ size of 1 MB, up to 10,000 log events."
           format: int32
           nullable: true
-          type: number
+          type: integer
         style: form
       - description: "The start of the time range, expressed in ISO8601 format (e.g.\
           \ '2021-01-01T20:00:00.000Z'). Events with a timestamp equal to this time\

--- a/cli/tests/pcluster/cli/test_get_cluster_log_events.py
+++ b/cli/tests/pcluster/cli/test_get_cluster_log_events.py
@@ -125,6 +125,10 @@ class TestGetClusterLogEventsCommand:
         assert_that(expected).is_equal_to(out)
         assert_that(get_cluster_log_events_mock.call_args).is_length(2)
 
+        if args.get("limit", None):
+            limit_val = get_cluster_log_events_mock.call_args[1].get("limit")
+            assert_that(limit_val).is_type_of(int)
+
         # verify arguments
         kwargs = {
             "start_time": args.get("start_time", None),

--- a/cli/tests/pcluster/cli/test_get_image_log_events.py
+++ b/cli/tests/pcluster/cli/test_get_image_log_events.py
@@ -131,6 +131,10 @@ class TestGetImageLogEventsCommand:
         assert_that(expected).is_equal_to(out)
         assert_that(get_image_log_events_mock.call_args).is_length(2)
 
+        if args.get("limit", None):
+            limit_val = get_image_log_events_mock.call_args[1].get("limit")
+            assert_that(limit_val).is_type_of(int)
+
         # verify arguments
         kwargs = {
             "start_time": args.get("start_time", None),


### PR DESCRIPTION
**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*
- Small fix to the limit parameter on `get-image-log-events`
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
