### PR TITLE
Fix integ-tests: test_public_network_topology

### DIFF
--- a/tests/integration-tests/tests/networking/test_networking.py
+++ b/tests/integration-tests/tests/networking/test_networking.py
@@ -36,7 +36,7 @@ def test_public_network_topology(region, vpc_stack, parameterized_cfn_stacks_fac
     _assert_internet_gateway_id(ec2_client, vpc_id, expected_internet_gateway_id=internet_gateway_id)
     _assert_internet_gateway_in_subnet_route(ec2_client, public_subnet_id, internet_gateway_id)
     _assert_subnet_property(
-        region, public_subnet_id, expected_autoassign_ip_value=False, expected_availability_zone=availability_zone
+        region, public_subnet_id, expected_autoassign_ip_value=True, expected_availability_zone=availability_zone
     )
 
 


### PR DESCRIPTION
Fix integration test test_public_network_topology failed because we change autoassignip in public.cfn.json for pcluster configure to be true instead of false

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
