### PR TITLE
[release-3.0] Add export to ParallelClusterApiInvokeUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@ CHANGELOG
 
 3.0.1
 ------
-
 **BUG FIXES**
 - Pin to the transitive dependencies resulting from the dependency on connexion.
 - Fix deletion of API infrastructure when CloudFormation used to deploy API stack is deleted.
@@ -11,6 +10,10 @@ CHANGELOG
 **ENHANCEMENTS**
 - The region parameter is now retrieved from the provider chain, thus supporting the use of profiles and defaults specified
   in the `~/.aws/config` file.
+- export `ParallelClusterApiInvokeUrl` and `ParallelClusterApiUserRole` so they can be used by cross-stack references.
+
+**CHANGES**
+- Drop support for SysVinit. Only Systemd is supported.
 
 3.0.0
 ------

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -1242,6 +1242,8 @@ Outputs:
 
   ParallelClusterApiInvokeUrl:
     Description: 'Url to reach the API endpoint'
+    Export:
+      Name: !Sub ${AWS::StackName}-ParallelClusterApiInvokeUrl
     Value: !If
       - UseCustomDomain
       - !Sub
@@ -1269,6 +1271,8 @@ Outputs:
 
   ParallelClusterApiUserRole:
     Condition: CreateApiUserRoleCondition
+    Export:
+      Name: !Sub ${AWS::StackName}-ParallelClusterApiUserRole
     Description: 'IAM Role with permissions to invoke the ParallelCluster API'
     Value: !GetAtt ParallelClusterApiUserRole.Arn
 


### PR DESCRIPTION
This allows cross-stack references which enables people to build upon the API more easily.

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
