### PR TITLE
[develop] Remove run_list and prefer using --override-runlist param

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -82,8 +82,7 @@ write_files:
           "custom_awsbatchcli_package": "${CustomAwsBatchCliPackage}",
           "use_private_hostname": "${UsePrivateHostname}",
           "head_node_private_ip": "${HeadNodePrivateIp}"
-        },
-        "run_list": "recipe[aws-parallelcluster::${Scheduler}_config]"
+        }
       }
   - path: /etc/chef/client.rb
     permissions: '0644'
@@ -168,7 +167,7 @@ jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .clus
   pushd /etc/chef &&
   chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::init &&
   /opt/parallelcluster/scripts/fetch_and_run -preinstall &&
-  chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json &&
+  chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::config &&
   /opt/parallelcluster/scripts/fetch_and_run -postinstall &&
   chef-client --local-mode --config /etc/chef/client.rb --log_level auto --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::finalize &&
   popd

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -990,7 +990,6 @@ class ClusterCdkStack(Stack):
                     if self._condition_is_slurm()
                     else "false",
                 },
-                "run_list": f"recipe[aws-parallelcluster::{self.config.scheduling.scheduler}_config]",
             },
             indent=4,
         )
@@ -1100,7 +1099,8 @@ class ClusterCdkStack(Stack):
                         "command": (
                             "chef-client --local-mode --config /etc/chef/client.rb --log_level info "
                             "--logfile /var/log/chef-client.log --force-formatter --no-color "
-                            "--chef-zero-port 8889 --json-attributes /etc/chef/dna.json"
+                            "--chef-zero-port 8889 --json-attributes /etc/chef/dna.json "
+                            "--override-runlist aws-parallelcluster::config"
                         ),
                         "cwd": "/etc/chef",
                     }

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
@@ -39,6 +39,5 @@
     "stack_name": "clustername",
     "volume": "NONE",
     "use_private_hostname": "false"
-  },
-  "run_list": "recipe[aws-parallelcluster::awsbatch_config]"
+  }
 }

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
@@ -39,6 +39,5 @@
     "stack_name": "clustername",
     "volume": "NONE",
     "use_private_hostname": "false"
-  },
-  "run_list": "recipe[aws-parallelcluster::slurm_config]"
+  }
 }

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
@@ -39,6 +39,5 @@
     "stack_name": "clustername",
     "volume": "NONE",
     "use_private_hostname": "false"
-  },
-  "run_list": "recipe[aws-parallelcluster::slurm_config]"
+  }
 }


### PR DESCRIPTION
Remove run_list from dna.json and always call chef run setting runlist override with --override-runlist

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
