### PR TITLE
Fix cfn-up update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ X.X.X
 - Redirect stderr and stdout to CLI log file to prevent unwanted text to pollute the pcluster CLI output.
 - Fix ecs:ListContainerInstances permission in BatchUserRole
 - Fix exporting of cluster logs when there is no prefix specified, previously exported to a `None` prefix.
+- Fix rollback not being performed in case of cluster update failure.  
 
 3.0.2
 -----

--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -36,7 +36,7 @@ class ValidatorSuppressor(ABC):
 class AllValidatorsSuppressor(ValidatorSuppressor):
     """Suppressor that suppresses all validators."""
 
-    def __eq__(self, o: object) -> bool:
+    def __eq__(self, o: object) -> bool:  # pylint: disable=C0103
         return isinstance(o, AllValidatorsSuppressor)
 
     def __hash__(self) -> int:
@@ -49,7 +49,7 @@ class AllValidatorsSuppressor(ValidatorSuppressor):
 class TypeMatchValidatorsSuppressor(ValidatorSuppressor):
     """Suppressor that suppresses validators based on their type."""
 
-    def __eq__(self, o: object) -> bool:
+    def __eq__(self, o: object) -> bool:  # pylint: disable=C0103
         if isinstance(o, TypeMatchValidatorsSuppressor):
             return o._validators_to_suppress == self._validators_to_suppress
         return False

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -914,7 +914,7 @@ class ClusterCdkStack(Stack):
                     "shellRunPostInstall",
                     "chefFinalize",
                 ],
-                "update": ["deployConfigFiles", "chefUpdate", "sendSignal"],
+                "update": ["deployConfigFiles", "chefUpdate"],
             },
             "deployConfigFiles": {
                 "files": {
@@ -1041,22 +1041,16 @@ class ClusterCdkStack(Stack):
                 "commands": {
                     "chef": {
                         "command": (
-                            "cinc-client --local-mode --config /etc/chef/client.rb --log_level info "
-                            "--logfile /var/log/chef-client.log --force-formatter --no-color "
-                            "--chef-zero-port 8889 --json-attributes /etc/chef/dna.json "
-                            "--override-runlist aws-parallelcluster::update_head_node || "
-                            "cfn-signal --exit-code=1 --reason='Chef client failed' "
-                            f"'{self.wait_condition_handle.ref}'"
+                            "cinc-client --local-mode --config /etc/chef/client.rb --log_level info"
+                            " --logfile /var/log/chef-client.log --force-formatter --no-color"
+                            " --chef-zero-port 8889 --json-attributes /etc/chef/dna.json"
+                            " --override-runlist aws-parallelcluster::update_head_node &&"
+                            " cfn-signal --exit-code=0 --reason='Update complete'"
+                            f" '{self.wait_condition_handle.ref}' ||"
+                            " cfn-signal --exit-code=1 --reason='Update failed'"
+                            f" '{self.wait_condition_handle.ref}'"
                         ),
                         "cwd": "/etc/chef",
-                    }
-                }
-            },
-            "sendSignal": {
-                "commands": {
-                    "sendSignal": {
-                        "command": f"cfn-signal --exit-code=0 --reason='HeadNode setup complete' "
-                        f"'{self.wait_condition_handle.ref}'"
                     }
                 }
             },


### PR DESCRIPTION
The sendSignal was always called, even if the chefUpdate command was failing. To fix this, move the "complete" signal in the same block of the chefUpdate command.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

**Please See** [Git Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions)

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
