### PR TITLE
Add architecture details within dcv validator error message

### DIFF
--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -649,7 +649,8 @@ class DcvValidator(Validator):
             allowed_oses = get_supported_dcv_os(architecture)
             if os not in allowed_oses:
                 self._add_failure(
-                    f"NICE DCV can be used with one of the following operating systems: {allowed_oses}. "
+                    f"NICE DCV can be used with one of the following operating systems "
+                    f"when using {architecture} architecture: {allowed_oses}. "
                     "Please double check the os configuration.",
                     FailureLevel.ERROR,
                 )


### PR DESCRIPTION
### Changes
1. Add architecture details within dcv validator error message.

Example of error message after this change:

```
 "NICE DCV can be used with one of the following operating systems when using arm64 architecture: ['ubuntu1804', 'alinux2', 'centos7']. Please double check the os configuration."
```

### Test
1. Manual test
2. Unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
