### PR TITLE
Move test_no_errors_in_logs before cluster update

### DIFF
--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
@@ -122,6 +122,8 @@ def test_scheduler_plugin_integration(
     command_executor = RemoteCommandExecutor(cluster)
     # Test cluster configuration before cluster update
     _test_cluster_config(command_executor, before_update_cluster_config, PCLUSTER_CLUSTER_CONFIG)
+    # Test no errors in clusterstatusmgtd log
+    _test_no_errors_in_logs(command_executor)
     # Test compute fleet status update
     _test_compute_fleet_status_update(cluster, command_executor)
     # Test cluster update
@@ -167,8 +169,6 @@ def test_scheduler_plugin_integration(
     _test_tags(cluster, os)
     # Test get or update compute fleet_status_script
     _test_update_compute_fleet_status_script(command_executor)
-    # Test no errors in log
-    _test_no_errors_in_logs(command_executor)
     # Test invoke scheduler plugin event handler script
     _test_invoke_scheduler_plugin_event_handler_script(command_executor, compute_node, run_as_user)
     # Test computes are terminated on cluster deletion


### PR DESCRIPTION
In the test of computefleet update, we intentionally trigger error. Move test_no_errors_in_logs before cluster update to avoid test fail.
Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
