### PR TITLE
3.0: Fix image is not deleted if it failed in imagebuilder test stage

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -99,6 +99,7 @@ PCLUSTER_CLUSTER_NAME_TAG = f"{PCLUSTER_PREFIX}cluster-name"
 # PCLUSTER_NODE_TYPE_TAG needs to be the same as the hard coded strings in node package
 PCLUSTER_NODE_TYPE_TAG = f"{PCLUSTER_PREFIX}node-type"
 PCLUSTER_QUEUE_NAME_TAG = f"{PCLUSTER_PREFIX}queue-name"
+IMAGEBUILDER_ARN_TAG = "Ec2ImageBuilderArn"
 PCLUSTER_S3_ARTIFACTS_DICT = {
     "root_directory": "parallelcluster",
     "root_cluster_directory": "clusters",

--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -276,10 +276,23 @@ class ImageBuilder:
 
     @property
     def image(self):
-        """Return Image object."""
+        """Return avaible image object."""
         if not self.__image:
             try:
                 self.__image = AWSApi.instance().ec2.describe_image_by_id_tag(self.image_id)
+            except ImageNotFoundError:
+                raise NonExistingImageError(self.image_id)
+            except AWSClientError as e:
+                raise _image_error_mapper(e, f"Unable to get image {self.image_id}, due to {e}.")
+
+        return self.__image
+
+    @property
+    def failed_image(self):
+        """Return failed image object."""
+        if not self.__image:
+            try:
+                self.__image = AWSApi.instance().ec2.describe_image_by_imagebuilder_arn_tag(self.image_id)
             except ImageNotFoundError:
                 raise NonExistingImageError(self.image_id)
             except AWSClientError as e:
@@ -533,12 +546,19 @@ class ImageBuilder:
                     # Delete stack
                     AWSApi.instance().cfn.delete_stack(self.image_id)
 
-                if AWSApi.instance().ec2.image_exists(image_id=self.image_id, build_status_avaliable=False):
+                if AWSApi.instance().ec2.image_exists(image_id=self.image_id):
                     # Deregister image
                     AWSApi.instance().ec2.deregister_image(self.image.id)
 
                     # Delete snapshot
                     for snapshot_id in self.image.snapshot_ids:
+                        AWSApi.instance().ec2.delete_snapshot(snapshot_id)
+                elif AWSApi.instance().ec2.failed_image_exists(image_id=self.image_id):
+                    # Deregister image
+                    AWSApi.instance().ec2.deregister_image(self.failed_image.id)
+
+                    # Delete snapshot
+                    for snapshot_id in self.failed_image.snapshot_ids:
                         AWSApi.instance().ec2.delete_snapshot(snapshot_id)
 
                 # Delete s3 image directory


### PR DESCRIPTION
* If image id tag is not present because of test stage failure, search imagebuilder arn tag to get failed image and delete it

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
