### PR TITLE
Add depends on to cluster stack to ensure stack resource deletion order

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -241,7 +241,7 @@ def get_queue_security_groups_full(compute_security_groups: dict, queue: BaseQue
 
     # Default security groups, created by us or provided by the user
     if compute_security_groups and compute_security_groups.get(queue.name, None):
-        queue_security_groups.append(compute_security_groups[queue.name])
+        queue_security_groups.append(compute_security_groups[queue.name].ref)
     elif queue.networking.security_groups:
         queue_security_groups.extend(queue.networking.security_groups)
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -423,7 +423,7 @@ class ClusterCdkStack(Stack):
                     # Create a new security group
                     compute_security_group = self._add_compute_security_group()
                 # Associate created security group to the queue
-                self.compute_security_groups[queue.name] = compute_security_group.ref
+                self.compute_security_groups[queue.name] = compute_security_group
 
         if head_security_group and compute_security_group:
             # Access to head node from compute nodes


### PR DESCRIPTION
Ensure compute nodes are terminated before the deletion of security groups and placement groups

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
