### PR TITLE
[wip/ad_integration] Fix AD integration tests

### DIFF
--- a/tests/integration-tests/tests/ad_integration/cluster_user.py
+++ b/tests/integration-tests/tests/ad_integration/cluster_user.py
@@ -15,7 +15,7 @@ class ClusterUser:
         self.user_num = user_num  # TODO: don't need to keep this?
         self.alias = f"PclusterUser{user_num}"
         self.ssh_keypair_path_prefix = str(test_datadir / self.alias)
-        self.ssh_private_key_path = f"{self.ssh_keypair_path_prefix}.pem"
+        self.ssh_private_key_path = self.ssh_keypair_path_prefix
         self.ssh_public_key_path = f"{self.ssh_private_key_path}.pub"
         # TODO: randomly generate this. It's hardcoded here because it's also hard-coded in the script
         #       that creates users as part of the directory stack.
@@ -71,6 +71,14 @@ class ClusterUser:
     def submit_script(self, **submit_comand_kwargs):
         """Wrapper around SchedulerCommand's submit_script method."""
         return self._personalized_scheduler_commands.submit_script(**submit_comand_kwargs)
+
+    def assert_job_submitted(self, stdout):
+        """Wrapper around SchedulerCommand's assert_job_submitted method."""
+        return self._personalized_scheduler_commands.assert_job_submitted(stdout)
+
+    def wait_job_completed(self, job_id):
+        """Wrapper around SchedulerCommand's wait_job_completed method."""
+        return self._personalized_scheduler_commands.wait_job_completed(job_id)
 
     def assert_job_succeeded(self, job_id):
         """Wrapper around SchedulerCommand's assert_job_succeded method."""

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/workload.sh
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/workload.sh
@@ -8,13 +8,11 @@ done
 
 BENCHMARK_NAME=osu_barrier
 OSU_BENCHMARK_VERSION=5.7.1
-NUM_OF_PROCESSES=2
 
 module load openmpi
 # Run collective benchmark. The collective operations are close to what a real application looks like.
 # NOTE: The test is sized for 4 compute nodes.
 # -np total number of processes to run (all CPUs * 4 nodes)
 mpirun \
-    > /shared/${BENCHMARK_NAME}.out \
-    -np ${NUM_OF_PROCESSES} \
+    > /shared/$(date '+%Y%m%d%H%M%S')-$(whoami)-${BENCHMARK_NAME}.out \
     /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME}  


### PR DESCRIPTION
* fix path to private SSH key
* use kwarg when calling ClusterUser.submit_script method
* fix typos
* specify nodes/slots in python code rather than submission script
* fix process for submitting and waiting for jobs to finish
* use user-specific output file

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
