### PR TITLE
Integ-tests: Fix scaling test framework

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -786,22 +786,32 @@ def vpc(cfn_stacks_factory):
 Performance tests can run together with functionality tests, reusing clusters created by functionality test.
 
 To run performance test for a specific integration test, the following changes are required:
-1. Add `run_benchmarks` fixture to the test:
+1. Add `run_benchmarks` and `benchmarks` fixtures to the test:
 ```python
-def test_ad_integration(..., run_benchmarks):
+def test_feature(..., run_benchmarks, benchmarks):
     ...
 ```
-
-2. Decide the exact location in the test where the `run_benchmarks` should be called. The location is arbitrary. It can be the last line  of the test. Or if the test deletes/updates the cluster in the middle, you may want to call `run_benchmarks` before the deletes/updates.
+2. Add `benchmarks` parameter to `pcluster_config_reader`. This addition lets the `pcluster_config_reader` know benchmarks are used, therefore add placement groups and set larger max count in the configuration file.
 ```python
-def test_ad_integration(..., run_benchmarks):
+def test_feature(..., run_benchmarks, benchmarks):
+    ...
+    cluster_config = pcluster_config_reader(benchmarks=benchmarks)
+    ...
+```
+3. Decide the exact location in the test where the `run_benchmarks` should be called. The location is arbitrary. It can be the last line  of the test. Or if the test deletes/updates the cluster in the middle, you may want to call `run_benchmarks` before the deletes/updates.
+```python
+def test_feature(..., run_benchmarks, benchmarks):
+    ...
+    cluster_config = pcluster_config_reader(benchmarks=benchmarks)
     ...
     run_benchmarks(remote_command_executor, scheduler_commands)
     ...
 ```
 3. You may add more keyword arguments to the `run_benchmarks` calls. The keyword arguments will be added to the dimensions of CloudWatch metrics.
 ```python
-def test_ad_integration(..., run_benchmarks):
+def test_feature(..., run_benchmarks):
+    ...
+    cluster_config = pcluster_config_reader(benchmarks=benchmarks)
     ...
     run_benchmarks(remote_command_executor, scheduler_commands, diretory_type="MicrosoftAD")
     ...
@@ -812,8 +822,8 @@ def test_ad_integration(..., run_benchmarks):
 {%- import 'common.jinja2' as common -%}
 ---
 test-suites:
-  ad_integration:
-    test_ad_integration.py::test_ad_integration:
+  feature:
+    test_feature.py::test_feature:
       dimensions:
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -848,8 +858,8 @@ The current performance tests only support running OSU benchmarks. This section 
 {%- import 'common.jinja2' as common -%}
 ---
 test-suites:
-  ad_integration:
-    test_ad_integration.py::test_ad_integration:
+  feature:
+    test_feature.py::test_feature:
       dimensions:
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -493,7 +493,7 @@ def test_datadir(request, datadir):
 
 
 @pytest.fixture()
-def pcluster_config_reader(test_datadir, vpc_stack, request, region, benchmarks, scheduler_plugin_configuration):
+def pcluster_config_reader(test_datadir, vpc_stack, request, region, scheduler_plugin_configuration):
     """
     Define a fixture to render pcluster config templates associated to the running test.
 
@@ -509,7 +509,7 @@ def pcluster_config_reader(test_datadir, vpc_stack, request, region, benchmarks,
     :return: a _config_renderer(**kwargs) function which gets as input a dictionary of values to replace in the template
     """
 
-    def _config_renderer(config_file="pcluster.config.yaml", **kwargs):
+    def _config_renderer(config_file="pcluster.config.yaml", benchmarks=None, **kwargs):
         config_file_path = test_datadir / config_file
         if not os.path.isfile(config_file_path):
             raise FileNotFoundError(f"Cluster config file not found in the expected dir {config_file_path}")
@@ -554,7 +554,7 @@ def inject_additional_image_configs_settings(image_config, request):
 
 
 def inject_additional_config_settings(  # noqa: C901
-    cluster_config, request, region, benchmarks, scheduler_plugin_configuration=None
+    cluster_config, request, region, benchmarks=None, scheduler_plugin_configuration=None
 ):  # noqa C901
     with open(cluster_config, encoding="utf-8") as conf_file:
         config_content = yaml.safe_load(conf_file)

--- a/tests/integration-tests/conftest_tests_config.py
+++ b/tests/integration-tests/conftest_tests_config.py
@@ -40,7 +40,10 @@ def _get_combinations_of_dimensions_values(configured_dimensions_items):
                    ('region2', 'inst1', 'os2', 's'), ('region3', 'inst2', 'os1', 's'), ('region3', 'inst3', 'os1', 's')]
     """
     argnames = list(DIMENSIONS_MARKER_ARGS)
-    argnames.append("benchmarks")
+    # Add and only add benchmarks parametrization when necessary.
+    has_benchmarks = _has_benchmarks(configured_dimensions_items)
+    if has_benchmarks:
+        argnames.append("benchmarks")
     argvalues = []
     for item in configured_dimensions_items:
         dimensions_values = []
@@ -50,11 +53,19 @@ def _get_combinations_of_dimensions_values(configured_dimensions_items):
                 dimensions_values.append(values)
             elif dim in argnames:
                 argnames.remove(dim)
-        benchmarks_value = [item.get("benchmarks")]  # the benchmarks list is treated as a single item in a list
-        dimensions_values.append(benchmarks_value)
+        if has_benchmarks:
+            benchmarks_value = [item.get("benchmarks")]  # the benchmarks list is treated as a single item in a list
+            dimensions_values.append(benchmarks_value)
         argvalues.extend(list(product(*dimensions_values)))
 
     return argnames, argvalues
+
+
+def _has_benchmarks(configured_dimensions_items):
+    for item in configured_dimensions_items:
+        if item.get("benchmarks"):
+            return True
+    return False
 
 
 def remove_disabled_tests(session, config, items):

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -537,6 +537,7 @@ def test_ad_integration(
     store_secret_in_secret_manager,
     clusters_factory,
     run_benchmarks,
+    benchmarks,
 ):
     """Verify AD integration works as expected."""
     head_node_instance_type = "c5n.18xlarge" if request.config.getoption("benchmarks") else "c5.xlarge"
@@ -570,7 +571,7 @@ def test_ad_integration(
             directory_certificate_verification,
         )
     )
-    cluster_config = pcluster_config_reader(**config_params)
+    cluster_config = pcluster_config_reader(benchmarks=benchmarks, **config_params)
     cluster = clusters_factory(cluster_config)
 
     certificate_secret_arn = nlb_stack_parameters.get("CertificateSecretArn")
@@ -617,7 +618,9 @@ def test_ad_integration(
     _run_user_workloads(users, test_datadir, remote_command_executor)
     logging.info("Testing pcluster update and generate ssh keys for user")
     _check_ssh_key_generation(users[0], scheduler_commands, False)
-    updated_config_file = pcluster_config_reader(config_file="pcluster.config.update.yaml", **config_params)
+    updated_config_file = pcluster_config_reader(
+        config_file="pcluster.config.update.yaml", benchmarks=benchmarks, **config_params
+    )
     cluster.update(str(updated_config_file), force_update="true")
     # Reset stateful connection variables after the cluster update
     remote_command_executor = RemoteCommandExecutor(cluster)

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
@@ -27,11 +27,12 @@ def test_hit_disable_hyperthreading(
     clusters_factory,
     default_threads_per_core,
     run_benchmarks,
+    benchmarks,
     scheduler_commands_factory,
 ):
     """Test Disable Hyperthreading for HIT clusters."""
     slots_per_instance = fetch_instance_slots(region, instance)
-    cluster_config = pcluster_config_reader()
+    cluster_config = pcluster_config_reader(benchmarks=benchmarks)
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)


### PR DESCRIPTION
The thought was to always read `benchmarks` information even when it is None. However, the test complaint of unused parametrization when the `benchmarks` is not used.

Therefore, we only add the `benchmarks` to the parametrization only if the test definition file contains benchmarks specifications. Moreover, instead of consuming the `benchmarks` parameter from `pcluster_config_reader`, which is used by lots of tests without scaling tests, we now consume the `benchmarks` only when the test needs to run scaling tests.

Signed-off-by: Hanwen <hanwenli@amazon.com>


### Tests
* Describe the automated and/or manual tests executed to validate the patch.
The following tests are run
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  disable_hyperthreading:
    test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5.xlarge"]
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
          benchmarks:
            - mpi_variants: ["openmpi", "intelmpi"]
              num_instances: [20]
              slots_per_instance: 2
              partition: "ht-disabled"
              osu_benchmarks:
                # Available collective benchmarks "osu_allgather", "osu_allreduce", "osu_alltoall", "osu_barrier", "osu_bcast", "osu_gather", "osu_reduce", "osu_reduce_scatter", "osu_scatter"
                collective: ["osu_allreduce", "osu_alltoall"]
  cfn-init:
    test_cfn_init.py::test_replace_compute_on_failure:
      dimensions:
        - regions: ["af-south-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  cli_commands:
    test_cli_commands.py::test_slurm_cli_commands:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  configure:
    test_pcluster_configure.py::test_pcluster_configure:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  dns:
    test_dns.py::test_hit_no_cluster_dns_mpi:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  dashboard:
    test_dashboard.py::test_dashboard:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  cloudwatch_logging:
    test_cloudwatch_logging.py::test_cloudwatch_logging:
      dimensions:
        - regions: ["ap-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
  iam:
    test_iam.py::test_iam_policies:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  schedulers:
    test_awsbatch.py::test_awsbatch:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_slurm.py::test_slurm:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_pmix:
      dimensions:
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
  storage:
    test_efs.py::test_efs_compute_az:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_fsx_lustre.py::test_existing_fsx:
      dimensions:
        - regions: ["us-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
    test_ebs.py::test_ebs_single:
      dimensions:
        - regions: ["eu-west-3"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
        - regions: ["sa-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  update:
    test_update.py::test_update_awsbatch:
      dimensions:
        - regions: ["eu-south-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
    test_update.py::test_update_slurm:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
