### PR TITLE
[develop] Use unique tmp folder when preparing scheduler plugin artifacts

### DIFF
--- a/scheduler_plugins/plugin_template/utils/upload_artifacts.sh
+++ b/scheduler_plugins/plugin_template/utils/upload_artifacts.sh
@@ -54,6 +54,7 @@ done
 
 [ -z "${S3_BUCKET}" ] || [ -z "${AWS_REGION}" ] && usage
 [ -z "${S3_BUCKET_PREFIX}" ] && S3_BUCKET_PREFIX="/scheduler_plugins/plugin_template"
+TMP=$(TMPDIR="/tmp" mktemp -d)
 
 ADDITIONAL_CLUSTER_INFRASTRUCTURE_FILE="./additional_cluster_infrastructure.cfn.yaml"
 ADDITIONAL_CLUSTER_INFRASTRUCTURE_S3_URL="s3://${S3_BUCKET}${S3_BUCKET_PREFIX}/additional_cluster_infrastructure.cfn.yaml"
@@ -62,7 +63,7 @@ aws s3 cp --region "${AWS_REGION}" "${ADDITIONAL_CLUSTER_INFRASTRUCTURE_FILE}" "
 ADDITIONAL_CLUSTER_INFRASTRUCTURE_CHECKSUM=$(shasum --algorithm 256 "${ADDITIONAL_CLUSTER_INFRASTRUCTURE_FILE}" | cut -d' ' -f1)
 
 PLUGIN_ARTIFACTS_DIR="./artifacts"
-PLUGIN_ARTIFACTS_ARCHIVE="/tmp/artifacts.tar.gz"
+PLUGIN_ARTIFACTS_ARCHIVE="${TMP}/artifacts.tar.gz"
 PLUGIN_ARTIFACTS_S3_URL="s3://${S3_BUCKET}${S3_BUCKET_PREFIX}/artifacts.tar.gz"
 echo "Uploading plugin artifacts to ${PLUGIN_ARTIFACTS_S3_URL}"
 tar czf "${PLUGIN_ARTIFACTS_ARCHIVE}" "${PLUGIN_ARTIFACTS_DIR}"
@@ -71,7 +72,7 @@ aws s3 cp --region "${AWS_REGION}" "${PLUGIN_ARTIFACTS_ARCHIVE}" "${PLUGIN_ARTIF
 PLUGIN_ARTIFACTS_CHECKSUM=$(shasum --algorithm 256 "${PLUGIN_ARTIFACTS_ARCHIVE}" | cut -d' ' -f1)
 
 PLUGIN_DEFINITION_S3_URL="s3://${S3_BUCKET}${S3_BUCKET_PREFIX}/plugin_definition.yaml"
-GENERATED_PLUGIN_DEFINITION_PATH="/tmp/plugin_template_plugin_definition.yaml"
+GENERATED_PLUGIN_DEFINITION_PATH="${TMP}/plugin_template_plugin_definition.yaml"
 cp plugin_definition.yaml ${GENERATED_PLUGIN_DEFINITION_PATH}
 sed -i "s|<TEMPLATE_CHECKSUM>|${ADDITIONAL_CLUSTER_INFRASTRUCTURE_CHECKSUM}|g" ${GENERATED_PLUGIN_DEFINITION_PATH}
 sed -i "s|<ARTIFACTS_CHECKSUM>|${PLUGIN_ARTIFACTS_CHECKSUM}|g" ${GENERATED_PLUGIN_DEFINITION_PATH}
@@ -80,7 +81,7 @@ echo "Generated plugin definition:" && cat ${GENERATED_PLUGIN_DEFINITION_PATH}
 echo "Uploading plugin_definition to ${PLUGIN_DEFINITION_S3_URL}"
 aws s3 cp --region "${AWS_REGION}" "${GENERATED_PLUGIN_DEFINITION_PATH}" "${PLUGIN_DEFINITION_S3_URL}"
 
-GENERATED_CONFIG_PATH="/tmp/plugin_template_cluster_config.yaml"
+GENERATED_CONFIG_PATH="${TMP}/plugin_template_cluster_config.yaml"
 cp examples/cluster_configuration.yaml ${GENERATED_CONFIG_PATH}
 sed -i "s|<PLUGIN_DEFINITION>|${PLUGIN_DEFINITION_S3_URL}|g" ${GENERATED_CONFIG_PATH}
 PLUGIN_DEFINITION_CHECKSUM=$(shasum --algorithm 256 "${GENERATED_PLUGIN_DEFINITION_PATH}" | cut -d' ' -f1)

--- a/scheduler_plugins/slurm/utils/upload_artifacts.sh
+++ b/scheduler_plugins/slurm/utils/upload_artifacts.sh
@@ -54,6 +54,7 @@ done
 
 [ -z "${S3_BUCKET}" ] || [ -z "${AWS_REGION}" ] && usage
 [ -z "${S3_BUCKET_PREFIX}" ] && S3_BUCKET_PREFIX="/scheduler_plugins/slurm"
+TMP=$(TMPDIR="/tmp" mktemp -d)
 
 ADDITIONAL_CLUSTER_INFRASTRUCTURE_FILE="./slurm_plugin_infrastructure.cfn.yaml"
 ADDITIONAL_CLUSTER_INFRASTRUCTURE_S3_URL="s3://${S3_BUCKET}${S3_BUCKET_PREFIX}/slurm_plugin_infrastructure.cfn.yaml"
@@ -62,7 +63,7 @@ aws s3 cp --region "${AWS_REGION}" "${ADDITIONAL_CLUSTER_INFRASTRUCTURE_FILE}" "
 ADDITIONAL_CLUSTER_INFRASTRUCTURE_CHECKSUM=$(shasum --algorithm 256 "${ADDITIONAL_CLUSTER_INFRASTRUCTURE_FILE}" | cut -d' ' -f1)
 
 PLUGIN_ARTIFACTS_DIR="./artifacts"
-PLUGIN_ARTIFACTS_ARCHIVE="/tmp/artifacts.tar.gz"
+PLUGIN_ARTIFACTS_ARCHIVE="${TMP}/artifacts.tar.gz"
 PLUGIN_ARTIFACTS_S3_URL="s3://${S3_BUCKET}${S3_BUCKET_PREFIX}/artifacts.tar.gz"
 echo "Uploading plugin artifacts to ${PLUGIN_ARTIFACTS_S3_URL}"
 tar czf "${PLUGIN_ARTIFACTS_ARCHIVE}" "${PLUGIN_ARTIFACTS_DIR}"
@@ -71,7 +72,7 @@ aws s3 cp --region "${AWS_REGION}" "${PLUGIN_ARTIFACTS_ARCHIVE}" "${PLUGIN_ARTIF
 PLUGIN_ARTIFACTS_CHECKSUM=$(shasum --algorithm 256 "${PLUGIN_ARTIFACTS_ARCHIVE}" | cut -d' ' -f1)
 
 PLUGIN_DEFINITION_S3_URL="s3://${S3_BUCKET}${S3_BUCKET_PREFIX}/plugin_definition.yaml"
-GENERATED_PLUGIN_DEFINITION_PATH="/tmp/plugin_template_plugin_definition.yaml"
+GENERATED_PLUGIN_DEFINITION_PATH="${TMP}/plugin_template_plugin_definition.yaml"
 cp plugin_definition.yaml ${GENERATED_PLUGIN_DEFINITION_PATH}
 sed -i "s|<TEMPLATE_CHECKSUM>|${ADDITIONAL_CLUSTER_INFRASTRUCTURE_CHECKSUM}|g" ${GENERATED_PLUGIN_DEFINITION_PATH}
 sed -i "s|<ARTIFACTS_CHECKSUM>|${PLUGIN_ARTIFACTS_CHECKSUM}|g" ${GENERATED_PLUGIN_DEFINITION_PATH}
@@ -80,7 +81,7 @@ echo "Generated plugin definition:" && cat ${GENERATED_PLUGIN_DEFINITION_PATH}
 echo "Uploading plugin_definition to ${PLUGIN_DEFINITION_S3_URL}"
 aws s3 cp --region "${AWS_REGION}" "${GENERATED_PLUGIN_DEFINITION_PATH}" "${PLUGIN_DEFINITION_S3_URL}"
 
-GENERATED_CONFIG_PATH="/tmp/slurm_plugin_cluster_config.yaml"
+GENERATED_CONFIG_PATH="${TMP}/slurm_plugin_cluster_config.yaml"
 cp examples/cluster_configuration.yaml ${GENERATED_CONFIG_PATH}
 sed -i "s|<PLUGIN_DEFINITION>|${PLUGIN_DEFINITION_S3_URL}|g" ${GENERATED_CONFIG_PATH}
 PLUGIN_DEFINITION_CHECKSUM=$(shasum --algorithm 256 "${GENERATED_PLUGIN_DEFINITION_PATH}" | cut -d' ' -f1)


### PR DESCRIPTION
This to avoid concurrency problem of different processes calling the upload_artifacts script which are insisting on the same files

Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
