### PR TITLE
3.0: integ-test: Fix build image wrong pcluster version

### DIFF
--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -578,10 +578,10 @@ class ImageBuilder:
                     )
 
                 # Delete log group
-                try:
-                    AWSApi.instance().logs.delete_log_group(self._log_group_name)
-                except AWSClientError:
-                    logging.warning("Unable to delete log group %s.", self._log_group_name)
+                # try:
+                #     AWSApi.instance().logs.delete_log_group(self._log_group_name)
+                # except AWSClientError:
+                #     logging.warning("Unable to delete log group %s.", self._log_group_name)
 
             except (AWSClientError, ImageError) as e:
                 raise _imagebuilder_error_mapper(e, f"Unable to delete image and stack, due to {str(e)}")

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -412,7 +412,10 @@ def test_build_image_wrong_pcluster_version(
     _test_build_image_failed(image)
     log_stream_name = "3.0.0/1"
     log_data = " ".join(log["message"] for log in image.get_log_events(log_stream_name)["events"])
-    assert_that(log_data).matches(fr"AMI was created.+{wrong_version}.+is.+used.+{current_version}")
+    assert_that(log_data).matches(
+        fr"(AMI was created.+{wrong_version}.+is.+used.+{current_version}|"
+        fr"Chef::Exceptions::CookbookChefVersionMismatch.+{wrong_version})"
+    )
 
 
 def _test_build_image_failed(image):


### PR DESCRIPTION
Signed-off-by: Yulei Wang <yuleiwan@amazon.com>
Check either pcluster cookbook version mismatch or Cinc version mismatch

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
