### PR TITLE
3.0: Add EC2 image id to list image response

### DIFF
--- a/api/client/src/docs/ImageInfoSummary.md
+++ b/api/client/src/docs/ImageInfoSummary.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **version** | **str** | ParallelCluster version used to build the image. | 
 **cloudformation_stack_status** | [**CloudFormationStackStatus**](CloudFormationStackStatus.md) |  | [optional] 
 **cloudformation_stack_arn** | **str** | ARN of the main CloudFormation stack. | [optional] 
+**ec2_image_id** | **str** | Ec2 Id of the image. | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/client/src/pcluster_client/model/image_info_summary.py
+++ b/api/client/src/pcluster_client/model/image_info_summary.py
@@ -90,6 +90,7 @@ class ImageInfoSummary(ModelNormal):
             'version': (str,),  # noqa: E501
             'cloudformation_stack_status': (CloudFormationStackStatus,),  # noqa: E501
             'cloudformation_stack_arn': (str,),  # noqa: E501
+            'ec2_image_id': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -104,6 +105,7 @@ class ImageInfoSummary(ModelNormal):
         'version': 'version',  # noqa: E501
         'cloudformation_stack_status': 'cloudformationStackStatus',  # noqa: E501
         'cloudformation_stack_arn': 'cloudformationStackArn',  # noqa: E501
+        'ec2_image_id': 'ec2ImageId',  # noqa: E501
     }
 
     _composed_schemas = {}
@@ -160,6 +162,7 @@ class ImageInfoSummary(ModelNormal):
                                 _visited_composed_classes = (Animal,)
             cloudformation_stack_status (CloudFormationStackStatus): [optional]  # noqa: E501
             cloudformation_stack_arn (str): ARN of the main CloudFormation stack.. [optional]  # noqa: E501
+            ec2_image_id (str): Ec2 Id of the image.. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -2164,6 +2164,9 @@ components:
         cloudformationStackArn:
           type: string
           description: ARN of the main CloudFormation stack.
+        ec2ImageId:
+          type: string
+          description: Ec2 Id of the image.
         region:
           type: string
           description: AWS region where the image is built.

--- a/api/spec/smithy/model/types/Image.smithy
+++ b/api/spec/smithy/model/types/Image.smithy
@@ -29,6 +29,8 @@ structure ImageInfoSummary {
     @required
     @documentation("Id of the image.")
     imageId: ImageId,
+    @documentation("Ec2 Id of the image.")
+    ec2ImageId: String,
     @required
     @documentation("AWS region where the image is built.")
     region: Region,

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -384,6 +384,7 @@ def _image_info_to_image_info_summary(image):
     return ImageInfoSummary(
         image_id=image.pcluster_image_id,
         image_build_status=ImageBuildStatus.BUILD_COMPLETE,
+        ec2_image_id=image.id,
         region=os_lib.environ.get("AWS_DEFAULT_REGION"),
         version=image.version,
     )

--- a/cli/src/pcluster/api/models/image_info_summary.py
+++ b/cli/src/pcluster/api/models/image_info_summary.py
@@ -27,6 +27,7 @@ class ImageInfoSummary(Model):
         self,
         image_id=None,
         image_build_status=None,
+        ec2_image_id=None,
         cloudformation_stack_status=None,
         cloudformation_stack_arn=None,
         region=None,
@@ -42,6 +43,8 @@ class ImageInfoSummary(Model):
         :type cloudformation_stack_status: CloudFormationStackStatus
         :param cloudformation_stack_arn: The cloudformation_stack_arn of this ImageInfoSummary.
         :type cloudformation_stack_arn: str
+        :param ec2_image_id: The ec2_image_id of this ImageInfoSummary.
+        :type ec2_image_id: str
         :param region: The region of this ImageInfoSummary.
         :type region: str
         :param version: The version of this ImageInfoSummary.
@@ -52,6 +55,7 @@ class ImageInfoSummary(Model):
             "image_build_status": ImageBuildStatus,
             "cloudformation_stack_status": CloudFormationStackStatus,
             "cloudformation_stack_arn": str,
+            "ec2_image_id": str,
             "region": str,
             "version": str,
         }
@@ -61,6 +65,7 @@ class ImageInfoSummary(Model):
             "image_build_status": "imageBuildStatus",
             "cloudformation_stack_status": "cloudformationStackStatus",
             "cloudformation_stack_arn": "cloudformationStackArn",
+            "ec2_image_id": "ec2ImageId",
             "region": "region",
             "version": "version",
         }
@@ -69,6 +74,7 @@ class ImageInfoSummary(Model):
         self._image_build_status = image_build_status
         self._cloudformation_stack_status = cloudformation_stack_status
         self._cloudformation_stack_arn = cloudformation_stack_arn
+        self._ec2_image_id = ec2_image_id
         self._region = region
         self._version = version
 
@@ -176,6 +182,31 @@ class ImageInfoSummary(Model):
         :type cloudformation_stack_arn: str
         """
         self._cloudformation_stack_arn = cloudformation_stack_arn
+
+    @property
+    def ec2_image_id(self):
+        """Gets the ec2_image_id of this ImageInfoSummary.
+
+        Ec2 Id of the imag.
+
+        :return: The ec2_image_id of this ImageInfoSummary.
+        :rtype: str
+        """
+        return self._ec2_image_id
+
+    @ec2_image_id.setter
+    def ec2_image_id(self, ec2_image_id):
+        """Sets the ec2_image_id of this ImageInfoSummary.
+
+        Ec2 Id of the image.
+
+        :param ec2_image_id: The ec2_image_id of this ImageInfoSummary.
+        :type ec2_image_id: str
+        """
+        if ec2_image_id is None:
+            raise ValueError("Invalid value for `ec2_image_id`, must not be `None`")
+
+        self._ec2_image_id = ec2_image_id
 
     @property
     def region(self):

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -2994,12 +2994,14 @@ components:
           imageBuildStatus: null
           cloudformationStackStatus: null
           cloudformationStackArn: cloudformationStackArn
+          ec2ImageId: ec2ImageId
           region: region
           version: version
         - imageId: imageId
           imageBuildStatus: null
           cloudformationStackStatus: null
           cloudformationStackArn: cloudformationStackArn
+          ec2ImageId: ec2ImageId
           region: region
           version: version
       properties:

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -110,12 +110,14 @@ class TestListImages:
             "images": [
                 {
                     "imageId": "image1",
+                    "ec2ImageId": "image1",
                     "imageBuildStatus": ImageBuildStatus.BUILD_COMPLETE,
                     "region": "us-east-1",
                     "version": "3.0.0",
                 },
                 {
                     "imageId": "image2",
+                    "ec2ImageId": "image2",
                     "imageBuildStatus": ImageBuildStatus.BUILD_COMPLETE,
                     "region": "us-east-1",
                     "version": "3.0.0",

--- a/tests/integration-tests/images_factory.py
+++ b/tests/integration-tests/images_factory.py
@@ -33,6 +33,7 @@ class Image:
         self.image_status = None
         self.configuration_errors = None
         self.message = None
+        self.ec2_image_id = None
 
     @staticmethod
     def list_images(**kwargs):
@@ -161,6 +162,7 @@ class Image:
         ec2_ami_info = image_info.get("ec2AmiInfo")
         if ec2_ami_info:
             self.image_tags = ec2_ami_info.get("tags")
+            self.ec2_image_id = ec2_ami_info.get("amiId")
         self.creation_time = image_info.get("creationTime")
         self.build_log = image_info.get("buildLog")
         self.version = image_info.get("version")

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -126,6 +126,8 @@ def _test_list_images(image):
     assert_that(matches).is_length(1)
     assert_that(matches[0]["imageId"]).is_equal_to(image.image_id)
     assert_that(matches[0]["region"]).is_equal_to(image.region)
+    image.describe()
+    assert_that(matches[0]["ec2ImageId"]).is_equal_to(image.ec2_image_id)
     assert_that(matches[0]["imageBuildStatus"]).is_equal_to("BUILD_COMPLETE")
     assert_that(matches[0]).contains("version")
 


### PR DESCRIPTION
list images command: `pcluster list-images --region eu-west-1 --image-status AVAILABLE` 
response:
```
{
  "images": [
    {
      "imageId": "aws-parallelcluster-3-0-0-amzn2-hvm-arm64-202106251600",
      "imageBuildStatus": "BUILD_COMPLETE",
      "ec2ImageId": "ami-00187907515e1c39a",
      "region": "eu-west-1",
      "version": "3.0.0"
    },
    {
      "imageId": "aws-parallelcluster-3-0-0-ubuntu-2004-lts-hvm-arm64-202107091615",
      "imageBuildStatus": "BUILD_COMPLETE",
      "ec2ImageId": "ami-00322c500522b111f",
      "region": "eu-west-1",
      "version": "3.0.0"
    }
   ]
}
```
list images command: `pcluster list-images --region eu-west-1 --image-status PENDING`
```
{
  "images": [
    {
      "imageId": "test-nvidia",
      "imageBuildStatus": "BUILD_IN_PROGRESS",
      "cloudformationStackStatus": "CREATE_IN_PROGRESS",
      "cloudformationStackArn": "arn:aws:cloudformation:eu-west-1:109993544819:stack/no-nvidia-10/45733ce0-fee8-11eb-8699-02d3098ce6b9",
      "region": "eu-west-1",
      "version": "3.0.0"
    }
  ]
}
```

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
