### PR TITLE
[develop]Use randomly generated password for AD admin and AD users

### DIFF
--- a/tests/integration-tests/tests/ad_integration/cluster_user.py
+++ b/tests/integration-tests/tests/ad_integration/cluster_user.py
@@ -12,7 +12,7 @@ from tests.common.schedulers_common import get_scheduler_commands
 class ClusterUser:
     """Class to represent a cluster user in a multi-user environment."""
 
-    def __init__(self, user_num, test_datadir, cluster, scheduler, default_user_remote_command_executor):
+    def __init__(self, user_num, test_datadir, cluster, scheduler, default_user_remote_command_executor, password):
         self._default_user_remote_command_executor = default_user_remote_command_executor
         self.cluster = cluster
         self.scheduler = scheduler
@@ -23,7 +23,7 @@ class ClusterUser:
         self.ssh_public_key_path = f"{self.ssh_private_key_path}.pub"
         # TODO: randomly generate this. It's hardcoded here because it's also hard-coded in the script
         #       that creates users as part of the directory stack.
-        self.password = "ApplesBananasCherries!"
+        self.password = password
         self._personalized_remote_command_executor = RemoteCommandExecutor(
             self.cluster, username=self.alias, alternate_ssh_key=self.ssh_private_key_path
         )

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -14,7 +14,9 @@ import datetime
 import io
 import logging
 import os as os_lib
+import random
 import re
+import string
 import zipfile
 from collections import defaultdict
 
@@ -154,7 +156,15 @@ def store_secret_in_secret_manager(request, region, cfn_stacks_factory):
 
 
 def _create_directory_stack(
-    cfn_stacks_factory, request, directory_type, test_resources_dir, ad_admin_password, bucket_name, region, vpc_stack
+    cfn_stacks_factory,
+    request,
+    directory_type,
+    test_resources_dir,
+    ad_admin_password,
+    ad_user_password,
+    bucket_name,
+    region,
+    vpc_stack,
 ):
     directory_stack_name = generate_stack_name(
         f"integ-tests-MultiUserInfraStack{directory_type}", request.config.getoption("stackname_suffix")
@@ -177,6 +187,7 @@ def _create_directory_stack(
         "admin_node_instance_type": "c5.large",
         "admin_node_key_name": request.config.getoption("key_name"),
         "ad_admin_password": ad_admin_password,
+        "ad_user_password": ad_user_password,
         "ad_domain_name": f"{directory_type.lower()}.multiuser.pcluster",
         "default_ec2_domain": "ec2.internal" if region == "us-east-1" else f"{region}.compute.internal",
         "ad_admin_user": "Administrator" if directory_type == "SimpleAD" else "Admin",
@@ -290,6 +301,7 @@ def directory_factory(request, cfn_stacks_factory, vpc_stacks):
         test_resources_dir,
         region,
         ad_admin_password,
+        ad_user_password,
     ):
         directory_stack = None
         if existing_directory_stack_name:
@@ -307,6 +319,7 @@ def directory_factory(request, cfn_stacks_factory, vpc_stacks):
                 directory_type,
                 test_resources_dir,
                 ad_admin_password,
+                ad_user_password,
                 bucket_name,
                 region,
                 vpc_stacks[region],
@@ -493,7 +506,8 @@ def test_ad_integration(
     """Verify AD integration works as expected."""
     compute_instance_type_info = {"name": "c5.xlarge", "num_cores": 4}
     config_params = {"compute_instance_type": compute_instance_type_info.get("name")}
-    ad_admin_password = "MultiUserInfraDirectoryReadOnlyPassword!"  # TODO: not secure
+    ad_admin_password = "".join(random.choices(string.ascii_letters + string.digits, k=60))
+    ad_user_password = "".join(random.choices(string.ascii_letters + string.digits, k=60))
     password_secret_arn = store_secret_in_secret_manager(ad_admin_password)
     if directory_type:
         bucket_name = s3_bucket_factory()
@@ -505,6 +519,7 @@ def test_ad_integration(
             str(test_datadir),
             region,
             ad_admin_password=ad_admin_password,
+            ad_user_password=ad_user_password,
         )
         config_params.update(
             get_ad_config_param_vals(directory_stack_name, nlb_stack_name, bucket_name, password_secret_arn)
@@ -527,7 +542,7 @@ def test_ad_integration(
     assert_that(NUM_USERS_TO_TEST).is_less_than_or_equal_to(NUM_USERS_TO_CREATE)
     users = []
     for user_num in range(1, NUM_USERS_TO_TEST + 1):
-        users.append(ClusterUser(user_num, test_datadir, cluster, scheduler, remote_command_executor))
+        users.append(ClusterUser(user_num, test_datadir, cluster, scheduler, remote_command_executor, ad_user_password))
     _run_user_workloads(users, test_datadir, remote_command_executor)
     logging.info("Testing pcluster update and generate ssh keys for user")
     _check_ssh_key_generation(users[0], scheduler_commands, False)

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -203,7 +203,7 @@ Resources:
                         --region {{ region }} \
                         --directory-id "\${DIRECTORY_ID}" \
                         --user-name "\${NEW_USER_ALIAS}" \
-                        --new-password "ApplesBananasCherries!"  # TODO: generate random passwords
+                        --new-password "{{ ad_user_password }}"
                 done
                 EOF
                 chmod +x /usr/local/bin/add_a_number_of_users.sh
@@ -267,14 +267,22 @@ Outputs:
           - ""
           - - Ref: AWS::StackName
             - DomainName
-  Password:
+  AdminPassword:
     Value: {{ ad_admin_password }}
     Export:
       Name:
         Fn::Join:
           - ""
           - - Ref: AWS::StackName
-            - Password
+            - AdminPassword
+  UserPassword:
+    Value: {{ ad_user_password }}
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - UserPassword
   ReadOnlyUserName:
     Value: {{ ad_admin_user }}
     Export:


### PR DESCRIPTION
With this commit, although the passwords are randomly generated, all AD users use the same password. Using the same password does not have significant issue for integration test.

Signed-off-by: Hanwen <hanwenli@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
