### PR TITLE
Align output file name of mbw_mr benchmark to other benchmarks

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -269,7 +269,7 @@ def _test_osu_benchmarks_multiple_bandwidth(
         test_datadir,
     )
     max_bandwidth = remote_command_executor.run_remote_command(
-        "cat /shared/osu.out | tail -n +4 | awk '{print $2}' | sort -n | tail -n 1"
+        "cat /shared/mbw_mr.out | tail -n +4 | awk '{print $2}' | sort -n | tail -n 1"
     ).stdout
 
     # Expected bandwidth with 4 NICS:

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/osu_mbw_mr_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/osu_mbw_mr_submit_openmpi.sh
@@ -2,6 +2,7 @@
 set -e
 module load openmpi
 
+BENCHMARK_NAME=osu_mbw_mr
 OSU_BENCHMARK_VERSION={{ osu_benchmark_version }}
 
 # Run multiple bandwidth/message rate benchmark
@@ -9,4 +10,4 @@ OSU_BENCHMARK_VERSION={{ osu_benchmark_version }}
 # -N: number of processes per node (48, 1 for each CPU)
 # -n total number of processes to run (96, all CPUs from 2 nodes)
 # -x FI_EFA_USE_DEVICE_RDMA=1 Enables RDMA support
-mpirun --mca btl_tcp_if_exclude lo -n 96 -N 48 -x FI_EFA_USE_DEVICE_RDMA=1 /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/pt2pt/osu_mbw_mr > /shared/osu.out
+mpirun --mca btl_tcp_if_exclude lo -n 96 -N 48 -x FI_EFA_USE_DEVICE_RDMA=1 /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/pt2pt/${BENCHMARK_NAME} > /shared/${BENCHMARK_NAME}.out

--- a/tests/integration-tests/tests/efa/test_efa/test_sit_efa/osu_mbw_mr_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_sit_efa/osu_mbw_mr_submit_openmpi.sh
@@ -2,6 +2,7 @@
 set -e
 module load openmpi
 
+BENCHMARK_NAME=osu_mbw_mr
 OSU_BENCHMARK_VERSION={{ osu_benchmark_version }}
 
 # Run multiple bandwidth/message rate benchmark
@@ -9,4 +10,4 @@ OSU_BENCHMARK_VERSION={{ osu_benchmark_version }}
 # -N: number of processes per node (48, 1 for each CPU)
 # -n total number of processes to run (96, all CPUs from 2 nodes)
 # -x FI_EFA_USE_DEVICE_RDMA=1 Enables RDMA support
-mpirun --mca btl_tcp_if_exclude lo -n 96 -N 48 -x FI_EFA_USE_DEVICE_RDMA=1 /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/pt2pt/osu_mbw_mr > /shared/osu.out
+mpirun --mca btl_tcp_if_exclude lo -n 96 -N 48 -x FI_EFA_USE_DEVICE_RDMA=1 /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/pt2pt/${BENCHMARK_NAME} > /shared/${BENCHMARK_NAME}.out


### PR DESCRIPTION
The test was failing with: `cat: /shared/mbw_mr.out: No such file or directory`
because the `run_osu_benchmarks` function is a common one, used by both collective and pt2pt tests,
creating an output file named as the executed benchmark.
