### PR TITLE
3.x: Add support for NEW_CHANGED_DELETED FSx import policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 - Add support for `UseEc2Hostnames` in the cluster configuration file. When set to `true`, use EC2 default hostnames (e.g. ip-1-2-3-4) for compute nodes.
 - Add support for GPU scheduling with Slurm on ARM instances with NVIDIA cards. Install NVIDIA drivers and CUDA library for ARM.
 - Add `parallelcluster:compute-resource-name` tag to LaunchTemplates used by compute nodes.
+- Add support for `NEW_CHANGED_DELETED` as value of FSx for Lustre `AutoImportPolicy` option.
 - Explicitly set cloud-init datasource to be EC2. This save boot time for Ubuntu and CentOS platforms.
 - Improve Security Groups created within the cluster to allow inbound connections from custom security groups when `SecurityGroups` parameters are specified for some head node and/or queues.`
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -375,7 +375,8 @@ class FsxLustreSettingsSchema(BaseSchema):
         validate=validate.Regexp(r"^fs-[0-9a-z]{17}$"), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
     )
     auto_import_policy = fields.Str(
-        validate=validate.OneOf(["NEW", "NEW_CHANGED"]), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
+        validate=validate.OneOf(["NEW", "NEW_CHANGED", "NEW_CHANGED_DELETED"]),
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
     drive_cache_type = fields.Str(
         validate=validate.OneOf(["READ"]), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}

--- a/cli/tests/pcluster/cli/test_configuration_converter/test_pcluster3_configuration_converter/missing_vpc.ini
+++ b/cli/tests/pcluster/cli/test_configuration_converter/test_pcluster3_configuration_converter/missing_vpc.ini
@@ -80,7 +80,7 @@ fsx_kms_key_id = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 per_unit_storage_throughput = 200
 storage_type = SSD
 drive_cache_type = READ
-auto_import_policy = NEW_CHANGED
+auto_import_policy = NEW_CHANGED_DELETED
 
 [scaling custom]
 scaledown_idletime = 10

--- a/cli/tests/pcluster/example_configs/awsbatch.full.yaml
+++ b/cli/tests/pcluster/example_configs/awsbatch.full.yaml
@@ -105,7 +105,7 @@ SharedStorage:
       #BackupId: backup-12345678  # BackupId cannot coexist with some of the fields
       KmsKeyId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
       #FileSystemId: fs-12345678123456789  # FileSystemId cannot coexist with other fields
-      AutoImportPolicy: NEW_CHANGED  # NEW | NEW_CHANGED
+      AutoImportPolicy: NEW_CHANGED_DELETED  # NEW | NEW_CHANGED | NEW_CHANGED_DELETED
       DriveCacheType: READ  # READ
       StorageType: HDD  # HDD | SSD
 Iam:

--- a/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
+++ b/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
@@ -230,7 +230,7 @@ SharedStorage:
       # BackupId: backup-fedcba98 # BackupId cannot coexist with some of the fields
       KmsKeyId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
       # FileSystemId: fs-12345678123456789 # FileSystemId cannot coexist with other fields
-      AutoImportPolicy: NEW  # NEW | NEW_CHANGED
+      AutoImportPolicy: NEW  # NEW | NEW_CHANGED | NEW_CHANGED_DELETED
       DriveCacheType: READ  # READ
       StorageType: HDD  # HDD | SSD
 Iam:

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -158,7 +158,7 @@ SharedStorage:
       # BackupId: backup-fedcba98 # BackupId cannot coexist with some of the fields
       KmsKeyId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
       # FileSystemId: fs-12345678123456789 # FileSystemId cannot coexist with other fields
-      AutoImportPolicy: NEW  # NEW | NEW_CHANGED
+      AutoImportPolicy: NEW  # NEW | NEW_CHANGED | NEW_CHANGED_DELETED
       DriveCacheType: READ  # READ
       StorageType: HDD  # HDD | SSD
 Iam:

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -467,6 +467,7 @@ def test_efs_throughput_mode_provisioned_throughput_validator(section_dict, expe
         ({"BackupId": "backup-0a1b2c3d4e5f6a7b8"}, None),
         ({"AutoImportPolicy": "NEW"}, None),
         ({"AutoImportPolicy": "NEW_CHANGED"}, None),
+        ({"AutoImportPolicy": "NEW_CHANGED_DELETED"}, None),
         ({"StorageType": "SSD"}, None),
         ({"StorageType": "HDD"}, None),
         ({"StorageType": "INVALID_VALUE"}, "Must be one of"),

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -139,7 +139,7 @@ SharedStorage:
       # BackupId: backup-fedcba98 # BackupId cannot coexist with some of the fields
       KmsKeyId: String  # xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
       # FileSystemId: fs-12345678123456789 # FileSystemId cannot coexist with some of the fields
-      AutoImportPolicy: NEW  # NEW | NEW_CHANGED
+      AutoImportPolicy: NEW  # NEW | NEW_CHANGED | NEW_CHANGED_DELETED
       DriveCacheType: READ  # READ
       StorageType: HDD  # HDD | SSD
 Iam:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -49,7 +49,7 @@ MAX_MINUTES_TO_WAIT_FOR_BACKUP_COMPLETION = 7
     [
         ("PERSISTENT_1", 200, "NEW_CHANGED", None, None, 1200, 1024, None),
         ("SCRATCH_1", None, "NEW", None, None, 1200, 1024, "LZ4"),
-        ("SCRATCH_2", None, None, None, None, 1200, 1024, "LZ4"),
+        ("SCRATCH_2", None, "NEW_CHANGED_DELETED", None, None, 1200, 1024, "LZ4"),
         ("PERSISTENT_1", 200, None, "SSD", None, 1200, 2048, "LZ4"),
         ("PERSISTENT_1", 40, None, "HDD", None, 1800, 512, "LZ4"),
         ("PERSISTENT_1", 12, None, "HDD", "READ", 6000, 1024, "LZ4"),
@@ -454,24 +454,33 @@ def _test_auto_import(auto_import_policy, remote_command_executor, mount_dir, bu
     s3.put_object(Bucket=bucket_name, Key=filename, Body=new_file_body)
     # AutoImport has a P99.9 of 1 min for new/changed files to be imported onto the filesystem
     remote_command_executor.run_remote_command("sleep 1m")
-    if auto_import_policy in ("NEW", "NEW_CHANGED"):
+    if auto_import_policy in ("NEW", "NEW_CHANGED", "NEW_CHANGED_DELETED"):
         result = remote_command_executor.run_remote_command(f"cat {mount_dir}/{filename}")
         assert_that(result.stdout).is_equal_to(new_file_body)
     else:
-        result = remote_command_executor.run_remote_command(f"ls {mount_dir}/")
-        assert_that(result.stdout).does_not_contain(filename)
+        _assert_file_does_not_exist(remote_command_executor, filename, mount_dir)
 
     # Test modified file
     s3.put_object(Bucket=bucket_name, Key=filename, Body=modified_file_body)
     remote_command_executor.run_remote_command("sleep 1m")
-    if auto_import_policy in ("NEW", "NEW_CHANGED"):
-        result = remote_command_executor.run_remote_command(f"cat {mount_dir}/{filename}".format(mount_dir=mount_dir))
+    if auto_import_policy in ("NEW", "NEW_CHANGED", "NEW_CHANGED_DELETED"):
+        result = remote_command_executor.run_remote_command(f"cat {mount_dir}/{filename}")
         assert_that(result.stdout).is_equal_to(
-            modified_file_body if auto_import_policy == "NEW_CHANGED" else new_file_body
+            modified_file_body if auto_import_policy in ["NEW_CHANGED", "NEW_CHANGED_DELETED"] else new_file_body
         )
     else:
-        result = remote_command_executor.run_remote_command(f"ls {mount_dir}/")
-        assert_that(result.stdout).does_not_contain(filename)
+        _assert_file_does_not_exist(remote_command_executor, filename, mount_dir)
+
+    if auto_import_policy == "NEW_CHANGED_DELETED":
+        # Test deleted file
+        s3.delete_object(Bucket=bucket_name, Key=filename)
+        remote_command_executor.run_remote_command("sleep 1m")
+        _assert_file_does_not_exist(remote_command_executor, filename, mount_dir)
+
+
+def _assert_file_does_not_exist(remote_command_executor, filename, mount_dir):
+    result = remote_command_executor.run_remote_command(f"ls {mount_dir}/")
+    assert_that(result.stdout).does_not_contain(filename)
 
 
 @retry(


### PR DESCRIPTION
### Description of changes
* Added possibility to configure `NEW_CHANGED_DELETED` as `AutoImportPolicy` value.
* Extended validator and related tests

### Tests
* Extended unit tests to verify the new value is supported
* Extend test_fsx_lustre integration test to verify deleted files are removed as expected.
* Executed:
``` 
test_fsx_lustre.py::test_fsx_lustre:
test_fsx_lustre.py::test_fsx_lustre_configuration_options:
test_fsx_lustre.py::test_fsx_lustre_backup:
test_fsx_lustre.py::test_existing_fsx:
```
* There is an explicit test for: `[test_fsx_lustre_configuration_options[us-east-2-c5.xlarge-alinux2-slurm-SCRATCH_2-None-NEW_CHANGED_DELETED-None-None-1200-1024-LZ4]]`
### References
* Documentation change: https://github.com/awsdocs/aws-parallelcluster-user-guide/pull/65
> NEW_CHANGED_DELETED - AutoImport is on. Amazon FSx automatically imports file and directory
listings of any new objects added to the S3 bucket, any existing objects that are changed in the S3 bucket,
and any objects that were deleted in the S3 bucket.
* Official doc: https://docs.aws.amazon.com/fsx/latest/APIReference/API_DataRepositoryConfiguration.html

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
