### PR TITLE
Integ-tests: fix test framework

### DIFF
--- a/tests/integration-tests/conftest_tests_config.py
+++ b/tests/integration-tests/conftest_tests_config.py
@@ -40,6 +40,7 @@ def _get_combinations_of_dimensions_values(configured_dimensions_items):
                    ('region2', 'inst1', 'os2', 's'), ('region3', 'inst2', 'os1', 's'), ('region3', 'inst3', 'os1', 's')]
     """
     argnames = list(DIMENSIONS_MARKER_ARGS)
+    argnames.append("benchmarks")
     argvalues = []
     for item in configured_dimensions_items:
         dimensions_values = []
@@ -50,7 +51,6 @@ def _get_combinations_of_dimensions_values(configured_dimensions_items):
             elif dim in argnames:
                 argnames.remove(dim)
         benchmarks_value = [item.get("benchmarks")]  # the benchmarks list is treated as a single item in a list
-        argnames.append("benchmarks")
         dimensions_values.append(benchmarks_value)
         argvalues.extend(list(product(*dimensions_values)))
 


### PR DESCRIPTION
`argnames.append("benchmarks")` has to be done outside the loops for dimensions to ensure there is one `benchmarks` in the argnames even if there are multiple dimensions. In other words, the values can be multiple as the dimensions, but there is only one group of names

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
