### PR TITLE
Integ-tests: Improve test_ad_integration

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -48,7 +48,6 @@ DirectoryService:
   LdapAccessFilter: "!(CN=PclusterUser3)"
   AdditionalSssdConfigs:
     debug_level: "0x1ff"
-    enumerate: True
     {% if directory_protocol == "ldap" %}
     ldap_auth_disable_tls_never_use_in_production: True
     {% endif %}

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -47,7 +47,6 @@ DirectoryService:
   GenerateSshKeysForUsers: false
   AdditionalSssdConfigs:
     debug_level: "0x1ff"
-    enumerate: True
     {% if directory_protocol == "ldap" %}
     ldap_auth_disable_tls_never_use_in_production: True
     {% endif %}

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/workload.sh
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/workload.sh
@@ -3,7 +3,8 @@ set -ex
 
 # TODO: add efs
 for fspath in shared ebs; do
-    date '+%Y%m%d%H%M%S' > "/$fspath/$(whoami)"
+    # srun has to be used for whoami because slurm_nss plugin only send user information through srun
+    date '+%Y%m%d%H%M%S' > "/$fspath/$(srun whoami)"
 done
 
 BENCHMARK_NAME=osu_barrier
@@ -14,5 +15,5 @@ module load openmpi
 # NOTE: The test is sized for 4 compute nodes.
 # -np total number of processes to run (all CPUs * 4 nodes)
 mpirun \
-    > /shared/$(date '+%Y%m%d%H%M%S')-$(whoami)-${BENCHMARK_NAME}.out \
+    > /shared/"$(date '+%Y%m%d%H%M%S')-$(srun whoami)-${BENCHMARK_NAME}".out \
     /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME}  


### PR DESCRIPTION
1. Check `srun whoami` to ensure user information is sent to compute nodes
2. Remove `enumerate=True` because it might impact performance so not recommanded.
3. Only wait 10 minutes for the SSSD agent use the certificate when this functionality is tested.

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
test_ad_integration with MicrosoftAD has been passed

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
