### PR TITLE
Fix Tags in number interpret as integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Fix DCV connection through browsers.
+- Fix Tags in number interpreted as integer.
 
 **CHANGES**
 - Upgrade NVIDIA driver to version 470.103.01.

--- a/cloudformation/compute-fleet-hit-substack.cfn.yaml
+++ b/cloudformation/compute-fleet-hit-substack.cfn.yaml
@@ -201,8 +201,8 @@ Resources:
               - Key: aws-parallelcluster-node-type
                 Value: Compute
     {%- for tag in tags %}
-              - Key: {{ tag.Key }}
-                Value: {{ tag.Value }}
+              - Key: '{{ tag.Key }}'
+                Value: '{{ tag.Value }}'
     {%- endfor %}
           - ResourceType: volume
             Tags:
@@ -219,8 +219,8 @@ Resources:
               - Key: aws-parallelcluster-node-type
                 Value: Compute
     {%- for tag in tags %}
-              - Key: {{ tag.Key }}
-                Value: {{ tag.Value }}
+              - Key: '{{ tag.Key }}'
+                Value: '{{ tag.Value }}'
     {%- endfor %}
         BlockDeviceMappings:
           - DeviceName: /dev/xvdba

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -20,7 +20,7 @@ def substack_rendering(tmp_path, template_name, test_config):
     env.filters["bool"] = lambda value: value.lower() == "true"
     template = env.get_template(template_name)
     output_from_parsed_template = template.render(
-        config=test_config, config_version="version", tags=[{"Key": "TagKey", "Value": "TagValue"}]
+        config=test_config, config_version="version", tags=[{"Key": "000000", "Value": "000000"}]
     )
     rendered_file = tmp_path / template_name
     rendered_file.write_text(output_from_parsed_template)

--- a/tests/integration-tests/tests/tags/test_tag_propagation.py
+++ b/tests/integration-tests/tests/tags/test_tag_propagation.py
@@ -38,7 +38,7 @@ def test_tag_propagation(pcluster_config_reader, clusters_factory, scheduler, os
     - compute node's root EBS volume (traditional schedulers)
     - shared EBS volume
     """
-    config_file_tags = {"ConfigFileTag": "ConfigFileTagValue"}
+    config_file_tags = {"ConfigFileTag": "ConfigFileTagValue", "NumberTag": "00000122"}
     command_line_tags = {"CommandLineTag": "CommandLineTagValue"}
     version_tags = {"Version": get_pcluster_version()}
     cluster_config = pcluster_config_reader(tags=json.dumps(config_file_tags))


### PR DESCRIPTION
This PR is created to fix this issue: https://github.com/aws/aws-parallelcluster/issues/3711
When creating cluster with tags set in the cluster configuration, if the tag’s key or value are in number, they are interpreted as integer instead of string, possibly causing unexpected value conversion when tagging compute resources.
For example, cluster section with value tags = {"key" : "00000122"} is interpreted as “Key: key, Value: 82” for compute resources launched from launch template, because "00000122" is considered an octal and its string representation is converted to decimal.
