### PR TITLE
[develop] Add new policies for build-image stack deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ x.x.x
 
 **BUG FIXES**
 - Fix cluster stack in `DELETE_FAILED` when deleting a cluster, due to Route53 hosted zone not empty.
+- Fix build-image stack in `DELETE_FAILED` after image built successful, due to new EC2ImageBuilder policies.
 
 **CHANGES**
 - Add scheduler information to `list-clusters`, `describe-cluster`, `delete-cluster`, `update-cluster`, `create-cluster` results.

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -819,6 +819,8 @@ Resources:
             Effect: Allow
             Action:
               - imagebuilder:DeleteImage
+              - imagebuilder:GetImage
+              - imagebuilder:CancelImageCreation
               - imagebuilder:DeleteComponent
               - imagebuilder:DeleteImageRecipe
               - imagebuilder:DeleteInfrastructureConfiguration
@@ -994,7 +996,7 @@ Resources:
       InstanceProfileName: !Ref ImageBuilderInstanceProfile
       TerminateInstanceOnFailure: true
       SnsTopicArn: !Ref EcrImageBuilderSNSTopic
-      SubnetId: 
+      SubnetId:
         Fn::If:
           - NonDefaultVpc
           - !Ref ImageBuilderSubnetId

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -295,7 +295,7 @@ class ImageBuilderCdkStack(Stack):
         if not self.custom_cleanup_lambda_role:
             self._add_resource_delete_policy(
                 lambda_cleanup_policy_statements,
-                ["imagebuilder:DeleteImage"],
+                ["imagebuilder:DeleteImage", "imagebuilder:GetImage", "imagebuilder:CancelImageCreation"],
                 [
                     self.format_arn(
                         service="imagebuilder",

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -1323,7 +1323,11 @@ def test_imagebuilder_instance_role(
                                         },
                                     },
                                     {
-                                        "Action": "imagebuilder:DeleteImage",
+                                        "Action": [
+                                            "imagebuilder:DeleteImage",
+                                            "imagebuilder:GetImage",
+                                            "imagebuilder:CancelImageCreation",
+                                        ],
                                         "Effect": "Allow",
                                         "Resource": {
                                             "Fn::Join": [

--- a/tests/iam_policies/image-roles.cfn.yaml
+++ b/tests/iam_policies/image-roles.cfn.yaml
@@ -46,7 +46,10 @@ Resources:
               - Action: imagebuilder:DeleteDistributionConfiguration
                 Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
                 Effect: Allow
-              - Action: imagebuilder:DeleteImage
+              - Action:
+                  - imagebuilder:DeleteImage
+                  - imagebuilder:GetImage
+                  - imagebuilder:CancelImageCreation
                 Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/parallelclusterimage-*/*'
                 Effect: Allow
               - Action: cloudformation:DeleteStack

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -561,6 +561,8 @@ Resources:
             Effect: Allow
             Action:
               - imagebuilder:DeleteImage
+              - imagebuilder:GetImage
+              - imagebuilder:CancelImageCreation
               - imagebuilder:DeleteComponent
               - imagebuilder:DeleteImageRecipe
               - imagebuilder:DeleteInfrastructureConfiguration
@@ -842,7 +844,10 @@ Resources:
           - Action: imagebuilder:DeleteDistributionConfiguration
             Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
             Effect: Allow
-          - Action: imagebuilder:DeleteImage
+          - Action:
+              - imagebuilder:DeleteImage
+              - imagebuilder:GetImage
+              - imagebuilder:CancelImageCreation
             Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/parallelclusterimage-*/*'
             Effect: Allow
           - Action: cloudformation:DeleteStack


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Add the new policies imagebuilder:GetImage and imagebuilder:CancelImageCreation required to delete the ImageBuilderImage resource created by the build-image stack.

Solves https://github.com/aws/aws-parallelcluster/issues/3867

### Tests
n/a

### References
Doc already aligned https://docs.aws.amazon.com/parallelcluster/latest/ug/iam-roles-in-parallelcluster-v3.html#iam-roles-in-parallelcluster-v3-custom-image-configuration-cleanuplambdarole

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
