### PR TITLE
3.0 Fix integration test dashboard doesn't display failure by properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
           with:
             path: './cli'
             format: 'HTML'
+            project: 'aws-parallelcluster'
         - name: Upload Test results
           uses: actions/upload-artifact@master
           with:
@@ -23,6 +24,7 @@ jobs:
           with:
             path: './awsbatch-cli'
             format: 'HTML'
+            project: 'aws-parallelcluster'
         - name: Upload AWS Batch CLI Test results
           uses: actions/upload-artifact@master
           with:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -191,7 +191,6 @@ def pytest_sessionstart(session):
 
 def pytest_runtest_call(item):
     """Called to execute the test item."""
-    _add_properties_to_report(item)
     set_logger_formatter(
         logging.Formatter(fmt=f"%(asctime)s - %(levelname)s - %(process)d - {item.name} - %(module)s - %(message)s")
     )
@@ -1078,6 +1077,9 @@ def s3_bucket_factory(region):
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
     """Making test result information available in fixtures"""
+    # add dimension properties to report
+    _add_properties_to_report(item)
+
     # execute all other hooks to obtain the report object
     outcome = yield
     rep = outcome.get_result()


### PR DESCRIPTION
* Fix integration test dashboard doesn't display failure by properties(region, os, instance etc.)
* Add add_properties_to_report in pytest_runtest_makereport which is called during test fails to avoid generating wrong test_result json once test failed in environment setup

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
