### PR TITLE
Remove "-" from compute resources from launch template name

### DIFF
--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -515,8 +515,8 @@ class SlurmConstruct(Construct):
 
         ec2.CfnLaunchTemplate(
             self.stack_scope,
-            f"LaunchTemplate{create_hash_suffix(queue.name + compute_resource.name)}",
-            launch_template_name=f"{self.stack_name}-{queue.name}-{compute_resource.name}",
+            f"LaunchTemplate{create_hash_suffix(queue.name + compute_resource.name.replace('-', ''))}",
+            launch_template_name=f"{self.stack_name}-{queue.name}-{compute_resource.name.replace('-', '')}",
             launch_template_data=ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
                 instance_type=instance_type,
                 cpu_options=ec2.CfnLaunchTemplate.CpuOptionsProperty(


### PR DESCRIPTION
In node package, launch template name is "LaunchTemplateName": f"{self._cluster_name}-{queue}-{compute_resource}",
{compute_resource} is retrieved from node_name, "-" inside compute_resource name will be removed in a nodename.
This patch remove "-" from {compute_resource} from launch template name to be aligned with node package.

