### PR TITLE
[byos] Enable compute fleet update management

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -509,6 +509,7 @@ Resources:
               - dynamodb:DeleteTable
               - dynamodb:GetItem
               - dynamodb:PutItem
+              - dynamodb:UpdateItem
               - dynamodb:Query
               - dynamodb:TagResource
             Resource: !Sub arn:${AWS::Partition}:dynamodb:${Region}:${AWS::AccountId}:table/parallelcluster-*

--- a/cli/src/pcluster/api/controllers/cluster_logs_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_logs_controller.py
@@ -30,7 +30,7 @@ def join_filters(accepted_filters, filters):
     state = None
 
     filter_regex = rf"Name=({'|'.join(accepted_filters)}),Values=[\w\-_.,]+"
-    pattern = re.compile(fr"^({filter_regex})(\s+{filter_regex})*$")
+    pattern = re.compile(rf"^({filter_regex})(\s+{filter_regex})*$")
 
     def fail():
         raise BadRequestException(f"filters parameter must be in the form {pattern.pattern}.")

--- a/cli/src/pcluster/cli/commands/cluster_logs.py
+++ b/cli/src/pcluster/cli/commands/cluster_logs.py
@@ -88,7 +88,7 @@ class _FiltersArg:
 
     def __init__(self, accepted_filters: list):
         filter_regex = rf"Name=({'|'.join(accepted_filters)}),Values=[\w\-_.,]+"
-        self._pattern = re.compile(fr"^({filter_regex})(\s+{filter_regex})*$")
+        self._pattern = re.compile(rf"^({filter_regex})(\s+{filter_regex})*$")
 
     def __call__(self, value):
         if not self._pattern.match(value):

--- a/cli/src/pcluster/models/compute_fleet_status_manager.py
+++ b/cli/src/pcluster/models/compute_fleet_status_manager.py
@@ -19,7 +19,7 @@ from pkg_resources import packaging
 
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError
-from pcluster.constants import PCLUSTER_DYNAMODB_PREFIX, PCLUSTER_SLURM_DYNAMODB_PREFIX
+from pcluster.constants import PCLUSTER_DYNAMODB_PREFIX
 
 LOGGER = logging.getLogger(__name__)
 
@@ -148,10 +148,8 @@ class ComputeFleetStatusManager(metaclass=ABCMeta):
         """Return compute fleet status manager based on version and plugin."""
         if packaging.version.parse(version) < packaging.version.parse("3.2.0a0") and scheduler != "plugin":
             return PlainTextComputeFleetStatusManager(cluster_name)
-        elif scheduler == "plugin":
-            return JsonComputeFleetStatusManager(cluster_name)
         else:
-            return PlainTextComputeFleetStatusManager(cluster_name)
+            return JsonComputeFleetStatusManager(cluster_name)
 
     @staticmethod
     def _timeout_expired(start_time, timeout):
@@ -243,7 +241,7 @@ class PlainTextComputeFleetStatusManager(ComputeFleetStatusManager):
     LAST_UPDATED_TIME_ATTRIBUTE = "LastUpdatedTime"
 
     def __init__(self, cluster_name):
-        super().__init__(PCLUSTER_SLURM_DYNAMODB_PREFIX + cluster_name)
+        super().__init__(PCLUSTER_DYNAMODB_PREFIX + cluster_name)
 
     def get_status_with_last_updated_time(
         self, status_fallback=ComputeFleetStatus.UNKNOWN, last_updated_time_fallback=None

--- a/cli/tests/pcluster/models/test_compute_fleet_status_manager.py
+++ b/cli/tests/pcluster/models/test_compute_fleet_status_manager.py
@@ -173,8 +173,8 @@ class TestComputeFleetStatusManager:
             (
                 "3.2.0",
                 "slurm",
-                PlainTextComputeFleetStatusManager,
-            ),  # TODO to be changed after slurm refactoring
+                JsonComputeFleetStatusManager,
+            ),
             (
                 "3.2.0",
                 "plugin",

--- a/cli/tests/pcluster/models/test_plain_text_compute_fleet_status_manager.py
+++ b/cli/tests/pcluster/models/test_plain_text_compute_fleet_status_manager.py
@@ -48,7 +48,7 @@ class TestComputeFleetStatusManager:
             get_item_mock = mocker.patch("pcluster.aws.dynamo.DynamoResource.get_item", return_value=get_item_response)
         status, _ = compute_fleet_status_manager.get_status_with_last_updated_time(fallback)
         assert_that(status).is_equal_to(expected_status)
-        get_item_mock.assert_called_with("parallelcluster-slurm-cluster-name", {"Id": "COMPUTE_FLEET"})
+        get_item_mock.assert_called_with("parallelcluster-cluster-name", {"Id": "COMPUTE_FLEET"})
 
     @pytest.mark.parametrize(
         "put_item_response, expected_exception",

--- a/scheduler_plugins/slurm/artifacts/handlers/head_compute_fleet_update.sh
+++ b/scheduler_plugins/slurm/artifacts/handlers/head_compute_fleet_update.sh
@@ -12,11 +12,6 @@
 
 set -e
 
-# FIXME: temporary workaround
-PLUGIN_TABLE=$(jq -r .Outputs.DynamoDBTable ${PCLUSTER_SCHEDULER_PLUGIN_CFN_SUBSTACK_OUTPUTS})
-STATUS=$(jq -r .status ${PCLUSTER_COMPUTEFLEET_STATUS})
-LAST_UPDATED_TIME=$(jq -r .lastStatusUpdatedTime ${PCLUSTER_COMPUTEFLEET_STATUS})
-aws dynamodb put-item --table-name "${PLUGIN_TABLE}"\
-    --item "{\"Id\": {\"S\": \"COMPUTE_FLEET\"}, \"Status\": {\"S\": \"${STATUS}\"}, \"LastUpdatedTime\": {\"S\": \"${LAST_UPDATED_TIME}\"}}"\
-    --region ${PCLUSTER_AWS_REGION}
-sleep 120
+sudo "${PCLUSTER_PYTHON_ROOT}/supervisorctl" -c "${PCLUSTER_LOCAL_SCHEDULER_PLUGIN_DIR}/supervisord.conf" stop clustermgtd
+sudo "${PCLUSTER_LOCAL_SCHEDULER_PLUGIN_DIR}/scripts/slurm/slurm_fleet_status_manager" -cf "${PCLUSTER_COMPUTEFLEET_STATUS}"
+sudo "${PCLUSTER_PYTHON_ROOT}/supervisorctl" -c "${PCLUSTER_LOCAL_SCHEDULER_PLUGIN_DIR}/supervisord.conf" start clustermgtd

--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/recipes/config_head_node.rb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/recipes/config_head_node.rb
@@ -96,6 +96,26 @@ template "#{node['slurm']['install_dir']}/etc/slurm.csh" do
   mode '0755'
 end
 
+template "#{node['pcluster']['local_dir']}/scripts/slurm/slurm_fleet_status_manager" do
+  source 'slurm/fleet_status_manager_program.erb'
+  owner node['slurm']['user']
+  group node['slurm']['group']
+  mode '0744'
+end
+
+file "/var/log/parallelcluster/slurm_fleet_status_manager.log" do
+  owner node['plugin']['fleet_mgt_user']
+  group node['plugin']['fleet_mgt_user']
+  mode '0644'
+end
+
+template "#{node['pcluster']['local_dir']}/parallelcluster_slurm_fleet_status_manager.conf" do
+  source 'slurm/parallelcluster_slurm_fleet_status_manager.conf.erb'
+  owner node['plugin']['user']
+  group node['plugin']['user']
+  mode '0644'
+end
+
 template "#{node['pcluster']['local_dir']}/scripts/slurm/slurm_resume" do
   source 'slurm/resume_program.erb'
   owner node['slurm']['user']

--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/templates/default/slurm/fleet_status_manager_program.erb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/templates/default/slurm/fleet_status_manager_program.erb
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo -u <%= node['plugin']['fleet_mgt_user'] %> CONFIG_FILE="<%= node['pcluster']['local_dir'] %>/parallelcluster_slurm_fleet_status_manager.conf" SLURM_BINARIES_DIR="<%= node['slurm']['install_dir'] %>/bin" <%= node['pcluster']['python_root'] %>/slurm_fleet_status_manager "$@"

--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/templates/default/slurm/parallelcluster_slurm_fleet_status_manager.conf.erb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/templates/default/slurm/parallelcluster_slurm_fleet_status_manager.conf.erb
@@ -1,0 +1,4 @@
+[slurm_fleet_status_manager]
+cluster_name = <%= node['pcluster']['cluster_name'] %>
+region = <%= node['pcluster']['region'] %>
+proxy = <%= node['pcluster']['proxy'] %>

--- a/scheduler_plugins/slurm/plugin_definition.yaml
+++ b/scheduler_plugins/slurm/plugin_definition.yaml
@@ -21,7 +21,7 @@ SystemUsers:
   - Name: slurm-user
     EnableImds: false
     SudoerConfiguration:
-      - Commands: /opt/parallelcluster/shared/scheduler-plugin/*/bin/slurm_resume, /opt/parallelcluster/shared/scheduler-plugin/*/bin/slurm_suspend
+      - Commands: /opt/parallelcluster/shared/scheduler-plugin/*/bin/slurm_resume, /opt/parallelcluster/shared/scheduler-plugin/*/bin/slurm_suspend, /opt/parallelcluster/shared/scheduler-plugin/*/bin/slurm_fleet_status_manager
         RunAs: fleet-mgt-user
   - Name: fleet-mgt-user
     EnableImds: true

--- a/tests/integration-tests/configs/byos.yaml
+++ b/tests/integration-tests/configs/byos.yaml
@@ -1,12 +1,37 @@
 {%- import 'common.jinja2' as common with context -%}
 ---
 test-suites:
+  cli_commands:
+    test_cli_commands.py::test_slurm_cli_commands:
+      dimensions:
+        - regions: [ "ap-northeast-2" ]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: [ "ubuntu1804" ]
+          schedulers: [ "slurm" ]
   schedulers:
     test_slurm.py::test_slurm:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+    test_slurm.py::test_slurm_scaling:
+      dimensions:
+        - regions: ["us-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+    test_slurm.py::test_error_handling:
+      dimensions:
+        - regions: ["ca-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+    test_slurm.py::test_slurm_protected_mode:
+      dimensions:
+        - regions: ["eu-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
   update:
     test_update.py::test_update_slurm:

--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -238,12 +238,12 @@ def orchestrate_pcluster_configure_stages(
             "response": instance,
             "skip_for_batch": True,
         },
-        {"prompt": fr"Maximum {size_name} \[10\]: ", "response": ""},
+        {"prompt": rf"Maximum {size_name} \[10\]: ", "response": ""},
         {"prompt": r"Automate VPC creation\? \(y/n\) \[n\]: ", "response": "n"},
         {"prompt": r"VPC ID \[vpc-.+\]: ", "response": vpc_id},
         {"prompt": r"Automate Subnet creation\? \(y/n\) \[y\]: ", "response": "n"},
-        {"prompt": fr"{omitted_note}head node subnet ID \[subnet-.+\]: ", "response": head_node_subnet_id},
-        {"prompt": fr"{omitted_note}compute subnet ID \[{default_compute_subnet}\]: ", "response": compute_subnet_id},
+        {"prompt": rf"{omitted_note}head node subnet ID \[subnet-.+\]: ", "response": head_node_subnet_id},
+        {"prompt": rf"{omitted_note}compute subnet ID \[{default_compute_subnet}\]: ", "response": compute_subnet_id},
     ]
     # When a user selects Batch as the scheduler, pcluster configure does not prompt for OS or compute instance type.
     return [stage for stage in stage_list if scheduler != "awsbatch" or not stage.get("skip_for_batch")]

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -43,7 +43,7 @@ def test_create_wrong_os(region, os, pcluster_config_reader, clusters_factory, a
     assert_errors_in_logs(
         remote_command_executor,
         ["/var/log/chef-client.log"],
-        ["RuntimeError", fr"custom AMI.+{wrong_os}.+base.+os.+config file.+{os}"],
+        ["RuntimeError", rf"custom AMI.+{wrong_os}.+base.+os.+config file.+{os}"],
     )
 
 
@@ -69,7 +69,7 @@ def test_create_wrong_pcluster_version(
     assert_errors_in_logs(
         remote_command_executor,
         ["/var/log/cloud-init-output.log"],
-        ["error_exit", fr"AMI was created.+{wrong_version}.+is.+used.+{current_version}"],
+        ["error_exit", rf"AMI was created.+{wrong_version}.+is.+used.+{current_version}"],
     )
 
 

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -416,7 +416,7 @@ def test_build_image_wrong_pcluster_version(
     _test_build_image_failed(image)
     log_stream_name = f"{get_installed_parallelcluster_base_version()}/1"
     log_data = " ".join(log["message"] for log in image.get_log_events(log_stream_name, limit=100)["events"])
-    assert_that(log_data).matches(fr"AMI was created.+{wrong_version}.+is.+used.+{current_version}")
+    assert_that(log_data).matches(rf"AMI was created.+{wrong_version}.+is.+used.+{current_version}")
 
 
 def _test_build_image_failed(image):

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -239,12 +239,12 @@ def _assert_scheduler_nodes(queues_config, slurm_commands):
     for queue, queue_config in queues_config.items():
         for compute_resource_name, compute_resource_config in queue_config["compute_resources"].items():
             running_instances = len(
-                re.compile(fr"{queue}-(dy|st)-{compute_resource_name}-\d+ (idle|mixed|alloc)\n").findall(
+                re.compile(rf"{queue}-(dy|st)-{compute_resource_name}-\d+ (idle|mixed|alloc)\n").findall(
                     slurm_nodes_str
                 )
             )
             power_saved_instances = len(
-                re.compile(fr"{queue}-(dy|st)-{compute_resource_name}-\d+ idle~\n").findall(slurm_nodes_str)
+                re.compile(rf"{queue}-(dy|st)-{compute_resource_name}-\d+ idle~\n").findall(slurm_nodes_str)
             )
             assert_that(running_instances).is_equal_to(compute_resource_config["expected_running_instances"])
             assert_that(power_saved_instances).is_equal_to(compute_resource_config["expected_power_saved_instances"])
@@ -310,7 +310,7 @@ def _check_script(command_executor, slurm_commands, host, script_name, script_ar
     time.sleep(5)  # wait a bit to be sure to have the file
 
     result = command_executor.run_remote_command(f"cat {output_file_path}")
-    assert_that(result.stdout).matches(fr"{script_name}-{script_arg}")
+    assert_that(result.stdout).matches(rf"{script_name}-{script_arg}")
 
 
 def _add_compute_nodes(slurm_commands, partition, constraint, number_of_nodes=1):


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
Use new compute fleet status manager for all traditional scheduler

Both slurm and plugin are now using new compute fleet status manager

### Tests
* tested through config/byos.yaml definition

### References
* cookbook changes https://github.com/aws/aws-parallelcluster-cookbook/pull/1342
* node changes https://github.com/aws/aws-parallelcluster-node/pull/384

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
