### PR TITLE
2.11: Enable nccl tests for centos8

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -276,9 +276,11 @@ def _test_osu_benchmarks_multiple_bandwidth(
     ).stdout
 
     # Expected bandwidth with 4 NICS:
-    # OMPI 4.1.0: ~330Gbps = 41250MB/s
-    # OMPI 4.0.5: ~95Gbps = 11875MB/s
-    assert_that(float(max_bandwidth)).is_greater_than(41000)
+    # OMPI 4.1.0: ~330Gbps = 41250MB/s with Placement Group
+    # OMPI 4.1.0: ~252Gbps = 31550MB/s without Placement Group
+    # OMPI 4.0.5: ~95Gbps = 11875MB/s with Placement Group
+    expected_bandwidth = 30000
+    assert_that(float(max_bandwidth)).is_greater_than(expected_bandwidth)
 
 
 def run_osu_benchmarks(

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -160,7 +160,7 @@ def test_hit_efa(
         )
     _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor, partition="efa-enabled")
 
-    if instance == "p4d.24xlarge" and "centos" not in os:
+    if instance == "p4d.24xlarge" and os != "centos7":
         _test_nccl_benchmarks(remote_command_executor, test_datadir, "openmpi", scheduler_commands)
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.ini
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.ini
@@ -17,8 +17,9 @@ compute_resource_settings = efa-enabled_i1
 enable_efa = true
 {% if instance == "p4d.24xlarge" %}
 enable_efa_gdr = true
-{% endif %}
+{% else %}
 placement_group = DYNAMIC
+{% endif %}
 
 [compute_resource efa-enabled_i1]
 instance_type = {{ instance }}


### PR DESCRIPTION
All OSes should be supported:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl-base.html

