### PR TITLE
[release-2.11] Switch from g3.8xlarge to g4dn.xlarge for dcv test

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -132,8 +132,8 @@ dcv:
   test_dcv.py::test_dcv_configuration:
     dimensions:
       # DCV on GPU enabled instance
-      - regions: ["eu-west-1"]
-        instances: ["g3.8xlarge"]
+      - regions: ["ca-central-1"]
+        instances: ["g4dn.xlarge"]
         oss: {{common.OSS_COMMERCIAL_X86}}
         schedulers: ["slurm"]
       # DCV on ARM
@@ -145,8 +145,8 @@ dcv:
         {{- common.OSS_COMMERCIAL_ARM.append("ubuntu2004") or "" }}
         schedulers: ["slurm"]
       # DCV on Batch
-      - regions: ["eu-west-1"]
-        instances: ["g3.8xlarge"]
+      - regions: ["ca-central-1"]
+        instances: ["g4dn.xlarge"]
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
       # DCV on Batch + ARM

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -31,9 +31,9 @@ DCV_CONNECT_SCRIPT = "/opt/parallelcluster/scripts/pcluster_dcv_connect.sh"
 
 @pytest.mark.dimensions("cn-northwest-1", "c4.xlarge", "alinux2", "slurm")
 @pytest.mark.dimensions("us-gov-west-1", "c5.xlarge", "ubuntu1804", "slurm")
-@pytest.mark.dimensions("eu-west-1", "g3.8xlarge", "alinux2", "slurm")
-@pytest.mark.dimensions("eu-west-1", "g3.8xlarge", "centos7", "slurm")
-@pytest.mark.dimensions("eu-west-1", "g3.8xlarge", "ubuntu1804", "slurm")
+@pytest.mark.dimensions("ca-central-1", "g4dn.xlarge", "alinux2", "slurm")
+@pytest.mark.dimensions("ca-central-1", "g4dn.xlarge", "centos7", "slurm")
+@pytest.mark.dimensions("ca-central-1", "g4dn.xlarge", "ubuntu1804", "slurm")
 @pytest.mark.dimensions("eu-west-1", "m6g.xlarge", "alinux2", "slurm")
 @pytest.mark.dimensions("eu-west-1", "m6g.xlarge", "centos7", "slurm")
 @pytest.mark.dimensions("eu-west-1", "m6g.xlarge", "ubuntu1804", "slurm")

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.ini
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.ini
@@ -12,9 +12,9 @@ scheduler = {{ scheduler }}
 master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 {% if scheduler == "awsbatch" %}
-min_vcpus = 32
-desired_vcpus = 32
-max_vcpus = 32
+min_vcpus = 4
+desired_vcpus = 4
+max_vcpus = 4
 {% else %}
 initial_queue_size = 1
 maintain_initial_size = true

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.ini
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.ini
@@ -12,9 +12,9 @@ scheduler = {{ scheduler }}
 master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 {% if scheduler == "awsbatch" %}
-min_vcpus = 32
-desired_vcpus = 32
-max_vcpus = 32
+min_vcpus = 4
+desired_vcpus = 4
+max_vcpus = 4
 {% else %}
 initial_queue_size = 1
 maintain_initial_size = true


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Switch from g3.8xlarge to g4dn.xlarge for dcv test

### Tests
* Tested with following conf
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["g4dn.xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### References
N/A

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
