### PR TITLE
Remove possibility to specify file:// in urls

### DIFF
--- a/cli/src/pcluster/validators/s3_validators.py
+++ b/cli/src/pcluster/validators/s3_validators.py
@@ -13,12 +13,12 @@ class UrlValidator(Validator):
     """
     Url Validator.
 
-    Validate given url with s3, https or file prefix.
+    Validate given url with s3 or https prefix.
     """
 
     def _validate(self, url):
         scheme = get_url_scheme(url)
-        if scheme in ["https", "s3", "file"]:
+        if scheme in ["https", "s3"]:
             if scheme == "s3":
                 self._validate_s3_uri(url)
             else:
@@ -43,7 +43,7 @@ class UrlValidator(Validator):
                     )
         else:
             self._add_failure(
-                f"The value '{url}' is not a valid URL, choose URL with 'https', 's3' or 'file' prefix.",
+                f"The value '{url}' is not a valid URL, choose URL with 'https' or 's3' prefix.",
                 FailureLevel.ERROR,
             )
 

--- a/cli/tests/pcluster/models/test_imagebuilder.py
+++ b/cli/tests/pcluster/models/test_imagebuilder.py
@@ -103,7 +103,7 @@ def test_imagebuilder_kms_key_id_encrypted_validator_and_ami_volume_size_validat
         (
             {
                 "dev_settings": {
-                    "cookbook": {"chef_cookbook": "file:///test/aws-parallelcluster-cookbook-3.0.tgz"},
+                    "cookbook": {"chef_cookbook": "https:///test/aws-parallelcluster-cookbook-3.0.tgz"},
                     "node_package": "s3://test/aws-parallelcluster-node-3.0.tgz",
                     "aws_batch_cli_package": "ftp://test/aws-parallelcluster-batch-3.0.tgz",
                 },
@@ -112,11 +112,11 @@ def test_imagebuilder_kms_key_id_encrypted_validator_and_ami_volume_size_validat
             AWSClientError(function_name="head_object", message="error"),
             URLError("[Errno 2] No such file or directory: '/test/aws-parallelcluster-cookbook-3.0.tgz'"),
             [
-                "The url 'file:///test/aws-parallelcluster-cookbook-3.0.tgz' causes URLError, the error reason is "
+                "The url 'https:///test/aws-parallelcluster-cookbook-3.0.tgz' causes URLError, the error reason is "
                 "'[Errno 2] No such file or directory: '/test/aws-parallelcluster-cookbook-3.0.tgz''",
                 "The S3 object does not exist or you do not have access to it.",
                 "The value 'ftp://test/aws-parallelcluster-batch-3.0.tgz' is not a valid URL, choose URL with "
-                "'https', 's3' or 'file' prefix.",
+                "'https' or 's3' prefix.",
             ],
             [FailureLevel.WARNING, FailureLevel.ERROR, FailureLevel.ERROR],
         ),

--- a/cli/tests/pcluster/validators/test_s3_validators.py
+++ b/cli/tests/pcluster/validators/test_s3_validators.py
@@ -9,12 +9,15 @@ from tests.pcluster.validators.utils import assert_failure_messages
     [
         ("s3://test/post_install.sh", True, None),
         ("https://test/cookbook.tgz", True, None),
-        ("file:///test/node.tgz", True, None),
+        (
+            "file:///test/node.tgz",
+            False,
+            "The value 'file:///test/node.tgz' is not a valid URL, " "choose URL with 'https' or 's3' prefix.",
+        ),
         (
             "fake://test/cookbook.tgz",
             False,
-            "The value 'fake://test/cookbook.tgz' is not a valid URL, "
-            "choose URL with 'https', 's3' or 'file' prefix.",
+            "The value 'fake://test/cookbook.tgz' is not a valid URL, " "choose URL with 'https' or 's3' prefix.",
         ),
     ],
 )


### PR DESCRIPTION
Remove possibility to specify file:// in urls since it is not supported
Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
