### PR TITLE
Custom scheduler cluster update

### DIFF
--- a/scheduler_plugins/plugin_template/artifacts/handlers/head_cluster_update.sh
+++ b/scheduler_plugins/plugin_template/artifacts/handlers/head_cluster_update.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+### AVAILABLE ENV SET BY PARALLELCLUSTER
+# - PCLUSTER_CLUSTER_CONFIG: path to a file containing the cluster configuration in a YAML format.
+#   Changes to the content of this file are not preserved across handlers invocations.
+# - PCLUSTER_CLUSTER_CONFIG_OLD: path to a file containing the previous cluster configuration in a YAML format.
+#   Changes to the content of this file are not preserved across handlers invocations.
+# - PCLUSTER_LAUNCH_TEMPLATES: path to a JSON file containing the LaunchTemplate to use for each ComputeResource in each queue.
+#   Changes to this file are not preserved across handlers invocations.
+# - PCLUSTER_CLUSTER_NAME: Name of the cluster.
+# - PCLUSTER_CFN_STACK_ARN: ARN of the CloudFormation stack associated with the cluster.
+# - PCLUSTER_SCHEDULER_PLUGIN_CFN_SUBSTACK_ARN: ARN of the nested CloudFormation stack defining scheduler plugin custom resources.
+# - PCLUSTER_SCHEDULER_PLUGIN_CFN_SUBSTACK_OUTPUTS: path to a JSON file containing a key value pair mapping of all outputs present in the CFN substack defined by the scheduler plugin.
+#   Changes to this file are not preserved across handlers invocations.
+# - PCLUSTER_SHARED_SCHEDULER_DIR: cluster shared dir to use when installing the scheduler or other packages (/opt/parallecluster/shared/byos)
+# - PCLUSTER_LOCAL_SCHEDULER_DIR: local dir to use when installing the scheduler or other packages (/opt/parallecluster/byos)
+# - PCLUSTER_AWS_REGION: AWS region name
+# - PCLUSTER_EC2_INSTANCE_TYPE: type of the EC2 instance where the action is running
+# - PCLUSTER_OS: OS distribution of the instance where the script is running
+# - PCLUSTER_ARCH: architecture of the node: x86_64 or arm64
+# - PCLUSTER_VERSION: version of ParallelCluster the cluster belongs to.
+# - PCLUSTER_HEADNODE_PRIVATE_IP: private IP of the head node
+# - PCLUSTER_HEADNODE_HOSTNAME: hostname of the head node
+# - PCLUSTER_QUEUE_NAME: contains the name of the queue the node belongs to (empty in case of head node).
+# - PCLUSTER_COMPUTE_RESOURCE_NAME: contains the name of the compute resource the node belongs to (empty in case of head node).
+# - PCLUSTER_INSTANCE_TYPES_DATA: path to a JSON file containing the instance types data for the instances used in the queues
+# - PCLUSTER_NODE_TYPE: type of the node: head or compute
+##################################################################
+
+set -e
+
+echo "Handling event: HeadClusterUpdate"

--- a/scheduler_plugins/plugin_template/plugin_definition.yaml
+++ b/scheduler_plugins/plugin_template/plugin_definition.yaml
@@ -77,6 +77,9 @@ Events:
   ComputeFinalize:
     ExecuteCommand:
       Command: artifacts/handlers/compute_finalize.sh
+  HeadClusterUpdate:
+    ExecuteCommand:
+      Command: artifacts/handlers/head_cluster_update.sh
 # NOT AVAILABLE YET
 # Allows the registration of custom log files to be uploaded to the CloudWatch log group managed by ParallelCluster
 # Monitoring:

--- a/scheduler_plugins/slurm/artifacts/handlers/head_cluster_update.sh
+++ b/scheduler_plugins/slurm/artifacts/handlers/head_cluster_update.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+sudo -E cinc-client -z -o slurm_plugin_cookbook::update --log-level info --force-formatter

--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/attributes/default.rb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/attributes/default.rb
@@ -13,6 +13,7 @@ default['pcluster']['local_dir'] = ENV['PCLUSTER_LOCAL_SCHEDULER_PLUGIN_DIR']
 default['pcluster']['shared_dir'] = ENV['PCLUSTER_SHARED_SCHEDULER_PLUGIN_DIR']
 default['pcluster']['region'] = ENV['PCLUSTER_AWS_REGION']
 default['pcluster']['cluster_config_path'] = ENV['PCLUSTER_CLUSTER_CONFIG']
+default['pcluster']['previous_cluster_config_path'] = ENV['PCLUSTER_CLUSTER_CONFIG_OLD']
 default['pcluster']['cluster_config'] = YAML.load_file("#{node['pcluster']['cluster_config_path']}")
 default['pcluster']['launch_templates_config_path'] = ENV['PCLUSTER_LAUNCH_TEMPLATES']
 default['pcluster']['launch_templates_config'] = JSON.load_file(node['pcluster']['launch_templates_config_path'])

--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/recipes/update.rb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/recipes/update.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: slurm_plugin_cookbook
+# Recipe:: update_head_node
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+case node['pcluster']['node_type']
+when 'head'
+  include_recipe 'slurm_plugin_cookbook::update_head_node'
+else
+  raise 'node_type must be head'
+end

--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/recipes/update_head_node.rb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/recipes/update_head_node.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+#
+# Cookbook:: slurm_plugin_cookbook
+# Recipe:: update_head_node
+#
+# Copyright:: 2013-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+unless ::FileUtils.identical?(node['pcluster']['previous_cluster_config_path'], node['pcluster']['cluster_config_path'])
+  # Generate pcluster specific configs
+  no_gpu = nvidia_installed? ? "" : "--no-gpu"
+  execute "generate_pcluster_slurm_configs" do
+    command "#{node['pcluster']['python_root']}/python #{node['pcluster']['local_dir']}/scripts/slurm/pcluster_slurm_config_generator.py" \
+            " --output-directory #{node['slurm']['install_dir']}/etc/" \
+            " --template-directory #{node['pcluster']['local_dir']}/scripts/slurm/templates/" \
+            " --input-file #{node['pcluster']['cluster_config_path']}" \
+            " --instance-types-data #{node['pcluster']['instance_types_data_path']}" \
+            " #{no_gpu}"
+  end
+
+  execute 'stop clustermgtd' do
+    command "#{node['pcluster']['python_root']}/supervisorctl -c #{node['pcluster']['local_dir']}/supervisord.conf stop clustermgtd"
+  end
+
+  service 'slurmctld' do
+    action :restart
+  end
+
+  execute 'reload config for running nodes' do
+    command "#{node['slurm']['install_dir']}/bin/scontrol reconfigure && sleep 15"
+    retries 3
+    retry_delay 5
+  end
+
+  execute 'start clustermgtd' do
+    command "#{node['pcluster']['python_root']}/supervisorctl -c #{node['pcluster']['local_dir']}/supervisord.conf start clustermgtd"
+  end
+end

--- a/scheduler_plugins/slurm/plugin_definition.yaml
+++ b/scheduler_plugins/slurm/plugin_definition.yaml
@@ -37,3 +37,6 @@ Events:
   ComputeFinalize:
     ExecuteCommand:
       Command: artifacts/handlers/compute_finalize.sh
+  HeadClusterUpdate:
+    ExecuteCommand:
+      Command: artifacts/handlers/head_cluster_update.sh


### PR DESCRIPTION
* Rename entrypoint for cluster update recipes
This is related to https://github.com/aws/aws-parallelcluster-cookbook/pull/1264

* Add example for cluster update event using custom plugin

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
