### PR TITLE
Add export to ParallelClusterApiInvokeUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 CHANGELOG
 =========
 
+3.X.X
+------
+**ENHANCEMENTS**
+- export `ParallelClusterApiInvokeUrl` and `ParallelClusterApiUserRole` so they can be used by cross-stack references.
+
 3.0.0
 ------
-
 **BUG FIXES**
 - Pin to the transitive dependencies resulting from the dependency on connexion.
 

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -1242,6 +1242,8 @@ Outputs:
 
   ParallelClusterApiInvokeUrl:
     Description: 'Url to reach the API endpoint'
+    Export:
+      Name: !Sub ${AWS::StackName}-ParallelClusterApiInvokeUrl
     Value: !If
       - UseCustomDomain
       - !Sub
@@ -1269,6 +1271,8 @@ Outputs:
 
   ParallelClusterApiUserRole:
     Condition: CreateApiUserRoleCondition
+    Export:
+      Name: !Sub ${AWS::StackName}-ParallelClusterApiUserRole
     Description: 'IAM Role with permissions to invoke the ParallelCluster API'
     Value: !GetAtt ParallelClusterApiUserRole.Arn
 


### PR DESCRIPTION
This allows cross-stack references which enables people to build upon the API more easily. 

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
