### PR TITLE
API: Support for environments without a default VPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 3.1.3
 ------
 
+**ENHANCEMENTS**
+- Add support to deploy API infrastructure in environments without a default VPC.
+
 **CHANGES**
 - Add validator to verify that `DirectoryService.DomainName` is a FQDN or a LDAP Distinguished Name.
 

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -74,6 +74,16 @@ Parameters:
       - true
       - false
 
+  ImageBuilderVpcId:
+    Description: Optional. Provide a specific vpc id to use for building the container images. Use this if you don't have a default vpc available.
+    Type: String
+    Default: ''
+
+  ImageBuilderSubnetId:
+    Description: Optional. Provide a specific subnet id to use for building the container images. Use this if you don't have a default vpc available.
+    Type: String
+    Default: ''
+
 Mappings:
   ParallelCluster:
     Constants:
@@ -141,7 +151,10 @@ Conditions:
     - !Not [!Condition UsePrivateVpcEndpoint]
     - !Not [!Condition UseCustomDomainAndRoute53Configuration]
   CreateApiUserRoleCondition: !Equals [!Ref CreateApiUserRole, true]
-
+  NonDefaultVpc:
+    Fn::And:
+      - !Not [!Equals [!Ref ImageBuilderVpcId, ""]]
+      - !Not [!Equals [!Ref ImageBuilderSubnetId, ""]]
 
 Resources:
 
@@ -965,6 +978,13 @@ Resources:
       Roles:
         - !Ref ImageBuilderInstanceRole
 
+  InfrastructureConfigurationSecurityGroup:
+    Condition: NonDefaultVpc
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref ImageBuilderVpcId
+      GroupDescription: ParallelCluster image builder security group
+
   InfrastructureConfiguration:
     Condition: DoNotUseCustomEcrImageUri
     Type: AWS::ImageBuilder::InfrastructureConfiguration
@@ -975,6 +995,16 @@ Resources:
       InstanceProfileName: !Ref ImageBuilderInstanceProfile
       TerminateInstanceOnFailure: true
       SnsTopicArn: !Ref EcrImageBuilderSNSTopic
+      SubnetId: 
+        Fn::If:
+          - NonDefaultVpc
+          - !Ref ImageBuilderSubnetId
+          - !Ref AWS::NoValue
+      SecurityGroupIds:
+        Fn::If:
+          - NonDefaultVpc
+          - [!Ref InfrastructureConfigurationSecurityGroup]
+          - !Ref AWS::NoValue
 
   PrivateEcrRepository:
     Condition: DoNotUseCustomEcrImageUri


### PR DESCRIPTION
**CHERRY PICK (+commits squash) from [PR](https://github.com/aws/aws-parallelcluster/pull/3874)**

### Description of changes
Allows passing a VPC and subnet ID to be used for the image build infrastructure to allow for launching in an environment where no default VPC exists.

Of note, the subnet passed in as a parameter should have internet access (i.e private subnet with NAT gateway routes, or a public subnet). When a public subnet is used, it must have MapPublicIpOnLaunch enabled as image builder won't automatically map a public IP address and the image build will timeout.

### Tests
1. Manual test deploying the API in my personal account using the newly introduced parameters to specify VPC and Subnet.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani [mgiacomo@amazon.com](mailto:mgiacomo@amazon.com)
