### PR TITLE
expand cluster without internet access test and move slurm specific dna.json attributes to a separate function

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -29,6 +29,7 @@ from pcluster.config.cluster_config import (
     LocalStorage,
     RootVolume,
     SharedStorageType,
+    SlurmClusterConfig,
     SlurmQueue,
 )
 from pcluster.constants import (
@@ -106,6 +107,16 @@ def get_common_user_data_env(node: Union[HeadNode, SlurmQueue], config: BaseClus
         "CookbookVersion": COOKBOOK_PACKAGES_VERSIONS["cookbook"],
         "ChefVersion": COOKBOOK_PACKAGES_VERSIONS["chef"],
         "BerkshelfVersion": COOKBOOK_PACKAGES_VERSIONS["berkshelf"],
+    }
+
+
+def get_slurm_specific_dna_json_for_head_node(config: SlurmClusterConfig, scheduler_resources) -> dict:
+    """Return a dict containing slurm specific settings to be written to dna.json of head node."""
+    return {
+        "dns_domain": scheduler_resources.cluster_hosted_zone.name if scheduler_resources.cluster_hosted_zone else "",
+        "hosted_zone": scheduler_resources.cluster_hosted_zone.ref if scheduler_resources.cluster_hosted_zone else "",
+        "ddb_table": scheduler_resources.dynamodb_table.ref,
+        "use_private_hostname": str(config.scheduling.settings.dns.use_ec2_hostnames).lower(),
     }
 
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -81,6 +81,7 @@ from pcluster.templates.cdk_builder_utils import (
     get_queue_security_groups_full,
     get_shared_storage_ids_by_type,
     get_shared_storage_options_by_type,
+    get_slurm_specific_dna_json_for_head_node,
     get_user_data_content,
 )
 from pcluster.templates.cw_dashboard_builder import CWDashboardConstruct
@@ -871,15 +872,8 @@ class ClusterCdkStack(Stack):
                         self.shared_storage_options, SharedStorageType.EBS
                     ),
                     "proxy": head_node.networking.proxy.http_proxy_address if head_node.networking.proxy else "NONE",
-                    "dns_domain": self.scheduler_resources.cluster_hosted_zone.name
-                    if self._condition_is_slurm() and self.scheduler_resources.cluster_hosted_zone
-                    else "",
-                    "hosted_zone": self.scheduler_resources.cluster_hosted_zone.ref
-                    if self._condition_is_slurm() and self.scheduler_resources.cluster_hosted_zone
-                    else "",
                     "node_type": "HeadNode",
                     "cluster_user": OS_MAPPING[self.config.image.os]["user"],
-                    "ddb_table": self.scheduler_resources.dynamodb_table.ref if self._condition_is_slurm() else "NONE",
                     "log_group_name": self.log_group.log_group_name
                     if self.config.monitoring.logs.cloud_watch.enabled
                     else "NONE",
@@ -896,9 +890,11 @@ class ClusterCdkStack(Stack):
                     "custom_node_package": self.config.custom_node_package or "",
                     "custom_awsbatchcli_package": self.config.custom_aws_batch_cli_package or "",
                     "head_node_imds_secured": str(self.config.head_node.imds.secured).lower(),
-                    "use_private_hostname": str(self.config.scheduling.settings.dns.use_ec2_hostnames).lower()
-                    if self._condition_is_slurm()
-                    else "false",
+                    **(
+                        get_slurm_specific_dna_json_for_head_node(self.config, self.scheduler_resources)
+                        if self._condition_is_slurm()
+                        else {}
+                    ),
                     **get_directory_service_dna_json_for_head_node(self.config),
                 },
             },

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
@@ -10,9 +10,7 @@
     "cw_logging_enabled": "true",
     "dcv_enabled": "false",
     "dcv_port": "NONE",
-    "ddb_table": "NONE",
     "disable_hyperthreading_manually": "false",
-    "dns_domain": "",
     "ebs_shared_dirs": "NONE,NONE,NONE,NONE,NONE",
     "efs_fs_id": "NONE",
     "efs_shared_dir": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
@@ -23,7 +21,6 @@
     "fsx_mount_name": "",
     "fsx_options": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     "head_node_imds_secured": "false",
-    "hosted_zone": "",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",
     "log_group_name": "/aws/parallelcluster/clustername-202101010101",
     "node_type": "HeadNode",
@@ -38,7 +35,6 @@
     "scheduler": "awsbatch",
     "stack_name": "clustername",
     "volume": "NONE",
-    "use_private_hostname": "false",
     "scheduler_plugin_substack_arn": "",
     "stack_arn": "{'Ref': 'AWS::StackId'}"
   }

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/scheduler-plugin-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/scheduler-plugin-imds-secured-true.head-node.dna.json
@@ -10,9 +10,7 @@
     "cw_logging_enabled": "true",
     "dcv_enabled": "false",
     "dcv_port": "NONE",
-    "ddb_table": "NONE",
     "disable_hyperthreading_manually": "false",
-    "dns_domain": "",
     "ebs_shared_dirs": "NONE,NONE,NONE,NONE,NONE",
     "efs_fs_id": "NONE",
     "efs_shared_dir": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
@@ -23,7 +21,6 @@
     "fsx_mount_name": "",
     "fsx_options": "NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE,NONE",
     "head_node_imds_secured": "true",
-    "hosted_zone": "",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",
     "log_group_name": "/aws/parallelcluster/clustername-202101010101",
     "node_type": "HeadNode",
@@ -38,7 +35,6 @@
     "scheduler": "plugin",
     "stack_name": "clustername",
     "volume": "NONE",
-    "use_private_hostname": "false",
     "scheduler_plugin_substack_arn": "{'Ref': 'SchedulerPluginStack'}",
     "stack_arn": "{'Ref': 'AWS::StackId'}"
   }

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/osu_pt2pt_submit_openmpi.sh
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/osu_pt2pt_submit_openmpi.sh
@@ -4,4 +4,5 @@
 set -e
 
 module load openmpi
+srun --mpi=pmix /shared/openmpi/osu-micro-benchmarks-{{ osu_benchmark_version }}/mpi/pt2pt/osu_latency
 mpirun /shared/openmpi/osu-micro-benchmarks-{{ osu_benchmark_version }}/mpi/pt2pt/osu_latency


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

The workaround is in Cookbook. This commit will expand the `test_cluster_in_no_internet_subnet` test to verify `srun` with `OpenMPI`, which the workaround will be able to address.

This commit will also move Slurm specific dna.json attributes to a separate function, aiming at simplifying the code

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
`test_cluster_in_no_internet_subnet` is the integration tests for this feature.
I also manually submitted 150 OSU benchmark jobs that require 76 nodes in total. The jobs succeeded

### References
* Link to related PRs in other packages (i.e. cookbook, node).
This PR only works with https://github.com/aws/aws-parallelcluster-cookbook/pull/1310

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
