### PR TITLE
Improve get_image_log_events test to use the actual first message and not a predefined one

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -160,7 +160,6 @@ def _test_get_image_log_events(image):
     """Test pcluster get-image-log-events functionality."""
     logging.info("Testing that pcluster get-image-log-events is working as expected")
     log_stream_name = f"{get_installed_parallelcluster_version()}/1"
-    cloud_init_debug_msg = "Document arn:aws.*:imagebuilder:.*parallelclusterimage.*"
 
     # Get the first event to establish time boundary for testing
     initial_events = image.get_log_events(log_stream_name, limit=1, start_from_head=True)
@@ -189,10 +188,10 @@ def _test_get_image_log_events(image):
             assert_that(events).is_length(expect_count)
 
         if expect_first is True:
-            assert_that(events[0]["message"]).matches(cloud_init_debug_msg)
+            assert_that(events[0]["message"]).matches(first_event["message"])
 
         if expect_first is False:
-            assert_that(events[0]["message"]).does_not_match(cloud_init_debug_msg)
+            assert_that(events[0]["message"]).does_not_match(first_event["message"])
 
 
 def _test_export_logs(s3_bucket_factory, image, region):


### PR DESCRIPTION
It is not always true that the first message is the cloud init debug message,
sometimes the first message is "STARTED SETUP", causing the test to fail.

A failing test was returning:
`AssertionError: Expected <Setup: STARTED SETUP> to match pattern <Document arn:aws.*:imagebuilder:.*parallelclusterimage.*>, but did not.`

and the message order was:
```
events = [
  {'message': 'Setup: STARTED SETUP', 'timestamp': '2022-01-19T07:24:05.899Z'},
  {'message': 'Setup: Document arn:aws.*:imagebuilder:.*parallelclusterimage.* is an EC2 Image Builder Component Version Arn', 'timestamp': '2022-01-19T07:24:05.900Z'}
]
```

With this patch we're using the actual first message to verify if it's in the list of returned events.
We don't need to check the cloud init debug message is the first one or that it is present.

Signed-off-by: Enrico Usai <usai@amazon.com>
Signed-off-by: Hanwen <hanwenli@amazon.com>



### References
* Link to related PRs in other packages (i.e. cookbook, node).
This PR is created by cherry picking 
https://github.com/aws/aws-parallelcluster/pull/3679
https://github.com/aws/aws-parallelcluster/pull/3677

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
