### PR TITLE
Additional logging for scheduler plugin definition and CFN template

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -512,6 +512,7 @@ class Cluster:
             return
 
         try:
+            LOGGER.info("Downloading scheduler plugin CloudFormation template from %s", scheduler_plugin_template)
             if scheduler_plugin_template.startswith("s3"):
                 bucket_parsing_result = parse_bucket_url(scheduler_plugin_template)
                 result = AWSApi.instance().s3.get_object(
@@ -530,6 +531,7 @@ class Cluster:
 
         # jinja rendering
         try:
+            LOGGER.info("Rendering the following scheduler plugin CloudFormation template:\n%s", file_content)
             environment = SandboxedEnvironment(loader=BaseLoader)
             environment.filters["hash"] = (
                 lambda value: hashlib.sha1(value.encode()).hexdigest()[0:16].capitalize()  # nosec nosemgrep

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -15,6 +15,7 @@
 #
 
 import copy
+import logging
 import re
 from urllib.request import urlopen
 
@@ -118,6 +119,10 @@ from pcluster.schemas.common_schema import (
 from pcluster.validators.cluster_validators import FSX_MESSAGES
 
 # pylint: disable=C0302
+
+
+LOGGER = logging.getLogger(__name__)
+
 
 # ---------------------- Storage ---------------------- #
 
@@ -1443,6 +1448,7 @@ class SchedulerPluginSettingsSchema(BaseSchema):
         """Fetch scheduler definition if it is s3 or https url."""
         original_scheduler_definition = data["SchedulerDefinition"]
         if isinstance(original_scheduler_definition, str):
+            LOGGER.info("Downloading scheduler plugin definition from %s", original_scheduler_definition)
             try:
                 if original_scheduler_definition.startswith("s3"):
                     bucket_parsing_result = parse_bucket_url(original_scheduler_definition)
@@ -1461,6 +1467,7 @@ class SchedulerPluginSettingsSchema(BaseSchema):
                         "The provided value for SchedulerDefinition is invalid. "
                         "You can specify this as an S3 URL, HTTPS URL or as an inline YAML object."
                     )
+                LOGGER.info("Using the following scheduler plugin definition:\n%s", scheduler_definition)
                 data["SchedulerDefinition"] = yaml.safe_load(scheduler_definition)
             except YAMLError as e:
                 raise ValidationError(


### PR DESCRIPTION
### Description of changes
* Make sure we leave a trace in the CLI logs of the scheduler plugin definition and additional CFN template

### Tests
* Executed a cluster creation with `PCLUSTER_LOG_TO_STDOUT=1` and looked at logs in console.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
