### PR TITLE
3.0: Fix templates path for pcluster configure and print messages format

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ At the end of the process a message like this one will be shown:
 
 ```
 Configuration file written to /dir/conf_file
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-name cluster-name --cluster-configuration /dir/cluster-config.yaml' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-name cluster-name --cluster-configuration /dir/cluster-config.yaml' to create your cluster.
 ```
 
 

--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -351,9 +351,9 @@ def _choose_network_configuration(scheduler, head_node_instance_type, compute_in
         # But user can bypass it by using manual subnets creation during configure or modify the config file directly.
         print(
             "Error: There is no single availability zone offering head node and compute in current region.\n"
-            "To create your cluster, make sure you have a subnet for head node in {0}"
-            ", and a subnet for compute nodes in {1}. Then run pcluster configure again"
-            "and avoid using Automate VPC/Subnet creation.".format(azs_for_head_node_type, azs_for_compute_types)
+            f"To create your cluster, make sure you have a subnet for head node in {azs_for_head_node_type}, "
+            f"and a subnet for compute nodes in {azs_for_compute_types}. "
+            "Then run pcluster configure again and avoid using Automate VPC/Subnet creation."
         )
         print("Exiting...")
         sys.exit(1)
@@ -376,8 +376,8 @@ def _prompt_for_subnet(all_subnets, qualified_subnets, message, default_subnet=N
     total_omitted_subnets = len(all_subnets) - len(qualified_subnets)
     if total_omitted_subnets > 0:
         print(
-            "Note:  {0} subnet(s) is/are not listed, "
-            "because the instance type is not in their availability zone(s)".format(total_omitted_subnets)
+            f"Note: {total_omitted_subnets} subnet(s) is/are not listed, "
+            "because the instance type is not in their availability zone(s)"
         )
     return prompt_iterable(message, qualified_subnets, default_value=default_subnet)
 

--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -255,7 +255,7 @@ def configure(args):  # noqa: C901
     _write_configuration_file(config_file_path, result)
     print(
         "You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration "
-        f"{config_file_path} --cluster-name cluster-name' to create your cluster"
+        f"{config_file_path} --cluster-name cluster-name --region {get_region()}' to create your cluster."
     )
 
 

--- a/cli/src/pcluster/cli/commands/configure/utils.py
+++ b/cli/src/pcluster/cli/commands/configure/utils.py
@@ -73,7 +73,7 @@ def prompt(
     :return: the value inserted by the user validated
     """
     if options_to_print:
-        print("Allowed values for {0}:".format(message))
+        print(f"Allowed values for {message}:")
         if table_header:
             print(tabulate(options_to_print, table_header))
         else:
@@ -92,7 +92,7 @@ def prompt(
         if validator(result):
             valid_user_input = True
         else:
-            print("ERROR: {0} is not an acceptable value for {1}".format(user_input, message))
+            print(f"ERROR: {user_input} is not an acceptable value for {message}")
     return result
 
 

--- a/cli/src/pcluster/cli/commands/configure/utils.py
+++ b/cli/src/pcluster/cli/commands/configure/utils.py
@@ -28,7 +28,7 @@ def handle_client_exception(func):
         try:
             return func(*args, **kwargs)
         except (BotoCoreError, ClientError) as e:
-            print("Failed with error: %s", e)
+            print(f"Failed with error: {e}")
             if isinstance(e, ClientError) and "credentials" in str(e):
                 print("To set the credentials, run 'aws configure' or set them as environment variables")
 
@@ -107,7 +107,7 @@ def prompt_iterable(message, options, default_value=None):
     :return: the validated value
     """
     if not options:
-        print("ERROR: No options found for %s", message)
+        print(f"ERROR: No options found for {message}")
         sys.exit(1)
     is_dict = isinstance(options[0], dict)
     valid_options = [option["id"] for option in options] if is_dict else options

--- a/cli/src/pcluster/cli/commands/dcv_connect.py
+++ b/cli/src/pcluster/cli/commands/dcv_connect.py
@@ -62,7 +62,7 @@ def _dcv_connect(args):
 
         try:
             url = _retry(_retrieve_dcv_session_url, func_args=[cmd, args.cluster_name, head_node_ip], attempts=4)
-            url_message = "Please use the following one-time URL in your browser within 30 seconds:\n{0}".format(url)
+            url_message = f"Please use the following one-time URL in your browser within 30 seconds:\n{url}"
 
             if args.show_url:
                 print(url_message)

--- a/cli/src/pcluster/cli/commands/dcv_connect.py
+++ b/cli/src/pcluster/cli/commands/dcv_connect.py
@@ -72,7 +72,7 @@ def _dcv_connect(args):
                 if not webbrowser.open_new(url):
                     raise webbrowser.Error("Unable to open the Web browser.")
             except webbrowser.Error as e:
-                print("%s\n%s", e, url_message)
+                print(f"{e}\n{url_message}")
 
         except DCVConnectionError as e:
             error(

--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -198,7 +198,7 @@ def run(sys_args, model=None):
     # some commands (e.g. ssh and those defined as CliCommand objects) require 'extra_args'
     if extra_args and (not hasattr(args, "expects_extra_args") or not args.expects_extra_args):
         parser.print_usage()
-        print("Invalid arguments %s" % extra_args)
+        print(f"Invalid arguments {extra_args}")
         sys.exit(1)
 
     if args.debug:

--- a/cli/src/pcluster/networking/vpc_factory.py
+++ b/cli/src/pcluster/networking/vpc_factory.py
@@ -82,11 +82,11 @@ class VpcFactory:
         dns_hostnames = vpc.describe_attribute(Attribute="enableDnsHostnames")["EnableDnsHostnames"]["Value"]
 
         if not dns_hostnames:
-            print("DNS Hostnames of the VPC {0} must be set to True".format(vpc_id))
+            print(f"DNS Hostnames of the VPC {vpc_id} must be set to True")
         if not dns_resolution:
-            print("DNS Resolution of the VPC {0} must be set to True".format(vpc_id))
+            print(f"DNS Resolution of the VPC {vpc_id} must be set to True")
         if vpc.dhcp_options_id == "default":
-            print("DHCP options of the VPC {0} must be set.".format(vpc_id))
+            print(f"DHCP options of the VPC {vpc_id} must be set.")
 
         # default is equal to NO dhcp options set
         return dns_resolution and dns_hostnames and vpc.dhcp_options_id != "default"

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/send_build_notification.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/send_build_notification.py
@@ -28,8 +28,8 @@ def handler(event, context):  # pylint: disable=unused-argument
             "Data": "Build has completed.",
         }
     )
-    print("Notification URL: %s" % notification_url)
-    print("Notification data: %s" % data)
+    print(f"Notification URL: {notification_url}")
+    print(f"Notification data: {data}")
 
     # This function returns a 5-tuple: (addressing scheme, network location, path, query, fragment identifier)
     split_url = urlsplit(notification_url)
@@ -43,8 +43,8 @@ def handler(event, context):  # pylint: disable=unused-argument
                 method="PUT", url=url, body=data, headers={"Content-Type": "", "content-length": str(len(data))}
             )
             response = connection.getresponse()
-            print("CloudFormation returned status code: {}".format(response.reason))
+            print(f"CloudFormation returned status code: {response.reason}")
             break
         except Exception as e:
-            print("Unexpected failure sending response to CloudFormation {}".format(e), exc_info=True)
+            print(f"Unexpected failure sending response to CloudFormation {e}")
             time.sleep(5)

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -242,19 +242,19 @@ def check_if_latest_version():
         with urllib.request.urlopen(pypi_url) as url:  # nosec nosemgrep
             latest = json.loads(url.read())["info"]["version"]
         if packaging.version.parse(get_installed_version()) < packaging.version.parse(latest):
-            print("Info: There is a newer version %s of AWS ParallelCluster available." % latest)
+            print(f"Info: There is a newer version {latest} of AWS ParallelCluster available.")
     except Exception:  # nosec
         pass
 
 
 def warn(message):
     """Print a warning message."""
-    print("WARNING: {0}".format(message))
+    print(f"WARNING: {message}")
 
 
 def error(message) -> NoReturn:
     """Raise SystemExit exception to the stderr."""
-    sys.exit("ERROR: {0}".format(message))
+    sys.exit(f"ERROR: {message}")
 
 
 def get_cli_log_file():

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -223,8 +223,9 @@ def get_templates_bucket_path():
     """Return a string containing the path of bucket."""
     region = get_region()
     s3_suffix = ".cn" if region.startswith("cn") else ""
-    return "https://{REGION}-aws-parallelcluster.s3.{REGION}.amazonaws.com{S3_SUFFIX}/templates/".format(
-        REGION=region, S3_SUFFIX=s3_suffix
+    return (
+        f"https://{region}-aws-parallelcluster.s3.{region}.amazonaws.com{s3_suffix}/"
+        f"parallelcluster/{get_installed_version()}/templates/"
     )
 
 

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
@@ -41,15 +41,15 @@ Allowed values for VPC ID:
   2  vpc-23456789  ParallelClusterVPC-20190624105051                    0
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
-Note:  2 subnet(s) is/are not listed, because the instance type is not in their availability zone(s)
+Note: 2 subnet(s) is/are not listed, because the instance type is not in their availability zone(s)
 Allowed values for head node subnet ID:
   #  id               name      size  availability_zone
 ---  ---------------  ------  ------  -------------------
   1  subnet-45678912            4096  eu-west-1a
-Note:  2 subnet(s) is/are not listed, because the instance type is not in their availability zone(s)
+Note: 2 subnet(s) is/are not listed, because the instance type is not in their availability zone(s)
 Allowed values for compute subnet ID:
   #  id               name      size  availability_zone
 ---  ---------------  ------  ------  -------------------
   1  subnet-45678912            4096  eu-west-1a
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region us-east-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
@@ -52,4 +52,4 @@ Allowed values for compute subnet ID:
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
   2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region eu-west-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/output.txt
@@ -47,4 +47,4 @@ Allowed values for compute subnet ID:
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
   2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region eu-west-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/output.txt
@@ -52,4 +52,4 @@ Allowed values for compute subnet ID:
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
   2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region us-east-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
@@ -49,4 +49,4 @@ Allowed values for Network Configuration:
 1. Head node in a public subnet and compute fleet in a private subnet
 2. Head node and compute fleet in the same public subnet
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region eu-west-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
@@ -50,4 +50,4 @@ Allowed values for Network Configuration:
 1. Head node in a public subnet and compute fleet in a private subnet
 2. Head node and compute fleet in the same public subnet
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region eu-west-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/output.txt
@@ -37,4 +37,4 @@ Allowed values for VPC ID:
   3  vpc-34567891  default                                              3
   4  vpc-45678912  ParallelClusterVPC-20190626095403                    1
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region eu-west-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
@@ -43,4 +43,4 @@ Allowed values for Network Configuration:
 2. Head node and compute fleet in the same public subnet
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region eu-west-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
@@ -44,4 +44,4 @@ Allowed values for Network Configuration:
 2. Head node and compute fleet in the same public subnet
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region eu-west-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
@@ -44,4 +44,4 @@ Allowed values for Network Configuration:
 2. Head node and compute fleet in the same public subnet
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region eu-west-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/output.txt
@@ -31,4 +31,4 @@ Allowed values for Scheduler:
 2. awsbatch
 Beginning VPC creation. Please do not leave the terminal until the creation is finalized
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region eu-west-1' to create your cluster.

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/output.txt
@@ -35,4 +35,4 @@ Allowed values for compute subnet ID:
   1  subnet-12345678  ParallelClusterPublicSubnet      256  eu-west-1b
   2  subnet-23456789  ParallelClusterPrivateSubnet    4096  eu-west-1b
 Configuration file written to {{ CONFIG_FILE }}
-You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name' to create your cluster
+You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration {{ CONFIG_FILE }} --cluster-name cluster-name --region eu-west-1' to create your cluster.


### PR DESCRIPTION
Manual test:
```
...
Beginning VPC creation. Please do not leave the terminal until the creation is finalized
Creating CloudFormation stack...
Do not leave the terminal until the process has finished
Stack Name: parallelclusternetworking-pubpriv-20210901140455 (id: arn:aws:cloudformation:eu-west-1:xxx:stack/parallelclusternetworking-pubpriv-20210901140455/a61fd2a0-0b2d-11ec-9f8a-06628ab878f9)
Status: parallelclusternetworking-pubpriv-20210901140455 - CREATE_COMPLETE
The stack has been created
Configuration file written to test-config-from-configure.yaml
You can edit your configuration file or simply run 'pcluster create-cluster --cluster-configuration test-config-from-configure.yaml --cluster-name cluster-name' to create your cluster
```
