### PR TITLE
[byos] Inject headnode private ip  into compute launch template

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -81,7 +81,8 @@ write_files:
           "enable_efa_gdr": "${EnableEfaGdr}",
           "custom_node_package": "${CustomNodePackage}",
           "custom_awsbatchcli_package": "${CustomAwsBatchCliPackage}",
-          "use_private_hostname": "${UsePrivateHostname}"
+          "use_private_hostname": "${UsePrivateHostname}",
+          "head_node_private_ip": "${HeadNodePrivateIp}"
         },
         "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
       }

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -250,6 +250,7 @@ class ClusterCdkStack(Stack):
                 compute_node_instance_profiles=self._compute_instance_profiles,
                 cluster_hosted_zone=self.scheduler_resources.cluster_hosted_zone if self.scheduler_resources else None,
                 dynamodb_table=self.scheduler_resources.dynamodb_table if self.scheduler_resources else None,
+                head_eni=self._head_eni,
             )
 
         self._add_byos_substack()
@@ -1164,6 +1165,7 @@ class ComputeFleetConstruct(Construct):
         compute_node_instance_profiles: Dict[str, str],
         cluster_hosted_zone,
         dynamodb_table,
+        head_eni,
     ):
         super().__init__(scope, id)
         self._cleanup_lambda = cleanup_lambda
@@ -1177,7 +1179,7 @@ class ComputeFleetConstruct(Construct):
         self._cluster_hosted_zone = cluster_hosted_zone
         self._dynamodb_table = dynamodb_table
         self._compute_node_instance_profiles = compute_node_instance_profiles
-
+        self._head_eni = head_eni
         self._add_resources()
 
     # -- Utility methods --------------------------------------------------------------------------------------------- #
@@ -1416,6 +1418,7 @@ class ComputeFleetConstruct(Construct):
                                 "UsePrivateHostname": str(
                                     get_attr(self._config, "scheduling.settings.dns.use_ec2_hostnames", default=False)
                                 ).lower(),
+                                "HeadNodePrivateIp": self._head_eni.attr_primary_private_ip_address,
                             },
                             **get_common_user_data_env(queue, self._config),
                         },


### PR DESCRIPTION
Inject headnode private ip into compute launch template, storing it into dna.json used as input for the chef run, so that it's available in the early stages of the cookbook run.
This allows compute to be able to mount the shared folder from the head.

Headnode private ip is got from ENI attribute

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
