### PR TITLE
Disabling coverage report for awsbatch-cli

### DIFF
--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -19,7 +19,8 @@ commands =
     nocov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --ignore=src tests/
     cov: python setup.py clean --all build_ext --force --inplace
     cov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --cov=src --cov-report=xml --cov-append tests/
-    cov: codecov -e TOXENV
+    # Disabling coverage report for awsbatch-cli because it's currently conflicting with pcluster cli report
+    # cov: codecov -e TOXENV
 
 # Section used to define common variables used by multiple testenvs.
 [vars]


### PR DESCRIPTION
it's currently conflicting with pcluster cli report

Signed-off-by: Francesco De Martino <fdm@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
