### PR TITLE
[release-2.11] Make enable_efa_gdr a no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ CHANGELOG
   - Outdated CA certificates used by Cinc. Update ca-certificates package during AMI build time.
 - Fix cluster update when using proxy setup.
 - Upgrade EFA installer to version 1.14.1. Thereafter, EFA enables GDR support by default on supported instance type(s).
-  ParallelCluster does not reinstall EFA during node start. Previously, EFA was reinstalled if `enable_efa_gdr` had been
-  turned on in the configuration file.
+  ParallelCluster does not reinstall EFA during node start.
+  Previously, EFA was reinstalled if `enable_efa_gdr` had been turned on in the configuration file.
+  The `enable_efa_gdr` parameter has no effect and should no longer be used.
   - EFA configuration: ``efa-config-1.9-1``
   - EFA profile: ``efa-profile-1.5-1``
   - EFA kernel module: ``efa-1.14.2``

--- a/cli/src/pcluster/config/hit_converter.py
+++ b/cli/src/pcluster/config/hit_converter.py
@@ -82,7 +82,7 @@ class HitConverter:
                 self._copy_param_value(
                     sit_cluster_section.get_param("enable_efa_gdr"),
                     queue_section.get_param("enable_efa_gdr"),
-                    "compute" == sit_cluster_section.get_param("enable_efa_gdr").value,
+                    "compute" == sit_cluster_section.get_param("enable_efa_gdr").value or None,
                 )
                 self._copy_param_value(
                     sit_cluster_section.get_param("placement_group"), queue_section.get_param("placement_group")

--- a/cli/src/pcluster/config/json_param_types.py
+++ b/cli/src/pcluster/config/json_param_types.py
@@ -266,13 +266,6 @@ class QueueJsonSection(JsonSection):
             # None value at cluster level is converted to False at queue level
             self.get_param("enable_efa").value = cluster_enable_efa == "compute"
 
-        if self.get_param_value("enable_efa_gdr") is None:
-            cluster_enable_efa_gdr = self.pcluster_config.get_section("cluster").get_param_value("enable_efa_gdr")
-
-            # enable_efa_gdr is of string type in cluster section and of bool type in queue section.
-            # None value at cluster level is converted to False at queue level
-            self.get_param("enable_efa_gdr").value = cluster_enable_efa_gdr == "compute"
-
         compute_resource_labels = self.get_param("compute_resource_settings").referred_section_labels
         if compute_resource_labels:
             for compute_resource_label in compute_resource_labels:
@@ -310,13 +303,6 @@ class QueueJsonSection(JsonSection):
             enable_efa = self.get_param_value("enable_efa")
             compute_resource_section.get_param("enable_efa").value = (
                 enable_efa and instance_type_info.is_efa_supported()
-            )
-
-            # Set enable_efa_gdr according to queues' enable_efa_gdr and instance features
-            # Instance type must support EFA and have GPUs
-            enable_efa_gdr = self.get_param_value("enable_efa_gdr")
-            compute_resource_section.get_param("enable_efa_gdr").value = (
-                enable_efa_gdr and instance_type_info.is_efa_supported() and (gpus > 0)
             )
 
             # Set disable_hyperthreading according to queues' disable_hyperthreading and instance features

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -732,10 +732,8 @@ COMPUTE_RESOURCE = {
         }),
         ("enable_efa_gdr", {
             "type": BooleanJsonParam,
-            # This param is managed automatically
-            "update_policy": UpdatePolicy.IGNORED,
-            "visibility": Visibility.PRIVATE,
-            "default": False
+            "validators": [efa_gdr_validator],
+            "update_policy": UpdatePolicy.IGNORED
         }),
         ("disable_hyperthreading", {
             "type": BooleanJsonParam,
@@ -774,7 +772,8 @@ QUEUE = {
         }),
         ("enable_efa_gdr", {
             "type": BooleanJsonParam,
-            "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP,
+            "validators": [efa_gdr_validator],
+            "update_policy": UpdatePolicy.IGNORED,
         }),
         ("disable_hyperthreading", {
             "type": BooleanJsonParam,
@@ -889,7 +888,6 @@ CLUSTER_COMMON_PARAMS = [
     }),
     ("enable_efa_gdr", {
         "allowed_values": ["compute"],
-        "cfn_param_mapping": "EFAGDR",
         "validators": [efa_gdr_validator],
         "update_policy": UpdatePolicy.UNSUPPORTED
     }),

--- a/cli/src/pcluster/config/param_types.py
+++ b/cli/src/pcluster/config/param_types.py
@@ -164,11 +164,18 @@ class Param(ABC):
                         )
                     )
                 elif warnings:
-                    self.pcluster_config.warn(
-                        "The configuration parameter '{0}' generated the following warnings:\n{1}".format(
-                            self.key, "\n".join(warnings)
+                    if warnings[0].startswith("INFO"):
+                        print(
+                            "The configuration parameter '{0}' generated the following infos:\n{1}".format(
+                                self.key, "\n".join(warnings)
+                            )
                         )
-                    )
+                    else:
+                        self.pcluster_config.warn(
+                            "The configuration parameter '{0}' generated the following warnings:\n{1}".format(
+                                self.key, "\n".join(warnings)
+                            )
+                        )
                 else:
                     LOGGER.debug("Configuration parameter '%s' is valid", self.key)
 

--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -508,9 +508,12 @@ def efa_gdr_validator(param_key, param_value, pcluster_config):
     errors = []
     warnings = []
 
-    cluster_section = pcluster_config.get_section("cluster")
-    if param_value and cluster_section.get_param_value("enable_efa") is None:
-        errors.append("The parameter '{0}' can be used only in combination with 'enable_efa'".format(param_key))
+    if param_value:
+        warnings.append(
+            "INFO: '{0}' is ignored because EFA enables GDR support by default on supported instance type(s).".format(
+                param_key
+            )
+        )
 
     return errors, warnings
 
@@ -1239,7 +1242,6 @@ def queue_validator(section_key, section_label, pcluster_config):
                 instance_types.append(instance_type)
 
             check_unsupported_feature(compute_resource, "EFA", "enable_efa")
-            check_unsupported_feature(compute_resource, "EFA GDR", "enable_efa_gdr")
 
     # Check that efa_gdr is used with enable_efa
     if queue_section.get_param_value("enable_efa_gdr") and not queue_section.get_param_value("enable_efa"):

--- a/cli/tests/pcluster/config/defaults.py
+++ b/cli/tests/pcluster/config/defaults.py
@@ -235,8 +235,8 @@ class DefaultDict(Enum):
 # ------------------ Default CFN parameters ------------------ #
 
 # number of CFN parameters created by the PclusterConfig object.
-CFN_SIT_CONFIG_NUM_OF_PARAMS = 64
-CFN_HIT_CONFIG_NUM_OF_PARAMS = 54
+CFN_SIT_CONFIG_NUM_OF_PARAMS = 63
+CFN_HIT_CONFIG_NUM_OF_PARAMS = 53
 
 # CFN parameters created by the pcluster CLI
 CFN_CLI_RESERVED_PARAMS = ["ArtifactS3RootDirectory", "RemoveBucketOnDeletion"]
@@ -299,7 +299,6 @@ DEFAULT_CLUSTER_SIT_CFN_PARAMS = {
     "S3ReadResource": "NONE",
     "S3ReadWriteResource": "NONE",
     "EFA": "NONE",
-    "EFAGDR": "NONE",
     "EphemeralDir": "/scratch",
     "EncryptedEphemeral": "false",
     "CustomAMI": "NONE",
@@ -371,7 +370,6 @@ DEFAULT_CLUSTER_HIT_CFN_PARAMS = {
     "S3ReadResource": "NONE",
     "S3ReadWriteResource": "NONE",
     "EFA": "NONE",
-    "EFAGDR": "NONE",
     "EphemeralDir": "/scratch",
     "EncryptedEphemeral": "false",
     "CustomAMI": "NONE",

--- a/cli/tests/pcluster/config/test_json_param_types/s3_config.json
+++ b/cli/tests/pcluster/config/test_json_param_types/s3_config.json
@@ -7,7 +7,7 @@
       "queue1": {
         "compute_type": "ondemand",
         "enable_efa": true,
-        "enable_efa_gdr": true,
+        "enable_efa_gdr": null,
         "disable_hyperthreading": true,
         "placement_group": null,
         "compute_resource_settings": {
@@ -24,7 +24,7 @@
             "disable_hyperthreading": true,
             "disable_hyperthreading_via_cpu_options": true,
             "network_interfaces": 1,
-            "enable_efa_gdr": false
+            "enable_efa_gdr": null
           },
           "q1-i2": {
             "instance_type": "g4dn.metal",
@@ -39,7 +39,7 @@
             "disable_hyperthreading": true,
             "disable_hyperthreading_via_cpu_options": false,
             "network_interfaces": 1,
-            "enable_efa_gdr": true
+            "enable_efa_gdr": null
           },
           "q1-i3": {
             "instance_type": "i3en.24xlarge",
@@ -54,7 +54,7 @@
             "disable_hyperthreading": true,
             "disable_hyperthreading_via_cpu_options": true,
             "network_interfaces": 1,
-            "enable_efa_gdr": false
+            "enable_efa_gdr": null
           },
           "q1-i4": {
             "instance_type": "t2.xlarge",
@@ -69,7 +69,7 @@
             "disable_hyperthreading": false,
             "disable_hyperthreading_via_cpu_options": false,
             "network_interfaces": 1,
-            "enable_efa_gdr": false
+            "enable_efa_gdr": null
           },
           "q1-i5": {
             "instance_type": "m6g.xlarge",
@@ -84,14 +84,14 @@
             "disable_hyperthreading": false,
             "disable_hyperthreading_via_cpu_options": false,
             "network_interfaces": 1,
-            "enable_efa_gdr": false
+            "enable_efa_gdr": null
           }
         }
       },
       "queue2": {
         "compute_type": "spot",
         "enable_efa": false,
-        "enable_efa_gdr": false,
+        "enable_efa_gdr": null,
         "disable_hyperthreading": false,
         "placement_group": "DYNAMIC",
         "compute_resource_settings": {
@@ -108,7 +108,7 @@
             "disable_hyperthreading": false,
             "disable_hyperthreading_via_cpu_options": false,
             "network_interfaces": 1,
-            "enable_efa_gdr": false
+            "enable_efa_gdr": null
           },
           "q2-i2": {
             "instance_type": "g4dn.metal",
@@ -123,7 +123,7 @@
             "disable_hyperthreading": false,
             "disable_hyperthreading_via_cpu_options": false,
             "network_interfaces": 1,
-            "enable_efa_gdr": false
+            "enable_efa_gdr": null
           },
           "q2-i3": {
             "instance_type": "i3en.24xlarge",
@@ -138,7 +138,7 @@
             "disable_hyperthreading": false,
             "disable_hyperthreading_via_cpu_options": false,
             "network_interfaces": 1,
-            "enable_efa_gdr": false
+            "enable_efa_gdr": null
           },
           "q2-i4": {
             "instance_type": "t2.xlarge",
@@ -153,7 +153,7 @@
             "disable_hyperthreading": false,
             "disable_hyperthreading_via_cpu_options": false,
             "network_interfaces": 1,
-            "enable_efa_gdr": false
+            "enable_efa_gdr": null
           },
           "q2-i5": {
             "instance_type": "m6g.xlarge",
@@ -168,14 +168,14 @@
             "disable_hyperthreading": false,
             "disable_hyperthreading_via_cpu_options": false,
             "network_interfaces": 1,
-            "enable_efa_gdr": false
+            "enable_efa_gdr": null
           }
         }
       },
       "queue3": {
         "compute_type": "spot",
         "enable_efa": true,
-        "enable_efa_gdr": true,
+        "enable_efa_gdr": null,
         "disable_hyperthreading": false,
         "placement_group": "DYNAMIC",
         "compute_resource_settings": {
@@ -192,7 +192,7 @@
             "disable_hyperthreading": false,
             "disable_hyperthreading_via_cpu_options": false,
             "network_interfaces": 1,
-            "enable_efa_gdr": false
+            "enable_efa_gdr": null
           },
           "q3-i2": {
             "instance_type": "p4d.24xlarge",
@@ -207,7 +207,7 @@
             "disable_hyperthreading": false,
             "disable_hyperthreading_via_cpu_options": false,
             "network_interfaces": 4,
-            "enable_efa_gdr": true
+            "enable_efa_gdr": null
           }
         }
       }

--- a/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_json_param_types/test_config_to_json/pcluster.config.ini
@@ -4,7 +4,6 @@ cluster_template = default
 [cluster default]
 queue_settings = {{queue_settings}}
 enable_efa = compute
-enable_efa_gdr = compute
 disable_cluster_dns = true
 # disable_hyperthreading not defined, fallback to False expected
 # disable_hyperthreading = false
@@ -18,7 +17,6 @@ enable = false
 compute_resource_settings = q1-i1,q1-i2,q1-i3,q1-i4,q1-i5
 compute_type = ondemand
 enable_efa = true
-enable_efa_gdr = true
 disable_hyperthreading = true
 
 [compute_resource q1-i1]
@@ -45,7 +43,6 @@ instance_type = m6g.xlarge
 compute_resource_settings = q2-i1, q2-i2,    q2-i3 ,q2-i4   ,q2-i5   # extra spaces added to check for labels stripping
 compute_type = spot
 enable_efa = false
-enable_efa_gdr = false
 disable_hyperthreading = false
 placement_group = DYNAMIC
 
@@ -72,8 +69,6 @@ compute_resource_settings = q3-i1, q3-i2
 compute_type = spot
 # enable_efa should be inherited from cluster section
 # enable_efa = true
-# enable_efa_gdr should be inherited from cluster section
-# enable_efa_gdr = true
 # disable_hyperthreading should be inherited from cluster section
 # disable_hyperthreading = false
 placement_group = DYNAMIC

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -1631,20 +1631,23 @@ def test_efa_validator(boto3_stubber, mocker, capsys, section_dict, expected_err
 
 
 @pytest.mark.parametrize(
-    "cluster_dict, expected_error",
+    "cluster_dict, expected_warning",
     [
         # EFAGDR without EFA
         (
             {"enable_efa_gdr": "compute"},
-            "The parameter 'enable_efa_gdr' can be used only in combination with 'enable_efa'",
+            "'enable_efa_gdr' is ignored because EFA enables GDR support by default.",
         ),
         # EFAGDR with EFA
-        ({"enable_efa": "compute", "enable_efa_gdr": "compute"}, None),
+        (
+            {"enable_efa": "compute", "enable_efa_gdr": "compute"},
+            "'enable_efa_gdr' is ignored because EFA enables GDR support by default.",
+        ),
         # EFA withoud EFAGDR
         ({"enable_efa": "compute"}, None),
     ],
 )
-def test_efa_gdr_validator(cluster_dict, expected_error):
+def test_efa_gdr_validator(cluster_dict, expected_warning):
     config_parser_dict = {
         "cluster default": cluster_dict,
     }
@@ -1656,10 +1659,10 @@ def test_efa_gdr_validator(cluster_dict, expected_error):
     enable_efa_gdr_value = pcluster_config.get_section("cluster").get_param_value("enable_efa_gdr")
 
     errors, warnings = efa_gdr_validator("enable_efa_gdr", enable_efa_gdr_value, pcluster_config)
-    if expected_error:
-        assert_that(errors[0]).matches(expected_error)
+    if expected_warning:
+        assert_that(warnings[0]).matches(expected_warning)
     else:
-        assert_that(errors).is_empty()
+        assert_that(warnings).is_empty()
 
 
 @pytest.mark.parametrize(
@@ -2017,12 +2020,8 @@ def test_queue_settings_validator(mocker, cluster_section_dict, expected_message
             [
                 "EFA was enabled on queue 'default', but instance type 't2.micro' "
                 "defined in compute resource settings cr2 does not support EFA.",
-                "EFA GDR was enabled on queue 'default', but instance type 't2.micro' "
-                "defined in compute resource settings cr2 does not support EFA GDR.",
                 "EFA was enabled on queue 'default', but instance type 'c4.xlarge' "
                 "defined in compute resource settings cr4 does not support EFA.",
-                "EFA GDR was enabled on queue 'default', but instance type 'c4.xlarge' "
-                "defined in compute resource settings cr4 does not support EFA GDR.",
             ],
         ),
         (

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_unexisting_instance_type/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_unexisting_instance_type/pcluster.config.ini
@@ -24,7 +24,6 @@ ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
 
 [queue compute]
 enable_efa = false
-enable_efa_gdr = false
 compute_resource_settings = default
 
 [compute_resource default]

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.ini
@@ -25,7 +25,6 @@ use_public_ips = false
 
 [queue compute]
 enable_efa = false
-enable_efa_gdr = false
 compute_resource_settings = default
 
 [compute_resource default]

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.ini
@@ -23,7 +23,6 @@ master_subnet_id = subnet-12345678
 
 [queue compute]
 enable_efa = false
-enable_efa_gdr = false
 compute_resource_settings = default
 
 [compute_resource default]

--- a/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/pcluster.config.ini
+++ b/cli/tests/pcluster/configure/test_pcluster_configure/test_with_input_no_automation_no_errors_with_config_file/pcluster.config.ini
@@ -24,7 +24,6 @@ ssh = ssh {CFN_USER}@{MASTER_IP} {ARGS}
 
 [queue compute]
 enable_efa = false
-enable_efa_gdr = false
 compute_resource_settings = default
 
 [compute_resource default]

--- a/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_sit_full/expected_output.ini
+++ b/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_sit_full/expected_output.ini
@@ -84,7 +84,6 @@ queue_settings = compute
 [queue compute]
 compute_type = spot
 enable_efa = true
-enable_efa_gdr = false
 placement_group = DYNAMIC
 compute_resource_settings = default
 

--- a/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_sit_simple/expected_output.ini
+++ b/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_sit_simple/expected_output.ini
@@ -25,7 +25,6 @@ queue_settings = compute
 
 [queue compute]
 enable_efa = false
-enable_efa_gdr = false
 compute_resource_settings = default
 
 [compute_resource default]

--- a/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_unrelated_sections/expected_output.ini
+++ b/cli/tests/pcluster_config/test_pcluster_config_convert/test_slurm_unrelated_sections/expected_output.ini
@@ -84,7 +84,6 @@ queue_settings = compute
 [queue compute]
 compute_type = spot
 enable_efa = true
-enable_efa_gdr = false
 placement_group = DYNAMIC
 compute_resource_settings = default
 

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -355,11 +355,6 @@
       "Type": "String",
       "Default": "NONE"
     },
-    "EFAGDR": {
-      "Description": "Enable EFA GPUDirect Support on the compute nodes, enable_efa_gdr = compute",
-      "Type": "String",
-      "Default": "NONE"
-    },
     "DCVOptions": {
       "Description": "Comma separated list of NICE DCV related options, 3 parameters in total, [enabled,port,access_from]",
       "Type": "String",
@@ -3347,9 +3342,6 @@
           },
           "EFA": {
             "Ref": "EFA"
-          },
-          "EFAGDR": {
-            "Ref": "EFAGDR"
           },
           "BaseOS": {
             "Ref": "BaseOS"

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -358,8 +358,7 @@ Resources:
                         "cfn_cluster_user": "${OSUser}",
                         "enable_intel_hpc_platform": "${IntelHPCPlatform}",
                         "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}",
-                        "scheduler_queue_name": "{{ queue }}",
-                        "enable_efa_gdr": "{{ 'compute' if compute_resource.enable_efa_gdr else 'NONE' }}"
+                        "scheduler_queue_name": "{{ queue }}"
                       },
                       "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
                     }

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -32,8 +32,6 @@ Parameters:
     Type: String
   EFA:
     Type: String
-  EFAGDR:
-    Type: String
   BaseOS:
     Type: String
   OSUser:
@@ -470,7 +468,6 @@ Resources:
                         "cfn_cluster_user": "${OSUser}",
                         "enable_intel_hpc_platform": "${IntelHPCPlatform}",
                         "cfn_cluster_cw_logging_enabled": "${CWLoggingEnabled}",
-                        "enable_efa_gdr": "${EFAGDR}",
                         "instance_types_data": ${InstanceTypesData}
                       },
                       "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.ini
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.ini
@@ -15,11 +15,7 @@ queue_settings = efa-enabled
 [queue efa-enabled]
 compute_resource_settings = efa-enabled_i1
 enable_efa = true
-{% if instance == "p4d.24xlarge" %}
-enable_efa_gdr = true
-{% else %}
 placement_group = DYNAMIC
-{% endif %}
 
 [compute_resource efa-enabled_i1]
 instance_type = {{ instance }}

--- a/tests/integration-tests/tests/efa/test_efa/test_sit_efa/pcluster.config.ini
+++ b/tests/integration-tests/tests/efa/test_efa/test_sit_efa/pcluster.config.ini
@@ -15,9 +15,6 @@ initial_queue_size = {{ max_queue_size }}
 maintain_initial_size = true
 max_queue_size = {{ max_queue_size }}
 enable_efa = compute
-{% if instance == "p4d.24xlarge" %}
-enable_efa_gdr = compute
-{% endif %}
 placement_group = DYNAMIC
 
 [vpc parallelcluster-vpc]

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/HIT.ini
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/HIT.ini
@@ -22,7 +22,6 @@ use_public_ips = false
 
 [queue compute]
 enable_efa = false
-enable_efa_gdr = false
 compute_resource_settings = default
 
 [compute_resource default]


### PR DESCRIPTION
Starting from EFA 1.14, GDR support is enabled by default. Therefore, this commit stops the parameter being passed to dna.json in CloudFormation. This commit also updates unit tests and integration tests accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
