### PR TITLE
2.x Increase timeout of head node instance to 1h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ CHANGELOG
 - Upgrade NVIDIA driver to version 470.103.01.
 - Upgrade CUDA library to version 11.4.4.
 - Upgrade NVIDIA Fabric manager to version 470.103.01.
+- Extend head node creation timeout to 1h.
 
 **BUG FIXES**
 - Fix DCV connection through browsers.
-- Fix Tags in number interpreted as integer.
+- Fix YAML quoting to prevent custom Tags being parsed as numbers.
 
 2.11.4
 -----

--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -266,7 +266,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Count: 1
-        Timeout: PT30M
+        Timeout: PT1H
   MasterServerLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Properties:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -8,24 +8,18 @@ test-suites:
   runtime_bake:
     test_runtime_bake.py::test_runtime_bake: # arm instance tests are temporarily skipped
       dimensions:
-        {%- for os, scheduler in [("alinux2", "slurm")] %}
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["{{ os }}"]
-          schedulers: ["{{ scheduler }}"]
-        {%- endfor %}
-        {%- for os, scheduler in [("ubuntu1804", "slurm")] %}
+          oss: ["alinux2", "centos7"]
+          schedulers: ["slurm"]
         - regions: ["us-gov-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["{{ os }}"]
-          schedulers: ["{{ scheduler }}"]
-        {%- endfor %}
-#        {%- for os, scheduler in [("ubuntu1804", "slurm"), ("alinux2", "slurm")] %}
+          oss: ["ubuntu1804", "ubuntu2004"]
+          schedulers: ["slurm"]
 #        - regions: ["us-east-1"]
 #          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-#          oss: ["{{ os }}"]
-#          schedulers: ["{{ scheduler }}"]
-#        {%- endfor %}
+#          oss: ["ubuntu1804", "alinux2"]
+#          schedulers: ["slurm"]
   scaling:
     test_mpi.py::test_mpi:  # TODO: move outside of the scaling dir
       dimensions:


### PR DESCRIPTION
### Description of changes
This is required when using Slurm as scheduler and runtime-bake cluster creation, because the head node
waits for the compute node initialization but the compute node starts only when the head node is ready.
For ubuntu18, head node initialization for runtime-bake cluster takes 23 minutes.

With SGE and Torque there was the ASG managing the `initial_queue_size`
so the compute node started together with the head node.

Note: Alinux2 runtime bake test is passing, this confirms that the startup time depends by the base AMI too.
I tested Centos7, Ubuntu18 and Ubuntu20 and all of them were failing with a timeout set to 30m.
Head node + compute node creation requires about 40mins.
```
2022-02-23 16:19:58 UTC+0100 | MasterServer | CREATE_COMPLETE | -
2022-02-23 16:19:57 UTC+0100 | MasterServer | CREATE_IN_PROGRESS | Received SUCCESS signal with UniqueId i-068e3d619d9bd78e5
2022-02-23 15:38:23 UTC+0100 | MasterServer | CREATE_IN_PROGRESS | Resource creation Initiated
2022-02-23 15:38:21 UTC+0100 | MasterServer | CREATE_IN_PROGRESS | -
```

### Tests
* Tested runtime bake creation for all OSes with slurm scheduler, added these test to config setup.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
