### PR TITLE
[integ-tests] Add logs to better identify test phases

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -23,10 +23,12 @@ from itertools import product
 from pathlib import Path
 from shutil import copyfile
 from traceback import format_tb
+from typing import Any, Optional, Tuple
 
 import boto3
 import pytest
 import yaml
+from _pytest.fixtures import FixtureDef, SubRequest
 from cfn_stacks_factory import CfnStack, CfnStacksFactory
 from clusters_factory import Cluster, ClustersFactory
 from conftest_markers import (
@@ -204,16 +206,31 @@ def pytest_sessionstart(session):
     os.environ["AWS_MAX_ATTEMPTS"] = "10"
 
 
-def pytest_runtest_call(item):
+def pytest_runtest_logstart(nodeid: str, location: Tuple[str, Optional[int], str]):
     """Called to execute the test item."""
+    test_name = location[2]
     set_logger_formatter(
-        logging.Formatter(fmt=f"%(asctime)s - %(levelname)s - %(process)d - {item.name} - %(module)s - %(message)s")
+        logging.Formatter(fmt=f"%(asctime)s - %(levelname)s - %(process)d - {test_name} - %(module)s - %(message)s")
     )
-    logging.info("Running test " + item.name)
+    logging.info("Running test %s", test_name)
 
 
-def pytest_runtest_logfinish(nodeid, location):
+def pytest_runtest_logfinish(nodeid: str, location: Tuple[str, Optional[int], str]):
+    logging.info("Completed test %s", location[2])
     set_logger_formatter(logging.Formatter(fmt="%(asctime)s - %(levelname)s - %(process)d - %(module)s - %(message)s"))
+
+
+def pytest_runtest_setup(item):
+    logging.info("Starting setup for test %s", item.name)
+
+
+def pytest_runtest_teardown(item, nextitem):
+    logging.info("Starting teardown for test %s", item.name)
+
+
+def pytest_fixture_setup(fixturedef: FixtureDef[Any], request: SubRequest) -> Optional[object]:
+    logging.info("Setting up fixture %s", fixturedef)
+    return None
 
 
 def pytest_collection_modifyitems(session, config, items):

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -173,4 +173,5 @@ class RemoteCommandExecutor:
             # Assume files is a dict mapping local paths to remote paths
             local_remote_paths = [{"local": local, "remote": remote} for local, remote in files.items()]
         for local_remote_path in local_remote_paths or []:
+            logging.info("Copying file to remote location: %s", local_remote_path)
             self.__connection.put(**local_remote_path)


### PR DESCRIPTION
Added additional logs to integration tests in order to better identify the various phases of test case exectution.

Pytest hooks reference: https://docs.pytest.org/en/6.2.x/reference.html#hooks


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
