### PR TITLE
[develop] Set cloud-init datasource list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 CHANGELOG
 =========
 
-3.X.X
+X.X.X
 ------
 
 **ENHANCEMENTS**
 - Add support for `UseEc2Hostnames` in the cluster configuration file. When set to `true`, use EC2 default hostnames (e.g. ip-1-2-3-4) for compute nodes.
+- Explicitly set cloud-init datasource to be EC2. This save boot time for Ubuntu and CentOS platforms.
 
 **CHANGES**
 - Use compute resource name rather than instance type in compute fleet Launch Template name.

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -39,6 +39,7 @@ fi
 Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0
 
+datasource_list: [ Ec2, None ]
 output:
   all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"
 write_files:

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -34,6 +34,13 @@ export HTTPS_PROXY="${!proxy}"
 export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
 PROXY
 fi
+
+--==BOUNDARY==
+Content-Type: text/cloud-config; charset=us-ascii
+MIME-Version: 1.0
+
+datasource_list: [ Ec2, None ]
+
 --==BOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"
 MIME-Version: 1.0


### PR DESCRIPTION
This is already the default for Alinux platform, but not for Ubuntu and Centos.

Adding a datasource directive can save time when cloud-init runs, because prevent
cloud-init to attempt to identify the cloud platform using the script ds-identify and to cycle through all the supported datasources. This check takes around 10 seconds on a c5.2xlarge

Source https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_cloud-init_for_rhel_8/introduction-to-cloud-init_cloud-content#cloud-init-identifies-the-cloud-platform_introduction-to-cloud-init

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
