### PR TITLE
[Release-2.11] Add system report function to collect system information on cluster

### DIFF
--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -149,3 +149,22 @@ class RemoteCommandExecutor:
     def _copy_additional_files(self, files):
         for file in files or []:
             self.__connection.put(file, os.path.basename(file))
+
+    def get_remote_files(self, *args, **kwargs):
+        """
+        Get a remote file to the local filesystem or file-like object.
+
+        Simply a wrapper for `.Connection.get`. Please see its documentation for
+        all details.
+
+        :param str remote:
+            Remote file to download.
+            May be absolute, or relative to the remote working directory.
+        :param local:
+            Local path to store downloaded file in, or a file-like object.
+        :param bool preserve_mode:
+            Whether to `os.chmod` the local file so it matches the remote
+            file's mode (default: ``True``).
+        :returns: A `.Result` object.
+        """
+        return self.__connection.get(*args, **kwargs)

--- a/tests/integration-tests/tests/common/data/system-analyzer.sh
+++ b/tests/integration-tests/tests/common/data/system-analyzer.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+#
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with the
+# License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Requirements: sudo, user be able to become root without password, ethtool, netstat
+
+# Script to generate a system information archive.
+# This script needs to be run by a user in sudoers and it takes an existing directory as argument
+
+function log() {
+  local LEVEL="INFO"
+  if [ "${2}" != "" ]; then
+    LEVEL="${2}"
+  fi
+  echo "$(date) - system-analyzer - ${LEVEL} - ${1}"
+}
+
+function body() {
+  # Function to print the header passed in pipe and execute the argument
+  # example: cat file_with_header.csv | body sort > file_with_header_but_sorted_body.csv
+  IFS= read -r HEADER
+  printf '%s\n' "${HEADER}"
+  "${@}"
+}
+
+function _copy_if_exists() {
+  if [ -e "${1}" ]; then
+    cp -r "${1}" "${2}"
+  else
+    log "${1} do not exists" "WARNING"
+  fi
+}
+
+function signal_handler() {
+  # arg 1: return code
+  # arg 2: line number of the error
+  # arg 3: temporary directory to remove
+
+  if [ "${1}" != "0" ]; then
+    log "Catching a signal" "ERROR"
+    rm -fr "${BASE_TEMP_DIR}"
+    log "Return code:${1} occurred on line ${2} - Deleted ${3}" "ERROR"
+    exit "${1}"
+  fi
+}
+
+function _save_installed_services_timers() {
+  log "Save installed services and timer"
+  local OUT_DIR=${1}
+
+  # Save installed services
+  systemctl --all --type=service --state running,active | head -n -7 | body sort -du > "${OUT_DIR}"/services_active
+  systemctl list-unit-files --state enabled,generated | head -n -2 | body sort -du > "${OUT_DIR}"/services_enabled
+
+  # Save timers
+  systemctl list-timers | head -n -3 | body sort -du > "${OUT_DIR}"/timers
+}
+
+function _save_scheduled_commands() {
+  log "Save scheduled commands"
+  local OUT_DIR=${1}
+  local OS=${2}
+  local OS_VERSION=${3}
+
+  # Save scheduled commands and scripts
+  mkdir "${OUT_DIR}"/etc_cron
+  mkdir "${OUT_DIR}"/spool_cron
+
+
+  _copy_if_exists /etc/cron* "${OUT_DIR}"/etc_cron
+  _copy_if_exists /var/spool/cron "${OUT_DIR}"/spool_cron
+
+  _copy_if_exists /etc/anacrontab "${OUT_DIR}"/etc_cron
+  _copy_if_exists /var/spool/anacron "${OUT_DIR}"/spool_cron
+
+  _copy_if_exists /var/spool/at "${OUT_DIR}"/spool_cron
+
+}
+
+function _network_info() {
+  log "Save network information"
+  local OUT_DIR="${1}/network/"
+
+  # Save meaningful network statistic
+  mkdir "${OUT_DIR}"
+  for network in $(ip link | egrep "^[0-9]+" | awk -F\: '{print $2}' | tr -d " " | grep -v "lo"); do
+    ethtool -S "${network}" > "${OUT_DIR}"/eth0_stats
+  done
+  netstat -s > "${OUT_DIR}"/netstat_stats
+  ip address > "${OUT_DIR}"/address
+}
+
+function _save_avail_mpi() {
+  log "Save mpi versions"
+  local OUT_DIR="${1}/mpi/"
+
+  # Save available mpi
+  mkdir "${OUT_DIR}"
+  MODULES="$(echo "${MODULEPATH}" | tr : '\n')"
+  set +e +o pipefail
+  MPI_MODULES=$(for MODULE in $MODULES; do
+    ls -1 "${MODULE}" 2>/dev/null | grep -i mpi;
+    done)
+  set -e -o pipefail
+  for MPI_MODULE in $MPI_MODULES
+  do
+    module load "${MPI_MODULE}" 2>&1 1>/dev/null
+    mpirun --version > "${OUT_DIR}"/"${MPI_MODULE}"
+    module unload "${MPI_MODULE}" 2>&1 1>/dev/null
+  done
+}
+
+function _save_imds_info() {
+  log "Save IMDSv2 information"
+  # Misc IMDS info
+  TOKEN="$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")"
+  curl -s -H "X-aws-ec2-metadata-token: ${TOKEN}" http://169.254.169.254/latest/meta-data/ami-id > "${TEMP_DIR}"/ami-id
+  curl -s -H "X-aws-ec2-metadata-token: ${TOKEN}" http://169.254.169.254/latest/meta-data/instance-type > "${TEMP_DIR}"/instance-type
+  curl -s -H "X-aws-ec2-metadata-token: ${TOKEN}" http://169.254.169.254/latest/user-data > "${TEMP_DIR}"/user-data
+}
+
+function _is_user_root() {
+  [ "${EUID:-$(id -u)}" -eq 0 ]
+}
+
+function main() {
+
+  # Set switch to catch errors
+  set -e -o pipefail
+
+  # Check number of arguments
+  if [ $# -ne 1 ]; then
+    echo "usage: ${0} [directory]"
+    echo "es. ${0} /tmp/"
+    exit 1
+  fi
+
+  # Become root if not and re-execute the script itself
+  if ! _is_user_root; then
+    log "Running the script as root"
+    sudo bash --login ${0} ${1}
+    exit $?
+  fi
+
+
+  # Check if path exist
+  if [ -d "${1}" ]; then
+    log "Directory ${1} exists."
+  else
+    log "Directory ${1} does not exist - exiting"
+    exit 1
+  fi
+
+  local RESULT_ARCHIVE="${1}/system-information.tar.gz"
+
+  # temporary directory
+  local BASE_TEMP_DIR="$(mktemp -d)"
+  local TEMP_DIR="${BASE_TEMP_DIR}/system-information/"
+
+  # Register signal handling to clean the temporary directory in case of kill, kill -9, ctrl+c, error in the script
+  trap 'signal_handler ${?} ${LINENO} ${BASE_TEMP_DIR}' SIGKILL SIGINT SIGTERM SIGHUP INT ERR EXIT
+
+  log "Create temporary directory"
+  mkdir "${TEMP_DIR}"
+
+  # Find os type and select package command
+  local PACKAGE_REPORT_CMD=""
+  local OS="$(grep "^ID=" /etc/os-release | cut -d"=" -f 2 | xargs)"
+
+  case ${OS} in
+    ubuntu)
+      PACKAGE_REPORT_CMD="dpkg-query -l"
+      ;;
+    amzn | centos)
+      PACKAGE_REPORT_CMD="rpm -qa"
+      ;;
+    *)
+      echo "Unrecognized system. Found /etc/os-release ID content: ${OS}"
+      exit 1
+      ;;
+  esac
+
+  local OS_VERSION="$(grep "^VERSION_ID=" /etc/os-release | cut -d"=" -f 2 | xargs)"
+
+  log "Save OS type and version"
+  echo "${OS}" > "${TEMP_DIR}/os"
+  echo "${OS_VERSION}" > "${TEMP_DIR}/os_version"
+
+  # Save uname
+  log "Save uname"
+  uname -a > "${TEMP_DIR}/uname"
+
+  # Save installed packages on system
+  log "Save installed packages on system"
+  ${PACKAGE_REPORT_CMD} | sort -du > "${TEMP_DIR}"/packages
+
+  _save_installed_services_timers "${TEMP_DIR}"
+
+  _save_scheduled_commands "${TEMP_DIR}" "${OS}" "${OS_VERSION}"
+
+  _save_avail_mpi "${TEMP_DIR}"
+
+  _network_info "${TEMP_DIR}"
+
+  _save_imds_info "${TEMP_DIR}"
+
+  # Create the archive
+  log "Create the archive"
+  rm -fr "${RESULT_ARCHIVE}"
+  cd "${TEMP_DIR}/.."
+  tar -czf "${RESULT_ARCHIVE}" "system-information/" 1>/dev/null
+  cd "/"
+  rm -fr "${BASE_TEMP_DIR}"
+  log "DONE"
+}
+
+log "START"
+main "${@}"

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
@@ -18,7 +18,7 @@ from remote_command_executor import RemoteCommandExecutor
 
 from tests.common.assertions import assert_no_errors_in_logs
 from tests.common.schedulers_common import get_scheduler_commands
-from tests.common.utils import fetch_instance_slots
+from tests.common.utils import fetch_instance_slots, run_system_analyzer
 
 
 # Manually disabled HT
@@ -52,7 +52,14 @@ def test_sit_disable_hyperthreading(
 # HT disabled via CpuOptions
 @pytest.mark.dimensions("us-west-1", "c5.xlarge", "ubuntu1804", "slurm")
 def test_hit_disable_hyperthreading(
-    region, scheduler, instance, os, pcluster_config_reader, clusters_factory, default_threads_per_core
+    region,
+    scheduler,
+    instance,
+    os,
+    pcluster_config_reader,
+    clusters_factory,
+    default_threads_per_core,
+    request,
 ):
     """Test Disable Hyperthreading for HIT clusters."""
     slots_per_instance = fetch_instance_slots(region, instance)
@@ -80,6 +87,7 @@ def test_hit_disable_hyperthreading(
     )
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)
+    run_system_analyzer(cluster, get_scheduler_commands, request, partition="ht-disabled")
 
 
 def _test_disable_hyperthreading_settings(

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -23,7 +23,7 @@ from utils import get_compute_nodes_instance_ids
 from tests.common.assertions import assert_no_errors_in_logs
 from tests.common.mpi_common import _test_mpi
 from tests.common.schedulers_common import get_scheduler_commands
-from tests.common.utils import fetch_instance_slots
+from tests.common.utils import fetch_instance_slots, run_system_analyzer
 
 
 @pytest.mark.regions(["us-east-1", "us-gov-west-1"])
@@ -99,6 +99,7 @@ def test_hit_efa(
     test_datadir,
     architecture,
     network_interfaces_count,
+    request,
 ):
     """
     Test all EFA Features.
@@ -131,6 +132,8 @@ def test_hit_efa(
     _test_efa_installation(scheduler_commands, remote_command_executor, efa_installed=True, partition="efa-enabled")
     _test_mpi(remote_command_executor, slots_per_instance, scheduler, partition="efa-enabled")
     logging.info("Running on Instances: {0}".format(get_compute_nodes_instance_ids(cluster.cfn_name, region)))
+
+    run_system_analyzer(cluster, get_scheduler_commands, request, partition="efa-enabled")
 
     if instance in osu_benchmarks_instances:
         benchmark_failures = []


### PR DESCRIPTION
Cherry-pick from PR https://github.com/aws/aws-parallelcluster/pull/3897

### Description of changes
* Added to the integration tests common utility a function to collect and store all the relevant information about the head node and a compute fleet node. This system report can be compared performing a diff on two of them.

### Tests
* Manual test with slurm_scheduler test
* Manual and automated tests with test_disable_hyperthreading and test_efa
* All the tested tests produced the system report named ad the test

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
