### PR TITLE
Increase wait time to check instance status change

### DIFF
--- a/tests/integration-tests/tests/cfn-init/test_cfn_init.py
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init.py
@@ -51,7 +51,7 @@ def test_replace_compute_on_failure(
     _assert_compute_logs(remote_command_executor, instance_id)
 
     # check that instance got already replaced or is marked as Unhealthy
-    time.sleep(15)  # Instance waits for 10 seconds before terminating to allow logs to propagate to CloudWatch
+    time.sleep(25)  # Instance waits for 10 seconds before terminating to allow logs to propagate to CloudWatch
     assert_instance_replaced_or_terminating(instance_id, region)
 
 


### PR DESCRIPTION
Increase time from 5 to 15 seconds, before checking EC2 status after OS has been shutdown with `shutdown -h now` command

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
