### PR TITLE
Update NCCL_BENCHMARKS_VERSION from 2.0.0 to 2.10.0 branch for nccl test

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/init_nccl_benchmarks.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/init_nccl_benchmarks.sh
@@ -4,7 +4,7 @@ set -e
 rm -rf /shared/${1}
 
 module load ${1}
-NCCL_BENCHMARKS_VERSION='2.0.0'
+NCCL_BENCHMARKS_VERSION='2.10.0'
 NCCL_VERSION='2.7.8-1'
 ML_REPO_PKG='nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb'
 CUDA_VERSION='11.4'

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
@@ -14,4 +14,4 @@ mpirun \
 -x NCCL_ALGO=ring \
 -x NCCL_DEBUG=WARNING \
 --mca pml ^cm --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 --bind-to none \
-/shared/openmpi/nccl-tests-2.0.0/build/all_reduce_perf -b 8 -e 1G -f 2 -g 1 -c 1 -n 100 > /shared/nccl_tests.out
+/shared/openmpi/nccl-tests-2.10.0/build/all_reduce_perf -b 8 -e 1G -f 2 -g 1 -c 1 -n 100 > /shared/nccl_tests.out


### PR DESCRIPTION
This PR is adapted from the corresponding [PR for pcluster 2.x](https://github.com/aws/aws-parallelcluster/pull/2984). The upgrade fix nccl compilation error on alinux2.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
