### PR TITLE
[LTS] Use c5.large instead of t2.micro in update tests

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -177,7 +177,7 @@ def test_update_hit(region, scheduler, pcluster_config_reader, clusters_factory,
                     "disable_hyperthreading": False,
                 },
                 "queue1_i2": {
-                    "instance_type": "t2.micro",
+                    "instance_type": "c5.large",
                     "expected_running_instances": 1,
                     "expected_power_saved_instances": 9,
                     "enable_efa": False,
@@ -214,9 +214,9 @@ def test_update_hit(region, scheduler, pcluster_config_reader, clusters_factory,
     cluster.config_file = str(updated_config_file)
     cluster.update()
 
-    # Here is the expected list of nodes. Note that queue1-dy-t2micro-1 comes from the initial_count set when creating
+    # Here is the expected list of nodes. Note that queue1-dy-c5large-1 comes from the initial_count set when creating
     # the cluster:
-    # queue1-dy-t2micro-1
+    # queue1-dy-c5large-1
     # queue1-st-c5xlarge-1
     # queue1-st-c5xlarge-2
     assert_initial_conditions(slurm_commands, 2, 1, partition="queue1")
@@ -239,7 +239,7 @@ def test_update_hit(region, scheduler, pcluster_config_reader, clusters_factory,
                     "enable_efa": False,
                 },
                 "queue1_i3": {
-                    "instance_type": "t2.micro",
+                    "instance_type": "c5.large",
                     "expected_running_instances": 1,  # This comes from initial_count before update
                     "expected_power_saved_instances": 9,
                     "disable_hyperthreading": False,

--- a/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.ini
@@ -42,7 +42,7 @@ min_count = 1
 max_count = 2
 
 [compute_resource queue1_i2]
-instance_type = t2.micro
+instance_type = c5.large
 initial_count = 1
 
 [queue queue2]

--- a/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_hit/pcluster.config.update.ini
@@ -45,7 +45,7 @@ instance_type = c5.2xlarge
 spot_price = 2.1
 
 [compute_resource queue1_i3]
-instance_type = t2.micro
+instance_type = c5.large
 
 [queue queue2]
 compute_resource_settings = queue2_i1


### PR DESCRIPTION
This is done to avoid failures related to slurmctld not being able to
contact t2.micro compute nodes because of that instance type's limited
networking capabilities.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
