### PR TITLE
`[cli/export/logs]` Better handling of missing bucket-prefix on logs export.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ X.X.X
 **BUG FIXES**
 - Redirect stderr and stdout to CLI log file to prevent unwanted text to pollute the pcluster CLI output.
 - Fix ecs:ListContainerInstances permission in BatchUserRole
+- Fix exporting of cluster logs when there is no prefix specified, previously exported to a `None` prefix.
 
 3.0.2
 -----

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -146,7 +146,6 @@ class CloudWatchLogsExporter:
                 f"The bucket used for exporting logs must be in the same region as the {resource_id}. "
                 f"The given resource is in {get_region()}, but the bucket's region is {bucket_region}."
             )
-
         self.bucket = bucket
         self.log_group_name = log_group_name
         self.output_dir = output_dir

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -146,6 +146,7 @@ class CloudWatchLogsExporter:
                 f"The bucket used for exporting logs must be in the same region as the {resource_id}. "
                 f"The given resource is in {get_region()}, but the bucket's region is {bucket_region}."
             )
+
         self.bucket = bucket
         self.log_group_name = log_group_name
         self.output_dir = output_dir
@@ -273,8 +274,9 @@ def upload_archive(bucket: str, bucket_prefix: str, archive_path: str):
     archive_filename = os.path.basename(archive_path)
     with open(archive_path, "rb") as archive_file:
         archive_data = archive_file.read()
-    AWSApi.instance().s3.put_object(bucket, archive_data, f"{bucket_prefix}/{archive_filename}")
-    return f"s3://{bucket}/{bucket_prefix}/{archive_filename}"
+    bucket_path = f"{bucket_prefix}/{archive_filename}" if bucket_prefix else archive_filename
+    AWSApi.instance().s3.put_object(bucket, archive_data, bucket_path)
+    return f"s3://{bucket}/{bucket_path}"
 
 
 class LogStreams:

--- a/cli/tests/pcluster/cli/test_export_cluster_logs.py
+++ b/cli/tests/pcluster/cli/test_export_cluster_logs.py
@@ -55,6 +55,7 @@ class TestExportClusterLogsCommand:
         [
             {},
             {"output_file": "output-path"},
+            {"bucket": "bucket-name", "keep_s3_objects": True},
             {"bucket": "bucket-name", "bucket_prefix": "test", "keep_s3_objects": True},
             {"filters": "Name=private-dns-name,Values=ip-10-10-10-10"},
             {

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -226,18 +226,11 @@ class Cluster:
         instances = self.describe_cluster_instances(node_type=node_type, queue_name=queue_name)
         return [instance["instanceId"] for instance in instances]
 
-    def export_logs(self, bucket, output_file, bucket_prefix=None):
+    def export_logs(self, bucket, output_file=None, bucket_prefix=None):
         """Run pcluster export-cluster-logs and return the result."""
-        cmd_args = [
-            "pcluster",
-            "export-cluster-logs",
-            "--cluster-name",
-            self.name,
-            "--bucket",
-            bucket,
-            "--output-file",
-            output_file,
-        ]
+        cmd_args = ["pcluster", "export-cluster-logs", "--cluster-name", self.name, "--bucket", bucket]
+        if output_file:
+            cmd_args += ["--output-file", output_file]
         if bucket_prefix:
             cmd_args += ["--bucket-prefix", bucket_prefix]
         try:


### PR DESCRIPTION
**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
