### PR TITLE
Include tags in RunInstances dry run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.11.3
+-----
+
+**CHANGES**
+- Include tags from cluster configuration file in the RunInstances dry runs performed during configuration validation.
+
 2.11.2
 -----
 

--- a/cli/src/pcluster/models/hit/hit_cluster_model.py
+++ b/cli/src/pcluster/models/hit/hit_cluster_model.py
@@ -75,6 +75,17 @@ class HITClusterModel(ClusterModel):
 
             cluster_ami_id = self._get_cluster_ami_id(pcluster_config)
 
+            tags = cluster_section.get_param_value("tags")
+            if tags:
+                tag_specifications = [
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": key, "Value": value} for key, value in tags.items()],
+                    }
+                ]
+            else:
+                tag_specifications = []
+
             head_node_network_interfaces = self.build_launch_network_interfaces(
                 network_interfaces_count=int(cluster_section.get_param_value("network_interfaces_count")[0]),
                 use_efa=False,  # EFA is not supported on head node
@@ -93,6 +104,7 @@ class HITClusterModel(ClusterModel):
                 CpuOptions=head_node_cpu_options,
                 NetworkInterfaces=head_node_network_interfaces,
                 DryRun=True,
+                TagSpecifications=tag_specifications,
             )
 
             for _, queue_section in pcluster_config.get_sections("queue").items():
@@ -116,6 +128,7 @@ class HITClusterModel(ClusterModel):
                     subnet=compute_subnet,
                     security_groups_ids=security_groups_ids,
                     placement_group=queue_placement_group,
+                    tag_specifications=tag_specifications,
                 )
 
         except ClientError:
@@ -147,6 +160,7 @@ class HITClusterModel(ClusterModel):
         subnet=None,
         security_groups_ids=None,
         placement_group=None,
+        tag_specifications=None,
     ):
         """Test Compute Resource Instance Configuration."""
         vcpus = compute_resource_section.get_param_value("vcpus")
@@ -172,4 +186,5 @@ class HITClusterModel(ClusterModel):
             Placement=placement_group,
             NetworkInterfaces=network_interfaces,
             DryRun=True,
+            TagSpecifications=tag_specifications,
         )

--- a/cli/src/pcluster/models/sit/sit_cluster_model.py
+++ b/cli/src/pcluster/models/sit/sit_cluster_model.py
@@ -121,6 +121,17 @@ class SITClusterModel(ClusterModel):
                 use_public_ips=vpc_section.get_param_value("use_public_ips"),
             )
 
+            tags = cluster_section.get_param_value("tags")
+            if tags:
+                tag_specifications = [
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": key, "Value": value} for key, value in tags.items()],
+                    }
+                ]
+            else:
+                tag_specifications = []
+
             # Test head node configuration
             self._ec2_run_instance(
                 pcluster_config,
@@ -132,6 +143,7 @@ class SITClusterModel(ClusterModel):
                 NetworkInterfaces=head_node_network_interfaces,
                 Placement=head_node_placement_group,
                 DryRun=True,
+                TagSpecifications=tag_specifications,
             )
 
             compute_network_interfaces_count = int(cluster_section.get_param_value("network_interfaces_count")[1])
@@ -158,6 +170,7 @@ class SITClusterModel(ClusterModel):
                 Placement=compute_placement_group,
                 NetworkInterfaces=network_interfaces,
                 DryRun=True,
+                TagSpecifications=tag_specifications,
             )
         except ClientError:
             pcluster_config.error("Unable to validate configuration parameters.")


### PR DESCRIPTION
This change is motivated by users whose organizational security policies
require certain tags to be present when they're attempting to launch
instances. Without this change, the dry run performed as part of
validation would fail, and the CLI would incorrectly tell the customer
that there's an issue with their configuration file.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
