### PR TITLE
[release-3.0] Make GDRSupport a no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 CHANGELOG
 =========
 
+3.0.2
+-----
+
+**BUG FIXES**
+- Upgrade EFA installer to version 1.14.1. Thereafter, EFA enables GDR support by default on supported instance type(s).
+  ParallelCluster does not reinstall EFA during node start. Previously, EFA was reinstalled if `enable_efa_gdr` had been
+  turned on in the configuration file. The `GdrSupport` parameter has no effect and should no longer be used.
+  - EFA configuration: ``efa-config-1.9-1``
+  - EFA profile: ``efa-profile-1.5-1``
+  - EFA kernel module: ``efa-1.14.2``
+  - RDMA core: ``rdma-core-37.0``
+  - Libfabric: ``libfabric-1.13.2``
+  - Open MPI: ``openmpi40-aws-4.1.1-2``
+
 3.0.1
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Upgrade EFA installer to version 1.14.1. Thereafter, EFA enables GDR support by default on supported instance type(s).
-  ParallelCluster does not reinstall EFA during node start. Previously, EFA was reinstalled if `enable_efa_gdr` had been
+  ParallelCluster does not reinstall EFA during node start. Previously, EFA was reinstalled if `GdrSupport` had been
   turned on in the configuration file. The `GdrSupport` parameter has no effect and should no longer be used.
   - EFA configuration: ``efa-config-1.9-1``
   - EFA profile: ``efa-profile-1.5-1``

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -52,6 +52,7 @@ from pcluster.validators.cluster_validators import (
     DuplicateInstanceTypeValidator,
     DuplicateMountDirValidator,
     DuplicateNameValidator,
+    EfaGdrValidator,
     EfaOsArchitectureValidator,
     EfaPlacementGroupValidator,
     EfaSecurityGroupValidator,
@@ -489,7 +490,10 @@ class Efa(Resource):
     def __init__(self, enabled: bool = None, gdr_support: bool = None, **kwargs):
         super().__init__(**kwargs)
         self.enabled = enabled
-        self.gdr_support = Resource.init_param(gdr_support, default=False)
+        self.gdr_support = gdr_support
+
+    def _register_validators(self):
+        self._register_validator(EfaGdrValidator, gdr_support=self.gdr_support)
 
 
 # ---------------------- Monitoring ---------------------- #
@@ -1329,7 +1333,6 @@ class SlurmComputeResource(BaseComputeResource):
             EfaValidator,
             instance_type=self.instance_type,
             efa_enabled=self.efa.enabled,
-            gdr_support=self.efa.gdr_support,
         )
 
     @property

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -77,7 +77,6 @@ write_files:
           "enable_intel_hpc_platform": "${IntelHPCPlatform}",
           "cw_logging_enabled": "${CWLoggingEnabled}",
           "scheduler_queue_name": "${QueueName}",
-          "enable_efa_gdr": "${EnableEfaGdr}",
           "custom_node_package": "${CustomNodePackage}",
           "custom_awsbatchcli_package": "${CustomAwsBatchCliPackage}"
         },

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -612,7 +612,7 @@ class EfaSchema(BaseSchema):
     """Represent the schema of EFA for a Compute Resource."""
 
     enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
-    gdr_support = fields.Bool(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    gdr_support = fields.Bool(metadata={"update_policy": UpdatePolicy.IGNORED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -600,9 +600,6 @@ class SlurmConstruct(Construct):
                                 "IntelHPCPlatform": "true" if self.config.is_intel_hpc_platform_enabled else "false",
                                 "CWLoggingEnabled": "true" if self.config.is_cw_logging_enabled else "false",
                                 "QueueName": queue.name,
-                                "EnableEfaGdr": "compute"
-                                if compute_resource.efa and compute_resource.efa.gdr_support
-                                else "NONE",
                                 "CustomNodePackage": self.config.custom_node_package or "",
                                 "CustomAwsBatchCliPackage": self.config.custom_aws_batch_cli_package or "",
                                 "ExtraJson": self.config.extra_chef_attributes,

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -269,9 +269,9 @@ class DuplicateInstanceTypeValidator(Validator):
 
 
 class EfaValidator(Validator):
-    """Check if EFA and EFA GDR are supported features in the given instance type."""
+    """Check if EFA is supported feature in the given instance type."""
 
-    def _validate(self, instance_type, efa_enabled, gdr_support):
+    def _validate(self, instance_type, efa_enabled):
 
         instance_type_supports_efa = AWSApi.instance().ec2.get_instance_type_info(instance_type).is_efa_supported()
         if efa_enabled and not instance_type_supports_efa:
@@ -280,8 +280,6 @@ class EfaValidator(Validator):
             self._add_failure(
                 f"Instance type '{instance_type}' supports EFA, but it is not enabled.", FailureLevel.WARNING
             )
-        if gdr_support and not efa_enabled:
-            self._add_failure("The EFA GDR Support can be used only if EFA is enabled.", FailureLevel.ERROR)
 
 
 class EfaPlacementGroupValidator(Validator):
@@ -354,6 +352,18 @@ class EfaSecurityGroupValidator(Validator):
             except AWSClientError as e:
                 self._add_failure(str(e), FailureLevel.WARNING)
         return efa_sg_found
+
+
+class EfaGdrValidator(Validator):
+    """Hint that the GdrSupport has no effect."""
+
+    def _validate(self, gdr_support):
+        if gdr_support:
+            self._add_failure(
+                "The GDR Support setting is ignored because EFA enables GDR support by default "
+                "on supported instance type(s).",
+                FailureLevel.INFO,
+            )
 
 
 # --------------- Storage validators --------------- #

--- a/cli/src/pcluster3_config_converter/pcluster3_config_converter.py
+++ b/cli/src/pcluster3_config_converter/pcluster3_config_converter.py
@@ -934,8 +934,6 @@ class Pcluster3ConfigConverter(object):
         compute_resource["Name"] = compute_resource_name
         if self.cluster_config_get("enable_efa") == "compute":
             efa["Enabled"] = True
-        if self.cluster_config_get("enable_efa_gdr") == "compute":
-            efa["GdrSupport"] = True
 
         for item in [
             (compute_resource_section, "instance_type", compute_resource, "InstanceType"),
@@ -1005,8 +1003,6 @@ class Pcluster3ConfigConverter(object):
 
         if self.cluster_config_get("enable_efa") == "compute":
             efa["Enabled"] = True
-        if self.cluster_config_get("enable_efa_gdr") == "compute":
-            efa["GdrSupport"] = True
         _add_if(compute_resource, "Efa", efa)
         _append_if(compute_resources, compute_resource)
         _add_if(queue, "ComputeResources", compute_resources)

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -114,7 +114,6 @@ Scheduling:
           DisableSimultaneousMultithreading: true
           Efa:
             Enabled: true
-            GdrSupport: false
       Iam:
         InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
       Image:

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -145,8 +145,6 @@ def test_duplicate_instance_type_validator(instance_type_list, expected_message)
 @pytest.mark.parametrize(
     "instance_type, efa_enabled, gdr_support, efa_supported, expected_message",
     [
-        # EFAGDR without EFA
-        ("c5n.18xlarge", False, True, True, "GDR Support can be used only if EFA is enabled"),
         # EFAGDR with EFA
         ("c5n.18xlarge", True, True, True, None),
         # EFA without EFAGDR
@@ -171,7 +169,7 @@ def test_efa_validator(mocker, boto3_stubber, instance_type, efa_enabled, gdr_su
         ),
     )
 
-    actual_failures = EfaValidator().execute(instance_type, efa_enabled, gdr_support)
+    actual_failures = EfaValidator().execute(instance_type, efa_enabled)
     assert_failure_messages(actual_failures, expected_message)
     if efa_enabled:
         get_instance_type_info_mock.assert_called_with(instance_type)

--- a/cli/tests/pcluster3_config_converter/test_data.py
+++ b/cli/tests/pcluster3_config_converter/test_data.py
@@ -1278,7 +1278,6 @@ Scheduling:
         - DisableSimultaneousMultithreading: false
           Efa:
             Enabled: true
-            GdrSupport: true
           InstanceType: c5.xlarge
           MaxCount: 5
           Name: default-resource

--- a/cli/tests/pcluster3_config_converter/test_pcluster3_config_converter/test_pcluster3_config_converter/sit_full.yaml
+++ b/cli/tests/pcluster3_config_converter/test_pcluster3_config_converter/test_pcluster3_config_converter/sit_full.yaml
@@ -77,4 +77,3 @@ Scheduling:
           InstanceType: c5.xlarge
           Efa:
             Enabled: true
-            GdrSupport: true

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -25,7 +25,6 @@ Scheduling:
           MinCount: {{ max_queue_size }}
           Efa:
             Enabled: true
-            {% if instance == "p4d.24xlarge" %}GdrSupport: true{% endif %}
 SharedStorage:
   - MountDir: /shared
     Name: name1

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
@@ -30,7 +30,6 @@ Scheduling:
           InstanceType: {{ instance }}
           Efa:
             Enabled: false
-            GdrSupport: false
           {% endif %}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
@@ -29,7 +29,6 @@ Scheduling:
           InstanceType: {{ instance }}
           Efa:
             Enabled: false
-            GdrSupport: false
           {% endif %}
       {% if scheduler == "slurm" %}
       Iam:


### PR DESCRIPTION
Starting from EFA 1.14, GDR support is enabled by default. Therefore, this commit stops the parameter being passed to dna.json in CloudFormation. This commit also updates unit tests and integration tests accordingly.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
