### PR TITLE
Add support to specify SchedulerDefinition as an HTTPS or S3 url

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -537,6 +537,7 @@ class Cluster:
             rendered_template = template.render(
                 cluster_configuration=ClusterSchema(cluster_name=self.name).dump(deepcopy(self.config)),
                 cluster_name=self.name,
+                instance_types_info=self.config.get_instance_types_data(),
             )
         except Exception as e:
             raise BadRequestClusterActionError(

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -648,6 +648,7 @@ class TestCluster:
         cluster_config_mock.return_value.scheduling.settings.scheduler_definition.cluster_infrastructure.cloud_formation.template = (  # noqa
             template_url
         )
+        cluster_config_mock.return_value.get_instance_types_data.return_value = {"t2.micro": "instance_info"}
         upload_cfn_template_mock = mocker.patch.object(cluster.bucket, "upload_cfn_template", autospec=True)
 
         cluster._render_and_upload_scheduler_plugin_template()


### PR DESCRIPTION
* Add support to specify SchedulerDefinition as an HTTPS or S3 url
* Pass instance types info as input to Jinja rendering

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
