### PR TITLE
Various fixes to API, IAM policies and tests

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -581,7 +581,8 @@ Resources:
               StringEqualsIfExists:
                 iam:PassedToService:
                   - lambda.amazonaws.com
-                  - !Sub ec2.${AWS::URLSuffix}
+                  - ec2.amazonaws.com
+                  - ec2.amazonaws.com.cn
                   - spotfleet.amazonaws.com
             Sid: IamPassRole
           - Action:
@@ -700,7 +701,8 @@ Resources:
               StringEquals:
                 iam:PassedToService:
                   - lambda.amazonaws.com
-                  - !Sub 'ec2.${AWS::URLSuffix}'
+                  - ec2.amazonaws.com
+                  - ec2.amazonaws.com.cn
           - Sid: CloudWatch
             Effect: Allow
             Action:

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -104,7 +104,7 @@ Globals:
                 - CreateApiUserRoleCondition
                 - !Sub
                   - arn:${AWS::Partition}:*::${AWS::AccountId}:*/ParallelClusterApiUserRole-${StackIdSuffix}*
-                  - { StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+                  - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
                 - '*'
     TracingEnabled: True
     EndpointConfiguration:
@@ -244,7 +244,7 @@ Resources:
     Properties:
       RoleName:  !Sub
         - ParallelClusterApiUserRole-${StackIdSuffix}
-        - { StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+        - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -957,7 +957,7 @@ Resources:
     Properties:
       Name: !Sub
         - ParallelClusterImageBuilderInfrastructureConfiguration-${Version}-${StackIdSuffix}
-        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelCluster, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelCluster, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       InstanceProfileName: !Ref ImageBuilderInstanceProfile
       TerminateInstanceOnFailure: true
       SnsTopicArn: !Ref EcrImageBuilderSNSTopic
@@ -968,7 +968,7 @@ Resources:
     Properties:
       RepositoryName: !Sub
         - 'aws-parallelcluster-${StackIdSuffix}'
-        - { StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+        - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       Tags:
         - Key: 'parallelcluster:version'
           Value: !FindInMap [ParallelCluster, Constants, Version]
@@ -982,7 +982,7 @@ Resources:
       ContainerType: DOCKER
       Name: !Sub
         - 'ImportPublicEcrImage-${Version}-${StackIdSuffix}'
-        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelCluster, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelCluster, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       Version: !FindInMap [ParallelCluster, Constants, Version]
       ParentImage: !Ref PublicEcrImageUri
       PlatformOverride: Linux
@@ -1008,7 +1008,7 @@ Resources:
     Properties:
       Name: !Sub
         - 'EcrImagePipeline-${Version}-${StackIdSuffix}'
-        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelCluster, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+        - { Version: !Join ['_', !Split ['.', !FindInMap [ParallelCluster, Constants, Version]]], StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       Status: ENABLED
       ContainerRecipeArn: !Ref EcrImageRecipe
       InfrastructureConfigurationArn: !Ref InfrastructureConfiguration
@@ -1220,7 +1220,7 @@ Resources:
                   - imagebuilder:DeleteImage
                 Resource: !Sub
                   - arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:image/*${StackIdSuffix}*
-                  - { StackIdSuffix: !Select [2, !Split ['/', !Ref AWS::StackId]] }
+                  - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
 
   EcrImagesRemover:
     Condition: DoNotUseCustomEcrImageUri

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -337,7 +337,8 @@ Resources:
               StringEqualsIfExists:
                 iam:PassedToService:
                   - lambda.amazonaws.com
-                  - !Sub ec2.${AWS::URLSuffix}
+                  - ec2.amazonaws.com
+                  - ec2.amazonaws.com.cn
                   - spotfleet.amazonaws.com
             Sid: IamPassRole
           - Action:
@@ -456,7 +457,8 @@ Resources:
               StringEquals:
                 iam:PassedToService:
                   - lambda.amazonaws.com
-                  - !Sub 'ec2.${AWS::URLSuffix}'
+                  - ec2.amazonaws.com
+                  - ec2.amazonaws.com.cn
           - Sid: CloudWatch
             Effect: Allow
             Action:
@@ -764,7 +766,8 @@ Resources:
             Condition:
               StringEquals:
                 iam:PassedToService:
-                  - !Sub ec2.${AWS::URLSuffix}
+                  - ec2.amazonaws.com
+                  - ec2.amazonaws.com.cn
           - Action:
               - ec2:DescribeInstances
               - ec2:DescribeInstanceStatus

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -77,7 +77,7 @@ class CfnStacksFactory:
             raise ValueError("Stack {0} already exists in region {1}".format(name, region))
 
         logging.info("Creating stack {0} in region {1}".format(name, region))
-        is_template_url = stack.template.startswith("s3://")
+        is_template_url = stack.template.startswith("https://")
         with aws_credential_provider(region, self.__credentials):
             try:
                 cfn_client = boto3.client("cloudformation", region_name=region)


### PR DESCRIPTION
* add quotes to !Ref AWS::StackId in API template to handle template paring failures in some environments
* fix check for template url in cfn_stacks_factory. It needs to be an https url and not s3
* Add both ec2 service identifiers in PassRole policy - For some APIs such as AddRoleToInstanceProfile the PassedToService needs to be ec2.amazonaws.com also in China.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
