### PR TITLE
Update head node instance profile is not supported

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -716,13 +716,10 @@ class ClusterIamSchema(BaseSchema):
 
 
 class IamSchema(BaseSchema):
-    """Represent the schema of IAM for HeadNode and Queue."""
+    """Common schema of IAM for HeadNode and Queue."""
 
     instance_role = fields.Str(
         metadata={"update_policy": UpdatePolicy.SUPPORTED}, validate=validate.Regexp("^arn:.*:role/")
-    )
-    instance_profile = fields.Str(
-        metadata={"update_policy": UpdatePolicy.SUPPORTED}, validate=validate.Regexp("^arn:.*:instance-profile/")
     )
     s3_access = fields.Nested(
         S3AccessSchema, many=True, metadata={"update_policy": UpdatePolicy.SUPPORTED, "update_key": "BucketName"}
@@ -751,6 +748,22 @@ class IamSchema(BaseSchema):
     def make_resource(self, data, **kwargs):
         """Generate resource."""
         return Iam(**data)
+
+
+class HeadNodeIamSchema(IamSchema):
+    """Represent the schema of IAM for HeadNode."""
+
+    instance_profile = fields.Str(
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED}, validate=validate.Regexp("^arn:.*:instance-profile/")
+    )
+
+
+class QueueIamSchema(IamSchema):
+    """Represent the schema of IAM for Queue."""
+
+    instance_profile = fields.Str(
+        metadata={"update_policy": UpdatePolicy.SUPPORTED}, validate=validate.Regexp("^arn:.*:instance-profile/")
+    )
 
 
 class ImdsSchema(BaseSchema):
@@ -923,7 +936,7 @@ class HeadNodeSchema(BaseSchema):
     local_storage = fields.Nested(HeadNodeStorageSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     dcv = fields.Nested(DcvSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     custom_actions = fields.Nested(HeadNodeCustomActionsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
-    iam = fields.Nested(IamSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    iam = fields.Nested(HeadNodeIamSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     imds = fields.Nested(ImdsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     image = fields.Nested(HeadNodeImageSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 
@@ -1019,7 +1032,7 @@ class SlurmQueueSchema(BaseQueueSchema):
     custom_actions = fields.Nested(
         QueueCustomActionsSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP}
     )
-    iam = fields.Nested(IamSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    iam = fields.Nested(QueueIamSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     image = fields.Nested(QueueImageSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
 
     @post_load

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -167,6 +167,26 @@ def _compare_changes(changes, expected_changes):
             False,
             id="change compute resources instance type",
         ),
+        pytest.param(
+            ["HeadNode", "Iam"],
+            "head_node_instance_profile",
+            "InstanceProfile",
+            "arn:aws:iam::aws:instance-profile/InstanceProfileone",
+            "arn:aws:iam::aws:instance-profile/InstanceProfiletwo",
+            UpdatePolicy.UNSUPPORTED,
+            False,
+            id="change head node instance profile",
+        ),
+        pytest.param(
+            ["Scheduling", "SlurmQueues[queue1]", "Iam"],
+            "queue_instance_profile",
+            "InstanceProfile",
+            "arn:aws:iam::aws:instance-profile/InstanceProfileone",
+            "arn:aws:iam::aws:instance-profile/InstanceProfiletwo",
+            UpdatePolicy.SUPPORTED,
+            False,
+            id="change queue insatnce profile",
+        ),
     ],
 )
 def test_single_param_change(

--- a/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.yaml
+++ b/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.yaml
@@ -11,10 +11,18 @@ HeadNode:
     KeyName: test-key
   Image:
     CustomAmi: {{head_node_custom_ami}}
+  {% if head_node_instance_profile %}
+  Iam:
+    InstanceProfile: {{head_node_instance_profile}}
+  {% endif %}
 Scheduling:
   Scheduler: slurm
   SlurmQueues:
     - Name: queue1
+      {% if queue_instance_profile %}
+      Iam:
+        InstanceProfile: {{queue_instance_profile}}
+      {% endif %}
       Networking:
         SubnetIds:
           - {{compute_subnet_id}}

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -17,7 +17,14 @@ from assertpy import assert_that
 from marshmallow.validate import ValidationError
 
 from pcluster.constants import MAX_NUMBER_OF_COMPUTE_RESOURCES, MAX_NUMBER_OF_QUEUES
-from pcluster.schemas.cluster_schema import ClusterSchema, IamSchema, ImageSchema, SchedulingSchema, SharedStorageSchema
+from pcluster.schemas.cluster_schema import (
+    ClusterSchema,
+    HeadNodeIamSchema,
+    ImageSchema,
+    QueueIamSchema,
+    SchedulingSchema,
+    SharedStorageSchema,
+)
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.utils import load_cluster_model_from_yaml
 
@@ -124,9 +131,17 @@ def test_iam_schema(instance_role, instance_profile, additional_iam_policies, s3
             ValidationError,
             match=failure_message,
         ):
-            IamSchema().load(iam_dict)
+            HeadNodeIamSchema().load(iam_dict)
+        with pytest.raises(
+            ValidationError,
+            match=failure_message,
+        ):
+            QueueIamSchema().load(iam_dict)
     else:
-        iam = IamSchema().load(iam_dict)
+        iam = HeadNodeIamSchema().load(iam_dict)
+        assert_that(iam.instance_role).is_equal_to(instance_role)
+        assert_that(iam.instance_profile).is_equal_to(instance_profile)
+        iam = QueueIamSchema().load(iam_dict)
         assert_that(iam.instance_role).is_equal_to(instance_role)
         assert_that(iam.instance_profile).is_equal_to(instance_profile)
 


### PR DESCRIPTION
update compute node instance profile is still supported

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
