### PR TITLE
Force update where needed in integ tests

### DIFF
--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket.py
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket.py
@@ -29,7 +29,7 @@ def test_resource_bucket(region, scheduler, pcluster_config_reader, s3_bucket_fa
     updated_config_file = pcluster_config_reader(
         config_file="pcluster.config_{0}.yaml".format(scheduler), resource_bucket=update_bucket_name
     )
-    cluster.update(str(updated_config_file))
+    cluster.update(str(updated_config_file), force_update="true")
     assert_that(cluster.cfn_parameters.get("ResourcesS3Bucket")).is_equal_to(bucket_name)
     assert_that(cluster.cfn_parameters.get("ArtifactS3RootDirectory")).is_equal_to(artifact_directory)
 

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1002,7 +1002,7 @@ def _wait_for_partition_state_changed(scheduler_commands, partition, desired_sta
 def _update_and_start_cluster(cluster, config_file):
     cluster.stop()
     _wait_for_computefleet_changed(cluster, "STOPPED")
-    cluster.update(str(config_file))
+    cluster.update(str(config_file), force_update="true")
     cluster.start()
     _wait_for_computefleet_changed(cluster, "RUNNING")
 

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -98,7 +98,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
         resource_bucket=bucket_name,
         additional_policy_arn=additional_policy_arn,
     )
-    cluster.update(str(updated_config_file))
+    cluster.update(str(updated_config_file), force_update="true")
 
     # Here is the expected list of nodes.
     # the cluster:
@@ -369,7 +369,7 @@ def test_update_awsbatch(region, pcluster_config_reader, clusters_factory, test_
     _verify_initialization(region, cluster, cluster.config)
 
     # Update cluster with the same configuration
-    cluster.update(str(init_config_file), force=True)
+    cluster.update(str(init_config_file), force_update="true")
 
     # Update cluster with new configuration
     updated_config_file = pcluster_config_reader(config_file="pcluster.config.update.yaml")


### PR DESCRIPTION
In the LTS integ tests, cluster updates were forced by default. This
behavior was changed by 8a815fb96, but some of the tests require this
behavior in order to work.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
