### PR TITLE
Change SlurmQueues length and ComputeResources length schema validato…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ X.X.X
 **ENHANCEMENTS**
 - Add support for `UseEc2Hostnames` in the cluster configuration file. When set to `true`, use EC2 default hostnames (e.g. ip-1-2-3-4) for compute nodes.
 - Explicitly set cloud-init datasource to be EC2. This save boot time for Ubuntu and CentOS platforms.
+- Add support for multiple compute resources with same instance type per queue.
 
 **CHANGES**
 - Use compute resource name rather than instance type in compute fleet Launch Template name.
+- Change SlurmQueues length and ComputeResources length schema validators to be config validators. 
 
 3.0.1
 ------

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -32,6 +32,8 @@ from pcluster.constants import (
     EBS_VOLUME_SIZE_DEFAULT,
     EBS_VOLUME_TYPE_DEFAULT,
     EBS_VOLUME_TYPE_IOPS_DEFAULT,
+    MAX_NUMBER_OF_COMPUTE_RESOURCES,
+    MAX_NUMBER_OF_QUEUES,
     MAX_STORAGE_COUNT,
 )
 from pcluster.utils import get_partition, get_resource_name_from_resource_arn
@@ -49,7 +51,6 @@ from pcluster.validators.cluster_validators import (
     CustomAmiTagValidator,
     DcvValidator,
     DisableSimultaneousMultithreadingArchitectureValidator,
-    DuplicateInstanceTypeValidator,
     DuplicateMountDirValidator,
     DuplicateNameValidator,
     EfaOsArchitectureValidator,
@@ -65,6 +66,7 @@ from pcluster.validators.cluster_validators import (
     InstanceArchitectureCompatibilityValidator,
     IntelHpcArchitectureValidator,
     IntelHpcOsValidator,
+    MaxCountValidator,
     NameValidator,
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
@@ -1404,11 +1406,16 @@ class SlurmQueue(BaseQueue):
 
     def _register_validators(self):
         super()._register_validators()
-        self._register_validator(DuplicateInstanceTypeValidator, instance_type_list=self.instance_type_list)
         self._register_validator(
             DuplicateNameValidator,
             name_list=[compute_resource.name for compute_resource in self.compute_resources],
             resource_name="Compute resource",
+        )
+        self._register_validator(
+            MaxCountValidator,
+            resources_length=len(self.compute_resources),
+            max_length=MAX_NUMBER_OF_COMPUTE_RESOURCES,
+            resource_name="ComputeResources",
         )
         for compute_resource in self.compute_resources:
             self._register_validator(
@@ -1485,6 +1492,12 @@ class SlurmScheduling(Resource):
     def _register_validators(self):
         self._register_validator(
             DuplicateNameValidator, name_list=[queue.name for queue in self.queues], resource_name="Queue"
+        )
+        self._register_validator(
+            MaxCountValidator,
+            resources_length=len(self.queues),
+            max_length=MAX_NUMBER_OF_QUEUES,
+            resource_name="SlurmQueues",
         )
 
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -77,8 +77,6 @@ from pcluster.constants import (
     EBS_VOLUME_SIZE_DEFAULT,
     FSX_HDD_THROUGHPUT,
     FSX_SSD_THROUGHPUT,
-    MAX_NUMBER_OF_COMPUTE_RESOURCES,
-    MAX_NUMBER_OF_QUEUES,
     SUPPORTED_OSES,
 )
 from pcluster.schemas.common_schema import (
@@ -1040,7 +1038,6 @@ class SlurmQueueSchema(BaseQueueSchema):
     compute_resources = fields.Nested(
         SlurmComputeResourceSchema,
         many=True,
-        validate=validate.Length(max=MAX_NUMBER_OF_COMPUTE_RESOURCES),
         metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP, "update_key": "Name"},
     )
     custom_actions = fields.Nested(
@@ -1124,7 +1121,6 @@ class SchedulingSchema(BaseSchema):
     slurm_queues = fields.Nested(
         SlurmQueueSchema,
         many=True,
-        validate=validate.Length(max=MAX_NUMBER_OF_QUEUES),
         metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP, "update_key": "Name"},
     )
     # Awsbatch schema:

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -246,20 +246,16 @@ class NameValidator(Validator):
             self._add_failure(f"It is forbidden to use '{name}' as a name.", FailureLevel.ERROR)
 
 
-class DuplicateInstanceTypeValidator(Validator):
-    """
-    Instance type validator.
+class MaxCountValidator(Validator):
+    """Validate whether the number of resource exceeds the limits."""
 
-    Verify if there are duplicated instance types between compute resources in the same queue.
-    """
+    def _validate(self, resources_length, max_length, resource_name):
 
-    def _validate(self, instance_type_list):
-        duplicated_instance_types = _find_duplicate_params(instance_type_list)
-        if duplicated_instance_types:
+        if resources_length > max_length:
             self._add_failure(
-                "Instance {0} {1} cannot be specified for multiple compute resources in the same queue.".format(
-                    "types" if len(duplicated_instance_types) > 1 else "type",
-                    ", ".join(instance_type for instance_type in duplicated_instance_types),
+                "Invalid number of {resource_name} ({resources_length}) specified. Currently only supports "
+                "up to {max_length} {resource_name}.".format(
+                    resource_name=resource_name, resources_length=resources_length, max_length=max_length
                 ),
                 FailureLevel.ERROR,
             )

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -16,7 +16,6 @@ import yaml
 from assertpy import assert_that
 from marshmallow.validate import ValidationError
 
-from pcluster.constants import MAX_NUMBER_OF_COMPUTE_RESOURCES, MAX_NUMBER_OF_QUEUES
 from pcluster.schemas.cluster_schema import (
     ClusterSchema,
     HeadNodeIamSchema,
@@ -239,26 +238,12 @@ def dummy_slurm_compute_resource(name, instance_type):
             },
             None,
         ),
-        (  # beyond maximum slurm queue length
-            {
-                "Scheduler": "slurm",
-                "SlurmQueues": dummpy_slurm_queue_list(11),
-            },
-            f"Queue.*Longer than maximum length {MAX_NUMBER_OF_QUEUES}",
-        ),
         (  # maximum slurm queue length
             {
                 "Scheduler": "slurm",
                 "SlurmQueues": [dummy_slurm_queue("queue1", number_of_compute_resource=5)],
             },
             None,
-        ),
-        (  # beyond maximum slurm queue length
-            {
-                "Scheduler": "slurm",
-                "SlurmQueues": [dummy_slurm_queue("queue1", number_of_compute_resource=6)],
-            },
-            f"ComputeResources.*Longer than maximum length {MAX_NUMBER_OF_COMPUTE_RESOURCES}",
         ),
     ],
 )

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -114,9 +114,7 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
         cluster_validators + ".InstanceArchitectureCompatibilityValidator._validate", return_value=[]
     )
     name_validator = mocker.patch(cluster_validators + ".NameValidator._validate", return_value=[])
-    duplicate_instance_type_validator = mocker.patch(
-        cluster_validators + ".DuplicateInstanceTypeValidator._validate", return_value=[]
-    )
+    max_count_validator = mocker.patch(cluster_validators + ".MaxCountValidator._validate", return_value=[])
     fsx_architecture_os_validator = mocker.patch(
         cluster_validators + ".FsxArchitectureOsValidator._validate", return_value=[]
     )
@@ -203,8 +201,12 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
         ],
         any_order=True,
     )
-    duplicate_instance_type_validator.assert_has_calls(
-        [call(instance_type_list=["c5.2xlarge", "c4.2xlarge"]), call(instance_type_list=["c5.4xlarge", "c4.4xlarge"])],
+    max_count_validator.assert_has_calls(
+        [
+            call(max_length=10, resource_name="SlurmQueues", resources_length=2),
+            call(max_length=5, resource_name="ComputeResources", resources_length=2),
+            call(max_length=5, resource_name="ComputeResources", resources_length=2),
+        ],
         any_order=True,
     )
     key_pair_validator.assert_has_calls([call(key_name="ec2-key-name")])

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -22,7 +22,6 @@ from pcluster.validators.cluster_validators import (
     ComputeResourceSizeValidator,
     DcvValidator,
     DisableSimultaneousMultithreadingArchitectureValidator,
-    DuplicateInstanceTypeValidator,
     DuplicateMountDirValidator,
     EfaOsArchitectureValidator,
     EfaPlacementGroupValidator,
@@ -35,6 +34,7 @@ from pcluster.validators.cluster_validators import (
     InstanceArchitectureCompatibilityValidator,
     IntelHpcArchitectureValidator,
     IntelHpcOsValidator,
+    MaxCountValidator,
     NameValidator,
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
@@ -121,21 +121,28 @@ def test_compute_resource_size_validator(min_count, max_count, expected_message)
 
 
 @pytest.mark.parametrize(
-    "instance_type_list, expected_message",
+    "resource_name, resources_length, max_length, expected_message",
     [
-        (["i1"], None),
-        (["i1", "i2"], None),
-        (["i1", "i2", "i3"], None),
-        (["i1", "i1", "i2"], "Instance type i1 cannot be specified for multiple compute resources"),
+        ("SlurmQueues", 5, 10, None),
+        ("ComputeResources", 4, 5, None),
         (
-            ["i1", "i2", "i3", "i2", "i1"],
-            "Instance types i2, i1 cannot be specified for multiple compute resources",
+            "SlurmQueues",
+            11,
+            10,
+            "Invalid number of SlurmQueues (11) specified. Currently only supports up to 10 SlurmQueues.",
+        ),
+        (
+            "ComputeResources",
+            6,
+            5,
+            "Invalid number of ComputeResources (6) specified. Currently only supports up to 5 ComputeResources.",
         ),
     ],
 )
-def test_duplicate_instance_type_validator(instance_type_list, expected_message):
-    instance_type_param_list = [instance_type for instance_type in instance_type_list]
-    actual_failures = DuplicateInstanceTypeValidator().execute(instance_type_param_list)
+def test_max_count_validator(resource_name, resources_length, max_length, expected_message):
+    actual_failures = MaxCountValidator().execute(
+        resource_name=resource_name, resources_length=resources_length, max_length=max_length
+    )
     assert_failure_messages(actual_failures, expected_message)
 
 


### PR DESCRIPTION
…rs to be config validators

* Change SlurmQueues length and ComputeResources length schema validators to be config validators.
* Allow multiple compute resources with same instance type per queue.

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
