### PR TITLE
Pin to connexion transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ CHANGELOG
 3.0.0
 ------
 
+**BUG FIXES**
+- Pin to the transitive dependencies resulting from the dependency on connexion.
+
+
+3.0.0
+------
+
 **ENHANCEMENTS**
 - Add support for pcluster actions (e.g., create-cluster, update-cluster, delete-cluster) through HTTP endpoints
   with Amazon API Gateway.

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -22,5 +22,10 @@ aws-cdk.aws-sqs~=1.116
 aws-cdk.aws-cloudformation~=1.116
 werkzeug~=2.0
 connexion==2.7
+clickclick>=1.2,<21
+jsonschema>=2.5.1,<4
+requests>=2.9.1,<3
+inflection>=0.3.1,<0.6
+openapi-spec-validator>=0.2.4,<0.4
 flask~=2.0
 jmespath~=0.10

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -51,6 +51,13 @@ REQUIRES = [
     # This does not impact any functionality. Also next connexion release will lift this limitation
     # and we will be able to upgrade.
     "connexion==2.7.0",
+    # Pin to connexion transitive dependencies.
+    # These can be removed after the next connexion release (assuming they pin these dependencies as expected).
+    "clickclick>=1.2,<21",
+    "jsonschema>=2.5.1,<4",
+    "requests>=2.9.1,<3",
+    "inflection>=0.3.1,<0.6",
+    "openapi-spec-validator>=0.2.4,<0.4",
     "flask~=2.0",
     "jmespath~=0.10",
 ]


### PR DESCRIPTION
This change is being made to fix an issue related to the release of a new version of the jsonschema package, which is a transitive dependency of the API code via connexion. The list of dependencies was taken from [here](https://github.com/zalando/connexion/blob/main/setup.py).

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
