### PR TITLE
Remove API tests china partition

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -8,7 +8,7 @@ test-suites:
   pcluster_api:
     test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
       dimensions:
-        - regions: ["ap-south-1", "cn-north-1", "us-gov-west-1"]
+        - regions: ["ap-south-1", "us-gov-west-1"] # cn removed because doesn't support lambda backed docker image yet
     test_api.py::test_cluster_slurm:
       dimensions:
         - regions: ["sa-east-1"]


### PR DESCRIPTION
Test removed because china doesn't support lambda backed docker image yet

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
