### PR TITLE
Integ-tests: Add benchmark configuration to multiple EFS and FSx

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -466,6 +466,12 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
+        benchmarks:
+          - mpi_variants: ["openmpi", "intelmpi"]
+            num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+            slots_per_instance: 2
+            osu_benchmarks:
+              collective: ["osu_allreduce", "osu_alltoall"]
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: {{ common.OSS_COMMERCIAL_ARM }}
@@ -519,6 +525,12 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: {{ common.OSS_COMMERCIAL_ARM }}
         schedulers: [ "slurm" ]
+        benchmarks:
+          - mpi_variants: ["openmpi", "intelmpi"]
+            num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+            slots_per_instance: 2
+            osu_benchmarks:
+              collective: ["osu_allreduce", "osu_alltoall"]
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_GOVCLOUD_X86 }}

--- a/tests/integration-tests/configs/pcluster3.yaml
+++ b/tests/integration-tests/configs/pcluster3.yaml
@@ -76,12 +76,24 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
+          benchmarks:
+            - mpi_variants: ["openmpi", "intelmpi"]
+              num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+              slots_per_instance: 2
+              osu_benchmarks:
+                collective: ["osu_allreduce", "osu_alltoall"]
     test_fsx_lustre.py::test_multiple_fsx:
       dimensions:
         - regions: ["us-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["centos7"]
           schedulers: ["slurm"]
+          benchmarks:
+            - mpi_variants: ["openmpi", "intelmpi"]
+              num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+              slots_per_instance: 2
+              osu_benchmarks:
+                collective: ["osu_allreduce", "osu_alltoall"]
     test_ebs.py::test_ebs_single:
       dimensions:
         - regions: ["eu-west-3"]


### PR DESCRIPTION
I didn't realize that if `run_benchmarks` fixture was used for the tests, the `benchmarks` sections have to be defined in the test definition file. Otherwise, the tests would fail for "fixture not exists" error even if the `--benchmarks` flag is not specified with the test_runner. For sure, the benchmark testing framework should be improved. But now, it is easier to just add the `benchmarks` to the test definition

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
