### PR TITLE
[release-2.11] Revert "Disable createami test for alinux2"

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -99,7 +99,7 @@ createami:
     dimensions:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1804"] # temporary disable FPGA AMI since there is not enough free space on root partition, disable alinux2 due to endpoint from where SGE source is downloaded is down
+        oss: ["alinux2", "ubuntu1804"] # temporary disable FPGA AMI since there is not enough free space on root partition
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"] # alinux2 temporarily disabled due to incompatible device name


### PR DESCRIPTION
Reverts aws/aws-parallelcluster#3362