### PR TITLE
integ-tests: Fix ad_integration tests

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -156,15 +156,7 @@ def store_secret_in_secret_manager(request, region, cfn_stacks_factory):
 
 
 def _create_directory_stack(
-    cfn_stacks_factory,
-    request,
-    directory_type,
-    test_resources_dir,
-    ad_admin_password,
-    ad_user_password,
-    bucket_name,
-    region,
-    vpc_stack,
+    cfn_stacks_factory, request, directory_type, test_resources_dir, bucket_name, region, vpc_stack
 ):
     directory_stack_name = generate_stack_name(
         f"integ-tests-MultiUserInfraStack{directory_type}", request.config.getoption("stackname_suffix")
@@ -180,6 +172,8 @@ def _create_directory_stack(
         .get_caller_identity()
         .get("Account")
     )
+    ad_admin_password = "".join(random.choices(string.ascii_letters + string.digits, k=60))
+    ad_user_password = "".join(random.choices(string.ascii_letters + string.digits, k=60))
     config_args = {
         "region": region,
         "account": account_id,
@@ -294,14 +288,7 @@ def directory_factory(request, cfn_stacks_factory, vpc_stacks):
     created_directory_stacks = defaultdict(dict)
 
     def _directory_factory(
-        existing_directory_stack_name,
-        existing_nlb_stack_name,
-        directory_type,
-        bucket_name,
-        test_resources_dir,
-        region,
-        ad_admin_password,
-        ad_user_password,
+        existing_directory_stack_name, existing_nlb_stack_name, directory_type, bucket_name, test_resources_dir, region
     ):
         directory_stack = None
         if existing_directory_stack_name:
@@ -314,15 +301,7 @@ def directory_factory(request, cfn_stacks_factory, vpc_stacks):
             logging.info("Using directory stack named %s created by another test", directory_stack_name)
         else:
             directory_stack = _create_directory_stack(
-                cfn_stacks_factory,
-                request,
-                directory_type,
-                test_resources_dir,
-                ad_admin_password,
-                ad_user_password,
-                bucket_name,
-                region,
-                vpc_stacks[region],
+                cfn_stacks_factory, request, directory_type, test_resources_dir, bucket_name, region, vpc_stacks[region]
             )
             directory_stack_name = directory_stack.name
             created_directory_stacks[region]["directory"] = directory_stack_name
@@ -495,35 +474,32 @@ def test_ad_integration(
     instance,
     os,
     pcluster_config_reader,
-    clusters_factory,
     directory_type,
     test_datadir,
     s3_bucket_factory,
     directory_factory,
     request,
     store_secret_in_secret_manager,
+    clusters_factory,
 ):
     """Verify AD integration works as expected."""
     compute_instance_type_info = {"name": "c5.xlarge", "num_cores": 4}
     config_params = {"compute_instance_type": compute_instance_type_info.get("name")}
-    ad_admin_password = "".join(random.choices(string.ascii_letters + string.digits, k=60))
-    ad_user_password = "".join(random.choices(string.ascii_letters + string.digits, k=60))
-    password_secret_arn = store_secret_in_secret_manager(ad_admin_password)
-    if directory_type:
-        bucket_name = s3_bucket_factory()
-        directory_stack_name, nlb_stack_name = directory_factory(
-            request.config.getoption("directory_stack_name"),
-            request.config.getoption("ldaps_nlb_stack_name"),
-            directory_type,
-            bucket_name,
-            str(test_datadir),
-            region,
-            ad_admin_password=ad_admin_password,
-            ad_user_password=ad_user_password,
-        )
-        config_params.update(
-            get_ad_config_param_vals(directory_stack_name, nlb_stack_name, bucket_name, password_secret_arn)
-        )
+    bucket_name = s3_bucket_factory()
+    directory_stack_name, nlb_stack_name = directory_factory(
+        request.config.getoption("directory_stack_name"),
+        request.config.getoption("ldaps_nlb_stack_name"),
+        directory_type,
+        bucket_name,
+        str(test_datadir),
+        region,
+    )
+    directory_stack_outputs = get_infra_stack_outputs(directory_stack_name)
+    ad_user_password = directory_stack_outputs.get("UserPassword")
+    password_secret_arn = store_secret_in_secret_manager(directory_stack_outputs.get("AdminPassword"))
+    config_params.update(
+        get_ad_config_param_vals(directory_stack_name, nlb_stack_name, bucket_name, password_secret_arn)
+    )
     cluster_config = pcluster_config_reader(**config_params)
     cluster = clusters_factory(cluster_config)
 


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

The test was not able to reuse the directory service stack because the random passwords were generated/read in the wrong scope. This commit will generate the passwords in the same scope as the directory service stack. Following code will read the passwords from stack output.

This commit will move the clusters_factory fixture to the last argument of the test to ensure logs are cleaned up after a successful test run.
* Link to impacted open issues.

None

### Tests
* Describe the automated and/or manual tests executed to validate the patch.

Integration tests have been passed against the change

* Describe the added/modified tests.

This PR is a change in the integration test

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
