### PR TITLE
3.x: Fix create AMI test using the string message in assertion

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -193,10 +193,10 @@ def _test_get_image_log_events(image):
             assert_that(events).is_length(expect_count)
 
         if expect_first is True:
-            assert_that(events[0]["message"]).matches(first_event)
+            assert_that(events[0]["message"]).matches(first_event["message"])
 
         if expect_first is False:
-            assert_that(events[0]["message"]).does_not_match(first_event)
+            assert_that(events[0]["message"]).does_not_match(first_event["message"])
 
 
 def _test_export_logs(s3_bucket_factory, image, region):


### PR DESCRIPTION
### Description of changes
* first_event is a dictionary not a string causing the tests to fail.


### Tests
* test_createami.py::test_build_image:

### References
* Introduced by #3677 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.