### PR TITLE
3.x: Fix assertion in number of instances in Security Groups overwrite test

### DIFF
--- a/tests/integration-tests/tests/networking/test_security_groups.py
+++ b/tests/integration-tests/tests/networking/test_security_groups.py
@@ -54,7 +54,7 @@ def test_overwrite_sg(region, scheduler, custom_security_group, pcluster_config_
     ec2_client = boto3.client("ec2", region_name=region)
     instances = _get_instances_by_security_group(ec2_client, custom_security_group_id)
     logging.info("Asserting that head node and compute node has and only has the custom security group")
-    assert_that(instances).is_length(3)
+    assert_that(instances).is_length(3 if scheduler == "slurm" else 2)
     for instance in instances:
         assert_that(instance["SecurityGroups"]).is_length(1)
 


### PR DESCRIPTION
We modified the number of instances required by Slurm test in: https://github.com/aws/aws-parallelcluster/pull/3666

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
