### PR TITLE
3.x. Modify Intel MPI check to support 2021 version

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -235,9 +235,11 @@ phases:
                   rpm -qa | grep libfabric && rpm -qa | grep efa-
                   [[ $? -ne 0 ]] && echo "Check efa rpm failed" && exit 1
 
-                  echo "Checking intel mpi installed..."
-                  rpm -qa | grep intel-mpi
-                  [[ $? -ne 0 ]] && echo "Check intel-mpi rpm failed" && exit 1
+                  echo "Checking Intel MPI 20xx installed and module available..."
+                  unset MODULEPATH
+                  source /etc/profile.d/modules.sh
+                  (module avail intelmpi)2>&1 | grep "/opt/intel/mpi/20.*/modulefiles/"
+                  [[ $? -ne 0 ]] && echo "Check Intel MPI failed" && exit 1
                 else
                   dpkg -l | grep libfabric && modinfo efa | grep efa && [ -d /opt/amazon/efa ]
                   [[ $? -ne 0 ]] && echo "Check efa deb failed" && exit 1


### PR DESCRIPTION
### Description of changes
* With version 2021 the package is no longer installed from rpm package but with standalone installer from Intel.

### Tests
* Tested with build-ami process

### References
* Related to: https://github.com/aws/aws-parallelcluster-cookbook/pull/1313

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
