### PR TITLE
Fix nvidia-fabricmanager test

### DIFF
--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -719,7 +719,7 @@ paths:
         - name: filters
           in: query
           description: |-
-            Filter the log streams. Format: (Name=a,Values=1 Name=b,Values=2,3).
+            Filter the log streams. Format: 'Name=a,Values=1 Name=b,Values=2,3'.
             Accepted filters are:
             private-dns-name - The short form of the private DNS name of the instance (e.g. ip-10-0-0-101).
             node-type - The node type, the only accepted value for this filter is HeadNode.
@@ -730,7 +730,7 @@ paths:
               type: string
             uniqueItems: true
             description: |-
-              Filter the log streams. Format: (Name=a,Values=1 Name=b,Values=2,3).
+              Filter the log streams. Format: 'Name=a,Values=1 Name=b,Values=2,3'.
               Accepted filters are:
               private-dns-name - The short form of the private DNS name of the instance (e.g. ip-10-0-0-101).
               node-type - The node type, the only accepted value for this filter is HeadNode.

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -833,7 +833,7 @@ paths:
           description: Region that the given cluster belongs to.
           type: string
         style: form
-      - description: "Filter the log streams. Format: (Name=a,Values=1 Name=b,Values=2,3).\n\
+      - description: "Filter the log streams. Format: 'Name=a,Values=1 Name=b,Values=2,3'.\n\
           Accepted filters are:\nprivate-dns-name - The short form of the private\
           \ DNS name of the instance (e.g. ip-10-0-0-101).\nnode-type - The node type,\
           \ the only accepted value for this filter is HeadNode."
@@ -842,7 +842,7 @@ paths:
         name: filters
         required: false
         schema:
-          description: "Filter the log streams. Format: (Name=a,Values=1 Name=b,Values=2,3).\n\
+          description: "Filter the log streams. Format: 'Name=a,Values=1 Name=b,Values=2,3'.\n\
             Accepted filters are:\nprivate-dns-name - The short form of the private\
             \ DNS name of the instance (e.g. ip-10-0-0-101).\nnode-type - The node\
             \ type, the only accepted value for this filter is HeadNode."

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -179,7 +179,6 @@ phases:
               CUDA_VERSION="$(cat /usr/local/cuda/version.txt | cut -d' ' -f3)"
               add_tag "parallelcluster:cuda_version" "${CUDA_VERSION}"
               append_description "cuda" "${CUDA_VERSION}"
-              add_tag "parallelcluster:nvidia_fabricmanager_version" "$(get_package_version "nvidia-fabricmanager")"
 
               # Add description
               add_description

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -337,11 +337,11 @@ phases:
               echo "Testing Nvidia Fabric Manager version"
               nvidia_driver_version=$(modinfo -F version nvidia)
               if [ "${PLATFORM}" == "RHEL" ]; then
-                yum list installed | grep nvidia-fabricmanager | grep "${nvidia_driver_version}" || exit 1
-                yum versionlock list | grep nvidia-fabricmanager || exit 1
+                yum list installed | grep "nvidia-fabric.*manager" | grep "${nvidia_driver_version}" || exit 1
+                yum versionlock list | grep "nvidia-fabric.*manager" || exit 1
               else
-                apt list --installed | grep nvidia-fabricmanager | grep "${nvidia_driver_version}" || exit 1
-                apt-mark showhold | grep nvidia-fabricmanager || exit 1
+                apt list --installed | grep "nvidia-fabric.*manager" | grep "${nvidia_driver_version}" || exit 1
+                apt-mark showhold | grep "nvidia-fabric.*manager" || exit 1
               fi
               echo "Fabric Manager match Nvidia driver and version is locked"
 

--- a/cli/tests/pcluster/cli/test_list_cluster_log_streams/TestListClusterLogStreamsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_list_cluster_log_streams/TestListClusterLogStreamsCommand/test_helper/pcluster-help.txt
@@ -12,8 +12,8 @@ optional arguments:
                         Name of the cluster
   --region REGION       Region that the given cluster belongs to.
   --filters FILTERS [FILTERS ...]
-                        Filter the log streams. Format: (Name=a,Values=1
-                        Name=b,Values=2,3). Accepted filters are: private-dns-
+                        Filter the log streams. Format: 'Name=a,Values=1
+                        Name=b,Values=2,3'. Accepted filters are: private-dns-
                         name - The short form of the private DNS name of the
                         instance (e.g. ip-10-0-0-101). node-type - The node
                         type, the only accepted value for this filter is

--- a/cli/tests/pcluster/cli/test_list_cluster_logs/TestListClusterLogsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_list_cluster_logs/TestListClusterLogsCommand/test_helper/pcluster-help.txt
@@ -15,8 +15,8 @@ optional arguments:
   -r {af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-south-1,ap-southeast-1,ap-southeast-2,ca-central-1,cn-north-1,cn-northwest-1,eu-central-1,eu-north-1,eu-south-1,eu-west-1,eu-west-2,eu-west-3,me-south-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-1,us-west-2}, --region {af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-south-1,ap-southeast-1,ap-southeast-2,ca-central-1,cn-north-1,cn-northwest-1,eu-central-1,eu-north-1,eu-south-1,eu-west-1,eu-west-2,eu-west-3,me-south-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-1,us-west-2}
                         AWS Region to use.
   --filters FILTERS [FILTERS ...]
-                        The filters in the form Name=a,Values=1
-                        Name=b,Values=2,3. Accepted filters are: private-dns-
+                        The filters in the form 'Name=a,Values=1
+                        Name=b,Values=2,3'. Accepted filters are: private-dns-
                         name - The short form of the private DNS name of the
                         instance (e.g. ip-10-0-0-101). node-type - The node
                         type, the only accepted value for this filter is


### PR DESCRIPTION
Package has been renamed in RHEL systems to nvidia-fabric-manager

Also remove `parallelcluster:nvidia_fabricmanager_version` since fabricmanger version always matches Nvidia driver version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
