### PR TITLE
[release-3.0] Disable build AMI test for centos7

### DIFF
--- a/cli/src/pcluster/api/typing_utils.py
+++ b/cli/src/pcluster/api/typing_utils.py
@@ -25,7 +25,6 @@ if sys.version_info < (3, 7):
         """Determine whether klass is a List."""
         return klass.__extra__ == list
 
-
 else:
 
     def is_generic(klass):

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -104,7 +104,7 @@ createami:
     dimensions:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2", "ubuntu2004", "centos7"]
+        oss: ["alinux2", "ubuntu2004"]  # "centos7" removed because of https://github.com/aws/aws-parallelcluster/issues/3584
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"]


### PR DESCRIPTION
Disable test because of https://github.com/aws/aws-parallelcluster/issues/3584

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
