### PR TITLE
2.11: Remove hardcoding logic when checking if CpuOptions is supported

### DIFF
--- a/cli/src/pcluster/config/cfn_param_types.py
+++ b/cli/src/pcluster/config/cfn_param_types.py
@@ -661,7 +661,7 @@ class DisableHyperThreadingCfnParam(BoolCfnParam):
         else:
             cores = instance_type_info.vcpus_count() // default_threads_per_core
 
-        return cores, disable_ht_via_cpu_options(instance_type, default_threads_per_core)
+        return cores, disable_ht_via_cpu_options(instance_type)
 
     def to_cfn(self):
         """

--- a/cli/src/pcluster/config/json_param_types.py
+++ b/cli/src/pcluster/config/json_param_types.py
@@ -317,7 +317,7 @@ class QueueJsonSection(JsonSection):
             ).value = compute_resource_section.get_param(
                 "disable_hyperthreading"
             ).value and utils.disable_ht_via_cpu_options(
-                instance_type_param.value, instance_type_info.default_threads_per_core()
+                instance_type_param.value
             )
 
             # Set initial_count to min_count if not manually set

--- a/cli/src/pcluster/models/hit/hit_cluster_model.py
+++ b/cli/src/pcluster/models/hit/hit_cluster_model.py
@@ -67,8 +67,7 @@ class HITClusterModel(ClusterModel):
         head_node_threads_per_core = head_node_instance_type_info.default_threads_per_core()
         head_node_cpu_options = (
             {"CoreCount": head_node_vcpus // head_node_threads_per_core, "ThreadsPerCore": 1}
-            if disable_hyperthreading
-            and disable_ht_via_cpu_options(head_node_instance_type, head_node_threads_per_core)
+            if disable_hyperthreading and disable_ht_via_cpu_options(head_node_instance_type)
             else {}
         )
         try:

--- a/cli/src/pcluster/models/sit/sit_cluster_model.py
+++ b/cli/src/pcluster/models/sit/sit_cluster_model.py
@@ -88,13 +88,12 @@ class SITClusterModel(ClusterModel):
         compute_threads_per_core = compute_instance_type_info.default_threads_per_core()
         head_node_cpu_options = (
             {"CoreCount": head_node_vcpus // head_node_threads_per_core, "ThreadsPerCore": 1}
-            if disable_hyperthreading
-            and disable_ht_via_cpu_options(head_node_instance_type, head_node_threads_per_core)
+            if disable_hyperthreading and disable_ht_via_cpu_options(head_node_instance_type)
             else {}
         )
         compute_cpu_options = (
             {"CoreCount": compute_vcpus // compute_threads_per_core, "ThreadsPerCore": 1}
-            if disable_hyperthreading and disable_ht_via_cpu_options(compute_instance_type, compute_threads_per_core)
+            if disable_hyperthreading and disable_ht_via_cpu_options(compute_instance_type)
             else {}
         )
 

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -1050,21 +1050,12 @@ def cluster_has_running_capacity(stack_name):
     return cluster_has_running_capacity.cached_result
 
 
-def disable_ht_via_cpu_options(instance_type, default_threads_per_core=None):
-    """Return a boolean describing whether hyperthreading should be disabled via CPU options for instance_type."""
-    if default_threads_per_core is None:
-        default_threads_per_core = InstanceTypeInfo.init_from_instance_type(instance_type).default_threads_per_core()
-    res = all(
-        [
-            # If default threads per core is 1, HT doesn't need to be disabled
-            default_threads_per_core > 1,
-            # Currently, hyperthreading must be disabled manually on *.metal instances
-            not (
-                instance_type.endswith(".metal") or instance_type.startswith("m4.") or instance_type in ["cc2.8xlarge"]
-            ),
-        ]
-    )
-    return res
+def disable_ht_via_cpu_options(instance_type):
+    """Return a boolean describing whether hyper-threading should be disabled via CPU options for instance_type."""
+    instance_info = InstanceTypeInfo.init_from_instance_type(instance_type)
+    # If default threads per core is 1, HT doesn't need to be disabled
+    # When CpuOptions is not supported, ValidThreadsPerCore can't be found in VCpuInfo info
+    return instance_info.default_threads_per_core() > 1 and 1 in instance_info.valid_threads_per_core()
 
 
 def is_hit_enabled_scheduler(scheduler):
@@ -1316,16 +1307,11 @@ class InstanceTypeInfo:
 
     def default_threads_per_core(self):
         """Return the default threads per core for the given instance type."""
-        # NOTE: currently, .metal instances do not contain the DefaultThreadsPerCore
-        #       attribute in their VCpuInfo section. This is a known issue with the
-        #       ec2 DescribeInstanceTypes API. For these instance types an assumption
-        #       is made that if the instance's supported architectures list includes
-        #       x86_64 then the default is 2, otherwise it's 1.
-        threads_per_core = self.instance_type_data.get("VCpuInfo", {}).get("DefaultThreadsPerCore")
-        if threads_per_core is None:
-            supported_architectures = self.instance_type_data.get("ProcessorInfo", {}).get("SupportedArchitectures", [])
-            threads_per_core = 2 if "x86_64" in supported_architectures else 1
-        return threads_per_core
+        return self.instance_type_data.get("VCpuInfo", {}).get("DefaultThreadsPerCore")
+
+    def valid_threads_per_core(self):
+        """Return the valid threads per core for the given instance type."""
+        return self.instance_type_data.get("VCpuInfo", {}).get("ValidThreadsPerCore", [])
 
     def vcpus_count(self):
         """Get number of vcpus for the given instance type."""

--- a/cli/tests/pcluster/config/test_json_param_types.py
+++ b/cli/tests/pcluster/config/test_json_param_types.py
@@ -30,7 +30,13 @@ DESCRIBE_INSTANCE_TYPES_RESPONSES = {
         "InstanceTypes": [
             {
                 "InstanceType": "c4.xlarge",
-                "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2, "DefaultThreadsPerCore": 2},
+                "VCpuInfo": {
+                    "DefaultVCpus": 4,
+                    "DefaultCores": 2,
+                    "DefaultThreadsPerCore": 2,
+                    "ValidCores": [1, 2],
+                    "ValidThreadsPerCore": [1, 2],
+                },
                 "NetworkInfo": {"EfaSupported": False, "MaximumNetworkCards": 1},
                 "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
             }
@@ -42,7 +48,7 @@ DESCRIBE_INSTANCE_TYPES_RESPONSES = {
         "InstanceTypes": [
             {
                 "InstanceType": "g4dn.metal",
-                "VCpuInfo": {"DefaultVCpus": 96},
+                "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48, "DefaultThreadsPerCore": 2},
                 "GpuInfo": {"Gpus": [{"Name": "T4", "Manufacturer": "NVIDIA", "Count": 8}]},
                 "NetworkInfo": {"EfaSupported": True, "MaximumNetworkCards": 1},
                 "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
@@ -55,7 +61,38 @@ DESCRIBE_INSTANCE_TYPES_RESPONSES = {
         "InstanceTypes": [
             {
                 "InstanceType": "i3en.24xlarge",
-                "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48, "DefaultThreadsPerCore": 2},
+                "VCpuInfo": {
+                    "DefaultVCpus": 96,
+                    "DefaultCores": 48,
+                    "DefaultThreadsPerCore": 2,
+                    "ValidCores": [
+                        2,
+                        4,
+                        6,
+                        8,
+                        10,
+                        12,
+                        14,
+                        16,
+                        18,
+                        20,
+                        22,
+                        24,
+                        26,
+                        28,
+                        30,
+                        32,
+                        34,
+                        36,
+                        38,
+                        40,
+                        42,
+                        44,
+                        46,
+                        48,
+                    ],
+                    "ValidThreadsPerCore": [1, 2],
+                },
                 "NetworkInfo": {"EfaSupported": True, "MaximumNetworkCards": 1},
                 "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
             }
@@ -79,7 +116,13 @@ DESCRIBE_INSTANCE_TYPES_RESPONSES = {
         "InstanceTypes": [
             {
                 "InstanceType": "m6g.xlarge",
-                "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 4, "DefaultThreadsPerCore": 1},
+                "VCpuInfo": {
+                    "DefaultVCpus": 4,
+                    "DefaultCores": 4,
+                    "DefaultThreadsPerCore": 1,
+                    "ValidCores": [1, 2, 3, 4],
+                    "ValidThreadsPerCore": [1],
+                },
                 "NetworkInfo": {"EfaSupported": False, "MaximumNetworkCards": 1},
                 "ProcessorInfo": {"SupportedArchitectures": ["arm64"]},
             }
@@ -104,7 +147,38 @@ DESCRIBE_INSTANCE_TYPES_RESPONSES = {
         "InstanceTypes": [
             {
                 "InstanceType": "p4d.24xlarge",
-                "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48, "DefaultThreadsPerCore": 2},
+                "VCpuInfo": {
+                    "DefaultVCpus": 96,
+                    "DefaultCores": 48,
+                    "DefaultThreadsPerCore": 2,
+                    "ValidCores": [
+                        2,
+                        4,
+                        6,
+                        8,
+                        10,
+                        12,
+                        14,
+                        16,
+                        18,
+                        20,
+                        22,
+                        24,
+                        26,
+                        28,
+                        30,
+                        32,
+                        34,
+                        36,
+                        38,
+                        40,
+                        42,
+                        44,
+                        46,
+                        48,
+                    ],
+                    "ValidThreadsPerCore": [1, 2],
+                },
                 "GpuInfo": {"Gpus": [{"Name": "A100", "Manufacturer": "NVIDIA", "Count": 8}]},
                 "NetworkInfo": {"EfaSupported": True, "MaximumNetworkCards": 4},
                 "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},

--- a/cli/tests/pcluster/config/utils.py
+++ b/cli/tests/pcluster/config/utils.py
@@ -138,7 +138,7 @@ def mock_instance_type_info(mocker, instance_type="t2.micro"):
         return_value=InstanceTypeInfo(
             {
                 "InstanceType": instance_type,
-                "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2},
+                "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2, "DefaultThreadsPerCore": 2},
                 "NetworkInfo": {"EfaSupported": False},
                 "SupportedUsageClasses": ["on-demand", "spot"],
             }

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -1028,7 +1028,13 @@ class TestInstanceTypeInfo:
                     "InstanceTypes": [
                         {
                             "InstanceType": "c4.xlarge",
-                            "VCpuInfo": {"DefaultVCpus": 4, "DefaultCores": 2, "DefaultThreadsPerCore": 2},
+                            "VCpuInfo": {
+                                "DefaultVCpus": 4,
+                                "DefaultCores": 2,
+                                "DefaultThreadsPerCore": 2,
+                                "ValidCores": [1, 2],
+                                "ValidThreadsPerCore": [1, 2],
+                            },
                             "NetworkInfo": {"EfaSupported": False, "MaximumNetworkCards": 1},
                             "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
                         }
@@ -1042,7 +1048,7 @@ class TestInstanceTypeInfo:
                     "InstanceTypes": [
                         {
                             "InstanceType": "g4dn.metal",
-                            "VCpuInfo": {"DefaultVCpus": 96},
+                            "VCpuInfo": {"DefaultVCpus": 96, "DefaultCores": 48, "DefaultThreadsPerCore": 2},
                             "GpuInfo": {"Gpus": [{"Name": "T4", "Manufacturer": "NVIDIA", "Count": 8}]},
                             "NetworkInfo": {"EfaSupported": True, "MaximumNetworkCards": 4},
                             "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
@@ -1057,7 +1063,13 @@ class TestInstanceTypeInfo:
                     "InstanceTypes": [
                         {
                             "InstanceType": "g4ad.16xlarge",
-                            "VCpuInfo": {"DefaultVCpus": 64},
+                            "VCpuInfo": {
+                                "DefaultVCpus": 64,
+                                "DefaultCores": 32,
+                                "DefaultThreadsPerCore": 2,
+                                "ValidCores": [2, 4, 8, 16, 32],
+                                "ValidThreadsPerCore": [1, 2],
+                            },
                             "GpuInfo": {"Gpus": [{"Name": "*", "Manufacturer": "AMD", "Count": 4}]},
                             "NetworkInfo": {"EfaSupported": False, "MaximumNetworkCards": 1},
                             "ProcessorInfo": {"SupportedArchitectures": ["x86_64"]},
@@ -1078,6 +1090,7 @@ class TestInstanceTypeInfo:
         assert_that(capsys.readouterr().out).is_empty()
         assert_that(c4_instance_info.max_network_interface_count()).is_equal_to(1)
         assert_that(c4_instance_info.default_threads_per_core()).is_equal_to(2)
+        assert_that(c4_instance_info.valid_threads_per_core()).is_equal_to([1, 2])
         assert_that(c4_instance_info.vcpus_count()).is_equal_to(4)
         assert_that(c4_instance_info.supported_architecture()).is_equal_to(["x86_64"])
         assert_that(c4_instance_info.is_efa_supported()).is_equal_to(False)
@@ -1086,6 +1099,7 @@ class TestInstanceTypeInfo:
         assert_that(capsys.readouterr().out).is_empty()
         assert_that(g4dn_instance_info.max_network_interface_count()).is_equal_to(4)
         assert_that(g4dn_instance_info.default_threads_per_core()).is_equal_to(2)
+        assert_that(g4dn_instance_info.valid_threads_per_core()).is_equal_to([])
         assert_that(g4dn_instance_info.vcpus_count()).is_equal_to(96)
         assert_that(g4dn_instance_info.supported_architecture()).is_equal_to(["x86_64"])
         assert_that(g4dn_instance_info.is_efa_supported()).is_equal_to(True)
@@ -1094,6 +1108,7 @@ class TestInstanceTypeInfo:
         assert_that(capsys.readouterr().out).matches("not offer native support for 'AMD' GPUs.")
         assert_that(g4ad_instance_info.max_network_interface_count()).is_equal_to(1)
         assert_that(g4ad_instance_info.default_threads_per_core()).is_equal_to(2)
+        assert_that(g4ad_instance_info.valid_threads_per_core()).is_equal_to([1, 2])
         assert_that(g4ad_instance_info.vcpus_count()).is_equal_to(64)
         assert_that(g4ad_instance_info.supported_architecture()).is_equal_to(["x86_64"])
         assert_that(g4ad_instance_info.is_efa_supported()).is_equal_to(False)


### PR DESCRIPTION
When `CpuOptions` is not supported, `ValidThreadsPerCore` can't be found in `VCpuInfo` info.
See similar patch for 3.0.0: https://github.com/aws/aws-parallelcluster/pull/3291

