### PR TITLE
Set paramiko version to 2.10.2 in tests requirements to avoid stuck tests

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -22,3 +22,5 @@ untangle
 requests
 pyOpenSSL
 ../../api/client/src
+# Temporarily pinning Paramiko due to a bug that causes test processes to hang on terminated socket
+paramiko==2.10.2


### PR DESCRIPTION
### Description of changes
* Probably related issue: https://github.com/paramiko/paramiko/issues/2009

### Tests
* Manually tested install of requirements and run of test_ad_integration.py::test_ad_integration

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
