### PR TITLE
Wrap shared bucket fixture boto3 calls with aws_credential_provider

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1092,7 +1092,8 @@ def s3_bucket_factory_shared(request):
     regions = request.config.getoption("regions") or get_all_regions(request.config.getoption("tests_config"))
     s3_buckets_dict = {}
     for region in regions:
-        s3_buckets_dict[region] = _create_bucket(region)
+        with aws_credential_provider(region, request.config.getoption("credential")):
+            s3_buckets_dict[region] = _create_bucket(region)
 
     yield s3_buckets_dict
 
@@ -1102,7 +1103,8 @@ def s3_bucket_factory_shared(request):
         else:
             logging.info(f"Deleting S3 bucket {bucket[0]}")
             try:
-                delete_s3_bucket(bucket_name=bucket[0], region=bucket[1])
+                with aws_credential_provider(region, request.config.getoption("credential")):
+                    delete_s3_bucket(bucket_name=bucket[0], region=bucket[1])
             except Exception as e:
                 logging.error(f"Failed deleting bucket {bucket[0]} with exception: {e}")
 


### PR DESCRIPTION
boto3 calls require to be wrapped with a aws_credential_provider, in order to be able to set the right credentials for creating shared bucket

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
