### PR TITLE
2.11: Fix osu_mbw_mr test

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -262,7 +262,7 @@ def _test_osu_benchmarks_multiple_bandwidth(
     run_osu_benchmarks(
         "openmpi",
         "mbw_mr",
-        "mbw_mr",
+        "osu_mbw_mr",
         partition,
         remote_command_executor,
         scheduler_commands,
@@ -271,7 +271,7 @@ def _test_osu_benchmarks_multiple_bandwidth(
         test_datadir,
     )
     max_bandwidth = remote_command_executor.run_remote_command(
-        "cat /shared/mbw_mr.out | tail -n +4 | awk '{print $2}' | sort -n | tail -n 1"
+        "cat /shared/osu_mbw_mr.out | tail -n +4 | awk '{print $2}' | sort -n | tail -n 1"
     ).stdout
 
     # Expected bandwidth with 4 NICS:

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/osu_mbw_mr_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/osu_mbw_mr_submit_openmpi.sh
@@ -2,7 +2,7 @@
 set -e
 module load openmpi
 
-BENCHMARK_NAME=osu_mbw_mr
+BENCHMARK_NAME={{ benchmark_name }}
 OSU_BENCHMARK_VERSION={{ osu_benchmark_version }}
 
 # Run multiple bandwidth/message rate benchmark


### PR DESCRIPTION
The job is submitted with the following command:
```
mpirun ... /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/pt2pt/${BENCHMARK_NAME} > /shared/${BENCHMARK_NAME}.out
```

It means the output file is osu_mbw_mr.out and not mbw_mr.out.
Then I'm also propagating the benchmark name to be script to be sure the things are all aligned.
