### PR TITLE
Integ-tests: fix test_cluster_in_no_internet_subnet

### DIFF
--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
@@ -64,8 +64,9 @@ SharedStorage:
     Name: myfsx
     StorageType: FsxLustre
     FsxLustreSettings:
-      StorageCapacity: 3600
-{% if os == "centos7" %}
+      StorageCapacity: 1200
+      DeploymentType: SCRATCH_2
+{% if os == "centos7" and architechture=="x86_64"%}
 AdditionalPackages:
   IntelSoftware:
     IntelHpcPlatform: true


### PR DESCRIPTION
1. Specify a deployment type of FSx that is available in cn-north-1, us-east-1, us-gov-west-1
2. Only enable Intel HPC platform when CentOS7 and x86

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
