### PR TITLE
Fix UrlValidator for SchedulerPluginCloudFormationInfrastructure

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1702,7 +1702,11 @@ class SchedulerPluginCloudFormationInfrastructure(Resource):
 
     def _register_validators(self):
         self._register_validator(
-            UrlValidator, url=self.template, fail_on_https_error=True, expected_bucket_owner=self.s3_bucket_owner
+            UrlValidator,
+            url=self.template,
+            fail_on_https_error=True,
+            fail_on_s3_error=True,
+            expected_bucket_owner=self.s3_bucket_owner,
         )
 
 


### PR DESCRIPTION
Make SchedulerPluginCloudFormationInfrastructure validation failed on S3 error and https error
Manually test with create cluster with wrong template  s3 url:
Config validation failed with the following message
```
    {
      "level": "ERROR",
      "type": "UrlValidator",
      "message": "Failed when accessing object 'scheduler_plugin/scheduler_plugin_infra.cfn.yaml1' from bucket 'amibucket11223'. This can be due to 'scheduler_plugin/scheduler_plugin_infra.cfn.yaml1' not found in 'amibucket11223'"
    }
  ],
  "message": "Invalid cluster configuration."
}
```