### PR TITLE
[develop] Fix ordering for get_scheduler_commands parameters

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -541,7 +541,7 @@ class TorqueCommands(SchedulerCommands):
         raise NotImplementedError
 
 
-def get_scheduler_commands(scheduler, remote_command_executor):
+def get_scheduler_commands(remote_command_executor, scheduler):
     scheduler_commands = {
         "awsbatch": AWSBatchCommands,
         "slurm": SlurmCommands,


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
A partial get_scheduler_commands is returned by scheduler_commands_factory, with scheduler value set.
When calling the partial method returned by scheduler_commands_factory, the parameter passed was misinterpreted to be a scheduler value, which was already set.

### Tests
Tested with conf
```
test-suites:
  scaling:
    test_scaling.py::test_multiple_jobs_submission:
      dimensions:
        - regions: [ "eu-west-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```


### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
