### PR TITLE
[AD integration]  improve ad integration tests to test LDAPS with certificate verification

### DIFF
--- a/tests/integration-tests/configs/ad_integration.yaml
+++ b/tests/integration-tests/configs/ad_integration.yaml
@@ -5,6 +5,6 @@ test-suites:
     test_ad_integration.py::test_ad_integration:
       dimensions:
         - regions: ["us-east-1"]
-          instances: ["c5n.18xlarge"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2", "ubuntu2004"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -2,7 +2,7 @@ ad_integration:
   test_ad_integration.py::test_ad_integration:
     dimensions:
       - regions: ["us-east-1"]
-        instances: ["c5n.18xlarge"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
 arm_pl:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/NLB_SimpleAD.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/NLB_SimpleAD.yaml
@@ -23,6 +23,12 @@ Parameters:
     Description: IP Address of secondary Simple AD instance
     AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
     Type: String
+  CertificateSecretArn:
+    Description: The Arn of the secret storing the certificate
+    Type: String
+  DomainName:
+    Description: The domain name of the certificate in the CertificateSecretArn
+    Type: String
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -90,6 +96,22 @@ Resources:
       SslPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
       Certificates:
         - CertificateArn: !Ref LDAPSCertificateARN
+  DNS:
+    Type: AWS::Route53::HostedZone
+    Properties:
+      Name: !Ref DomainName
+      VPCs:
+        - VPCId: !Ref VPCId
+          VPCRegion: !Ref AWS::Region
+  DNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref DNS
+      Name: !Ref DomainName
+      AliasTarget:
+        DNSName: !GetAtt NetworkLoadBalancer.DNSName
+        HostedZoneId: !GetAtt NetworkLoadBalancer.CanonicalHostedZoneID
+      Type: A
 Outputs:
   LDAPSURL:
     Description: LDAPS Route53 Alias Target

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -42,7 +42,8 @@ DirectoryService:
   DomainAddr: {{ ldaps_uri }}
   PasswordSecretArn: {{ password_secret_arn }}
   DomainReadOnlyUser: {{ ldap_default_bind_dn }}
-  LdapTlsReqCert: never
+  LdapTlsCaCert: {{ ldap_tls_ca_cert }}
+  # LdapTlsReqCert: never
   GenerateSshKeysForUsers: true
   AdditionalSssdConfigs:
     debug_level: "0x1ff"

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -42,7 +42,8 @@ DirectoryService:
   DomainAddr: {{ ldaps_uri }}
   PasswordSecretArn: {{ password_secret_arn }}
   DomainReadOnlyUser: {{ ldap_default_bind_dn }}
-  LdapTlsReqCert: never
+  LdapTlsCaCert: {{ ldap_tls_ca_cert }}
+  # LdapTlsReqCert: never
   GenerateSshKeysForUsers: false
   AdditionalSssdConfigs:
     debug_level: "0x1ff"


### PR DESCRIPTION
Signed-off-by: Hanwen <hanwenli@amazon.com>

LDAPS connection has been tested, but without certificate verification. This commit create a self-signed certificate and instruct sssd agent to trust the certificate.

The reason for changing the `store_secret_in_secret_manager` from troposphere CloudFormation to boto3 calls is that CloudFormation only stores SecretString, but not SecretBytes

This commit also reduce the instance size used for the test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
