### PR TITLE
3.1.0: AD integration test: saving time by reducing the number of users to create/test

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -38,8 +38,8 @@ from tests.common.osu_common import compile_osu, run_osu_benchmarks
 from tests.common.schedulers_common import get_scheduler_commands
 from tests.common.utils import get_sts_endpoint, retrieve_latest_ami
 
-NUM_USERS_TO_CREATE = 20
-NUM_USERS_TO_TEST = 10
+NUM_USERS_TO_CREATE = 5
+NUM_USERS_TO_TEST = 3
 
 
 def get_infra_stack_outputs(stack_name):


### PR DESCRIPTION


Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>


### Description of changes
Saving test time by:
* reducing the number of users to create from 20 to 5
* reducing the number of users to test from 10 to 3.

The decrease can be done because these are not scale tests.

### Tests
The change does not require a dedicated test session. Will be tested directly in daily build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
