### PR TITLE
3.0: Restore cfn_ prefix in cfnconfig variables

### DIFF
--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/post_install.sh
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/post_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . "/etc/parallelcluster/cfnconfig"
 
-case "${node_type}" in
+case "${cfn_node_type}" in
     HeadNode)
         exit 0
     ;;


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
