### PR TITLE
2.x: Manage exception in case of missing networking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 2.11.6
 -----
 
+**ENHANCEMENTS**
+- Improve exception management in case of missing networking.
+
 **CHANGES**
 - OS package updates and security fixes.
 

--- a/cli/src/pcluster/cli.py
+++ b/cli/src/pcluster/cli.py
@@ -18,7 +18,7 @@ import textwrap
 from logging.handlers import RotatingFileHandler
 
 import argparse
-from botocore.exceptions import NoCredentialsError
+from botocore.exceptions import EndpointConnectionError, NoCredentialsError
 
 import pcluster.cli_commands.delete as pcluster_delete
 import pcluster.cli_commands.start as pcluster_start
@@ -469,6 +469,9 @@ def main():
         sys.exit(1)
     except KeyboardInterrupt:
         LOGGER.info("Exiting...")
+        sys.exit(1)
+    except EndpointConnectionError as e:
+        LOGGER.error("Error: Network connection is required to execute pcluster CLI commands. %s", e)
         sys.exit(1)
     except Exception as e:
         LOGGER.exception("Unexpected error of type %s: %s", type(e).__name__, e)


### PR DESCRIPTION
### Description of changes
Before this patch during handling of the above exception, another exception occurred causing a bad user experience.


### Tests
Before:
```
pcluster create test
Beginning cluster creation for cluster: test
Unexpected error of type EndpointConnectionError: Could not connect to the endpoint URL: "https://ec2.eu-west-1.amazonaws.com/"
Traceback (most recent call last):
  File "python3.6/site-packages/urllib3/connection.py", line 170, in _new_conn
    (self._dns_host, self.port), self.timeout, **extra_kw
 ...
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "python3.6/site-packages/botocore/httpsession.py", line 394, in send
    chunked=self._chunked(request.headers),
...
  File "python3.6/site-packages/urllib3/connection.py", line 182, in _new_conn
    self, "Failed to establish a new connection: %s" % e
urllib3.exceptions.NewConnectionError: <botocore.awsrequest.AWSHTTPSConnection object at 0x10e531668>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
...
  File "python3.6/site-packages/botocore/httpsession.py", line 414, in send
    raise EndpointConnectionError(endpoint_url=request.url, error=e)
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "https://ec2.eu-west-1.amazonaws.com/"

Process finished with exit code 1
```

After:
``` 
pcluster create test
Beginning cluster creation for cluster: test
Error: Network connection is required to execute pcluster CLI commands. Could not connect to the endpoint URL: "https://ec2.eu-west-1.amazonaws.com/"

Process finished with exit code 1
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

