### PR TITLE
Do not grant system users sudo privileges in case GrantSudoPrivileges is set to false

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -118,6 +118,7 @@ from pcluster.validators.s3_validators import (
     UrlValidator,
 )
 from pcluster.validators.scheduler_plugin_validators import (
+    GrantSudoPrivilegesValidator,
     SchedulerPluginOsArchitectureValidator,
     SchedulerPluginRegionValidator,
     SudoPrivilegesValidator,
@@ -1877,6 +1878,12 @@ class SchedulerPluginSettings(Resource):
             requires_sudo_privileges=self.scheduler_definition.requirements.requires_sudo_privileges
             if self.scheduler_definition.requirements
             else None,
+        )
+
+        self._register_validator(
+            GrantSudoPrivilegesValidator,
+            grant_sudo_privileges=self.grant_sudo_privileges,
+            system_users=get_attr(self.scheduler_definition, "system_users"),
         )
 
 

--- a/cli/src/pcluster/validators/scheduler_plugin_validators.py
+++ b/cli/src/pcluster/validators/scheduler_plugin_validators.py
@@ -14,6 +14,7 @@ from collections import namedtuple
 
 from pkg_resources import packaging
 
+from pcluster.utils import get_attr
 from pcluster.validators.common import FailureLevel, Validator
 
 
@@ -27,6 +28,24 @@ class SudoPrivilegesValidator(Validator):
                 "but these privileges were not granted because GrantSudoPrivileges was not set or set to false.",
                 FailureLevel.ERROR,
             )
+
+
+class GrantSudoPrivilegesValidator(Validator):
+    """Verify SystemUsers does not have SudoerConfiguration set when GrantSudoPrivileges is true."""
+
+    def _validate(self, grant_sudo_privileges: bool, system_users):
+        if not grant_sudo_privileges and system_users:
+            sudoer_configuration = [
+                get_attr(user, "sudoer_configuration")
+                for user in system_users
+                if get_attr(user, "sudoer_configuration")
+            ]
+            if sudoer_configuration:
+                self._add_failure(
+                    "The used scheduler plugin requires the creation of SystemUsers with sudo access. To grant such "
+                    "rights please set GrantSudoPrivileges to true.",
+                    FailureLevel.ERROR,
+                )
 
 
 class SchedulerPluginOsArchitectureValidator(Validator):

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.before_update.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.before_update.yaml
@@ -9,6 +9,7 @@ HeadNode:
 Scheduling:
   Scheduler: plugin
   SchedulerSettings:
+    GrantSudoPrivileges: true
     SchedulerDefinition:
       PluginInterfaceVersion: "1.0"
       Events:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.yaml
@@ -9,6 +9,7 @@ HeadNode:
 Scheduling:
   Scheduler: plugin
   SchedulerSettings:
+    GrantSudoPrivileges: true
     SchedulerDefinition:
       PluginInterfaceVersion: "1.0"
       Events:


### PR DESCRIPTION
Add a validator so that we fail in case `GrantSudoPrivileges: false` and SystemUsers in plugin definition have SudoerConfiguration
