### PR TITLE
[develop] Add retries on batch docker image build

### DIFF
--- a/cli/src/pcluster/resources/batch/docker/build-docker-images.sh
+++ b/cli/src/pcluster/resources/batch/docker/build-docker-images.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 set -eu
 
+retry() {
+    local loop=1
+    local max_retries=3
+    local retry_delays=5
+
+    set +e
+    while true; do
+        "$@" && break || {
+            if [[ ${loop} -le ${max_retries} ]]; then
+                echo "Command ($*) failed. Retrying..."
+                loop=$((loop+1))
+                sleep ${retry_delays}
+            else
+                echo "Command ($*) failed after ${max_retries} attempts."
+                exit 1
+            fi
+        }
+    done
+    set -e
+}
+
 build_docker_image() {
     local image=$1
     echo "Building image ${image}"
@@ -8,7 +29,7 @@ build_docker_image() {
         echo "Dockerfile not found for image ${image}. Exiting..."
         exit 1
     fi
-    docker build --build-arg AWS_REGION="${AWS_REGION}" -f "${image}/Dockerfile" -t "${IMAGE_REPO_NAME}:${image}" .
+    retry docker build --build-arg AWS_REGION="${AWS_REGION}" -f "${image}/Dockerfile" -t "${IMAGE_REPO_NAME}:${image}" .
 }
 
 if [ -z "${IMAGE}" ]; then


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
Add retries on batch docker image build
This can be useful for build in problematic networks

### Tests
* script manually tested
* integ tests with following config
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  storage:  
    test_efs.py::test_efs_same_az:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_BATCH }}
          schedulers: ["awsbatch"]
  schedulers:
    test_awsbatch.py::test_awsbatch:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]  
```

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
