### PR TITLE
3.0: Update of CustomAmi for head node is not supported

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -833,17 +833,13 @@ class ImageSchema(BaseSchema):
         return Image(**data)
 
 
-class BaseImageSchema(BaseSchema):
-    """Represent the common attributes in HeadNode Image and Queue Image."""
+class HeadNodeImageSchema(BaseSchema):
+    """Represent the schema of the HeadNode Image."""
 
     custom_ami = fields.Str(
         validate=validate.Regexp(r"^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$"),
-        metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP},
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
-
-
-class HeadNodeImageSchema(BaseImageSchema):
-    """Represent the schema of the HeadNode Image."""
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -851,8 +847,13 @@ class HeadNodeImageSchema(BaseImageSchema):
         return HeadNodeImage(**data)
 
 
-class QueueImageSchema(BaseImageSchema):
+class QueueImageSchema(BaseSchema):
     """Represent the schema of the Queue Image."""
+
+    custom_ami = fields.Str(
+        validate=validate.Regexp(r"^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$"),
+        metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP},
+    )
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -22,6 +22,9 @@ from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.test_utils import dummy_cluster
 
 default_cluster_params = {
+    "custom_ami": "ami-12345678",
+    "head_node_custom_ami": "ami-12345678",
+    "queue_custom_ami": "ami-12345678",
     "head_node_subnet_id": "subnet-12345678",
     "compute_subnet_id": "subnet-12345678",
     "additional_sg": "sg-12345678",
@@ -103,6 +106,36 @@ def _compare_changes(changes, expected_changes):
             UpdatePolicy.SUPPORTED,
             True,
             id="change additional security group",
+        ),
+        pytest.param(
+            ["Image"],
+            "custom_ami",
+            "CustomAmi",
+            "ami-12345678",
+            "ami-1234567a",
+            UpdatePolicy.UNSUPPORTED,
+            False,
+            id="change top level custom ami",
+        ),
+        pytest.param(
+            ["HeadNode", "Image"],
+            "head_node_custom_ami",
+            "CustomAmi",
+            "ami-12345678",
+            "ami-1234567a",
+            UpdatePolicy.UNSUPPORTED,
+            False,
+            id="change head node custom ami",
+        ),
+        pytest.param(
+            ["Scheduling", "SlurmQueues[queue1]", "Image"],
+            "queue_custom_ami",
+            "CustomAmi",
+            "ami-12345678",
+            "ami-1234567a",
+            UpdatePolicy.COMPUTE_FLEET_STOP,
+            False,
+            id="change queue custom ami",
         ),
         pytest.param(
             ["SharedStorage[ebs1]", "EbsSettings"],

--- a/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.yaml
+++ b/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.yaml
@@ -1,5 +1,6 @@
 Image:
   Os: alinux2
+  CustomAmi: {{custom_ami}}
 HeadNode:
   InstanceType: t2.micro
   Networking:
@@ -8,6 +9,8 @@ HeadNode:
       - {{additional_sg}}
   Ssh:
     KeyName: test-key
+  Image:
+    CustomAmi: {{head_node_custom_ami}}
 Scheduling:
   Scheduler: slurm
   SlurmQueues:
@@ -20,6 +23,8 @@ Scheduling:
           InstanceType: {{compute_instance_type}}
           MinCount: 1
           MaxCount: {{max_count}}
+      Image:
+        CustomAmi: {{queue_custom_ami}}
 SharedStorage:
   - MountDir: vol1
     Name: ebs1


### PR DESCRIPTION
+ Add unit tests for CustomAmi update.