### PR TITLE
[ad_integration] Only set directory service in dna.json when enabled.

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -112,20 +112,24 @@ def get_common_user_data_env(node: Union[HeadNode, SlurmQueue], config: BaseClus
 def get_directory_service_dna_json_for_head_node(config: BaseClusterConfig) -> dict:
     """Return a dict containing directory service settings to be written to dna.json of head node."""
     directory_service = config.directory_service
-    return {
-        "enabled": "true" if directory_service else "false",
-        "domain_name": directory_service.domain_name if directory_service else "NONE",
-        "domain_addr": directory_service.domain_addr if directory_service else "NONE",
-        "password_secret_arn": directory_service.password_secret_arn if directory_service else "NONE",
-        "domain_read_only_user": directory_service.domain_read_only_user if directory_service else "NONE",
-        "ldap_tls_ca_cert": directory_service.ldap_tls_ca_cert or "NONE" if directory_service else "NONE",
-        "ldap_tls_req_cert": directory_service.ldap_tls_req_cert or "NONE" if directory_service else "NONE",
-        "ldap_access_filter": directory_service.ldap_access_filter or "NONE" if directory_service else "NONE",
-        "generate_ssh_keys_for_users": str(directory_service.generate_ssh_keys_for_users).lower()
+    return (
+        {
+            "directory_service": {
+                "enabled": "true",
+                "domain_name": directory_service.domain_name,
+                "domain_addr": directory_service.domain_addr,
+                "password_secret_arn": directory_service.password_secret_arn,
+                "domain_read_only_user": directory_service.domain_read_only_user,
+                "ldap_tls_ca_cert": directory_service.ldap_tls_ca_cert or "NONE",
+                "ldap_tls_req_cert": directory_service.ldap_tls_req_cert or "NONE",
+                "ldap_access_filter": directory_service.ldap_access_filter or "NONE",
+                "generate_ssh_keys_for_users": str(directory_service.generate_ssh_keys_for_users).lower(),
+                "additional_sssd_configs": directory_service.additional_sssd_configs,
+            }
+        }
         if directory_service
-        else "NONE",
-        "additional_sssd_configs": directory_service.additional_sssd_configs if directory_service else "NONE",
-    }
+        else {}
+    )
 
 
 def get_shared_storage_ids_by_type(shared_storage_ids: dict, storage_type: SharedStorageType):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -899,7 +899,7 @@ class ClusterCdkStack(Stack):
                     "use_private_hostname": str(self.config.scheduling.settings.dns.use_ec2_hostnames).lower()
                     if self._condition_is_slurm()
                     else "false",
-                    "directory_service": get_directory_service_dna_json_for_head_node(self.config),
+                    **get_directory_service_dna_json_for_head_node(self.config),
                 },
             },
             indent=4,

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
@@ -40,18 +40,6 @@
     "volume": "NONE",
     "use_private_hostname": "false",
     "scheduler_plugin_substack_arn": "",
-    "stack_arn": "{'Ref': 'AWS::StackId'}",
-    "directory_service": {
-      "enabled": "false",
-      "domain_name": "NONE",
-      "domain_addr": "NONE",
-      "password_secret_arn": "NONE",
-      "domain_read_only_user": "NONE",
-      "ldap_tls_ca_cert": "NONE",
-      "ldap_tls_req_cert": "NONE",
-      "ldap_access_filter": "NONE",
-      "generate_ssh_keys_for_users": "NONE",
-      "additional_sssd_configs": "NONE"
-    }
+    "stack_arn": "{'Ref': 'AWS::StackId'}"
   }
 }

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/scheduler-plugin-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/scheduler-plugin-imds-secured-true.head-node.dna.json
@@ -40,18 +40,6 @@
     "volume": "NONE",
     "use_private_hostname": "false",
     "scheduler_plugin_substack_arn": "{'Ref': 'SchedulerPluginStack'}",
-    "stack_arn": "{'Ref': 'AWS::StackId'}",
-    "directory_service": {
-      "enabled": "false",
-      "domain_name": "NONE",
-      "domain_addr": "NONE",
-      "password_secret_arn": "NONE",
-      "domain_read_only_user": "NONE",
-      "ldap_tls_ca_cert": "NONE",
-      "ldap_tls_req_cert": "NONE",
-      "ldap_access_filter": "NONE",
-      "generate_ssh_keys_for_users": "NONE",
-      "additional_sssd_configs": "NONE"
-    }
+    "stack_arn": "{'Ref': 'AWS::StackId'}"
   }
 }

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
@@ -40,18 +40,6 @@
     "volume": "NONE",
     "use_private_hostname": "false",
     "scheduler_plugin_substack_arn": "",
-    "stack_arn": "{'Ref': 'AWS::StackId'}",
-    "directory_service": {
-      "enabled": "false",
-      "domain_name": "NONE",
-      "domain_addr": "NONE",
-      "password_secret_arn": "NONE",
-      "domain_read_only_user": "NONE",
-      "ldap_tls_ca_cert": "NONE",
-      "ldap_tls_req_cert": "NONE",
-      "ldap_access_filter": "NONE",
-      "generate_ssh_keys_for_users": "NONE",
-      "additional_sssd_configs": "NONE"
-    }
+    "stack_arn": "{'Ref': 'AWS::StackId'}"
   }
 }

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
@@ -40,18 +40,6 @@
     "volume": "NONE",
     "use_private_hostname": "false",
     "scheduler_plugin_substack_arn": "",
-    "stack_arn": "{'Ref': 'AWS::StackId'}",
-    "directory_service": {
-      "enabled": "false",
-      "domain_name": "NONE",
-      "domain_addr": "NONE",
-      "password_secret_arn": "NONE",
-      "domain_read_only_user": "NONE",
-      "ldap_tls_ca_cert": "NONE",
-      "ldap_tls_req_cert": "NONE",
-      "ldap_access_filter": "NONE",
-      "generate_ssh_keys_for_users": "NONE",
-      "additional_sssd_configs": "NONE"
-    }
+    "stack_arn": "{'Ref': 'AWS::StackId'}"
   }
 }


### PR DESCRIPTION
Otherwise, the cookbook will use the defaults in default.rb

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
