### PR TITLE
[develop] Wrap scheduler definition uploader with credential provider

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1134,9 +1134,10 @@ def upload_scheduler_plugin_definitions(s3_bucket_factory_shared, request) -> di
                 )
                 scheduler_definition_dict[plugin_name] = {}
                 for region, s3_bucket in s3_bucket_factory_shared.items():
-                    scheduler_plugin_definition_url = scheduler_plugin_definition_uploader(
-                        scheduler_definition, s3_bucket, plugin_name, region
-                    )
+                    with aws_credential_provider(region, request.config.getoption("credential")):
+                        scheduler_plugin_definition_url = scheduler_plugin_definition_uploader(
+                            scheduler_definition, s3_bucket, plugin_name, region
+                        )
                     scheduler_definition_dict[plugin_name].update({region: scheduler_plugin_definition_url})
             else:
                 logging.info(


### PR DESCRIPTION
Required to set the right credentials when uploading custom scheduler definition

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
