### PR TITLE
Enable NCCL tests for Centos8 and remove Placement Group when using p4d

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -102,7 +102,7 @@ def test_efa(
         )
     _test_shm_transfer_is_enabled(scheduler_commands, remote_command_executor, partition="efa-enabled")
 
-    if instance == "p4d.24xlarge" and "centos" not in os:
+    if instance == "p4d.24xlarge" and os != "centos7":
         _test_nccl_benchmarks(remote_command_executor, test_datadir, "openmpi", scheduler_commands)
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -218,9 +218,11 @@ def _test_osu_benchmarks_multiple_bandwidth(
     ).stdout
 
     # Expected bandwidth with 4 NICS:
-    # OMPI 4.1.0: ~330Gbps = 41250MB/s
-    # OMPI 4.0.5: ~95Gbps = 11875MB/s
-    assert_that(float(max_bandwidth)).is_greater_than(41000)
+    # OMPI 4.1.0: ~330Gbps = 41250MB/s with Placement Group
+    # OMPI 4.1.0: ~252Gbps = 31550MB/s without Placement Group
+    # OMPI 4.0.5: ~95Gbps = 11875MB/s with Placement Group
+    expected_bandwidth = 30000
+    assert_that(float(max_bandwidth)).is_greater_than(expected_bandwidth)
 
 
 def run_osu_benchmarks(

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -14,8 +14,10 @@ Scheduling:
   SlurmQueues:
     - Name: efa-enabled
       Networking:
+        {% if instance != "p4d.24xlarge" %}
         PlacementGroup:
           Enabled: true
+        {% endif %}
         SubnetIds:
           - {{ private_subnet_id }}
       ComputeResources:


### PR DESCRIPTION
* Enable nccl tests for centos8
* Remove placement group from EFA test when using p4d
* Use different threshold for OSU p4d benchmark when running without Placement Group

Without PG the results are:
```
2021-08-25 17:33:59,661 - ERROR - test_hit_efa[us-west-2-p4d.24xlarge-ubuntu2004-slurm] - test_efa - osu_mbw_mr benchmarks failed. Expected bandwidth greater than: 41000, current: 32598.48

2021-08-25 20:42:16,415 - ERROR - test_hit_efa[us-west-2-p4d.24xlarge-alinux2-slurm] - test_efa - osu_mbw_mr benchmarks failed. Expected bandwidth greater than: 41000, current: 31550.50
```
