### PR TITLE
Fix OverlappingMountDirValidator

### DIFF
--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -507,7 +507,7 @@ def _find_overlapping_paths(paths_list):
     overlapping_paths = []
     if paths_list:
         for path in paths_list:
-            is_overlapping = any(x for x in paths_list if x != path and x.startswith(path))
+            is_overlapping = any(x for x in paths_list if x != path and x.startswith(path + "/"))
             if is_overlapping:
                 overlapping_paths.append(path)
 

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -720,6 +720,10 @@ def test_duplicate_mount_dir_validator(mount_dir_list, expected_message):
             ["dir1", "dir1/subdir", "dir2", "dir2/subdir", "dir3"],
             "Mount directories dir1, dir2 cannot contain other mount directories",
         ),
+        (
+            ["dir", "dir1"],
+            None,
+        ),
     ],
 )
 def test_overlapping_mount_dir_validator(mount_dir_list, expected_message):


### PR DESCRIPTION
Not consider shared and shared1 as overlapping, consider shared and shared/1 as overlapping

Signed-off-by: chenwany <chenwany@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
