### PR TITLE
[develop] Fix check for image build in progress

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -376,7 +376,7 @@ def _test_build_image_success(image):
     pcluster_describe_image_result = image.describe()
     logging.info(pcluster_describe_image_result)
 
-    while image.image_status == "BUILD_IN_PROGRESS":
+    while image.image_status.endswith("_IN_PROGRESS"):  # e.g. BUILD_IN_PROGRESS, DELETE_IN_PROGRESS
         time.sleep(600)
         pcluster_describe_image_result = image.describe()
         logging.info(pcluster_describe_image_result)
@@ -425,7 +425,7 @@ def _test_build_image_failed(image):
     pcluster_describe_image_result = image.describe()
     logging.info(pcluster_describe_image_result)
 
-    while image.image_status == "BUILD_IN_PROGRESS":
+    while image.image_status.endswith("_IN_PROGRESS"):  # e.g. BUILD_IN_PROGRESS, DELETE_IN_PROGRESS
         time.sleep(600)
         pcluster_describe_image_result = image.describe()
         logging.info(pcluster_describe_image_result)


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
There could be an interval during the build of an image where the building stack is being deleted (DELETE_IN_PROGRESS). We need to cycle again and query for another describe image.

### Tests
N/A

### References

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
