### PR TITLE
Disable createami test for alinux2

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -99,7 +99,7 @@ createami:
     dimensions:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2", "ubuntu1804"] # temporary disable FPGA AMI since there is not enough free space on root partition
+        oss: ["ubuntu1804"] # temporary disable FPGA AMI since there is not enough free space on root partition, disable alinux2 due to endpoint from where SGE source is downloaded is down
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"] # alinux2 temporarily disabled due to incompatible device name


### PR DESCRIPTION
* Due to PCluster 2.x create AMI fails because endpoint from where SGE source is downloaded is down https://github.com/aws/aws-parallelcluster/issues/3359

Signed-off-by: Yulei Wang <yuleiwan@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
