### PR TITLE
Disable PlacementGroup in case of p4d.24xlarge

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -15,7 +15,7 @@ Scheduling:
     - Name: efa-enabled
       Networking:
         PlacementGroup:
-          Enabled: true
+          Enabled: {{ 'true' if instance != "p4d.24xlarge" else 'false' }}
         SubnetIds:
           - {{ private_subnet_id }}
       ComputeResources:


### PR DESCRIPTION
When there is On-Demand Capacity Reservations which specify the placement group, there is no need to set it at the instances level.

Tests
Executed integration test with p4d.24xlarge and c5n.18xlarge up to the cluster configuration creation.

References
[Capacity Reservations in cluster placement groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/cr-cpg.html)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
