### PR TITLE
Integ-tests: Temporarily disable DCV test.

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -128,48 +128,48 @@ dashboard:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
-dcv:
-  test_dcv.py::test_dcv_configuration:
-    dimensions:
-      # DCV on GPU enabled instance
-      - regions: ["us-east-1"]
-        instances: ["g4dn.2xlarge"]
-        oss: {{common.OSS_COMMERCIAL_X86}}
-        schedulers: ["slurm"]
-      # DCV on ARM
-      - regions: ["eu-west-1"]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        # DCV does not support ubuntu2004 yet
-        {{- common.OSS_COMMERCIAL_ARM.remove("ubuntu2004") or "" }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
-        {{- common.OSS_COMMERCIAL_ARM.append("ubuntu2004") or "" }}
-        schedulers: ["slurm"]
-      # DCV on Batch
-      - regions: ["us-east-1"]
-        instances: ["g4dn.2xlarge"]
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
-      # DCV on Batch + ARM
-      - regions: ["us-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
-      # DCV in cn regions and non GPU enabled instance
-      - regions: ["cn-northwest-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["slurm"]
-      # DCV in gov-cloud regions and non GPU enabled instance
-      - regions: ["us-gov-west-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1804"]
-        schedulers: ["slurm"]
-  test_dcv.py::test_dcv_with_remote_access:
-    dimensions:
-      - regions: ["ap-southeast-2"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["centos7"]
-        schedulers: ["sge"]
+#dcv:
+#  test_dcv.py::test_dcv_configuration:
+#    dimensions:
+#      # DCV on GPU enabled instance
+#      - regions: ["us-east-1"]
+#        instances: ["g4dn.2xlarge"]
+#        oss: {{common.OSS_COMMERCIAL_X86}}
+#        schedulers: ["slurm"]
+#      # DCV on ARM
+#      - regions: ["eu-west-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+#        # DCV does not support ubuntu2004 yet
+#        {{- common.OSS_COMMERCIAL_ARM.remove("ubuntu2004") or "" }}
+#        oss: {{ common.OSS_COMMERCIAL_ARM }}
+#        {{- common.OSS_COMMERCIAL_ARM.append("ubuntu2004") or "" }}
+#        schedulers: ["slurm"]
+#      # DCV on Batch
+#      - regions: ["us-east-1"]
+#        instances: ["g4dn.2xlarge"]
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
+#      # DCV on Batch + ARM
+#      - regions: ["us-east-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
+#      # DCV in cn regions and non GPU enabled instance
+#      - regions: ["cn-northwest-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["slurm"]
+#      # DCV in gov-cloud regions and non GPU enabled instance
+#      - regions: ["us-gov-west-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["ubuntu1804"]
+#        schedulers: ["slurm"]
+#  test_dcv.py::test_dcv_with_remote_access:
+#    dimensions:
+#      - regions: ["ap-southeast-2"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["centos7"]
+#        schedulers: ["sge"]
 disable_hyperthreading:
   test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
     dimensions:


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
Release tests are running against 2.11.4, instead of the latest code. However, the tests use the latest code. So the newly added check https://github.com/aws/aws-parallelcluster/commit/fdd7df852f17a4dac99b52dbed71ee7d215292e4 will fail.

The tests should be enabled for 2.11.5

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
