### PR TITLE
Add new policies for build-image stack deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 3.1.3
 ------
 
+**BUG FIXES**
+- Fix build-image stack in `DELETE_FAILED` after image built successful, due to new EC2ImageBuilder policies.
+
 3.1.2
 ------
 

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -805,6 +805,8 @@ Resources:
             Effect: Allow
             Action:
               - imagebuilder:DeleteImage
+              - imagebuilder:GetImage
+              - imagebuilder:CancelImageCreation
               - imagebuilder:DeleteComponent
               - imagebuilder:DeleteImageRecipe
               - imagebuilder:DeleteInfrastructureConfiguration

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -295,7 +295,7 @@ class ImageBuilderCdkStack(Stack):
         if not self.custom_cleanup_lambda_role:
             self._add_resource_delete_policy(
                 lambda_cleanup_policy_statements,
-                ["imagebuilder:DeleteImage"],
+                ["imagebuilder:DeleteImage", "imagebuilder:GetImage", "imagebuilder:CancelImageCreation"],
                 [
                     self.format_arn(
                         service="imagebuilder",

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -1323,7 +1323,11 @@ def test_imagebuilder_instance_role(
                                         },
                                     },
                                     {
-                                        "Action": "imagebuilder:DeleteImage",
+                                        "Action": [
+                                            "imagebuilder:DeleteImage",
+                                            "imagebuilder:GetImage",
+                                            "imagebuilder:CancelImageCreation",
+                                        ],
                                         "Effect": "Allow",
                                         "Resource": {
                                             "Fn::Join": [

--- a/tests/iam_policies/image-roles.cfn.yaml
+++ b/tests/iam_policies/image-roles.cfn.yaml
@@ -46,7 +46,10 @@ Resources:
               - Action: imagebuilder:DeleteDistributionConfiguration
                 Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
                 Effect: Allow
-              - Action: imagebuilder:DeleteImage
+              - Action:
+                  - imagebuilder:DeleteImage
+                  - imagebuilder:GetImage
+                  - imagebuilder:CancelImageCreation
                 Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/parallelclusterimage-*/*'
                 Effect: Allow
               - Action: cloudformation:DeleteStack

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -560,6 +560,8 @@ Resources:
             Effect: Allow
             Action:
               - imagebuilder:DeleteImage
+              - imagebuilder:GetImage
+              - imagebuilder:CancelImageCreation
               - imagebuilder:DeleteComponent
               - imagebuilder:DeleteImageRecipe
               - imagebuilder:DeleteInfrastructureConfiguration
@@ -840,7 +842,10 @@ Resources:
           - Action: imagebuilder:DeleteDistributionConfiguration
             Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
             Effect: Allow
-          - Action: imagebuilder:DeleteImage
+          - Action:
+              - imagebuilder:DeleteImage
+              - imagebuilder:GetImage
+              - imagebuilder:CancelImageCreation
             Resource: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/parallelclusterimage-*/*'
             Effect: Allow
           - Action: cloudformation:DeleteStack


### PR DESCRIPTION
**CHERRY-PICKED [PR](https://github.com/aws/aws-parallelcluster/pull/3881)**

### Description of changes
Add the new policies imagebuilder:GetImage and imagebuilder:CancelImageCreation required to delete the ImageBuilderImage resource created by the build-image stack.

Solves https://github.com/aws/aws-parallelcluster/issues/3867

### Tests
Will build&test the cherry-picked change directly on the commercial pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Luca Carrogu <carrogu@amazon.com>
Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>