### PR TITLE
Execute CloudFormation template download and rendering as part of the dryrun

### DIFF
--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -116,7 +116,7 @@ def create_cluster(
 
         if dryrun:
             ignored_validation_failures = cluster.validate_create_request(
-                get_validator_suppressors(suppress_validators), FailureLevel[validation_failure_level]
+                get_validator_suppressors(suppress_validators), FailureLevel[validation_failure_level], dry_run=dryrun
             )
             validation_messages = validation_results_to_config_validation_errors(ignored_validation_failures)
             raise DryrunOperationException(validation_messages=validation_messages or None)
@@ -343,6 +343,7 @@ def update_cluster(
                 force=force_update,
                 validator_suppressors=get_validator_suppressors(suppress_validators),
                 validation_failure_level=FailureLevel[validation_failure_level],
+                dry_run=dryrun,
             )
             change_set, _ = _analyze_changes(changes)
             validation_messages = validation_results_to_config_validation_errors(ignored_validation_failures)


### PR DESCRIPTION
### Description of changes
* Execute CloudFormation template download and rendering as part of the dryrun

### Tests
* Manually test with dryrun with fake input:
```
{
  "message": "Bad Request: Error while downloading scheduler plugin artifacts from 's3://mybucket/cinc-install-1.1.0.sh1': The specified key does not exist."
} 
 ```
* Test with invalid template with Template: `{{%%%%}`:
```
{
  "message": "Bad Request: Error while rendering scheduler plugin template 's3://mybucket/test_render.yaml': unexpected '%'"
}

Process finished with exit code 1
```
### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
