### PR TITLE
[api] add 'parallelcluster:resource': api tag to lambda function

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -226,6 +226,8 @@ Resources:
       PackageType: Image
       MemorySize: 512
       Role: !If [UseCustomParallelClusterFunctionRole, !Ref ParallelClusterFunctionRole, !GetAtt ParallelClusterUserRole.Arn]
+      Tags:
+        'parallelcluster:resource': api
       ImageUri: !If
         - UseCustomEcrImageUri
         - !Ref EcrImageUri


### PR DESCRIPTION
The extra tag is useful to discriminate between the Lambda function used by the ParallelCluster API and the Lambda functions deployed with cluster or image stacks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
