### PR TITLE
Do not access the bucket name at logging time

### DIFF
--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -566,7 +566,9 @@ class ImageBuilder:
                     self.bucket.check_bucket_exists()
                     self.bucket.delete_s3_artifacts()
                 except AWSClientError:
-                    logging.warning("S3 bucket %s does not exist, skip image s3 artifacts deletion.", self.bucket.name)
+                    logging.warning(
+                        "S3 bucket associated to the image does not exist, skip image s3 artifacts deletion."
+                    )
 
                 # Delete log group
                 try:


### PR DESCRIPTION
If `self.bucket.check_bucket_exists()` fails because the bucket doesn't exist
the call to `self.bucket.name` in the log message will fail too.

This patch permits to avoid triggering `AWSClientError` in case of un-existing buckets.

## Test

Before:
```
$ pcluster delete-image --region eu-west-3 --image-id aws-parallelcluster-3-0-0-centos7-hvm-x86-64-202107151137
{
  "message": "Unable to delete image and stack, due to Unable to access config-specified S3 bucket pr-ae5a9f1a011e9d83-v1-do-not-delete. Due to Unexpected error when calling get_bucket_location on S3 bucket 'pr-ae5a9f1a011e9d83-v1-do-not-delete': 'Not Found'"
}
$ pcluster delete-image --region eu-west-3 --image-id aws-parallelcluster-3-0-0-centos7-hvm-x86-64-202107151137 --debug
{
  "message": "No image or stack associated with ParallelCluster image id: aws-parallelcluster-3-0-0-centos7-hvm-x86-64-202107151137."
}
```



After: manually tested renaming the Tag of the bucket associated to an image and trying to delete it:
```
$ pcluster delete-image --region eu-west-3 --image-id integ-test-build-image-qpofvydus5gv7m39
{
  "image": {
    "imageId": "integ-test-build-image-qpofvydus5gv7m39",
    "imageBuildStatus": "DELETE_IN_PROGRESS",
    "region": "eu-west-3",
    "version": "3.0.0"
  }
}
$ pcluster delete-image --region eu-west-3 --image-id integ-test-build-image-qpofvydus5gv7m39
{
  "message": "No image or stack associated with ParallelCluster image id: integ-test-build-image-qpofvydus5gv7m39."
}
```