### PR TITLE
[develop] new QueueUpdateStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ x.x.x
 ------
 
 **ENHANCEMENTS**
+- Add new configuration parameter QueueUpdateStrategy to override the "compute fleet stop" update policy 
+  for parameters under the SlurmQueues section.
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File Systems.
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1619,10 +1619,20 @@ class Dns(Resource):
 class SlurmSettings(Resource):
     """Represent the Slurm settings."""
 
-    def __init__(self, scaledown_idletime: int = None, dns: Dns = None, **kwargs):
+    def __init__(self, scaledown_idletime: int = None, dns: Dns = None, queue_update_strategy: str = None, **kwargs):
         super().__init__()
         self.scaledown_idletime = Resource.init_param(scaledown_idletime, default=10)
         self.dns = dns or Dns(implied=True)
+        self.queue_update_strategy = Resource.init_param(
+            queue_update_strategy, default=QueueUpdateStrategy.COMPUTE_FLEET_STOP.value
+        )
+
+
+class QueueUpdateStrategy(Enum):
+    """Enum to identify the update strategy supported by the queue."""
+
+    DRAIN = "DRAIN"
+    COMPUTE_FLEET_STOP = "COMPUTE_FLEET_STOP"
 
 
 class SlurmScheduling(Resource):

--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -219,7 +219,9 @@ class ConfigPatch:
 
         :return: A tuple containing the patch applicability and the report rows.
         """
-        rows = [["param_path", "parameter", "old value", "new value", "check", "reason", "action_needed"]]
+        rows = [
+            ["param_path", "parameter", "old value", "new value", "check", "reason", "action_needed", "update_policy"]
+        ]
 
         patch_allowed = True
 
@@ -239,6 +241,7 @@ class ConfigPatch:
                         check_result.value,
                         reason,
                         action_needed,
+                        change.update_policy.name,
                     ]
                 )
 

--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -113,30 +113,30 @@ class ConfigPatch:
                     )
                 else:
                     # Single nested section
-                    target_value = target_section.get(data_key, None)
-                    base_value = base_section.get(data_key, None)
+                    target_value = target_section.get(data_key, None) if target_section else None
+                    base_value = base_section.get(data_key, None) if base_section else None
 
-                    if target_value and base_value:
+                    if target_value or base_value:
                         # Compare nested sections and params
+                        if not (target_value and base_value):
+                            # One section has been added or removed, add section change information
+                            self.changes.append(
+                                Change(
+                                    param_path,
+                                    data_key,
+                                    base_value if base_value else "-",
+                                    target_value if target_value else "-",
+                                    change_update_policy,
+                                    is_list=False,
+                                )
+                            )
                         nested_path = copy.deepcopy(param_path)
                         nested_path.append(data_key)
                         self._compare_section(base_value, target_value, field_obj.schema, nested_path)
-                    elif target_value or base_value:
-                        # One section has been added or removed, add section change information
-                        self.changes.append(
-                            Change(
-                                param_path,
-                                data_key,
-                                base_value if base_value else "-",
-                                target_value if target_value else "-",
-                                change_update_policy,
-                                is_list=False,
-                            )
-                        )
             else:
                 # Simple param
-                target_value = target_section.get(data_key, None)
-                base_value = base_section.get(data_key, None)
+                target_value = target_section.get(data_key, None) if target_section else None
+                base_value = base_section.get(data_key, None) if base_section else None
 
                 if target_value != base_value:
                     # Add param change information

--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -183,7 +183,6 @@ class ConfigPatch:
         # Then, compare all non visited base sections vs target config.
         for base_nested_section in base_section.get(data_key, []):
             if not base_nested_section.get("visited", False):
-                update_key_value = base_nested_section.get(update_key)
                 self.changes.append(
                     Change(
                         param_path,

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -26,12 +26,14 @@ class UpdatePolicy:
     def __init__(
         self,
         base_policy=None,
+        name=None,
         level=None,
         fail_reason=None,
         action_needed=None,
         condition_checker=None,
         print_succeeded=True,
     ):
+        self.name = None
         self.fail_reason = None
         self.action_needed = None
         self.condition_checker = None
@@ -39,11 +41,14 @@ class UpdatePolicy:
         self.level = 0
 
         if base_policy:
+            self.name = base_policy.name
             self.fail_reason = base_policy.fail_reason
             self.action_needed = base_policy.action_needed
             self.condition_checker = base_policy.condition_checker
             self.level = base_policy.level
 
+        if name:
+            self.name = name
         if level:
             self.level = level
         if fail_reason:
@@ -122,6 +127,7 @@ UpdatePolicy.ACTIONS_NEEDED = {
 
 # Update is ignored
 UpdatePolicy.IGNORED = UpdatePolicy(
+    name="IGNORED",
     level=-10,
     fail_reason="-",
     condition_checker=(lambda change, patch: True),
@@ -130,10 +136,13 @@ UpdatePolicy.IGNORED = UpdatePolicy(
 )
 
 # Update supported
-UpdatePolicy.SUPPORTED = UpdatePolicy(level=0, fail_reason="-", condition_checker=(lambda change, patch: True))
+UpdatePolicy.SUPPORTED = UpdatePolicy(
+    name="SUPPORTED", level=0, fail_reason="-", condition_checker=(lambda change, patch: True)
+)
 
 # Checks resize of max_vcpus in Batch Compute Environment
 UpdatePolicy.AWSBATCH_CE_MAX_RESIZE = UpdatePolicy(
+    name="AWSBATCH_CE_MAX_RESIZE",
     level=1,
     fail_reason=lambda change, patch: "Max vCPUs can not be lower than the current Desired vCPUs ({0})".format(
         patch.cluster.get_running_capacity()
@@ -145,6 +154,7 @@ UpdatePolicy.AWSBATCH_CE_MAX_RESIZE = UpdatePolicy(
 
 # Checks resize of max_count
 UpdatePolicy.MAX_COUNT = UpdatePolicy(
+    name="MAX_COUNT",
     level=1,
     fail_reason=lambda change, patch: "Shrinking a queue requires the compute fleet to be stopped first",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
@@ -155,6 +165,7 @@ UpdatePolicy.MAX_COUNT = UpdatePolicy(
 
 # Update supported only with all compute nodes down
 UpdatePolicy.COMPUTE_FLEET_STOP = UpdatePolicy(
+    name="COMPUTE_FLEET_STOP",
     level=10,
     fail_reason="All compute nodes must be stopped",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
@@ -163,6 +174,7 @@ UpdatePolicy.COMPUTE_FLEET_STOP = UpdatePolicy(
 
 # Update supported only with head node down
 UpdatePolicy.HEAD_NODE_STOP = UpdatePolicy(
+    name="HEAD_NODE_STOP",
     level=20,
     fail_reason="To perform this update action, the head node must be in a stopped state",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
@@ -173,6 +185,7 @@ UpdatePolicy.HEAD_NODE_STOP = UpdatePolicy(
 # No bucket specified when create, no bucket specified when update: Display no diff, proceed with update
 # For all other cases: Display diff and block, value will not be updated even if forced
 UpdatePolicy.READ_ONLY_RESOURCE_BUCKET = UpdatePolicy(
+    name="READ_ONLY_RESOURCE_BUCKET",
     level=30,
     fail_reason=lambda change, patch: (
         "'{0}' parameter is a read only parameter that cannot be updated. "
@@ -189,6 +202,7 @@ UpdatePolicy.READ_ONLY_RESOURCE_BUCKET = UpdatePolicy(
 # update policy instead of UNKNOWN to pass unit tests.
 #
 UpdatePolicy.UNKNOWN = UpdatePolicy(
+    name="UNKNOWN",
     level=100,
     fail_reason="Update currently not supported",
     action_needed="Restore the previous parameter value for the unsupported changes.",
@@ -196,6 +210,7 @@ UpdatePolicy.UNKNOWN = UpdatePolicy(
 
 # Update not supported
 UpdatePolicy.UNSUPPORTED = UpdatePolicy(
+    name="UNSUPPORTED",
     level=1000,
     fail_reason=lambda change, patch: (f"Update actions are not currently supported for the '{change.key}' parameter"),
     action_needed=lambda change, patch: (

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -118,6 +118,7 @@ PCLUSTER_S3_ARTIFACTS_DICT = {
     "instance_types_data_name": "instance-types-data.json",
     "custom_artifacts_name": "artifacts.zip",
     "scheduler_resources_name": "scheduler_resources.zip",
+    "change_set_name": "change-set.json",
 }
 
 PCLUSTER_TAG_VALUE_REGEX = r"^([\w\+\-\=\.\_\:\@/]{0,256})$"

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -62,6 +62,7 @@ from pcluster.config.cluster_config import (
     PlacementGroup,
     Proxy,
     QueueImage,
+    QueueUpdateStrategy,
     Raid,
     Roles,
     RootVolume,
@@ -1193,6 +1194,10 @@ class SlurmSettingsSchema(BaseSchema):
 
     scaledown_idletime = fields.Int(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
     dns = fields.Nested(DnsSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
+    queue_update_strategy = fields.Str(
+        validate=validate.OneOf([strategy.value for strategy in QueueUpdateStrategy]),
+        metadata={"update_policy": UpdatePolicy.IGNORED},
+    )
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1192,7 +1192,7 @@ class SlurmSettingsSchema(BaseSchema):
     """Represent the schema of the Scheduling Settings."""
 
     scaledown_idletime = fields.Int(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
-    dns = fields.Nested(DnsSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    dns = fields.Nested(DnsSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1630,7 +1630,7 @@ class SchedulingSchema(BaseSchema):
         metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
     # Slurm schema
-    slurm_settings = fields.Nested(SlurmSettingsSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    slurm_settings = fields.Nested(SlurmSettingsSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
     slurm_queues = fields.Nested(
         SlurmQueueSchema,
         many=True,

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -896,7 +896,10 @@ class ClusterCdkStack(Stack):
                         self.bucket.artifact_directory, PCLUSTER_S3_ARTIFACTS_DICT.get("config_name")
                     ),
                     "cluster_config_version": self.config.config_version,
-                    "instance_types_data_s3_key": f"{self.bucket.artifact_directory}/configs/instance-types-data.json",
+                    "change_set_s3_key": f"{self.bucket.artifact_directory}/configs/"
+                    f"{PCLUSTER_S3_ARTIFACTS_DICT.get('change_set_name')}",
+                    "instance_types_data_s3_key": f"{self.bucket.artifact_directory}/configs/"
+                    f"{PCLUSTER_S3_ARTIFACTS_DICT.get('instance_types_data_name')}",
                     "custom_node_package": self.config.custom_node_package or "",
                     "custom_awsbatchcli_package": self.config.custom_aws_batch_cli_package or "",
                     "head_node_imds_secured": str(self.config.head_node.imds.secured).lower(),

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -314,6 +314,7 @@ def _test_less_target_sections(base_conf, target_conf):
                 None,
                 UpdatePolicy(
                     UpdatePolicy.UNSUPPORTED,
+                    name="UNSUPPORTED",
                     fail_reason=(
                         "Shared Storage cannot be added or removed during a 'pcluster update-cluster' operation"
                     ),

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -573,7 +573,7 @@ def test_patch_check_cluster_resource_bucket(
 ):
     mock_aws_api(mocker)
     expected_message_rows = [
-        ["param_path", "parameter", "old value", "new value", "check", "reason", "action_needed"],
+        ["param_path", "parameter", "old value", "new value", "check", "reason", "action_needed", "update_policy"],
         # ec2_iam_role is to make sure other parameters are not affected by cluster_resource_bucket custom logic
         [
             ["HeadNode", "Iam"],
@@ -583,6 +583,7 @@ def test_patch_check_cluster_resource_bucket(
             "SUCCEEDED",
             "-",
             None,
+            UpdatePolicy.SUPPORTED.name,
         ],
     ]
     if expected_error_row:
@@ -599,6 +600,7 @@ def test_patch_check_cluster_resource_bucket(
                 )
             ),
             f"Restore the value of parameter 'CustomS3Bucket' to '{old_bucket_name}'",
+            UpdatePolicy.READ_ONLY_RESOURCE_BUCKET.name,
         ]
         expected_message_rows.append(error_message_row)
     src_dict = {"cluster_resource_bucket": old_bucket_name, "ec2_iam_role": "arn:aws:iam::aws:role/some_old_role"}

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -290,6 +290,9 @@ def _test_less_target_sections(base_conf, target_conf):
     # add new section + param in the base conf so that it appears as removed in the target conf
     base_conf["Scheduling"].update({"SlurmSettings": {"ScaledownIdletime": 30}})
     base_conf["Scheduling"]["SlurmSettings"].update({"QueueUpdateStrategy": QueueUpdateStrategy.DRAIN.value})
+    base_conf["Scheduling"]["SlurmQueues"][0].update(
+        {"Iam": {"AdditionalIamPolicies": [{"Policy": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"}]}}
+    )
 
     # add new param in the base conf so that it appears as removed in the target conf
     base_conf["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MinCount"] = 1
@@ -360,6 +363,22 @@ def _test_less_target_sections(base_conf, target_conf):
                 UpdatePolicy.IGNORED,
                 is_list=False,
             ),
+            Change(
+                ["Scheduling", "SlurmQueues[queue1]"],
+                "Iam",
+                {"AdditionalIamPolicies": [{"Policy": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"}]},
+                "-",
+                UpdatePolicy.SUPPORTED,
+                is_list=False,
+            ),
+            Change(
+                ["Scheduling", "SlurmQueues[queue1]", "Iam"],
+                "AdditionalIamPolicies",
+                {"Policy": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"},
+                None,
+                UpdatePolicy.SUPPORTED,
+                is_list=True,
+            ),
         ],
         UpdatePolicy.UNSUPPORTED,
     )
@@ -392,6 +411,9 @@ def _test_more_target_sections(base_conf, target_conf):
     target_conf["Scheduling"].update({"SlurmSettings": {"ScaledownIdletime": 30}})
     target_conf["Scheduling"]["SlurmSettings"].update(
         {"QueueUpdateStrategy": QueueUpdateStrategy.COMPUTE_FLEET_STOP.value}
+    )
+    target_conf["Scheduling"]["SlurmQueues"][0].update(
+        {"Iam": {"AdditionalIamPolicies": [{"Policy": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"}]}}
     )
 
     # add new param in the target conf
@@ -456,6 +478,22 @@ def _test_more_target_sections(base_conf, target_conf):
                 QueueUpdateStrategy.COMPUTE_FLEET_STOP.value,
                 UpdatePolicy.IGNORED,
                 is_list=False,
+            ),
+            Change(
+                ["Scheduling", "SlurmQueues[queue1]"],
+                "Iam",
+                "-",
+                {"AdditionalIamPolicies": [{"Policy": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"}]},
+                UpdatePolicy.SUPPORTED,
+                is_list=False,
+            ),
+            Change(
+                ["Scheduling", "SlurmQueues[queue1]", "Iam"],
+                "AdditionalIamPolicies",
+                None,
+                {"Policy": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"},
+                UpdatePolicy.SUPPORTED,
+                is_list=True,
             ),
         ],
         UpdatePolicy.UNSUPPORTED,

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -11,6 +11,7 @@
 import pytest
 from assertpy import assert_that
 
+from pcluster.config.cluster_config import QueueUpdateStrategy
 from pcluster.config.update_policy import UpdatePolicy
 from tests.pcluster.test_utils import dummy_cluster
 
@@ -42,3 +43,305 @@ def test_max_count_policy(mocker, is_fleet_stopped, old_max, new_max, expected_r
 
     assert_that(UpdatePolicy.MAX_COUNT.condition_checker(change_mock, patch_mock)).is_equal_to(expected_result)
     cluster_has_running_capacity_mock.assert_called()
+
+
+@pytest.mark.parametrize(
+    "is_fleet_stopped, key, path, old_value, new_value, update_strategy, expected_result",
+    [
+        pytest.param(
+            True,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue1]", "ComputeResources[compute1]"],
+            10,
+            9,
+            None,
+            True,
+            id="stopped fleet and new_min < old_min",
+        ),
+        pytest.param(
+            True,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue2]", "ComputeResources[compute2]"],
+            10,
+            11,
+            None,
+            True,
+            id="stopped fleet new_min > old_min",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue1]", "ComputeResources[compute1]"],
+            10,
+            9,
+            None,
+            False,
+            id="running fleet and new_min < old_min with no update strategy set",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue2]", "ComputeResources[compute2]"],
+            10,
+            11,
+            None,
+            False,
+            id="running fleet and new_min > old_min with no update strategy set",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue3]", "ComputeResources[compute3]"],
+            None,
+            0,
+            None,
+            False,
+            id="running fleet and new_min = DEFAULT_MIN_COUNT with no update strategy set",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue4]", "ComputeResources[compute4]"],
+            None,
+            11,
+            None,
+            False,
+            id="running fleet and new_min > DEFAULT_MIN_COUNT with no update strategy set",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue5]", "ComputeResources[compute5]"],
+            11,
+            None,
+            None,
+            False,
+            id="running fleet and DEFAULT_MIN_COUNT < old_min with no update strategy set",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue6]", "ComputeResources[compute6]"],
+            0,
+            None,
+            None,
+            False,
+            id="running fleet and DEFAULT_MIN_COUNT = old_min with no update strategy set",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue1]", "ComputeResources[compute1]"],
+            10,
+            9,
+            QueueUpdateStrategy.COMPUTE_FLEET_STOP.value,
+            False,
+            id="running fleet and new_min < old_min with update strategy COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue2]", "ComputeResources[compute2]"],
+            10,
+            11,
+            QueueUpdateStrategy.COMPUTE_FLEET_STOP.value,
+            False,
+            id="running fleet and new_min > old_min with update strategy COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue3]", "ComputeResources[compute3]"],
+            None,
+            0,
+            QueueUpdateStrategy.COMPUTE_FLEET_STOP.value,
+            False,
+            id="running fleet and new_min = DEFAULT_MIN_COUNT with update strategy COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue4]", "ComputeResources[compute4]"],
+            None,
+            11,
+            QueueUpdateStrategy.COMPUTE_FLEET_STOP.value,
+            False,
+            id="running fleet and new_min > DEFAULT_MIN_COUNT with update strategy COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue5]", "ComputeResources[compute5]"],
+            11,
+            None,
+            QueueUpdateStrategy.COMPUTE_FLEET_STOP.value,
+            False,
+            id="running fleet and DEFAULT_MIN_COUNT < old_min with update strategy COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue6]", "ComputeResources[compute6]"],
+            0,
+            None,
+            QueueUpdateStrategy.COMPUTE_FLEET_STOP.value,
+            False,
+            id="running fleet and DEFAULT_MIN_COUNT = old_min with update strategy COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue1]", "ComputeResources[compute1]"],
+            10,
+            9,
+            QueueUpdateStrategy.DRAIN.value,
+            True,
+            id="running fleet and new_min < old_min with update strategy DRAIN",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue2]", "ComputeResources[compute2]"],
+            10,
+            11,
+            QueueUpdateStrategy.DRAIN.value,
+            True,
+            id="running fleet and new_min > old_min with update strategy DRAIN",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue3]", "ComputeResources[compute3]"],
+            None,
+            0,
+            QueueUpdateStrategy.DRAIN.value,
+            True,
+            id="running fleet and new_min = DEFAULT_MIN_COUNT with update strategy DRAIN",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue4]", "ComputeResources[compute4]"],
+            None,
+            11,
+            QueueUpdateStrategy.DRAIN.value,
+            True,
+            id="running fleet and new_min > DEFAULT_MIN_COUNT with update strategy DRAIN",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue5]", "ComputeResources[compute5]"],
+            11,
+            None,
+            QueueUpdateStrategy.DRAIN.value,
+            True,
+            id="running fleet and DEFAULT_MIN_COUNT < old_min with update strategy DRAIN",
+        ),
+        pytest.param(
+            False,
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue6]", "ComputeResources[compute6]"],
+            0,
+            None,
+            QueueUpdateStrategy.DRAIN.value,
+            True,
+            id="running fleet and DEFAULT_MIN_COUNT = old_min with update strategy DRAIN",
+        ),
+        pytest.param(
+            False,
+            "GenerateSshKeysForUsers",
+            ["DirectoryService"],
+            None,
+            True,
+            QueueUpdateStrategy.DRAIN.value,
+            False,
+            id="running fleet with change outside SlurmQueues which requires COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "GenerateSshKeysForUsers",
+            ["DirectoryService"],
+            False,
+            None,
+            QueueUpdateStrategy.DRAIN.value,
+            False,
+            id="running fleet with change outside SlurmQueues which requires COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "GenerateSshKeysForUsers",
+            ["DirectoryService"],
+            True,
+            False,
+            QueueUpdateStrategy.DRAIN.value,
+            False,
+            id="running fleet with change outside SlurmQueues which requires COMPUTE_FLEET_STOP",
+        ),
+    ],
+)
+def test_queue_update_strategy_condition_checker(
+    mocker, is_fleet_stopped, key, path, old_value, new_value, update_strategy, expected_result
+):
+    cluster = dummy_cluster()
+    cluster_has_running_capacity_mock = mocker.patch.object(
+        cluster, "has_running_capacity", return_value=not is_fleet_stopped
+    )
+
+    patch_mock = mocker.MagicMock()
+    patch_mock.cluster = cluster
+    patch_mock.target_config = (
+        {"Scheduling": {"SlurmSettings": {"QueueUpdateStrategy": update_strategy}}}
+        if update_strategy
+        else {"Scheduling": {"SlurmSettings": {}}}
+    )
+    change_mock = mocker.MagicMock()
+    change_mock.path = path
+    change_mock.key = key
+    change_mock.old_value = old_value
+    change_mock.new_value = new_value
+
+    assert_that(UpdatePolicy.COMPUTE_FLEET_STOP.condition_checker(change_mock, patch_mock)).is_equal_to(expected_result)
+    cluster_has_running_capacity_mock.assert_called()
+
+
+@pytest.mark.parametrize(
+    "key, path, old_value, new_value, expected_fail_reason, expected_actions_needed",
+    [
+        pytest.param(
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue6]", "ComputeResources[compute6]"],
+            0,
+            None,
+            "All compute nodes must be stopped or queue update strategy must be set",
+            "Stop the compute fleet with the pcluster update-compute-fleet command "
+            "or set QueueUpdateStrategy in the configuration used for the 'update-cluster' operation",
+            id="change within SlurmQueues",
+        ),
+        pytest.param(
+            "GenerateSshKeysForUsers",
+            ["DirectoryService"],
+            None,
+            True,
+            "All compute nodes must be stopped",
+            "Stop the compute fleet with the pcluster update-compute-fleet command",
+            id="change outside SlurmQueues",
+        ),
+    ],
+)
+def test_queue_update_strategy_fail_reason_and_actions_needed(
+    mocker, key, path, old_value, new_value, expected_fail_reason, expected_actions_needed
+):
+    cluster = dummy_cluster()
+    patch_mock = mocker.MagicMock()
+    patch_mock.cluster = cluster
+    change_mock = mocker.MagicMock()
+    change_mock.path = path
+    change_mock.key = key
+    change_mock.old_value = old_value
+    change_mock.new_value = new_value
+
+    assert_that(UpdatePolicy.COMPUTE_FLEET_STOP.fail_reason(change_mock, patch_mock)).is_equal_to(expected_fail_reason)
+    assert_that(UpdatePolicy.COMPUTE_FLEET_STOP.action_needed(change_mock, patch_mock)).is_equal_to(
+        expected_actions_needed
+    )

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -678,7 +678,16 @@ class TestCluster:
                 "Update failure: The scheduler plugin used for this cluster does not support updating the scheduling "
                 "configuration.",
                 [
-                    ["param_path", "parameter", "old value", "new value", "check", "reason", "action_needed"],
+                    [
+                        "param_path",
+                        "parameter",
+                        "old value",
+                        "new value",
+                        "check",
+                        "reason",
+                        "action_needed",
+                        "update_policy",
+                    ],
                     [
                         ["Scheduling", "SchedulerQueues[queue1]", "ComputeResources[compute-resource1]"],
                         "InstanceType",
@@ -687,6 +696,7 @@ class TestCluster:
                         "SUCCEEDED",
                         "-",
                         None,
+                        "COMPUTE_FLEET_STOP",
                     ],
                 ],
             ),

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
@@ -3,6 +3,7 @@
     "base_os": "alinux2",
     "cluster_config_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/cluster-config-with-implied-values.yaml",
     "cluster_config_version": "",
+    "change_set_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/change-set.json",
     "cluster_s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
     "cluster_user": "ec2-user",
     "custom_awsbatchcli_package": "",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/scheduler-plugin-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/scheduler-plugin-imds-secured-true.head-node.dna.json
@@ -3,6 +3,7 @@
     "base_os": "alinux2",
     "cluster_config_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/cluster-config-with-implied-values.yaml",
     "cluster_config_version": "",
+    "change_set_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/change-set.json",
     "cluster_s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
     "cluster_user": "ec2-user",
     "custom_awsbatchcli_package": "",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
@@ -3,6 +3,7 @@
     "base_os": "alinux2",
     "cluster_config_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/cluster-config-with-implied-values.yaml",
     "cluster_config_version": "",
+    "change_set_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/change-set.json",
     "cluster_s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
     "cluster_user": "ec2-user",
     "custom_awsbatchcli_package": "",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
@@ -3,6 +3,7 @@
     "base_os": "alinux2",
     "cluster_config_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/cluster-config-with-implied-values.yaml",
     "cluster_config_version": "",
+    "change_set_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/change-set.json",
     "cluster_s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
     "cluster_user": "ec2-user",
     "custom_awsbatchcli_package": "",


### PR DESCRIPTION
### Description of changes
* Add new parameter QueueUpdateStrategy

  This parameter is meant to be used as update policy override for the parameters under the SlurmQueue section which by default require a COMPUTE_FLEET_STOP for the update of their value.
  
  Possible values for QueueUpdateStrategy
  * COMPUTE_FLEET_STOP - it keeps the same behaviour as of today
  * DRAIN - will replace nodes using a DRAIN strategy, i.e. nodes will be put in DRAINING and replaced only when jobs running on them terminate. The new value of the parameter changed during the update, will be applied to the new nodes.

* Add change set file into S3 bucket during cluster update

  Upload a json file containing the change set to be performed during an update.
  The important part is that it will bring information about the update policies of all the changed parameters.
  This information is then consumed during the update by the update replacement logic.
  The file is in the form:
```
{
  "changeSet": [
    {
      "parameter": "Scheduling.SlurmQueues[compute2].ComputeResources[compute2-i1].MinCount",
      "requestedValue": 0,
      "currentValue": 1,
      "updatePolicy": "COMPUTE_FLEET_STOP"
    }
  ]
}
```

* Fix policy for SlurmSettings and Dns section

  As general rule the update policy for a section should have a policy IGNORED, because the updatability should be driven by the single policies if its children.
  In this case the parameters under SlurmSettings section have different update policies, from COMPUTE_FLEET_STOP to UNSUPPORTED.
  In this case all parameters under DNS section have update policy UNSUPPORTED.  

* Add name to instance of UpdatePolicy class

  This is useful for debugging purposes, to be able to know the name of the policy from an instance of the class

* Enable traversing of config comparison

  Currently, the configuration comparison stops as soon as a new parameter is found in the new configuration.
  With this patch, the comparison goes further, traversing also the children of the new parameter when this is a section.
  This change allows to be able to ignore the update policy of a section and have the updatability depending on the policies of its children.
  
  Example: changing config from
```
Scheduling:
  SlurmQueues:
    [...]
```
  to
```
Scheduling:
  SlurmSettings:
    ScaledownIdletime: 12
  SlurmQueues:
    [...]
```

  the output of update-cluster changes from
```
{
  "message": "Update failure",
  "updateValidationErrors": [
    {
      "parameter": "Scheduling.SlurmSettings",
      "requestedValue": {
        "ScaledownIdletime": 12
      },
      "message": "All compute nodes must be stopped. Stop the compute fleet with the pcluster update-compute-fleet command",
      "currentValue": "-"
    }
  ],
  "changeSet": [
    {
      "parameter": "Scheduling.SlurmSettings",
      "requestedValue": {
        "ScaledownIdletime": 12
      },
      "currentValue": "-"
    }
  ]
}
```
to
```
{
  "message": "Update failure",
  "updateValidationErrors": [
    {
      "parameter": "Scheduling.SlurmSettings.ScaledownIdletime",
      "requestedValue": 12,
      "message": "All compute nodes must be stopped. Stop the compute fleet with the pcluster update-compute-fleet command"
    }
  ],
  "changeSet": [
    {
      "parameter": "Scheduling.SlurmSettings.ScaledownIdletime",
      "requestedValue": 12
    }
  ]
}
```
  which is consistent to the output showed when adding a single parameter under a section that already exist

### Tests
* added unit tests

### References
* n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
