### PR TITLE
Integ-tests: Remove p4d test to from common.yaml

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -213,10 +213,6 @@ efa:
         instances: ["c5n.18xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
-      - regions: ["eu-west-1"]
-        instances: ["p4d.24xlarge"]
-        oss: ["ubuntu2004"]
-        schedulers: ["slurm"]
       - regions: ["us-west-2"]
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
@@ -603,10 +599,3 @@ resource_bucket:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm", "awsbatch"]
-#nccl:
-#  test_nccl.py::test_nccl:
-#    dimensions:
-#      - regions: ["eu-west-1"]
-#        instances: ["p4d.24xlarge"]
-#        oss: ["ubuntu1804"]
-#        schedulers: ["slurm"]

--- a/tests/integration-tests/configs/p4d.yaml
+++ b/tests/integration-tests/configs/p4d.yaml
@@ -1,32 +1,11 @@
 {%- import 'common.jinja2' as common -%}
-  {%- set regions = ["us-east-1", "us-west-2"] -%}
+  {%- set regions = ["us-west-2"] -%}
   {%- set instances = ["p4d.24xlarge"] -%}
 
 ---
 test-suites:
   efa:
-    test_efa.py::test_sit_efa:
-      dimensions:
-        - regions: {{ regions }}
-          instances: {{ instances }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
-          # Torque is not supported by OpenMPI distributed with EFA
-          schedulers: ["slurm"]
-  dns:
-    test_dns.py::test_hit_no_cluster_dns_mpi:
-      dimensions:
-        - regions: {{ regions }}
-          instances: {{ instances }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
-          schedulers: ["slurm"]
-  scaling:
-    test_mpi.py::test_mpi_ssh:
-      dimensions:
-        - regions: {{ regions }}
-          instances: {{ instances }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
-          schedulers: ["slurm"]
-    test_scaling.py::test_multiple_jobs_submission:
+    test_efa.py::test_hit_efa:
       dimensions:
         - regions: {{ regions }}
           instances: {{ instances }}
@@ -38,4 +17,11 @@ test-suites:
         - regions: {{ regions }}
           instances: {{ instances }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+  nccl:
+    test_nccl.py::test_nccl:
+      dimensions:
+        - regions: {{ regions }}
+          instances: {{ instances }}
+          oss: ["ubuntu1804", "ubuntu2004"]
           schedulers: ["slurm"]


### PR DESCRIPTION
p4d.yaml will be used to test p4d instances

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
