### PR TITLE
Add CreateServiceLinkedRole for build image policy

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -769,6 +769,15 @@ Resources:
               - s3:GetObject
             Resource:
               - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*/*'
+          - Action:
+              - iam:CreateServiceLinkedRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/imagebuilder.amazonaws.com/AWSServiceRoleForImageBuilder
+            Effect: Allow
+            Condition:
+              StringLike:
+                iam:AWSServiceName:
+                  - imagebuilder.amazonaws.com
 
   ParallelClusterDeleteImageManagedPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -524,6 +524,15 @@ Resources:
               - s3:GetObject
             Resource:
               - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*/*'
+          - Action:
+              - iam:CreateServiceLinkedRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/imagebuilder.amazonaws.com/AWSServiceRoleForImageBuilder
+            Effect: Allow
+            Condition:
+              StringLike:
+                iam:AWSServiceName:
+                  - imagebuilder.amazonaws.com
 
   ParallelClusterDeleteImageManagedPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
This policy is required to create at least once the role AWSServiceRoleForImageBuilder, which is needed to allow EC2 Image Builder to access AWS resources on user behalf.

Ref https://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-service-linked-role.html

### Tests
Tested by hand running pcluster build-image command

### References
Related to this doc change https://github.com/awsdocs/aws-parallelcluster-user-guide/pull/62

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
