### PR TITLE
Add initial support for BYOS scheduler type

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -16,9 +16,9 @@ PCLUSTER_ISSUES_LINK = "https://github.com/aws/aws-parallelcluster/issues"
 CIDR_ALL_IPS = "0.0.0.0/0"
 
 SUPPORTED_SCHEDULERS = ["slurm", "awsbatch"]
-SCHEDULERS_SUPPORTING_IMDS_SECURED = ["slurm"]
+SCHEDULERS_SUPPORTING_IMDS_SECURED = ["slurm", "byos"]
 SUPPORTED_OSES = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004"]
-SUPPORTED_OSES_FOR_SCHEDULER = {"slurm": SUPPORTED_OSES, "awsbatch": ["alinux2"]}
+SUPPORTED_OSES_FOR_SCHEDULER = {"slurm": SUPPORTED_OSES, "byos": SUPPORTED_OSES, "awsbatch": ["alinux2"]}
 DELETION_POLICIES = ["Retain", "Delete"]
 DELETION_POLICIES_WITH_SNAPSHOT = DELETION_POLICIES + ["Snapshot"]
 SUPPORTED_ARCHITECTURES = ["x86_64", "arm64"]

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -271,14 +271,14 @@ class Cluster:
     def compute_fleet_status_with_last_updated_time(self):
         """Status of the cluster compute fleet and the last compute fleet status updated time."""
         if self.stack.is_working_status or self.stack.status == "UPDATE_IN_PROGRESS":
-            if self.stack.scheduler == "slurm":
-                compute_fleet_status_manager = ComputeFleetStatusManager(self.name)
-                status, last_updated_time = compute_fleet_status_manager.get_status_with_last_updated_time()
-            else:  # scheduler is AWS Batch:
+            if self.stack.scheduler == "awsbatch":
                 status = ComputeFleetStatus(
                     AWSApi.instance().batch.get_compute_environment_state(self.stack.batch_compute_environment)
                 )
                 last_updated_time = None
+            else:
+                compute_fleet_status_manager = ComputeFleetStatusManager(self.name)
+                status, last_updated_time = compute_fleet_status_manager.get_status_with_last_updated_time()
             return status, last_updated_time
         else:
             LOGGER.info(
@@ -377,7 +377,7 @@ class Cluster:
                 self.bucket.delete_s3_artifacts()
             raise _cluster_error_mapper(e, str(e))
 
-    def _load_config(self, cluster_config: dict) -> ClusterSchema:
+    def _load_config(self, cluster_config: dict) -> BaseClusterConfig:
         """Load the config and catch / translate any errors that occur during loading."""
         try:
             return ClusterSchema(cluster_name=self.name).load(cluster_config)

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -17,21 +17,32 @@
 import json
 from collections import namedtuple
 from datetime import datetime
-from typing import Union
+from typing import Dict, List, Union
 
 from aws_cdk import aws_cloudformation as cfn
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_efs as efs
 from aws_cdk import aws_fsx as fsx
 from aws_cdk import aws_iam as iam
+from aws_cdk import aws_lambda as awslambda
 from aws_cdk import aws_logs as logs
-from aws_cdk.core import CfnOutput, CfnParameter, CfnStack, CfnTag, Construct, CustomResource, Fn, Stack
+from aws_cdk.core import (
+    CfnCustomResource,
+    CfnOutput,
+    CfnParameter,
+    CfnResource,
+    CfnStack,
+    CfnTag,
+    Construct,
+    CustomResource,
+    Fn,
+    Stack,
+)
 
 from pcluster.aws.aws_api import AWSApi
 from pcluster.config.cluster_config import (
     AwsBatchClusterConfig,
-    BaseQueue,
-    HeadNode,
+    CapacityType,
     SharedEbs,
     SharedEfs,
     SharedFsx,
@@ -41,19 +52,21 @@ from pcluster.config.cluster_config import (
 from pcluster.constants import (
     CW_LOG_GROUP_NAME_PREFIX,
     CW_LOGS_CFN_PARAM_NAME,
-    IAM_ROLE_PATH,
     OS_MAPPING,
+    PCLUSTER_CLUSTER_NAME_TAG,
+    PCLUSTER_QUEUE_NAME_TAG,
     PCLUSTER_S3_ARTIFACTS_DICT,
 )
-from pcluster.models.s3_bucket import S3Bucket, parse_bucket_url
+from pcluster.models.s3_bucket import S3Bucket
 from pcluster.templates.awsbatch_builder import AwsBatchConstruct
 from pcluster.templates.cdk_builder_utils import (
+    ComputeNodeIamResources,
+    HeadNodeIamResources,
     PclusterLambdaConstruct,
     add_lambda_cfn_role,
     apply_permissions_boundary,
     convert_deletion_policy,
     create_hash_suffix,
-    get_assume_role_policy_document,
     get_block_device_mappings,
     get_cloud_watch_logs_policy_statement,
     get_cloud_watch_logs_retention_days,
@@ -62,13 +75,14 @@ from pcluster.templates.cdk_builder_utils import (
     get_default_instance_tags,
     get_default_volume_tags,
     get_log_group_deletion_policy,
+    get_queue_security_groups_full,
     get_shared_storage_ids_by_type,
     get_shared_storage_options_by_type,
     get_user_data_content,
 )
 from pcluster.templates.cw_dashboard_builder import CWDashboardConstruct
 from pcluster.templates.slurm_builder import SlurmConstruct
-from pcluster.utils import get_resource_name_from_resource_arn, join_shell_args, policy_name_to_arn
+from pcluster.utils import join_shell_args
 
 StorageInfo = namedtuple("StorageInfo", ["id", "config"])
 
@@ -101,9 +115,6 @@ class ClusterCdkStack(Stack):
                 timestamp = f"{datetime.utcnow().strftime('%Y%m%d%H%M')}"
                 self.log_group_name = f"{CW_LOG_GROUP_NAME_PREFIX}{self.stack_name}-{timestamp}"
 
-        self.instance_roles = {}
-        self.instance_profiles = {}
-        self.compute_security_groups = {}
         self.shared_storage_mappings = {storage_type: [] for storage_type in SharedStorageType}
         self.shared_storage_options = {storage_type: "" for storage_type in SharedStorageType}
         self.shared_storage_attributes = {storage_type: {} for storage_type in SharedStorageType}
@@ -145,10 +156,6 @@ class ClusterCdkStack(Stack):
             compute_group_set.append(self._compute_security_group.ref)
 
         return compute_group_set
-
-    def _cluster_scoped_iam_path(self):
-        """Return a path to be associated IAM roles and instance profiles."""
-        return f"{IAM_ROLE_PATH}{self.stack_name}/"
 
     # -- Parameters -------------------------------------------------------------------------------------------------- #
 
@@ -194,13 +201,7 @@ class ClusterCdkStack(Stack):
         if self.config.is_cw_logging_enabled:
             self.log_group = self._add_cluster_log_group()
 
-        # Head Node EC2 Iam Role
-        self._add_role_and_policies(self.config.head_node, "HeadNode")
-
-        if self._condition_is_slurm():
-            # Compute Nodes EC2 Iam Roles
-            for queue in self.config.scheduling.queues:
-                self._add_role_and_policies(queue, queue.name)
+        self._add_iam_resources()
 
         # Managed security groups
         self._head_security_group, self._compute_security_group = self._add_security_groups()
@@ -228,15 +229,27 @@ class ClusterCdkStack(Stack):
                 stack_name=self._stack_name,
                 cluster_config=self.config,
                 bucket=self.bucket,
-                log_group=self.log_group,
-                instance_roles=self.instance_roles,  # Empty dict if provided by the user
-                instance_profiles=self.instance_profiles,
+                managed_head_node_instance_role=self._managed_head_node_instance_role,
+                managed_compute_instance_roles=self._managed_compute_instance_roles,
                 cleanup_lambda_role=cleanup_lambda_role,  # None if provided by the user
                 cleanup_lambda=cleanup_lambda,
-                compute_security_groups=self.compute_security_groups,  # Empty dict if provided by the user
+            )
+        self.compute_fleet_resources = None
+        if not self._condition_is_batch():
+            self.compute_fleet_resources = ComputeFleetConstruct(
+                scope=self,
+                id="ComputeFleet",
+                cluster_config=self.config,
+                log_group=self.log_group,
+                cleanup_lambda=cleanup_lambda,
+                cleanup_lambda_role=cleanup_lambda_role,
+                compute_security_group=self._compute_security_group,
                 shared_storage_mappings=self.shared_storage_mappings,
                 shared_storage_options=self.shared_storage_options,
                 shared_storage_attributes=self.shared_storage_attributes,
+                compute_node_instance_profiles=self._compute_instance_profiles,
+                cluster_hosted_zone=self.scheduler_resources.cluster_hosted_zone if self.scheduler_resources else None,
+                dynamodb_table=self.scheduler_resources.dynamodb_table if self.scheduler_resources else None,
             )
 
         # Wait condition
@@ -254,11 +267,11 @@ class ClusterCdkStack(Stack):
                 cluster_config=self.config,
                 bucket=self.bucket,
                 create_lambda_roles=self._condition_create_lambda_iam_role(),
-                compute_security_groups=self.compute_security_groups,  # Empty dict if provided by the user
+                compute_security_group=self._compute_security_group,
                 shared_storage_mappings=self.shared_storage_mappings,
                 shared_storage_options=self.shared_storage_options,
                 head_node_instance=self.head_node_instance,
-                instance_roles=self.instance_roles,  # Empty dict if provided by the user
+                managed_head_node_instance_role=self._managed_head_node_instance_role,  # None if provided by the user
             )
 
         # CloudWatch Dashboard
@@ -273,6 +286,23 @@ class ClusterCdkStack(Stack):
                 cw_log_group_name=self.log_group.log_group_name if self.config.is_cw_logging_enabled else None,
             )
 
+    def _add_iam_resources(self):
+        head_node_iam_resources = HeadNodeIamResources(
+            self, "HeadNodeIamResources", self.config, self.config.head_node, "HeadNode", self.bucket
+        )
+        self._head_node_instance_profile = head_node_iam_resources.instance_profile
+        self._managed_head_node_instance_role = head_node_iam_resources.instance_role
+
+        if not self._condition_is_batch():
+            iam_resources = {}
+            for queue in self.config.scheduling.queues:
+                iam_resources[queue.name] = ComputeNodeIamResources(
+                    self, f"ComputeNodeIamResources{queue.name}", self.config, queue, queue.name
+                )
+
+            self._compute_instance_profiles = {k: v.instance_profile for k, v in iam_resources.items()}
+            self._managed_compute_instance_roles = {k: v.instance_role for k, v in iam_resources.items()}
+
     def _add_cluster_log_group(self):
         log_group = logs.CfnLogGroup(
             self,
@@ -282,35 +312,6 @@ class ClusterCdkStack(Stack):
         )
         log_group.cfn_options.deletion_policy = get_log_group_deletion_policy(self.config)
         return log_group
-
-    def _add_role_and_policies(self, node: Union[HeadNode, BaseQueue], name: str):
-        """Create role and policies for the given node/queue."""
-        suffix = create_hash_suffix(name)
-        if node.instance_profile:
-            # If existing InstanceProfile provided, do not create InstanceRole
-            self.instance_profiles[name] = get_resource_name_from_resource_arn(node.instance_profile)
-        elif node.instance_role:
-            node_role_ref = get_resource_name_from_resource_arn(node.instance_role)
-            self.instance_profiles[name] = self._add_instance_profile(node_role_ref, f"InstanceProfile{suffix}")
-        else:
-            node_role_ref = self._add_node_role(node, f"Role{suffix}")
-
-            # ParallelCluster Policies
-            self._add_pcluster_policies_to_role(node_role_ref, f"ParallelClusterPolicies{suffix}")
-
-            # Custom Cookbook S3 url policy
-            if self._condition_custom_cookbook_with_s3_url():
-                self._add_custom_cookbook_policies_to_role(node_role_ref, f"CustomCookbookPolicies{suffix}")
-
-            # S3 Access Policies
-            if self._condition_create_s3_access_policies(node):
-                self._add_s3_access_policies_to_role(node, node_role_ref, f"S3AccessPolicies{suffix}")
-
-            # Only add role to instance_roles if it is created by ParallelCluster
-            self.instance_roles[name] = {"RoleRef": node_role_ref}
-
-            # Head node Instance Profile
-            self.instance_profiles[name] = self._add_instance_profile(node_role_ref, f"InstanceProfile{suffix}")
 
     def _add_cleanup_resources_lambda(self):
         """Create Lambda cleanup resources function and its role."""
@@ -400,16 +401,11 @@ class ClusterCdkStack(Stack):
             head_security_group = self._add_head_security_group()
 
         # Compute Security Groups
-        compute_security_group = None
-        for queue in self.config.scheduling.queues:
-            if not queue.networking.security_groups:
-                if not compute_security_group:
-                    # Create a new security group
-                    compute_security_group = self._add_compute_security_group()
-                # Associate created security group to the queue
-                self.compute_security_groups[queue.name] = compute_security_group
+        managed_compute_security_group = None
+        if any(not queue.networking.security_groups for queue in self.config.scheduling.queues):
+            managed_compute_security_group = self._add_compute_security_group()
 
-        if head_security_group and compute_security_group:
+        if head_security_group and managed_compute_security_group:
             # Access to head node from compute nodes
             ec2.CfnSecurityGroupIngress(
                 self,
@@ -417,7 +413,7 @@ class ClusterCdkStack(Stack):
                 ip_protocol="-1",
                 from_port=0,
                 to_port=65535,
-                source_security_group_id=compute_security_group.ref,
+                source_security_group_id=managed_compute_security_group.ref,
                 group_id=head_security_group.ref,
             )
 
@@ -429,10 +425,10 @@ class ClusterCdkStack(Stack):
                 from_port=0,
                 to_port=65535,
                 source_security_group_id=head_security_group.ref,
-                group_id=compute_security_group.ref,
+                group_id=managed_compute_security_group.ref,
             )
 
-        return head_security_group, compute_security_group
+        return head_security_group, managed_compute_security_group
 
     def _add_compute_security_group(self):
         compute_security_group = ec2.CfnSecurityGroup(
@@ -476,117 +472,6 @@ class ClusterCdkStack(Stack):
         )
 
         return compute_security_group
-
-    def _add_s3_access_policies_to_role(self, node: Union[HeadNode, BaseQueue], role_ref: str, name: str):
-        """Attach S3 policies to given role."""
-        read_only_s3_resources = []
-        read_write_s3_resources = []
-        for s3_access in node.iam.s3_access:
-            for resource in s3_access.resource_regex:
-                arn = self.format_arn(service="s3", resource=resource, region="", account="")
-                if s3_access.enable_write_access:
-                    read_write_s3_resources.append(arn)
-                else:
-                    read_only_s3_resources.append(arn)
-
-        s3_access_policy = iam.CfnPolicy(
-            self, name, policy_document=iam.PolicyDocument(statements=[]), roles=[role_ref], policy_name="S3Access"
-        )
-
-        if read_only_s3_resources:
-            s3_access_policy.policy_document.add_statements(
-                iam.PolicyStatement(
-                    sid="S3Read",
-                    effect=iam.Effect.ALLOW,
-                    actions=["s3:Get*", "s3:List*"],
-                    resources=read_only_s3_resources,
-                )
-            )
-
-        if read_write_s3_resources:
-            s3_access_policy.policy_document.add_statements(
-                iam.PolicyStatement(
-                    sid="S3ReadWrite", effect=iam.Effect.ALLOW, actions=["s3:*"], resources=read_write_s3_resources
-                )
-            )
-
-    def _add_instance_profile(self, role_ref: str, name: str):
-        return iam.CfnInstanceProfile(self, name, roles=[role_ref], path=self._cluster_scoped_iam_path()).ref
-
-    def _add_node_role(self, node: Union[HeadNode, BaseQueue], name: str):
-        additional_iam_policies = node.iam.additional_iam_policy_arns
-        if self.config.monitoring.logs.cloud_watch.enabled:
-            cloud_watch_policy_arn = policy_name_to_arn("CloudWatchAgentServerPolicy")
-            if cloud_watch_policy_arn not in additional_iam_policies:
-                additional_iam_policies.append(cloud_watch_policy_arn)
-        if self._condition_is_batch():
-            awsbatch_full_access_arn = policy_name_to_arn("AWSBatchFullAccess")
-            if awsbatch_full_access_arn not in additional_iam_policies:
-                additional_iam_policies.append(awsbatch_full_access_arn)
-        return iam.CfnRole(
-            self,
-            name,
-            path=self._cluster_scoped_iam_path(),
-            managed_policy_arns=additional_iam_policies,
-            assume_role_policy_document=get_assume_role_policy_document("ec2.{0}".format(self.url_suffix)),
-        ).ref
-
-    def _add_pcluster_policies_to_role(self, role_ref: str, name: str):
-        iam.CfnPolicy(
-            self,
-            name,
-            policy_name="parallelcluster",
-            policy_document=iam.PolicyDocument(
-                statements=[
-                    iam.PolicyStatement(
-                        sid="Ec2", actions=["ec2:DescribeInstanceAttribute"], effect=iam.Effect.ALLOW, resources=["*"]
-                    ),
-                    iam.PolicyStatement(
-                        sid="S3GetObj",
-                        actions=["s3:GetObject"],
-                        effect=iam.Effect.ALLOW,
-                        resources=[
-                            self.format_arn(
-                                service="s3",
-                                resource="{0}-aws-parallelcluster/*".format(self.region),
-                                region="",
-                                account="",
-                            )
-                        ],
-                    ),
-                ]
-            ),
-            roles=[role_ref],
-        )
-
-    def _add_custom_cookbook_policies_to_role(self, role_ref: str, name: str):
-        bucket_info = parse_bucket_url(self.config.dev_settings.cookbook.chef_cookbook)
-        bucket_name = bucket_info.get("bucket_name")
-        object_key = bucket_info.get("object_key")
-        iam.CfnPolicy(
-            self,
-            name,
-            policy_name="CustomCookbookS3Url",
-            policy_document=iam.PolicyDocument(
-                statements=[
-                    iam.PolicyStatement(
-                        actions=["s3:GetObject"],
-                        effect=iam.Effect.ALLOW,
-                        resources=[
-                            self.format_arn(
-                                region="", service="s3", account="", resource=bucket_name, resource_name=object_key
-                            )
-                        ],
-                    ),
-                    iam.PolicyStatement(
-                        actions=["s3:GetBucketLocation"],
-                        effect=iam.Effect.ALLOW,
-                        resources=[self.format_arn(service="s3", resource=bucket_name, region="", account="")],
-                    ),
-                ]
-            ),
-            roles=[role_ref],
-        )
 
     def _add_head_security_group(self):
         head_security_group_ingress = [
@@ -886,7 +771,7 @@ class ClusterCdkStack(Stack):
                 image_id=self.config.head_node_ami,
                 ebs_optimized=head_node.is_ebs_optimized,
                 iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(
-                    name=self.instance_profiles["HeadNode"]
+                    name=self._head_node_instance_profile
                 ),
                 user_data=Fn.base64(
                     Fn.sub(
@@ -1159,7 +1044,7 @@ class ClusterCdkStack(Stack):
             ),
         )
         if isinstance(self.scheduler_resources, SlurmConstruct):
-            head_node_instance.add_depends_on(self.scheduler_resources.terminate_compute_fleet_custom_resource)
+            head_node_instance.node.add_dependency(self.compute_fleet_resources)
         return head_node_instance
 
     # -- Conditions -------------------------------------------------------------------------------------------------- #
@@ -1172,22 +1057,11 @@ class ClusterCdkStack(Stack):
             or self.config.iam.roles.get_param("lambda_functions_role").implied
         )
 
-    def _condition_create_s3_access_policies(self, node: Union[HeadNode, BaseQueue]):
-        return node.iam and node.iam.s3_access
-
     def _condition_is_slurm(self):
         return self.config.scheduling.scheduler == "slurm"
 
     def _condition_is_batch(self):
         return self.config.scheduling.scheduler == "awsbatch"
-
-    def _condition_custom_cookbook_with_s3_url(self):
-        return (
-            self.config.dev_settings
-            and self.config.dev_settings.cookbook
-            and self.config.dev_settings.cookbook.chef_cookbook
-            and self.config.dev_settings.cookbook.chef_cookbook.startswith("s3://")
-        )
 
     # -- Outputs ----------------------------------------------------------------------------------------------------- #
 
@@ -1220,4 +1094,288 @@ class ClusterCdkStack(Stack):
             "HeadNodePrivateDnsName",
             description="Private DNS name of the head node",
             value=self.head_node_instance.attr_private_dns_name,
+        )
+
+
+class ComputeFleetConstruct(Construct):
+    """Construct defining compute fleet specific resources."""
+
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        cluster_config: SlurmClusterConfig,
+        log_group: logs.CfnLogGroup,
+        cleanup_lambda: awslambda.CfnFunction,
+        cleanup_lambda_role: iam.CfnRole,
+        compute_security_group: ec2.CfnSecurityGroup,
+        shared_storage_mappings: Dict,
+        shared_storage_options: Dict,
+        shared_storage_attributes: Dict,
+        compute_node_instance_profiles: Dict[str, str],
+        cluster_hosted_zone,
+        dynamodb_table,
+    ):
+        super().__init__(scope, id)
+        self._cleanup_lambda = cleanup_lambda
+        self._cleanup_lambda_role = cleanup_lambda_role
+        self._compute_security_group = compute_security_group
+        self._config = cluster_config
+        self._shared_storage_mappings = shared_storage_mappings
+        self._shared_storage_attributes = shared_storage_attributes
+        self._shared_storage_options = shared_storage_options
+        self._log_group = log_group
+        self._cluster_hosted_zone = cluster_hosted_zone
+        self._dynamodb_table = dynamodb_table
+        self._compute_node_instance_profiles = compute_node_instance_profiles
+
+        self._add_resources()
+
+    # -- Utility methods --------------------------------------------------------------------------------------------- #
+
+    @property
+    def stack_name(self):
+        """Name of the CFN stack."""
+        return Stack.of(self).stack_name
+
+    # -- Resources --------------------------------------------------------------------------------------------------- #
+
+    def _add_resources(self):
+        managed_placement_groups = self._add_placement_groups()
+        self._add_launch_templates(managed_placement_groups, self._compute_node_instance_profiles)
+        self._add_cleanup_custom_resource(
+            dependencies=[self._compute_security_group] + list(managed_placement_groups.values())
+        )
+
+    def _add_cleanup_custom_resource(self, dependencies: List[CfnResource]):
+        terminate_compute_fleet_custom_resource = CfnCustomResource(
+            self,
+            "TerminateComputeFleetCustomResource",
+            service_token=self._cleanup_lambda.attr_arn,
+        )
+        terminate_compute_fleet_custom_resource.add_property_override("StackName", self.stack_name)
+        terminate_compute_fleet_custom_resource.add_property_override("Action", "TERMINATE_EC2_INSTANCES")
+        for dep in dependencies:
+            terminate_compute_fleet_custom_resource.add_depends_on(dep)
+
+        if self._cleanup_lambda_role:
+            self._add_policies_to_cleanup_resources_lambda_role()
+
+    def _add_policies_to_cleanup_resources_lambda_role(self):
+        self._cleanup_lambda_role.policies[0].policy_document.add_statements(
+            iam.PolicyStatement(
+                actions=["ec2:DescribeInstances"],
+                resources=["*"],
+                effect=iam.Effect.ALLOW,
+                sid="DescribeInstances",
+            ),
+            iam.PolicyStatement(
+                actions=["ec2:TerminateInstances"],
+                resources=["*"],
+                effect=iam.Effect.ALLOW,
+                conditions={"StringEquals": {f"ec2:ResourceTag/{PCLUSTER_CLUSTER_NAME_TAG}": self.stack_name}},
+                sid="FleetTerminatePolicy",
+            ),
+        )
+
+    def _add_placement_groups(self) -> Dict[str, ec2.CfnPlacementGroup]:
+        managed_placement_groups = {}
+        for queue in self._config.scheduling.queues:
+            if (
+                queue.networking.placement_group
+                and queue.networking.placement_group.enabled
+                and not queue.networking.placement_group.id
+            ):
+                managed_placement_groups[queue.name] = ec2.CfnPlacementGroup(
+                    self, f"PlacementGroup{create_hash_suffix(queue.name)}", strategy="cluster"
+                )
+        return managed_placement_groups
+
+    def _add_launch_templates(self, managed_placement_groups, instance_profiles):
+        for queue in self._config.scheduling.queues:
+            queue_lt_security_groups = get_queue_security_groups_full(self._compute_security_group, queue)
+
+            queue_placement_group = None
+            if queue.networking.placement_group and queue.networking.placement_group.enabled:
+                if queue.networking.placement_group.id:
+                    queue_placement_group = queue.networking.placement_group.id
+                else:
+                    queue_placement_group = managed_placement_groups[queue.name].ref
+
+            queue_pre_install_action, queue_post_install_action = (None, None)
+            if queue.custom_actions:
+                queue_pre_install_action = queue.custom_actions.on_node_start
+                queue_post_install_action = queue.custom_actions.on_node_configured
+
+            for compute_resource in queue.compute_resources:
+                self._add_compute_resource_launch_template(
+                    queue,
+                    compute_resource,
+                    queue_pre_install_action,
+                    queue_post_install_action,
+                    queue_lt_security_groups,
+                    queue_placement_group,
+                    instance_profiles,
+                )
+
+    def _add_compute_resource_launch_template(
+        self,
+        queue,
+        compute_resource,
+        queue_pre_install_action,
+        queue_post_install_action,
+        queue_lt_security_groups,
+        queue_placement_group,
+        instance_profiles,
+    ):
+        # LT network interfaces
+        compute_lt_nw_interfaces = [
+            ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
+                device_index=0,
+                associate_public_ip_address=queue.networking.assign_public_ip
+                if compute_resource.max_network_interface_count == 1
+                else None,  # parameter not supported for instance types with multiple network interfaces
+                interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
+                groups=queue_lt_security_groups,
+                subnet_id=queue.networking.subnet_ids[0],
+            )
+        ]
+        for device_index in range(1, compute_resource.max_network_interface_count):
+            compute_lt_nw_interfaces.append(
+                ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
+                    device_index=device_index,
+                    network_card_index=device_index,
+                    interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
+                    groups=queue_lt_security_groups,
+                    subnet_id=queue.networking.subnet_ids[0],
+                )
+            )
+
+        instance_market_options = None
+        if queue.capacity_type == CapacityType.SPOT:
+            instance_market_options = ec2.CfnLaunchTemplate.InstanceMarketOptionsProperty(
+                market_type="spot",
+                spot_options=ec2.CfnLaunchTemplate.SpotOptionsProperty(
+                    spot_instance_type="one-time",
+                    instance_interruption_behavior="terminate",
+                    max_price=None if compute_resource.spot_price is None else str(compute_resource.spot_price),
+                ),
+            )
+
+        ec2.CfnLaunchTemplate(
+            self,
+            f"ComputeServerLaunchTemplate{create_hash_suffix(queue.name + compute_resource.instance_type)}",
+            launch_template_name=f"{self.stack_name}-{queue.name}-{compute_resource.instance_type}",
+            launch_template_data=ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
+                instance_type=compute_resource.instance_type,
+                cpu_options=ec2.CfnLaunchTemplate.CpuOptionsProperty(
+                    core_count=compute_resource.vcpus, threads_per_core=1
+                )
+                if compute_resource.pass_cpu_options_in_launch_template
+                else None,
+                block_device_mappings=get_block_device_mappings(
+                    queue.compute_settings.local_storage, self._config.image.os
+                ),
+                # key_name=,
+                network_interfaces=compute_lt_nw_interfaces,
+                placement=ec2.CfnLaunchTemplate.PlacementProperty(group_name=queue_placement_group),
+                image_id=self._config.image_dict[queue.name],
+                ebs_optimized=compute_resource.is_ebs_optimized,
+                iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(
+                    name=instance_profiles[queue.name]
+                ),
+                instance_market_options=instance_market_options,
+                user_data=Fn.base64(
+                    Fn.sub(
+                        get_user_data_content("../resources/compute_node/user_data.sh"),
+                        {
+                            **{
+                                "EnableEfa": "efa" if compute_resource.efa and compute_resource.efa.enabled else "NONE",
+                                "RAIDOptions": get_shared_storage_options_by_type(
+                                    self._shared_storage_options, SharedStorageType.RAID
+                                ),
+                                "DisableHyperThreadingManually": "true"
+                                if compute_resource.disable_simultaneous_multithreading_manually
+                                else "false",
+                                "BaseOS": self._config.image.os,
+                                "PreInstallScript": queue_pre_install_action.script
+                                if queue_pre_install_action
+                                else "NONE",
+                                "PreInstallArgs": join_shell_args(queue_pre_install_action.args)
+                                if queue_pre_install_action and queue_pre_install_action.args
+                                else "NONE",
+                                "PostInstallScript": queue_post_install_action.script
+                                if queue_post_install_action
+                                else "NONE",
+                                "PostInstallArgs": join_shell_args(queue_post_install_action.args)
+                                if queue_post_install_action and queue_post_install_action.args
+                                else "NONE",
+                                "EFSId": get_shared_storage_ids_by_type(
+                                    self._shared_storage_mappings, SharedStorageType.EFS
+                                ),
+                                "EFSOptions": get_shared_storage_options_by_type(
+                                    self._shared_storage_options, SharedStorageType.EFS
+                                ),  # FIXME
+                                "FSXId": get_shared_storage_ids_by_type(
+                                    self._shared_storage_mappings, SharedStorageType.FSX
+                                ),
+                                "FSXMountName": self._shared_storage_attributes[SharedStorageType.FSX].get(
+                                    "MountName", ""
+                                ),
+                                "FSXDNSName": self._shared_storage_attributes[SharedStorageType.FSX].get("DNSName", ""),
+                                "FSXOptions": get_shared_storage_options_by_type(
+                                    self._shared_storage_options, SharedStorageType.FSX
+                                ),
+                                "Scheduler": self._config.scheduling.scheduler,
+                                "EphemeralDir": queue.compute_settings.local_storage.ephemeral_volume.mount_dir
+                                if queue.compute_settings
+                                and queue.compute_settings.local_storage
+                                and queue.compute_settings.local_storage.ephemeral_volume
+                                else "/scratch",
+                                "EbsSharedDirs": get_shared_storage_options_by_type(
+                                    self._shared_storage_options, SharedStorageType.EBS
+                                ),
+                                "ClusterDNSDomain": str(self._cluster_hosted_zone.name)
+                                if self._cluster_hosted_zone
+                                else "",
+                                "ClusterHostedZone": str(self._cluster_hosted_zone.ref)
+                                if self._cluster_hosted_zone
+                                else "",
+                                "OSUser": OS_MAPPING[self._config.image.os]["user"],
+                                "DynamoDBTable": self._dynamodb_table.ref if self._dynamodb_table else "NONE",
+                                "LogGroupName": self._log_group.log_group_name
+                                if self._config.monitoring.logs.cloud_watch.enabled
+                                else "NONE",
+                                "IntelHPCPlatform": "true" if self._config.is_intel_hpc_platform_enabled else "false",
+                                "CWLoggingEnabled": "true" if self._config.is_cw_logging_enabled else "false",
+                                "QueueName": queue.name,
+                                "EnableEfaGdr": "compute"
+                                if compute_resource.efa and compute_resource.efa.gdr_support
+                                else "NONE",
+                                "CustomNodePackage": self._config.custom_node_package or "",
+                                "CustomAwsBatchCliPackage": self._config.custom_aws_batch_cli_package or "",
+                                "ExtraJson": self._config.extra_chef_attributes,
+                            },
+                            **get_common_user_data_env(queue, self._config),
+                        },
+                    )
+                ),
+                monitoring=ec2.CfnLaunchTemplate.MonitoringProperty(enabled=False),
+                tag_specifications=[
+                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
+                        resource_type="instance",
+                        tags=get_default_instance_tags(
+                            self.stack_name, self._config, compute_resource, "Compute", self._shared_storage_mappings
+                        )
+                        + [CfnTag(key=PCLUSTER_QUEUE_NAME_TAG, value=queue.name)]
+                        + get_custom_tags(self._config),
+                    ),
+                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
+                        resource_type="volume",
+                        tags=get_default_volume_tags(self.stack_name, "Compute")
+                        + [CfnTag(key=PCLUSTER_QUEUE_NAME_TAG, value=queue.name)]
+                        + get_custom_tags(self._config),
+                    ),
+                ],
+            ),
         )

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -9,41 +9,24 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import namedtuple
+from typing import Dict
 
 from aws_cdk import aws_dynamodb as dynamodb
-from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as awslambda
-from aws_cdk import aws_logs as logs
 from aws_cdk import aws_route53 as route53
-from aws_cdk.core import CfnCustomResource, CfnDeletionPolicy, CfnOutput, CfnParameter, CfnTag, Construct, Fn, Stack
+from aws_cdk.core import CfnCustomResource, CfnDeletionPolicy, CfnOutput, CfnParameter, Construct, Fn, Stack
 
 from pcluster.aws.aws_api import AWSApi
-from pcluster.config.cluster_config import CapacityType, SharedStorageType, SlurmClusterConfig
-from pcluster.constants import (
-    IAM_ROLE_PATH,
-    OS_MAPPING,
-    PCLUSTER_CLUSTER_NAME_TAG,
-    PCLUSTER_DYNAMODB_PREFIX,
-    PCLUSTER_QUEUE_NAME_TAG,
-)
+from pcluster.config.cluster_config import SlurmClusterConfig
+from pcluster.constants import IAM_ROLE_PATH, PCLUSTER_CLUSTER_NAME_TAG, PCLUSTER_DYNAMODB_PREFIX
 from pcluster.models.s3_bucket import S3Bucket
 from pcluster.templates.cdk_builder_utils import (
     PclusterLambdaConstruct,
     add_lambda_cfn_role,
     create_hash_suffix,
-    get_block_device_mappings,
     get_cloud_watch_logs_policy_statement,
-    get_common_user_data_env,
-    get_custom_tags,
-    get_default_instance_tags,
-    get_default_volume_tags,
-    get_queue_security_groups_full,
-    get_shared_storage_ids_by_type,
-    get_shared_storage_options_by_type,
-    get_user_data_content,
 )
-from pcluster.utils import join_shell_args
 
 CustomDns = namedtuple("CustomDns", ["ref", "name"])
 
@@ -58,31 +41,20 @@ class SlurmConstruct(Construct):
         stack_name: str,
         cluster_config: SlurmClusterConfig,
         bucket: S3Bucket,
-        log_group: logs.CfnLogGroup,
-        instance_roles: dict,
-        instance_profiles: dict,
+        managed_head_node_instance_role: iam.CfnRole,
+        managed_compute_instance_roles: Dict[str, iam.CfnRole],
         cleanup_lambda_role: iam.CfnRole,
         cleanup_lambda: awslambda.CfnFunction,
-        compute_security_groups: dict,
-        shared_storage_mappings: dict,
-        shared_storage_options: dict,
-        shared_storage_attributes: dict,
-        **kwargs,
     ):
         super().__init__(scope, id)
         self.stack_scope = scope
         self.stack_name = stack_name
         self.config = cluster_config
         self.bucket = bucket
-        self.log_group = log_group
-        self.instance_roles = instance_roles
-        self.instance_profiles = instance_profiles
         self.cleanup_lambda_role = cleanup_lambda_role
         self.cleanup_lambda = cleanup_lambda
-        self.compute_security_groups = compute_security_groups
-        self.shared_storage_mappings = shared_storage_mappings
-        self.shared_storage_options = shared_storage_options
-        self.shared_storage_attributes = shared_storage_attributes
+        self.managed_head_node_instance_role = managed_head_node_instance_role
+        self.managed_compute_instance_roles = managed_compute_instance_roles
 
         self._add_parameters()
         self._add_resources()
@@ -132,140 +104,34 @@ class SlurmConstruct(Construct):
         self._add_dynamodb_table()
 
         # Add Slurm Policies to new instances roles
-        for node_name, role_info in self.instance_roles.items():
-            self._add_policies_to_role(node_name, role_info.get("RoleRef"))
+        if self.managed_head_node_instance_role:
+            self._add_policies_to_head_node_role("HeadNode", self.managed_head_node_instance_role.ref)
+        for queue_name, role in self.managed_compute_instance_roles.items():
+            if role:
+                self._add_policies_to_compute_node_role(queue_name, role.ref)
 
-        if self.cleanup_lambda_role:
-            self._add_policies_to_cleanup_resources_lambda_role()
+        self.cluster_hosted_zone = None
+        if not self._condition_disable_cluster_dns():
+            self.cluster_hosted_zone = self._add_private_hosted_zone()
 
-        self._add_slurm_compute_fleet()
-
-    def _add_policies_to_role(self, node_name, role):
+    def _add_policies_to_compute_node_role(self, node_name, role):
         suffix = create_hash_suffix(node_name)
 
-        if node_name == "HeadNode":
-            policy_statements = [
-                {
-                    "sid": "DynamoDBTable",
-                    "actions": [
-                        "dynamodb:PutItem",
-                        "dynamodb:BatchWriteItem",
-                        "dynamodb:GetItem",
-                    ],
-                    "effect": iam.Effect.ALLOW,
-                    "resources": [
-                        self._format_arn(
-                            service="dynamodb", resource=f"table/{PCLUSTER_DYNAMODB_PREFIX}{self.stack_name}"
-                        )
-                    ],
-                },
-                {
-                    "sid": "EC2Terminate",
-                    "effect": iam.Effect.ALLOW,
-                    "actions": ["ec2:TerminateInstances"],
-                    "resources": ["*"],
-                    "conditions": {"StringEquals": {f"ec2:ResourceTag/{PCLUSTER_CLUSTER_NAME_TAG}": self.stack_name}},
-                },
-                {
-                    "sid": "EC2RunInstances",
-                    "effect": iam.Effect.ALLOW,
-                    "actions": ["ec2:RunInstances"],
-                    "resources": [
-                        self._format_arn(service="ec2", resource=f"subnet/{subnet_id}")
-                        for subnet_id in self.config.compute_subnet_ids
-                    ]
-                    + [
-                        self._format_arn(service="ec2", resource="network-interface/*"),
-                        self._format_arn(service="ec2", resource="instance/*"),
-                        self._format_arn(service="ec2", resource="volume/*"),
-                        self._format_arn(service="ec2", resource=f"key-pair/{self.config.head_node.ssh.key_name}"),
-                        self._format_arn(service="ec2", resource="security-group/*"),
-                        self._format_arn(service="ec2", resource="launch-template/*"),
-                        self._format_arn(service="ec2", resource="placement-group/*"),
-                    ]
-                    + [
-                        self._format_arn(service="ec2", resource=f"image/{queue_ami}", account="")
-                        for _, queue_ami in self.config.image_dict.items()
-                    ],
-                },
-                {
-                    "sid": "PassRole",
-                    "actions": ["iam:PassRole"],
-                    "effect": iam.Effect.ALLOW,
-                    "resources": self._generate_head_node_pass_role_resources(),
-                },
-                {
-                    "sid": "EC2",
-                    "effect": iam.Effect.ALLOW,
-                    "actions": [
-                        "ec2:DescribeInstances",
-                        "ec2:DescribeInstanceStatus",
-                        "ec2:CreateTags",
-                        "ec2:DescribeVolumes",
-                        "ec2:AttachVolume",
-                    ],
-                    "resources": ["*"],
-                },
-                {
-                    "sid": "ResourcesS3Bucket",
-                    "effect": iam.Effect.ALLOW,
-                    "actions": ["s3:*"],
-                    "resources": [
-                        self._format_arn(service="s3", resource=self.bucket.name, region="", account=""),
-                        self._format_arn(
-                            service="s3",
-                            resource=f"{self.bucket.name}/{self.bucket.artifact_directory}/*",
-                            region="",
-                            account="",
-                        ),
-                    ],
-                },
-                {
-                    "sid": "Cloudformation",
-                    "actions": [
-                        "cloudformation:DescribeStackResource",
-                        "cloudformation:SignalResource",
-                    ],
-                    "effect": iam.Effect.ALLOW,
-                    "resources": [
-                        self._format_arn(service="cloudformation", resource=f"stack/{self.stack_name}/*"),
-                        # ToDo: This resource is for substack. Check if this is necessary for pcluster3
-                        self._format_arn(service="cloudformation", resource=f"stack/{self.stack_name}-*/*"),
-                    ],
-                },
-                {
-                    "sid": "DcvLicense",
-                    "actions": ["s3:GetObject"],
-                    "effect": iam.Effect.ALLOW,
-                    "resources": [
-                        self._format_arn(
-                            service="s3",
-                            resource="dcv-license.{0}/*".format(self._stack_region),
-                            region="",
-                            account="",
-                        )
-                    ],
-                },
-            ]
-            policy_name = "parallelcluster-slurm-head-node"
-        else:
-            policy_statements = [
-                {
-                    "sid": "DynamoDBTableQuery",
-                    "effect": iam.Effect.ALLOW,
-                    "actions": ["dynamodb:Query"],
-                    "resources": [
-                        self._format_arn(
-                            service="dynamodb", resource=f"table/{PCLUSTER_DYNAMODB_PREFIX}{self.stack_name}"
-                        ),
-                        self._format_arn(
-                            service="dynamodb",
-                            resource=f"table/{PCLUSTER_DYNAMODB_PREFIX}{self.stack_name}/index/*",
-                        ),
-                    ],
-                },
-            ]
-            policy_name = "parallelcluster-slurm-compute"
+        policy_statements = [
+            {
+                "sid": "DynamoDBTableQuery",
+                "effect": iam.Effect.ALLOW,
+                "actions": ["dynamodb:Query"],
+                "resources": [
+                    self._format_arn(service="dynamodb", resource=f"table/{PCLUSTER_DYNAMODB_PREFIX}{self.stack_name}"),
+                    self._format_arn(
+                        service="dynamodb",
+                        resource=f"table/{PCLUSTER_DYNAMODB_PREFIX}{self.stack_name}/index/*",
+                    ),
+                ],
+            },
+        ]
+        policy_name = "parallelcluster-slurm-compute"
         iam.CfnPolicy(
             self.stack_scope,
             f"SlurmPolicies{suffix}",
@@ -276,79 +142,69 @@ class SlurmConstruct(Construct):
             roles=[role],
         )
 
-    def _add_policies_to_cleanup_resources_lambda_role(self):
-        self.cleanup_lambda_role.policies[0].policy_document.add_statements(
-            iam.PolicyStatement(
-                actions=["ec2:DescribeInstances"],
-                resources=["*"],
-                effect=iam.Effect.ALLOW,
-                sid="DescribeInstances",
-            ),
-            iam.PolicyStatement(
-                actions=["ec2:TerminateInstances"],
-                resources=["*"],
-                effect=iam.Effect.ALLOW,
-                conditions={"StringEquals": {f"ec2:ResourceTag/{PCLUSTER_CLUSTER_NAME_TAG}": self.stack_name}},
-                sid="FleetTerminatePolicy",
-            ),
-        )
+    def _add_policies_to_head_node_role(self, node_name, role):
+        suffix = create_hash_suffix(node_name)
 
-    def _add_slurm_compute_fleet(self):
+        policy_statements = [
+            {
+                "sid": "DynamoDBTable",
+                "actions": [
+                    "dynamodb:PutItem",
+                    "dynamodb:BatchWriteItem",
+                    "dynamodb:GetItem",
+                ],
+                "effect": iam.Effect.ALLOW,
+                "resources": [
+                    self._format_arn(service="dynamodb", resource=f"table/{PCLUSTER_DYNAMODB_PREFIX}{self.stack_name}")
+                ],
+            },
+            {
+                "sid": "EC2Terminate",
+                "effect": iam.Effect.ALLOW,
+                "actions": ["ec2:TerminateInstances"],
+                "resources": ["*"],
+                "conditions": {"StringEquals": {f"ec2:ResourceTag/{PCLUSTER_CLUSTER_NAME_TAG}": self.stack_name}},
+            },
+            {
+                "sid": "EC2RunInstances",
+                "effect": iam.Effect.ALLOW,
+                "actions": ["ec2:RunInstances"],
+                "resources": [
+                    self._format_arn(service="ec2", resource=f"subnet/{subnet_id}")
+                    for subnet_id in self.config.compute_subnet_ids
+                ]
+                + [
+                    self._format_arn(service="ec2", resource="network-interface/*"),
+                    self._format_arn(service="ec2", resource="instance/*"),
+                    self._format_arn(service="ec2", resource="volume/*"),
+                    self._format_arn(service="ec2", resource=f"key-pair/{self.config.head_node.ssh.key_name}"),
+                    self._format_arn(service="ec2", resource="security-group/*"),
+                    self._format_arn(service="ec2", resource="launch-template/*"),
+                    self._format_arn(service="ec2", resource="placement-group/*"),
+                ]
+                + [
+                    self._format_arn(service="ec2", resource=f"image/{queue_ami}", account="")
+                    for _, queue_ami in self.config.image_dict.items()
+                ],
+            },
+            {
+                "sid": "PassRole",
+                "actions": ["iam:PassRole"],
+                "effect": iam.Effect.ALLOW,
+                "resources": self._generate_head_node_pass_role_resources(),
+            },
+        ]
+        policy_name = "parallelcluster-slurm-head-node"
 
-        self.cluster_hosted_zone = None
-        if not self._condition_disable_cluster_dns():
-            self.cluster_hosted_zone = self._add_private_hosted_zone()
-
-        self.terminate_compute_fleet_custom_resource = CfnCustomResource(
+        iam.CfnPolicy(
             self.stack_scope,
-            "TerminateComputeFleetCustomResource",
-            service_token=self.cleanup_lambda.attr_arn,
+            f"SlurmPolicies{suffix}",
+            policy_name=policy_name,
+            policy_document=iam.PolicyDocument(
+                statements=[iam.PolicyStatement(**statement) for statement in policy_statements]
+            ),
+            roles=[role],
         )
-        self.terminate_compute_fleet_custom_resource.add_property_override("StackName", self.stack_name)
-        self.terminate_compute_fleet_custom_resource.add_property_override("Action", "TERMINATE_EC2_INSTANCES")
-        if not self._condition_disable_cluster_dns():
-            self.terminate_compute_fleet_custom_resource.add_depends_on(self.cleanup_route53_custom_resource)
-        for security_group in self.compute_security_groups.values():
-            # Control the order of resource deletion.
-            # Security groups can be deleted only after the compute nodes are terminated.
-            self.terminate_compute_fleet_custom_resource.add_depends_on(security_group)
-        # TODO: add depends_on resources from CloudWatchLogsSubstack and ComputeFleetHitSubstack?
-        # terminate_compute_fleet_custom_resource.add_depends_on()
-
-        for queue in self.config.scheduling.queues:
-            queue_lt_security_groups = get_queue_security_groups_full(self.compute_security_groups, queue)
-
-            queue_placement_group = None
-            if queue.networking.placement_group and queue.networking.placement_group.enabled:
-                if queue.networking.placement_group.id:
-                    queue_placement_group = queue.networking.placement_group.id
-                else:
-                    # Create Placement Group
-                    queue_placement_group = ec2.CfnPlacementGroup(
-                        self.stack_scope, f"PlacementGroup{create_hash_suffix(queue.name)}", strategy="cluster"
-                    )
-                    # Control the order of resource deletion.
-                    # Placement group can be deleted only after the compute nodes are terminated.
-                    self.terminate_compute_fleet_custom_resource.add_depends_on(queue_placement_group)
-                    queue_placement_group = queue_placement_group.ref
-
-            queue_pre_install_action, queue_post_install_action = (None, None)
-            if queue.custom_actions:
-                queue_pre_install_action = queue.custom_actions.on_node_start
-                queue_post_install_action = queue.custom_actions.on_node_configured
-
-            for compute_resource in queue.compute_resources:
-                instance_type = compute_resource.instance_type
-
-                self._add_compute_resource_launch_template(
-                    queue,
-                    compute_resource,
-                    instance_type,
-                    queue_pre_install_action,
-                    queue_post_install_action,
-                    queue_lt_security_groups,
-                    queue_placement_group,
-                )
 
     def _add_dynamodb_table(self):
         table = dynamodb.CfnTable(
@@ -386,8 +242,7 @@ class SlurmConstruct(Construct):
             )
 
         # If Headnode InstanceRole is created by ParallelCluster, add Route53 policy for InstanceRole
-        head_node_role_info = self.instance_roles.get("HeadNode")
-        if head_node_role_info:
+        if self.managed_head_node_instance_role:
             iam.CfnPolicy(
                 self.stack_scope,
                 "ParallelClusterSlurmRoute53Policies",
@@ -409,7 +264,7 @@ class SlurmConstruct(Construct):
                         ),
                     ]
                 ),
-                roles=[head_node_role_info.get("RoleRef")],
+                roles=[self.managed_head_node_instance_role.ref],
             )
 
         cleanup_route53_lambda_execution_role = None
@@ -466,168 +321,6 @@ class SlurmConstruct(Construct):
         )
 
         return cluster_hosted_zone
-
-    def _add_compute_resource_launch_template(
-        self,
-        queue,
-        compute_resource,
-        instance_type,
-        queue_pre_install_action,
-        queue_post_install_action,
-        queue_lt_security_groups,
-        queue_placement_group,
-    ):
-        # LT network interfaces
-        compute_lt_nw_interfaces = [
-            ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
-                device_index=0,
-                associate_public_ip_address=queue.networking.assign_public_ip
-                if compute_resource.max_network_interface_count == 1
-                else None,  # parameter not supported for instance types with multiple network interfaces
-                interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
-                groups=queue_lt_security_groups,
-                subnet_id=queue.networking.subnet_ids[0],
-            )
-        ]
-        for device_index in range(1, compute_resource.max_network_interface_count):
-            compute_lt_nw_interfaces.append(
-                ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
-                    device_index=device_index,
-                    network_card_index=device_index,
-                    interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
-                    groups=queue_lt_security_groups,
-                    subnet_id=queue.networking.subnet_ids[0],
-                )
-            )
-
-        instance_market_options = None
-        if queue.capacity_type == CapacityType.SPOT:
-            instance_market_options = ec2.CfnLaunchTemplate.InstanceMarketOptionsProperty(
-                market_type="spot",
-                spot_options=ec2.CfnLaunchTemplate.SpotOptionsProperty(
-                    spot_instance_type="one-time",
-                    instance_interruption_behavior="terminate",
-                    max_price=None if compute_resource.spot_price is None else str(compute_resource.spot_price),
-                ),
-            )
-
-        ec2.CfnLaunchTemplate(
-            self.stack_scope,
-            f"ComputeServerLaunchTemplate{create_hash_suffix(queue.name + instance_type)}",
-            launch_template_name=f"{self.stack_name}-{queue.name}-{instance_type}",
-            launch_template_data=ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
-                instance_type=instance_type,
-                cpu_options=ec2.CfnLaunchTemplate.CpuOptionsProperty(
-                    core_count=compute_resource.vcpus, threads_per_core=1
-                )
-                if compute_resource.pass_cpu_options_in_launch_template
-                else None,
-                block_device_mappings=get_block_device_mappings(
-                    queue.compute_settings.local_storage, self.config.image.os
-                ),
-                # key_name=,
-                network_interfaces=compute_lt_nw_interfaces,
-                placement=ec2.CfnLaunchTemplate.PlacementProperty(group_name=queue_placement_group),
-                image_id=self.config.image_dict[queue.name],
-                ebs_optimized=compute_resource.is_ebs_optimized,
-                iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(
-                    name=self.instance_profiles[queue.name]
-                ),
-                instance_market_options=instance_market_options,
-                user_data=Fn.base64(
-                    Fn.sub(
-                        get_user_data_content("../resources/compute_node/user_data.sh"),
-                        {
-                            **{
-                                "EnableEfa": "efa" if compute_resource.efa and compute_resource.efa.enabled else "NONE",
-                                "RAIDOptions": get_shared_storage_options_by_type(
-                                    self.shared_storage_options, SharedStorageType.RAID
-                                ),
-                                "DisableHyperThreadingManually": "true"
-                                if compute_resource.disable_simultaneous_multithreading_manually
-                                else "false",
-                                "BaseOS": self.config.image.os,
-                                "PreInstallScript": queue_pre_install_action.script
-                                if queue_pre_install_action
-                                else "NONE",
-                                "PreInstallArgs": join_shell_args(queue_pre_install_action.args)
-                                if queue_pre_install_action and queue_pre_install_action.args
-                                else "NONE",
-                                "PostInstallScript": queue_post_install_action.script
-                                if queue_post_install_action
-                                else "NONE",
-                                "PostInstallArgs": join_shell_args(queue_post_install_action.args)
-                                if queue_post_install_action and queue_post_install_action.args
-                                else "NONE",
-                                "EFSId": get_shared_storage_ids_by_type(
-                                    self.shared_storage_mappings, SharedStorageType.EFS
-                                ),
-                                "EFSOptions": get_shared_storage_options_by_type(
-                                    self.shared_storage_options, SharedStorageType.EFS
-                                ),  # FIXME
-                                "FSXId": get_shared_storage_ids_by_type(
-                                    self.shared_storage_mappings, SharedStorageType.FSX
-                                ),
-                                "FSXMountName": self.shared_storage_attributes[SharedStorageType.FSX].get(
-                                    "MountName", ""
-                                ),
-                                "FSXDNSName": self.shared_storage_attributes[SharedStorageType.FSX].get("DNSName", ""),
-                                "FSXOptions": get_shared_storage_options_by_type(
-                                    self.shared_storage_options, SharedStorageType.FSX
-                                ),
-                                "Scheduler": self.config.scheduling.scheduler,
-                                "EphemeralDir": queue.compute_settings.local_storage.ephemeral_volume.mount_dir
-                                if queue.compute_settings
-                                and queue.compute_settings.local_storage
-                                and queue.compute_settings.local_storage.ephemeral_volume
-                                else "/scratch",
-                                "EbsSharedDirs": get_shared_storage_options_by_type(
-                                    self.shared_storage_options, SharedStorageType.EBS
-                                ),
-                                "ClusterDNSDomain": str(self.cluster_hosted_zone.name)
-                                if self.cluster_hosted_zone
-                                else "",
-                                "ClusterHostedZone": str(self.cluster_hosted_zone.ref)
-                                if self.cluster_hosted_zone
-                                else "",
-                                "OSUser": OS_MAPPING[self.config.image.os]["user"],
-                                "DynamoDBTable": self.dynamodb_table.ref,
-                                "LogGroupName": self.log_group.log_group_name
-                                if self.config.monitoring.logs.cloud_watch.enabled
-                                else "NONE",
-                                "IntelHPCPlatform": "true" if self.config.is_intel_hpc_platform_enabled else "false",
-                                "CWLoggingEnabled": "true" if self.config.is_cw_logging_enabled else "false",
-                                "QueueName": queue.name,
-                                "EnableEfaGdr": "compute"
-                                if compute_resource.efa and compute_resource.efa.gdr_support
-                                else "NONE",
-                                "CustomNodePackage": self.config.custom_node_package or "",
-                                "CustomAwsBatchCliPackage": self.config.custom_aws_batch_cli_package or "",
-                                "ExtraJson": self.config.extra_chef_attributes,
-                            },
-                            **get_common_user_data_env(queue, self.config),
-                        },
-                    )
-                ),
-                monitoring=ec2.CfnLaunchTemplate.MonitoringProperty(enabled=False),
-                tag_specifications=[
-                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
-                        resource_type="instance",
-                        tags=get_default_instance_tags(
-                            self.stack_name, self.config, compute_resource, "Compute", self.shared_storage_mappings
-                        )
-                        + [CfnTag(key=PCLUSTER_QUEUE_NAME_TAG, value=queue.name)]
-                        + get_custom_tags(self.config),
-                    ),
-                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
-                        resource_type="volume",
-                        tags=get_default_volume_tags(self.stack_name, "Compute")
-                        + [CfnTag(key=PCLUSTER_QUEUE_NAME_TAG, value=queue.name)]
-                        + get_custom_tags(self.config),
-                    ),
-                ],
-            ),
-        )
 
     def _generate_head_node_pass_role_resources(self):
         """Return a unique list of ARNs that the head node should be able to use when calling PassRole."""

--- a/cli/tests/pcluster/example_configs/byos.full.yaml
+++ b/cli/tests/pcluster/example_configs/byos.full.yaml
@@ -1,0 +1,199 @@
+Region: us-east-1
+Image:
+  Os: centos7
+  CustomAmi: ami-12345678
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+    ElasticIp: true  # true|false|EIP-id
+    AdditionalSecurityGroups:
+      - sg-34567890
+      - sg-45678901
+    Proxy:
+      HttpProxyAddress: https://proxy-address:port
+  DisableSimultaneousMultithreading: false
+  Ssh:
+    KeyName: ec2-key-name
+    AllowedIps: 1.2.3.4/32
+  LocalStorage:
+    RootVolume:
+      Size: 40
+      Encrypted: true
+      VolumeType: gp2
+      Iops: 100
+      DeleteOnTermination: true
+    EphemeralVolume:
+      MountDir: /test
+  Dcv:
+    Enabled: true
+    Port: 8443
+    AllowedIps: 0.0.0.0/0
+  CustomActions:
+    OnNodeStart:
+      Script: https://test.tgz  # s3:// | https://
+      Args:
+        - arg1
+        - arg2
+    OnNodeConfigured:
+      Script: https://test.tgz  # s3:// | https://
+      Args:
+        - arg1
+        - arg2
+  Iam:
+    InstanceRole: arn:aws:iam::aws:role/CustomHeadNodeRole
+  Imds:
+    Secured: True
+  Image:
+    CustomAmi: ami-98765432
+Scheduling:
+  Scheduler: byos
+  ByosSettings:
+    SchedulerDefinition:
+      Key1: Value1
+      Key2: Value2
+  ByosQueues:
+    - Name: queue1
+      CapacityType: ONDEMAND
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute-resource-1
+          InstanceType: c5.xlarge
+        - Name: compute-resource-2
+          InstanceType: c4.xlarge
+      CustomActions:
+        OnNodeStart:
+          Script: https://test.tgz  # s3:// | https://
+          Args:
+            - arg1
+            - arg2
+        OnNodeConfigured:
+          Script: https://test.tgz  # s3:// | https://
+          Args:
+            - arg1
+            - arg2
+      Iam:
+        S3Access:
+          - BucketName: string1
+            EnableWriteAccess: False
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::aws:policy/AdministratorAccess
+      Image:
+        CustomAmi: ami-12345678
+    - Name: queue2
+      ComputeSettings:
+        LocalStorage:
+          RootVolume:
+            Size: 35
+            Encrypted: true
+            VolumeType: gp2
+            Iops: 100
+          EphemeralVolume:
+            MountDir: /scratch
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+        AssignPublicIp: true
+        SecurityGroups:
+          - sg-12345678
+        PlacementGroup:
+          Enabled: true
+          Id: String
+        Proxy:
+          HttpProxyAddress: https://proxy-address:port
+      ComputeResources:
+        - Name: compute-resource-1
+          InstanceType: c4.2xlarge
+        - Name: compute-resource-2
+          InstanceType: c5.2xlarge
+          MinCount: 1
+          MaxCount: 15
+          SpotPrice: 1.1
+          DisableSimultaneousMultithreading: true
+          Efa:
+            Enabled: true
+            GdrSupport: false
+      Iam:
+        InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
+      Image:
+        CustomAmi: ami-23456789
+SharedStorage:
+  - MountDir: /my/mount/point1
+    Name: name1
+    StorageType: Ebs
+    EbsSettings:
+      VolumeType: gp2  # gp2 | gp3 | io1 | io2 | sc1 | st1 | standard
+      Iops: 100
+      Size: 150
+      Encrypted: True
+      KmsKeyId: String
+      SnapshotId: snap-12345678
+      VolumeId: vol-12345678
+      DeletionPolicy: Retain
+  - MountDir: /my/mount/point2
+    Name: name2
+    StorageType: Efs
+    EfsSettings:
+      ThroughputMode: provisioned  # bursting | provisioned
+      ProvisionedThroughput: 1024
+  - MountDir: /my/mount/point3
+    Name: name3
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 3600
+      DeploymentType: PERSISTENT_1  # PERSISTENT_1 | SCRATCH_1 | SCRATCH_2
+      ImportedFileChunkSize: 1024
+      DataCompressionType: LZ4
+      ExportPath: s3://bucket/folder
+      ImportPath: s3://bucket
+      WeeklyMaintenanceStartTime: "1:00:00"
+      AutomaticBackupRetentionDays: 0
+      CopyTagsToBackups: true
+      DailyAutomaticBackupStartTime: 01:03
+      PerUnitStorageThroughput: 200
+      # BackupId: backup-fedcba98 # BackupId cannot coexist with some of the fields
+      KmsKeyId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+      # FileSystemId: fs-12345678123456789 # FileSystemId cannot coexist with other fields
+      AutoImportPolicy: NEW  # NEW | NEW_CHANGED
+      DriveCacheType: READ  # READ
+      StorageType: HDD  # HDD | SSD
+Iam:
+  Roles:
+    LambdaFunctionsRole: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
+Monitoring:
+  DetailedMonitoring: true  # false
+  Logs:
+    CloudWatch:
+      Enabled: true  # true
+      RetentionInDays: 30  # 14
+      DeletionPolicy: Retain
+  Dashboards:
+    CloudWatch:
+      Enabled: true  # true
+AdditionalPackages:
+  IntelSoftware:
+    IntelHpcPlatform: false
+Tags:
+  - Key: String
+    Value: String
+  - Key: two
+    Value: two22
+CustomS3Bucket: String
+AdditionalResources: https://template.url
+DevSettings:
+  ClusterTemplate: https://tests/aws-parallelcluster-template-3.0.tgz
+  Cookbook:
+    ChefCookbook: https://tests/aws-parallelcluster-cookbook-3.0.tgz
+    ExtraChefAttributes: |
+      {"cluster": {"scheduler_slots": "cores"}}
+  AwsBatchCliPackage: s3://test/aws-parallelcluster-batch-3.0.tgz
+  NodePackage: s3://test/aws-parallelcluster-node-3.0.tgz
+  AmiSearchFilters:
+    Tags:
+    - Key: tag1
+      Value: value1
+    - Key: tag2
+      Value: value2
+    Owner: self

--- a/cli/tests/pcluster/example_configs/byos.required.yaml
+++ b/cli/tests/pcluster/example_configs/byos.required.yaml
@@ -1,0 +1,22 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+Scheduling:
+  Scheduler: byos
+  ByosSettings:
+    SchedulerDefinition:
+      Key1: Value1
+      Key2: Value2
+  ByosQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute-resource1
+          InstanceType: c5.2xlarge

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -38,7 +38,15 @@ def test_slurm_cluster_builder(mocker):
 
 
 @pytest.mark.parametrize(
-    "config_file_name", ["slurm.required.yaml", "slurm.full.yaml", "awsbatch.simple.yaml", "awsbatch.full.yaml"]
+    "config_file_name",
+    [
+        "slurm.required.yaml",
+        "slurm.full.yaml",
+        "awsbatch.simple.yaml",
+        "awsbatch.full.yaml",
+        "byos.required.yaml",
+        "byos.full.yaml",
+    ],
 )
 def test_cluster_builder_from_configuration_file(mocker, config_file_name):
     mock_aws_api(mocker)

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -5,6 +5,13 @@ arm_pl:
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: {{ common.OSS_COMMERCIAL_ARM }}
         schedulers: ["slurm"]
+byos:
+  test_byos.py::test_byos:
+    dimensions:
+      - regions: ["ca-central-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["byos"]
 cfn-init:
   test_cfn_init.py::test_replace_compute_on_failure:
     dimensions:

--- a/tests/integration-tests/tests/byos/test_byos.py
+++ b/tests/integration-tests/tests/byos/test_byos.py
@@ -1,0 +1,27 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+
+import pytest
+
+from tests.common.assertions import assert_head_node_is_running
+
+
+@pytest.mark.usefixtures("instance", "scheduler", "os")
+def test_byos(region, pcluster_config_reader, clusters_factory):
+    """Test usage of a custom scheduler integration."""
+    logging.info("Testing custom scheduler integration.")
+
+    cluster_config = pcluster_config_reader()
+    cluster = clusters_factory(cluster_config)
+
+    assert_head_node_is_running(region, cluster)

--- a/tests/integration-tests/tests/byos/test_create/test_byos/pcluster.config.yaml
+++ b/tests/integration-tests/tests/byos/test_create/test_byos/pcluster.config.yaml
@@ -1,0 +1,21 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: byos
+  ByosSettings:
+    SchedulerDefinition:
+      Key: value
+  ByosQueues:
+    - Name: compute
+      ComputeResources:
+        - Name: compute-i1
+          InstanceType: {{ instance }}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}


### PR DESCRIPTION
* Create minimal schema for BYOS config. Currently a BYOS queue is the same as a Slurm queue in terms of schema.
* Generate correct CloudFormation template when byos scheduler is selected

Signed-off-by: Francesco De Martino <fdm@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
