### PR TITLE
Revert "Set paramiko version to 2.10.2 in tests requirements"

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -22,5 +22,3 @@ untangle
 requests
 pyOpenSSL
 ../../api/client/src
-# Temporarily pinning Paramiko due to a bug that causes test processes to hang on terminated socket
-paramiko==2.10.2


### PR DESCRIPTION
This reverts commit 0938d6e8747289e9a4891f85e9b794d04fda5cc7.
Revert PR https://github.com/aws/aws-parallelcluster/pull/3901

### Description of changes
* Revert "Set paramiko version to 2.10.2 in tests requirements"s.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
