### PR TITLE
Include tags in RunInstances dry run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ CHANGELOG
 3.0.1
 ------
 
+**CHANGES**
+- Include tags from cluster configuration file in the RunInstances dry runs performed during configuration validation.
+
 **ENHANCEMENTS**
 - The region parameter is now retrieved from the provider chain, thus supporting the use of profiles and defaults specified
 in the `~/.aws/config` file.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -972,7 +972,9 @@ class BaseClusterConfig(Resource):
             SubnetsValidator, subnet_ids=self.compute_subnet_ids + [self.head_node.networking.subnet_id]
         )
         self._register_storage_validators()
-        self._register_validator(HeadNodeLaunchTemplateValidator, head_node=self.head_node, ami_id=self.head_node_ami)
+        self._register_validator(
+            HeadNodeLaunchTemplateValidator, head_node=self.head_node, ami_id=self.head_node_ami, tags=self.tags
+        )
 
         if self.head_node.dcv:
             self._register_validator(
@@ -1523,7 +1525,7 @@ class SlurmClusterConfig(BaseClusterConfig):
 
         for queue in self.scheduling.queues:
             self._register_validator(
-                ComputeResourceLaunchTemplateValidator, queue=queue, ami_id=self.image_dict[queue.name]
+                ComputeResourceLaunchTemplateValidator, queue=queue, ami_id=self.image_dict[queue.name], tags=self.tags
             )
             queue_image = self.image_dict[queue.name]
             if queue_image not in checked_images and queue.queue_ami:


### PR DESCRIPTION
This change is motivated by users whose organizational security policies
require certain tags to be present when they're attempting to launch
instances. Without this change, the dry run performed as part of
validation would fail, and the CLI would incorrectly tell the customer
that there's an issue with their configuration file.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
