### PR TITLE
Add S3 owner and checksum verification for artifacts referenced by the scheduler plugin

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1687,12 +1687,16 @@ class SchedulerPluginRequirements(Resource):
 class SchedulerPluginCloudFormationInfrastructure(Resource):
     """Represent the CloudFormation infrastructure for a Scheduler Plugin."""
 
-    def __init__(self, template: str, **kwargs):
+    def __init__(self, template: str, s3_bucket_owner: str = None, checksum: str = None, **kwargs):
         super().__init__(**kwargs)
         self.template = replace_url_parameters(template)
+        self.s3_bucket_owner = s3_bucket_owner
+        self.checksum = checksum
 
     def _register_validators(self):
-        self._register_validator(UrlValidator, url=self.template, fail_on_https_error=True)
+        self._register_validator(
+            UrlValidator, url=self.template, fail_on_https_error=True, expected_bucket_owner=self.s3_bucket_owner
+        )
 
 
 class SchedulerPluginClusterInfrastructure(Resource):
@@ -1706,12 +1710,14 @@ class SchedulerPluginClusterInfrastructure(Resource):
 class SchedulerPluginClusterSharedArtifact(Resource):
     """Represent the ClusterSharedArtifact config for a Scheduler Plugin."""
 
-    def __init__(self, source: str, **kwargs):
+    def __init__(self, source: str, s3_bucket_owner: str = None, checksum: str = None, **kwargs):
         super().__init__(**kwargs)
         self.source = replace_url_parameters(source)
+        self.s3_bucket_owner = s3_bucket_owner
+        self.checksum = checksum
 
     def _register_validators(self):
-        self._register_validator(UrlValidator, url=self.source)
+        self._register_validator(UrlValidator, url=self.source, expected_bucket_owner=self.s3_bucket_owner)
 
 
 class SchedulerPluginPluginResources(Resource):

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -518,7 +518,13 @@ class Cluster:
             if scheduler_plugin_template.startswith("s3"):
                 bucket_parsing_result = parse_bucket_url(scheduler_plugin_template)
                 result = AWSApi.instance().s3.get_object(
-                    bucket_name=bucket_parsing_result["bucket_name"], key=bucket_parsing_result["object_key"]
+                    bucket_name=bucket_parsing_result["bucket_name"],
+                    key=bucket_parsing_result["object_key"],
+                    expected_bucket_owner=get_attr(
+                        self.config,
+                        "scheduling.settings.scheduler_definition.cluster_infrastructure.cloud_formation."
+                        "s3_bucket_owner",
+                    ),
                 )
                 file_content = result["Body"].read().decode("utf-8")
             else:
@@ -530,6 +536,9 @@ class Cluster:
             raise BadRequestClusterActionError(
                 f"Error while downloading scheduler plugin artifacts from '{scheduler_plugin_template}': {str(e)}"
             ) from e
+
+        # checksum
+        self.validate_scheduler_plugin_template_checksum(file_content, scheduler_plugin_template)
 
         # jinja rendering
         try:
@@ -1144,4 +1153,17 @@ class Cluster:
                     "Update failure: The scheduler plugin used for this cluster does not support updating the "
                     "scheduling configuration.",
                     [changes[0]] + scheduling_changes,
+                )
+
+    def validate_scheduler_plugin_template_checksum(self, file_content, scheduler_plugin_template):
+        """Validate scheduler plugin template checksum match the expected checksum."""
+        checksum = get_attr(
+            self.config, "scheduling.settings.scheduler_definition.cluster_infrastructure.cloud_formation.checksum"
+        )
+        if checksum:
+            actual_checksum = hashlib.sha256(file_content.encode()).hexdigest()
+            if actual_checksum != checksum:
+                raise BadRequestClusterActionError(
+                    f"Error when validating scheduler plugin template '{scheduler_plugin_template}': "
+                    f"checksum: {actual_checksum} does not match expected one: {checksum}"
                 )

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1248,6 +1248,12 @@ class SchedulerPluginCloudFormationClusterInfrastructureSchema(BaseSchema):
     """Represent the CloudFormation section of the Scheduler Plugin ClusterInfrastructure schema."""
 
     template = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+    s3_bucket_owner = fields.Str(
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED}, validate=validate.Regexp(r"^\d{12}$")
+    )
+    checksum = fields.Str(
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED}, validate=validate.Regexp(r"^[A-Fa-f0-9]{64}$")
+    )
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -1274,6 +1280,12 @@ class SchedulerPluginClusterSharedArtifactSchema(BaseSchema):
     """Represent the schema for Cluster Shared Artifact in a Scheduler Plugin."""
 
     source = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+    s3_bucket_owner = fields.Str(
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED}, validate=validate.Regexp(r"^\d{12}$")
+    )
+    checksum = fields.Str(
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED}, validate=validate.Regexp(r"^[A-Fa-f0-9]{64}$")
+    )
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/validators/s3_validators.py
+++ b/cli/src/pcluster/validators/s3_validators.py
@@ -17,13 +17,24 @@ class UrlValidator(Validator):
     Validate given url with s3 or https prefix.
     """
 
-    def _validate(self, url, retries=3, fail_on_https_error: bool = False, fail_on_s3_error: bool = False):
+    def _validate(
+        self,
+        url,
+        retries=3,
+        fail_on_https_error: bool = False,
+        fail_on_s3_error: bool = False,
+        expected_bucket_owner: str = None,
+    ):
         scheme = get_url_scheme(url)
         if scheme in ["https", "s3"]:
             try:
                 if scheme == "s3":
-                    self._validate_s3_uri(url, fail_on_error=fail_on_s3_error)
+                    self._validate_s3_uri(
+                        url, fail_on_error=fail_on_s3_error, expected_bucket_owner=expected_bucket_owner
+                    )
                 else:
+                    if expected_bucket_owner:
+                        self._add_failure("S3BucketOwner can only be specified with S3 URL", FailureLevel.ERROR)
                     self._validate_https_uri(url, fail_on_error=fail_on_https_error)
             except ConnectionError as e:
                 if retries > 0:
@@ -38,20 +49,21 @@ class UrlValidator(Validator):
                 FailureLevel.ERROR,
             )
 
-    def _validate_s3_uri(self, url: str, fail_on_error: bool):
+    def _validate_s3_uri(self, url: str, fail_on_error: bool, expected_bucket_owner: str):
         try:
             match = re.match(r"s3://(.*?)/(.*)", url)
             if not match or len(match.groups()) < 2:
                 self._add_failure(f"s3 url '{url}' is invalid.", FailureLevel.ERROR)
             else:
                 bucket_name, object_name = match.group(1), match.group(2)
-                AWSApi.instance().s3.head_object(bucket_name=bucket_name, object_name=object_name)
+                AWSApi.instance().s3.head_object(
+                    bucket_name=bucket_name, object_name=object_name, expected_bucket_owner=expected_bucket_owner
+                )
 
-        except AWSClientError:
+        except AWSClientError as e:
             # Todo: Check that bucket is in s3_read_resource or s3_read_write_resource.
             self._add_failure(
-                f"The S3 object '{url}' does not exist or you do not have access to it.",
-                FailureLevel.ERROR if fail_on_error else FailureLevel.WARNING,
+                str(e), FailureLevel.ERROR if expected_bucket_owner or fail_on_error else FailureLevel.WARNING
             )
 
     def _validate_https_uri(self, url: str, fail_on_error: bool):

--- a/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
+++ b/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
@@ -66,9 +66,12 @@ Scheduling:
       ClusterInfrastructure:
         CloudFormation:
           Template: https://bucket/scheduler_plugin/additional_cluster_infrastructure_no_jinja.cfn.yaml
+          Checksum: b4479e35f4e1f60b680f343b21d9dc30c958a6d239974e96a463b4479e35f4e1
       PluginResources:
         ClusterSharedArtifacts:
           - Source: s3://${Region}-aws-parallelcluster.s3.${Region}.${URLSuffix}/plugins/slurm/v1.0.0/artifacts.tar.gz
+            S3BucketOwner: "012345678910"
+            Checksum: b4479e35f4e1f60b680f343b21d9dc30c958a6d239974e96a463b4479e35f4e0
           - Source: s3://${Region}-aws-parallelcluster.s3.${Region}.${URLSuffix}/plugins/slurm/v1.0.0/artifacts2.tar.gz
       Events:
         HeadInit:

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -648,6 +648,9 @@ class TestCluster:
         cluster_config_mock.return_value.scheduling.settings.scheduler_definition.cluster_infrastructure.cloud_formation.template = (  # noqa
             template_url
         )
+        cluster_config_mock.return_value.scheduling.settings.scheduler_definition.cluster_infrastructure.cloud_formation.checksum = (  # noqa
+            "532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25"
+        )
         cluster_config_mock.return_value.get_instance_types_data.return_value = {"t2.micro": "instance_info"}
         upload_cfn_template_mock = mocker.patch.object(cluster.bucket, "upload_cfn_template", autospec=True)
 

--- a/cli/tests/pcluster/models/test_imagebuilder.py
+++ b/cli/tests/pcluster/models/test_imagebuilder.py
@@ -109,13 +109,17 @@ def test_imagebuilder_kms_key_id_encrypted_validator_and_ami_volume_size_validat
                 },
             },
             True,
-            AWSClientError(function_name="head_object", message="error"),
+            AWSClientError(
+                function_name="head_object",
+                message="Failed when accessing object 'aws-parallelcluster-node-3.0.tgz' from bucket 'test'. "
+                "This can be due to 'aws-parallelcluster-node-3.0.tgz' not found in 'test'",
+            ),
             URLError("[Errno 2] No such file or directory: '/test/aws-parallelcluster-cookbook-3.0.tgz'"),
             [
                 "The url 'https:///test/aws-parallelcluster-cookbook-3.0.tgz' causes URLError, the error reason is "
                 "'[Errno 2] No such file or directory: '/test/aws-parallelcluster-cookbook-3.0.tgz''",
-                "The S3 object 's3://test/aws-parallelcluster-node-3.0.tgz' does not exist or you do not have access "
-                "to it.",
+                "Failed when accessing object 'aws-parallelcluster-node-3.0.tgz' from bucket 'test'. This can be due "
+                "to 'aws-parallelcluster-node-3.0.tgz' not found in 'test'",
                 "The value 'ftp://test/aws-parallelcluster-batch-3.0.tgz' is not a valid URL, choose URL with "
                 "'https' or 's3' prefix.",
             ],

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
@@ -58,6 +58,7 @@ def test_scheduler_plugin_integration(
     # Create bucket and upload resources
     bucket_name = s3_bucket_factory()
     bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+    account_id = boto3.client("sts", region_name=region).get_caller_identity().get("Account")
     for file in ["scheduler_plugin_infra.cfn.yaml", "artifact"]:
         bucket.upload_file(str(test_datadir / file), f"scheduler_plugin/{file}")
     # Create cluster
@@ -66,6 +67,7 @@ def test_scheduler_plugin_integration(
         another_instance=ANOTHER_INSTANCE_TYPE,
         user1=SCHEDULER_PLUGIN_USERS_LIST[0],
         user2=SCHEDULER_PLUGIN_USERS_LIST[1],
+        account_id=account_id,
     )
     cluster = clusters_factory(cluster_config)
     # Verify head node is running

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.yaml
@@ -56,9 +56,13 @@ Scheduling:
         ClusterSharedArtifacts:
           - Source: https://${Region}-aws-parallelcluster.s3.${Region}.${URLSuffix}/parallelcluster/3.0.0/cookbooks/aws-parallelcluster-cookbook-3.0.0.tgz
           - Source: s3://{{ bucket }}/scheduler_plugin/artifact
+            Checksum: cb30bed55f490e4f718dec95d841c5db175d9f9c5342fd8cb29af873e0efd9ee
+            S3BucketOwner: '{{account_id}}'
       ClusterInfrastructure:
         CloudFormation:
           Template: s3://{{ bucket }}/scheduler_plugin/scheduler_plugin_infra.cfn.yaml
+          Checksum: 6f9db6ee447ef457e8e58a0da79c14039154f5b4785a03a2fd2348079f90cf1e
+          S3BucketOwner: '{{account_id}}'
       SystemUsers:
         - Name: {{ user1 }}
           EnableImds: false


### PR DESCRIPTION
### Description of changes
* Add support for S3BucketOwner and Checksum for Scheduler Plugin
```
Scheduling:
  Scheduler: plugin
  SchedulerSettings:
    SchedulerDefinition:
      ClusterInfrastructure:
        CloudFormation:
          Template: s3://
          S3BucketOwner: "012345678910"
          Checksum: string
      PluginResources:
        ClusterSharedArtifacts:
          - Source: s3://
            S3BucketOwner: "012345678910"
            Checksum: fakechecksumf60b680f343b21d9dc30c958a6d239974e96a463b4479e35f4e0
```
* Add validation: "S3BucketOwner can only be specified with URL with 's3' prefix"
* checksum using sha256 checksum
* Validate S3BucketOwner with head_object. According to boto3 doc: `ExpectedBucketOwner (string) -- The account ID of the expected bucket owner. If the bucket is owned by a different account, the request will fail with an HTTP 403 (Access Denied) error.`
* Regex for BucketOwner: account id is a 12-digit number, according to here: https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html
* Add validation for scheduler plugin template checksum: `{
  "message": "Bad Request: Error while downloading scheduler plugin template 's3://mybucket/cinc-install-1.1.0.sh': Checksum: b66ef647c286e683d0b8da502338f5b1102943e6e8ef8a4f41ab8d5249982234 does not match expected checksum: 90127bc92b52f60b680f343b21d9dc30c958a6d239974e96a463b4479e35f4e1"
}`
### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
