### PR TITLE
[develop] Add head node dependency to cleanup R53 resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+x.x.x
+------
+
+**BUG FIXES**
+- Fix cluster stack in `DELETE_FAILED` when deleting a cluster, due to Route53 hosted zone not empty.
+
 3.1.1
 ------
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -298,6 +298,9 @@ class ClusterCdkStack(Stack):
 
         # Head Node
         self.head_node_instance = self._add_head_node()
+        # Add a dependency to the cleanup Route53 resource, so that Route53 Hosted Zone is cleaned after node is deleted
+        if self._condition_is_slurm() and hasattr(self.scheduler_resources, "cleanup_route53_custom_resource"):
+            self.head_node_instance.add_depends_on(self.scheduler_resources.cleanup_route53_custom_resource)
 
         # AWS Batch related resources
         if self._condition_is_batch():

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -242,56 +242,7 @@ class ClusterCdkStack(Stack):
             for storage in self.config.shared_storage:
                 self._add_shared_storage(storage)
 
-        # Compute Fleet and scheduler related resources
-        self.scheduler_resources = None
-        if self._condition_is_slurm():
-            self.scheduler_resources = SlurmConstruct(
-                scope=self,
-                id="Slurm",
-                stack_name=self._stack_name,
-                cluster_config=self.config,
-                bucket=self.bucket,
-                managed_head_node_instance_role=self._managed_head_node_instance_role,
-                managed_compute_instance_roles=self._managed_compute_instance_roles,
-                cleanup_lambda_role=cleanup_lambda_role,  # None if provided by the user
-                cleanup_lambda=cleanup_lambda,
-            )
-
-        if not self._condition_is_batch():
-            _dynamodb_table_status = dynamomdb.CfnTable(
-                self,
-                "DynamoDBTable",
-                table_name=PCLUSTER_DYNAMODB_PREFIX + self.stack_name,
-                attribute_definitions=[
-                    dynamomdb.CfnTable.AttributeDefinitionProperty(attribute_name="Id", attribute_type="S"),
-                ],
-                key_schema=[dynamomdb.CfnTable.KeySchemaProperty(attribute_name="Id", key_type="HASH")],
-                billing_mode="PAY_PER_REQUEST",
-            )
-            _dynamodb_table_status.cfn_options.update_replace_policy = CfnDeletionPolicy.RETAIN
-            _dynamodb_table_status.cfn_options.deletion_policy = CfnDeletionPolicy.DELETE
-            self.dynamodb_table_status = _dynamodb_table_status
-
-        self.compute_fleet_resources = None
-        if not self._condition_is_batch():
-            self.compute_fleet_resources = ComputeFleetConstruct(
-                scope=self,
-                id="ComputeFleet",
-                cluster_config=self.config,
-                log_group=self.log_group,
-                cleanup_lambda=cleanup_lambda,
-                cleanup_lambda_role=cleanup_lambda_role,
-                compute_security_group=self._compute_security_group,
-                shared_storage_mappings=self.shared_storage_mappings,
-                shared_storage_options=self.shared_storage_options,
-                shared_storage_attributes=self.shared_storage_attributes,
-                compute_node_instance_profiles=self._compute_instance_profiles,
-                cluster_hosted_zone=self.scheduler_resources.cluster_hosted_zone if self.scheduler_resources else None,
-                dynamodb_table=self.scheduler_resources.dynamodb_table if self.scheduler_resources else None,
-                head_eni=self._head_eni,
-            )
-
-        self._add_scheduler_plugin_substack()
+        self._add_fleet_and_scheduler_resources(cleanup_lambda, cleanup_lambda_role)
 
         # Wait condition
         self.wait_condition, self.wait_condition_handle = self._add_wait_condition()
@@ -356,6 +307,55 @@ class ClusterCdkStack(Stack):
         )
         log_group.cfn_options.deletion_policy = get_log_group_deletion_policy(self.config)
         return log_group
+
+    def _add_fleet_and_scheduler_resources(self, cleanup_lambda, cleanup_lambda_role):
+        # Compute Fleet and scheduler related resources
+        self.scheduler_resources = None
+        if self._condition_is_slurm():
+            self.scheduler_resources = SlurmConstruct(
+                scope=self,
+                id="Slurm",
+                stack_name=self._stack_name,
+                cluster_config=self.config,
+                bucket=self.bucket,
+                managed_head_node_instance_role=self._managed_head_node_instance_role,
+                managed_compute_instance_roles=self._managed_compute_instance_roles,
+                cleanup_lambda_role=cleanup_lambda_role,  # None if provided by the user
+                cleanup_lambda=cleanup_lambda,
+            )
+        if not self._condition_is_batch():
+            _dynamodb_table_status = dynamomdb.CfnTable(
+                self,
+                "DynamoDBTable",
+                table_name=PCLUSTER_DYNAMODB_PREFIX + self.stack_name,
+                attribute_definitions=[
+                    dynamomdb.CfnTable.AttributeDefinitionProperty(attribute_name="Id", attribute_type="S"),
+                ],
+                key_schema=[dynamomdb.CfnTable.KeySchemaProperty(attribute_name="Id", key_type="HASH")],
+                billing_mode="PAY_PER_REQUEST",
+            )
+            _dynamodb_table_status.cfn_options.update_replace_policy = CfnDeletionPolicy.RETAIN
+            _dynamodb_table_status.cfn_options.deletion_policy = CfnDeletionPolicy.DELETE
+            self.dynamodb_table_status = _dynamodb_table_status
+        self.compute_fleet_resources = None
+        if not self._condition_is_batch():
+            self.compute_fleet_resources = ComputeFleetConstruct(
+                scope=self,
+                id="ComputeFleet",
+                cluster_config=self.config,
+                log_group=self.log_group,
+                cleanup_lambda=cleanup_lambda,
+                cleanup_lambda_role=cleanup_lambda_role,
+                compute_security_group=self._compute_security_group,
+                shared_storage_mappings=self.shared_storage_mappings,
+                shared_storage_options=self.shared_storage_options,
+                shared_storage_attributes=self.shared_storage_attributes,
+                compute_node_instance_profiles=self._compute_instance_profiles,
+                cluster_hosted_zone=self.scheduler_resources.cluster_hosted_zone if self.scheduler_resources else None,
+                dynamodb_table=self.scheduler_resources.dynamodb_table if self.scheduler_resources else None,
+                head_eni=self._head_eni,
+            )
+        self._add_scheduler_plugin_substack()
 
     def _add_cleanup_resources_lambda(self):
         """Create Lambda cleanup resources function and its role."""


### PR DESCRIPTION
For the head node, add a dependency to the cleanup Route53 resource, so that Route53 Hosted Zone is cleaned after node is deleted.
This will solve random stack delete failed issue due to Route53 hosted zone not empty, occuring when head node is pushing entries in the hosted zone right after the cleanup function is already deleted.

Template diff
* before
```
  HeadNode:
    DependsOn:
    - ComputeFleetLaunchTemplate173566ba834494dcC0292928
    - ComputeFleetTerminateComputeFleetCustomResource9CE1795B
```

* after
```
  HeadNode:
    DependsOn:
    - CleanupRoute53CustomResource
    - ComputeFleetLaunchTemplate173566ba834494dcC0292928
    - ComputeFleetTerminateComputeFleetCustomResource9CE1795B
```

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
