### PR TITLE
Pin connexion to 2.7.0

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -21,6 +21,6 @@ aws-cdk.aws-ssm~=1.116
 aws-cdk.aws-sqs~=1.116
 aws-cdk.aws-cloudformation~=1.116
 werkzeug~=2.0
-connexion~=2.7
+connexion==2.7
 flask~=2.0
 jmespath~=0.10

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -47,7 +47,10 @@ REQUIRES = [
     "aws-cdk.aws-sqs~=" + CDK_VERSION,
     "aws-cdk.aws-cloudformation~=" + CDK_VERSION,
     "werkzeug~=2.0",
-    "connexion~=2.7",
+    # pin connexion to 2.7.0 since 2.8.0,2.9.0 have introduced stricter requirements for werkzeug and flask.
+    # This does not impact any functionality. Also next connexion release will lift this limitation
+    # and we will be able to upgrade.
+    "connexion==2.7.0",
     "flask~=2.0",
     "jmespath~=0.10",
 ]


### PR DESCRIPTION
pin connexion to 2.7.0 since 2.8.0,2.9.0 have introduced stricter requirements for werkzeug and flask.
This does not impact any functionality. Also next connexion release will lift this limitation
and we will be able to upgrade.

I verified that we have been testing connexion with version 2.7.0 until now. This is because more recent versions of pip (>20) are smart enough to install 2.7.0 when >=2.7.0 is specified while older versions will install 2.9.0 and report an inconsistency in the python environment. 

Signed-off-by: Francesco De Martino <fdm@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
