### PR TITLE
Inject headnode private ip into compute launch template

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -80,7 +80,8 @@ write_files:
           "enable_efa_gdr": "${EnableEfaGdr}",
           "custom_node_package": "${CustomNodePackage}",
           "custom_awsbatchcli_package": "${CustomAwsBatchCliPackage}",
-          "use_private_hostname": "${UsePrivateHostname}"
+          "use_private_hostname": "${UsePrivateHostname}",
+          "head_node_private_ip": "${HeadNodePrivateIp}"
         },
         "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
       }

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -237,6 +237,7 @@ class ClusterCdkStack(Stack):
                 shared_storage_mappings=self.shared_storage_mappings,
                 shared_storage_options=self.shared_storage_options,
                 shared_storage_attributes=self.shared_storage_attributes,
+                head_eni=self._head_eni,
             )
 
         # Wait condition

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -67,6 +67,7 @@ class SlurmConstruct(Construct):
         shared_storage_mappings: dict,
         shared_storage_options: dict,
         shared_storage_attributes: dict,
+        head_eni,
         **kwargs,
     ):
         super().__init__(scope, id)
@@ -83,6 +84,7 @@ class SlurmConstruct(Construct):
         self.shared_storage_mappings = shared_storage_mappings
         self.shared_storage_options = shared_storage_options
         self.shared_storage_attributes = shared_storage_attributes
+        self._head_eni = head_eni
 
         self._add_parameters()
         self._add_resources()
@@ -607,6 +609,7 @@ class SlurmConstruct(Construct):
                                 "UsePrivateHostname": str(
                                     self.config.scheduling.settings.dns.use_ec2_hostnames
                                 ).lower(),
+                                "HeadNodePrivateIp": self._head_eni.attr_primary_private_ip_address,
                             },
                             **get_common_user_data_env(queue, self.config),
                         },


### PR DESCRIPTION
Inject headnode private ip into compute launch template, storing it into dna.json used as input for the chef run, so that it's available in the early stages of the cookbook run.
This allows compute to be able to mount the shared folder from the head.

Headnode private ip is got from ENI attribute

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
