### PR TITLE
Change EFA and Placement Group Defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ CHANGELOG
   per cluster.
 - Encrypt root EBS volumes and shared EBS volumes by default.
   Note that if the scheduler is AWS Batch, the root volumes of the compute nodes cannot be encrypted by ParallelCluster.
-- Enable EFA for a compute resource by default if the instance type supports EFA.
 - Add multiple queues and compute resources support for `pcluster configure` when the scheduler is Slurm.
 - Add prompt for availability zone in `pcluster configure` automated subnets creation.
 - Use different permissions in instance roles based on the scheduler and the node's role in the cluster.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1450,13 +1450,13 @@ class SlurmQueue(BaseQueue):
                 security_groups=self.networking.security_groups,
                 additional_security_groups=self.networking.additional_security_groups,
             )
-            if self.networking.placement_group:
-                self._register_validator(
-                    EfaPlacementGroupValidator,
-                    efa_enabled=compute_resource.efa.enabled,
-                    placement_group_id=self.networking.placement_group.id,
-                    placement_group_enabled=self.networking.placement_group.enabled,
-                )
+            self._register_validator(
+                EfaPlacementGroupValidator,
+                efa_enabled=compute_resource.efa.enabled,
+                placement_group_enabled=self.networking.placement_group and self.networking.placement_group.enabled,
+                placement_group_config_implicit=self.networking.placement_group is None
+                or self.networking.placement_group.is_implied("enabled"),
+            )
 
     @property
     def instance_type_list(self):

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1338,8 +1338,7 @@ class SlurmComputeResource(BaseComputeResource):
             disable_simultaneous_multithreading, default=False
         )
         self.__instance_type_info = None
-        efa_supported = self.instance_type_info.is_efa_supported()
-        self.efa = efa or Efa(enabled=efa_supported, implied=True)
+        self.efa = efa or Efa(enabled=False, implied=True)
 
     @property
     def instance_type_info(self) -> InstanceTypeInfo:

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -302,8 +302,15 @@ class EfaValidator(Validator):
 class EfaPlacementGroupValidator(Validator):
     """Validate placement group if EFA is enabled."""
 
-    def _validate(self, efa_enabled, placement_group_id, placement_group_enabled):
-        if efa_enabled and not placement_group_id and not placement_group_enabled:
+    def _validate(self, efa_enabled, placement_group_enabled, placement_group_config_implicit):
+        if efa_enabled and placement_group_config_implicit:
+            self._add_failure(
+                "The placement group for EFA-enabled compute resources must be explicit. "
+                "You may see better performance using a placement group, but if you don't wish to use one please add "
+                "'Enabled: false' to the compute resource's configuration section.",
+                FailureLevel.ERROR,
+            )
+        elif efa_enabled and not placement_group_enabled:
             self._add_failure(
                 "You may see better performance using a placement group for the queue.", FailureLevel.WARNING
             )

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -174,18 +174,27 @@ def test_efa_validator(mocker, boto3_stubber, instance_type, efa_enabled, gdr_su
 
 
 @pytest.mark.parametrize(
-    "efa_enabled, placement_group_id, placement_group_enabled, expected_message",
+    "efa_enabled, placement_group_enabled, placement_group_config_implicit, expected_message",
     [
-        # Efa disabled, no check on placement group configuration
-        (False, None, False, None),
+        # Efa disabled
+        (False, False, False, None),
+        (False, True, False, None),
+        (False, False, True, None),
+        (False, True, True, None),
         # Efa enabled
-        (True, None, False, "You may see better performance using a placement group"),
-        (True, None, True, None),
-        (True, "existing_pg", False, None),
+        (True, False, False, "may see better performance using a placement group"),
+        (True, False, True, "placement group for EFA-enabled compute resources must be explicit"),
+        (True, True, True, "placement group for EFA-enabled compute resources must be explicit"),
+        (True, True, False, None),
     ],
 )
-def test_efa_placement_group_validator(efa_enabled, placement_group_id, placement_group_enabled, expected_message):
-    actual_failures = EfaPlacementGroupValidator().execute(efa_enabled, placement_group_id, placement_group_enabled)
+def test_efa_placement_group_validator(
+    efa_enabled, placement_group_enabled, placement_group_config_implicit, expected_message
+):
+    actual_failures = EfaPlacementGroupValidator().execute(
+        efa_enabled, placement_group_enabled, placement_group_config_implicit
+    )
+
     assert_failure_messages(actual_failures, expected_message)
 
 

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.yaml
@@ -39,26 +39,6 @@ Scheduling:
           MinCount: 1
           Efa:
             Enabled: false
-    - Name: efa-disabled-by-default
-      Networking:
-        SubnetIds:
-          - {{ private_subnet_id }}
-      ComputeResources:
-        - Name: efa-disabled-by-def-i1
-          InstanceType: {{ no_efa_instance }}
-          MaxCount: {{ max_queue_size }}
-          MinCount: 1
-    - Name: efa-enabled-by-default
-      Networking:
-        PlacementGroup:
-          Enabled: true
-        SubnetIds:
-          - {{ private_subnet_id }}
-      ComputeResources:
-        - Name: efa-enabled-by-def-i1
-          InstanceType: {{ instance }}
-          MaxCount: {{ max_queue_size }}
-          MinCount: 2
 SharedStorage:
   - MountDir: /shared
     Name: name1

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -22,10 +22,16 @@ Scheduling:
           {% else %}
           InstanceType: {{ instance }}
           MinCount: 1
+          Efa:
+            Enabled: true
           {% endif %}
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+        {% if scheduler != "awsbatch" %}
+        PlacementGroup:
+          Enabled: true
+        {% endif %}
 SharedStorage:
   - MountDir: /shared
     Name: name1


### PR DESCRIPTION
* Disable EFA by default, rather than a conditional default based on whether the instance type supports it.
* Require the use of a placement group when EFA is enabled.
* Warn user when instance type supports EFA but it is not enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
