### PR TITLE
Added toggle for EnhancedImageMetadataEnabled in imagebuilder config

### DIFF
--- a/cli/src/pcluster/config/imagebuilder_config.py
+++ b/cli/src/pcluster/config/imagebuilder_config.py
@@ -56,11 +56,13 @@ class Image(Resource):
         name: str = None,
         tags: List[BaseTag] = None,
         root_volume: Volume = None,
+        enhanced_image_metadata_enabled: bool = None
     ):
         super().__init__()
         self.name = name
         self.tags = tags
         self.root_volume = root_volume
+        self.enhanced_image_metadata_enabled = Resource.init_param(enhanced_image_metadata_enabled, default=True)
 
 
 # ---------------------- Build ---------------------- #

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -67,6 +67,7 @@ class ImageSchema(BaseSchema):
     )
     tags = fields.List(fields.Nested(TagSchema))
     root_volume = fields.Nested(VolumeSchema)
+    enhanced_image_metadata_enabled = fields.Bool()
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -290,7 +290,7 @@ class ImageBuilderCdkStack(Stack):
             image_recipe_arn=Fn.ref("ImageRecipe"),
             infrastructure_configuration_arn=Fn.ref("InfrastructureConfiguration"),
             distribution_configuration_arn=Fn.ref("DistributionConfiguration"),
-            enhanced_image_metadata_enabled=self.config.image.enhanced_image_metadata_enabled,
+            enhanced_image_metadata_enabled=self.config.image.enhanced_image_metadata_enabled if self.config.image else True
         )
         if not self.custom_cleanup_lambda_role:
             self._add_resource_delete_policy(

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -290,6 +290,7 @@ class ImageBuilderCdkStack(Stack):
             image_recipe_arn=Fn.ref("ImageRecipe"),
             infrastructure_configuration_arn=Fn.ref("InfrastructureConfiguration"),
             distribution_configuration_arn=Fn.ref("DistributionConfiguration"),
+            enhanced_image_metadata_enabled=self.config.image.enhanced_image_metadata_enabled,
         )
         if not self.custom_cleanup_lambda_role:
             self._add_resource_delete_policy(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Pcluster `create-image` config files are missing [enhancedImageMetadataEnabled](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-image.html#cfn-imagebuilder-image-enhancedimagemetadataenabled). This allows us to disable inventory collection in cases where SSM inventory conflicts with imagebuilder and causes builds to fail. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
