### PR TITLE
Fix test parametrization

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -522,6 +522,7 @@ def _check_ssh_key_generation(user, scheduler_commands, generate_ssh_keys_for_us
         ("MicrosoftAD", "ldaps", True),
     ],
 )
+@pytest.mark.usefixtures("os", "instance")
 def test_ad_integration(
     region,
     scheduler,

--- a/tests/integration-tests/tests/arm_pl/test_arm_pl.py
+++ b/tests/integration-tests/tests/arm_pl/test_arm_pl.py
@@ -12,11 +12,13 @@
 import logging
 import re
 
+import pytest
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 
 
-def test_arm_pl(region, scheduler, instance, os, pcluster_config_reader, clusters_factory, test_datadir):
+@pytest.mark.usefixtures("region", "instance", "scheduler")
+def test_arm_pl(os, pcluster_config_reader, clusters_factory, test_datadir):
     """Test Arm Performance Library"""
     cluster_config = pcluster_config_reader()
     cluster = clusters_factory(cluster_config)

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init.py
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init.py
@@ -17,7 +17,7 @@ from utils import check_status
 from tests.common.assertions import wait_for_num_instances_in_cluster, wait_instance_replaced_or_terminating
 
 
-@pytest.mark.usefixtures("os", "instance")
+@pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_replace_compute_on_failure(
     region, pcluster_config_reader, s3_bucket_factory, clusters_factory, test_datadir, scheduler_commands_factory
 ):

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -34,7 +34,7 @@ from tests.common.assertions import assert_no_errors_in_logs, wait_for_num_insta
 from tests.common.utils import get_installed_parallelcluster_version, retrieve_latest_ami
 
 
-@pytest.mark.usefixtures("region", "instance")
+@pytest.mark.usefixtures("instance")
 def test_slurm_cli_commands(
     request, scheduler, region, os, pcluster_config_reader, clusters_factory, s3_bucket_factory
 ):

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -18,6 +18,7 @@ from os import environ
 from pathlib import Path
 
 import boto3
+import pytest
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
@@ -633,6 +634,7 @@ def get_config_param_vals():
     return {"enable": "true", "retention_days": retention_days, "queue_size": queue_size}
 
 
+@pytest.mark.usefixtures("instance")
 def test_cloudwatch_logging(
     region, scheduler, os, pcluster_config_reader, test_datadir, clusters_factory, scheduler_commands_factory
 ):

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -33,9 +33,9 @@ from tests.common.utils import (
 )
 
 
+@pytest.mark.usefixtures("instance", "scheduler")
 def test_invalid_config(
     region,
-    instance,
     os,
     pcluster_config_reader,
     architecture,
@@ -83,9 +83,9 @@ def test_invalid_config(
     assert_that(suppressed.message).contains("Request would have succeeded")
 
 
+@pytest.mark.usefixtures("instance", "scheduler")
 def test_build_image(
     region,
-    instance,
     os,
     pcluster_config_reader,
     architecture,
@@ -385,9 +385,9 @@ def _test_build_image_success(image):
     assert_that(image.image_status).is_equal_to("BUILD_COMPLETE")
 
 
+@pytest.mark.usefixtures("os", "scheduler")
 def test_build_image_wrong_pcluster_version(
     region,
-    os,
     instance,
     pcluster_config_reader,
     architecture,

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
@@ -12,6 +12,7 @@
 import logging
 import re
 
+import pytest
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 
@@ -19,6 +20,7 @@ from tests.common.assertions import assert_no_errors_in_logs
 from tests.common.utils import fetch_instance_slots
 
 
+@pytest.mark.usefixtures("os")
 def test_hit_disable_hyperthreading(
     region,
     scheduler,

--- a/tests/integration-tests/tests/iam/test_iam_image.py
+++ b/tests/integration-tests/tests/iam/test_iam_image.py
@@ -22,7 +22,7 @@ from utils import generate_stack_name
 from tests.common.utils import retrieve_latest_ami
 
 
-@pytest.mark.usefixtures("instance")
+@pytest.mark.usefixtures("instance", "scheduler")
 def test_iam_roles(
     region,
     os,

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
@@ -12,6 +12,7 @@
 import logging
 
 import boto3
+import pytest
 from assertpy import assert_that
 from botocore.exceptions import ClientError
 from remote_command_executor import RemoteCommandExecutor
@@ -19,6 +20,7 @@ from remote_command_executor import RemoteCommandExecutor
 from tests.common.assertions import assert_no_errors_in_logs
 
 
+@pytest.mark.usefixtures("os", "instance")
 def test_intel_hpc(
     region, scheduler, pcluster_config_reader, clusters_factory, test_datadir, scheduler_commands_factory
 ):

--- a/tests/integration-tests/tests/scaling/test_mpi.py
+++ b/tests/integration-tests/tests/scaling/test_mpi.py
@@ -51,7 +51,7 @@ def test_mpi(scheduler, region, instance, pcluster_config_reader, clusters_facto
     )
 
 
-@pytest.mark.usefixtures("region", "instance", "os")
+@pytest.mark.usefixtures("region", "instance", "os", "scheduler")
 def test_mpi_ssh(pcluster_config_reader, clusters_factory, test_datadir, scheduler_commands_factory):
     cluster_config = pcluster_config_reader()
     cluster = clusters_factory(cluster_config)

--- a/tests/integration-tests/tests/scaling/test_scaling.py
+++ b/tests/integration-tests/tests/scaling/test_scaling.py
@@ -22,7 +22,7 @@ from tests.common.scaling_common import get_compute_nodes_allocation
 from tests.schedulers.test_slurm import _assert_job_state
 
 
-@pytest.mark.usefixtures("region", "os", "instance")
+@pytest.mark.usefixtures("os", "instance")
 def test_multiple_jobs_submission(
     scheduler,
     region,

--- a/tests/integration-tests/tests/schedulers/test_awsbatch.py
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch.py
@@ -21,7 +21,7 @@ from tests.common.schedulers_common import AWSBatchCommands
 
 @pytest.mark.batch_dockerfile_deps
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
-def test_awsbatch(pcluster_config_reader, clusters_factory, test_datadir, caplog, region):
+def test_awsbatch(pcluster_config_reader, clusters_factory, test_datadir, caplog):
     """
     Test all AWS Batch related features.
 

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -110,7 +110,7 @@ def test_slurm(
     )
 
 
-@pytest.mark.usefixtures("os", "instance", "scheduler")
+@pytest.mark.usefixtures("region", "os", "instance", "scheduler")
 def test_slurm_pmix(pcluster_config_reader, clusters_factory):
     """Test interactive job submission using PMIx."""
     num_computes = 2

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -45,12 +45,11 @@ def test_ebs_single(
     _test_root_volume_encryption(cluster, os, region, scheduler, encrypted=True)
 
 
-@pytest.mark.usefixtures("os", "instance")
+@pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_ebs_snapshot(
     request,
     vpc_stacks,
     region,
-    scheduler,
     pcluster_config_reader,
     snapshots_factory,
     clusters_factory,

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -25,7 +25,7 @@ from tests.common.utils import get_default_vpc_security_group, retrieve_latest_a
 from tests.storage.storage_common import verify_directory_correctly_shared
 
 
-@pytest.mark.usefixtures("region", "os", "instance")
+@pytest.mark.usefixtures("os", "scheduler", "instance")
 def test_efs_compute_az(region, pcluster_config_reader, clusters_factory, vpc_stack, scheduler_commands_factory):
     """
     Test when compute subnet is in a different AZ from head node subnet.
@@ -44,7 +44,7 @@ def test_efs_compute_az(region, pcluster_config_reader, clusters_factory, vpc_st
     _test_efs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
 
-@pytest.mark.usefixtures("region", "os", "instance")
+@pytest.mark.usefixtures("os", "scheduler", "instance")
 def test_efs_same_az(region, pcluster_config_reader, clusters_factory, vpc_stack, scheduler_commands_factory):
     """
     Test when compute subnet is in the same AZ as head node subnet.
@@ -63,7 +63,7 @@ def test_efs_same_az(region, pcluster_config_reader, clusters_factory, vpc_stack
     _test_efs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
 
-@pytest.mark.usefixtures("os", "instance")
+@pytest.mark.usefixtures("os", "scheduler", "instance")
 def test_existing_efs(
     region,
     efs_stack,

--- a/tests/integration-tests/tests/storage/test_ephemeral.py
+++ b/tests/integration-tests/tests/storage/test_ephemeral.py
@@ -18,8 +18,8 @@ from remote_command_executor import RemoteCommandExecutor
 from tests.common.utils import reboot_head_node, restart_head_node
 
 
-@pytest.mark.usefixtures("instance")
-def test_head_node_stop(scheduler, pcluster_config_reader, clusters_factory, region, os):
+@pytest.mark.usefixtures("region", "os", "instance", "scheduler")
+def test_head_node_stop(pcluster_config_reader, clusters_factory):
     head_ephemeral_mount = "/scratch_head"
     compute_ephemeral_mount = "/scratch_compute"
     folder = "myFolder"

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -53,7 +53,7 @@ MAX_MINUTES_TO_WAIT_FOR_BACKUP_COMPLETION = 7
         ("PERSISTENT_1", 12, None, "HDD", "READ", 6000, 1024, "LZ4"),
     ],
 )
-@pytest.mark.usefixtures("instance")
+@pytest.mark.usefixtures("os", "instance")
 def test_fsx_lustre_configuration_options(
     deployment_type,
     per_unit_storage_throughput,
@@ -133,7 +133,7 @@ def _test_fsx_lustre_configuration_options(
     _test_data_compression_type(data_compression_type, fsx)
 
 
-@pytest.mark.usefixtures("instance")
+@pytest.mark.usefixtures("os", "instance")
 def test_fsx_lustre(
     region,
     pcluster_config_reader,
@@ -184,7 +184,7 @@ def _test_fsx_lustre(
     _test_data_repository_task(remote_command_executor, mount_dir, bucket_name, fsx_fs_id, region)
 
 
-@pytest.mark.usefixtures("instance")
+@pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_fsx_lustre_backup(region, pcluster_config_reader, clusters_factory, scheduler_commands_factory):
     """
     Test FSx Lustre backup feature. As part of this test, following steps are performed
@@ -251,7 +251,7 @@ def test_fsx_lustre_backup(region, pcluster_config_reader, clusters_factory, sch
     _test_delete_manual_backup(manual_backup, region)
 
 
-@pytest.mark.usefixtures("instance")
+@pytest.mark.usefixtures("os", "instance")
 def test_existing_fsx(
     region,
     fsx_factory,

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -26,7 +26,7 @@ from tests.common.schedulers_common import SlurmCommands
 from tests.common.utils import generate_random_string, retrieve_latest_ami
 
 
-@pytest.mark.usefixtures("os", "instance")
+@pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, clusters_factory, test_datadir):
     # Create S3 bucket for pre/post install scripts
     bucket_name = s3_bucket_factory()
@@ -352,7 +352,7 @@ def _check_extra_json(command_executor, slurm_commands, host, expected_value):
     assert_that(result.stdout).is_equal_to('"{0}"'.format(expected_value))
 
 
-@pytest.mark.usefixtures("os", "instance")
+@pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_update_awsbatch(region, pcluster_config_reader, clusters_factory, test_datadir):
     # Create cluster with initial configuration
     init_config_file = pcluster_config_reader()
@@ -376,7 +376,7 @@ def test_update_awsbatch(region, pcluster_config_reader, clusters_factory, test_
     _verify_initialization(region, cluster, updated_config)
 
 
-@pytest.mark.usefixtures("instance")
+@pytest.mark.usefixtures("instance", "scheduler")
 def test_update_compute_ami(region, os, pcluster_config_reader, ami_copy, clusters_factory, test_datadir, request):
     # Create cluster with initial configuration
     ec2 = boto3.client("ec2", region)


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
If region, os, scheduler and instance are specified in the test config definition, when test is not using them as parameters, they must be set with mark.usefixtures

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
