### PR TITLE
[develop] Upgrade NVIDIA drivers, CUDA and Fabric Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ CHANGELOG
 **CHANGES**
 - Upgrade Slurm to version 21.08.5.
 - Upgrade NICE DCV to version 2021.3-11591.
-- Upgrade NVIDIA driver to version 470.82.01.
-- Upgrade CUDA library to version 11.4.3.
-- Upgrade NVIDIA Fabric manager to version 470.82.01.
+- Upgrade NVIDIA driver to version 470.103.01.
+- Upgrade CUDA library to version 11.4.4.
+- Upgrade NVIDIA Fabric manager to version 470.103.01.
 - Upgrade Intel MPI Library to 2021.4.0.441.
 - Upgrade PMIx to version 3.2.3.
 - Disable package update at instance launch time on Amazon Linux 2.


### PR DESCRIPTION
NVIDIA drivers from 470.82.01 to 470.103.01
CUDA from 11.4.3 to 11.4.4
Fabric Manager from 470.82.01 to 470.103.01

Related to https://github.com/aws/aws-parallelcluster-cookbook/pull/1351

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
