### PR TITLE
Integ tests: various fixes and enhancements

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -438,6 +438,7 @@ Resources:
               - ec2:DisassociateAddress
               - ec2:ModifyLaunchTemplate
               - ec2:ModifyNetworkInterfaceAttribute
+              - ec2:ModifyVolume
               - ec2:ModifyVolumeAttribute
               - ec2:ReleaseAddress
               - ec2:RevokeSecurityGroupEgress

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -206,6 +206,7 @@ Resources:
               - ec2:DisassociateAddress
               - ec2:ModifyLaunchTemplate
               - ec2:ModifyNetworkInterfaceAttribute
+              - ec2:ModifyVolume
               - ec2:ModifyVolumeAttribute
               - ec2:ReleaseAddress
               - ec2:RevokeSecurityGroupEgress

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -654,11 +654,18 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
+          # Required to test AdditionalIamPolicies
           - Action:
               - iam:AttachRolePolicy
               - iam:DetachRolePolicy
             Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
             Effect: Allow
+          # Required to use KMS encryption key in tests
+          - Action:
+              - kms:DescribeKey
+            Resource: '*'
+            Effect: Allow
+          # Required to use test bucket (e.g. to test pre/post_install scripts)
           - Action:
               - s3:*
             Resource:

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -524,7 +524,7 @@ storage:
       - regions: ["us-east-1"]
         instances: ["m5d.xlarge", "h1.2xlarge"]
         oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+        schedulers: ["slurm"]
 tags:
   test_tag_propagation.py::test_tag_propagation:
     dimensions:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -397,6 +397,7 @@ def api_client(region, api_server_factory, api_uri):
         host = stack.cfn_outputs["ParallelClusterApiInvokeUrl"]
 
     api_configuration = Configuration(host=host)
+    api_configuration.retries = 3
 
     with ApiClient(api_configuration) as api_client_instance:
         yield api_client_instance

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -948,6 +948,7 @@ def role_factory(region):
             RoleName=iam_role_name,
             AssumeRolePolicyDocument=json.dumps(trust_relationship_policy_ec2),
             Description="Role for create custom KMS key",
+            Path="/parallelcluster/",
         )["Role"]["Arn"]
 
         logging.info(f"Attaching iam policy to the role {iam_role_name}...")

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -19,6 +19,7 @@ import os
 import random
 import re
 import time
+from pathlib import Path
 from shutil import copyfile
 from traceback import format_tb
 
@@ -39,6 +40,7 @@ from conftest_markers import (
 )
 from conftest_tests_config import apply_cli_dimensions_filtering, parametrize_from_config, remove_disabled_tests
 from constants import SCHEDULERS_SUPPORTING_IMDS_SECURED
+from filelock import FileLock
 from framework.credential_providers import aws_credential_provider, register_cli_credentials_for_region
 from framework.tests_configuration.config_renderer import read_config_file
 from framework.tests_configuration.config_utils import get_all_regions
@@ -1108,6 +1110,43 @@ def pytest_runtest_makereport(item, call):
     # set a report attribute for each phase of a call, which can
     # be "setup", "call", "teardown"
     setattr(item, "rep_" + rep.when, rep)
+
+    if rep.when in ["setup", "call"] and rep.failed:
+        try:
+            update_failed_tests_config(item)
+        except Exception as e:
+            logging.error("Failed when generating config for failed tests: %s", e, exc_info=True)
+
+
+def update_failed_tests_config(item):
+    out_dir = Path(item.config.getoption("output_dir"))
+    if not str(out_dir).endswith(".out"):
+        # Navigate to the parent dir in case of parallel run so that we can access the shared parent dir
+        out_dir = out_dir.parent
+
+    out_file = out_dir / "failed_tests_config.yaml"
+    logging.info("Updating failed tests config file %s", out_file)
+    # We need to acquire a lock first to prevent concurrent edits to this file
+    with FileLock(str(out_file) + ".lock"):
+        failed_tests = {"test-suites": {}}
+        if out_file.is_file():
+            with open(str(out_file)) as f:
+                failed_tests = yaml.safe_load(f)
+
+        feature, test_id = item.nodeid.split("/", 1)
+        test_id = test_id.split("[", 1)[0]
+        dimensions = {}
+        for dimension in DIMENSIONS_MARKER_ARGS:
+            value = item.callspec.params.get(dimension)
+            if value:
+                dimensions[dimension + "s"] = [value]
+
+        if not dict_has_nested_key(failed_tests, ("test-suites", feature, test_id)):
+            dict_add_nested_key(failed_tests, [], ("test-suites", feature, test_id, "dimensions"))
+        if dimensions not in failed_tests["test-suites"][feature][test_id]["dimensions"]:
+            failed_tests["test-suites"][feature][test_id]["dimensions"].append(dimensions)
+            with open(out_file, "w") as f:
+                yaml.dump(failed_tests, f)
 
 
 @pytest.fixture()

--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -4,6 +4,7 @@ aws-parallelcluster
 boto3
 cfn_flip
 fabric
+filelock
 jinja2
 junitparser
 pexpect

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -32,6 +32,7 @@ def test_build_image(
     s3_bucket_factory,
     build_image_custom_resource,
     images_factory,
+    request,
 ):
     """Test build image for given region and os"""
     # Get base AMI
@@ -41,7 +42,7 @@ def test_build_image(
     else:
         base_ami = retrieve_latest_ami(region, os, architecture=architecture)
 
-    image_id = f"integ-test-build-image-{generate_random_string()}"
+    image_id = generate_stack_name("integ-tests-build-image", request.config.getoption("stackname_suffix"))
 
     # Get custom instance role
     instance_role = build_image_custom_resource(image_id=image_id)
@@ -91,7 +92,7 @@ def _assert_image_tag_and_volume(image):
 
 
 @pytest.fixture()
-def build_image_custom_resource(cfn_stacks_factory, region):
+def build_image_custom_resource(cfn_stacks_factory, region, request):
     """
     Define a fixture to manage the creation and destruction of build image resource( custom instance role).
 
@@ -102,7 +103,9 @@ def build_image_custom_resource(cfn_stacks_factory, region):
     def _custom_resource(image_id):
         nonlocal stack_name_post_test
         # custom resource stack
-        custom_resource_stack_name = generate_stack_name("-".join([image_id, "custom", "resource"]), "")
+        custom_resource_stack_name = generate_stack_name(
+            "-".join([image_id, "custom", "resource"]), request.config.getoption("stackname_suffix")
+        )
         stack_name_post_test = custom_resource_stack_name
         custom_resource_template = Template()
         custom_resource_template.set_version()
@@ -166,7 +169,7 @@ def build_image_custom_resource(cfn_stacks_factory, region):
 
 
 def test_build_image_custom_components(
-    region, os, instance, test_datadir, pcluster_config_reader, architecture, s3_bucket_factory, images_factory
+    region, os, instance, test_datadir, pcluster_config_reader, architecture, s3_bucket_factory, images_factory, request
 ):
     """Test custom components and base AMI is ParallelCluster AMI"""
     # Custom script
@@ -180,7 +183,9 @@ def test_build_image_custom_components(
     # Get ParallelCluster AMI as base AMI
     base_ami = retrieve_latest_ami(region, os, ami_type="pcluster", architecture=architecture)
 
-    image_id = f"integ-test-build-image-custom-components-{generate_random_string()}"
+    image_id = generate_stack_name(
+        "integ-tests-build-image-custom-components", request.config.getoption("stackname_suffix")
+    )
     image_config = pcluster_config_reader(
         config_file="image.config.yaml",
         parent_image=base_ami,
@@ -210,7 +215,14 @@ def _assert_build_image_success(image):
 
 
 def test_build_image_wrong_pcluster_version(
-    region, os, instance, pcluster_config_reader, architecture, pcluster_ami_without_standard_naming, images_factory
+    region,
+    os,
+    instance,
+    pcluster_config_reader,
+    architecture,
+    pcluster_ami_without_standard_naming,
+    images_factory,
+    request,
 ):
     """Test error message when AMI provided was baked by a pcluster whose version is different from current version"""
     current_version = get_installed_parallelcluster_version()
@@ -226,7 +238,9 @@ def test_build_image_wrong_pcluster_version(
         parent_image=wrong_ami,
         instance_type=instance,
     )
-    image_id = f"integ-test-build-image-wrong-version-{generate_random_string()}"
+    image_id = generate_stack_name(
+        "integ-tests-build-image-wrong-version", request.config.getoption("stackname_suffix")
+    )
 
     image = images_factory(image_id, image_config, region)
 

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -141,7 +141,7 @@ def build_image_custom_resource(cfn_stacks_factory, region):
             },
             Description="custom instance role for build image test.",
             ManagedPolicyArns=managed_policy_arns,
-            Path="/myInstanceRole/",
+            Path="/parallelcluster/",
             Policies=[policy_document],
             RoleName=role_name,
         )


### PR DESCRIPTION
| [integ-tests] Fix config for test_ephemeral.py::test_head_node_stop
The test was meant to run with slurm scheduler

| [integ-tests] Add KMS policy to user role
Policy required for storage encryption validator

| [integ-tests] Fix stack name used for createami tests
stack names were non compliant

| [integ-tests] Create test roles with /parallelcluster/ path
pcluster user role is authorized to roles created on /parallelcluster/ path

| [integ-tests] Add logic to generate a test config including all failed tests
the testing framework will produce failed_tests_config.yaml in the output folder that contains a test config with all tests that failed during that run. It can be used to rerun only failed tests.

| [integ-tests] Add retries in API client

| [iam] Add missing ec2:ModifyVolume policy
Needed to update EBS volumes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
