### PR TITLE
[byos] merge develop into byos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ X.X.X
 - Use compute resource name rather than instance type in compute fleet Launch Template name.
 - Change SlurmQueues length and ComputeResources length schema validators to be config validators. 
 
+**BUG FIXES**
+- Redirect stderr and stdout to CLI log file to prevent unwanted text to pollute the pcluster CLI output.
+
 3.0.1
 ------
 

--- a/api/client/patch-client.sh
+++ b/api/client/patch-client.sh
@@ -11,3 +11,4 @@ cp client/resources/sigv4_auth.py client/src/pcluster_client
 patch -u -N client/src/pcluster_client/api_client.py < client/resources/api_client.py.diff
 patch -u -N client/src/requirements.txt < client/resources/client-requirements.txt.diff
 patch -u -N client/src/setup.py < client/resources/setup.py.diff
+patch -u -N client/src/README.md < client/resources/readme.md.diff

--- a/api/client/resources/readme.md.diff
+++ b/api/client/resources/readme.md.diff
@@ -1,0 +1,44 @@
+--- a/api/client/src/README.md
++++ b/api/client/src/README.md
+@@ -17,7 +17,7 @@ Python >= 3.6
+ If the python package is hosted on a repository, you can install directly using:
+
+ ```sh
+-pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git
++pip install git+https://github.com/aws/aws-parallelcluster.git#subdirectory=api/client/src
+ ```
+ (you may need to run `pip` with root permission: `sudo pip install git+https://github.com/GIT_USER_ID/GIT_REPO_ID.git`)
+
+@@ -60,27 +60,18 @@ from pcluster_client.model.update_compute_fleet_request_content import UpdateCom
+ from pcluster_client.model.update_compute_fleet_response_content import UpdateComputeFleetResponseContent
+ # Defining the host is optional and defaults to http://localhost
+ # See configuration.py for a list of all supported configuration parameters.
+-configuration = pcluster_client.Configuration(
+-    host = "http://localhost"
+-)
++configuration = pcluster_client.Configuration(host = "http://localhost") # Set the base URL of the ParallelCluster API
+
+-# The client must configure the authentication and authorization parameters
+-# in accordance with the API server security policy.
+-# Examples for each auth method are provided below, use the example that
+-# satisfies your auth use case.
+-
+-# Configure API key authorization: aws.auth.sigv4
+-configuration.api_key['aws.auth.sigv4'] = 'YOUR_API_KEY'
+-
+-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+-# configuration.api_key_prefix['aws.auth.sigv4'] = 'Bearer'
++# The client needs to authenticate with the ParallelCluster API server using SigV4.
++# Please ensure that your `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID`
++# are set appropriately for the client to authenticate using SigV4.
+
+
+ # Enter a context with an instance of the API client
+ with pcluster_client.ApiClient(configuration) as api_client:
+     # Create an instance of the API class
+     api_instance = cluster_compute_fleet_api.ClusterComputeFleetApi(api_client)
+-    cluster_name = "AqWzy" # str | Name of the cluster
++    cluster_name = "mycluster" # str | Name of the cluster
+ region = "region_example" # str | AWS Region that the operation corresponds to. (optional)
+
+     try:

--- a/api/client/src/.openapi-generator/FILES
+++ b/api/client/src/.openapi-generator/FILES
@@ -155,5 +155,4 @@ setup.cfg
 setup.py
 test-requirements.txt
 test/__init__.py
-test/test_list_official_images_response_content.py
 tox.ini

--- a/api/client/src/README.md
+++ b/api/client/src/README.md
@@ -60,10 +60,10 @@ from pcluster_client.model.update_compute_fleet_request_content import UpdateCom
 from pcluster_client.model.update_compute_fleet_response_content import UpdateComputeFleetResponseContent
 # Defining the host is optional and defaults to http://localhost
 # See configuration.py for a list of all supported configuration parameters.
-configuration = pcluster_client.Configuration(host = "http://localhost") # Set the base URL of the ParallelCluster API 
+configuration = pcluster_client.Configuration(host = "http://localhost") # Set the base URL of the ParallelCluster API
 
 # The client needs to authenticate with the ParallelCluster API server using SigV4.
-# Please ensure that your `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` 
+# Please ensure that your `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID`
 # are set appropriately for the client to authenticate using SigV4.
 
 

--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -35,6 +35,7 @@ import pcluster.cli.model
 from pcluster.api import encoder
 from pcluster.cli.commands.common import CliCommand, exit_msg, to_bool, to_int, to_number
 from pcluster.cli.exceptions import APIOperationException, ParameterException
+from pcluster.cli.logger import redirect_stdouterr_to_logger
 from pcluster.cli.middleware import add_additional_args, middleware_hooks
 from pcluster.utils import to_camel_case, to_snake_case
 
@@ -167,7 +168,8 @@ def add_cli_commands(parser_map):
 def _run_operation(model, args, extra_args):
     if args.operation in model:
         try:
-            return args.func(args)
+            with redirect_stdouterr_to_logger():
+                return args.func(args)
         except KeyboardInterrupt as e:
             raise e
         except APIOperationException as e:

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -271,7 +271,8 @@ def error(message) -> NoReturn:
 
 
 def get_cli_log_file():
-    return os.path.expanduser(os.path.join("~", ".parallelcluster", "pcluster-cli.log"))
+    default_log_file = os.path.expanduser(os.path.join("~", ".parallelcluster", "pcluster-cli.log"))
+    return os.environ.get("PCLUSTER_LOG_FILE", default=default_log_file)
 
 
 def ellipsize(text, max_length):


### PR DESCRIPTION
Fix API client generation by embedding customizations in diff files

Signed-off-by: Francesco De Martino <fdm@amazon.com>

Log to stdout when PCLUSTER_LOG_TO_STDOUT env is set

Facilitates development and debugging
For example you can do: `PCLUSTER_LOG_TO_STDOUT=1 pcluster list-clusters`

Signed-off-by: Francesco De Martino <fdm@amazon.com>

Override CLI log file name with PCLUSTER_LOG_FILE env variable

Signed-off-by: Francesco De Martino <fdm@amazon.com>

Redirect stderr and stdout to logfile

This prevents dependencies to print unwanted output to console

Signed-off-by: Francesco De Martino <fdm@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
