### PR TITLE
Fix hash of Slurm 21.08.6

### DIFF
--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/attributes/default.rb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/attributes/default.rb
@@ -25,7 +25,7 @@ default['pcluster']['python_root'] = ENV['PCLUSTER_PYTHON_ROOT']
 
 default['slurm']['version'] = '21-08-6-1'
 default['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['slurm']['version']}.tar.gz"
-default['slurm']['sha1'] = 'f2672e03dd4fe63cc682df2333182c5fb3033279'
+default['slurm']['sha1'] = '61c24d0dc89981112710cca571fcd0a2bdefb879'
 default['slurm']['user'] = 'slurm-user'
 default['slurm']['group'] = node['slurm']['user']
 default['slurm']['install_dir'] = "#{node['pcluster']['shared_dir']}/slurm"


### PR DESCRIPTION
We download Slurm from Github, so the hash is different from SchedMD release docs.

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
