### PR TITLE
[release-3.0] Fix API docker image deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Pin to the transitive dependencies resulting from the dependency on connexion.
+- Fix deletion of API infrastructure when CloudFormation used to deploy API stack is deleted.
 
 
 3.0.0

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -1115,12 +1115,12 @@ Resources:
           imagebuilder = boto3.client('imagebuilder')
 
           def get_image_ids(repository_name, version):
-              image_ids = []
+              image_digests = set()
               paginator = ecr.get_paginator('list_images')
               response_iterator = paginator.paginate(repositoryName=repository_name, filter={'tagStatus': 'TAGGED'})
               for response in response_iterator:
-                  image_ids.extend([{'imageTag': image_id['imageTag']} for image_id in response['imageIds'] if image_id['imageTag'].startswith(version + "-")])
-              return image_ids
+                  image_digests.update([image_id['imageDigest'] for image_id in response['imageIds'] if f"{version}-" in image_id['imageTag']])
+              return list({'imageDigest': image_digest} for image_digest in image_digests)
 
           def get_imagebuilder_images(ecr_image_pipeline_arn):
               response = imagebuilder.list_image_pipeline_images(imagePipelineArn=ecr_image_pipeline_arn)

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -6,10 +6,9 @@ test-suites:
 {% endfilter %}
   # need to duplicate api section because test_official_images works only after release
   pcluster_api:
-# Test temporarily disabled for not able to delete the api infrastructure
-#    test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
-#      dimensions:
-#        - regions: ["ap-south-1", "cn-north-1", "us-gov-west-1"]
+    test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
+      dimensions:
+        - regions: ["ap-south-1", "cn-north-1", "us-gov-west-1"]
     test_api.py::test_cluster_slurm:
       dimensions:
         - regions: ["sa-east-1"]


### PR DESCRIPTION
Docker Image built with Image Builder are now tagged with `{{imageName}}-{{imageVersionNumber}}-{{imageBuildNumber}` in addition to `{{imageVersionNumber}}-{{imageBuildNumber}}`

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
