### PR TITLE
[develop] Switch from g3.8xlarge to g4dn.xlarge for dcv test

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -147,7 +147,7 @@ dcv:
     dimensions:
       # DCV on GPU enabled instance
       - regions: ["ca-central-1"]
-        instances: ["g3.8xlarge"]
+        instances: ["g4dn.xlarge"]
         oss: {{common.OSS_COMMERCIAL_X86}}
         schedulers: ["slurm"]
       # DCV on ARM
@@ -156,8 +156,8 @@ dcv:
         oss: ["alinux2", "ubuntu1804"]
         schedulers: ["slurm"]
       # DCV on Batch
-      - regions: ["eu-west-1"]
-        instances: ["g3.8xlarge"]
+      - regions: ["ca-central-1"]
+        instances: ["g4dn.xlarge"]
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
       # DCV on Batch + ARM

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
@@ -21,10 +21,10 @@ Scheduling:
           {% if scheduler == "awsbatch" %}
           InstanceTypes:
             - {{ instance }}
-          # Cpu count is valid for g3.8xlarge
-          MinvCpus: 32
-          DesiredvCpus: 32
-          MaxvCpus: 32
+          # Cpu count is valid for g4dn.xlarge
+          MinvCpus: 4
+          DesiredvCpus: 4
+          MaxvCpus: 4
           {% else %}
           InstanceType: {{ instance }}
           MinCount: 1

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
@@ -21,10 +21,10 @@ Scheduling:
           {% if scheduler == "awsbatch" %}
           InstanceTypes:
             - {{ instance }}
-          # Cpu count is valid for g3.8xlarge
-          MinvCpus: 32
-          DesiredvCpus: 32
-          MaxvCpus: 32
+          # Cpu count is valid for g4dn.xlarge
+          MinvCpus: 4
+          DesiredvCpus: 4
+          MaxvCpus: 4
           {% else %}
           InstanceType: {{ instance }}
           MinCount: 1


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Switch from g3.8xlarge to g4dn.xlarge for dcv test

### Tests
* Tested with following conf
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["g4dn.xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### References
N/A

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
