### PR TITLE
[develop] Switch region and instance type size for dcv test

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -146,8 +146,8 @@ dcv:
   test_dcv.py::test_dcv_configuration:
     dimensions:
       # DCV on GPU enabled instance
-      - regions: ["ca-central-1"]
-        instances: ["g4dn.xlarge"]
+      - regions: ["us-east-1"]
+        instances: ["g4dn.2xlarge"]
         oss: {{common.OSS_COMMERCIAL_X86}}
         schedulers: ["slurm"]
       # DCV on ARM
@@ -156,8 +156,8 @@ dcv:
         oss: ["alinux2", "ubuntu1804"]
         schedulers: ["slurm"]
       # DCV on Batch
-      - regions: ["ca-central-1"]
-        instances: ["g4dn.xlarge"]
+      - regions: ["us-east-1"]
+        instances: ["g4dn.2xlarge"]
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
       # DCV on Batch + ARM

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
@@ -21,10 +21,10 @@ Scheduling:
           {% if scheduler == "awsbatch" %}
           InstanceTypes:
             - {{ instance }}
-          # Cpu count is valid for g4dn.xlarge
-          MinvCpus: 4
-          DesiredvCpus: 4
-          MaxvCpus: 4
+          # Cpu count is valid for g4dn.2xlarge
+          MinvCpus: 8
+          DesiredvCpus: 8
+          MaxvCpus: 8
           {% else %}
           InstanceType: {{ instance }}
           MinCount: 1

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
@@ -21,10 +21,10 @@ Scheduling:
           {% if scheduler == "awsbatch" %}
           InstanceTypes:
             - {{ instance }}
-          # Cpu count is valid for g4dn.xlarge
-          MinvCpus: 4
-          DesiredvCpus: 4
-          MaxvCpus: 4
+          # Cpu count is valid for g4dn.2xlarge
+          MinvCpus: 8
+          DesiredvCpus: 8
+          MaxvCpus: 8
           {% else %}
           InstanceType: {{ instance }}
           MinCount: 1


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Switch region and instance type size for dcv test
from g4dn.xlarge to g4dn.2xlarge
from ca-central-1 to us-east-1

### Tests
N/A

### References

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
