### PR TITLE
3.0: integ-tests: do not use EFA instances for head node

### DIFF
--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -36,7 +36,7 @@ class ValidatorSuppressor(ABC):
 class AllValidatorsSuppressor(ValidatorSuppressor):
     """Suppressor that suppresses all validators."""
 
-    def __eq__(self, o: object) -> bool:
+    def __eq__(self, o: object) -> bool:  # pylint: disable=C0103
         return isinstance(o, AllValidatorsSuppressor)
 
     def __hash__(self) -> int:
@@ -49,7 +49,7 @@ class AllValidatorsSuppressor(ValidatorSuppressor):
 class TypeMatchValidatorsSuppressor(ValidatorSuppressor):
     """Suppressor that suppresses validators based on their type."""
 
-    def __eq__(self, o: object) -> bool:
+    def __eq__(self, o: object) -> bool:  # pylint: disable=C0103
         if isinstance(o, TypeMatchValidatorsSuppressor):
             return o._validators_to_suppress == self._validators_to_suppress
         return False

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -53,7 +53,7 @@ def test_efa(
     # 2 instances are enough for other EFA tests.
     max_queue_size = 4 if instance in osu_benchmarks_instances else 2
     slots_per_instance = fetch_instance_slots(region, instance)
-    head_node_instance = "c5n.18xlarge" if architecture == "x86_64" else "c6gn.16xlarge"
+    head_node_instance = "c5.18xlarge" if architecture == "x86_64" else "c6g.16xlarge"
     cluster_config = pcluster_config_reader(max_queue_size=max_queue_size, head_node_instance=head_node_instance)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)


### PR DESCRIPTION
The big head node instance type was used to speed up NCCL tests but we don't need EFA-enabled instances for it because we're not enabling it from the Launch Template.
