### PR TITLE
Download/install aws-cfn-bootstrap-py3-latest.tar.gz for all OSes besides Amazon Linux

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -123,14 +123,7 @@ phases:
               set -v
               BUCKET="s3.amazonaws.com"
               [[ ${AWS::Region} =~ ^cn- ]] && BUCKET="s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
-
-              OS='{{ build.OperatingSystemName.outputs.stdout }}'
-
-              if [[ ${!OS} =~ ^(ubuntu2004)$ ]]; then
-                echo "https://${!BUCKET}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
-              else
-                echo "https://${!BUCKET}/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz"
-              fi
+              echo "https://${!BUCKET}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
 
       # Get input base AMI Architecture
       - name: OperatingSystemArchitecture
@@ -273,21 +266,8 @@ phases:
               OS='{{ build.OperatingSystemName.outputs.stdout }}'
 
               if [[ ${!OS} =~ ^(centos7|ubuntu(18|20)04)$ ]]; then
-                if [[ ${!OS} == centos7 ]]; then
-                  which pip2
-                  if [ $? -eq 0 ]; then
-                    PIP_COMMAND="pip2"
-                  else
-                    PIP_COMMAND="pip"
-                  fi
-                elif [[ ${!OS} == ubuntu1804 ]]; then
-                  PIP_COMMAND="pip"
-                elif [[ ${!OS} == ubuntu2004 ]]; then
-                  PIP_COMMAND="pip3"
-                fi
-
                 curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz {{ build.CfnBootstrapUrl.outputs.stdout }}
-                ${!PIP_COMMAND} install /tmp/aws-cfn-bootstrap-latest.tar.gz
+                pip3 install /tmp/aws-cfn-bootstrap-latest.tar.gz
               fi
 
       - name: CreateBootstrapFile


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

The latest release (version 0.6.0) of [pystache](https://pypi.org/project/pystache/) removed the support for Python2. This package is a dependency of aws-cfn-bootstrap-latest.tar.gz.

The latest (version 1.4-34) [aws-cfn-bootstrap-latest.tar.gz](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/releasehistory-aws-cfn-bootstrap.html#releasehistory-aws-cfn-bootstrap-v1) became incompatible with Python2 after the pystache update, and it is recommended in [CloudFormation helper scripts reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-helper-scripts-reference.html) to use the latest installation package for Python3.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
All tests in pcluster3.yaml have been passed
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
