### PR TITLE
Remove FSx as shared storage from clusters used by AD integration tests. Using EFS as a replacement.

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -471,7 +471,8 @@ def _check_files_permissions(users):
             f"{user.home_dir}/my_file",
             f"/shared/{user.alias}_file",
             f"/ebs/{user.alias}_file",
-            f"/efs/{user.alias}_file",
+            # TODO EFS mounted on /shared as replacement for FSx which is currently casuing issues.
+            # f"/efs/{user.alias}_file",
         ]:
             user.run_remote_command(f"touch {path}")
             # Specify that only owner of file should have read/write access.

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -26,15 +26,16 @@ Monitoring:
       Enabled: true
       RetentionInDays: 14
 SharedStorage:
-  - MountDir: /shared
-    Name: fsx
-    StorageType: FsxLustre
-    FsxLustreSettings:
-      StorageCapacity: 2400
+#TODO Temporarily removed due to FSx issues
+#  - MountDir: /shared
+#    Name: fsx
+#    StorageType: FsxLustre
+#    FsxLustreSettings:
+#      StorageCapacity: 2400
   - MountDir: /ebs
     Name: ebs
     StorageType: Ebs
-  - MountDir: /efs
+  - MountDir: /shared
     Name: efs
     StorageType: Efs
 DirectoryService:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -26,15 +26,16 @@ Monitoring:
       Enabled: true
       RetentionInDays: 14
 SharedStorage:
-  - MountDir: /shared
-    Name: fsx
-    StorageType: FsxLustre
-    FsxLustreSettings:
-      StorageCapacity: 2400
+#TODO Temporarily removed due to FSx issues
+#  - MountDir: /shared
+#    Name: fsx
+#    StorageType: FsxLustre
+#    FsxLustreSettings:
+#      StorageCapacity: 2400
   - MountDir: /ebs
     Name: ebs
     StorageType: Ebs
-  - MountDir: /efs
+  - MountDir: /shared
     Name: efs
     StorageType: Efs
 DirectoryService:


### PR DESCRIPTION
### Description of changes
1.  Remove FSx as shared storage from clusters used by AD integration tests. Using EFS as a replacement.

### Tests
1. [ONGOING] Build&Test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>