### PR TITLE
3.x: Fix test_pcluster_get_cluster_log_events test assertion

### DIFF
--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -372,10 +372,10 @@ def _test_pcluster_get_cluster_log_events(cluster):
             assert_that(events).is_length(expect_count)
 
         if expect_first is True:
-            assert_that(events[0]["message"]).matches(first_event["message"])
+            assert_that(events[0]["message"]).is_equal_to(first_event["message"])
 
         if expect_first is False:
-            assert_that(events[0]["message"]).does_not_match(first_event["message"])
+            assert_that(events[0]["message"]).is_not_equal_to(first_event["message"])
 
 
 def _test_pcluster_get_cluster_stack_events(cluster):


### PR DESCRIPTION
### Description of changes
I wrongly introduced the `matches` keyword in the assertion and the test is failing with: 
```
AssertionError: Expected 
<2022-01-26 20:01:39,388 [DEBUG] CloudFormation client initialized with endpoint https://cloudformation.us-west-2.amazonaws.com> 
to match pattern
<2022-01-26 20:01:39,388 [DEBUG] CloudFormation client initialized with endpoint https://cloudformation.us-west-2.amazonaws.com>
, but did not.
```

### Tests
* Tested running `test_slurm_cli_commands` integ test

### References
* Issue introduced with: https://github.com/aws/aws-parallelcluster/pull/3710

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.


