### PR TITLE
Upgrade to Slurm21.08.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ X.X.X
 **CHANGES**
 - Use compute resource name rather than instance type in compute fleet Launch Template name.
 - Change SlurmQueues length and ComputeResources length schema validators to be config validators. 
+- Upgrade Slurm to version 21.08.3.
 
 **BUG FIXES**
 - Redirect stderr and stdout to CLI log file to prevent unwanted text to pollute the pcluster CLI output.

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -837,7 +837,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
 def _test_slurm_version(remote_command_executor):
     logging.info("Testing Slurm Version")
     version = remote_command_executor.run_remote_command("sinfo -V").stdout
-    assert_that(version).is_equal_to("slurm 20.11.8")
+    assert_that(version).is_equal_to("slurm 21.08.3")
 
 
 def _test_job_dependencies(slurm_commands, region, stack_name, scaledown_idletime):

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -705,7 +705,7 @@ def _test_cluster_gpu_limits(slurm_commands, partition, instance_type, max_count
             "command": "sleep 1",
             "partition": partition,
             "constraint": instance_type,
-            "other_options": "--gpus-per-task {0}".format(gpu_per_instance + 1),
+            "other_options": "--gpus-per-task {0} -n 1".format(gpu_per_instance + 1),
             "raise_on_error": False,
         },
     )
@@ -725,7 +725,7 @@ def _test_cluster_gpu_limits(slurm_commands, partition, instance_type, max_count
             "command": "sleep 1",
             "partition": partition,
             "constraint": instance_type,
-            "other_options": "-G:{0}".format(gpu_per_instance * max_count + 1),
+            "other_options": "-G {0}".format(gpu_per_instance * max_count + 1),
             "raise_on_error": False,
         },
     )
@@ -739,6 +739,7 @@ def _test_cluster_gpu_limits(slurm_commands, partition, instance_type, max_count
             "other_options": "-G 1 --cpus-per-gpu 32 --cpus-per-task 20",
             "raise_on_error": False,
         },
+        reason="sbatch: error: --cpus-per-gpu is mutually exclusive with --cpus-per-task",
     )
 
     # Commands below should be correctly submitted
@@ -799,10 +800,12 @@ def _test_cluster_limits(slurm_commands, partition, instance_type, max_count, cp
     )
 
 
-def _submit_command_and_assert_job_rejected(slurm_commands, submit_command_args):
+def _submit_command_and_assert_job_rejected(
+    slurm_commands, submit_command_args, reason="sbatch: error: Batch job submission failed:"
+):
     """Submit a limit-violating job and assert the job is failed at submission."""
     result = slurm_commands.submit_command(**submit_command_args)
-    assert_that(result.stdout).contains("sbatch: error: Batch job submission failed:")
+    assert_that(result.stdout).contains(reason)
 
 
 def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_info):
@@ -819,7 +822,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
         }
     )
     job_info = slurm_commands.get_job_info(job_id)
-    assert_that(job_info).contains("TresPerJob=gpu:1", f"CpusPerTres=gpu:{cpus_per_gpu}")
+    assert_that(job_info).contains("TresPerJob=gres:gpu:1", f"CpusPerTres=gres:gpu:{cpus_per_gpu}")
 
     gpus_per_instance = _get_num_gpus_on_instance(instance_type_info)
     job_id = slurm_commands.submit_command_and_assert_job_accepted(
@@ -831,7 +834,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
         }
     )
     job_info = slurm_commands.get_job_info(job_id)
-    assert_that(job_info).contains(f"TresPerNode=gpu:{gpus_per_instance}", f"CpusPerTres=gpu:{cpus_per_gpu}")
+    assert_that(job_info).contains(f"TresPerNode=gres:gpu:{gpus_per_instance}", f"CpusPerTres=gres:gpu:{cpus_per_gpu}")
 
 
 def _test_slurm_version(remote_command_executor):
@@ -996,7 +999,14 @@ def _wait_for_partition_state_changed(scheduler_commands, partition, desired_sta
 def _update_and_start_cluster(cluster, config_file):
     cluster.stop()
     _wait_for_computefleet_changed(cluster, "STOPPED")
+    # After cluster stop, add time sleep here to wait longer than SuspendTimeout for nodes turn from
+    # powering down(%) to power save(~) to avoid the problem in slurm 21.08.3 before cluster update
+    time.sleep(150)
     cluster.update(str(config_file), force_update="true")
+    # During cluster update, slurmctld will be restart and clustermgtd restart, nodes will be up during slurmctld
+    # restart,and powered down when clustermgtd start. Add time sleep here to wait longer than SuspendTimeout for
+    # nodes turn from powering down(% to power save(~) to avoid the problem in slurm 21.08.3
+    time.sleep(150)
     cluster.start()
     _wait_for_computefleet_changed(cluster, "RUNNING")
 


### PR DESCRIPTION
* `sbatch -G:n` is not valid in slurm21, change it to be `sbatch -G n`
* `--gpus-per-task` need to be specify with either `--gpus` or `-n/--ntasks`
* Some error message changes
    * When submit job with mutually exclusive options, error message in slurm20 is `sbatch: error: Batch job submission failed:`. Error message in slurm21 is `sbatch: error: --cpus-per-gpu is mutually exclusive with —cpus-per-task`


* job info in slurm20: `TresPerNode=gpu:{gpus_per_instance}, CpusPerTres=gpu:{cpus_per_gpu}` become `TresPerNode=gres:gpu:{gpus_per_instance}, CpusPerTres=gres:gpu:{cpus_per_gpu}` in slurm21
* Add time sleep before cluster update and after cluster update for the powering down node issue found in slurm21