### PR TITLE
3.1: Fix the way extra.json is merged into the final dna.json

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -171,7 +171,7 @@ cd /tmp
 
 mkdir -p /etc/chef/ohai/hints
 touch /etc/chef/ohai/hints/ec2.json
-jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 + $f2 | .cluster = $f1.cluster + $f2.cluster' > /etc/chef/dna.json || ( echo "jq not installed or invalid extra_json"; cp /tmp/dna.json /etc/chef/dna.json)
+jq --argfile f1 /tmp/dna.json --argfile f2 /tmp/extra.json -n '$f1 * $f2' > /etc/chef/dna.json || ( echo "jq not installed or invalid extra_json"; cp /tmp/dna.json /etc/chef/dna.json)
 {
   pushd /etc/chef &&
   cinc-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/chef/dna.json --override-runlist aws-parallelcluster::init &&


### PR DESCRIPTION
### Description of changes
Fix the way ExtraChefAttributes are merged into the final /etc/chef/dna.json. In particular, I've replaced the logic based on the simple merge operator (+) with the logic based on the recursive merging operator (*). The simple merge operator was not the correct solution because it overrides the nested elements in the final json rather than merging them. With this fix we can now merge nested elements using ExtraChefAttributes.

This change has been already verified and approved in other part of our code base, see https://github.com/aws/aws-parallelcluster/pull/3664

### Tests
Verified that the `/etc/chef/dna.json` contains the expected json both in head node and compute node in the following cases:
1. No extra json specified
2. Extra json specified, e.g. `ExtraChefAttributes: '{ "cluster" : { "directory_service" : { "something": "true" } } }'`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
