### PR TITLE
3.1.0: Improve AD integration tests: add users via ldapadd rather than adcli

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -126,6 +126,7 @@ Resources:
                 AD_ADMIN_PASSWORD='{{ ad_admin_password }}'
                 AD_DOMAIN='{{ ad_domain_name }}'
                 AD_ADMIN_USER='{{ ad_admin_user }}'
+                AD_USERS_BASE_SEARCH='{{ ad_users_base_search }}'
                 DEFAULT_EC2_DOMAIN={{ default_ec2_domain }}
 
                 cat << EOF > /etc/resolv.conf
@@ -158,23 +159,6 @@ Resources:
                 grep -E '\s*PasswordAuthentication\s+yes' "$SSHD_CONFIG_PATH"
                 systemctl restart sshd
 
-                # Write a script that will be invoked via SSM in order to add users to the domain
-                mkdir -p $(dirname /usr/local/bin/add_user.sh)
-                # Script to add a single user
-                cat << EOF > /usr/local/bin/add_user.sh
-                #!/bin/bash
-                NEW_USER_ALIAS=\$1
-                if [ -z "\${NEW_USER_ALIAS}" ]; then
-                    echo 1>&2 "Alias for new user must be passed as first arg"
-                    exit 1
-                fi
-                result=\$(echo "${AD_ADMIN_PASSWORD}" | adcli create-user -U ${AD_ADMIN_USER} \${NEW_USER_ALIAS} --domain="${AD_DOMAIN}" --display-name="\${NEW_USER_ALIAS}" --stdin-password 2>&1)
-                if [[ \$? != "0" && "\${result}" != *"already exists"* ]]; then
-                  echo "Creation of user \${NEW_USER_ALIAS} failed: \${result}"
-                  exit 1
-                fi
-                EOF
-                chmod +x /usr/local/bin/add_user.sh
                 # Script to add a number of users
                 cat << EOF > /usr/local/bin/add_a_number_of_users.sh
                 #!/bin/bash
@@ -191,22 +175,38 @@ Resources:
                 for i in \$(seq 1 "\${NUM_USERS_TO_CREATE}"); do
                     NEW_USER_ALIASES="\${NEW_USER_ALIASES} PclusterUser\${i}"
                 done
+
+                # Create LDIF file to create users
+                LDIF_FILE="adusers.ldif"
+                rm -rf \${LDIF_FILE}
+                for NEW_USER_ALIAS in \${NEW_USER_ALIASES}; do
+                  echo "dn: CN=\${NEW_USER_ALIAS},${AD_USERS_BASE_SEARCH}" >> \${LDIF_FILE}
+                  echo "objectClass: top" >> \${LDIF_FILE}
+                  echo "objectClass: person" >> \${LDIF_FILE}
+                  echo "objectClass: organizationalPerson" >> \${LDIF_FILE}
+                  echo "objectClass: user" >> \${LDIF_FILE}
+                  echo "userAccountControl: 514" >> \${LDIF_FILE}
+                  echo "accountExpires: 0" >> \${LDIF_FILE}
+                  echo "sAMAccountName: \${NEW_USER_ALIAS}" >> \${LDIF_FILE}
+                  echo "" >> \${LDIF_FILE}
+                done
+                echo "Wrote LDIF file: \${LDIF_FILE}"
+                cat \${LDIF_FILE}
+
                 # Create users in directory
                 # TODO: add ability to trigger this via lambda
-                for NEW_USER_ALIAS in \${NEW_USER_ALIASES}; do
-                  MAX_ATTEMPTS=5
-                  for ATTEMPT in \$(seq 1 \${MAX_ATTEMPTS}); do
-                    echo "Creating user \${NEW_USER_ALIAS} (attempt \${ATTEMPT}/\${MAX_ATTEMPTS})"
-                    /usr/local/bin/add_user.sh \${NEW_USER_ALIAS} && break
-                    if [ \${ATTEMPT} -ge \${MAX_ATTEMPTS} ]; then
-                      echo "ERROR: Cannot create user \${NEW_USER_ALIAS}"
-                      exit 1
-                    else
-                      SLEEP_TIME=\${ATTEMPT}
-                      echo "WARNING: Cannot create user \${NEW_USER_ALIAS}. Will retry in \${SLEEP_TIME} seconds"
-                      sleep \${SLEEP_TIME}
-                    fi
-                  done
+                MAX_ATTEMPTS=5
+                for ATTEMPT in \$(seq 1 \${MAX_ATTEMPTS}); do
+                  echo "Creating users from LDIF file \${LDIF_FILE} (attempt \${ATTEMPT}/\${MAX_ATTEMPTS})"
+                  ldapadd -f "\${LDIF_FILE}" -x -h "${DNS_IP_ONE}" -D "CN=${AD_ADMIN_USER},${AD_USERS_BASE_SEARCH}" -w "${AD_ADMIN_PASSWORD}" && break
+                  if [ \${ATTEMPT} -ge \${MAX_ATTEMPTS} ]; then
+                    echo "ERROR: Cannot create users"
+                    exit 1
+                  else
+                    SLEEP_TIME=\${ATTEMPT}
+                    echo "WARNING: Cannot create users. Will retry in \${SLEEP_TIME} seconds"
+                    sleep \${SLEEP_TIME}
+                  fi
                 done
 
                 # Change user passwords


### PR DESCRIPTION
### Description of changes
* Adding users in bulk via ldapadd rather than on by one via adcli. Apart from the advantage of the bulk add w.r.t the one by one insertion, we sporadically observed issues in using adcli.

### Tests
* Tested in personal Docker (concurrency 8)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
