### PR TITLE
3.1: Improve AD integration tests

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -815,7 +815,7 @@ def initialize_cli_creds(cfn_stacks_factory, request):
     for region in regions:
         if request.config.getoption("iam_user_role_stack_name"):
             stack_name = request.config.getoption("iam_user_role_stack_name")
-            logging.info("Using stack {0} in region {1}".format(stack_name, region))
+            logging.info(f"Using stack {stack_name} in region {region}")
             stack = CfnStack(
                 name=stack_name, region=region, capabilities=["CAPABILITY_IAM"], template=stack_template_data
             )

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -87,7 +87,7 @@ class RemoteCommandExecutor:
         if isinstance(command, list):
             command = " ".join(command)
         self._copy_additional_files(additional_files)
-        logging.info("Executing remote command command on {0}: {1}".format(self.__user_at_hostname, command))
+        logging.info("Executing remote command on {0}: {1}".format(self.__user_at_hostname, command))
         if login_shell:
             command = "/bin/bash --login -c {0}".format(shlex.quote(command))
 

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -80,6 +80,7 @@ TEST_DEFAULTS = {
     "tests_root_dir": "./tests",
     "instance_types_data": None,
     "use_default_iam_credentials": False,
+    "iam_user_role_stack_name": None,
     "directory_stack_name": None,
     "ldaps_nlb_stack_name": None,
 }
@@ -353,6 +354,11 @@ def _init_argparser():
         default=TEST_DEFAULTS.get("dry_run"),
     )
     debug_group.add_argument(
+        "--iam-user-role-stack-name",
+        help="Name of an existing IAM user role stack.",
+        default=TEST_DEFAULTS.get("iam_user_role_stack_name"),
+    )
+    debug_group.add_argument(
         "--directory-stack-name",
         help="Name of CFN stack providing AD domain to be used for testing AD integration feature.",
         default=TEST_DEFAULTS.get("directory_stack_name"),
@@ -547,6 +553,9 @@ def _set_custom_stack_args(args, pytest_args):
 
     if args.no_delete:
         pytest_args.append("--no-delete")
+
+    if args.iam_user_role_stack_name:
+        pytest_args.extend(["--iam-user-role-stack-name", args.iam_user_role_stack_name])
 
     if args.directory_stack_name:
         pytest_args.extend(["--directory-stack-name", args.directory_stack_name])

--- a/tests/integration-tests/tests/ad_integration/cluster_user.py
+++ b/tests/integration-tests/tests/ad_integration/cluster_user.py
@@ -97,11 +97,16 @@ class ClusterUser:
         logging.info("Removing home directory for user %s (%s)", self.alias, user_home_dir)
         self._default_user_remote_command_executor.run_remote_command(f"sudo rm -rf {user_home_dir}")
 
-    def validate_password_auth_and_automatic_homedir_creation(self, port=22):
-        """Ensure password can be used to login to cluster and that user's home directory is created."""
+    def ssh_connect(self, port=22):
+        """Establish a SSH connection to the cluster head node with the current user."""
         ssh = SSHClient()
         ssh.set_missing_host_key_policy(AutoAddPolicy())
         ssh.connect(self.cluster.head_node_ip, port, self.alias, self.password, allow_agent=False, look_for_keys=False)
+        return ssh
+
+    def validate_password_auth_and_automatic_homedir_creation(self, port=22):
+        """Ensure password can be used to login to cluster and that user's home directory is created."""
+        ssh = self.ssh_connect()
 
         homedir = f"/home/{self.alias}"
         command = f"[ -d {homedir} ] || echo failure"

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -42,7 +42,7 @@ Resources:
       {% if directory_type == "SimpleAD" %}
       Size: Large
       {% endif %}
-      ShortName: NET
+      ShortName: {{ ad_domain_short_name }}
   AdDomainAdminNodeWaitConditionHandle:
     Type: AWS::CloudFormation::WaitConditionHandle
   AdDomainAdminNodeWaitCondition:
@@ -197,13 +197,23 @@ Resources:
                 # Change user passwords
                 # TODO: put this in a lambda that can be triggered by users
                 for NEW_USER_ALIAS in \${NEW_USER_ALIASES}; do
-                    sleep 1  # TODO: retry w/ backoff instead of sleeping
-                    echo "Setting password for user \${NEW_USER_ALIAS}"
-                    aws ds reset-user-password \
-                        --region {{ region }} \
-                        --directory-id "\${DIRECTORY_ID}" \
-                        --user-name "\${NEW_USER_ALIAS}" \
-                        --new-password "{{ ad_user_password }}"
+                    max_attempts=5
+                    for attempt in $(seq 1 $max_attempts); do
+                      echo "Setting password for user \${NEW_USER_ALIAS} (attempt $attempt/$max_attempts)"
+                      aws ds reset-user-password \
+                          --region {{ region }} \
+                          --directory-id "\${DIRECTORY_ID}" \
+                          --user-name "\${NEW_USER_ALIAS}" \
+                          --new-password "{{ ad_user_password }}" && break
+                      if [ $attempt -ge $max_attempts ]; then
+                        echo "ERROR: Cannot set password for user \${NEW_USER_ALIAS}"
+                        exit 1
+                      else
+                        sleep_time=$attempt
+                        echo "WARNING: Cannot set password for user \${NEW_USER_ALIAS}. Will retry in $sleep_time seconds"
+                        sleep $sleep_time
+                      fi
+                    done
                 done
                 EOF
                 chmod +x /usr/local/bin/add_a_number_of_users.sh
@@ -267,6 +277,14 @@ Outputs:
           - ""
           - - Ref: AWS::StackName
             - DomainName
+  DomainShortName:
+    Value: {{ ad_domain_short_name }}
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - DomainShortName
   AdminPassword:
     Value: {{ ad_admin_password }}
     Export:
@@ -304,4 +322,3 @@ Outputs:
           - ""
           - - Ref: AWS::StackName
             - DirectoryDnsIpAddresses
-

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -39,12 +39,16 @@ SharedStorage:
     StorageType: Efs
 DirectoryService:
   DomainName: {{ ldap_search_base }}
-  DomainAddr: {{ ldaps_uri }}
+  DomainAddr: {{ ldap_uri }}
   PasswordSecretArn: {{ password_secret_arn }}
   DomainReadOnlyUser: {{ ldap_default_bind_dn }}
   LdapTlsCaCert: {{ ldap_tls_ca_cert }}
-  # LdapTlsReqCert: never
+  LdapTlsReqCert: {{ ldap_tls_req_cert }}
   GenerateSshKeysForUsers: true
+  LdapAccessFilter: "!(CN=PclusterUser3)"
   AdditionalSssdConfigs:
     debug_level: "0x1ff"
     enumerate: True
+    {% if directory_protocol == "ldap" %}
+    ldap_auth_disable_tls_never_use_in_production: True
+    {% endif %}

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -39,12 +39,15 @@ SharedStorage:
     StorageType: Efs
 DirectoryService:
   DomainName: {{ ldap_search_base }}
-  DomainAddr: {{ ldaps_uri }}
+  DomainAddr: {{ ldap_uri }}
   PasswordSecretArn: {{ password_secret_arn }}
   DomainReadOnlyUser: {{ ldap_default_bind_dn }}
   LdapTlsCaCert: {{ ldap_tls_ca_cert }}
-  # LdapTlsReqCert: never
+  LdapTlsReqCert: {{ ldap_tls_req_cert }}
   GenerateSshKeysForUsers: false
   AdditionalSssdConfigs:
     debug_level: "0x1ff"
     enumerate: True
+    {% if directory_protocol == "ldap" %}
+    ldap_auth_disable_tls_never_use_in_production: True
+    {% endif %}


### PR DESCRIPTION
### Description of changes
1. Add testing for MicrosoftAD.
2. Add testing for LDAP.
3. Add testing for LDAPS with and without certificate verification.
4. Add testing for LdapAccessFilter
5. Execute user password reset within a retry with backoff block. With this change we are now more robust against failures in reset. Consider that a failed password reset would make the user disabled, thus causing apparently random test failures.
6. Fix ACM certificated deletion: it should be deleted only if no-delete option is missing
7. Add log line to explain 10min sleep time waiting for certificate setup in the head node.
8. Allow reusing of an existent IAM user role stack.
9. Fix typo in remote command executor log.

### Tests
1 Integration tests manually launched locally, both for SimpleAd and MsAD.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
