### PR TITLE
Add security group ingress if custom security groups are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 - Install NVIDIA drivers and CUDA library for ARM.
 - Add `parallelcluster:compute-resource-name` tag to LaunchTemplates used by compute nodes.
 - Explicitly set cloud-init datasource to be EC2. This save boot time for Ubuntu and CentOS platforms.
+- Improve Security Groups created within the cluster to allow inbound connections from custom security groups when `SecurityGroups` parameters are specified for some head node and/or queues.`
 
 **CHANGES**
 - Upgrade Slurm to version 21.08.5.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -74,6 +74,7 @@ from pcluster.validators.cluster_validators import (
     IntelHpcArchitectureValidator,
     IntelHpcOsValidator,
     MaxCountValidator,
+    MixedSecurityGroupOverwriteValidator,
     NameValidator,
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
@@ -2015,6 +2016,11 @@ class SlurmClusterConfig(BaseClusterConfig):
         self._register_validator(SchedulerOsValidator, scheduler=self.scheduling.scheduler, os=self.image.os)
         self._register_validator(
             HeadNodeImdsValidator, imds_secured=self.head_node.imds.secured, scheduler=self.scheduling.scheduler
+        )
+        self._register_validator(
+            MixedSecurityGroupOverwriteValidator,
+            head_node_security_groups=self.head_node.networking.security_groups,
+            queues=self.scheduling.queues,
         )
         if self.scheduling.settings and self.scheduling.settings.dns and self.scheduling.settings.dns.hosted_zone_id:
             self._register_validator(

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -417,39 +417,77 @@ class ClusterCdkStack(Stack):
     def _add_security_groups(self):
         """Associate security group to Head node and queues."""
         # Head Node Security Group
-        head_security_group = None
-        if not self.config.head_node.networking.security_groups:
-            head_security_group = self._add_head_security_group()
+        managed_head_security_group = None
+        custom_head_security_groups = self.config.head_node.networking.security_groups or []
+        if not custom_head_security_groups:
+            managed_head_security_group = self._add_head_security_group()
+            head_node_security_groups = [managed_head_security_group.ref]
+        else:
+            head_node_security_groups = custom_head_security_groups
 
         # Compute Security Groups
         managed_compute_security_group = None
-        if any(not queue.networking.security_groups for queue in self.config.scheduling.queues):
+        custom_compute_security_groups = set()
+        managed_compute_security_group_required = False
+        for queue in self.config.scheduling.queues:
+            queue_security_groups = queue.networking.security_groups
+            if queue_security_groups:
+                for security_group in queue_security_groups:
+                    custom_compute_security_groups.add(security_group)
+            else:
+                managed_compute_security_group_required = True
+        compute_security_groups = list(custom_compute_security_groups)
+        if managed_compute_security_group_required:
             managed_compute_security_group = self._add_compute_security_group()
+            compute_security_groups.append(managed_compute_security_group.ref)
 
-        if head_security_group and managed_compute_security_group:
-            # Access to head node from compute nodes
-            ec2.CfnSecurityGroupIngress(
-                self,
-                "HeadNodeSecurityGroupComputeIngress",
-                ip_protocol="-1",
-                from_port=0,
-                to_port=65535,
-                source_security_group_id=managed_compute_security_group.ref,
-                group_id=head_security_group.ref,
-            )
+        self._add_inbounds_to_managed_security_groups(
+            compute_security_groups,
+            custom_compute_security_groups,
+            head_node_security_groups,
+            managed_compute_security_group,
+            managed_head_security_group,
+        )
 
+        return managed_head_security_group, managed_compute_security_group
+
+    def _add_inbounds_to_managed_security_groups(
+        self,
+        compute_security_groups,
+        custom_compute_security_groups,
+        head_node_security_groups,
+        managed_compute_security_group,
+        managed_head_security_group,
+    ):
+        if managed_head_security_group:
+            for security_group in compute_security_groups:
+                # Access to head node from compute nodes
+                self._allow_all_ingress(
+                    "HeadNodeSecurityGroupComputeIngress", security_group, managed_head_security_group.ref
+                )
+        if managed_compute_security_group:
             # Access to compute nodes from head node
-            ec2.CfnSecurityGroupIngress(
-                self,
-                "ComputeSecurityGroupHeadNodeIngress",
-                ip_protocol="-1",
-                from_port=0,
-                to_port=65535,
-                source_security_group_id=head_security_group.ref,
-                group_id=managed_compute_security_group.ref,
-            )
+            for security_group in head_node_security_groups:
+                self._allow_all_ingress(
+                    "ComputeSecurityGroupHeadNodeIngress", security_group, managed_compute_security_group.ref
+                )
+            for security_group in custom_compute_security_groups:
+                self._allow_all_ingress(
+                    "ComputeSecurityGroupCustomComputeSecurityGroupIngress",
+                    security_group,
+                    managed_compute_security_group.ref,
+                )
 
-        return head_security_group, managed_compute_security_group
+    def _allow_all_ingress(self, description, source_security_group_id, group_id):
+        ec2.CfnSecurityGroupIngress(
+            self,
+            description,
+            ip_protocol="-1",
+            from_port=0,
+            to_port=65535,
+            source_security_group_id=source_security_group_id,
+            group_id=group_id,
+        )
 
     def _add_compute_security_group(self):
         compute_security_group = ec2.CfnSecurityGroup(

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 import pytest
 from assertpy import assert_that
+from munch import DefaultMunch
 
 from pcluster.aws.aws_resources import InstanceTypeInfo
 from pcluster.config.cluster_config import Tag
@@ -35,6 +36,7 @@ from pcluster.validators.cluster_validators import (
     IntelHpcArchitectureValidator,
     IntelHpcOsValidator,
     MaxCountValidator,
+    MixedSecurityGroupOverwriteValidator,
     NameValidator,
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
@@ -950,3 +952,37 @@ def test_generate_tag_specifications(input_tags):
     else:
         expected_output_tags = []
     assert_that(_LaunchTemplateValidator._generate_tag_specifications(input_tags)).is_equal_to(expected_output_tags)
+
+
+@pytest.mark.parametrize(
+    "head_node_security_groups, queues, expect_warning",
+    [
+        [None, [{"networking": {"security_groups": None}}, {"networking": {"security_groups": None}}], False],
+        [None, [{"networking": {"security_groups": "sg-123456"}}, {"networking": {"security_groups": None}}], True],
+        [
+            None,
+            [{"networking": {"security_groups": "sg-123456"}}, {"networking": {"security_groups": "sg-123456"}}],
+            True,
+        ],
+        ["sg-123456", [{"networking": {"security_groups": None}}, {"networking": {"security_groups": None}}], True],
+        [
+            "sg-123456",
+            [{"networking": {"security_groups": "sg-123456"}}, {"networking": {"security_groups": None}}],
+            True,
+        ],
+        [
+            "sg-123456",
+            [{"networking": {"security_groups": "sg-123456"}}, {"networking": {"security_groups": "sg-123456"}}],
+            False,
+        ],
+    ],
+)
+def test_mixed_security_group_overwrite_validator(head_node_security_groups, queues, expect_warning):
+    """Verify validator for mixed security group."""
+    queues = DefaultMunch.fromDict(queues)
+    actual_failures = MixedSecurityGroupOverwriteValidator().execute(
+        head_node_security_groups=head_node_security_groups,
+        queues=queues,
+    )
+    expected_message = "make sure.*cluster nodes are reachable" if expect_warning else None
+    assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -8,3 +8,4 @@ pytest-html
 pytest-mock
 pytest-xdist
 recordclass
+munch

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -27,12 +27,22 @@ class RemoteCommandExecutionError(Exception):
 class RemoteCommandExecutor:
     """Execute remote commands on the cluster head node."""
 
-    def __init__(self, cluster, username=None, bastion=None, alternate_ssh_key=None):
-        head_node_ip = cluster.head_node_ip
+    def __init__(self, cluster, compute_node_ip=None, username=None, bastion=None, alternate_ssh_key=None):
+        """
+        Initiate SSH connection
+
+        By default, commands are executed on head node. If `compute_node_ip` is specified, execute commands on compute.
+        """
         if not username:
             username = get_username_for_os(cluster.os)
+        if compute_node_ip:
+            # Since compute nodes may not be publicly accessible, always use head node as the bastion.
+            node_ip = compute_node_ip
+            bastion = f"{username}@{cluster.head_node_ip}"
+        else:
+            node_ip = cluster.head_node_ip
         connection_kwargs = {
-            "host": head_node_ip,
+            "host": node_ip,
             "user": username,
             "forward_agent": False,
             "connect_kwargs": {"key_filename": [alternate_ssh_key if alternate_ssh_key else cluster.ssh_key]},
@@ -43,7 +53,7 @@ class RemoteCommandExecutor:
                 "ssh -tt -i {key_path} -o StrictHostKeyChecking=no "
                 '-o ProxyCommand="ssh -tt -o StrictHostKeyChecking=no -W %h:%p -A {bastion}" '
                 "-A {user}@{head_node} hostname".format(
-                    key_path=cluster.ssh_key, bastion=bastion, user=username, head_node=head_node_ip
+                    key_path=cluster.ssh_key, bastion=bastion, user=username, head_node=node_ip
                 ),
                 timeout=30,
                 shell=True,
@@ -51,7 +61,7 @@ class RemoteCommandExecutor:
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
         self.__connection = Connection(**connection_kwargs)
-        self.__user_at_hostname = "{0}@{1}".format(username, head_node_ip)
+        self.__user_at_hostname = "{0}@{1}".format(username, node_ip)
 
     def __del__(self):
         try:

--- a/tests/integration-tests/tests/networking/test_security_groups.py
+++ b/tests/integration-tests/tests/networking/test_security_groups.py
@@ -15,9 +15,10 @@ import boto3
 import pytest
 from assertpy import assert_that
 from cfn_stacks_factory import CfnStack
+from remote_command_executor import RemoteCommandExecutor
 from troposphere import Ref, Template
 from troposphere.ec2 import SecurityGroup, SecurityGroupIngress
-from utils import check_head_node_security_group, generate_stack_name
+from utils import check_head_node_security_group, generate_stack_name, get_username_for_os
 
 
 @pytest.mark.usefixtures("os", "scheduler", "instance")
@@ -44,8 +45,8 @@ def test_additional_sg_and_ssh_from(region, custom_security_group, pcluster_conf
     check_head_node_security_group(region, cluster, 22, ssh_from)
 
 
-@pytest.mark.usefixtures("os", "scheduler", "instance")
-def test_overwrite_sg(region, custom_security_group, pcluster_config_reader, clusters_factory):
+@pytest.mark.usefixtures("os", "instance")
+def test_overwrite_sg(region, scheduler, custom_security_group, pcluster_config_reader, clusters_factory):
     """Test vpc_security_group_id overwrites pcluster default sg on head and compute nodes, efs, fsx"""
     custom_security_group_id = custom_security_group.cfn_resources["SecurityGroupResource"]
     cluster_config = pcluster_config_reader(vpc_security_group_id=custom_security_group_id)
@@ -53,7 +54,7 @@ def test_overwrite_sg(region, custom_security_group, pcluster_config_reader, clu
     ec2_client = boto3.client("ec2", region_name=region)
     instances = _get_instances_by_security_group(ec2_client, custom_security_group_id)
     logging.info("Asserting that head node and compute node has and only has the custom security group")
-    assert_that(instances).is_length(2)
+    assert_that(instances).is_length(3)
     for instance in instances:
         assert_that(instance["SecurityGroups"]).is_length(1)
 
@@ -85,27 +86,80 @@ def test_overwrite_sg(region, custom_security_group, pcluster_config_reader, clu
         assert_that(mount_target_security_groups[0]).is_equal_to(custom_security_group_id)
         assert_that(mount_target_security_groups).is_length(1)
 
+    if scheduler == "slurm":
+        _check_connections_between_head_node_and_compute_nodes(cluster)
+        # Update the cluster by removing the custom security group from head node.
+        # As a result, head node uses pcluster created security group while compute nodes use custom security group.
+        # The aim is to test that the pcluster creates proper inbound rules in the head node security group to allow
+        # access from compute security groups.
+        updated_config_file = pcluster_config_reader(
+            config_file="pcluster.config.update.yaml",
+            vpc_security_group_id=custom_security_group_id,
+        )
+        cluster.update(str(updated_config_file), force_update="true")
+        _check_connections_between_head_node_and_compute_nodes(cluster)
+
+
+def _check_connections_between_head_node_and_compute_nodes(cluster):
+    username = get_username_for_os(cluster.os)
+    head_node = cluster.describe_cluster_instances(node_type="HeadNode")[0]
+    head_node_public_ip = head_node.get("publicIpAddress")
+    head_node_private_ip = head_node.get("privateIpAddress")
+    head_node_username_ip = f"{username}@{head_node_public_ip}"
+    head_node_remote_command_executor = RemoteCommandExecutor(cluster)
+
+    compute_nodes = cluster.describe_cluster_instances(node_type="Compute")
+    for compute_node in compute_nodes:
+        compute_node_ip = compute_node.get("privateIpAddress")
+        ping_ip = "ping {0} -c 5"
+        head_node_remote_command_executor.run_remote_command(ping_ip.format(compute_node_ip))
+        compute_remote_command_executor = RemoteCommandExecutor(
+            cluster, compute_node_ip=compute_node_ip, bastion=head_node_username_ip
+        )
+        compute_remote_command_executor.run_remote_command(ping_ip.format(head_node_private_ip))
+        for other_compute_node in compute_nodes:
+            other_compute_node_ip = other_compute_node.get("privateIpAddress")
+            compute_remote_command_executor.run_remote_command(ping_ip.format(other_compute_node_ip))
+
 
 @pytest.fixture(scope="class")
 def custom_security_group(vpc_stack, region, request, cfn_stacks_factory):
     template = Template()
     template.set_version("2010-09-09")
     template.set_description("custom security group stack for testing additional_sg and vpc_security_group_id")
+    vpc_id = vpc_stack.cfn_outputs["VpcId"]
     security_group = template.add_resource(
         SecurityGroup(
             "SecurityGroupResource",
             GroupDescription="custom security group for testing additional_sg and vpc_security_group_id",
-            VpcId=vpc_stack.cfn_outputs["VpcId"],
+            VpcId=vpc_id,
         )
     )
+    cidr_block_association_set = boto3.client("ec2").describe_vpcs(VpcIds=[vpc_id])["Vpcs"][0][
+        "CidrBlockAssociationSet"
+    ]
+    # Allow inbound connection within the VPC
+    for index, cidr_block_association in enumerate(cidr_block_association_set):
+        vpc_cidr = cidr_block_association["CidrBlock"]
+        template.add_resource(
+            SecurityGroupIngress(
+                f"SecurityGroupIngressResource{index}",
+                IpProtocol="-1",
+                FromPort=0,
+                ToPort=65535,
+                CidrIp=vpc_cidr,
+                GroupId=Ref(security_group),
+            )
+        )
+    # Allow all inbound SSH connection
     template.add_resource(
         SecurityGroupIngress(
-            "SecurityGroupIngressResource",
-            IpProtocol="-1",
-            FromPort=0,
-            ToPort=65535,
-            SourceSecurityGroupId=Ref(security_group),
+            "SecurityGroupSSHIngressResource",
+            IpProtocol="tcp",
+            FromPort=22,
+            ToPort=22,
             GroupId=Ref(security_group),
+            CidrIp="0.0.0.0/0",
         )
     )
     stack = CfnStack(

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
@@ -4,8 +4,6 @@ HeadNode:
   InstanceType: {{ instance }}
   Networking:
     SubnetId: {{ public_subnet_id }}
-    SecurityGroups:
-      - {{ vpc_security_group_id }}
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -29,6 +27,8 @@ Scheduling:
           - {{ private_additional_cidr_subnet_id }}
         SecurityGroups:
           - {{ vpc_security_group_id }}
+          # Compute nodes use custom sg while the head node is using managed id
+          # to test the managed sg allow access from the custom sg
 SharedStorage:
   - MountDir: efs
     Name: efs


### PR DESCRIPTION
Signed-off-by: Hanwen <hanwenli@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
If custom security groups are provided in the cluster configuration to some queues and/or the head node, but not to all of the cluster nodes, the pcluster created security groups will allow inbound connections from the custom security groups.

Before this change, the mixture of managed and custom security groups led to cluster nodes not accessible to each other. Specifically, nodes in custom security groups cannot access nodes in managed security groups.

With this change, we ensure managed security groups allows access from nodes in custom security groups. However, if the custom security groups are not properly configured, there will still be connection issues among cluster nodes.

Mixing managed security groups and custom security groups is not common. So a warning is added.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
`test_security_group` has been passed.
configs/pcluster3.yaml is under testing
* Describe the added/modified tests.
A unit test is added for the warning validator. `test_security_group` integration test is expanded to test the scenario when a managed security group and a custom security group are mixed.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
