### PR TITLE
2.11: Refactor EFA tests by creating specific tests for OSU and NCCL benchmarks

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -209,15 +209,6 @@ dns:
 efa:
   test_efa.py::test_hit_efa:
     dimensions:
-      - regions: ["us-east-1"]
-        instances: ["c5n.18xlarge"]
-        oss: ["alinux2"]
-        schedulers: ["slurm"]
-        # TODO: remove p4d test
-      - regions: ["us-west-2"]
-        instances: ["p4d.24xlarge"]
-        oss: ["ubuntu2004"]
-        schedulers: ["slurm"]
       - regions: ["us-west-2"]
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
@@ -234,6 +225,19 @@ efa:
         # Torque is not supported by OpenMPI distributed with EFA
         # Slurm test is to verify EFA works correctly when using the SIT model in the config file
         schedulers: ["sge", "slurm"]
+  test_efa.py::test_efa_osu:
+    dimensions:
+      - regions: ["us-east-1"]
+        instances: ["c5n.18xlarge"]
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
+  # TODO: remove p4d test
+  test_efa.py::test_efa_osu_nccl:
+    - dimensions:
+        - regions: ["us-west-2"]
+          instances: ["p4d.24xlarge"]
+          oss: ["ubuntu2004"]
+          schedulers: ["slurm"]
 iam:
   test_iam.py::test_iam_policies:
     dimensions:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -91,8 +91,8 @@ test-suites:
           instances: ["p4d.24xlarge"]
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
-  nccl:
-    test_nccl.py::test_nccl:
+  efa:
+    test_efa.py::test_efa_osu_nccl:
       dimensions:
         - regions: ["us-west-2"]
           instances: ["p4d.24xlarge"]

--- a/tests/integration-tests/configs/p4d.yaml
+++ b/tests/integration-tests/configs/p4d.yaml
@@ -5,7 +5,7 @@
 ---
 test-suites:
   efa:
-    test_efa.py::test_hit_efa:
+    test_efa.py::test_efa_osu_nccl:
       dimensions:
         - regions: {{ regions }}
           instances: {{ instances }}


### PR DESCRIPTION
* test_hit_efa is now executed only on c5n.18xlarge and c6gn.16xlarge
* test_efa_osu is executed only on c5n.18xlarge and runs EFA tests + OSU benchmarks
* test_efa_osu_nccl is executed only on p4d.24xlarge and runs EFA tests + OSU multi-bandwidth benchmark + NCCL benchmarks
* We're also skipping NCCL benchmarks for CentOS.

Next steps will be to move OSU and NCCL into specific folders.