### PR TITLE
Run integration tests with ParalleCluster user role

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -434,6 +434,7 @@ Resources:
               - ec2:CreateNetworkInterface
               - ec2:CreatePlacementGroup
               - ec2:CreateSecurityGroup
+              - ec2:CreateSnapshot
               - ec2:CreateTags
               - ec2:CreateVolume
               - ec2:DeleteLaunchTemplate
@@ -547,6 +548,16 @@ Resources:
                   - codebuild.amazonaws.com
             Sid: IamPassRole
           - Action:
+              - iam:CreateServiceLinkedRole
+              - iam:DeleteServiceLinkedRole
+            Resource: '*'
+            Effect: Allow
+            Condition:
+              StringEquals:
+                iam:AWSServiceName:
+                  - fsx.amazonaws.com
+                  - s3.data-source.lustre.fsx.amazonaws.com
+          - Action:
               - lambda:CreateFunction
               - lambda:DeleteFunction
               - lambda:GetFunctionConfiguration
@@ -554,6 +565,7 @@ Resources:
               - lambda:InvokeFunction
               - lambda:AddPermission
               - lambda:RemovePermission
+              - lambda:UpdateFunctionConfiguration
             Resource:
               - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:parallelcluster-*
               - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:pcluster-*
@@ -588,25 +600,15 @@ Resources:
             Sid: S3ParallelClusterReadOnly
           - Action:
               - fsx:*
-            Resource: '*'
+            Resource:
+              - !Sub arn:${AWS::Partition}:fsx:${Region}:${AWS::AccountId}:*
             Effect: Allow
-            Condition: !If
-              - IsMultiRegion
-              - !Ref AWS::NoValue
-              - StringEquals:
-                  aws:RequestedRegion:
-                    - !Ref Region
             Sid: FSx
           - Action:
               - elasticfilesystem:*
-            Resource: '*'
+            Resource:
+              - !Sub arn:${AWS::Partition}:elasticfilesystem:${Region}:${AWS::AccountId}:*
             Effect: Allow
-            Condition: !If
-              - IsMultiRegion
-              - !Ref AWS::NoValue
-              - StringEquals:
-                  aws:RequestedRegion:
-                    - !Ref Region
             Sid: EFS
           - Action:
               - logs:DeleteLogGroup

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -196,6 +196,7 @@ Resources:
               - ec2:CreateNetworkInterface
               - ec2:CreatePlacementGroup
               - ec2:CreateSecurityGroup
+              - ec2:CreateSnapshot
               - ec2:CreateTags
               - ec2:CreateVolume
               - ec2:DeleteLaunchTemplate
@@ -309,6 +310,16 @@ Resources:
                   - codebuild.amazonaws.com
             Sid: IamPassRole
           - Action:
+              - iam:CreateServiceLinkedRole
+              - iam:DeleteServiceLinkedRole
+            Resource: '*'
+            Effect: Allow
+            Condition:
+              StringEquals:
+                iam:AWSServiceName:
+                  - fsx.amazonaws.com
+                  - s3.data-source.lustre.fsx.amazonaws.com
+          - Action:
               - lambda:CreateFunction
               - lambda:DeleteFunction
               - lambda:GetFunctionConfiguration
@@ -316,6 +327,7 @@ Resources:
               - lambda:InvokeFunction
               - lambda:AddPermission
               - lambda:RemovePermission
+              - lambda:UpdateFunctionConfiguration
             Resource:
               - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:parallelcluster-*
               - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:pcluster-*
@@ -350,25 +362,15 @@ Resources:
             Sid: S3ParallelClusterReadOnly
           - Action:
               - fsx:*
-            Resource: '*'
+            Resource:
+              - !Sub arn:${AWS::Partition}:fsx:${Region}:${AWS::AccountId}:*
             Effect: Allow
-            Condition: !If
-              - IsMultiRegion
-              - !Ref AWS::NoValue
-              - StringEquals:
-                  aws:RequestedRegion:
-                    - !Ref Region
             Sid: FSx
           - Action:
               - elasticfilesystem:*
-            Resource: '*'
+            Resource:
+              - !Sub arn:${AWS::Partition}:elasticfilesystem:${Region}:${AWS::AccountId}:*
             Effect: Allow
-            Condition: !If
-              - IsMultiRegion
-              - !Ref AWS::NoValue
-              - StringEquals:
-                  aws:RequestedRegion:
-                    - !Ref Region
             Sid: EFS
           - Action:
               - logs:DeleteLogGroup
@@ -663,8 +665,18 @@ Resources:
           # Required to use KMS encryption key in tests
           - Action:
               - kms:DescribeKey
+              - kms:Decrypt
+              - kms:GenerateDataKeyWithoutPlainText
+              - kms:ReEncrypt
             Resource: '*'
             Effect: Allow
+          - Action:
+              - kms:CreateGrant
+            Resource: '*'
+            Effect: Allow
+            Condition:
+              Bool:
+                kms:GrantIsForAWSResource: true
           # Required to use test bucket (e.g. to test pre/post_install scripts)
           - Action:
               - s3:*

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1131,6 +1131,8 @@ def update_failed_tests_config(item):
             with open(str(out_file)) as f:
                 failed_tests = yaml.safe_load(f)
 
+        # item.node.nodeid example:
+        # 'dcv/test_dcv.py::test_dcv_configuration[eu-west-1-c5.xlarge-centos7-slurm-8443-0.0.0.0/0-/shared]'
         feature, test_id = item.nodeid.split("/", 1)
         test_id = test_id.split("[", 1)[0]
         dimensions = {}

--- a/tests/integration-tests/images_factory.py
+++ b/tests/integration-tests/images_factory.py
@@ -13,7 +13,8 @@ import json
 import logging
 
 import yaml
-from utils import kebab_case, run_command
+from framework.credential_providers import run_pcluster_command
+from utils import kebab_case
 
 
 class Image:
@@ -39,7 +40,7 @@ class Image:
         command = ["pcluster", "list-images"]
         for k, val in kwargs.items():
             command.extend([f"--{kebab_case(k)}", str(val)])
-        result = run_command(command)
+        result = run_pcluster_command(command)
         response = json.loads(result.stdout)
         return response
 
@@ -62,7 +63,7 @@ class Image:
         for k, val in kwargs.items():
             command.extend([f"--{kebab_case(k)}", str(val)])
 
-        result = run_command(command, raise_on_error=raise_on_error, log_error=log_error)
+        result = run_pcluster_command(command, raise_on_error=raise_on_error, log_error=log_error)
         response = json.loads(result.stdout)
         try:
             if response["image"]["imageBuildStatus"] == "BUILD_IN_PROGRESS":
@@ -88,7 +89,7 @@ class Image:
         command = ["pcluster", "delete-image", "--image-id", self.image_id, "--region", self.region]
         if force:
             command.extend(["--force", "true"])
-        result = run_command(command).stdout
+        result = run_pcluster_command(command).stdout
         response = json.loads(result.stdout)
         if "message" in response and response["message"].startswith("No image or stack associated"):
             logging.error("Delete on non-existing image: %s", self.image_id)
@@ -100,7 +101,7 @@ class Image:
         """Describe image."""
         logging.info("Describe image %s in region %s.", self.image_id, self.region)
         command = ["pcluster", "describe-image", "--image-id", self.image_id, "--region", self.region]
-        result = run_command(command).stdout
+        result = run_pcluster_command(command).stdout
         response = json.loads(result)
         if "message" in response and response["message"].startswith("No image or stack associated"):
             if log_on_error:
@@ -125,7 +126,7 @@ class Image:
         for k, val in args.items():
             if val is not None:
                 command.extend([f"--{kebab_case(k)}", str(val)])
-        result = run_command(command).stdout
+        result = run_pcluster_command(command).stdout
         response = json.loads(result)
         return response
 
@@ -135,7 +136,7 @@ class Image:
         command = ["pcluster", "get-image-stack-events", "--region", self.region, "--image-id", self.image_id]
         for k, val in args.items():
             command.extend([f"--{kebab_case(k)}", str(val)])
-        result = run_command(command).stdout
+        result = run_pcluster_command(command).stdout
         response = json.loads(result)
         return response
 
@@ -143,7 +144,7 @@ class Image:
         """Get image build log streams."""
         logging.info("Get image %s build log streams.", self.image_id)
         command = ["pcluster", "list-image-log-streams", "--region", self.region, "--image-id", self.image_id]
-        result = run_command(command).stdout
+        result = run_pcluster_command(command).stdout
         response = json.loads(result)
         return response
 

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -21,8 +21,9 @@ import botocore
 import pytest
 from assertpy import assert_that
 from dateutil.parser import parse as date_parse
+from framework.credential_providers import run_pcluster_command
 from remote_command_executor import RemoteCommandExecutor
-from utils import check_status, get_cluster_nodes_instance_ids, run_command
+from utils import check_status, get_cluster_nodes_instance_ids
 
 from tests.common.assertions import assert_no_errors_in_logs, wait_for_num_instances_in_cluster
 from tests.common.utils import get_installed_parallelcluster_version, retrieve_latest_ami
@@ -270,12 +271,12 @@ def _test_list_cluster(cluster_name, expected_status):
 
 
 def _find_cluster_with_pagination(cmd_args, cluster_name):
-    result = run_command(cmd_args)
+    result = run_pcluster_command(cmd_args)
     response = json.loads(result.stdout)
     found_cluster = _find_cluster_in_list(cluster_name, response["items"])
     while response.get("nextToken") and found_cluster is None:
         cmd_args_with_next_token = cmd_args + ["--next-token", response["nextToken"]]
-        result = run_command(cmd_args_with_next_token)
+        result = run_pcluster_command(cmd_args_with_next_token)
         response = json.loads(result.stdout)
         found_cluster = _find_cluster_in_list(cluster_name, response["items"])
     return found_cluster

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -14,13 +14,13 @@ import re
 
 import pytest
 from assertpy import assert_that
+from framework.credential_providers import run_pcluster_command
 from remote_command_executor import RemoteCommandExecutor
 from utils import (
     add_keys_to_known_hosts,
     check_headnode_security_group,
     get_username_for_os,
     remove_keys_from_known_hosts,
-    run_command,
 )
 
 from tests.cloudwatch_logging.test_cloudwatch_logging import FeatureSpecificCloudWatchLoggingTestRunner
@@ -113,7 +113,9 @@ def _test_dcv_configuration(
     add_keys_to_known_hosts(cluster.head_node_ip, host_keys_file)
 
     try:
-        result = run_command(["pcluster", "dcv-connect", "--cluster-name", cluster.name, "--show-url"], env=env)
+        result = run_pcluster_command(
+            ["pcluster", "dcv-connect", "--cluster-name", cluster.name, "--show-url"], env=env
+        )
     finally:
         # remove ssh key from jenkins user known hosts file
         remove_keys_from_known_hosts(cluster.head_node_ip, host_keys_file, env=env)

--- a/tests/integration-tests/tests/storage/kms_key_factory.py
+++ b/tests/integration-tests/tests/storage/kms_key_factory.py
@@ -81,6 +81,7 @@ class KMSKeyFactory:
             RoleName=iam_role_name,
             AssumeRolePolicyDocument=json.dumps(trust_relationship_policy_ec2),
             Description="Role for create custom KMS key",
+            Path="/parallelcluster/",
         )["Role"]["Arn"]
         # Having time.sleep here because because it take a while for the the IAM role to become valid for use in the
         # put_key_policy step for creating KMS key, read the following link for reference :
@@ -155,7 +156,7 @@ class KMSKeyFactory:
         file_loader = FileSystemLoader(pkg_resources.resource_filename(__name__, "/../../resources"))
         env = Environment(loader=file_loader, trim_blocks=True, lstrip_blocks=True)
         key_policy = env.get_template("key_policy.json").render(
-            partition=self.partition, account_id=self.account_id, iam_role_name=self.iam_role_name
+            partition=self.partition, account_id=self.account_id, iam_role_name=f"parallelcluster/{self.iam_role_name}"
         )
 
         # attach key policy to the key


### PR DESCRIPTION
All invocation of pcluster CLI in integ tests will be using a specific IAM role rather than defaulting to the credentials configured for the test runner. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
