### PR TITLE
Improvements to integ-tests when running with high parallelism

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -163,6 +163,21 @@ def pytest_configure(config):
     _setup_custom_logger(config.getoption("tests_log_file"))
 
 
+def pytest_sessionstart(session):
+    # The number of seconds before a connection to the instance metadata service should time out.
+    # When attempting to retrieve credentials on an Amazon EC2 instance that is configured with an IAM role,
+    # a connection to the instance metadata service will time out after 1 second by default. If you know you're
+    # running on an EC2 instance with an IAM role configured, you can increase this value if needed.
+    os.environ["AWS_METADATA_SERVICE_TIMEOUT"] = "5"
+    # When attempting to retrieve credentials on an Amazon EC2 instance that has been configured with an IAM role,
+    # Boto3 will make only one attempt to retrieve credentials from the instance metadata service before giving up.
+    # If you know your code will be running on an EC2 instance, you can increase this value to make Boto3 retry
+    # multiple times before giving up.
+    os.environ["AWS_METADATA_SERVICE_NUM_ATTEMPTS"] = "5"
+    # Increasing default max attempts retry
+    os.environ["AWS_MAX_ATTEMPTS"] = "10"
+
+
 def pytest_runtest_call(item):
     """Called to execute the test item."""
     _add_properties_to_report(item)

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -181,12 +181,14 @@ def pytest_sessionstart(session):
 def pytest_runtest_call(item):
     """Called to execute the test item."""
     _add_properties_to_report(item)
-    set_logger_formatter(logging.Formatter(fmt=f"%(asctime)s - %(levelname)s - {item.name} - %(module)s - %(message)s"))
+    set_logger_formatter(
+        logging.Formatter(fmt=f"%(asctime)s - %(levelname)s - %(process)d - {item.name} - %(module)s - %(message)s")
+    )
     logging.info("Running test " + item.name)
 
 
 def pytest_runtest_logfinish(nodeid, location):
-    set_logger_formatter(logging.Formatter(fmt="%(asctime)s - %(levelname)s - %(module)s - %(message)s"))
+    set_logger_formatter(logging.Formatter(fmt="%(asctime)s - %(levelname)s - %(process)d - %(module)s - %(message)s"))
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -268,7 +270,7 @@ def _parametrize_from_option(metafunc, test_arg_name, option_name):
 
 
 def _setup_custom_logger(log_file):
-    formatter = logging.Formatter(fmt="%(asctime)s - %(levelname)s - %(module)s - %(message)s")
+    formatter = logging.Formatter(fmt="%(asctime)s - %(levelname)s - %(process)d - %(module)s - %(message)s")
     logger = logging.getLogger()
     logger.handlers = []
 


### PR DESCRIPTION
* Increase the number of retries and timeout when boto3 accesses the IMDS service to retrieve credentials. This fixes the "Unable to locate credentials" problem happening when running with a high parallelism on an EC2 instance.
* Add the process id to log entries to facilitate extracting logs for a single test process when running in parallel mode.
* Bumping the default boto3 retry to 10 for all boto3 service calls

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
