### PR TITLE
[integ-tests] adjust api_infrastructure assertions to work in GovCloud

### DIFF
--- a/tests/integration-tests/tests/api/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/api/test_api_infrastructure.py
@@ -49,10 +49,11 @@ def api_with_default_settings(api_infrastructure_s3_uri, public_ecr_image_uri, a
         capabilities=["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
         template=template,
     )
-    factory.create_stack(stack)
-    yield stack
-
-    factory.delete_all_stacks()
+    try:
+        factory.create_stack(stack)
+        yield stack
+    finally:
+        factory.delete_all_stacks()
 
 
 def test_api_infrastructure_with_default_parameters(region, api_with_default_settings):

--- a/tests/integration-tests/tests/api/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/api/test_api_infrastructure.py
@@ -97,8 +97,11 @@ def _assert_parallelcluster_lambda(lambda_name, lambda_arn, lambda_image_uri):
     assert_that(lambda_configuration["FunctionArn"]).is_equal_to(lambda_arn)
     assert_that(lambda_configuration["Timeout"]).is_equal_to(30)
     assert_that(lambda_configuration["MemorySize"]).is_equal_to(512)
-    assert_that(lambda_configuration["TracingConfig"]["Mode"]).is_equal_to("Active")
+    if "TracingConfig" in lambda_configuration:
+        # When executed in GovCloud get_function does not return TracingConfig
+        assert_that(lambda_configuration["TracingConfig"]["Mode"]).is_equal_to("Active")
     assert_that(lambda_resource["Tags"]).contains("parallelcluster:version")
+    assert_that(lambda_resource["Tags"]).contains("parallelcluster:resource")
     assert_that(lambda_resource["Code"]["ImageUri"]).is_equal_to(lambda_image_uri)
 
 


### PR DESCRIPTION
When executed in GovCloud get_function does not return TracingConfig

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
