### PR TITLE
[api] add support for PermissionsBoundary in API template

### DIFF
--- a/api/infrastructure/deploy-api.sh
+++ b/api/infrastructure/deploy-api.sh
@@ -91,8 +91,8 @@ aws cloudformation deploy \
     --capabilities CAPABILITY_NAMED_IAM
 
 echo "Updating API Lambda since updates are not fully automated yet"
-LAMBDA_FUNCTION_ARN=$(aws cloudformation describe-stacks --stack-name ParallelClusterApi --query "Stacks[0].Outputs[?OutputKey=='ParallelClusterLambdaArn'].OutputValue" --output text)
-ECR_IMAGE_URI=$(aws cloudformation describe-stacks --stack-name ParallelClusterApi --query "Stacks[0].Outputs[?OutputKey=='UriOfCopyOfPublicEcrImage'].OutputValue" --output text)
+LAMBDA_FUNCTION_ARN=$(aws cloudformation describe-stacks --stack-name ${STACK_NAME} --query "Stacks[0].Outputs[?OutputKey=='ParallelClusterLambdaArn'].OutputValue" --output text)
+ECR_IMAGE_URI=$(aws cloudformation describe-stacks --stack-name ${STACK_NAME} --query "Stacks[0].Outputs[?OutputKey=='UriOfCopyOfPublicEcrImage'].OutputValue" --output text)
 
 aws lambda update-function-code \
     --function-name ${LAMBDA_FUNCTION_ARN} \

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -56,6 +56,13 @@ Parameters:
       - true
       - false
 
+  PermissionsBoundaryPolicy:
+    Description: |
+      ARN of a IAM policy to use as PermissionsBoundary for all IAM resources created by ParallelCluster API.
+      When specified, IAM permissions assumed by the API are conditionally restricted to the usage of the given PermissionsBoundary
+    Type: String
+    Default: ''
+
   CreateApiUserRole:
     Description: Creates a IAM role authorized to invoke the API. The Api is configured with a resource based policy to grant invoke permission to the created user only.
     Type: String
@@ -120,6 +127,7 @@ Conditions:
   EnableIamPolicy: !And
     - !Equals [!Ref EnableIamAdminAccess, true]
     - !Not [!Condition UseCustomParallelClusterFunctionRole]
+  EnablePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicy, '']]
   UsePrivateVpcEndpoint: !And
     - !Not [!Condition UseCustomDomainAndRoute53Configuration]
     - !Not [!Equals [!Ref VpcEndpointId, '']]
@@ -302,10 +310,12 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
             Effect: Allow
-            # Condition:
-            #   StringEquals:
-            #     iam:PermissionsBoundary:
-            #       - !Ref ParallelClusterPermissionBoundaryPolicy
+            Condition: !If
+              - EnablePermissionsBoundary
+              - StringEquals:
+                  iam:PermissionsBoundary:
+                    - !Ref PermissionsBoundaryPolicy
+              - !Ref AWS::NoValue
             Sid: IamCreateRole
           - Action:
               - iam:PutRolePolicy
@@ -313,6 +323,12 @@ Resources:
             Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
             Effect: Allow
             Sid: IamInlinePolicy
+            Condition: !If
+              - EnablePermissionsBoundary
+              - StringEquals:
+                  iam:PermissionsBoundary:
+                    - !Ref PermissionsBoundaryPolicy
+              - !Ref AWS::NoValue
           - Action:
               - iam:AttachRolePolicy
               - iam:DetachRolePolicy
@@ -332,6 +348,11 @@ Resources:
                   - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
                   - !Sub arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder
                   - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+              StringEquals: !If
+                - EnablePermissionsBoundary
+                - iam:PermissionsBoundary:
+                    - !Ref PermissionsBoundaryPolicy
+                - !Ref AWS::NoValue
             Effect: Allow
             Sid: IamPolicy
 

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -636,9 +636,6 @@ Resources:
               - logs:PutRetentionPolicy
               - logs:DescribeLogGroups
               - logs:CreateLogGroup
-              - logs:FilterLogEvents
-              - logs:GetLogEvents
-              - logs:CreateExportTask
             Resource: '*'
             Effect: Allow
             Condition: !If
@@ -896,6 +893,7 @@ Resources:
             - logs:GetLogEvents
             - logs:CreateExportTask
             - logs:DescribeLogStreams
+            - logs:DescribeExportTasks
             Resource: '*'
             Effect: Allow
             Condition: !If

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -399,9 +399,6 @@ Resources:
               - logs:PutRetentionPolicy
               - logs:DescribeLogGroups
               - logs:CreateLogGroup
-              - logs:FilterLogEvents
-              - logs:GetLogEvents
-              - logs:CreateExportTask
             Resource: '*'
             Effect: Allow
             Condition: !If
@@ -659,6 +656,7 @@ Resources:
             - logs:GetLogEvents
             - logs:CreateExportTask
             - logs:DescribeLogStreams
+            - logs:DescribeExportTasks
             Resource: '*'
             Effect: Allow
             Condition: !If

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -13,8 +13,17 @@ Parameters:
       - true
       - false
 
+  EnablePermissionsBoundary:
+    Description: Force iam:CreateRole and iam:PutRolePolicy to use PermissionsBoundary
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+
 Conditions:
   EnableIamPolicy: !Equals [!Ref EnableIamAdminAccess, true]
+  EnablePermissionsBoundary: !Equals [!Ref EnablePermissionsBoundary, true]
   IsMultiRegion: !Equals [!Ref Region, '*']
   CreateIamResources: !Equals [true, true]  # to keep aligned the resources in the API stack
 
@@ -64,10 +73,12 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
             Effect: Allow
-            # Condition:
-            #   StringEquals:
-            #     iam:PermissionsBoundary:
-            #       - !Ref ParallelClusterPermissionBoundaryPolicy
+            Condition: !If
+              - EnablePermissionsBoundary
+              - StringEquals:
+                  iam:PermissionsBoundary:
+                    - !Ref PermissionsBoundaryPolicy
+              - !Ref AWS::NoValue
             Sid: IamCreateRole
           - Action:
               - iam:PutRolePolicy
@@ -75,6 +86,12 @@ Resources:
             Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
             Effect: Allow
             Sid: IamInlinePolicy
+            Condition: !If
+              - EnablePermissionsBoundary
+              - StringEquals:
+                  iam:PermissionsBoundary:
+                    - !Ref PermissionsBoundaryPolicy
+              - !Ref AWS::NoValue
           - Action:
               - iam:AttachRolePolicy
               - iam:DetachRolePolicy
@@ -94,6 +111,11 @@ Resources:
                   - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
                   - !Sub arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder
                   - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+              StringEquals: !If
+                - EnablePermissionsBoundary
+                - iam:PermissionsBoundary:
+                    - !Ref PermissionsBoundaryPolicy
+                - !Ref AWS::NoValue
             Effect: Allow
             Sid: IamPolicy
 
@@ -683,6 +705,231 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:s3:::integ-tests-*
             Effect: Allow
+
+  ### PERMISSIONS BOUNDARY
+
+  PermissionsBoundaryPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - route53:ListResourceRecordSets
+              - route53:ChangeResourceRecordSets
+            Effect: Allow
+            Resource: !Sub arn:${AWS::Partition}:route53:::hostedzone/*
+          - Action:
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource: !Sub arn:${AWS::Partition}:logs:*:*:*
+          - Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Query
+              - dynamodb:GetItem
+              - dynamodb:PutItem
+              - dynamodb:BatchWriteItem
+            Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/parallelcluster-*
+            Effect: Allow
+          - Action: ec2:DescribeInstances
+            Effect: Allow
+            Resource: '*'
+          - Action: ec2:TerminateInstances
+            Condition:
+              StringEquals:
+                ec2:ResourceTag/parallelcluster:node-type: ComputeNode
+            Effect: Allow
+            Resource: '*'
+          - Action:
+              - s3:GetObject
+            Effect: Allow
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::${AWS::Region}-aws-parallelcluster/*
+              - !Sub arn:${AWS::Partition}:s3:::dcv-license.${AWS::Region}/*
+          - Action: ec2:RunInstances
+            Resource: '*'
+            Effect: Allow
+          - Action:
+              - iam:PassRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*
+            Effect: Allow
+            Condition:
+              StringEquals:
+                iam:PassedToService:
+                  - !Sub ec2.${AWS::URLSuffix}
+          - Action:
+              - ec2:DescribeInstances
+              - ec2:DescribeInstanceStatus
+              - ec2:CreateTags
+              - ec2:DescribeVolumes
+              - ec2:AttachVolume
+              - ec2:DescribeInstanceAttribute
+            Effect: Allow
+            Resource: '*'
+          - Action:
+              - cloudformation:DescribeStackResource
+              - cloudformation:SignalResource
+              - cloudformation:DescribeStacks
+            Effect: Allow
+            Resource: '*'
+          - Action:
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+              - s3:ListBucket
+              - s3:ListBucketVersions
+              - s3:GetObject
+              - s3:PutObject
+              - s3:GetObjectVersion
+            Effect: Allow
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::parallelcluster-*-v1-do-not-delete
+              - !Sub arn:${AWS::Partition}:s3:::parallelcluster-*-v1-do-not-delete/*
+          - Action:
+              - ecr:BatchDeleteImage
+              - ecr:ListImages
+            Effect: Allow
+            Resource: !Sub arn:${AWS::Partition}:ecr:${AWS::Region}:${AWS::AccountId}:repository/*parallelcluster*
+          - Action:
+              - codebuild:BatchGetBuilds
+              - codebuild:StartBuild
+            Effect: Allow
+            Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/pcluster-*
+          - Action:
+              - iam:PassRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*
+            Effect: Allow
+            Condition:
+              StringEquals:
+                iam:PassedToService:
+                  - batch.amazonaws.com
+          - Action:
+              - cloudformation:DescribeStackResource
+              - cloudformation:DescribeStacks
+              - cloudformation:SignalResource
+            Effect: Allow
+            Resource: '*'
+          # Image Build
+          - Action:
+              - iam:DetachRolePolicy
+              - iam:DeleteRole
+              - iam:DeleteRolePolicy
+            Resource: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+            Effect: Allow
+          - Action:
+              - iam:DeleteInstanceProfile
+              - iam:RemoveRoleFromInstanceProfile
+            Resource: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+            Effect: Allow
+          - Action: imagebuilder:DeleteInfrastructureConfiguration
+            Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:infrastructure-configuration/parallelclusterimage-*'
+            Effect: Allow
+          - Action:
+              - imagebuilder:DeleteComponent
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:component/parallelclusterimage-*/*'
+            Effect: Allow
+          - Action: imagebuilder:DeleteImageRecipe
+            Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image-recipe/parallelclusterimage-*/*'
+            Effect: Allow
+          - Action: imagebuilder:DeleteDistributionConfiguration
+            Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
+            Effect: Allow
+          - Action: imagebuilder:DeleteImage
+            Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/parallelclusterimage-*/*'
+            Effect: Allow
+          - Action: cloudformation:DeleteStack
+            Resource: !Sub 'arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*/*'
+            Effect: Allow
+          - Action: ec2:CreateTags
+            Resource: !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}::image/*'
+            Effect: Allow
+          - Action: tag:TagResources
+            Resource: '*'
+            Effect: Allow
+          - Action:
+              - lambda:DeleteFunction
+              - lambda:RemovePermission
+            Resource: !Sub 'arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:ParallelClusterImage-*'
+            Effect: Allow
+          - Action: logs:DeleteLogGroup
+            Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*:*'
+            Effect: Allow
+          - Action:
+              - SNS:GetTopicAttributes
+              - SNS:DeleteTopic
+              - SNS:GetSubscriptionAttributes
+              - SNS:Unsubscribe
+            Resource: !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:ParallelClusterImage-*'
+            Effect: Allow
+          - Action:
+              - ec2:CreateTags
+              - ec2:ModifyImageAttribute
+            Resource: !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}::image/*'
+            Effect: Allow
+          # From arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+          - Effect: Allow
+            Action:
+              - ssm:DescribeAssociation
+              - ssm:GetDeployablePatchSnapshotForInstance
+              - ssm:GetDocument
+              - ssm:DescribeDocument
+              - ssm:GetManifest
+              - ssm:GetParameter
+              - ssm:GetParameters
+              - ssm:ListAssociations
+              - ssm:ListInstanceAssociations
+              - ssm:PutInventory
+              - ssm:PutComplianceItems
+              - ssm:PutConfigurePackageResult
+              - ssm:UpdateAssociationStatus
+              - ssm:UpdateInstanceAssociationStatus
+              - ssm:UpdateInstanceInformation
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - ssmmessages:CreateControlChannel
+              - ssmmessages:CreateDataChannel
+              - ssmmessages:OpenControlChannel
+              - ssmmessages:OpenDataChannel
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - ec2messages:AcknowledgeMessage
+              - ec2messages:DeleteMessage
+              - ec2messages:FailMessage
+              - ec2messages:GetEndpoint
+              - ec2messages:GetMessages
+              - ec2messages:SendReply
+            Resource: "*"
+          # From arn:aws:iam::aws:policy/EC2InstanceProfileForImageBuilder
+          - Effect: Allow
+            Action:
+              - imagebuilder:GetComponent
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - kms:Decrypt
+            Resource: "*"
+            Condition:
+              ForAnyValue:StringEquals:
+                kms:EncryptionContextKeys: aws:imagebuilder:arn
+                aws:CalledVia:
+                  - imagebuilder.amazonaws.com
+          - Effect: Allow
+            Action:
+              - s3:GetObject
+            Resource: arn:aws:s3:::ec2imagebuilder*
+          - Effect: Allow
+            Action:
+              - logs:CreateLogStream
+              - logs:CreateLogGroup
+              - logs:PutLogEvents
+            Resource: arn:aws:logs:*:*:log-group:/aws/imagebuilder/*
 
 Outputs:
   ParallelClusterUserRole:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -363,14 +363,18 @@ def api_server_factory(
         if public_ecr_image_uri:
             params.append({"ParameterKey": "PublicEcrImageUri", "ParameterValue": public_ecr_image_uri})
 
+        template = (
+            api_infrastructure_s3_uri
+            or f"s3://{server_region}-aws-parallelcluster/parallelcluster/3.0.0/api/parallelcluster-api.yaml"
+        )
         if server_region not in api_servers:
-            logging.info(f"Creating API Server stack: {api_stack_name} in {server_region}")
+            logging.info(f"Creating API Server stack: {api_stack_name} in {server_region} with template {template}")
             stack = CfnStack(
                 name=api_stack_name,
                 region=server_region,
                 parameters=params,
                 capabilities=["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
-                template=api_infrastructure_s3_uri,
+                template=template,
             )
             cfn_stacks_factory.create_stack(stack)
             api_servers[server_region] = stack

--- a/tests/integration-tests/tests/api/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/api/test_api_infrastructure.py
@@ -37,12 +37,17 @@ def api_with_default_settings(api_infrastructure_s3_uri, public_ecr_image_uri, a
     if public_ecr_image_uri:
         params.append({"ParameterKey": "PublicEcrImageUri", "ParameterValue": public_ecr_image_uri})
 
+    template = (
+        api_infrastructure_s3_uri
+        or f"s3://{region}-aws-parallelcluster/parallelcluster/3.0.0/api/parallelcluster-api.yaml"
+    )
+    logging.info(f"Creating API Server stack in {region} with template {template}")
     stack = CfnStack(
         name=generate_stack_name("integ-tests-api", request.config.getoption("stackname_suffix")),
         region=region,
         parameters=params,
         capabilities=["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
-        template=api_infrastructure_s3_uri,
+        template=template,
     )
     factory.create_stack(stack)
     yield stack


### PR DESCRIPTION
Added new parameter to configure API role with PermissionsBoundary:

```
  PermissionsBoundaryPolicy:
    Description: |
      ARN of a IAM policy to use as PermissionsBoundary for all IAM resources created by ParallelCluster API.
      When specified, IAM permissions assumed by the API are conditionally restricted to the usage of the given PermissionsBoundary
    Type: String
    Default: ''
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
