### PR TITLE
Support using custom template with S3 Block Public Access

### DIFF
--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -714,7 +714,12 @@ def url_validator(param_key, param_value, pcluster_config):
 
     else:
         try:
-            urllib.request.urlopen(param_value)  # nosec nosemgrep
+            match = re.match(r"https://(.*?)\.s3\.(.*?)amazonaws\.com(.*?)/(.*)", param_value)
+            if match and len(match.groups()) == 4:  # If S3 URL is provided.
+                bucket_name, object_name = match.group(1), match.group(4)
+                boto3.client("s3").head_object(Bucket=bucket_name, Key=object_name)
+            else:
+                urllib.request.urlopen(param_value)  # nosec nosemgrep
         except urllib.error.HTTPError as e:
             warnings.append("{0} {1} {2}".format(param_value, e.code, e.reason))
         except urllib.error.URLError as e:

--- a/util/uploadTemplate.sh
+++ b/util/uploadTemplate.sh
@@ -108,8 +108,8 @@ main() {
     sed -i "s#.*aws-parallelcluster.*/templates/master-server-substack-\${version}.cfn.yaml.*#\"https://${_s3_folder_url}/master-server-substack.cfn.yaml\",#" ${_temp_dir}/aws-parallelcluster.cfn.json
 
     # upload templates
-    aws ${_profile} --region "${_region}" s3 cp --acl public-read ${_temp_dir}/aws-parallelcluster.cfn.json s3://${_bucket}/${_templates_folder}/ || _error_exit 'Failed to push cloudformation template to S3'
-    aws ${_profile} --region "${_region}" s3 cp --acl public-read --recursive --exclude "*" --include "*substack.cfn.json" --include "*substack.cfn.yaml" ${_srcdir}/cloudformation/ s3://${_bucket}/${_templates_folder}/ || _error_exit 'Failed to push substack cfn templates to S3'
+    aws ${_profile} --region "${_region}" s3 cp ${_temp_dir}/aws-parallelcluster.cfn.json s3://${_bucket}/${_templates_folder}/ || _error_exit 'Failed to push cloudformation template to S3'
+    aws ${_profile} --region "${_region}" s3 cp --recursive --exclude "*" --include "*substack.cfn.json" --include "*substack.cfn.yaml" ${_srcdir}/cloudformation/ s3://${_bucket}/${_templates_folder}/ || _error_exit 'Failed to push substack cfn templates to S3'
 
     echo ""
     echo "Done. Add the following variables to the pcluster config file, under the [cluster ...] section"


### PR DESCRIPTION
1. Relax URL checks in CLI and integration tests. When a S3 URL (e.g. https://...s3...) is provided, we use boto3 call to validate the URL. A simple https request can only validate the URL if the object is public while a boto3 call can validate the object as long as the CLI role has access to the object.
2. When uploading templates to S3 bucket, set the ACL to private. Therefore, the upload does not require a public bucket.

### Tests
I ran the following test
```
  configure:
    test_pcluster_configure.py::test_pcluster_configure:
      dimensions:
        - regions: [ "ap-northeast-2" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: [ "slurm" ]
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
