### PR TITLE
3.1 Fix DomainAddrValidator when checking TLS disablement in SSD additional config

### DIFF
--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -37,7 +37,8 @@ class DomainAddrValidator(Validator):
         elif domain_addr_scheme == "ldap":
             warning_message = "The use of the ldaps protocol is strongly encouraged for security reasons."
             tls_disabled = (
-                additional_sssd_configs.get("ldap_auth_disable_tls_never_use_in_production", "false").lower() == "true"
+                str(additional_sssd_configs.get("ldap_auth_disable_tls_never_use_in_production", "false")).lower()
+                == "true"
             )
             if not tls_disabled:
                 warning_message += (

--- a/cli/tests/pcluster/validators/test_directory_service_validators.py
+++ b/cli/tests/pcluster/validators/test_directory_service_validators.py
@@ -25,6 +25,11 @@ from tests.pcluster.validators.utils import assert_failure_messages
         ),
         (
             "ldap://172.31.8.14",
+            {"ldap_auth_disable_tls_never_use_in_production": True},
+            "The use of the ldaps protocol is strongly encouraged for security reasons.",
+        ),
+        (
+            "ldap://172.31.8.14",
             {},
             [
                 "The use of the ldaps protocol is strongly encouraged for security reasons.",
@@ -35,6 +40,15 @@ from tests.pcluster.validators.utils import assert_failure_messages
         (
             "ldap://172.31.8.14",
             {"ldap_auth_disable_tls_never_use_in_production": "false"},
+            [
+                "The use of the ldaps protocol is strongly encouraged for security reasons.",
+                "When using ldap, the additional SSSD config is required: "
+                "'ldap_auth_disable_tls_never_use_in_production: true'.",
+            ],
+        ),
+        (
+            "ldap://172.31.8.14",
+            {"ldap_auth_disable_tls_never_use_in_production": False},
             [
                 "The use of the ldaps protocol is strongly encouraged for security reasons.",
                 "When using ldap, the additional SSSD config is required: "


### PR DESCRIPTION
### Description of changes
1. Fix DomainAddrValidator when checking TLS disablement in SSD additional config. The bug causes boolean values to be  wrongly evaluated. Without this fix, customer cannot create a cluster integrated with LDAP because validator raises an exception
1. Added unit tests to cover patch

### Tests
1. Unit tests
1. Manual test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
