### PR TITLE
Use validator for max compute resources and max queue for scheduler plugin

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -103,8 +103,6 @@ from pcluster.constants import (
     EBS_VOLUME_SIZE_DEFAULT,
     FSX_HDD_THROUGHPUT,
     FSX_SSD_THROUGHPUT,
-    MAX_NUMBER_OF_COMPUTE_RESOURCES,
-    MAX_NUMBER_OF_QUEUES,
     SCHEDULER_PLUGIN_MAX_NUMBER_OF_USERS,
     SUPPORTED_OSES,
 )
@@ -1134,7 +1132,6 @@ class SchedulerPluginQueueSchema(_CommonQueueSchema):
     compute_resources = fields.Nested(
         SchedulerPluginComputeResourceSchema,
         many=True,
-        validate=validate.Length(max=MAX_NUMBER_OF_COMPUTE_RESOURCES),
         metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP, "update_key": "Name"},
     )
     networking = fields.Nested(
@@ -1508,7 +1505,6 @@ class SchedulingSchema(BaseSchema):
     scheduler_queues = fields.Nested(
         SchedulerPluginQueueSchema,
         many=True,
-        validate=validate.Length(max=MAX_NUMBER_OF_QUEUES),
         metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP, "update_key": "Name"},
     )
 

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -124,12 +124,19 @@ def test_compute_resource_size_validator(min_count, max_count, expected_message)
     "resource_name, resources_length, max_length, expected_message",
     [
         ("SlurmQueues", 5, 10, None),
+        ("SchedulerQueues", 10, 10, None),
         ("ComputeResources", 4, 5, None),
         (
             "SlurmQueues",
             11,
             10,
             "Invalid number of SlurmQueues (11) specified. Currently only supports up to 10 SlurmQueues.",
+        ),
+        (
+            "SchedulerQueues",
+            12,
+            10,
+            "Invalid number of SchedulerQueues (12) specified. Currently only supports up to 10 SchedulerQueues.",
         ),
         (
             "ComputeResources",


### PR DESCRIPTION
Use validator for max compute resources and max queue for scheduler plugin instead of validate through schema, so the validator can be suppressed when more queues and compute resources are configured

Manually test with using a config with more than 10 queues and 5 compute resources.
Manually test with changing MaxCount of QueueConstraints and ComputeResourceConstraints in the config