### PR TITLE
Use Python 3.9 for Code Checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             toxdir: cli
             toxenv: py38-cov
           - name: Code Checks
-            python: 3.8
+            python: 3.9
             toxdir: cli
             toxenv: code-linters
           - name: CLI CloudFormation Templates Checks
@@ -130,7 +130,7 @@ jobs:
             toxdir: awsbatch-cli
             toxenv: py38-cov
           - name: Code Checks AWS Batch CLI
-            python: 3.6
+            python: 3.9
             toxdir: awsbatch-cli
             toxenv: code-linters
     steps:


### PR DESCRIPTION
This is a backport PR from https://github.com/aws/aws-parallelcluster/pull/3949

semgrep, a part of the code checks, dropped support for Python 3.6. See https://github.com/returntocorp/semgrep/blob/develop/CHANGELOG.md#changed-7

As a result, the AWS Batch CLI code check was failing. This commit uses Python 3.9 for Code Checks for AWS Batch CLI and ParallelCluster CLI

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
