### PR TITLE
3.1: Fix the way ExtraChefAttributes are merged into the final dna.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ CHANGELOG
 
 **CHANGES**
 - Use compute resource name rather than instance type in compute fleet Launch Template name.
-- Change SlurmQueues length and ComputeResources length schema validators to be config validators. 
+- Change SlurmQueues length and ComputeResources length schema validators to be config validators.
 - Upgrade Slurm to version 21.08.5.
 - Disable EC2 ImageBuilder enhanced image metadata when building ParallelCluster custom images.
 - Disable packages update at instance launch time on Amazon Linux 2.
@@ -23,9 +23,10 @@ CHANGELOG
 - Redirect stderr and stdout to CLI log file to prevent unwanted text to pollute the pcluster CLI output.
 - Fix ecs:ListContainerInstances permission in BatchUserRole
 - Fix exporting of cluster logs when there is no prefix specified, previously exported to a `None` prefix.
-- Fix rollback not being performed in case of cluster update failure.  
+- Fix rollback not being performed in case of cluster update failure.
 - Fix RootVolume schema for the HeadNode.
 - Fix EfaSecurityGroupValidator. Previously, it may produce false failures when custom security groups were provided and EFA was enabled.
+- Fix the way ExtraChefAttributes are merged into the final configuration.
 
 3.0.3
 -----
@@ -79,7 +80,7 @@ CHANGELOG
 **ENHANCEMENTS**
 - Add support for pcluster actions (e.g., create-cluster, update-cluster, delete-cluster) through HTTP endpoints
   with Amazon API Gateway.
-- Revamp custom AMI creation and management by leveraging EC2 Image Builder. This also includes the implementation of 
+- Revamp custom AMI creation and management by leveraging EC2 Image Builder. This also includes the implementation of
   `build-image`, `delete-image`, `describe-image` and `list-image` commands to manage custom ParallelCluster images.
 - Add `list-official-images` command to describe ParallelCluster official AMIs.
 - Add `export-cluster-logs`, `list-cluster-logs` and `get-cluster-log-events` commands to retrieve both CloudWatch Logs
@@ -99,7 +100,7 @@ CHANGELOG
 - Add multiple queues and compute resources support for pcluster configure when the scheduler is Slurm.
 - Add prompt for availability zone in pcluster configure automated subnets creation.
 - Add configuration `HeadNode / Imds / Secured` to enable/disable restricted access to Instance Metadata Service (IMDS).
-- Implement scaling protection mechanism with Slurm scheduler: compute fleet is automatically set to 'PROTECTED' 
+- Implement scaling protection mechanism with Slurm scheduler: compute fleet is automatically set to 'PROTECTED'
   state in case recurrent failures are encountered when provisioning nodes.
 - Add `--suppress-validators` and `--validation-failure-level` parameters to `create` and `update` commands.
 - Add support for associating an existing Elastic IP to the head node.

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -951,8 +951,8 @@ class ClusterCdkStack(Stack):
                     "touch": {"command": "touch /etc/chef/ohai/hints/ec2.json"},
                     "jq": {
                         "command": (
-                            "jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 "
-                            "| .cluster = $f1.cluster + $f2.cluster' > /etc/chef/dna.json "
+                            "jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 * $f2' "
+                            "> /etc/chef/dna.json "
                             '|| ( echo "jq not installed"; cp /tmp/dna.json /etc/chef/dna.json )'
                         )
                     },


### PR DESCRIPTION
### Description of changes
1. Fix the way `ExtraChefAttributes` are merged into the final `/etc/chef/dna.json`. In particular, I've replaced the logic based on the simple merge operator (+) with the logic based on the recursive merging operator (*). The simple merge operator was not the correct solution because it overrides the nested elements in the final json rather than merging them. With this fix we can now merge nested elements using `ExtraChefAttributes`.
2. Minor: automatic changes to CHANGELOG made by pre-commit hook.

### Tests
Given the following clusters:
1. cluster without the fix and without extra json
1. cluster with the fix and without extra json
1. cluster with the fix and with extra json

the following checks succeeded:

1. compared `/etc/chef/dna.json` of cluster 1 and cluster 2: the only diffs are those related to specific ids
1. compared `/etc/chef/dna.json` of cluster 2 and cluster 3: the only diffs are those related to specific ids and the expected additional property defined in `ExtraChefAttributes `.

### References
1. https://stedolan.github.io/jq/manual/#Builtinoperatorsandfunctions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
