### PR TITLE
2.11: Avoid conflict between os module and fixture names

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -91,9 +91,10 @@ test-suites:
           instances: ["p4d.24xlarge"]
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
-  nccl:
-    test_nccl.py::test_nccl:
+  efa:
+    test_efa.py::test_hit_efa:
       dimensions:
+          # TODO: remove p4d test
         - regions: ["us-west-2"]
           instances: ["p4d.24xlarge"]
           oss: ["alinux2", "ubuntu1804"]

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -10,7 +10,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
-import os
+import os as os_lib
 import re
 from shutil import copyfile
 
@@ -89,8 +89,8 @@ def test_sit_efa(
 @pytest.mark.instances(["c5n.18xlarge"])
 @pytest.mark.oss(["alinux2"])
 @pytest.mark.schedulers(["slurm"])
-@pytest.mark.usefixtures("os")
 def test_hit_efa(
+    os,
     region,
     scheduler,
     instance,
@@ -372,9 +372,9 @@ def _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor, p
 
 
 def _render_jinja_template(template_file_path, **kwargs):
-    file_loader = FileSystemLoader(str(os.path.dirname(template_file_path)))
+    file_loader = FileSystemLoader(str(os_lib.path.dirname(template_file_path)))
     env = Environment(loader=file_loader)
-    rendered_template = env.get_template(os.path.basename(template_file_path)).render(**kwargs)
+    rendered_template = env.get_template(os_lib.path.basename(template_file_path)).render(**kwargs)
     with open(template_file_path, "w") as f:
         f.write(rendered_template)
     return template_file_path


### PR DESCRIPTION
The check was failing with:
```
if instance == "p4d.24xlarge" and "centos" not in os:
argument of type 'module' is not iterable
```