### PR TITLE
Add prolog and epilog test in cluster without internet access

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -361,6 +361,7 @@ class SlurmCommands(SchedulerCommands):
         try:
             assert_that(result.stdout).contains("JobState=COMPLETED")
         except AssertionError:
+            logging.error("JobState of jobid %s not in COMPLETED:\n%s", job_id, result.stdout)
             self._dump_job_output(result.stdout)
             raise
 


### PR DESCRIPTION
### Description of changes
* Add a test to catch if the prolog or the epilog fail.
* Add logging job info in case of assert_job_succeeded failure 

### Tests
* Tested if it catch an error in the job execution and the log file

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1372

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
