### PR TITLE
Disable EnhancedImageMetadataEnabled when building custom image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ X.X.X
 - Use compute resource name rather than instance type in compute fleet Launch Template name.
 - Change SlurmQueues length and ComputeResources length schema validators to be config validators. 
 - Upgrade Slurm to version 21.08.4.
+- Disable EC2 ImageBuilder enhanced image metadata when building ParallelCluster custom images.
 
 **BUG FIXES**
 - Redirect stderr and stdout to CLI log file to prevent unwanted text to pollute the pcluster CLI output.

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -290,6 +290,7 @@ class ImageBuilderCdkStack(Stack):
             image_recipe_arn=Fn.ref("ImageRecipe"),
             infrastructure_configuration_arn=Fn.ref("InfrastructureConfiguration"),
             distribution_configuration_arn=Fn.ref("DistributionConfiguration"),
+            enhanced_image_metadata_enabled=False,
         )
         if not self.custom_cleanup_lambda_role:
             self._add_resource_delete_policy(


### PR DESCRIPTION
This option doesn't give advantage for PCluster use case. It is used to collect metadata of the building instance and these metadata are queryable against the ImageBuilder Image through the ListImagePackages API. But since the ImageBuilder Image resource is being deleted after a PCluster successful build, it doesn't make sense to keep this option enabled. Eventually, we can keep an option to enable back the enhancedImageMetadata, but this can be placed under a DevSettings section.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
