### PR TITLE
3.0: Write Imds>Secured from pcluster configure only when using AWS Batch

### DIFF
--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -857,8 +857,7 @@ class HeadNodeImdsValidator(Validator):
         elif imds_secured and scheduler not in SCHEDULERS_SUPPORTING_IMDS_SECURED:
             # TODO move validation for Imds parameter in the schema
             self._add_failure(
-                f"IMDS Secured cannot be enabled when using scheduler {scheduler}. "
-                "Please, remove related configuration parameter.",
+                f"IMDS Secured cannot be enabled when using scheduler {scheduler}. Please, disable IMDS Secured.",
                 FailureLevel.ERROR,
             )
 

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_yes_awsbatch_no_errors/pcluster.config.yaml
@@ -7,6 +7,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: false
 Scheduling:
   Scheduler: awsbatch
   AwsBatchQueues:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_yes_awsbatch_invalid_vpc/pcluster.config.yaml
@@ -7,6 +7,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: false
 Scheduling:
   Scheduler: awsbatch
   AwsBatchQueues:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_yes_awsbatch_no_errors/pcluster.config.yaml
@@ -7,6 +7,8 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: key1
+  Imds:
+    Secured: false
 Scheduling:
   Scheduler: awsbatch
   AwsBatchQueues:

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -822,8 +822,7 @@ def test_intel_hpc_os_validator(os, expected_message):
         (
             True,
             "awsbatch",
-            "IMDS Secured cannot be enabled when using scheduler awsbatch. "
-            "Please, remove related configuration parameter.",
+            "IMDS Secured cannot be enabled when using scheduler awsbatch. Please, disable IMDS Secured.",
         ),
         (None, None, "Cannot validate IMDS configuration if scheduler is not set."),
         (True, None, "Cannot validate IMDS configuration if scheduler is not set."),


### PR DESCRIPTION
The default of the parameter is True, so AWS Batch cluster creation was failing
if the parameter is not set.


