### PR TITLE
Fix configuration parameters used for AWS Batch tests: Vcpus vs vCpus

### DIFF
--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -18,7 +18,7 @@ Scheduling:
           {% if scheduler == "awsbatch" %}
           InstanceTypes:
             - {{ instance }}
-          MinVcpus: 4
+          MinvCpus: 4
           {% else %}
           InstanceType: {{ instance }}
           MinCount: 1

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_existing_fsx/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_existing_fsx/pcluster.config.yaml
@@ -24,7 +24,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           MinvCpus: 1
-          DesiredVcpus: 1
+          DesiredvCpus: 1
           {% else %}
           InstanceType: {{ instance }}
           MinCount: 1


### PR DESCRIPTION
### Description of changes
* Tests were failing because `MinVcpus` and `DesiredVcpus` weren't valid config parameters.
* We're following naming convention from CFN:


### Tests
* Tests were failing with an error like:
```
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "ConfigSchemaValidator",
      "message": "[('Scheduling', {'AwsBatchQueues': {0: {'ComputeResources': {0: {'DesiredVcpus': ['Unknown field.']}}, 'Iam': ['Unknown field.']}}})]"
    }
  ],
  "message": "Invalid cluster configuration."
}
```
* Manually tested the new configuration.

### References
* CFN documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
