### PR TITLE
integ-tests: fix deletion order of AD integration test

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -323,7 +323,8 @@ def directory_factory(request, cfn_stacks_factory, vpc_stacks):
     yield _directory_factory
 
     for region, stack_dict in created_directory_stacks.items():
-        for stack_type, stack_name in stack_dict.items():
+        for stack_type in ["nlb", "directory"]:
+            stack_name = stack_dict[stack_type]
             if request.config.getoption("no_delete"):
                 logging.info(
                     "Not deleting %s stack named %s in region %s because --no-delete option was specified",


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

NLB stack has to be deleted before directory stack.

* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
test_ad_integration test has been passed
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
