### PR TITLE
AD Integration tests: remove test cases covering LDAPS without certificate verification

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -571,12 +571,15 @@ def _run_benchmarks(
             cloudwatch_client.put_metric_data(Namespace="ParallelCluster/AdIntegration", MetricData=metric_data)
 
 
+# Some tests have been disabled to save time and reduce costs.
 @pytest.mark.parametrize(
     "directory_type,directory_protocol,directory_certificate_verification",
     [
         ("SimpleAD", "ldap", False),
+        # ("SimpleAD", "ldaps", False),
         ("SimpleAD", "ldaps", True),
         ("MicrosoftAD", "ldap", False),
+        # ("MicrosoftAD", "ldaps", False),
         ("MicrosoftAD", "ldaps", True),
     ],
 )

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -575,10 +575,8 @@ def _run_benchmarks(
     "directory_type,directory_protocol,directory_certificate_verification",
     [
         ("SimpleAD", "ldap", False),
-        ("SimpleAD", "ldaps", False),
         ("SimpleAD", "ldaps", True),
         ("MicrosoftAD", "ldap", False),
-        ("MicrosoftAD", "ldaps", False),
         ("MicrosoftAD", "ldaps", True),
     ],
 )


### PR DESCRIPTION
### Description of changes
1.  AD Integration tests: remove test cases covering LDAPS without certificate verification. This change aims at saving time and reduce costs in our integration tests. We can assume this change to be safe because (i) if LDAPS with certificate verification works it also proved that LDAPS without certificate verification does too and (ii) it is more probable for a customer to have certificate verification when using LDAPS.

### Tests
1. We are removing test cases here: not test required.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
