### PR TITLE
3.1.0 Add validation warning message when LDAP is used and required additional SSSD configuration is missing

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -697,7 +697,9 @@ class DirectoryService(Resource):
 
     def _register_validators(self):
         if self.domain_addr:
-            self._register_validator(DomainAddrValidator, domain_addr=self.domain_addr)
+            self._register_validator(
+                DomainAddrValidator, domain_addr=self.domain_addr, additional_sssd_configs=self.additional_sssd_configs
+            )
         if self.ldap_tls_req_cert:
             self._register_validator(LdapTlsReqCertValidator, ldap_tls_reqcert=self.ldap_tls_req_cert)
 

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -18,7 +18,7 @@ from pcluster.validators.common import FailureLevel, Validator
 class DomainAddrValidator(Validator):
     """Domain address validator."""
 
-    def _validate(self, domain_addr):
+    def _validate(self, domain_addr, additional_sssd_configs):
         """Warn user when ldap is used for the protocol instead of ldaps."""
         domain_addr_scheme = urlparse(domain_addr).scheme
         default_domain_addr_scheme = "ldaps"
@@ -35,9 +35,16 @@ class DomainAddrValidator(Validator):
                 FailureLevel.WARNING,
             )
         elif domain_addr_scheme == "ldap":
-            self._add_failure(
-                "The use of the ldaps protocol is strongly encouraged for security reasons.", FailureLevel.WARNING
+            warning_message = "The use of the ldaps protocol is strongly encouraged for security reasons."
+            tls_disabled = (
+                additional_sssd_configs.get("ldap_auth_disable_tls_never_use_in_production", "false").lower() == "true"
             )
+            if not tls_disabled:
+                warning_message += (
+                    " When using ldap, the additional SSSD config is required: "
+                    "'ldap_auth_disable_tls_never_use_in_production: true'."
+                )
+            self._add_failure(warning_message, FailureLevel.WARNING)
 
 
 class LdapTlsReqCertValidator(Validator):

--- a/cli/tests/pcluster/validators/test_directory_service_validators.py
+++ b/cli/tests/pcluster/validators/test_directory_service_validators.py
@@ -15,16 +15,40 @@ from tests.pcluster.validators.utils import assert_failure_messages
 
 
 @pytest.mark.parametrize(
-    "domain_addr, expected_message",
+    "domain_addr, additional_sssd_configs, expected_message",
     [
-        ("ldaps://172.31.8.14", None),
-        ("ldap://172.31.8.14", "use of the ldaps protocol is strongly encouraged for security reasons"),
-        ("https://172.31.8.14", "Unsupported protocol 'https'. Supported protocols are: ldaps ldap"),
-        ("172.31.8.14", "No protocol specified. Assuming the use of 'ldaps'"),
+        ("ldaps://172.31.8.14", "WHATEVER", None),
+        (
+            "ldap://172.31.8.14",
+            {"ldap_auth_disable_tls_never_use_in_production": "true"},
+            "The use of the ldaps protocol is strongly encouraged for security reasons.",
+        ),
+        (
+            "ldap://172.31.8.14",
+            {},
+            [
+                "The use of the ldaps protocol is strongly encouraged for security reasons.",
+                "When using ldap, the additional SSSD config is required: "
+                "'ldap_auth_disable_tls_never_use_in_production: true'.",
+            ],
+        ),
+        (
+            "ldap://172.31.8.14",
+            {"ldap_auth_disable_tls_never_use_in_production": "false"},
+            [
+                "The use of the ldaps protocol is strongly encouraged for security reasons.",
+                "When using ldap, the additional SSSD config is required: "
+                "'ldap_auth_disable_tls_never_use_in_production: true'.",
+            ],
+        ),
+        ("https://172.31.8.14", "WHATEVER", "Unsupported protocol 'https'. Supported protocols are: ldaps ldap"),
+        ("172.31.8.14", "WHATEVER", "No protocol specified. Assuming the use of 'ldaps'"),
     ],
 )
-def test_domain_addr_protocol(domain_addr, expected_message):
-    actual_failures = DomainAddrValidator().execute(domain_addr=domain_addr)
+def test_domain_addr_protocol(domain_addr, additional_sssd_configs, expected_message):
+    actual_failures = DomainAddrValidator().execute(
+        domain_addr=domain_addr, additional_sssd_configs=additional_sssd_configs
+    )
     assert_failure_messages(actual_failures, expected_message)
 
 


### PR DESCRIPTION
### Description of changes
1. Add a validation warning message when LDAP is used and required additional SSSD configuration is missing

### Tests
1. Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
