### PR TITLE
[ad_integration] Use LDAPS for Simple AD integration test

### DIFF
--- a/tests/integration-tests/configs/ad_integration.yaml
+++ b/tests/integration-tests/configs/ad_integration.yaml
@@ -6,5 +6,5 @@ test-suites:
       dimensions:
         - regions: ["us-east-1"]
           instances: ["c5n.18xlarge"]
-          oss: ["alinux2"]
+          oss: ["alinux2", "ubuntu2004"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -132,6 +132,11 @@ def pytest_addoption(parser):
         "--directory-stack-name",
         help="Name of CFN stack providing AD domain to be used for testing AD integration feature.",
     )
+    parser.addoption(
+        "--ldaps-nlb-stack-name",
+        help="Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD "
+        "integration feature.",
+    )
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -81,6 +81,7 @@ TEST_DEFAULTS = {
     "instance_types_data": None,
     "use_default_iam_credentials": False,
     "directory_stack_name": None,
+    "ldaps_nlb_stack_name": None,
 }
 
 
@@ -356,6 +357,12 @@ def _init_argparser():
         help="Name of CFN stack providing AD domain to be used for testing AD integration feature.",
         default=TEST_DEFAULTS.get("directory_stack_name"),
     )
+    debug_group.add_argument(
+        "--ldaps-nlb-stack-name",
+        help="Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD "
+        "integration feature.",
+        default=TEST_DEFAULTS.get("ldaps_nlb_stack_name"),
+    )
 
     return parser
 
@@ -543,6 +550,9 @@ def _set_custom_stack_args(args, pytest_args):
 
     if args.directory_stack_name:
         pytest_args.extend(["--directory-stack-name", args.directory_stack_name])
+
+    if args.ldaps_nlb_stack_name:
+        pytest_args.extend(["--ldaps-nlb-stack-name", args.ldaps_nlb_stack_name])
 
 
 def _set_api_args(args, pytest_args):

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -214,12 +214,12 @@ def directory_factory(request, cfn_stacks_factory):
         created_directory_stacks[region] = stack_name
         logging.info("Creating %s users in directory service", str(NUM_USERS_TO_CREATE))
         ssm_client = boto3.client("ssm", region_name=region)
-        document_name = stack.cfn_resources["MultiUserInfraUserAddingDocument"]
-        admin_node_instance_id = stack.cfn_resources["MultiUserInfraAdDomainAdminNode"]
-        directory_id = stack.cfn_resources["MultiUserInfraDirectory"]
+        document_name = stack.cfn_resources["UserAddingDocument"]
+        admin_node_instance_id = stack.cfn_resources["AdDomainAdminNode"]
+        directory_id = stack.cfn_resources["Directory"]
         command_id = ssm_client.send_command(
             DocumentName=document_name,
-            InstanceIds=[stack.cfn_resources["MultiUserInfraAdDomainAdminNode"]],
+            InstanceIds=[stack.cfn_resources["AdDomainAdminNode"]],
             MaxErrors="0",
             TimeoutSeconds=600,
             Parameters={"DirectoryId": [directory_id], "NumUsersToCreate": [str(NUM_USERS_TO_CREATE)]},

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -14,7 +14,6 @@ import datetime
 import io
 import logging
 import os as os_lib
-import random
 import re
 import zipfile
 
@@ -55,7 +54,8 @@ def get_ad_config_param_vals(stack_name, bucket_name, password_secret_arn):
     )
     read_only_username = infra_stack_outputs.get("ReadOnlyUserName")
     return {
-        "directory_subnet": random.choice(infra_stack_outputs.get("SubnetIds").split(",")),
+        "public_directory_subnet": infra_stack_outputs.get("PublicSubnetIds").split(",")[0],
+        "private_directory_subnet": infra_stack_outputs.get("PrivateSubnetIds").split(",")[0],
         "ldap_uri": infra_stack_outputs.get("LdapUris").split(",")[0],
         "ldap_search_base": ldap_search_base,
         # TODO: is the CN=Users portion of this a valid assumption?

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -16,6 +16,7 @@ import logging
 import os as os_lib
 import re
 import zipfile
+from collections import defaultdict
 
 import boto3
 import pytest
@@ -46,17 +47,18 @@ def get_infra_stack_outputs(stack_name):
     }
 
 
-def get_ad_config_param_vals(stack_name, bucket_name, password_secret_arn):
+def get_ad_config_param_vals(directory_stack_name, nlb_stack_name, bucket_name, password_secret_arn):
     """Return a dict used to set values for config file parameters."""
-    infra_stack_outputs = get_infra_stack_outputs(stack_name)
+    directory_stack_outputs = get_infra_stack_outputs(directory_stack_name)
+    nlb_stack_outputs = get_infra_stack_outputs(nlb_stack_name)
     ldap_search_base = ",".join(
-        [f"dc={domain_component}" for domain_component in infra_stack_outputs.get("DomainName").split(".")]
+        [f"dc={domain_component}" for domain_component in directory_stack_outputs.get("DomainName").split(".")]
     )
-    read_only_username = infra_stack_outputs.get("ReadOnlyUserName")
+    read_only_username = directory_stack_outputs.get("ReadOnlyUserName")
     return {
-        "public_directory_subnet": infra_stack_outputs.get("PublicSubnetIds").split(",")[0],
-        "private_directory_subnet": infra_stack_outputs.get("PrivateSubnetIds").split(",")[0],
-        "ldap_uri": infra_stack_outputs.get("LdapUris").split(",")[0],
+        "public_directory_subnet": directory_stack_outputs.get("PublicSubnetIds").split(",")[0],
+        "private_directory_subnet": directory_stack_outputs.get("PrivateSubnetIds").split(",")[0],
+        "ldaps_uri": nlb_stack_outputs.get("LDAPSURL"),
         "ldap_search_base": ldap_search_base,
         # TODO: is the CN=Users portion of this a valid assumption?
         "ldap_default_bind_dn": f"CN={read_only_username},CN=Users,{ldap_search_base}",
@@ -153,89 +155,178 @@ def store_secret_in_secret_manager(request, region, cfn_stacks_factory):
         cfn_stacks_factory.delete_stack(secret_stack_name, region)
 
 
+def _create_directory_stack(
+    cfn_stacks_factory, request, directory_type, test_resources_dir, ad_admin_password, bucket_name, region
+):
+    directory_stack_name = generate_stack_name(
+        f"integ-tests-MultiUserInfraStack{directory_type}", request.config.getoption("stackname_suffix")
+    )
+
+    if directory_type not in ("MicrosoftAD", "SimpleAD"):
+        raise Exception(f"Unknown directory type: {directory_type}")
+
+    upload_custom_resources(test_resources_dir, bucket_name)
+    directory_stack_template_path = os_lib.path.join(test_resources_dir, "ad_stack.yaml")
+    account_id = (
+        boto3.client("sts", region_name=region, endpoint_url=get_sts_endpoint(region))
+        .get_caller_identity()
+        .get("Account")
+    )
+    config_args = {
+        "region": region,
+        "account": account_id,
+        "admin_node_ami_id": retrieve_latest_ami(region, "alinux2"),
+        "admin_node_instance_type": "c5.large",
+        "admin_node_key_name": request.config.getoption("key_name"),
+        "ad_admin_password": ad_admin_password,
+        "ad_domain_name": f"{directory_type.lower()}.multiuser.pcluster",
+        "default_ec2_domain": "ec2.internal" if region == "us-east-1" else f"{region}.compute.internal",
+        "ad_admin_user": "Administrator" if directory_type == "SimpleAD" else "Admin",
+        "num_users_to_create": 100,
+        "bucket_name": bucket_name,
+        "directory_type": directory_type,
+    }
+    logging.info("Creating stack %s", directory_stack_name)
+    with open(render_jinja_template(directory_stack_template_path, **config_args)) as directory_stack_template:
+        directory_stack = CfnStack(
+            name=directory_stack_name,
+            region=region,
+            template=directory_stack_template.read(),
+            capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
+        )
+    cfn_stacks_factory.create_stack(directory_stack)
+    logging.info("Creation of stack %s complete", directory_stack_name)
+    return directory_stack
+
+
+@retry(wait_fixed=seconds(20), stop_max_delay=seconds(700))
+def _check_ssm_success(ssm_client, command_id, instance_id):
+    assert_that(
+        ssm_client.get_command_invocation(CommandId=command_id, InstanceId=instance_id)["Status"] == "Success"
+    ).is_true()
+
+
+def _populate_directory_with_users(directory_stack, num_users_to_create, region):
+    logging.info("Creating %s users in directory service", str(num_users_to_create))
+    ssm_client = boto3.client("ssm", region_name=region)
+    document_name = directory_stack.cfn_resources["UserAddingDocument"]
+    admin_node_instance_id = directory_stack.cfn_resources["AdDomainAdminNode"]
+    directory_id = directory_stack.cfn_resources["Directory"]
+    command_id = ssm_client.send_command(
+        DocumentName=document_name,
+        InstanceIds=[directory_stack.cfn_resources["AdDomainAdminNode"]],
+        MaxErrors="0",
+        TimeoutSeconds=600,
+        Parameters={"DirectoryId": [directory_id], "NumUsersToCreate": [str(num_users_to_create)]},
+    )["Command"]["CommandId"]
+    _check_ssm_success(ssm_client, command_id, admin_node_instance_id)
+    logging.info("Creation of %s users in directory service completed", str(num_users_to_create))
+
+
+def _create_nlb_stack(cfn_stacks_factory, request, directory_stack, region, test_resources_dir):
+    nlb_stack_template_path = os_lib.path.join(test_resources_dir, "NLB_SimpleAD.yaml")
+    nlb_stack_name = generate_stack_name(
+        "integ-tests-MultiUserInfraStackNLB", request.config.getoption("stackname_suffix")
+    )
+    logging.info("Creating stack %s", nlb_stack_name)
+    # TODO: don't hardcode this ARN
+    certificate_arn = "arn:aws:acm:us-east-1:447714826191:certificate/a17e8574-0cea-4d4c-8e79-a8ebb60f6f47"
+    nlb_stack = None
+    with open(nlb_stack_template_path) as nlb_stack_template:
+        nlb_stack = CfnStack(
+            name=nlb_stack_name,
+            region=region,
+            template=nlb_stack_template.read(),
+            parameters=[
+                {
+                    "ParameterKey": "LDAPSCertificateARN",
+                    "ParameterValue": certificate_arn,
+                },
+                {
+                    "ParameterKey": "VPCId",
+                    "ParameterValue": directory_stack.cfn_outputs["VpcId"],
+                },
+                {
+                    "ParameterKey": "SubnetId1",
+                    "ParameterValue": directory_stack.cfn_outputs["PrivateSubnetIds"].split(",")[0],
+                },
+                {
+                    "ParameterKey": "SubnetId2",
+                    "ParameterValue": directory_stack.cfn_outputs["PrivateSubnetIds"].split(",")[1],
+                },
+                {
+                    "ParameterKey": "SimpleADPriIP",
+                    "ParameterValue": directory_stack.cfn_outputs["DirectoryDnsIpAddresses"].split(",")[0],
+                },
+                {
+                    "ParameterKey": "SimpleADSecIP",
+                    "ParameterValue": directory_stack.cfn_outputs["DirectoryDnsIpAddresses"].split(",")[1],
+                },
+            ],
+        )
+    cfn_stacks_factory.create_stack(nlb_stack)
+    logging.info("Creation of NLB stack %s complete", nlb_stack_name)
+    return nlb_stack
+
+
 @pytest.fixture(scope="module")
 def directory_factory(request, cfn_stacks_factory):
-    created_directory_stacks = {}
-
-    @retry(wait_fixed=seconds(20), stop_max_delay=seconds(700))
-    def _check_ssm_success(ssm_client, command_id, instance_id):
-        assert_that(
-            ssm_client.get_command_invocation(CommandId=command_id, InstanceId=instance_id)["Status"] == "Success"
-        ).is_true()
+    # TODO: use external data file and file locking in order to share directories across processes
+    created_directory_stacks = defaultdict(dict)
 
     def _directory_factory(
-        existing_stack_name, directory_type, bucket_name, test_resources_dir, region, ad_admin_password
+        existing_directory_stack_name,
+        existing_nlb_stack_name,
+        directory_type,
+        bucket_name,
+        test_resources_dir,
+        region,
+        ad_admin_password,
     ):
-        if existing_stack_name:
-            logging.info("Using pre-existing directory stack named %s", existing_stack_name)
-            return existing_stack_name
-        created_directory_stack_in_region = created_directory_stacks.get(region)
-        if created_directory_stack_in_region:
-            logging.info("Using directory stack named %s created by another test", created_directory_stack_in_region)
-            return created_directory_stack_in_region
-
-        if directory_type not in ("MicrosoftAD", "SimpleAD"):
-            raise Exception(f"Unknown directory type: {directory_type}")
-
-        upload_custom_resources(test_resources_dir, bucket_name)
-        template_path = os_lib.path.join(test_resources_dir, "ad_stack.yaml")
-        account_id = (
-            boto3.client("sts", region_name=region, endpoint_url=get_sts_endpoint(region))
-            .get_caller_identity()
-            .get("Account")
-        )
-        config_args = {
-            "region": region,
-            "account": account_id,
-            "admin_node_ami_id": retrieve_latest_ami(region, "alinux2"),
-            "admin_node_instance_type": "c5.large",
-            "admin_node_key_name": request.config.getoption("key_name"),
-            "ad_admin_password": ad_admin_password,
-            "ad_domain_name": f"{directory_type.lower()}.multiuser.pcluster",
-            "default_ec2_domain": "ec2.internal" if region == "us-east-1" else f"{region}.compute.internal",
-            "ad_admin_user": "Administrator" if directory_type == "SimpleAD" else "Admin",
-            "num_users_to_create": 100,
-            "bucket_name": bucket_name,
-            "directory_type": directory_type,
-        }
-        stack_name = generate_stack_name(
-            f"integ-tests-MultiUserInfraStack{directory_type}", request.config.getoption("stackname_suffix")
-        )
-        logging.info("Creating stack %s", stack_name)
-        with open(render_jinja_template(template_path, **config_args)) as template:
-            stack = CfnStack(
-                name=stack_name,
-                region=region,
-                template=template.read(),
-                capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
+        directory_stack = None
+        if existing_directory_stack_name:
+            directory_stack_name = existing_directory_stack_name
+            directory_stack = CfnStack(name=directory_stack_name, region=region, template=None)
+            logging.info("Using pre-existing directory stack named %s", directory_stack_name)
+        elif created_directory_stacks.get(region, {}).get("directory"):
+            directory_stack_name = created_directory_stacks.get(region, {}).get("directory")
+            directory_stack = CfnStack(name=directory_stack_name, region=region, template=None)
+            logging.info("Using directory stack named %s created by another test", directory_stack_name)
+        else:
+            directory_stack = _create_directory_stack(
+                cfn_stacks_factory, request, directory_type, test_resources_dir, ad_admin_password, bucket_name, region
             )
-        cfn_stacks_factory.create_stack(stack)
-        logging.info("Creation of stack %s complete", stack_name)
-        created_directory_stacks[region] = stack_name
-        logging.info("Creating %s users in directory service", str(NUM_USERS_TO_CREATE))
-        ssm_client = boto3.client("ssm", region_name=region)
-        document_name = stack.cfn_resources["UserAddingDocument"]
-        admin_node_instance_id = stack.cfn_resources["AdDomainAdminNode"]
-        directory_id = stack.cfn_resources["Directory"]
-        command_id = ssm_client.send_command(
-            DocumentName=document_name,
-            InstanceIds=[stack.cfn_resources["AdDomainAdminNode"]],
-            MaxErrors="0",
-            TimeoutSeconds=600,
-            Parameters={"DirectoryId": [directory_id], "NumUsersToCreate": [str(NUM_USERS_TO_CREATE)]},
-        )["Command"]["CommandId"]
-        _check_ssm_success(ssm_client, command_id, admin_node_instance_id)
-        logging.info("Creation of %s users in directory service completed", str(NUM_USERS_TO_CREATE))
-        return stack_name
+            directory_stack_name = directory_stack.name
+            created_directory_stacks[region]["directory"] = directory_stack_name
+            _populate_directory_with_users(directory_stack, NUM_USERS_TO_CREATE, region)
+        # Create NLB that will be used to enable LDAPS
+        if existing_nlb_stack_name:
+            nlb_stack_name = existing_nlb_stack_name
+            logging.info("Using pre-existing NLB stack named %s", nlb_stack_name)
+        elif created_directory_stacks.get(region, {}).get("nlb"):
+            nlb_stack_name = created_directory_stacks.get(region, {}).get("nlb")
+            logging.info("Using NLB stack named %s created by another test", nlb_stack_name)
+        else:
+            nlb_stack_name = _create_nlb_stack(
+                cfn_stacks_factory, request, directory_stack, region, test_resources_dir
+            ).name
+            created_directory_stacks[region]["nlb"] = nlb_stack_name
+        return directory_stack_name, nlb_stack_name
 
     yield _directory_factory
 
-    for directory_stack in created_directory_stacks.values():
-        if request.config.getoption("no_delete"):
-            logging.info("Not deleting stack %s because --no-delete option was specified", directory_stack)
-        else:
-            logging.info("Deleting stack %s", directory_stack)
-            boto3.client("cloudformation").delete_stack(StackName=directory_stack)
+    for region, stack_dict in created_directory_stacks.items():
+        for stack_type, stack_name in stack_dict.items():
+            if request.config.getoption("no_delete"):
+                logging.info(
+                    "Not deleting %s stack named %s in region %s because --no-delete option was specified",
+                    stack_type,
+                    stack_name,
+                    region,
+                )
+            else:
+                logging.info("Deleting %s stack named %s in region %s", stack_type, stack_name, region)
+                cfn_stacks_factory.delete_stack(stack_name, region)
 
 
 @pytest.fixture(scope="module")
@@ -410,15 +501,18 @@ def test_ad_integration(
     password_secret_arn = store_secret_in_secret_manager(ad_admin_password)
     if directory_type:
         bucket_name = s3_bucket_factory()
-        directory_stack_name = directory_factory(
+        directory_stack_name, nlb_stack_name = directory_factory(
             request.config.getoption("directory_stack_name"),
+            request.config.getoption("ldaps_nlb_stack_name"),
             directory_type,
             bucket_name,
             str(test_datadir),
             region,
             ad_admin_password=ad_admin_password,
         )
-        config_params.update(get_ad_config_param_vals(directory_stack_name, bucket_name, password_secret_arn))
+        config_params.update(
+            get_ad_config_param_vals(directory_stack_name, nlb_stack_name, bucket_name, password_secret_arn)
+        )
     cluster_config = pcluster_config_reader(**config_params)
     cluster = clusters_factory(cluster_config)
 

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -380,10 +380,8 @@ def _check_files_permissions(users):
             f"/efs/{user.alias}_file",
         ]:
             user.run_remote_command(f"touch {path}")
-            if not path.startswith(f"/home/{user.alias}/"):
-                # Files under homedir is only readable by the owner by default.
-                # Otherwise, change the permission to 600 for the test.
-                user.run_remote_command(f"chmod 600 {path}")
+            # Specify that only owner of file should have read/write access.
+            user.run_remote_command(f"chmod 600 {path}")
             # If the user is the first user, choose the last user as previous user
             logging.info("Check %s is not able to read files created by %s", previous_user.alias, user.alias)
             result = previous_user.run_remote_command(f"cat {path}", raise_on_error=False)

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -305,6 +305,16 @@ def _check_failed_result_for_permission_denied(result):
 
 
 def _check_ssh_key_generation(user, scheduler_commands, generate_ssh_keys_for_user):
+    # Remove user's home directory to ensure public SSH key doesn't exist
+    user.cleanup()
+    # Run remote command as user via password so that the feature has a chance to generate
+    # SSH keys if their ~/.ssh directory doesn't exist (and the cluster is configured to do so).
+    user.validate_password_auth_and_automatic_homedir_creation()
+    # Copy user's SSH key to the head node to facilitate the validation to follow. Note that this
+    # must be done after the above validation of home directory creation. If it's done before,
+    # then the user's ~/.ssh directory will have already been created and thus a keypair won't be
+    # generated regardless of the value of the GenerateSshKeysForUsers parameter in the cluster config.
+    user.copy_public_ssh_key_to_authorized_keys()
     result = user.run_remote_command("cat ~/.ssh/id_rsa", raise_on_error=generate_ssh_keys_for_user)
     if not generate_ssh_keys_for_user:
         assert_that(result.failed).is_true()

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -433,6 +433,11 @@ def test_ad_integration(
     _check_ssh_key_generation(users[0], scheduler_commands, False)
     updated_config_file = pcluster_config_reader(config_file="pcluster.config.update.yaml", **config_params)
     cluster.update(str(updated_config_file), force_update="true")
+    # Reset stateful connection variables after the cluster update
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
+    for user in users:
+        user.reset_stateful_connection_objects(remote_command_executor)
     _check_ssh_key_generation(users[1], scheduler_commands, True)
     _run_benchmarks(
         os,

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/NLB_SimpleAD.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/NLB_SimpleAD.yaml
@@ -1,0 +1,98 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: |-
+  LDAPS NLB Stack from https://aws.amazon.com/blogs/security/how-to-configure-ldaps-endpoint-for-simple-ad/
+Parameters:
+  LDAPSCertificateARN:
+    Description: ARN of SSL Certificate
+    AllowedPattern: "arn:aws:acm:.*"
+    Type: String
+  VPCId:
+    Description: Please provide a VPC to deploy the solution into.
+    Type: AWS::EC2::VPC::Id
+  SubnetId1:
+    Description: Please provide the first Simple AD private subnet id with outbound connectivity within the VPC you selected above.
+    Type: AWS::EC2::Subnet::Id
+  SubnetId2:
+    Description: Please provide the second Simple AD private subnet id with outbound connectivity within the VPC you selected above.
+    Type: AWS::EC2::Subnet::Id
+  SimpleADPriIP:
+    Description: IP Address of primary Simple AD instance
+    AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
+    Type: String
+  SimpleADSecIP:
+    Description: IP Address of secondary Simple AD instance
+    AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
+    Type: String
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: Network Configuration
+      Parameters:
+      - VPCId
+      - SubnetId1
+      - SubnetId2
+      - SimpleADPriIP
+      - SimpleADSecIP
+      - LDAPSCertificateARN
+    ParameterLabels:
+      VPCId:
+        default: Target VPC for solution
+      SubnetId1:
+        default: Simple AD Primary Subnet
+      SubnetId2:
+        default: Simple AD Secondary Subnet
+      SimpleADPriIP:
+        default: Primary Simple AD Server IP
+      SimpleADSecIP:
+        default: Secondary Simple AD Server IP
+      LDAPSCertificateARN:
+        default: ARN for SSL Certificate
+Resources:
+  NetworkLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: IntegTestsLdapsNlb
+      Scheme: internal
+      Subnets:
+        - !Ref SubnetId1
+        - !Ref SubnetId2
+      Type: network
+  NetworkLoadBalancerTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: IntegTestsLdapsEndpoint
+      Port: 389
+      Protocol: TCP
+      VpcId: !Ref VPCId
+      HealthCheckEnabled: True
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPort: 389
+      HealthCheckProtocol: TCP
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 3
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+      Targets:
+        - Id: !Ref SimpleADPriIP
+          Port: 389
+        - Id: !Ref SimpleADSecIP
+          Port: 389
+      TargetType: ip
+  NetworkLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref NetworkLoadBalancerTargetGroup
+      LoadBalancerArn: !Ref NetworkLoadBalancer
+      Port: '636'
+      Protocol: TLS
+      SslPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
+      Certificates:
+        - CertificateArn: !Ref LDAPSCertificateARN
+Outputs:
+  LDAPSURL:
+    Description: LDAPS Route53 Alias Target
+    Value: !GetAtt NetworkLoadBalancer.DNSName

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -6,10 +6,88 @@ Resources:
       EnableDnsHostnames: true
       EnableDnsSupport: true
       InstanceTenancy: default
+  PrivateSubnetOne:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: Vpc
+      AvailabilityZone: {{ region }}a
+      CidrBlock: 172.31.0.0/18
+      MapPublicIpOnLaunch: false
+  NatGatewayOneEIP:
+    Type: AWS::EC2::EIP
+    DependsOn: VpcGatewayAttachment
+    Properties:
+      Domain: vpc
+  NatGatewayOne:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatGatewayOneEIP.AllocationId
+      SubnetId:
+        Ref: PublicSubnetOne
+  PrivateRouteTableOne:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: Vpc
+  DefaultPrivateRouteOne:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTableOne
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NatGatewayOne
+  PrivateSubnetOneRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTableOne
+      SubnetId:
+        Ref: PrivateSubnetOne
+  PrivateSubnetTwo:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId:
+        Ref: Vpc
+      AvailabilityZone: {{ region }}b
+      CidrBlock: 172.31.64.0/18
+      MapPublicIpOnLaunch: false
+  NatGatewayTwoEIP:
+    Type: AWS::EC2::EIP
+    DependsOn: VpcGatewayAttachment
+    Properties:
+      Domain: vpc
+  NatGatewayTwo:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatGatewayTwoEIP.AllocationId
+      SubnetId:
+        Ref: PublicSubnetTwo
+  PrivateRouteTableTwo:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: Vpc
+  DefaultPrivateRouteTwo:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTableTwo
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NatGatewayTwo
+  PrivateSubnetTwoRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTableTwo
+      SubnetId:
+        Ref: PrivateSubnetTwo
   PublicSubnetOne:
     Type: AWS::EC2::Subnet
     Properties:
-      CidrBlock: 172.31.0.0/17
+      CidrBlock: 172.31.128.0/18
       VpcId:
         Ref: Vpc
       AvailabilityZone: {{ region }}a
@@ -39,7 +117,7 @@ Resources:
   PublicSubnetTwo:
     Type: AWS::EC2::Subnet
     Properties:
-      CidrBlock: 172.31.128.0/17
+      CidrBlock: 172.31.192.0/18
       VpcId:
         Ref: Vpc
       AvailabilityZone: {{ region }}b
@@ -98,8 +176,8 @@ Resources:
       Password: {{ ad_admin_password }}
       VpcSettings:
         SubnetIds:
-          - Ref: PublicSubnetOne
-          - Ref: PublicSubnetTwo
+          - Ref: PrivateSubnetOne
+          - Ref: PrivateSubnetTwo
         VpcId:
           Ref: Vpc
       {% if directory_type == "SimpleAD" %}
@@ -311,7 +389,7 @@ Outputs:
           - ""
           - - Ref: AWS::StackName
             - VpcId
-  SubnetIds:
+  PublicSubnetIds:
     Value:
       Fn::Join:
         - ""
@@ -323,7 +401,19 @@ Outputs:
         Fn::Join:
           - ""
           - - Ref: AWS::StackName
-            - SubnetIds
+            - PublicSubnetIds
+  PrivateSubnetIds:
+    Value:
+      Fn::Join:
+        - ","
+        - - Ref: PrivateSubnetOne
+          - Ref: PrivateSubnetTwo
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - PrivateSubnetIds
   DomainName:
     Value: {{ ad_domain_name }}
     Export:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -1,81 +1,81 @@
 Resources:
-  MultiUserInfraVpc:
+  Vpc:
     Type: AWS::EC2::VPC
     Properties:
       CidrBlock: 172.31.0.0/16
       EnableDnsHostnames: true
       EnableDnsSupport: true
       InstanceTenancy: default
-  MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet1Subnet281E6D3C:
+  PublicSubnetOne:
     Type: AWS::EC2::Subnet
     Properties:
       CidrBlock: 172.31.0.0/17
       VpcId:
-        Ref: MultiUserInfraVpc
+        Ref: Vpc
       AvailabilityZone: {{ region }}a
       MapPublicIpOnLaunch: true
-  MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet1RouteTable440E65B1:
+  PublicSubnetOneRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId:
-        Ref: MultiUserInfraVpc
-  MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet1RouteTableAssociation2F67DCF9:
+        Ref: Vpc
+  PublicSubnetOneRouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       RouteTableId:
-        Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet1RouteTable440E65B1
+        Ref: PublicSubnetOneRouteTable
       SubnetId:
-        Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet1Subnet281E6D3C
-  MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet1DefaultRouteB1A9DE6E:
+        Ref: PublicSubnetOne
+  PublicSubnetOneIgwRoute:
     Type: AWS::EC2::Route
     Properties:
       RouteTableId:
-        Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet1RouteTable440E65B1
+        Ref: PublicSubnetOneRouteTable
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId:
-        Ref: MultiUserInfraVpcIGW322D5805
+        Ref: InternetGateway
     DependsOn:
-      - MultiUserInfraVpcVPCGW8C41E9C2
-  MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet2Subnet5218CAF9:
+      - VpcGatewayAttachment
+  PublicSubnetTwo:
     Type: AWS::EC2::Subnet
     Properties:
       CidrBlock: 172.31.128.0/17
       VpcId:
-        Ref: MultiUserInfraVpc
+        Ref: Vpc
       AvailabilityZone: {{ region }}b
       MapPublicIpOnLaunch: true
-  MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet2RouteTable94561FFD:
+  PublicSubnetTwoRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
       VpcId:
-        Ref: MultiUserInfraVpc
-  MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet2RouteTableAssociation69E447BF:
+        Ref: Vpc
+  PublicSubnetTwoRouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       RouteTableId:
-        Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet2RouteTable94561FFD
+        Ref: PublicSubnetTwoRouteTable
       SubnetId:
-        Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet2Subnet5218CAF9
-  MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet2DefaultRouteFFA92127:
+        Ref: PublicSubnetTwo
+  PublicSubnetTwoIgwRoute:
     Type: AWS::EC2::Route
     Properties:
       RouteTableId:
-        Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet2RouteTable94561FFD
+        Ref: PublicSubnetTwoRouteTable
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId:
-        Ref: MultiUserInfraVpcIGW322D5805
+        Ref: InternetGateway
     DependsOn:
-      - MultiUserInfraVpcVPCGW8C41E9C2
-  MultiUserInfraVpcIGW322D5805:
+      - VpcGatewayAttachment
+  InternetGateway:
     Type: AWS::EC2::InternetGateway
-  MultiUserInfraVpcVPCGW8C41E9C2:
+  VpcGatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
       VpcId:
-        Ref: MultiUserInfraVpc
+        Ref: Vpc
       InternetGatewayId:
-        Ref: MultiUserInfraVpcIGW322D5805
-  MultiUserInfraAdDomainAdminNodeSecurityGroup:
+        Ref: InternetGateway
+  AdDomainAdminNodeSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Allow SSH access
@@ -90,49 +90,49 @@ Resources:
           IpProtocol: tcp
           ToPort: 22
       VpcId:
-        Ref: MultiUserInfraVpc
-  MultiUserInfraDirectory:
+        Ref: Vpc
+  Directory:
     Type: AWS::DirectoryService::{{ directory_type }}
     Properties:
       Name: {{ ad_domain_name }}
       Password: {{ ad_admin_password }}
       VpcSettings:
         SubnetIds:
-          - Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet1Subnet281E6D3C
-          - Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet2Subnet5218CAF9
+          - Ref: PublicSubnetOne
+          - Ref: PublicSubnetTwo
         VpcId:
-          Ref: MultiUserInfraVpc
+          Ref: Vpc
       {% if directory_type == "SimpleAD" %}
       Size: Large
       {% endif %}
       ShortName: NET
-  MultiUserInfraVpcDhcpOptsSet:
+  VpcDhcpOptsSet:
     Type: AWS::EC2::DHCPOptions
     Properties:
       DomainName: {{ ad_domain_name }} {{ default_ec2_domain }}
       DomainNameServers:
         Fn::GetAtt:
-          - MultiUserInfraDirectory
+          - Directory
           - DnsIpAddresses
-  MultiUserInfraAdDomainAdminNodeWaitConditionHandle:
+  AdDomainAdminNodeWaitConditionHandle:
     Type: AWS::CloudFormation::WaitConditionHandle
-  MultiUserInfraVpcDhcpOptsSetAssociation:
+  VpcDhcpOptsSetAssociation:
     Type: AWS::EC2::VPCDHCPOptionsAssociation
     Properties:
       DhcpOptionsId:
-        Ref: MultiUserInfraVpcDhcpOptsSet
+        Ref: VpcDhcpOptsSet
       VpcId:
-        Ref: MultiUserInfraVpc
-  MultiUserInfraAdDomainAdminNodeWaitCondition:
+        Ref: Vpc
+  AdDomainAdminNodeWaitCondition:
     Type: AWS::CloudFormation::WaitCondition
     Properties:
       Count: 1
       Handle:
-        Ref: MultiUserInfraAdDomainAdminNodeWaitConditionHandle
+        Ref: AdDomainAdminNodeWaitConditionHandle
       Timeout: "1800"
     DependsOn:
-      - MultiUserInfraDirectory
-  MultiUserInfraJoinRole:
+      - Directory
+  JoinRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -157,32 +157,32 @@ Resources:
                       - - "arn:"
                         - Ref: AWS::Partition
                         - :ds:{{ region }}:{{ account }}:directory/
-                        - Ref: MultiUserInfraDirectory
+                        - Ref: Directory
           PolicyName:
             Fn::Join:
               - ""
               - - Ref: AWS::StackName
                 - resetuserpassword
-  MultiUserInfraJoinProfile:
+  JoinProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Roles:
-        - Ref: MultiUserInfraJoinRole
+        - Ref: JoinRole
     DependsOn:
-      - MultiUserInfraJoinRole
-  MultiUserInfraAdDomainAdminNode:
+      - JoinRole
+  AdDomainAdminNode:
     Type: AWS::EC2::Instance
     Properties:
       AvailabilityZone: {{ region }}a
       IamInstanceProfile:
-        Ref: MultiUserInfraJoinProfile
+        Ref: JoinProfile
       ImageId: {{ admin_node_ami_id }}
       InstanceType: {{ admin_node_instance_type }}
       KeyName: {{ admin_node_key_name }}
       SecurityGroupIds:
-        - Ref: MultiUserInfraAdDomainAdminNodeSecurityGroup
+        - Ref: AdDomainAdminNodeSecurityGroup
       SubnetId:
-        Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet1Subnet281E6D3C
+        Ref: PublicSubnetOne
       UserData:
         Fn::Base64:
           Fn::Join:
@@ -273,14 +273,14 @@ Resources:
                 # Signal success
                 # TODO: don't assumed this is installed (in case non-AL2 AMI used)
                 /opt/aws/bin/cfn-signal --exit-code=0 --reason="admin node setup complete" '
-              - Ref: MultiUserInfraAdDomainAdminNodeWaitConditionHandle
+              - Ref: AdDomainAdminNodeWaitConditionHandle
               - "'"
     DependsOn:
-      - MultiUserInfraDirectory
-      - MultiUserInfraJoinProfile
-      - MultiUserInfraVpcDhcpOptsSet
-      - MultiUserInfraVpcDhcpOptsSetAssociation
-  MultiUserInfraUserAddingDocument:
+      - Directory
+      - JoinProfile
+      - VpcDhcpOptsSet
+      - VpcDhcpOptsSetAssociation
+  UserAddingDocument:
     Type: AWS::SSM::Document
     Properties:
       Content:
@@ -304,7 +304,7 @@ Resources:
 Outputs:
   VpcId:
     Value:
-      Ref: MultiUserInfraVpc
+      Ref: Vpc
     Export:
       Name:
         Fn::Join:
@@ -315,9 +315,9 @@ Outputs:
     Value:
       Fn::Join:
         - ""
-        - - Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet1Subnet281E6D3C
+        - - Ref: PublicSubnetOne
           - ","
-          - Ref: MultiUserInfraVpcMultiUserSubnetOneConfigurationSubnet2Subnet5218CAF9
+          - Ref: PublicSubnetTwo
     Export:
       Name:
         Fn::Join:
@@ -340,7 +340,7 @@ Outputs:
           - Fn::Select:
               - 0
               - Fn::GetAtt:
-                  - MultiUserInfraDirectory
+                  - Directory
                   - DnsIpAddresses
     Export:
       Name:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -422,22 +422,6 @@ Outputs:
           - ""
           - - Ref: AWS::StackName
             - DomainName
-  LdapUris:
-    Value:
-      Fn::Join:
-        - ""
-        - - ldap://
-          - Fn::Select:
-              - 0
-              - Fn::GetAtt:
-                  - Directory
-                  - DnsIpAddresses
-    Export:
-      Name:
-        Fn::Join:
-          - ""
-          - - Ref: AWS::StackName
-            - LdapUris
   Password:
     Value: {{ ad_admin_password }}
     Export:
@@ -454,4 +438,17 @@ Outputs:
           - ""
           - - Ref: AWS::StackName
             - ReadOnlyUserName
+  DirectoryDnsIpAddresses:
+    Value:
+      Fn::Join:
+        - ","
+        - Fn::GetAtt:
+          - Directory
+          - DnsIpAddresses
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - DirectoryDnsIpAddresses
 

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -3,7 +3,7 @@ Image:
 HeadNode:
   InstanceType: {{ instance }}
   Networking:
-    SubnetId: {{ directory_subnet }}
+    SubnetId: {{ public_directory_subnet }}
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -19,7 +19,7 @@ Scheduling:
           MaxCount: 3000
       Networking:
         SubnetIds:
-          - {{ directory_subnet }}
+          - {{ private_directory_subnet }}
 Monitoring:
   Logs:
     CloudWatch:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -39,12 +39,11 @@ SharedStorage:
     StorageType: Efs
 DirectoryService:
   DomainName: {{ ldap_search_base }}
-  DomainAddr: {{ ldap_uri }}
+  DomainAddr: {{ ldaps_uri }}
   PasswordSecretArn: {{ password_secret_arn }}
   DomainReadOnlyUser: {{ ldap_default_bind_dn }}
   LdapTlsReqCert: never
   GenerateSshKeysForUsers: true
   AdditionalSssdConfigs:
-    debug_level: 0x1ff
-    ldap_auth_disable_tls_never_use_in_production: True
+    debug_level: "0x1ff"
     enumerate: True

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -39,12 +39,11 @@ SharedStorage:
     StorageType: Efs
 DirectoryService:
   DomainName: {{ ldap_search_base }}
-  DomainAddr: {{ ldap_uri }}
+  DomainAddr: {{ ldaps_uri }}
   PasswordSecretArn: {{ password_secret_arn }}
   DomainReadOnlyUser: {{ ldap_default_bind_dn }}
   LdapTlsReqCert: never
   GenerateSshKeysForUsers: false
   AdditionalSssdConfigs:
-    debug_level: 0x1ff
-    ldap_auth_disable_tls_never_use_in_production: True
+    debug_level: "0x1ff"
     enumerate: True

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -3,7 +3,7 @@ Image:
 HeadNode:
   InstanceType: {{ instance }}
   Networking:
-    SubnetId: {{ directory_subnet }}
+    SubnetId: {{ public_directory_subnet }}
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -19,7 +19,7 @@ Scheduling:
           MaxCount: 3000
       Networking:
         SubnetIds:
-          - {{ directory_subnet }}
+          - {{ private_directory_subnet }}
 Monitoring:
   Logs:
     CloudWatch:


### PR DESCRIPTION
* Explicitly set file permissions being tested
*  Use NLB to implement LDAPS for SimpleAD
* Create integ test directory in private subnets
* Use better resource names in AD stack
* Manage existence of ~/.ssh directories when testing automatic keypair generation
* Reset SSH connections after cluster update
* Run AD integration integ test on ubuntu20

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
