### PR TITLE
Redirect stderr and stdout to logfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ X.X.X
 - Use compute resource name rather than instance type in compute fleet Launch Template name.
 - Change SlurmQueues length and ComputeResources length schema validators to be config validators. 
 
+**BUG FIXES**
+- Redirect stderr and stdout to CLI log file to prevent unwanted text to pollute the pcluster CLI output.
+
 3.0.1
 ------
 

--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -35,6 +35,7 @@ import pcluster.cli.model
 from pcluster.api import encoder
 from pcluster.cli.commands.common import CliCommand, exit_msg, to_bool, to_int, to_number
 from pcluster.cli.exceptions import APIOperationException, ParameterException
+from pcluster.cli.logger import redirect_stdouterr_to_logger
 from pcluster.cli.middleware import add_additional_args, middleware_hooks
 from pcluster.utils import to_camel_case, to_snake_case
 
@@ -167,7 +168,8 @@ def add_cli_commands(parser_map):
 def _run_operation(model, args, extra_args):
     if args.operation in model:
         try:
-            return args.func(args)
+            with redirect_stdouterr_to_logger():
+                return args.func(args)
         except KeyboardInterrupt as e:
             raise e
         except APIOperationException as e:

--- a/cli/src/pcluster/cli/logger.py
+++ b/cli/src/pcluster/cli/logger.py
@@ -14,6 +14,7 @@
 
 import logging.config
 import os
+import sys
 
 from pcluster.utils import get_cli_log_file
 
@@ -40,11 +41,20 @@ def config_logger():
                 "maxBytes": 5 * 1024 * 1024,
                 "backupCount": 3,
             },
+            "console": {
+                "level": "DEBUG",
+                "formatter": "standard",
+                "class": "logging.StreamHandler",
+                "stream": sys.stdout,
+            },
         },
         "loggers": {
             "": {"handlers": ["default"], "level": "WARNING", "propagate": False},  # root logger
             "pcluster": {"handlers": ["default"], "level": "INFO", "propagate": False},
         },
     }
+    if os.environ.get("PCLUSTER_LOG_TO_STDOUT"):
+        for logger in logging_config["loggers"].values():
+            logger["handlers"] = ["console"]
     os.makedirs(os.path.dirname(logfile), exist_ok=True)
     logging.config.dictConfig(logging_config)

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -258,7 +258,8 @@ def error(message) -> NoReturn:
 
 
 def get_cli_log_file():
-    return os.path.expanduser(os.path.join("~", ".parallelcluster", "pcluster-cli.log"))
+    default_log_file = os.path.expanduser(os.path.join("~", ".parallelcluster", "pcluster-cli.log"))
+    return os.environ.get("PCLUSTER_LOG_FILE", default=default_log_file)
 
 
 def ellipsize(text, max_length):


### PR DESCRIPTION
* Log to stdout when PCLUSTER_LOG_TO_STDOUT env is set
* Override CLI log file name with PCLUSTER_LOG_FILE env variable
* Redirect stderr and stdout to logfile: this prevents unwanted text from polluting CLI output. For example prints executed by Python dependencies are now being redirected to log files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
