### PR TITLE
2.x: Fix NCCL tests using the right version of CUDA

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/nccl_benchmarks/init_nccl_benchmarks.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/nccl_benchmarks/init_nccl_benchmarks.sh
@@ -4,10 +4,13 @@ set -e
 rm -rf /shared/${1}
 
 module load ${1}
-NCCL_BENCHMARKS_VERSION='2.10.0'
+
+# The following variables must be aligned with those in nccl_tests_submit_openmpi.sh
+# NCCL and Cuda compatibility available here: https://docs.nvidia.com/deeplearning/nccl/release-notes/
+NCCL_BENCHMARKS_VERSION='2.0.0'
 NCCL_VERSION='2.7.8-1'
 ML_REPO_PKG='nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb'
-CUDA_VERSION='11.3'
+CUDA_VERSION='11.4'
 OFI_NCCL_VERSION='1.1.1'
 MPI_HOME=$(which mpirun | awk -F '/bin' '{print $1}')
 NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80" # Arch for NVIDIA A100

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
@@ -5,7 +5,11 @@
 
 
 module load openmpi
+
+# The following variables must be aligned with those in init_nccl_benchmarks.sh
+NCCL_BENCHMARKS_VERSION='2.0.0'
 NCCL_VERSION='2.7.8-1'
+
 mpirun \
 -x FI_PROVIDER="efa" \
 -x FI_EFA_USE_DEVICE_RDMA=1 \
@@ -14,4 +18,4 @@ mpirun \
 -x NCCL_ALGO=ring \
 -x NCCL_DEBUG=WARNING \
 --mca pml ^cm --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 --bind-to none \
-/shared/openmpi/nccl-tests-2.10.0/build/all_reduce_perf -b 8 -e 1G -f 2 -g 1 -c 1 -n 100 > /shared/nccl_tests.out
+/shared/openmpi/nccl-tests-${NCCL_BENCHMARKS_VERSION}/build/all_reduce_perf -b 8 -e 1G -f 2 -g 1 -c 1 -n 100 > /shared/nccl_tests.out


### PR DESCRIPTION
### Description of changes
I'm aligning NCCL_BENCHMARKS_VERSION to the value used in release-3.1 branch
and fixing the CUDA_VERSION to be aligned with the installed one.

Note: According to the documentation our version of cuda (11.4) is not supported by 2.7.8 NCCL version
 but anyway the tests are working.
https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-7-8.html#rel_2-7-8

Before this patch compilation was failing with:
```
configure: WARNING: rdma/fabric.h: accepted by the compiler, rejected by the preprocessor!
configure: WARNING: rdma/fabric.h: proceeding with the compiler's result
checking for rdma/fabric.h... yes
checking cuda_runtime.h usability... no
checking cuda_runtime.h presence... no
checking for cuda_runtime.h... no
configure: error: unable to find required headers
```
### Tests
* Executed test_hit_efa for all OSes with p4d instances.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
