### PR TITLE
Add validator for property DirectoryService.DomainName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ x.x.x
 **CHANGES**
 - Add scheduler information to `list-clusters`, `describe-cluster`, `delete-cluster`, `update-cluster`, `create-cluster` results.
 - Add validator to detect when using FSx for Lustre with AWS Batch as a scheduler, this combination is not supported yet.
+- Add validator to verify that `DirectoryService.DomainName` is a FQDN or a LDAP Distinguished Name.
 
 **ENHANCEMENTS**
 - Add support to deploy API infrastructure in environments without a default VPC.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -86,7 +86,11 @@ from pcluster.validators.cluster_validators import (
     SchedulerOsValidator,
     SharedStorageNameValidator,
 )
-from pcluster.validators.directory_service_validators import DomainAddrValidator, LdapTlsReqCertValidator
+from pcluster.validators.directory_service_validators import (
+    DomainAddrValidator,
+    DomainNameValidator,
+    LdapTlsReqCertValidator,
+)
 from pcluster.validators.ebs_validators import (
     EbsVolumeIopsValidator,
     EbsVolumeSizeSnapshotValidator,
@@ -704,6 +708,8 @@ class DirectoryService(Resource):
         self.additional_sssd_configs = Resource.init_param(additional_sssd_configs, default={})
 
     def _register_validators(self):
+        if self.domain_name:
+            self._register_validator(DomainNameValidator, domain_name=self.domain_name)
         if self.domain_addr:
             self._register_validator(
                 DomainAddrValidator, domain_addr=self.domain_addr, additional_sssd_configs=self.additional_sssd_configs

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -9,7 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import re
 from urllib.parse import urlparse
 
 from pcluster.validators.common import FailureLevel, Validator
@@ -46,6 +46,25 @@ class DomainAddrValidator(Validator):
                     "'ldap_auth_disable_tls_never_use_in_production: true'."
                 )
             self._add_failure(warning_message, FailureLevel.WARNING)
+
+
+class DomainNameValidator(Validator):
+    """Domain name validator."""
+
+    FQDN_PATTERN = "^([a-zA-Z0-9_-]+)(\\.[a-zA-Z0-9_-]+)*$"
+    LDAP_DN_PATTERN = "^((DC|dc)=[a-zA-Z0-9_-]+)(,(DC|dc)=[a-zA-Z0-9_-]+)*$"
+
+    def _validate(self, domain_name):
+        """Validate that domain address is a Fully Qualified Domain Name (FQDN) or a LDAP Distinguished Name (DN)."""
+        match = re.match(DomainNameValidator.FQDN_PATTERN, domain_name) or re.match(
+            DomainNameValidator.LDAP_DN_PATTERN, domain_name
+        )
+        if not match:
+            self._add_failure(
+                "Unsupported domain address format. "
+                "Supported formats are FQDN (corp.example.com) or LDAP Distinguished Name (DC=corp,DC=example,DC=com).",
+                FailureLevel.ERROR,
+            )
 
 
 class LdapTlsReqCertValidator(Validator):

--- a/cli/tests/pcluster/validators/test_directory_service_validators.py
+++ b/cli/tests/pcluster/validators/test_directory_service_validators.py
@@ -10,8 +10,37 @@
 # limitations under the License.
 import pytest
 
-from pcluster.validators.directory_service_validators import DomainAddrValidator, LdapTlsReqCertValidator
+from pcluster.validators.directory_service_validators import (
+    DomainAddrValidator,
+    DomainNameValidator,
+    LdapTlsReqCertValidator,
+)
 from tests.pcluster.validators.utils import assert_failure_messages
+
+DOMAIN_NAME_ERROR_MESSAGE = (
+    "Unsupported domain address format. "
+    "Supported formats are FQDN (corp.example.com) or LDAP Distinguished Name (DC=corp,DC=example,DC=com)."
+)
+
+
+@pytest.mark.parametrize(
+    "domain_name, expected_message",
+    [
+        ("corp.example.com", None),
+        ("DC=corp,DC=example,DC=com", None),
+        ("dc=corp,dc=example,dc=com", None),
+        ("dc=corp,DC=example,dc=com", None),
+        ("", DOMAIN_NAME_ERROR_MESSAGE),
+        ("   ", DOMAIN_NAME_ERROR_MESSAGE),
+        ("corp.", DOMAIN_NAME_ERROR_MESSAGE),
+        ("DC=corp,", DOMAIN_NAME_ERROR_MESSAGE),
+        ("corp.examp/e.com", DOMAIN_NAME_ERROR_MESSAGE),
+        ("DC=corp,DC=examp/e,DC=com", DOMAIN_NAME_ERROR_MESSAGE),
+    ],
+)
+def test_domain_name(domain_name, expected_message):
+    actual_failures = DomainNameValidator().execute(domain_name=domain_name)
+    assert_failure_messages(actual_failures, expected_message)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**WARNING: This PR depends on [PR](https://github.com/aws/aws-parallelcluster-cookbook/pull/1391)**

### Description of changes
Add validator for property `DirectoryService.DomainName` that accepts only a value in FQDN or LDAP DN format. The validator fails the validation with an error, otherwise.

Added unit tests to cover the validation.

Examples:
```sh
# FQDN
DirectoryService:
  DomainName: corp.mgiacomo.com

# LDAP DN
DirectoryService:
  DomainName: DC=corp,DC=mgiacomo,DC=com
```

### Tests
1. Unit testing
2. Build&Test in Jenkins

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>