### PR TITLE
Fix RootVolume schema for the HeadNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ X.X.X
 - Fix ecs:ListContainerInstances permission in BatchUserRole
 - Fix exporting of cluster logs when there is no prefix specified, previously exported to a `None` prefix.
 - Fix rollback not being performed in case of cluster update failure.  
+- Fix RootVolume schema for the HeadNode.
 
 3.0.2
 -----

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -144,7 +144,6 @@ class HeadNodeRootVolumeSchema(BaseSchema):
             )
         }
     )
-    kms_key_id = fields.Str(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     throughput = fields.Int(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     encrypted = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     delete_on_termination = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -25,6 +25,7 @@ from pcluster.constants import SUPPORTED_OSES
 from pcluster.schemas.cluster_schema import (
     ClusterSchema,
     HeadNodeIamSchema,
+    HeadNodeRootVolumeSchema,
     ImageSchema,
     QueueIamSchema,
     SchedulerPluginCloudFormationClusterInfrastructureSchema,
@@ -171,6 +172,35 @@ def test_iam_schema(instance_role, instance_profile, additional_iam_policies, s3
         iam = QueueIamSchema().load(iam_dict)
         assert_that(iam.instance_role).is_equal_to(instance_role)
         assert_that(iam.instance_profile).is_equal_to(instance_profile)
+
+
+@pytest.mark.parametrize(
+    "config_dict, failure_message",
+    [
+        # failures
+        ({"KmsKeyId": "test"}, "Unknown field"),
+        # success
+        (
+            {
+                "VolumeType": "gp3",
+                "Iops": 100,
+                "Size": 50,
+                "Throughput": 300,
+                "Encrypted": True,
+                "DeleteOnTermination": True,
+            },
+            None,
+        ),
+    ],
+)
+def test_head_node_root_volume_schema(mocker, config_dict, failure_message):
+    mock_aws_api(mocker)
+
+    if failure_message:
+        with pytest.raises(ValidationError, match=failure_message):
+            HeadNodeRootVolumeSchema().load(config_dict)
+    else:
+        HeadNodeRootVolumeSchema().load(config_dict)
 
 
 DUMMY_AWSBATCH_QUEUE = {


### PR DESCRIPTION
The `kms_key_id` was defined in the schema structure but it was unused in the `RootVolume` resource.

If defined in the configuration, the creation was failing with:
```
  "message": "Invalid cluster configuration: __init__() got an unexpected keyword argument 'kms_key_id'"
```
After the fix the error is:
```
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "ConfigSchemaValidator",
      "message": "[('HeadNode', {'LocalStorage': {'RootVolume': {'KmsKeyId': ['Unknown field.']}}})]"
    }
  ],
  "message": "Invalid cluster configuration."
```

Added unit tests for `HeadNodeRootVolumeSchema`.