### PR TITLE
2.x: Upgrade NCCL benchmark version to 2.10.0

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/nccl_benchmarks/init_nccl_benchmarks.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/nccl_benchmarks/init_nccl_benchmarks.sh
@@ -7,7 +7,7 @@ module load ${1}
 
 # The following variables must be aligned with those in nccl_tests_submit_openmpi.sh
 # NCCL and Cuda compatibility available here: https://docs.nvidia.com/deeplearning/nccl/release-notes/
-NCCL_BENCHMARKS_VERSION='2.0.0'
+NCCL_BENCHMARKS_VERSION='2.10.0'
 NCCL_VERSION='2.7.8-1'
 ML_REPO_PKG='nvidia-machine-learning-repo-ubuntu1804_1.0.0-1_amd64.deb'
 CUDA_VERSION='11.4'

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
@@ -7,7 +7,7 @@
 module load openmpi
 
 # The following variables must be aligned with those in init_nccl_benchmarks.sh
-NCCL_BENCHMARKS_VERSION='2.0.0'
+NCCL_BENCHMARKS_VERSION='2.10.0'
 NCCL_VERSION='2.7.8-1'
 
 mpirun \


### PR DESCRIPTION
The upgrade fixes compilation error on alinux2.
The 2.0.0 was wrongly introduced with: https://github.com/aws/aws-parallelcluster/commit/00371121c9b3b1c018992e4c9675f043cdd234b7

Compilation error with 2.0.0 is:
```
Compiling  common.cu                           > ../build/common.o
Linking  ../build/all_reduce.o               > ../build/all_reduce_perf
/usr/bin/ld: cannot find -lmpi
collect2: error: ld returned 1 exit status
make[1]: *** [../build/all_reduce_perf] Error 1
make[1]: Leaving directory `/shared/openmpi/nccl-tests-2.0.0/src'
make: *** [src.build] Error 2
```

### Tests
* Manual compilation with both openmpi and intelmpi

### References
* Same patch for develop: https://github.com/aws/aws-parallelcluster/pull/3214

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
