### PR TITLE
Move some AD integration tests from ap-northeast-1 to us-west-2

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -13,7 +13,7 @@ ad_integration:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"]
         schedulers: ["slurm"]
-      - regions: ["ap-northeast-1"]
+      - regions: ["us-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004"]
         schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
* Move some AD integration tests from ap-northeast-1 to us-west-2. This change is necessary because some AZs in ap-northeast-1 does not provide FSx Lustre.

### Tests
* Will be tested directly in the dev commercial pipeline

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
