### PR TITLE
Re-enable FSxLustre in integration tests

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -424,46 +424,46 @@ spot:
         schedulers: ["slurm"]
 storage:
   # Commercial regions that cant test FSx: ap-northeast-1, ap-southeast-1, ap-southeast-2, eu-central-1, eu-north-1, eu-west-1, eu-west-2, us-east-1, us-east-2, us-west-1, us-west-2
-#  test_fsx_lustre.py::test_fsx_lustre:
-#    dimensions:
-#      - regions: ["eu-west-2"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: {{ common.OSS_COMMERCIAL_X86 }}
-#        schedulers: ["slurm"]
-#      - regions: ["eu-north-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-#        oss: {{ common.OSS_COMMERCIAL_ARM }}
-#        schedulers: ["slurm"]
-#      - regions: ["cn-north-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["slurm"]
-#      - regions: ["us-gov-west-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["slurm"]
-#  test_fsx_lustre.py::test_fsx_lustre_configuration_options:
-#    dimensions:
-#      - regions: ["us-east-2"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["slurm"]
-#  test_fsx_lustre.py::test_fsx_lustre_backup:
-#    dimensions:
-#      - regions: ["eu-south-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: {{ common.OSS_ONE_PER_DISTRO }}
-#        schedulers: ["slurm"]
-#      - regions: ["ap-southeast-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-#        oss: {{ common.OSS_COMMERCIAL_ARM }}
-#        schedulers: ["slurm"]
-#  test_fsx_lustre.py::test_existing_fsx:
-#    dimensions:
-#      - regions: ["us-west-2"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["centos7"]
-#        schedulers: ["slurm"]
+  test_fsx_lustre.py::test_fsx_lustre:
+    dimensions:
+      - regions: ["eu-west-2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        schedulers: ["slurm"]
+      - regions: ["eu-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        schedulers: ["slurm"]
+      - regions: ["cn-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
+      - regions: ["us-gov-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
+  test_fsx_lustre.py::test_fsx_lustre_configuration_options:
+    dimensions:
+      - regions: ["us-east-2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
+  test_fsx_lustre.py::test_fsx_lustre_backup:
+    dimensions:
+      - regions: ["eu-south-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: {{ common.OSS_ONE_PER_DISTRO }}
+        schedulers: ["slurm"]
+      - regions: ["ap-southeast-1"]
+        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        schedulers: ["slurm"]
+  test_fsx_lustre.py::test_existing_fsx:
+    dimensions:
+      - regions: ["us-west-2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["centos7"]
+        schedulers: ["slurm"]
   # EFS tests can be done in any region.
   test_efs.py::test_efs_compute_az:
     dimensions:

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -275,12 +275,12 @@ intel_hpc:
         oss: ["centos7"]
         schedulers: ["slurm"]
 networking:
-#  test_cluster_networking.py::test_cluster_in_private_subnet:
-#    dimensions:
-#      - regions: ["me-south-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2", "centos7"]
-#        schedulers: ["slurm"]
+  test_cluster_networking.py::test_cluster_in_private_subnet:
+    dimensions:
+      - regions: ["me-south-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2", "centos7"]
+        schedulers: ["slurm"]
   test_cluster_networking.py::test_existing_eip:
     dimensions:
       - regions: ["me-south-1"]
@@ -293,26 +293,26 @@ networking:
   test_networking.py::test_public_private_network_topology:
     dimensions:
       - regions: ["af-south-1", "us-gov-east-1", "cn-northwest-1"]
-#  test_cluster_networking.py::test_cluster_in_no_internet_subnet:
-#    dimensions:
-#        # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an
-#        # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
-#      - regions: ["us-east-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: {{ common.OSS_COMMERCIAL_X86 }}
-#        schedulers: ["slurm"]
-#      - regions: ["us-east-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-#        oss: {{ common.OSS_COMMERCIAL_ARM }}
-#        schedulers: ["slurm"]
-#      - regions: ["cn-north-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["slurm"]
-#      - regions: ["us-gov-west-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["ubuntu2004"]
-#        schedulers: ["slurm"]
+  test_cluster_networking.py::test_cluster_in_no_internet_subnet:
+    dimensions:
+        # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an
+        # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
+      - regions: ["us-east-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        schedulers: ["slurm"]
+      - regions: ["us-east-1"]
+        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        schedulers: ["slurm"]
+      - regions: ["cn-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
+      - regions: ["us-gov-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["ubuntu2004"]
+        schedulers: ["slurm"]
   test_multi_cidr.py::test_multi_cidr:
     dimensions:
       - regions: ["ap-northeast-2"]
@@ -329,16 +329,16 @@ networking:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
-#  test_security_groups.py::test_overwrite_sg:
-#    dimensions:
-#      - regions: ["eu-north-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["centos7"]
-#        schedulers: ["slurm"]
-#      - regions: ["eu-north-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
+  test_security_groups.py::test_overwrite_sg:
+    dimensions:
+      - regions: ["eu-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["centos7"]
+        schedulers: ["slurm"]
+      - regions: ["eu-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
   test_placement_group.py::test_placement_group:
     dimensions:
       - regions: ["eu-central-1"]
@@ -575,11 +575,11 @@ update:
       - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-#  test_update.py::test_update_slurm:
-#    dimensions:
-#      - regions: ["eu-west-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: {{ common.OSS_COMMERCIAL_X86 }}
+  test_update.py::test_update_slurm:
+    dimensions:
+      - regions: ["eu-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86 }}
   test_update.py::test_update_compute_ami:
     dimensions:
       - regions: ["eu-west-1"]

--- a/tests/integration-tests/configs/new_region.yaml
+++ b/tests/integration-tests/configs/new_region.yaml
@@ -130,12 +130,12 @@ test-suites:
           oss: ["centos7"]
           schedulers: ["slurm"]
   storage:
-#    test_fsx_lustre.py::test_fsx_lustre:
-#      dimensions:
-#        - regions: {{ NEW_REGION }}
-#          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#          oss: ["alinux2"]
-#          schedulers: ["slurm"]
+    test_fsx_lustre.py::test_fsx_lustre:
+      dimensions:
+        - regions: {{ NEW_REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
     test_efs.py::test_efs_compute_az:
       dimensions:
         - regions: {{ NEW_REGION }}

--- a/tests/integration-tests/configs/new_region.yaml
+++ b/tests/integration-tests/configs/new_region.yaml
@@ -55,13 +55,13 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu1804"]
           schedulers: ["slurm"]
-#  update:
-#    test_update.py::test_update_slurm:
-#      dimensions:
-#        - regions: {{ NEW_REGION }}
-#          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#          oss: ["alinux2"]
-#          schedulers: ["slurm"]
+  update:
+    test_update.py::test_update_slurm:
+      dimensions:
+        - regions: {{ NEW_REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
   dashboard:
     test_dashboard.py::test_dashboard:
       dimensions:
@@ -104,12 +104,12 @@ test-suites:
           oss: ["alinux2"]
           schedulers: ["slurm"]
   networking:
-#    test_cluster_networking.py::test_cluster_in_private_subnet:
-#      dimensions:
-#        - regions: {{ NEW_REGION }}
-#          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#          oss: ["ubuntu1804"]
-#          schedulers: ["slurm"]
+    test_cluster_networking.py::test_cluster_in_private_subnet:
+      dimensions:
+        - regions: {{ NEW_REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1804"]
+          schedulers: ["slurm"]
     test_networking.py::test_public_network_topology:
       dimensions:
         - regions: {{ NEW_REGION }}

--- a/tests/integration-tests/configs/pcluster3.yaml
+++ b/tests/integration-tests/configs/pcluster3.yaml
@@ -76,12 +76,12 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
-#    test_fsx_lustre.py::test_existing_fsx:
-#      dimensions:
-#        - regions: ["us-west-2"]
-#          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#          oss: ["centos7"]
-#          schedulers: ["slurm"]
+    test_fsx_lustre.py::test_existing_fsx:
+      dimensions:
+        - regions: ["us-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7"]
+          schedulers: ["slurm"]
     test_ebs.py::test_ebs_single:
       dimensions:
         - regions: ["eu-west-3"]

--- a/tests/integration-tests/configs/pcluster3.yaml
+++ b/tests/integration-tests/configs/pcluster3.yaml
@@ -101,8 +101,8 @@ test-suites:
         - regions: ["eu-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
-#    test_update.py::test_update_slurm:
-#      dimensions:
-#        - regions: ["eu-west-1"]
-#          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#          oss: ["centos7"]
+    test_update.py::test_update_slurm:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7"]

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -485,8 +485,7 @@ def _check_files_permissions(users):
             f"/home/{user.alias}/my_file",
             f"/shared/{user.alias}_file",
             f"/ebs/{user.alias}_file",
-            # TODO EFS mounted on /shared as replacement for FSx which is currently casuing issues.
-            # f"/efs/{user.alias}_file",
+            f"/efs/{user.alias}_file",
         ]:
             user.run_remote_command(f"touch {path}")
             # Specify that only owner of file should have read/write access.

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -26,16 +26,15 @@ Monitoring:
       Enabled: true
       RetentionInDays: 14
 SharedStorage:
-#TODO Temporarily removed due to FSx issues
-#  - MountDir: /shared
-#    Name: fsx
-#    StorageType: FsxLustre
-#    FsxLustreSettings:
-#      StorageCapacity: 2400
+  - MountDir: /shared
+    Name: fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 2400
   - MountDir: /ebs
     Name: ebs
     StorageType: Ebs
-  - MountDir: /shared
+  - MountDir: /efs
     Name: efs
     StorageType: Efs
 DirectoryService:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -26,16 +26,15 @@ Monitoring:
       Enabled: true
       RetentionInDays: 14
 SharedStorage:
-#TODO Temporarily removed due to FSx issues
-#  - MountDir: /shared
-#    Name: fsx
-#    StorageType: FsxLustre
-#    FsxLustreSettings:
-#      StorageCapacity: 2400
+  - MountDir: /shared
+    Name: fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 2400
   - MountDir: /ebs
     Name: ebs
     StorageType: Ebs
-  - MountDir: /shared
+  - MountDir: /efs
     Name: efs
     StorageType: Efs
 DirectoryService:


### PR DESCRIPTION
### Description of changes
1. Re-enable FSxLustre in integration tests by reverting the commits that disabled it.

### Tests
Will be tested on the dev commercial pipeline, directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.