### PR TITLE
Add support for NEW_CHANGED_DELETED FSx import policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ CHANGELOG
 - Upgrade CUDA library to version 11.4.4.
 - Upgrade NVIDIA Fabric manager to version 470.103.01.
 
+**ENHANCEMENTS**
+- Add support for `NEW_CHANGED_DELETED` as value of FSx for Lustre `AutoImportPolicy` option.
+
 2.11.4
 -----
 

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -171,7 +171,7 @@ ALLOWED_VALUES = {
     "fsx_ssd_throughput": FSX_SSD_THROUGHPUT,
     "fsx_hdd_throughput": FSX_HDD_THROUGHPUT,
     "architectures": SUPPORTED_ARCHITECTURES,
-    "fsx_auto_import_policy": ["NEW", "NEW_CHANGED"],
+    "fsx_auto_import_policy": ["NEW", "NEW_CHANGED", "NEW_CHANGED_DELETED"],
     "fsx_storage_type": ["SSD", "HDD"],
     "fsx_drive_cache_type": ["READ"],
     "fsx_data_compression_type": ["LZ4"]

--- a/cli/src/pcluster/examples/config
+++ b/cli/src/pcluster/examples/config
@@ -281,5 +281,5 @@ master_subnet_id = subnet-12345678
 # For SCRATCH_2 and PERSISTENT_1 you can provide a KMS Key for in transit encryption
 #fsx_kms_key_id = XXXX-XXXXX-XXX-XXXXX
 # AutoImportPolicy configures how the filesystem is automatically updated with new and changed files from the linked S3 bucket
-# Valid options are NONE, NEW, NEW_CHANGED
+# Valid options are NONE, NEW, NEW_CHANGED, NEW_CHANGED_DELETED
 #auto_import_policy = NEW_CHANGED

--- a/cli/tests/pcluster/config/test_section_fsx.py
+++ b/cli/tests/pcluster/config/test_section_fsx.py
@@ -309,6 +309,7 @@ def test_fsx_section_to_cfn(mocker, section_dict, expected_cfn_params):
         ("auto_import_policy", None, None, None),
         ("auto_import_policy", "NEW", "NEW", None),
         ("auto_import_policy", "NEW_CHANGED", "NEW_CHANGED", None),
+        ("auto_import_policy", "NEW_CHANGED_DELETED", "NEW_CHANGED_DELETED", None),
         ("storage_type", None, None, None),
         ("storage_type", "SSD", "SSD", None),
         ("storage_type", "HDD", "HDD", None),


### PR DESCRIPTION
This commit is a backport of this PR https://github.com/aws/aws-parallelcluster/pull/3759
* Extended test_fsx_lustre integration test to verify deleted files are removed as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
