### PR TITLE
3.x: Improve get_cluster_log_events test looking for the actual first message

### DIFF
--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -344,7 +344,6 @@ def _test_pcluster_get_cluster_log_events(cluster):
     logging.info("Testing that pcluster get-cluster-log-events is working as expected")
     cluster_info = cluster.describe_cluster()
     cfn_init_log_stream = instance_stream_name(cluster_info["headNode"], "cfn-init")
-    cloud_init_debug_msg = "[DEBUG] CloudFormation client initialized with endpoint"
 
     # Get the first event to establish time boundary for testing
     initial_events = cluster.get_log_events(cfn_init_log_stream, limit=1, start_from_head=True)
@@ -373,10 +372,10 @@ def _test_pcluster_get_cluster_log_events(cluster):
             assert_that(events).is_length(expect_count)
 
         if expect_first is True:
-            assert_that(events[0]["message"]).contains(cloud_init_debug_msg)
+            assert_that(events[0]["message"]).matches(first_event["message"])
 
         if expect_first is False:
-            assert_that(events[0]["message"]).does_not_contain(cloud_init_debug_msg)
+            assert_that(events[0]["message"]).does_not_match(first_event["message"])
 
 
 def _test_pcluster_get_cluster_stack_events(cluster):


### PR DESCRIPTION
### Description of changes
It is not always true that the first message is the cloud init debug message,
sometimes the first message is another one causing the test to fail.

With this patch we're using the actual first message to verify if it's in the list of returned events.
We don't need to check the cloud init debug message is the first one or that it is present.

### References
Similar to: https://github.com/aws/aws-parallelcluster/pull/3690

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
