### PR TITLE
Remove shell symbol from pcluster ssh examples

### DIFF
--- a/cli/src/pcluster/cli/commands/ssh.py
+++ b/cli/src/pcluster/cli/commands/ssh.py
@@ -90,11 +90,11 @@ class SshCommand(CliCommand):
     epilog = textwrap.dedent(
         """Example:
 
-  $ pcluster ssh --cluster-name mycluster -i ~/.ssh/id_rsa
+  pcluster ssh --cluster-name mycluster -i ~/.ssh/id_rsa
 
 Returns an ssh command with the cluster username and IP address pre-populated:
 
-  $ ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa"""
+  ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa"""
     )
 
     def __init__(self, subparsers):


### PR DESCRIPTION
Before:
```
Example:

  $ pcluster ssh --cluster-name mycluster -i ~/.ssh/id_rsa

Returns an ssh command with the cluster username and IP address pre-populated:

  $ ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa
```

After:
```
Example:

  pcluster ssh --cluster-name mycluster -i ~/.ssh/id_rsa

Returns an ssh command with the cluster username and IP address pre-populated:

  ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa
```