### PR TITLE
3.1.0: Integration tests: add retry with exponential backoff to SSH commands

### DIFF
--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -14,6 +14,7 @@ import os
 import shlex
 
 from fabric import Connection
+from retrying import retry
 from utils import get_username_for_os, run_command
 
 
@@ -60,6 +61,10 @@ class RemoteCommandExecutor:
             # Catch all exceptions if we fail to close the clients
             logging.warning("Exception raised when closing remote ssh client: {0}".format(e))
 
+    @retry(wait_exponential_multiplier=1000, stop_max_attempt_number=5)
+    def _run_command(self, command, **kwargs):
+        return self.__connection.run(command, **kwargs)
+
     def run_remote_command(
         self,
         command,
@@ -91,7 +96,7 @@ class RemoteCommandExecutor:
         if login_shell:
             command = "/bin/bash --login -c {0}".format(shlex.quote(command))
 
-        result = self.__connection.run(command, warn=True, pty=True, hide=hide, timeout=timeout)
+        result = self._run_command(command, warn=True, pty=True, hide=hide, timeout=timeout)
         result.stdout = "\n".join(result.stdout.splitlines())
         result.stderr = "\n".join(result.stderr.splitlines())
         if log_output:


### PR DESCRIPTION
### Description of changes
1.  Add retry with exponential backoff to SSH commands. This change aims at making our integration tests more robust against transient networking failures.

### Tests
1. Tested in my personal Jenkins (concurrency: 8)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
