### PR TITLE
[byos] Make test_scheduler_plugin_integration compatible with ubuntu18

### DIFF
--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.before_update.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.before_update.yaml
@@ -86,12 +86,12 @@ Scheduling:
           SudoerConfiguration:
             - Commands: ALL
               RunAs: root
-            - Commands: /usr/bin/ls, /usr/bin/touch
+            - Commands: /bin/ls, /usr/bin/touch
               RunAs: {{ run_as_user }}
         - Name: {{ user2 }}
           EnableImds: true
           SudoerConfiguration:
-            - Commands: /usr/bin/ls
+            - Commands: /bin/ls
               RunAs: root
       Tags:
         - Key: SchedulerPluginTag

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.yaml
@@ -91,7 +91,7 @@ Scheduling:
         - Name: {{ user2 }}
           EnableImds: true
           SudoerConfiguration:
-            - Commands: /usr/bin/ls
+            - Commands: /bin/ls
               RunAs: root
       Tags:
         - Key: SchedulerPluginTag


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
