### PR TITLE
Integ-tests: fix test_update_awsbatch

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -289,8 +289,8 @@ def test_update_awsbatch(region, pcluster_config_reader, clusters_factory, test_
     # Verify initial configuration
     _verify_initialization(region, cluster, cluster.config)
 
-    # Update cluster with the same configuration, command should not result any error even if not using force update
-    cluster.update(str(init_config_file), force=False)
+    # Update cluster with the same configuration
+    cluster.update(str(init_config_file), force=True)
 
     # Update cluster with new configuration
     updated_config_file = pcluster_config_reader(config_file="pcluster.config.update.yaml")


### PR DESCRIPTION
Updating using the same configuration without `--force` will return a BadRequest error "No changes found in your cluster configuration.". So in the test, `--force` should be used. This also aligns test_update_awsbatch with test_update_slurm, which already uses `--force`

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
