### PR TITLE
Fix remaining update integ tests

### DIFF
--- a/api/client/src/pcluster_client/model_utils.py
+++ b/api/client/src/pcluster_client/model_utils.py
@@ -1230,7 +1230,7 @@ def deserialize_file(response_data, configuration, content_disposition=None):
                              content_disposition).group(1)
         path = os.path.join(os.path.dirname(path), filename)
 
-    with open(path, "wb", encoding="utf-8") as f:
+    with open(path, "wb") as f:
         if isinstance(response_data, str):
             # change str to bytes so we can write it
             response_data = response_data.encode('utf-8')

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -260,7 +260,7 @@ def create_logs_archive(directory: str, output_file: str = None):
 
 def upload_archive(bucket: str, bucket_prefix: str, archive_path: str):
     archive_filename = os.path.basename(archive_path)
-    with open(archive_path, "rb", encoding="utf-8") as archive_file:
+    with open(archive_path, "rb") as archive_file:
         archive_data = archive_file.read()
     AWSApi.instance().s3.put_object(bucket, archive_data, f"{bucket_prefix}/{archive_filename}")
     return f"s3://{bucket}/{bucket_prefix}/{archive_filename}"

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -69,7 +69,7 @@ def _add_file_to_zip(zip_file, path, arcname):
     :param path: string; path to file being added
     :param arcname: string; filename to put bytes from path under in created archive
     """
-    with open(path, "rb", encoding="utf-8") as input_file:
+    with open(path, "rb") as input_file:
         zinfo = zipfile.ZipInfo(filename=arcname)
         zinfo.external_attr = 0o644 << 16
         zip_file.writestr(zinfo, input_file.read())

--- a/tests/integration-tests/benchmarks/common/metrics_reporter.py
+++ b/tests/integration-tests/benchmarks/common/metrics_reporter.py
@@ -180,5 +180,5 @@ def _write_results_to_outdir(request, image_bytes):
     graph_dst = "{out_dir}/benchmarks/{test_name}.png".format(
         out_dir=out_dir, test_name=request.node.nodeid.replace("::", "-")
     )
-    with open(graph_dst, "wb", encoding="utf-8") as image:
+    with open(graph_dst, "wb") as image:
         image.write(image_bytes)

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -117,7 +117,7 @@ class Cluster:
                 dict_add_nested_key(self.config, "Delete", ("Monitoring", "Logs", "CloudWatch", "DeletionPolicy"))
                 with open(self.config_file, "w", encoding="utf-8") as conf_file:
                     yaml.dump(self.config, conf_file)
-                self.update(self.config_file, force=True)
+                self.update(self.config_file, force_update="true")
             except subprocess.CalledProcessError as e:
                 logging.error(
                     "Failed updating cluster to delete log with error:\n%s\nand output:\n%s", e.stderr, e.stdout

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -100,7 +100,7 @@ def _test_create_with_warnings(cluster_config, clusters_factory):
 
 def _test_update_with_warnings(cluster_config, cluster):
     def run_fn(extra_args):
-        response = cluster.update(cluster_config, force_update=True, **extra_args)
+        response = cluster.update(cluster_config, force_update="true", **extra_args)
         if response["message"].startswith("Request would have succeeded"):
             assert_that(response).contains("changeSet")
         else:

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -40,7 +40,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     cluster = clusters_factory(init_config_file)
 
     # Update cluster with the same configuration, command should not result any error even if not using force update
-    cluster.update(str(init_config_file), force=True)
+    cluster.update(str(init_config_file), force_update="true")
 
     # Command executors
     command_executor = RemoteCommandExecutor(cluster)
@@ -409,7 +409,7 @@ def test_update_compute_ami(region, os, pcluster_config_reader, clusters_factory
 
     # stop compute fleet before updating queue image
     cluster.stop()
-    cluster.update(str(updated_config_file))
+    cluster.update(str(updated_config_file), force_update="true")
     instances = cluster.get_cluster_instance_ids(node_type="Compute")
     logging.info(instances)
     _check_instance_ami_id(ec2, instances, pcluster_dlami_id)

--- a/util/sync_buckets.py
+++ b/util/sync_buckets.py
@@ -137,7 +137,7 @@ def _get_s3_object_metadata(s3_url):
 def _checksum(filename, base64_encoded=True, algorithm=HashingAlgorithm.SHA256):
     init_function = {HashingAlgorithm.SHA256: hashlib.sha256, HashingAlgorithm.MD5: hashlib.md5}
     checksum = init_function[algorithm]()
-    with open(filename, "rb", encoding="utf-8") as f:
+    with open(filename, "rb") as f:
         for data in iter(lambda: f.read(1024 * 1024), b""):
             checksum.update(data)
     return base64.b64encode(checksum.digest()).decode("utf-8") if base64_encoded else checksum.hexdigest()
@@ -161,7 +161,7 @@ def _upload_files(args, files, sts_credentials, dir):
 
             md5 = _checksum(file_path, base64_encoded=True, algorithm=HashingAlgorithm.MD5)
             logging.info("Computed md5 checksum for S3 upload: %s", md5)
-            with open(file_path, "rb", encoding="utf-8") as data:
+            with open(file_path, "rb") as data:
                 doc_manager.upload(dest_bucket, file, data, dryrun=not args.deploy, md5=md5)
 
 

--- a/util/upload-cookbook.py
+++ b/util/upload-cookbook.py
@@ -135,7 +135,7 @@ def _get_bucket_name(args, region):
 def _md5sum(cookbook_archive_file, md5sum_file):
     blocksize = 65536
     hasher = hashlib.md5()  # nosec nosemgrep
-    with open(cookbook_archive_file, "rb", encoding="utf-8") as arch:
+    with open(cookbook_archive_file, "rb") as arch:
         buf = arch.read(blocksize)
         while len(buf) > 0:
             hasher.update(buf)

--- a/util/upload-script.py
+++ b/util/upload-script.py
@@ -55,7 +55,7 @@ def _upload_documents(regions, bucket, s3_path, script, sts_credentials, deploy,
         if exists and not override:
             logging.warning(f"Version s3://{bucket}/{s3_path} exists, skipping upload.")
         else:
-            with open(script, "rb", encoding="utf-8") as data:
+            with open(script, "rb") as data:
                 doc_manager.upload(bucket.format(region=region), s3_path, data, dryrun=not deploy)
 
 


### PR DESCRIPTION
In f02f0902 some integ tests were updated to account for the fact that
cluster updates done via the Cluster class were no longer forced by
default. This commit does more of the same. It also updates other tests
that weren't failing but were using a now-ineffective kwarg to attempt
to force an update.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
