### PR TITLE
Add system report function to collect system information on cluster

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -976,3 +976,58 @@ Scheduling:
         SubnetIds:
           - {{ public_subnet_id }}
 ```
+## Collect system analysis
+
+In case of performance degradation detected in tests, to speed up the root cause analysis it is useful to have a
+report of all the services, cron settings and information about the tested cluster. The function `run_system_analyzer` creates a subfolder
+in `out_dir` called `system_analyzer`. Every run the function creates 2 files, one for the head node and one
+for a compute node of the fleet. The generated file is a `tar.gz` archive containing a directory structure
+which is comparable with `diff`. Moreover, the function also collects some network statistics which can be inspected to
+get information about dropped packages and other meaningful network metrics.
+
+The information collected are:
+* System id: ubuntu, amzn or centos
+* System version
+* uname with kernel version
+* Installed packages
+* Services and timers active on the system
+* Scheduled commands like cron, at, anacron
+* The available MPI modules
+* The configured network and the statistics associated to those network
+* ami-id, instance-type and user data queried from the instance metadata service (IMDSv2)
+
+### How to add system analysis to a test
+
+In order to add the system analysis to a test do the following:
+1. Import the function from utils.py (e.g. `from tests.common.utils import run_system_analyzer`)
+2. Call the function after the cluster creation; can be useful to run it as the last step of the test.
+If needed, it is possible to specify the partition from which to collect compute node info.
+```python
+def run_system_analyzer(cluster, scheduler_commands_factory, request, partition=None):
+...
+```
+### How to compare system analysis
+
+The nodeJS `diff2html` generates a html file from a diff which helps to compare the differences.
+Compare result from different node type (head, compute) can create misleading results: it is suggested to compare the
+same node type (e.g. head with head) 
+Below an example on how compare system analysis results :
+```bash
+npm install -g diff2html
+
+# Get the archives
+ls .
+headnode-current-run.tar.gz
+headnode-previous-run.tar.gz
+
+# Extract the archives in 2 separated directory
+mkdir current-run
+mkdir previous-run
+tar xzvf headnode-current-run.tar.gz -C current-run/
+tar xzvf headnode-previous-run.tar.gz -C previous-run/
+
+# Compare and generate the diff.html file
+diff --exclude=network/ -u *-run/system-information | diff2html -s side -i stdin -o stdout > diff.html ;
+```
+
+Once generated the file it can be inspected in the browser.

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -175,3 +175,22 @@ class RemoteCommandExecutor:
         for local_remote_path in local_remote_paths or []:
             logging.info("Copying file to remote location: %s", local_remote_path)
             self.__connection.put(**local_remote_path)
+
+    def get_remote_files(self, *args, **kwargs):
+        """
+        Get a remote file to the local filesystem or file-like object.
+
+        Simply a wrapper for `.Connection.get`. Please see its documentation for
+        all details.
+
+        :param str remote:
+            Remote file to download.
+            May be absolute, or relative to the remote working directory.
+        :param local:
+            Local path to store downloaded file in, or a file-like object.
+        :param bool preserve_mode:
+            Whether to `os.chmod` the local file so it matches the remote
+            file's mode (default: ``True``).
+        :returns: A `.Result` object.
+        """
+        return self.__connection.get(*args, **kwargs)

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -34,7 +34,7 @@ from utils import generate_stack_name, render_jinja_template
 
 from tests.ad_integration.cluster_user import ClusterUser
 from tests.common.osu_common import compile_osu
-from tests.common.utils import get_sts_endpoint, retrieve_latest_ami
+from tests.common.utils import get_sts_endpoint, retrieve_latest_ami, run_system_analyzer
 
 NUM_USERS_TO_CREATE = 5
 NUM_USERS_TO_TEST = 3
@@ -760,6 +760,7 @@ def test_ad_integration(
         logging.info(f"Checking SSH access for user {user.alias}")
         _check_ssh_auth(user=user, expect_success=user.alias != "PclusterUser2")
     run_benchmarks(users[0].remote_command_executor(), users[0].scheduler_commands(), diretory_type=directory_type)
+    run_system_analyzer(cluster, scheduler_commands_factory, request)
 
 
 def _check_ssh_auth(user, expect_success=True):

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -759,8 +759,8 @@ def test_ad_integration(
     for user in users:
         logging.info(f"Checking SSH access for user {user.alias}")
         _check_ssh_auth(user=user, expect_success=user.alias != "PclusterUser2")
-    run_benchmarks(users[0].remote_command_executor(), users[0].scheduler_commands(), diretory_type=directory_type)
     run_system_analyzer(cluster, scheduler_commands_factory, request)
+    run_benchmarks(users[0].remote_command_executor(), users[0].scheduler_commands(), diretory_type=directory_type)
 
 
 def _check_ssh_auth(user, expect_success=True):

--- a/tests/integration-tests/tests/common/data/system-analyzer.sh
+++ b/tests/integration-tests/tests/common/data/system-analyzer.sh
@@ -32,6 +32,14 @@ function body() {
   "${@}"
 }
 
+function _copy_if_exists() {
+  if [ -e "${1}" ]; then
+    cp -r "${1}" "${2}"
+  else
+    log "${1} do not exists" "WARNING"
+  fi
+}
+
 function signal_handler() {
   # arg 1: return code
   # arg 2: line number of the error
@@ -68,17 +76,14 @@ function _save_scheduled_commands() {
   mkdir "${OUT_DIR}"/spool_cron
 
 
-  cp -r /etc/cron* "${OUT_DIR}"/etc_cron
-  cp -r /var/spool/cron "${OUT_DIR}"/spool_cron
+  _copy_if_exists /etc/cron* "${OUT_DIR}"/etc_cron
+  _copy_if_exists /var/spool/cron "${OUT_DIR}"/spool_cron
 
-  if [ "${OS}" != "ubuntu" ] || [ "${OS_VERSION}" != "18.04" ]; then
-    cp /etc/anacrontab "${OUT_DIR}"/etc_cron
-    cp -r /var/spool/anacron "${OUT_DIR}"/spool_cron
-  fi
+  _copy_if_exists /etc/anacrontab "${OUT_DIR}"/etc_cron
+  _copy_if_exists /var/spool/anacron "${OUT_DIR}"/spool_cron
 
-  if [ "${OS}" != "ubuntu" ]; then
-    cp -r /var/spool/at "${OUT_DIR}"/spool_cron
-  fi
+  _copy_if_exists /var/spool/at "${OUT_DIR}"/spool_cron
+
 }
 
 function _network_info() {

--- a/tests/integration-tests/tests/common/data/system-analyzer.sh
+++ b/tests/integration-tests/tests/common/data/system-analyzer.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+#
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Requirements: sudo, user be able to become root without password, ethtool, netstat
+
+# Script to generate a system information archive.
+# This script needs to be run by a user in sudoers and it takes an existing directory as argument
+
+function log() {
+  local LEVEL="INFO"
+  if [ "${2}" != "" ]; then
+    LEVEL="${2}"
+  fi
+  echo "$(date) - system-analyzer - ${LEVEL} - ${1}"
+}
+
+function body() {
+  # Function to print the header passed in pipe and execute the argument
+  # example: cat file_with_header.csv | body sort > file_with_header_but_sorted_body.csv
+  IFS= read -r HEADER
+  printf '%s\n' "${HEADER}"
+  "${@}"
+}
+
+function signal_handler() {
+  # arg 1: return code
+  # arg 2: line number of the error
+  # arg 3: temporary directory to remove
+
+  if [ "${1}" != "0" ]; then
+    log "Catching a signal" "ERROR"
+    rm -fr "${BASE_TEMP_DIR}"
+    log "Return code:${1} occurred on line ${2} - Deleted ${3}" "ERROR"
+    exit "${1}"
+  fi
+}
+
+function _save_installed_services_timers() {
+  log "Save installed services and timer"
+  local OUT_DIR=${1}
+
+  # Save installed services
+  systemctl --all --type=service --state running,active | head -n -7 | body sort -du > "${OUT_DIR}"/services_active
+  systemctl list-unit-files --state enabled,generated | head -n -2 | body sort -du > "${OUT_DIR}"/services_enabled
+
+  # Save timers
+  systemctl list-timers | head -n -3 | body sort -du > "${OUT_DIR}"/timers
+}
+
+function _save_scheduled_commands() {
+  log "Save scheduled commands"
+  local OUT_DIR=${1}
+  local OS=${2}
+  local OS_VERSION=${3}
+
+  # Save scheduled commands and scripts
+  mkdir "${OUT_DIR}"/etc_cron
+  mkdir "${OUT_DIR}"/spool_cron
+
+
+  cp -r /etc/cron* "${OUT_DIR}"/etc_cron
+  cp -r /var/spool/cron "${OUT_DIR}"/spool_cron
+
+  if [ "${OS}" != "ubuntu" ] || [ "${OS_VERSION}" != "18.04" ]; then
+    cp /etc/anacrontab "${OUT_DIR}"/etc_cron
+    cp -r /var/spool/anacron "${OUT_DIR}"/spool_cron
+  fi
+
+  if [ "${OS}" != "ubuntu" ]; then
+    cp -r /var/spool/at "${OUT_DIR}"/spool_cron
+  fi
+}
+
+function _network_info() {
+  log "Save network information"
+  local OUT_DIR="${1}/network/"
+
+  # Save meaningful network statistic
+  mkdir "${OUT_DIR}"
+  for network in $(ip link | egrep "^[0-9]+" | awk -F\: '{print $2}' | tr -d " " | grep -v "lo"); do
+    ethtool -S "${network}" > "${OUT_DIR}"/eth0_stats
+  done
+  netstat -s > "${OUT_DIR}"/netstat_stats
+  ip address > "${OUT_DIR}"/address
+}
+
+function _save_avail_mpi() {
+  log "Save mpi versions"
+  local OUT_DIR="${1}/mpi/"
+
+  # Save available mpi
+  mkdir "${OUT_DIR}"
+  MODULES="$(echo "${MODULEPATH}" | tr : '\n')"
+  set +e +o pipefail
+  MPI_MODULES=$(for MODULE in $MODULES; do
+    ls -1 "${MODULE}" 2>/dev/null | grep -i mpi;
+    done)
+  set -e -o pipefail
+  for MPI_MODULE in $MPI_MODULES
+  do
+    module load "${MPI_MODULE}" 2>&1 1>/dev/null
+    mpirun --version > "${OUT_DIR}"/"${MPI_MODULE}"
+    module unload "${MPI_MODULE}" 2>&1 1>/dev/null
+  done
+}
+
+function _save_imds_info() {
+  log "Save IMDSv2 information"
+  # Misc IMDS info
+  TOKEN="$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+  curl -s -H "X-aws-ec2-metadata-token: ${TOKEN}" http://169.254.169.254/latest/meta-data/ami-id > "${TEMP_DIR}"/ami-id
+  curl -s -H "X-aws-ec2-metadata-token: ${TOKEN}" http://169.254.169.254/latest/meta-data/instance-type > "${TEMP_DIR}"/instance-type
+  curl -s -H "X-aws-ec2-metadata-token: ${TOKEN}" http://169.254.169.254/latest/user-data > "${TEMP_DIR}"/user-data
+}
+
+function _is_user_root() {
+  [ "${EUID:-$(id -u)}" -eq 0 ]
+}
+
+function main() {
+
+  # Set switch to catch errors
+  set -e -o pipefail
+
+  # Check number of arguments
+  if [ $# -ne 1 ]; then
+    echo "usage: ${0} [directory]"
+    echo "es. ${0} /tmp/"
+    exit 1
+  fi
+
+  # Become root if not and re-execute the script itself
+  if ! _is_user_root; then
+    log "Running the script as root"
+    sudo bash --login ${0} ${1}
+    exit $?
+  fi
+
+
+  # Check if path exist
+  if [ -d "${1}" ]; then
+    log "Directory ${1} exists."
+  else
+    log "Directory ${1} does not exist - exiting"
+    exit 1
+  fi
+
+  local RESULT_ARCHIVE="${1}/system-information.tar.gz"
+
+  # temporary directory
+  local BASE_TEMP_DIR="$(mktemp -d)"
+  local TEMP_DIR="${BASE_TEMP_DIR}/system-information/"
+
+  # Register signal handling to clean the temporary directory in case of kill, kill -9, ctrl+c, error in the script
+  trap 'signal_handler ${?} ${LINENO} ${BASE_TEMP_DIR}' SIGKILL SIGINT SIGTERM SIGHUP INT ERR EXIT
+
+  log "Create temporary directory"
+  mkdir "${TEMP_DIR}"
+
+  # Find os type and select package command
+  local PACKAGE_REPORT_CMD=""
+  local OS="$(grep "^ID=" /etc/os-release | cut -d"=" -f 2 | xargs)"
+
+  case ${OS} in
+    ubuntu)
+      PACKAGE_REPORT_CMD="dpkg-query -l"
+      ;;
+    amzn | centos)
+      PACKAGE_REPORT_CMD="rpm -qa"
+      ;;
+    *)
+      echo "Unrecognized system. Found /etc/os-release ID content: ${OS}"
+      exit 1
+      ;;
+  esac
+
+  local OS_VERSION="$(grep "^VERSION_ID=" /etc/os-release | cut -d"=" -f 2 | xargs)"
+
+  log "Save OS type and version"
+  echo "${OS}" > "${TEMP_DIR}/os"
+  echo "${OS_VERSION}" > "${TEMP_DIR}/os_version"
+
+  # Save uname
+  log "Save uname"
+  uname -a > "${TEMP_DIR}/uname"
+
+  # Save installed packages on system
+  log "Save installed packages on system"
+  ${PACKAGE_REPORT_CMD} | sort -du > "${TEMP_DIR}"/packages
+
+  _save_installed_services_timers "${TEMP_DIR}"
+
+  _save_scheduled_commands "${TEMP_DIR}" "${OS}" "${OS_VERSION}"
+
+  _save_avail_mpi "${TEMP_DIR}"
+
+  _network_info "${TEMP_DIR}"
+
+  _save_imds_info "${TEMP_DIR}"
+
+  # Create the archive
+  log "Create the archive"
+  rm -fr "${RESULT_ARCHIVE}"
+  cd "${TEMP_DIR}/.."
+  tar -czf "${RESULT_ARCHIVE}" "system-information/" 1>/dev/null
+  cd "/"
+  rm -fr "${BASE_TEMP_DIR}"
+  log "DONE"
+}
+
+log "START"
+main "${@}"

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -9,6 +9,8 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
+import pathlib
 import random
 import string
 import time
@@ -23,6 +25,8 @@ from time_utils import seconds
 from utils import get_instance_info
 
 LOGGER = logging.getLogger(__name__)
+
+SYSTEM_ANALYZER_SCRIPT = pathlib.Path(__file__).parent / "data/system-analyzer.sh"
 
 OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "alinux2": {"name": "amzn2-ami-hvm-*.*.*.*-*-gp2", "owners": ["amazon"]},
@@ -231,3 +235,50 @@ def get_route_tables(subnet_id, region):
         Filters=[{"Name": "association.subnet-id", "Values": [subnet_id]}]
     )
     return [table["RouteTableId"] for table in response["RouteTables"]]
+
+
+def run_system_analyzer(cluster, scheduler_commands_factory, request, partition=None):
+    """Run script to collect system information on head and a compute node of a cluster."""
+
+    out_dir = request.config.getoption("output_dir")
+    local_result_dir = f"{out_dir}/system_analyzer"
+    compute_node_shared_dir = "/opt/parallelcluster/shared"
+    head_node_dir = "/tmp"
+
+    logging.info("Creating remote_command_executor and scheduler_commands")
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+
+    logging.info(f"Retrieve head node system information for test: {request.node.name}")
+    result = remote_command_executor.run_remote_script(SYSTEM_ANALYZER_SCRIPT, args=[head_node_dir])
+    logging.debug(f"result.failed={result.failed}")
+    logging.debug(f"result.stdout={result.stdout}")
+    logging.info(
+        "Copy results from remote cluster into: "
+        f"{local_result_dir}/system_information_head_node_{request.node.name}.tar.gz"
+    )
+    os.makedirs(f"{local_result_dir}", exist_ok=True)
+    remote_command_executor.get_remote_files(
+        f"{head_node_dir}/system-information.tar.gz",
+        f"{local_result_dir}/system_information_head_node_{request.node.name}.tar.gz",
+        preserve_mode=False,
+    )
+    logging.info("Head node system information correctly retrieved.")
+
+    logging.info(f"Retrieve compute node system information for test: {request.node.name}")
+    result = scheduler_commands.submit_script(
+        SYSTEM_ANALYZER_SCRIPT, script_args=[compute_node_shared_dir], partition=partition
+    )
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)
+    logging.info(
+        "Copy results from remote cluster into: "
+        f"{local_result_dir}/system_information_compute_node_{request.node.name}.tar.gz"
+    )
+    remote_command_executor.get_remote_files(
+        f"{compute_node_shared_dir}/system-information.tar.gz",
+        f"{local_result_dir}/system_information_compute_node_{request.node.name}.tar.gz",
+        preserve_mode=False,
+    )
+    logging.info("Compute node system information correctly retrieved.")

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
@@ -59,8 +59,8 @@ def test_hit_disable_hyperthreading(
     )
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)
-    run_benchmarks(remote_command_executor, scheduler_commands)
     run_system_analyzer(cluster, scheduler_commands_factory, request)
+    run_benchmarks(remote_command_executor, scheduler_commands)
 
 
 def _test_disable_hyperthreading_settings(

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
@@ -17,7 +17,7 @@ from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 
 from tests.common.assertions import assert_no_errors_in_logs
-from tests.common.utils import fetch_instance_slots
+from tests.common.utils import fetch_instance_slots, run_system_analyzer
 
 
 @pytest.mark.usefixtures("os")
@@ -31,6 +31,7 @@ def test_hit_disable_hyperthreading(
     run_benchmarks,
     benchmarks,
     scheduler_commands_factory,
+    request,
 ):
     """Test Disable Hyperthreading for HIT clusters."""
     slots_per_instance = fetch_instance_slots(region, instance)
@@ -59,6 +60,7 @@ def test_hit_disable_hyperthreading(
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)
     run_benchmarks(remote_command_executor, scheduler_commands)
+    run_system_analyzer(cluster, scheduler_commands_factory, request)
 
 
 def _test_disable_hyperthreading_settings(

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -68,6 +68,8 @@ def test_efa(
     _test_mpi(remote_command_executor, slots_per_instance, scheduler, scheduler_commands, partition="efa-enabled")
     logging.info("Running on Instances: {0}".format(get_compute_nodes_instance_ids(cluster.cfn_name, region)))
 
+    run_system_analyzer(cluster, scheduler_commands_factory, request, partition="efa-enabled")
+
     if instance in osu_benchmarks_instances:
         benchmark_failures = []
 
@@ -107,7 +109,6 @@ def test_efa(
     if instance == "p4d.24xlarge" and os != "centos7":
         _test_nccl_benchmarks(remote_command_executor, test_datadir, "openmpi", scheduler_commands)
 
-    run_system_analyzer(cluster, scheduler_commands_factory, request, partition="efa-enabled")
     assert_no_errors_in_logs(remote_command_executor, scheduler)
 
 

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -19,7 +19,7 @@ from utils import get_compute_nodes_instance_ids
 from tests.common.assertions import assert_no_errors_in_logs
 from tests.common.mpi_common import _test_mpi
 from tests.common.osu_common import run_individual_osu_benchmark
-from tests.common.utils import fetch_instance_slots
+from tests.common.utils import fetch_instance_slots, run_system_analyzer
 
 
 def test_efa(
@@ -34,6 +34,7 @@ def test_efa(
     network_interfaces_count,
     mpi_variants,
     scheduler_commands_factory,
+    request,
 ):
     """
     Test all EFA Features.
@@ -106,6 +107,7 @@ def test_efa(
     if instance == "p4d.24xlarge" and os != "centos7":
         _test_nccl_benchmarks(remote_command_executor, test_datadir, "openmpi", scheduler_commands)
 
+    run_system_analyzer(cluster, scheduler_commands_factory, request, partition="efa-enabled")
     assert_no_errors_in_logs(remote_command_executor, scheduler)
 
 


### PR DESCRIPTION
### Description of changes
* Added to the integration tests common utility a function to collect and store all the relevant information about the head node and a compute fleet node. This system report can be compared performing a diff on two of them.

### Tests
* Manual test with slurm_scheduler test
* Manual and automated tests with test_disable_hyperthreading, test_ad_integration and test_efa
* All the tested tests produced the system report named ad the test (eg. systemreport_compute_node_test_ad_integration[us-west-1-c5.xlarge-alinux2-slurm-benchmarks0-MicrosoftAD-ldap-False].tar.gz)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
