### PR TITLE
3.x: Add validator to fail when FSx is used with AWS Batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ x.x.x
 
 **CHANGES**
 - Add scheduler information to `list-clusters`, `describe-cluster`, `delete-cluster`, `update-cluster`, `create-cluster` results.
+- Add validator to detect when using FSx for Lustre with AWS Batch as a scheduler, this combination is not supported yet.
 
 3.1.2
 ------

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -48,6 +48,7 @@ from pcluster.utils import (
 from pcluster.validators.awsbatch_validators import (
     AwsBatchComputeInstanceTypeValidator,
     AwsBatchComputeResourceSizeValidator,
+    AwsBatchFsxValidator,
     AwsBatchInstancesArchitectureCompatibilityValidator,
     AwsBatchRegionValidator,
 )
@@ -1358,6 +1359,10 @@ class AwsBatchClusterConfig(BaseClusterConfig):
             HeadNodeImdsValidator, imds_secured=self.head_node.imds.secured, scheduler=self.scheduling.scheduler
         )
         # TODO add InstanceTypesBaseAMICompatibleValidator
+
+        for storage in self.shared_storage:
+            if isinstance(storage, SharedFsx):
+                self._register_validator(AwsBatchFsxValidator)
 
         for queue in self.scheduling.queues:
             for compute_resource in queue.compute_resources:

--- a/cli/src/pcluster/validators/awsbatch_validators.py
+++ b/cli/src/pcluster/validators/awsbatch_validators.py
@@ -195,3 +195,14 @@ class AwsBatchInstancesArchitectureCompatibilityValidator(Validator):
     def _is_instance_type_format(candidate):
         """Return a boolean describing whether or not candidate is of the format of an instance type."""
         return re.search(r"^([a-z0-9\-]+)\.", candidate) is not None
+
+
+class AwsBatchFsxValidator(Validator):
+    """
+    Validator for FSx and AWS Batch scheduler.
+
+    Fail if using AWS Batch and FSx for Lustre, not supported yet.
+    """
+
+    def _validate(self):
+        self._add_failure("FSx for Lustre is not supported when using AWS Batch as scheduler.", FailureLevel.ERROR)

--- a/cli/tests/pcluster/validators/test_awsbatch_validators.py
+++ b/cli/tests/pcluster/validators/test_awsbatch_validators.py
@@ -24,6 +24,7 @@ from pcluster.aws.batch import BatchErrorMessageParsingException
 from pcluster.validators.awsbatch_validators import (
     AwsBatchComputeInstanceTypeValidator,
     AwsBatchComputeResourceSizeValidator,
+    AwsBatchFsxValidator,
     AwsBatchInstancesArchitectureCompatibilityValidator,
     AwsBatchRegionValidator,
 )
@@ -358,3 +359,8 @@ def test_is_instance_type_format(candidate, expected_return_value):
     assert_that(AwsBatchInstancesArchitectureCompatibilityValidator._is_instance_type_format(candidate)).is_equal_to(
         expected_return_value
     )
+
+
+def test_awsbatch_fsx_validator():
+    actual_failures = AwsBatchFsxValidator().execute()
+    assert_failure_messages(actual_failures, "FSx for Lustre is not supported when using AWS Batch as scheduler")


### PR DESCRIPTION
### Description of changes
* FSx for Lustre is not yet supported when using AWS Batch as scheduler.

### Tests
* Added unit tests for the validator.

#### Manual tests 

* slurm scheduler
   * with fsx -- cluster creation is ok
   * without fsx -- cluster create is ok
 * awsbatch scheduler 
   * without fsx -- cluster creation is ok
   * with fsx -- blocked by validator:
```
    {
      "level": "ERROR",
      "type": "AwsBatchFsxValidator",
      "message": "FSx for Lustre is not supported when using AWS Batch as scheduler."
    }
  ],
  "message": "Invalid cluster configuration."
}
```


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
