### PR TITLE
Integ-tests: Add SecretsManager VPC endpoint

### DIFF
--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -229,6 +229,12 @@ def enable_vpc_endpoints(vpc_stack, region, cfn_stacks_factory, request):
             enable_private_dns=True,
         ),
         VPCEndpointConfig(
+            name="SecretsManager",
+            service_name=prefix + f"com.amazonaws.{region}.secretsmanager",
+            type=VPCEndpointConfig.EndpointType.INTERFACE,
+            enable_private_dns=True,
+        ),
+        VPCEndpointConfig(
             name="S3Endpoint",
             service_name=f"com.amazonaws.{region}.s3",
             type=VPCEndpointConfig.EndpointType.GATEWAY,


### PR DESCRIPTION
This endpoint is required when `DirectoryService` is to be integrated with the cluster. It enables the head node retrieve from `PasswordSecretArn`

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
