### PR TITLE
New IAM tests for cluster and build image 

### DIFF
--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -151,8 +151,6 @@ class SlurmConstruct(Construct):
                         "dynamodb:PutItem",
                         "dynamodb:BatchWriteItem",
                         "dynamodb:GetItem",
-                        "dynamodb:DeleteItem",
-                        "dynamodb:DescribeTable",
                     ],
                     "effect": iam.Effect.ALLOW,
                     "resources": [

--- a/tests/iam_policies/cluster-roles.cfn.yaml
+++ b/tests/iam_policies/cluster-roles.cfn.yaml
@@ -33,7 +33,7 @@ Resources:
               - Action: ec2:TerminateInstances
                 Condition:
                   StringEquals:
-                    ec2:ResourceTag/parallelcluster:node-type: ComputeNode
+                    ec2:ResourceTag/parallelcluster:node-type: Compute
                 Effect: Allow
                 Resource: '*'
               - Action:
@@ -76,13 +76,14 @@ Resources:
                   - !Sub arn:${AWS::Partition}:s3:::parallelcluster-*-v1-do-not-delete/*
               - Action:
                   - dynamodb:PutItem
+                  - dynamodb:GetItem
                   - dynamodb:BatchWriteItem
                 Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/parallelcluster-*
                 Effect: Allow
               - Action: ec2:TerminateInstances
                 Condition:
                   StringEquals:
-                    ec2:ResourceTag/parallelcluster:node-type: ComputeNode
+                    ec2:ResourceTag/parallelcluster:node-type: Compute
                 Effect: Allow
                 Resource: '*'
               - Action: ec2:RunInstances

--- a/tests/iam_policies/cluster-roles.cfn.yaml
+++ b/tests/iam_policies/cluster-roles.cfn.yaml
@@ -152,6 +152,13 @@ Resources:
             Version: '2012-10-17'
     Type: AWS::IAM::Role
 
+  ComputeNodeInstanceProfileSlurm:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /parallelcluster/
+      Roles:
+        - !Ref ComputeNodeRoleSlurm
+
   CustomLambdaResourcesRoleBatch:
     Properties:
       Description: Role to be used in 'Iam:Roles:CustomLambdaResources' when the scheduler is AwsBatch
@@ -257,3 +264,16 @@ Resources:
             Version: '2012-10-17'
     Type: AWS::IAM::Role
 
+Outputs:
+  HeadNodeRoleSlurm:
+    Value: !GetAtt HeadNodeRoleSlurm.Arn
+  ComputeNodeRoleSlurm:
+    Value: !GetAtt ComputeNodeRoleSlurm.Arn
+  ComputeNodeInstanceProfileSlurm:
+    Value: !GetAtt ComputeNodeInstanceProfileSlurm.Arn
+  CustomLambdaResourcesRoleSlurm:
+    Value: !GetAtt CustomLambdaResourcesRoleSlurm.Arn
+  HeadNodeRoleBatch:
+    Value: !GetAtt HeadNodeRoleBatch.Arn
+  CustomLambdaResourcesRoleBatch:
+    Value: !GetAtt CustomLambdaResourcesRoleBatch.Arn

--- a/tests/iam_policies/image-roles.cfn.yaml
+++ b/tests/iam_policies/image-roles.cfn.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Resources:
-  PClusterBuildImageLambdaCleanupRole:
+  BuildImageLambdaCleanupRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -74,14 +74,14 @@ Resources:
                 Resource: !Sub 'arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:ParallelClusterImage-*'
                 Effect: Allow
 
-  PClusterBuildImageInstanceProfile:
+  BuildImageInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /parallelcluster/
       Roles:
-        - !Ref PClusterBuildImageInstanceRole
+        - !Ref BuildImageInstanceRole
 
-  PClusterBuildImageInstanceRole:
+  BuildImageInstanceRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -108,3 +108,11 @@ Resources:
                   - ec2:ModifyImageAttribute
                 Resource: !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}::image/*'
                 Effect: Allow
+
+Outputs:
+  BuildImageLambdaCleanupRole:
+    Value: !GetAtt BuildImageLambdaCleanupRole.Arn
+  BuildImageInstanceProfile:
+    Value: !GetAtt BuildImageInstanceProfile.Arn
+  BuildImageInstanceRole:
+    Value: !GetAtt BuildImageInstanceRole.Arn

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -226,6 +226,11 @@ iam:
         schedulers: ["awsbatch", "slurm"]
         oss: ["alinux2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
+  test_iam_image.py::test_iam_roles:
+    dimensions:
+      - regions: ["eu-south-1"]
+        oss: ["alinux2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
   test_iam.py::test_s3_read_write_resource:
     dimensions:
       - regions: ["eu-central-1"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -409,6 +409,7 @@ def api_client(region, api_server_factory, api_uri):
 
 
 @pytest.fixture(scope="class")
+@pytest.mark.usefixtures("setup_credentials")
 def images_factory(request):
     """
     Define a fixture to manage the creation and destruction of images.
@@ -874,7 +875,7 @@ def vpc_stacks(cfn_stacks_factory, request):
 
 
 @pytest.fixture(scope="class")
-@pytest.mark.usefixtures("setup_credentials", "clusters_factory", "images_factory")
+@pytest.mark.usefixtures("clusters_factory", "images_factory")
 def create_roles_stack(request, region):
     """Define a fixture that returns a stack factory for IAM roles."""
     logging.info("Creating IAM roles stack")

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -18,7 +18,6 @@ import logging
 import os
 import random
 import re
-import time
 from pathlib import Path
 from shutil import copyfile
 from traceback import format_tb
@@ -27,7 +26,6 @@ import boto3
 import pkg_resources
 import pytest
 import yaml
-from botocore.config import Config
 from cfn_stacks_factory import CfnStack, CfnStacksFactory
 from clusters_factory import Cluster, ClustersFactory
 from conftest_markers import (
@@ -800,7 +798,7 @@ def initialize_cli_creds(cfn_stacks_factory, request):
     regions = request.config.getoption("regions") or get_all_regions(request.config.getoption("tests_config"))
     for region in regions:
         logging.info("Creating IAM roles for pcluster CLI")
-        stack_name = generate_stack_name("integ-tests-iam", request.config.getoption("stackname_suffix"))
+        stack_name = generate_stack_name("integ-tests-iam-user-role", request.config.getoption("stackname_suffix"))
         stack_template_path = os.path.join("..", "iam_policies", "user-role.cfn.yaml")
         with open(stack_template_path, encoding="utf-8") as stack_template_file:
             stack_template_data = stack_template_file.read()
@@ -876,112 +874,34 @@ def vpc_stacks(cfn_stacks_factory, request):
 
 
 @pytest.fixture(scope="class")
-def common_pcluster_policies(region):
-    """Create four policies to be attached to ec2_iam_role, iam_lamda_role for awsbatch or traditional schedulers."""
-    policies = {}
-    policies["awsbatch_instance_policy"] = _create_iam_policies(
-        "integ-tests-ParallelClusterInstancePolicy-batch-" + random_alphanumeric(), region, "batch_instance_policy.json"
-    )
-    policies["traditional_instance_policy"] = _create_iam_policies(
-        "integ-tests-ParallelClusterInstancePolicy-traditional-" + random_alphanumeric(),
-        region,
-        "traditional_instance_policy.json",
-    )
-    policies["awsbatch_lambda_policy"] = _create_iam_policies(
-        "integ-tests-ParallelClusterLambdaPolicy-batch-" + random_alphanumeric(),
-        region,
-        "batch_lambda_function_policy.json",
-    )
-    policies["traditional_lambda_policy"] = _create_iam_policies(
-        "integ-tests-ParallelClusterLambdaPolicy-traditional-" + random_alphanumeric(),
-        region,
-        "traditional_lambda_function_policy.json",
-    )
+@pytest.mark.usefixtures("setup_credentials", "clusters_factory", "images_factory")
+def create_roles_stack(request, region):
+    """Define a fixture that returns a stack factory for IAM roles."""
+    logging.info("Creating IAM roles stack")
+    factory = CfnStacksFactory(request.config.getoption("credential"))
 
-    yield policies
+    def _create_stack(stack_prefix, roles_file):
+        stack_template_path = os.path.join("..", "iam_policies", roles_file)
+        template_data = read_template(stack_template_path)
+        stack = CfnStack(
+            name=generate_stack_name(stack_prefix, request.config.getoption("stackname_suffix")),
+            region=region,
+            template=template_data,
+            capabilities=["CAPABILITY_IAM"],
+        )
+        factory.create_stack(stack)
+        return stack
 
-    iam_client = boto3.client("iam", region_name=region)
-    for policy in policies.values():
-        iam_client.delete_policy(PolicyArn=policy)
+    def read_template(template_path):
+        with open(template_path, encoding="utf-8") as cfn_file:
+            file_content = cfn_file.read()
+        return file_content
 
-
-@pytest.fixture(scope="class")
-def role_factory(region):
-    roles = []
-    iam_client = boto3.client("iam", region_name=region, config=Config(retries={"max_attempts": 10}))
-
-    def create_role(trusted_service, policies=()):
-        iam_role_name = f"integ-tests_{trusted_service}_{region}_{random_alphanumeric()}"
-        logging.info(f"Creating iam role {iam_role_name} for {trusted_service}")
-
-        partition = get_arn_partition(region)
-        domain_suffix = ".cn" if partition == "aws-cn" else ""
-
-        trust_relationship_policy_ec2 = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {"Service": f"{trusted_service}.amazonaws.com{domain_suffix}"},
-                    "Action": "sts:AssumeRole",
-                }
-            ],
-        }
-        role_arn = iam_client.create_role(
-            RoleName=iam_role_name,
-            AssumeRolePolicyDocument=json.dumps(trust_relationship_policy_ec2),
-            Description="Role for create custom KMS key",
-            Path="/parallelcluster/",
-        )["Role"]["Arn"]
-
-        logging.info(f"Attaching iam policy to the role {iam_role_name}...")
-        for policy in policies:
-            iam_client.attach_role_policy(RoleName=iam_role_name, PolicyArn=policy)
-
-        # Having time.sleep here because because it take a while for the the IAM role to become valid for use in the
-        # put_key_policy step for creating KMS key, read the following link for reference :
-        # https://stackoverflow.com/questions/20156043/how-long-should-i-wait-after-applying-an-aws-iam-policy-before-it-is-valid
-        time.sleep(60)
-        logging.info(f"Iam role is ready: {role_arn}")
-        roles.append({"role_name": iam_role_name, "policies": policies})
-        return iam_role_name, role_arn
-
-    yield create_role
-
-    for role in roles:
-        role_name = role["role_name"]
-        policies = role["policies"]
-        for policy in policies:
-            iam_client.detach_role_policy(RoleName=role_name, PolicyArn=policy)
-        logging.info(f"Deleting iam role {role_name}")
-        iam_client.delete_role(RoleName=role_name)
-
-
-@pytest.fixture(scope="class")
-def instance_profile_factory(region, role_factory):
-    instance_profiles = []
-    iam_client = boto3.client("iam", region_name=region, config=Config(retries={"max_attempts": 10}))
-
-    def create_instance_profile(policies=()):
-        instance_profile_name = f"integ-tests_{region}_{random_alphanumeric()}"
-        logging.info(f"Creating instance profile {instance_profile_name}")
-        instance_profile_arn = iam_client.create_instance_profile(InstanceProfileName=instance_profile_name)[
-            "InstanceProfile"
-        ]["Arn"]
-        role_name, _ = role_factory("ec2", policies)
-        iam_client.add_role_to_instance_profile(InstanceProfileName=instance_profile_name, RoleName=role_name)
-        logging.info(f"Iam profile is ready: {instance_profile_arn}")
-        instance_profiles.append({"profile_name": instance_profile_name, "role_name": role_name})
-        return instance_profile_arn
-
-    yield create_instance_profile
-
-    for instance_profile in instance_profiles:
-        profile_name = instance_profile["profile_name"]
-        role_name = instance_profile["role_name"]
-        iam_client.remove_role_from_instance_profile(InstanceProfileName=profile_name, RoleName=role_name)
-        logging.info(f"Deleting instance profile {profile_name}")
-        iam_client.delete_instance_profile(InstanceProfileName=profile_name)
+    yield _create_stack
+    if not request.config.getoption("no_delete"):
+        factory.delete_all_stacks()
+    else:
+        logging.warning("Skipping deletion of IAM roles stack because --no-delete option is set")
 
 
 def _create_iam_policies(iam_policy_name, region, policy_filename):

--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -10,7 +10,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
-import os
+import os as os_lib
 from shutil import copyfile
 
 import boto3
@@ -21,93 +21,266 @@ from remote_command_executor import RemoteCommandExecutor
 from s3_common_utils import check_s3_read_resource, check_s3_read_write_resource, get_policy_resources
 
 from tests.common.assertions import assert_no_errors_in_logs
+from tests.common.schedulers_common import get_scheduler_commands
+from tests.schedulers.test_awsbatch import _test_job_submission as test_job_submission_awsbatch
+from tests.schedulers.test_slurm import _wait_for_computefleet_changed as wait_for_computefleet_changed
 
 
 @pytest.mark.usefixtures("os", "instance")
 def test_iam_roles(
     region,
     scheduler,
-    common_pcluster_policies,
-    role_factory,
-    instance_profile_factory,
+    create_roles_stack,
     pcluster_config_reader,
     clusters_factory,
     test_datadir,
 ):
     is_awsbatch = scheduler == "awsbatch"
-    if is_awsbatch:
-        instance_policies = common_pcluster_policies["awsbatch_instance_policy"]
-        lambda_policies = common_pcluster_policies["awsbatch_lambda_policy"]
-    else:
-        instance_policies = common_pcluster_policies["traditional_instance_policy"]
-        lambda_policies = common_pcluster_policies["traditional_lambda_policy"]
-    _, cluster_role_arn = role_factory("ec2", [instance_policies])
-    instance_profile = instance_profile_factory([instance_policies])
-    lambda_role_name, lambda_role_arn = role_factory("lambda", [lambda_policies])
 
+    cfn_client, ec2_client, iam_client, lambda_client = _create_boto3_clients(region)
+
+    compute_instance_profile, compute_instance_role, head_instance_role, lambda_role = _create_cluster_roles(
+        create_roles_stack, "integ-tests-iam-cluster-roles", "cluster-roles.cfn.yaml", is_awsbatch
+    )
+
+    create_config, update_config = _get_config_create_and_update(test_datadir)
+
+    cluster = _test_cluster_create(
+        cfn_client,
+        clusters_factory,
+        compute_instance_profile,
+        compute_instance_role,
+        create_config,
+        ec2_client,
+        head_instance_role,
+        iam_client,
+        is_awsbatch,
+        lambda_client,
+        lambda_role,
+        pcluster_config_reader,
+    )
+
+    _test_cluster_update(
+        cfn_client,
+        cluster,
+        compute_instance_profile,
+        compute_instance_role,
+        create_roles_stack,
+        ec2_client,
+        head_instance_role,
+        iam_client,
+        is_awsbatch,
+        lambda_client,
+        lambda_role,
+        pcluster_config_reader,
+        update_config,
+    )
+
+    _test_cluster_scaling(cluster, is_awsbatch, region, scheduler)
+
+
+def _get_config_create_and_update(test_datadir):
     # Copy the config file template for reuse in update.
     config_file_name = "pcluster.config.yaml"
-    config_file_path = os.path.join(str(test_datadir), config_file_name)
+    config_file_path = os_lib.path.join(str(test_datadir), config_file_name)
     updated_config_file_name = "pcluster.config.update.yaml"
-    updated_config_file_path = os.path.join(str(test_datadir), updated_config_file_name)
+    updated_config_file_path = os_lib.path.join(str(test_datadir), updated_config_file_name)
     copyfile(config_file_path, updated_config_file_path)
+    return config_file_name, updated_config_file_name
 
+
+def _create_boto3_clients(region):
+    # Create boto3 client
+    cfn_client = boto3.client("cloudformation", region_name=region)
+    ec2_client = boto3.client("ec2", region_name=region)
+    iam_client = boto3.client("iam", region_name=region)
+    lambda_client = boto3.client("lambda", region_name=region)
+    return cfn_client, ec2_client, iam_client, lambda_client
+
+
+def _test_cluster_create(
+    cfn_client,
+    clusters_factory,
+    compute_instance_profile,
+    compute_instance_role,
+    config_file_name,
+    ec2_client,
+    head_instance_role,
+    iam_client,
+    is_awsbatch,
+    lambda_client,
+    lambda_role,
+    pcluster_config_reader,
+):
     cluster_config = pcluster_config_reader(
         config_file=config_file_name,
-        ec2_iam_role=cluster_role_arn,
-        iam_lambda_role=lambda_role_arn,
-        instance_profile=instance_profile,
+        head_instance_role=head_instance_role,
+        compute_instance_role=compute_instance_role,
+        compute_instance_profile=compute_instance_profile,
+        iam_lambda_role=lambda_role,
+        min_count=1,
     )
     cluster = clusters_factory(cluster_config)
-
-    cfn_client = boto3.client("cloudformation", region_name=region)
-    lambda_client = boto3.client("lambda", region_name=region)
-
-    # Check all CloudFormation stacks after creation
+    # Check roles are attached to the resources
     # If scheduler is awsbatch, there will still be IAM roles created.
-    _check_lambda_role(cfn_client, lambda_client, cluster.name, lambda_role_name, not is_awsbatch)
+    _check_roles(
+        cfn_client,
+        ec2_client,
+        iam_client,
+        lambda_client,
+        cluster.name,
+        head_instance_role,
+        compute_instance_role,
+        lambda_role,
+        not is_awsbatch,
+    )
+    return cluster
 
-    # Test updating the iam_lambda_role, instance_role and instance profile
-    updated_lambda_role_name, updated_lambda_role_arn = role_factory("lambda", [lambda_policies])
-    _, update_cluster_role_arn = role_factory("ec2", [instance_policies])
-    updated_instance_profile = instance_profile_factory([instance_policies])
 
-    assert_that(updated_lambda_role_arn == lambda_role_arn).is_false()
-    assert_that(update_cluster_role_arn == cluster_role_arn).is_false()
-    assert_that(updated_instance_profile == instance_profile).is_false()
+def _test_cluster_scaling(cluster, is_awsbatch, region, scheduler):
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    if is_awsbatch:
+        timeout = (
+            120 if region.startswith("cn-") else 60
+        )  # Longer timeout in china regions due to less reliable networking
+        test_job_submission_awsbatch(
+            remote_command_executor, f"awsbsub --vcpus 2 --memory 256 --timeout {timeout} sleep 1"
+        )
+    else:
+        scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+        job_id = scheduler_commands.submit_command_and_assert_job_accepted(
+            submit_command_args={"command": "sleep 1", "nodes": 1}
+        )
+        scheduler_commands.wait_job_completed(job_id)
 
+
+def _test_cluster_update(
+    cfn_client,
+    cluster,
+    compute_instance_profile,
+    compute_instance_role,
+    create_roles_stack,
+    ec2_client,
+    head_instance_role,
+    iam_client,
+    is_awsbatch,
+    lambda_client,
+    lambda_role,
+    pcluster_config_reader,
+    updated_config_file_name,
+):
+    (
+        another_compute_instance_profile,
+        another_compute_instance_role,
+        another_head_instance_role,
+        another_lambda_role,
+    ) = _create_cluster_roles(
+        create_roles_stack, "integ-tests-iam-cluster-roles", "cluster-roles.cfn.yaml", is_awsbatch
+    )
+
+    assert_that(another_lambda_role == lambda_role).is_false()
+    assert_that(another_head_instance_role == head_instance_role).is_false()
+    if not is_awsbatch:
+        assert_that(another_compute_instance_profile == compute_instance_profile).is_false()
+        assert_that(another_compute_instance_role == compute_instance_role).is_false()
+
+    # Update cluster with new roles
+    cluster.stop()
+    wait_for_computefleet_changed(cluster, "DISABLED" if is_awsbatch else "STOPPED")
     cluster.update(
         str(
             pcluster_config_reader(
                 config_file=updated_config_file_name,
-                ec2_iam_role=update_cluster_role_arn,
-                iam_lambda_role=updated_lambda_role_arn,
-                instance_profile=updated_instance_profile,
+                head_instance_role=another_head_instance_role,
+                compute_instance_role=another_compute_instance_role,
+                compute_instance_profile=another_compute_instance_profile,
+                iam_lambda_role=another_lambda_role,
+                min_count=0,
             )
         )
     )
+    cluster.start()
+    wait_for_computefleet_changed(cluster, "ENABLED" if is_awsbatch else "RUNNING")
+    # Check new roles are attached to the resources
+    _check_roles(
+        cfn_client,
+        ec2_client,
+        iam_client,
+        lambda_client,
+        cluster.name,
+        another_head_instance_role,
+        another_compute_instance_role,
+        another_lambda_role,
+        not is_awsbatch,
+    )
 
-    # Check all CloudFormation stacks after update
-    _check_lambda_role(cfn_client, lambda_client, cluster.name, updated_lambda_role_name, not is_awsbatch)
+
+def _create_cluster_roles(create_roles_stack, stack_prefix, roles_file, is_awsbatch):
+    cluster_roles_stack = create_roles_stack(stack_prefix=stack_prefix, roles_file=roles_file)
+    if is_awsbatch:
+        head_instance_role = cluster_roles_stack.cfn_outputs["HeadNodeRoleBatch"]
+        lambda_role = cluster_roles_stack.cfn_outputs["CustomLambdaResourcesRoleBatch"]
+        compute_instance_role = ""
+        compute_instance_profile = ""
+    else:
+        head_instance_role = cluster_roles_stack.cfn_outputs["HeadNodeRoleSlurm"]
+        compute_instance_profile = cluster_roles_stack.cfn_outputs["ComputeNodeInstanceProfileSlurm"]
+        compute_instance_role = cluster_roles_stack.cfn_outputs["ComputeNodeRoleSlurm"]
+        lambda_role = cluster_roles_stack.cfn_outputs["CustomLambdaResourcesRoleSlurm"]
+    return compute_instance_profile, compute_instance_role, head_instance_role, lambda_role
 
 
-def _check_lambda_role(cfn_client, lambda_client, stack_name, lambda_role_name, check_no_role_is_created):
-    """Test lambda role is attached to all Lambda functions in the stack and its substack."""
+def _check_roles(
+    cfn_client,
+    ec2_client,
+    iam_client,
+    lambda_client,
+    stack_name,
+    head_instance_role,
+    compute_instance_role,
+    lambda_role,
+    check_no_role_is_created,
+):
+    """Test roles are attached to EC2 instances and Lambda functions."""
     resources = cfn_client.describe_stack_resources(StackName=stack_name)["StackResources"]
     for resource in resources:
         resource_type = resource["ResourceType"]
         if check_no_role_is_created:
-            # If check_no_role_is_created, check that there is no role created in the stack and its substack.
+            # If check_no_role_is_created, check that there is no role created in the stack.
             assert_that(resource_type).is_not_equal_to("AWS::IAM::Role")
-        if resource_type == "AWS::CloudFormation::Stack":
-            # Recursively check substacks
-            _check_lambda_role(
-                cfn_client, lambda_client, resource["PhysicalResourceId"], lambda_role_name, check_no_role_is_created
-            )
         if resource_type == "AWS::Lambda::Function":
             # Check the role is attached to the Lambda function
             lambda_function = lambda_client.get_function(FunctionName=resource["PhysicalResourceId"])["Configuration"]
-            assert_that(lambda_role_name in lambda_function["Role"]).is_true()
+            assert_that(lambda_function["Role"]).is_equal_to(lambda_role)
+        if resource_type == "AWS::EC2::Instance":
+            # Check the role is attached to the EC2 instance
+            instance_profile_arn = (
+                ec2_client.describe_instances(InstanceIds=[resource["PhysicalResourceId"]])
+                .get("Reservations")[0]
+                .get("Instances")[0]
+                .get("IamInstanceProfile")
+                .get("Arn")
+            )
+
+            instance_roles_list = [
+                role.get("Arn")
+                for role in (
+                    iam_client.get_instance_profile(
+                        InstanceProfileName=_get_resource_name_from_resource_arn(instance_profile_arn)
+                    )
+                    .get("InstanceProfile")
+                    .get("Roles")
+                )
+            ]
+
+            if resource["LogicalResourceId"] == "HeadNode":
+                assert_that(instance_roles_list).contains(head_instance_role)
+            elif resource["LogicalResourceId"] == "ComputeNode":
+                assert_that(instance_roles_list).contains(compute_instance_role)
+
+
+def _get_resource_name_from_resource_arn(resource_arn):
+    return resource_arn.rsplit("/", 1)[-1] if resource_arn else ""
 
 
 @pytest.mark.regions(["ap-northeast-2"])

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
@@ -10,7 +10,7 @@ HeadNode:
   Ssh:
     KeyName: {{ key_name }}
   Iam:
-    InstanceRole: {{ ec2_iam_role }}
+    InstanceRole: {{ head_instance_role }}
   Imds:
     Secured: {{ imds_secured }}
 Scheduling:
@@ -19,7 +19,7 @@ Scheduling:
     - Name: queue-0
       {% if scheduler != "awsbatch" %}
       Iam:
-        InstanceProfile: {{ instance_profile }}
+        InstanceProfile: {{ compute_instance_profile }}
       {% endif %}
       ComputeResources:
         - Name: compute-resource-0
@@ -28,6 +28,7 @@ Scheduling:
             - {{ instance }}
           {% else %}
           InstanceType: {{ instance }}
+          MinCount: {{ min_count }}
           Efa:
             Enabled: false
             GdrSupport: false
@@ -35,3 +36,18 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+    {% if scheduler == "slurm" %}
+    - Name: queue-1
+      Iam:
+        InstanceRole: {{ compute_instance_role }}
+      ComputeResources:
+        - Name: compute-resource-0
+          InstanceType: {{ instance }}
+          MinCount: {{ min_count }}
+          Efa:
+            Enabled: false
+            GdrSupport: false
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+    {% endif %}

--- a/tests/integration-tests/tests/iam/test_iam_image.py
+++ b/tests/integration-tests/tests/iam/test_iam_image.py
@@ -1,0 +1,121 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+import time
+
+import boto3
+import pytest
+from assertpy import assert_that
+from retrying import retry
+from time_utils import minutes
+from utils import generate_stack_name
+
+from tests.common.utils import retrieve_latest_ami
+
+
+@pytest.mark.usefixtures("instance")
+def test_iam_roles(
+    region,
+    os,
+    create_roles_stack,
+    pcluster_config_reader,
+    images_factory,
+    test_datadir,
+):
+    instance_profile, lambda_cleanup_role = _create_image_roles(create_roles_stack)
+
+    image = _build_image(images_factory, instance_profile, lambda_cleanup_role, os, pcluster_config_reader, region)
+
+    cfn_client = boto3.client("cloudformation", region_name=region)
+    ec2_client = boto3.client("ec2", region_name=region)
+    lambda_client = boto3.client("lambda", region_name=region)
+
+    # Give 10 minutes to EC2ImageBuilder to spin up the build instance
+    time.sleep(600)
+    pcluster_describe_image_result = image.describe()
+    logging.info(pcluster_describe_image_result)
+    _check_roles(
+        cfn_client,
+        ec2_client,
+        lambda_client,
+        pcluster_describe_image_result.get("cloudformationStackArn"),
+        instance_profile,
+        lambda_cleanup_role,
+    )
+
+    _wait_build_image_complete(image)
+
+
+def _build_image(images_factory, instance_profile, lambda_cleanup_role, os, pcluster_config_reader, region):
+    # Generate image ID
+    image_id = generate_stack_name("integ-tests-build-image", "")
+    # Get base AMI
+    base_ami = retrieve_latest_ami(region, os, ami_type="pcluster", architecture="x86_64")
+    image_config = pcluster_config_reader(
+        config_file="image.config.yaml",
+        parent_image=base_ami,
+        instance_profile=instance_profile,
+        lambda_cleanup_role=lambda_cleanup_role,
+    )
+    image = images_factory(image_id, image_config, region)
+    return image
+
+
+def _create_image_roles(create_roles_stack):
+    # Create build image roles
+    image_roles_stack = create_roles_stack(
+        stack_prefix="integ-tests-iam-image-roles", roles_file="image-roles.cfn.yaml"
+    )
+    lambda_cleanup_role = image_roles_stack.cfn_outputs["BuildImageLambdaCleanupRole"]
+    instance_profile = image_roles_stack.cfn_outputs["BuildImageInstanceProfile"]
+    # instance_role = image_roles_stack.cfn_outputs["BuildImageInstanceRole"]
+    return instance_profile, lambda_cleanup_role
+
+
+@retry(wait_fixed=minutes(1), stop_max_delay=minutes(60))
+def _wait_build_image_complete(image):
+    pcluster_describe_image_result = image.describe()
+    logging.info(pcluster_describe_image_result)
+    assert_that(image.image_status).is_equal_to("BUILD_COMPLETE")
+
+
+def _check_roles(
+    cfn_client,
+    ec2_client,
+    lambda_client,
+    stack_name,
+    instance_profile,
+    lambda_cleanup_role,
+):
+    """Test roles are attached to EC2 build instance and Lambda cleanup function in the building stack."""
+    resources = cfn_client.describe_stack_resources(StackName=stack_name)["StackResources"]
+    for resource in resources:
+        resource_type = resource["ResourceType"]
+        # Check that there is no role created in the stack.
+        assert_that(resource_type).is_not_equal_to("AWS::IAM::Role")
+        if resource_type == "AWS::Lambda::Function":
+            # Check the role is attached to the Lambda function
+            lambda_function = lambda_client.get_function(FunctionName=resource["PhysicalResourceId"])["Configuration"]
+            assert_that(lambda_function["Role"]).is_equal_to(lambda_cleanup_role)
+        if resource_type == "AWS::ImageBuilder::Image":
+            # Check the instance profile is attached to the EC2 instance
+            imagebuilder_image_arn = resource["PhysicalResourceId"]
+            instance_profile_arn = (
+                ec2_client.describe_instances(
+                    Filters=[{"Name": "tag:Ec2ImageBuilderArn", "Values": [imagebuilder_image_arn]}]
+                )
+                .get("Reservations")[0]
+                .get("Instances")[0]
+                .get("IamInstanceProfile")
+                .get("Arn")
+            )
+            assert_that(instance_profile_arn).contains(instance_profile)

--- a/tests/integration-tests/tests/iam/test_iam_image/test_iam_roles/image.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam_image/test_iam_roles/image.config.yaml
@@ -1,0 +1,16 @@
+Image:
+    Tags:
+        - Key: dummyImageTag
+          Value: dummyImageTag
+    RootVolume:
+        Size: 35
+
+Build:
+    Iam:
+        InstanceProfile: {{ instance_profile }}
+        CleanupLambdaRole: {{ lambda_cleanup_role }}
+    InstanceType: {{ instance }}
+    ParentImage: {{ parent_image }}
+    Tags:
+        - Key: dummyBuildTag
+          Value: dummyBuildTag


### PR DESCRIPTION
### Add new test for IAM roles used in build image process

Test launched with command
`python test_runner.py --key-name xxx --key-path xxx --show-output --stackname-suffix iamtest --tests-config configs/iam_image.yaml`

Configuration test used `iam_image.yaml`:
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  iam:
    test_iam_image.py::test_iam_roles:
      dimensions:
        - regions: ["eu-south-1"]
          oss: ["alinux2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
```
---
### Refactor test for IAM roles

Test is now using roles defined in cluster-roles.cfn.yaml which are deployed through a CFN stack.

Test check updatabilty of the roles and perform job submission to check scaling works

Test launched with command
`python test_runner.py --key-name xxx --key-path xxx --show-output --stackname-suffix iamtest --tests-config configs/iam.yaml`

Configuration test used `iam.yaml`:
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  iam:
    test_iam.py::test_iam_roles:
      dimensions:
        - regions: ["eu-south-1"]
          schedulers: ["slurm", "awsbatch"]
          oss: ["alinux2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
```
---
and also:
* Remove unneeded policies for dynamodb
* Add instance profile and stack output
* add missing policy for dynamodb
* fix value for compute node-type

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
