### PR TITLE
3.x: Disable packages update at instance launch time on Amazon Linux 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
 - Change SlurmQueues length and ComputeResources length schema validators to be config validators. 
 - Upgrade Slurm to version 21.08.4.
 - Disable EC2 ImageBuilder enhanced image metadata when building ParallelCluster custom images.
+- Disable packages update at instance launch time on Amazon Linux 2.
 
 **BUG FIXES**
 - Redirect stderr and stdout to CLI log file to prevent unwanted text to pollute the pcluster CLI output.
@@ -149,6 +150,7 @@ CHANGELOG
 - Add tag 'Name' to every shared storage with the value specified in the shared storage name config.
 - Remove installation of MPICH and FFTW packages.
 - Remove Ganglia support.
+- Disable unattended packages update on Ubuntu.
 
 2.11.3
 -----

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -39,6 +39,10 @@ fi
 Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0
 
+package_update: false
+package_upgrade: false
+repo_upgrade: none
+
 datasource_list: [ Ec2, None ]
 output:
   all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -39,6 +39,10 @@ fi
 Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0
 
+package_update: false
+package_upgrade: false
+repo_upgrade: none
+
 datasource_list: [ Ec2, None ]
 
 --==BOUNDARY==


### PR DESCRIPTION
### Description of changes
* The automatic boot update can create misalignment in the new compute node nodes and increases boot time.
* In this way we're sure that the version of all the packages is aligned in all the instances for the entire cluster lifecycle.
* Actually the updates were enabled for AmazonLinux2 only, in this way we're aligning the behaviour of all OSes.

### Tests
* Verified by checking the generated `/var/lib/cloud/instance/cloud-config.txt` file content:
```
$ sudo cat /var/lib/cloud/instance/cloud-config.txt
#cloud-config

# from 1 files
# part-002

---
datasource_list:
- Ec2
- None
package_update: false
package_upgrade: false
repo_upgrade: none
...
```
* Verified `/var/log/yum.log` and `/var/log/apt/` are empty.
* Tested creation of a cluster for alinux2, centos7, ubuntu1804 and ubuntu2004, with modified CLI/user-data, verifying there are no `yum` actions in the `cloud-init-output.log` file.


### References
* Same patch for 2.x branch: https://github.com/aws/aws-parallelcluster/pull/3587
* Amazon Linux2 default settings: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/amazon-linux-ami-basics.html#package-repository
* cloud-init update/upgrade doc: https://cloudinit.readthedocs.io/en/latest/topics/modules.html?highlight=repo_upgrade#package-update-upgrade-install

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.