### PR TITLE
Integ-tests: Move test_head_node_stop to us-east-2

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -558,7 +558,7 @@ storage:
   # Ephemeral test requires instance type with instance store
   test_ephemeral.py::test_head_node_stop:
     dimensions:
-      - regions: ["us-east-1"]
+      - regions: ["us-east-2"]
         instances: ["m5d.xlarge", "h1.2xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]


### PR DESCRIPTION
h1.2xlarge is not supported in some of the availability zones in us east 1

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
