### PR TITLE
Revert "Set paramiko version to 2.10.2 in tests requirements"

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -22,5 +22,3 @@ untangle
 requests
 pyOpenSSL
 ../../api/client/src
-# Temporarily pinning Paramiko due to a bug that causes test processes to hang on terminated socket
-paramiko==2.10.2

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -485,8 +485,8 @@ def _check_files_permissions(users):
             f"/home/{user.alias}/my_file",
             f"/shared/{user.alias}_file",
             f"/ebs/{user.alias}_file",
-            #TODO EFS mounted on /shared as replacement for FSx which is currently casuing issues.
-            #f"/efs/{user.alias}_file",
+            # TODO EFS mounted on /shared as replacement for FSx which is currently casuing issues.
+            # f"/efs/{user.alias}_file",
         ]:
             user.run_remote_command(f"touch {path}")
             # Specify that only owner of file should have read/write access.


### PR DESCRIPTION
This reverts commit 0e26fe5564c16531f954b73b988934000d70950d.
Revert PR https://github.com/aws/aws-parallelcluster/pull/3902

### Description of changes
* Revert "Set paramiko version to 2.10.2 in tests requirements"s.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
