### PR TITLE
integ-tests: do not use EFA instances for head node

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -49,7 +49,7 @@ def test_efa(
     # 2 instances are enough for other EFA tests.
     max_queue_size = 4 if instance in osu_benchmarks_instances else 2
     slots_per_instance = fetch_instance_slots(region, instance)
-    head_node_instance = "c5n.18xlarge" if architecture == "x86_64" else "c6gn.16xlarge"
+    head_node_instance = "c5.18xlarge" if architecture == "x86_64" else "c6g.16xlarge"
     cluster_config = pcluster_config_reader(max_queue_size=max_queue_size, head_node_instance=head_node_instance)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)


### PR DESCRIPTION
The big head node instance type was used to speed up NCCL tests but we don't need EFA enabled instances for it because we're not enabling it from the Launch Template.

