### PR TITLE
3.1: `[cli]` Add abbreviations for arguments for non-api based commands

### DIFF
--- a/cli/src/pcluster/cli/commands/common.py
+++ b/cli/src/pcluster/cli/commands/common.py
@@ -53,19 +53,13 @@ def to_int(param, in_str):
 class CliCommand(ABC):
     """Abstract class for a CLI command."""
 
-    def __init__(
-        self,
-        subparsers,
-        region_arg: bool = True,
-        expects_extra_args: bool = False,
-        **argparse_kwargs,
-    ):
+    def __init__(self, subparsers, region_arg: bool = True, expects_extra_args: bool = False, **argparse_kwargs):
         """Initialize a CLI command."""
         parser_name = argparse_kwargs.pop("name")
         parser = subparsers.add_parser(parser_name, **argparse_kwargs)
         parser.add_argument("--debug", action="store_true", help="Turn on debug logging.", default=False)
         if region_arg:
-            parser.add_argument("--region", help="AWS Region this operation corresponds to.")
+            parser.add_argument("-r", "--region", help="AWS Region this operation corresponds to.")
         self.register_command_args(parser)
         parser.set_defaults(func=self.execute, expects_extra_args=expects_extra_args)
 

--- a/cli/src/pcluster/cli/commands/configure/command.py
+++ b/cli/src/pcluster/cli/commands/configure/command.py
@@ -30,7 +30,7 @@ class ConfigureCommand(CliCommand):
         super().__init__(subparsers, name=self.name, help=self.help, description=self.description)
 
     def register_command_args(self, parser: argparse.ArgumentParser) -> None:  # noqa: D102
-        parser.add_argument("--config", help="Path to output the generated config file.", required=True)
+        parser.add_argument("-c", "--config", help="Path to output the generated config file.", required=True)
 
     def execute(self, args: Namespace, extra_args: List[str]) -> None:  # noqa: D102  #pylint: disable=unused-argument
         from pcluster.cli.commands.configure.easyconfig import configure

--- a/cli/src/pcluster/cli/commands/dcv_connect.py
+++ b/cli/src/pcluster/cli/commands/dcv_connect.py
@@ -155,7 +155,7 @@ class DcvConnectCommand(CliCommand):
         super().__init__(subparsers, name=self.name, help=self.help, description=self.description)
 
     def register_command_args(self, parser: ArgumentParser) -> None:  # noqa: D102
-        parser.add_argument("--cluster-name", help="Name of the cluster to connect to", required=True)
+        parser.add_argument("-n", "--cluster-name", help="Name of the cluster to connect to", required=True)
         parser.add_argument("--key-path", dest="key_path", help="Key path of the SSH key to use for the connection")
         parser.add_argument("--show-url", action="store_true", default=False, help="Print URL and exit")
 

--- a/cli/src/pcluster/cli/commands/ssh.py
+++ b/cli/src/pcluster/cli/commands/ssh.py
@@ -110,7 +110,7 @@ Returns an ssh command with the cluster username and IP address pre-populated:
         )
 
     def register_command_args(self, parser: ArgumentParser) -> None:  # noqa: D102
-        parser.add_argument("--cluster-name", help="Name of the cluster to connect to.", required=True)
+        parser.add_argument("-n", "--cluster-name", help="Name of the cluster to connect to.", required=True)
         parser.add_argument(
             "--dryrun",
             default=False,

--- a/cli/tests/pcluster/cli/test_configure/TestConfigureCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_configure/TestConfigureCommand/test_helper/pcluster-help.txt
@@ -1,10 +1,11 @@
-usage: pcluster configure [-h] [--debug] [--region REGION] -c CONFIG
+usage: pcluster configure [-h] [--debug] [-r REGION] -c CONFIG
 
 Start the AWS ParallelCluster configuration.
 
 optional arguments:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
-  --region REGION       AWS Region this operation corresponds to.
+  -r REGION, --region REGION
+                        AWS Region this operation corresponds to.
   -c CONFIG, --config CONFIG
                         Path to output the generated config file.

--- a/cli/tests/pcluster/cli/test_configure/TestConfigureCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_configure/TestConfigureCommand/test_helper/pcluster-help.txt
@@ -1,9 +1,10 @@
-usage: pcluster configure [-h] [--debug] [--region REGION] --config CONFIG
+usage: pcluster configure [-h] [--debug] [--region REGION] -c CONFIG
 
 Start the AWS ParallelCluster configuration.
 
 optional arguments:
-  -h, --help       show this help message and exit
-  --debug          Turn on debug logging.
-  --region REGION  AWS Region this operation corresponds to.
-  --config CONFIG  Path to output the generated config file.
+  -h, --help            show this help message and exit
+  --debug               Turn on debug logging.
+  --region REGION       AWS Region this operation corresponds to.
+  -c CONFIG, --config CONFIG
+                        Path to output the generated config file.

--- a/cli/tests/pcluster/cli/test_dcv_connect.py
+++ b/cli/tests/pcluster/cli/test_dcv_connect.py
@@ -9,7 +9,7 @@
 
 class TestDcvConnectCommand:
     def test_helper(self, test_datadir, run_cli, assert_out_err):
-        command = ["pcluster", "ssh", "--help"]
+        command = ["pcluster", "dcv-connect", "--help"]
         run_cli(command, expect_failure=False)
 
         assert_out_err(expected_out=(test_datadir / "pcluster-help.txt").read_text().strip(), expected_err="")

--- a/cli/tests/pcluster/cli/test_dcv_connect.py
+++ b/cli/tests/pcluster/cli/test_dcv_connect.py
@@ -1,0 +1,17 @@
+#  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+#  with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/
+#  or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from pcluster.cli.entrypoint import run
+
+
+class TestDcvConnectCommand:
+    def test_helper(self, test_datadir, run_cli, assert_out_err):
+        command = ["pcluster", "ssh", "--help"]
+        run_cli(command, expect_failure=False)
+
+        assert_out_err(expected_out=(test_datadir / "pcluster-help.txt").read_text().strip(), expected_err="")

--- a/cli/tests/pcluster/cli/test_dcv_connect.py
+++ b/cli/tests/pcluster/cli/test_dcv_connect.py
@@ -6,8 +6,6 @@
 #  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from pcluster.cli.entrypoint import run
-
 
 class TestDcvConnectCommand:
     def test_helper(self, test_datadir, run_cli, assert_out_err):

--- a/cli/tests/pcluster/cli/test_dcv_connect/TestDcvConnectCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_dcv_connect/TestDcvConnectCommand/test_helper/pcluster-help.txt
@@ -1,4 +1,4 @@
-usage: pcluster dcv-connect [-h] [--debug] [--region REGION] -n CLUSTER_NAME
+usage: pcluster dcv-connect [-h] [--debug] [-r REGION] -n CLUSTER_NAME
                             [--key-path KEY_PATH] [--show-url]
 
 Permits to connect to the head node through an interactive session by using
@@ -7,7 +7,8 @@ NICE DCV.
 optional arguments:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
-  --region REGION       AWS Region this operation corresponds to.
+  -r REGION, --region REGION
+                        AWS Region this operation corresponds to.
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster to connect to
   --key-path KEY_PATH   Key path of the SSH key to use for the connection

--- a/cli/tests/pcluster/cli/test_dcv_connect/TestDcvConnectCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_dcv_connect/TestDcvConnectCommand/test_helper/pcluster-help.txt
@@ -1,0 +1,14 @@
+usage: pcluster dcv-connect [-h] [--debug] [--region REGION] -n CLUSTER_NAME
+                            [--key-path KEY_PATH] [--show-url]
+
+Permits to connect to the head node through an interactive session by using
+NICE DCV.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --debug               Turn on debug logging.
+  --region REGION       AWS Region this operation corresponds to.
+  -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
+                        Name of the cluster to connect to
+  --key-path KEY_PATH   Key path of the SSH key to use for the connection
+  --show-url            Print URL and exit

--- a/cli/tests/pcluster/cli/test_export_cluster_logs/TestExportClusterLogsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_export_cluster_logs/TestExportClusterLogsCommand/test_helper/pcluster-help.txt
@@ -1,5 +1,5 @@
-usage: pcluster export-cluster-logs [-h] [--debug] [--region REGION] -n
-                                    CLUSTER_NAME --bucket BUCKET
+usage: pcluster export-cluster-logs [-h] [--debug] [-r REGION] -n CLUSTER_NAME
+                                    --bucket BUCKET
                                     [--output-file OUTPUT_FILE]
                                     [--bucket-prefix BUCKET_PREFIX]
                                     [--keep-s3-objects KEEP_S3_OBJECTS]
@@ -13,7 +13,8 @@ Amazon S3 Bucket.
 optional arguments:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
-  --region REGION       AWS Region this operation corresponds to.
+  -r REGION, --region REGION
+                        AWS Region this operation corresponds to.
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Export the logs of the cluster name provided here.
   --bucket BUCKET       S3 bucket to export cluster logs data to. It must be

--- a/cli/tests/pcluster/cli/test_export_image_logs/TestExportImageLogsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_export_image_logs/TestExportImageLogsCommand/test_helper/pcluster-help.txt
@@ -1,4 +1,4 @@
-usage: pcluster export-image-logs [-h] [--debug] [--region REGION]
+usage: pcluster export-image-logs [-h] [--debug] [-r REGION]
                                   [--output-file OUTPUT_FILE]
                                   [--bucket-prefix BUCKET_PREFIX]
                                   [--keep-s3-objects KEEP_S3_OBJECTS]
@@ -12,7 +12,8 @@ passing through an Amazon S3 Bucket.
 optional arguments:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
-  --region REGION       AWS Region this operation corresponds to.
+  -r REGION, --region REGION
+                        AWS Region this operation corresponds to.
   --output-file OUTPUT_FILE
                         File path to save log archive to. If this is provided
                         the logs are saved locally. Otherwise they are

--- a/cli/tests/pcluster/cli/test_ssh.py
+++ b/cli/tests/pcluster/cli/test_ssh.py
@@ -6,8 +6,6 @@
 #  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from pcluster.cli.entrypoint import run
-
 
 class TestSshCommand:
     def test_helper(self, test_datadir, run_cli, assert_out_err):

--- a/cli/tests/pcluster/cli/test_ssh.py
+++ b/cli/tests/pcluster/cli/test_ssh.py
@@ -1,0 +1,17 @@
+#  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+#  with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/
+#  or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from pcluster.cli.entrypoint import run
+
+
+class TestSshCommand:
+    def test_helper(self, test_datadir, run_cli, assert_out_err):
+        command = ["pcluster", "ssh", "--help"]
+        run_cli(command, expect_failure=False)
+
+        assert_out_err(expected_out=(test_datadir / "pcluster-help.txt").read_text().strip(), expected_err="")

--- a/cli/tests/pcluster/cli/test_ssh/TestSshCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_ssh/TestSshCommand/test_helper/pcluster-help.txt
@@ -1,4 +1,4 @@
-usage: pcluster ssh [-h] [--debug] [--region REGION] -n CLUSTER_NAME
+usage: pcluster ssh [-h] [--debug] [-r REGION] -n CLUSTER_NAME
                     [--dryrun DRYRUN]
 
 Run ssh command with the cluster username and IP address pre-populated. Arbitrary arguments are appended to the end of the ssh command.
@@ -6,7 +6,8 @@ Run ssh command with the cluster username and IP address pre-populated. Arbitrar
 optional arguments:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
-  --region REGION       AWS Region this operation corresponds to.
+  -r REGION, --region REGION
+                        AWS Region this operation corresponds to.
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster to connect to.
   --dryrun DRYRUN       Prints command and exits (defaults to 'false').

--- a/cli/tests/pcluster/cli/test_ssh/TestSshCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_ssh/TestSshCommand/test_helper/pcluster-help.txt
@@ -1,0 +1,20 @@
+usage: pcluster ssh [-h] [--debug] [--region REGION] -n CLUSTER_NAME
+                    [--dryrun DRYRUN]
+
+Run ssh command with the cluster username and IP address pre-populated. Arbitrary arguments are appended to the end of the ssh command.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --debug               Turn on debug logging.
+  --region REGION       AWS Region this operation corresponds to.
+  -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
+                        Name of the cluster to connect to.
+  --dryrun DRYRUN       Prints command and exits (defaults to 'false').
+
+Example:
+
+  pcluster ssh --cluster-name mycluster -i ~/.ssh/id_rsa
+
+Returns an ssh command with the cluster username and IP address pre-populated:
+
+  ssh ec2-user@1.1.1.1 -i ~/.ssh/id_rsa


### PR DESCRIPTION

### Description of changes
* Add support for abbreviated arguments for commands: `ssh`, `dcv-connect` and `configure`

### Tests
* Updated help text for command(s) covered by existing cli test coverage

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
