### PR TITLE
Fix run_system_analyzer to get the scheduler as an argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
             toxdir: cli
             toxenv: py38-cov
           - name: Code Checks
-            python: 3.6
+            python: 3.7
             toxdir: cli
             toxenv: code-linters
           - name: CloudFormation Templates Checks

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -206,7 +206,7 @@ deps =
     semgrep
 commands =
     semgrep \
-            --config p/r2c-security-audit \
+        --config p/r2c-security-audit \
         --config p/secrets \
         --exclude 'tests/**' \
         --exclude 'Dockerfile' \

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -206,7 +206,7 @@ deps =
     semgrep
 commands =
     semgrep \
-        --config p/r2c-security-audit \
+            --config p/r2c-security-audit \
         --config p/secrets \
         --exclude 'tests/**' \
         --exclude 'Dockerfile' \

--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -801,9 +801,10 @@ In order to add the system analysis to a test do the following:
 2. Call the function after the cluster creation; can be useful to run it as the last step of the test.
 If needed, it is possible to specify the partition from which to collect compute node info.
 ```python
-def run_system_analyzer(cluster, scheduler_commands_factory, request, partition=None):
+def run_system_analyzer(cluster, scheduler, request, partition=None):
 ...
 ```
+The function assumes the existence of a shared folder between compute and head node called `/shared`.
 ### How to compare system analysis
 
 The nodeJS `diff2html` generates a html file from a diff which helps to compare the differences.
@@ -811,7 +812,7 @@ Compare result from different node type (head, compute) can create misleading re
 same node type (e.g. head with head) 
 Below an example on how compare system analysis results :
 ```bash
-npm install -g diff2html
+npm install -g diff2html-cli
 
 # Get the archives
 ls .

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -21,6 +21,8 @@ from retrying import retry
 from time_utils import seconds
 from utils import get_instance_info
 
+from tests.common.schedulers_common import get_scheduler_commands
+
 LOGGER = logging.getLogger(__name__)
 
 SYSTEM_ANALYZER_SCRIPT = pathlib.Path(__file__).parent / "data/system-analyzer.sh"
@@ -153,16 +155,16 @@ def get_sts_endpoint(region):
     return "https://sts.{0}.{1}".format(region, "amazonaws.com.cn" if region.startswith("cn-") else "amazonaws.com")
 
 
-def run_system_analyzer(cluster, scheduler_commands_factory, request, partition=None):
+def run_system_analyzer(cluster, scheduler, request, partition=None):
     """Run script to collect system information on head and a compute node of a cluster."""
     out_dir = request.config.getoption("output_dir")
     local_result_dir = f"{out_dir}/system_analyzer"
-    compute_node_shared_dir = "/opt/parallelcluster/shared"
+    compute_node_shared_dir = "/shared"
     head_node_dir = "/tmp"
 
     logging.info("Creating remote_command_executor and scheduler_commands")
     remote_command_executor = RemoteCommandExecutor(cluster)
-    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+    scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
 
     logging.info(f"Retrieve head node system information for test: {request.node.name}")
     result = remote_command_executor.run_remote_script(SYSTEM_ANALYZER_SCRIPT, args=[head_node_dir])

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading.py
@@ -87,7 +87,7 @@ def test_hit_disable_hyperthreading(
     )
 
     assert_no_errors_in_logs(remote_command_executor, scheduler)
-    run_system_analyzer(cluster, get_scheduler_commands, request, partition="ht-disabled")
+    run_system_analyzer(cluster, scheduler, request, partition="ht-disabled")
 
 
 def _test_disable_hyperthreading_settings(

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -133,7 +133,7 @@ def test_hit_efa(
     _test_mpi(remote_command_executor, slots_per_instance, scheduler, partition="efa-enabled")
     logging.info("Running on Instances: {0}".format(get_compute_nodes_instance_ids(cluster.cfn_name, region)))
 
-    run_system_analyzer(cluster, get_scheduler_commands, request, partition="efa-enabled")
+    run_system_analyzer(cluster, scheduler, request, partition="efa-enabled")
 
     if instance in osu_benchmarks_instances:
         benchmark_failures = []


### PR DESCRIPTION
### Description of changes
* Fix bug in run_system_analyzer to get the scheduler as an argument to create the scheduler_commands

**Minor** - Fix semgrep metavariable-analysis error
To avoid the error "Additional properties are not allowed ('metavariable-analysis' was unexpected)"
bump python version for code check from 3.6 to 3.7
semgrep dropped support for 3.6 from version 0.82.0 - 2022-02-08


### Tests
Automated tests:
test_hit_efa[us-west-2-c6gn.16xlarge-ubuntu2004-slurm] – efa.test_efa
test_hit_efa[us-west-2-c6gn.16xlarge-alinux2-slurm] – efa.test_efa
test_hit_efa[us-west-2-c6gn.16xlarge-ubuntu1804-slurm] – efa.test_efa
test_hit_efa[us-west-2-p4d.24xlarge-alinux2-slurm] – efa.test_efa
test_hit_efa[us-west-2-c6gn.16xlarge-ubuntu2004-slurm] – efa.test_efa
test_hit_efa[us-west-2-c6gn.16xlarge-alinux2-slurm] – efa.test_efa
test_hit_efa[us-west-2-c6gn.16xlarge-ubuntu1804-slurm] – efa.test_efa
test_hit_efa[us-west-2-p4d.24xlarge-alinux2-slurm] – efa.test_efa
test_hit_disable_hyperthreading[us-west-1-m4.xlarge-centos7-slurm] – disable_hyperthreading.test_disable_hyperthreading
test_hit_disable_hyperthreading[us-west-1-m4.xlarge-alinux2-slurm] – disable_hyperthreading.test_disable_hyperthreading
test_hit_disable_hyperthreading[us-west-1-c5.xlarge-ubuntu2004-slurm] – disable_hyperthreading.test_disable_hyperthreading
test_hit_disable_hyperthreading[us-west-1-c5.xlarge-ubuntu1804-slurm] – disable_hyperthreading.test_disable_hyperthreading

### References
* https://github.com/aws/aws-parallelcluster/pull/3941


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
