### PR TITLE
[develop] Fix shared artifacts test for byos

### DIFF
--- a/cli/src/pcluster/api/typing_utils.py
+++ b/cli/src/pcluster/api/typing_utils.py
@@ -25,7 +25,6 @@ if sys.version_info < (3, 7):
         """Determine whether klass is a List."""
         return klass.__extra__ == list
 
-
 else:
 
     def is_generic(klass):

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
@@ -237,7 +237,8 @@ def _test_artifacts_shared_from_head(command_executor, compute_node):
     """Test artifacts shared from head to compute node"""
     compute_node_private_ip = compute_node.get("privateIpAddress")
     shared_listing = command_executor.run_remote_command(
-        f"ssh -q {compute_node_private_ip} ls {PCLUSTER_SHARED_SCHEDULER_PLUGIN_DIR}"
+        f"ssh -q {compute_node_private_ip} "
+        "\"sudo su - {SCHEDULER_PLUGIN_USER} -c 'ls {PCLUSTER_SHARED_SCHEDULER_PLUGIN_DIR}'\""
     ).stdout
     assert_that(shared_listing).contains("sharedFromHead")
 


### PR DESCRIPTION
Regression introduced by https://github.com/aws/aws-parallelcluster-cookbook/pull/1280,
which changed permission (to be more restrictive) on shared folder.

Tested running command
```
$ ssh -q queue1-st-computeresource1-1 "sudo su - pcluster-scheduler-plugin -c 'ls /opt/parallelcluster/shared/scheduler-plugin'"
parallelcluster_computemgtd.conf
slurm
```
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
