### PR TITLE
Revert "Move c6gn EFA tests to ap-northeast-1"

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -212,7 +212,7 @@ efa:
       #   instances: ["p4d.24xlarge"]
       #   oss: {{ common.OSS_COMMERCIAL_X86 }}
       #   schedulers: ["slurm"]
-      - regions: ["ap-northeast-1"]
+      - regions: ["us-west-2"]
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
         schedulers: ["slurm"]


### PR DESCRIPTION
Reverts aws/aws-parallelcluster#3536