### PR TITLE
Fix test_update_compute_ami

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -407,7 +407,7 @@ def test_update_compute_ami(region, os, pcluster_config_reader, ami_copy, cluste
     cluster.update(str(updated_config_file), force_update="true")
     instances = cluster.get_cluster_instance_ids(node_type="Compute")
     logging.info(instances)
-    _check_instance_ami_id(ec2, instances, pcluster_dlami_id)
+    _check_instance_ami_id(ec2, instances, pcluster_copy_ami_id)
 
 
 def _check_instance_ami_id(ec2, instances, expected_queue_ami):


### PR DESCRIPTION
Fix variable name used to check AMI once update is performed

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
