### PR TITLE
Split shell command into a sequence of arguments

### DIFF
--- a/scheduler_plugins/plugin_template/tests/render_cfn_template_test.py
+++ b/scheduler_plugins/plugin_template/tests/render_cfn_template_test.py
@@ -45,7 +45,7 @@ def test_render_cfn_template():
     with NamedTemporaryFile(mode="w") as f:
         f.write(rendered_template)
         f.flush()
-        subprocess.check_call(f"cfn-lint -i W2001 W8001 -- {f.name}", shell=True)
+        subprocess.check_call(["cfn-lint", "-i", "W2001", "W8001", "--", f.name])
 
 
 def _read_yaml_file(file):

--- a/scheduler_plugins/slurm/tests/render_cfn_template_test.py
+++ b/scheduler_plugins/slurm/tests/render_cfn_template_test.py
@@ -45,7 +45,7 @@ def test_render_cfn_template():
     with NamedTemporaryFile(mode="w") as f:
         f.write(rendered_template)
         f.flush()
-        subprocess.check_call(f"cfn-lint -i W2001 W8001 -- {f.name}", shell=True)
+        subprocess.check_call((["cfn-lint", "-i", "W2001", "W8001", "--", f.name]))
 
 
 def _read_yaml_file(file):


### PR DESCRIPTION
### Description of changes
* If the shell is invoked explicitly, via `shell=True`, it is the application’s responsibility to ensure that all whitespace and metacharacters are quoted appropriately to avoid shell injection vulnerabilities, by using `shell=False` we're skipping this problem.

### Tests
* Installed cfn-lint from pypi and executed `test_render_cfn_template` from IDE.

### References
* https://docs.python.org/3/library/subprocess.html#security-considerations
* https://docs.python.org/3/library/subprocess.html#subprocess.check_call

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
