### PR TITLE
2.11: Use c6gn.large in place of c6gn.16xlarge for EFA tests

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -214,7 +214,7 @@ efa:
         oss: ["alinux2"]
         schedulers: ["slurm"]
       - regions: ["us-west-2"]
-        instances: ["c6gn.16xlarge"]
+        instances: ["c6gn.large"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
         schedulers: ["slurm"]
       - regions: ["us-east-2"]

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -112,7 +112,7 @@ def test_hit_efa(
     # 2 instances are enough for other EFA tests.
     max_queue_size = 4 if instance in osu_benchmarks_instances else 2
     slots_per_instance = fetch_instance_slots(region, instance)
-    head_node_instance = "c5n.18xlarge" if architecture == "x86_64" else "c6gn.16xlarge"
+    head_node_instance = "c5n.18xlarge" if architecture == "x86_64" else "c6gn.large"
     cluster_config = pcluster_config_reader(max_queue_size=max_queue_size, head_node_instance=head_node_instance)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)


### PR DESCRIPTION
The test is useful to verify EFA kernel module is installed correctly on ARM instances with alinux2 and ubuntu1804 and that openmpi is installed correctly but it's not needed to use the biggest c6gn instance type.
