### PR TITLE
2.11: Disable cloud-init boot updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 - Upgrade Slurm to version 20.11.8.
 - Upgrade Cinc Client to version 17.2.29.
 - Disable packages update at instance launch time on Amazon Linux 2.
+- Disable unattended packages update on Ubuntu.
 
 **BUG FIXES**
 - Disable update of ec2_iam_role parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 - CentOS 8 is no longer supported (EOL on December 31st, 2021).
 - Upgrade Slurm to version 20.11.8.
 - Upgrade Cinc Client to version 17.2.29.
+- Disable packages update at instance launch time on Amazon Linux 2.
 
 **BUG FIXES**
 - Disable update of ec2_iam_role parameter.

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -319,6 +319,10 @@ Resources:
               Content-Type: text/cloud-config; charset=us-ascii
               MIME-Version: 1.0
 
+              package_update: false
+              package_upgrade: false
+              repo_upgrade: none
+
               output:
                 all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"
               write_files:

--- a/cloudformation/compute-fleet-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-substack.cfn.yaml
@@ -429,6 +429,10 @@ Resources:
               Content-Type: text/cloud-config; charset=us-ascii
               MIME-Version: 1.0
 
+              package_update: false
+              package_upgrade: false
+              repo_upgrade: none
+
               output:
                 all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"
               write_files:

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -450,6 +450,15 @@ Resources:
               export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
               PROXY
               fi
+
+              --==BOUNDARY==
+              Content-Type: text/cloud-config; charset=us-ascii
+              MIME-Version: 1.0
+
+              package_update: false
+              package_upgrade: false
+              repo_upgrade: none
+
               --==BOUNDARY==
               Content-Type: text/x-shellscript; charset="us-ascii"
               MIME-Version: 1.0


### PR DESCRIPTION
### Description of changes
* The automatic boot update can create misalignment in the new compute node nodes and increases boot time.
* In this way we're sure that the version of all the packages is aligned in all the instances for the entire cluster lifecycle.
* Actually the updates were enabled for AmazonLinux2 only, in this way we're aligning the behaviour of all OSes.

### Tests
* Verified by checking the generated `/var/lib/cloud/instance/cloud-config.txt` file content:
```
[ec2-user@ip-10-0-0-125 ~]$ sudo cat /var/lib/cloud/instance/cloud-config.txt
#cloud-config

# from 1 files
# part-002

---
package_update: false
package_upgrade: false
repo_upgrade: none
...
```
* Verified `/var/log/yum.log` and `/var/log/apt/` are empty.
* Tested creation of a cluster for alinux2, centos7, ubuntu1804 and ubuntu2004, with modified templates, verifying there are no `yum` actions in the `cloud-init-output.log` file.
```
template_url = https://<bucket>/templates/2.11.3/aws-parallelcluster.cfn.json
hit_template_url = s3://<bucket>/templates/2.11.3/compute-fleet-hit-substack.cfn.yaml
cw_dashboard_template_url = s3://<bucket>/templates/2.11.3/cw-dashboard-substack.cfn.yaml
```

### References
* Amazon Linux2 default settings: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html#package-repository
* cloud-init update/upgrade doc: https://cloudinit.readthedocs.io/en/latest/topics/modules.html?highlight=repo_upgrade#package-update-upgrade-install

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
