### PR TITLE
[develop] Fix recipe called as part of cluster update

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1044,7 +1044,7 @@ class ClusterCdkStack(Stack):
                             "cinc-client --local-mode --config /etc/chef/client.rb --log_level info"
                             " --logfile /var/log/chef-client.log --force-formatter --no-color"
                             " --chef-zero-port 8889 --json-attributes /etc/chef/dna.json"
-                            " --override-runlist aws-parallelcluster::update_head_node &&"
+                            " --override-runlist aws-parallelcluster::update &&"
                             " cfn-signal --exit-code=0 --reason='Update complete'"
                             f" '{self.wait_condition_handle.ref}' ||"
                             " cfn-signal --exit-code=1 --reason='Update failed'"


### PR DESCRIPTION
Commit f39ecf8a8b in the cookbook repo changed the name of the recipe
used to update a running cluster. This makes the corresponding change
to the portion of the head node's cfn-init configuration.

Signed-off-by: Tim Lane <tilne@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
