### PR TITLE
[develop] integ-tests: make test_ad_integration reuse vpc_stack 

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -1,3 +1,10 @@
+ad_integration:
+  test_ad_integration.py::test_ad_integration:
+    dimensions:
+      - regions: ["us-east-1"]
+        instances: ["c5n.18xlarge"]
+        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        schedulers: ["slurm"]
 arm_pl:
   test_arm_pl.py::test_arm_pl:
     dimensions:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -699,9 +699,7 @@ def parameterized_cfn_stacks_factory(request):
 AVAILABILITY_ZONE_OVERRIDES = {
     # c5.xlarge is not supported in use1-az3
     # FSx Lustre file system creation is currently not supported for use1-az3
-    # m6g.xlarge is not supported in use1-az2 or use1-az3
-    # p4d.24xlarge is only available on use1-az2
-    "us-east-1": ["use1-az2"],
+    "us-east-1": ["use1-az1", "use1-az2"],
     # some instance type is only supported in use2-az2
     "us-east-2": ["use2-az2"],
     # c4.xlarge is not supported in usw2-az4

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -1,158 +1,17 @@
-Resources:
+Parameters:
   Vpc:
-    Type: AWS::EC2::VPC
-    Properties:
-      CidrBlock: 172.31.0.0/16
-      EnableDnsHostnames: true
-      EnableDnsSupport: true
-      InstanceTenancy: default
+    Description: VPC ID.
+    Type: String
   PrivateSubnetOne:
-    Type: AWS::EC2::Subnet
-    Properties:
-      VpcId:
-        Ref: Vpc
-      AvailabilityZone: {{ region }}a
-      CidrBlock: 172.31.0.0/18
-      MapPublicIpOnLaunch: false
-  NatGatewayOneEIP:
-    Type: AWS::EC2::EIP
-    DependsOn: VpcGatewayAttachment
-    Properties:
-      Domain: vpc
-  NatGatewayOne:
-    Type: AWS::EC2::NatGateway
-    Properties:
-      AllocationId: !GetAtt NatGatewayOneEIP.AllocationId
-      SubnetId:
-        Ref: PublicSubnetOne
-  PrivateRouteTableOne:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId:
-        Ref: Vpc
-  DefaultPrivateRouteOne:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId:
-        Ref: PrivateRouteTableOne
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NatGatewayOne
-  PrivateSubnetOneRouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId:
-        Ref: PrivateRouteTableOne
-      SubnetId:
-        Ref: PrivateSubnetOne
+    Description: Subnet ID of the first subnet.
+    Type: String
   PrivateSubnetTwo:
-    Type: AWS::EC2::Subnet
-    Properties:
-      VpcId:
-        Ref: Vpc
-      AvailabilityZone: {{ region }}b
-      CidrBlock: 172.31.64.0/18
-      MapPublicIpOnLaunch: false
-  NatGatewayTwoEIP:
-    Type: AWS::EC2::EIP
-    DependsOn: VpcGatewayAttachment
-    Properties:
-      Domain: vpc
-  NatGatewayTwo:
-    Type: AWS::EC2::NatGateway
-    Properties:
-      AllocationId: !GetAtt NatGatewayTwoEIP.AllocationId
-      SubnetId:
-        Ref: PublicSubnetTwo
-  PrivateRouteTableTwo:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId:
-        Ref: Vpc
-  DefaultPrivateRouteTwo:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId:
-        Ref: PrivateRouteTableTwo
-      DestinationCidrBlock: 0.0.0.0/0
-      NatGatewayId:
-        Ref: NatGatewayTwo
-  PrivateSubnetTwoRouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId:
-        Ref: PrivateRouteTableTwo
-      SubnetId:
-        Ref: PrivateSubnetTwo
+    Description: Subnet ID of the second subnet. This subnet should be in another availability zone
+    Type: String
   PublicSubnetOne:
-    Type: AWS::EC2::Subnet
-    Properties:
-      CidrBlock: 172.31.128.0/18
-      VpcId:
-        Ref: Vpc
-      AvailabilityZone: {{ region }}a
-      MapPublicIpOnLaunch: true
-  PublicSubnetOneRouteTable:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId:
-        Ref: Vpc
-  PublicSubnetOneRouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId:
-        Ref: PublicSubnetOneRouteTable
-      SubnetId:
-        Ref: PublicSubnetOne
-  PublicSubnetOneIgwRoute:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId:
-        Ref: PublicSubnetOneRouteTable
-      DestinationCidrBlock: 0.0.0.0/0
-      GatewayId:
-        Ref: InternetGateway
-    DependsOn:
-      - VpcGatewayAttachment
-  PublicSubnetTwo:
-    Type: AWS::EC2::Subnet
-    Properties:
-      CidrBlock: 172.31.192.0/18
-      VpcId:
-        Ref: Vpc
-      AvailabilityZone: {{ region }}b
-      MapPublicIpOnLaunch: true
-  PublicSubnetTwoRouteTable:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId:
-        Ref: Vpc
-  PublicSubnetTwoRouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId:
-        Ref: PublicSubnetTwoRouteTable
-      SubnetId:
-        Ref: PublicSubnetTwo
-  PublicSubnetTwoIgwRoute:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId:
-        Ref: PublicSubnetTwoRouteTable
-      DestinationCidrBlock: 0.0.0.0/0
-      GatewayId:
-        Ref: InternetGateway
-    DependsOn:
-      - VpcGatewayAttachment
-  InternetGateway:
-    Type: AWS::EC2::InternetGateway
-  VpcGatewayAttachment:
-    Type: AWS::EC2::VPCGatewayAttachment
-    Properties:
-      VpcId:
-        Ref: Vpc
-      InternetGatewayId:
-        Ref: InternetGateway
+    Description: Subnet ID of the public subnet.
+    Type: String
+Resources:
   AdDomainAdminNodeSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -251,7 +110,6 @@ Resources:
   AdDomainAdminNode:
     Type: AWS::EC2::Instance
     Properties:
-      AvailabilityZone: {{ region }}a
       IamInstanceProfile:
         Ref: JoinProfile
       ImageId: {{ admin_node_ami_id }}
@@ -389,19 +247,6 @@ Outputs:
           - ""
           - - Ref: AWS::StackName
             - VpcId
-  PublicSubnetIds:
-    Value:
-      Fn::Join:
-        - ""
-        - - Ref: PublicSubnetOne
-          - ","
-          - Ref: PublicSubnetTwo
-    Export:
-      Name:
-        Fn::Join:
-          - ""
-          - - Ref: AWS::StackName
-            - PublicSubnetIds
   PrivateSubnetIds:
     Value:
       Fn::Join:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -3,7 +3,7 @@ Image:
 HeadNode:
   InstanceType: {{ instance }}
   Networking:
-    SubnetId: {{ public_directory_subnet }}
+    SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -19,7 +19,7 @@ Scheduling:
           MaxCount: 3000
       Networking:
         SubnetIds:
-          - {{ private_directory_subnet }}
+          - {{ private_subnet_id }}
 Monitoring:
   Logs:
     CloudWatch:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -3,7 +3,7 @@ Image:
 HeadNode:
   InstanceType: {{ instance }}
   Networking:
-    SubnetId: {{ public_directory_subnet }}
+    SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -19,7 +19,7 @@ Scheduling:
           MaxCount: 3000
       Networking:
         SubnetIds:
-          - {{ private_directory_subnet }}
+          - {{ private_subnet_id }}
 Monitoring:
   Logs:
     CloudWatch:


### PR DESCRIPTION
Instead of creating its own VPC in ad_stack.yaml, test_ad_integration will reuse vpc_stack

This commit also relaxes availability zones restriction in us-east-1 because we are not Launching P4D in us-east-1 anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
