### PR TITLE
Fix slurm cluster update integ tests

### DIFF
--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -87,6 +87,8 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+        PlacementGroup:
+          Enabled: false
     - Name: queue3
       Iam:
         S3Access:
@@ -121,6 +123,8 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+        PlacementGroup:
+          Enabled: false
 SharedStorage:
   - MountDir: shared
     Name: ebs

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -118,8 +118,6 @@ Scheduling:
         - Name: queue3-i2
           InstanceType: t2.xlarge
           DisableSimultaneousMultithreading: true
-          Efa:
-            Enabled: true
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -55,6 +55,8 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+        PlacementGroup:
+          Enabled: false
 SharedStorage:
   - MountDir: shared
     Name: ebs


### PR DESCRIPTION
The integ test for validating slurm cluster updates has configs with EFA-enabled compute resources embedded in queues that don't explicitly enable or disable the use of a placement group. I missed these when creating #3103 .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
