### PR TITLE
Pin minor version of werkzeug and flask

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -20,7 +20,7 @@ aws-cdk.aws-route53~=1.137
 aws-cdk.aws-ssm~=1.137
 aws-cdk.aws-sqs~=1.137
 aws-cdk.aws-cloudformation~=1.137
-werkzeug~=2.0
+werkzeug~=2.0.0
 connexion==2.10.0
-flask~=2.0
+flask~=2.0.0
 jmespath~=0.10

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -46,9 +46,9 @@ REQUIRES = [
     "aws-cdk.aws-ssm~=" + CDK_VERSION,
     "aws-cdk.aws-sqs~=" + CDK_VERSION,
     "aws-cdk.aws-cloudformation~=" + CDK_VERSION,
-    "werkzeug~=2.0",
+    "werkzeug~=2.0.0",
     "connexion==2.10.0",
-    "flask~=2.0",
+    "flask~=2.0.0",
     "jmespath~=0.10",
 ]
 


### PR DESCRIPTION
werkzeug~=2.0.0 means werkzeug has to be 2.0.x

Without the pin, test_unsupported_content_type would fail.

Signed-off-by: Hanwen <hanwenli@amazon.com>


### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
