### PR TITLE
Revert "Remove API tests china partition"

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -8,7 +8,7 @@ test-suites:
   pcluster_api:
     test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
       dimensions:
-        - regions: ["ap-south-1", "us-gov-west-1"] # cn removed because doesn't support lambda backed docker image yet
+        - regions: ["ap-south-1", "cn-north-1", "us-gov-west-1"]
     test_api.py::test_cluster_slurm:
       dimensions:
         - regions: ["sa-east-1"]


### PR DESCRIPTION
Reverts aws/aws-parallelcluster#3270
Because  Lambda / Docker Image support in China was launched yesterday: https://www.amazonaws.cn/en/new/2021/amazon-lambda-supports-container-images-packaging-format/