### PR TITLE
2.11: Upgrade slurm from 20.11.7 to 20.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 2.11.4
 -----
 
+**CHANGES**
+- Upgrade Slurm to version 20.11.8.
+
 **BUG FIXES**
 - Disable update of ec2_iam_role parameter.
 

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -895,7 +895,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
 def _test_slurm_version(remote_command_executor):
     logging.info("Testing Slurm Version")
     version = remote_command_executor.run_remote_command("sinfo -V").stdout
-    assert_that(version).is_equal_to("slurm 20.11.7")
+    assert_that(version).is_equal_to("slurm 20.11.8")
 
 
 def _test_job_dependencies(slurm_commands, region, stack_name, scaledown_idletime):


### PR DESCRIPTION
Cherry pick of: https://github.com/aws/aws-parallelcluster/pull/3013
Related to: https://github.com/aws/aws-parallelcluster-cookbook/pull/1250
