### PR TITLE
Support FSx for lustre Persistent_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ x.x.x
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File Systems.
 - Add validation for `DirectoryService/AdditionalSssdConfigs` to fail in case of invalid overrides.
+- Add support for FSx Lustre Persistent_2 deployment type.
 
 **CHANGES**
 - Remove support for Python 3.6.

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -48,7 +48,8 @@ IMAGE_NAME_PART_TO_OS_MAP = {value: key for key, value in OS_TO_IMAGE_NAME_PART_
 # i.e. aws-parallelcluster-awsbatch-cli>=2.0.0,aws-parallelcluster-awsbatch-cli<3.0.0
 AWSBATCH_CLI_REQUIREMENTS = "aws-parallelcluster-awsbatch-cli<2.0.0"
 
-FSX_SSD_THROUGHPUT = [50, 100, 200]
+
+FSX_SSD_THROUGHPUT = {"PERSISTENT_1": [50, 100, 200], "PERSISTENT_2": [125, 250, 500, 1000]}
 FSX_HDD_THROUGHPUT = [12, 40]
 
 EBS_VOLUME_TYPE_IOPS_DEFAULT = {

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -106,8 +106,6 @@ from pcluster.constants import (
     DELETION_POLICIES,
     DELETION_POLICIES_WITH_SNAPSHOT,
     EBS_VOLUME_SIZE_DEFAULT,
-    FSX_HDD_THROUGHPUT,
-    FSX_SSD_THROUGHPUT,
     SCHEDULER_PLUGIN_MAX_NUMBER_OF_USERS,
     SUPPORTED_OSES,
 )
@@ -350,7 +348,7 @@ class FsxLustreSettingsSchema(BaseSchema):
 
     storage_capacity = fields.Int(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     deployment_type = fields.Str(
-        validate=validate.OneOf(["SCRATCH_1", "SCRATCH_2", "PERSISTENT_1"]),
+        validate=validate.OneOf(["SCRATCH_1", "SCRATCH_2", "PERSISTENT_1", "PERSISTENT_2"]),
         metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
     imported_file_chunk_size = fields.Int(
@@ -370,10 +368,7 @@ class FsxLustreSettingsSchema(BaseSchema):
     daily_automatic_backup_start_time = fields.Str(
         validate=validate.Regexp(r"^([01]\d|2[0-3]):([0-5]\d)$"), metadata={"update_policy": UpdatePolicy.SUPPORTED}
     )
-    per_unit_storage_throughput = fields.Int(
-        validate=validate.OneOf(FSX_SSD_THROUGHPUT + FSX_HDD_THROUGHPUT),
-        metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
-    )
+    per_unit_storage_throughput = fields.Int(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     backup_id = fields.Str(
         validate=validate.Regexp("^(backup-[0-9a-f]{8,})$"), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
     )

--- a/cli/src/pcluster/validators/fsx_validators.py
+++ b/cli/src/pcluster/validators/fsx_validators.py
@@ -56,21 +56,23 @@ class FsxPersistentOptionsValidator(Validator):
     """
 
     def _validate(self, deployment_type, kms_key_id, per_unit_storage_throughput):
-        if deployment_type == "PERSISTENT_1":
+        persistent_deployment_types = ["PERSISTENT_1", "PERSISTENT_2"]
+        if deployment_type in persistent_deployment_types:
             if not per_unit_storage_throughput:
                 self._add_failure(
-                    "Per unit storage throughput must be specified when deployment type is `PERSISTENT_1'.",
+                    f"Per unit storage throughput must be specified when deployment type is {deployment_type}.",
                     FailureLevel.ERROR,
                 )
         else:
             if kms_key_id:
                 self._add_failure(
-                    "KMS key id can only be used when deployment type is `PERSISTENT_1'.",
+                    f"KMS key id can only be used when deployment type is one of {persistent_deployment_types}.",
                     FailureLevel.ERROR,
                 )
             if per_unit_storage_throughput:
                 self._add_failure(
-                    "Per unit storage throughput can only be used when deployment type is `PERSISTENT_1'.",
+                    "Per unit storage throughput can only be used when deployment type is one of"
+                    f" {persistent_deployment_types}.",
                     FailureLevel.ERROR,
                 )
 
@@ -100,9 +102,10 @@ class FsxBackupOptionsValidator(Validator):
                 "When specifying copy tags to backups, the automatic backup retention days option must be specified.",
                 FailureLevel.ERROR,
             )
-        if deployment_type != "PERSISTENT_1" and automatic_backup_retention_days:
+        persistent_deployment_types = ["PERSISTENT_1", "PERSISTENT_2"]
+        if deployment_type not in persistent_deployment_types and automatic_backup_retention_days:
             self._add_failure(
-                "FSx automatic backup features can be used only with 'PERSISTENT_1' file systems.",
+                f"FSx automatic backup features can be used only with {persistent_deployment_types} file systems.",
                 FailureLevel.ERROR,
             )
         if (
@@ -127,27 +130,25 @@ class FsxStorageTypeOptionsValidator(Validator):
         if fsx_storage_type == "HDD":
             if deployment_type != "PERSISTENT_1":
                 self._add_failure(
-                    "For HDD filesystems, deployment type must be 'PERSISTENT_1'.",
+                    "For HDD file systems, deployment type must be PERSISTENT_1.",
                     FailureLevel.ERROR,
                 )
             if per_unit_storage_throughput not in FSX_HDD_THROUGHPUT:
                 self._add_failure(
-                    "For HDD filesystems, per unit storage throughput can only have the following values: {0}.".format(
-                        FSX_HDD_THROUGHPUT
-                    ),
+                    "For HDD file systems, per unit storage throughput can only have "
+                    f"the following values: {FSX_HDD_THROUGHPUT}.",
                     FailureLevel.ERROR,
                 )
         else:  # SSD or None
             if drive_cache_type:
                 self._add_failure(
-                    "Drive cache type features can be used only with HDD filesystems.",
+                    "Drive cache type features can be used only with HDD file systems.",
                     FailureLevel.ERROR,
                 )
-            if per_unit_storage_throughput and per_unit_storage_throughput not in FSX_SSD_THROUGHPUT:
+            if per_unit_storage_throughput and per_unit_storage_throughput not in FSX_SSD_THROUGHPUT[deployment_type]:
                 self._add_failure(
-                    "For SSD filesystems, per unit storage throughput can only have the following values: {0}.".format(
-                        FSX_SSD_THROUGHPUT
-                    ),
+                    f"For {deployment_type} SSD file systems, per unit storage throughput can only have "
+                    f"the following values: {FSX_SSD_THROUGHPUT[deployment_type]}.",
                     FailureLevel.ERROR,
                 )
 
@@ -177,7 +178,7 @@ class FsxStorageCapacityValidator(Validator):
         elif deployment_type == "SCRATCH_1":
             if not (storage_capacity == 1200 or storage_capacity == 2400 or storage_capacity % 3600 == 0):
                 self._add_failure(
-                    "Capacity for FSx SCRATCH_1 filesystem is 1,200 GB, 2,400 GB or increments of 3,600 GB.",
+                    "Capacity for FSx SCRATCH_1 file systems is 1,200 GB, 2,400 GB or increments of 3,600 GB.",
                     FailureLevel.ERROR,
                 )
         elif deployment_type == "PERSISTENT_1" and fsx_storage_type == "HDD":
@@ -191,10 +192,10 @@ class FsxStorageCapacityValidator(Validator):
                     "Capacity for FSx PERSISTENT HDD 40 MB/s/TiB file systems is increments of 1,800 GiB.",
                     FailureLevel.ERROR,
                 )
-        elif deployment_type in ["SCRATCH_2", "PERSISTENT_1"]:
+        elif deployment_type in ["SCRATCH_2", "PERSISTENT_1", "PERSISTENT_2"]:
             if not (storage_capacity == 1200 or storage_capacity % 2400 == 0):
                 self._add_failure(
-                    "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB.",
+                    f"Capacity for FSx {deployment_type} file systems is 1,200 GB or increments of 2,400 GB.",
                     FailureLevel.ERROR,
                 )
 

--- a/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
+++ b/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
@@ -221,7 +221,7 @@ SharedStorage:
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: 3600
-      DeploymentType: PERSISTENT_1  # PERSISTENT_1 | SCRATCH_1 | SCRATCH_2
+      DeploymentType: PERSISTENT_1  # PERSISTENT_1 | PERSISTENT_2 | SCRATCH_1 | SCRATCH_2
       ImportedFileChunkSize: 1024
       DataCompressionType: LZ4
       ExportPath: s3://bucket/folder

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -145,7 +145,7 @@ SharedStorage:
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: 3600
-      DeploymentType: PERSISTENT_1  # PERSISTENT_1 | SCRATCH_1 | SCRATCH_2
+      DeploymentType: PERSISTENT_1  # PERSISTENT_1 | PERSISTENT_2 | SCRATCH_1 | SCRATCH_2
       ImportedFileChunkSize: 1024
       DataCompressionType: LZ4
       ExportPath: s3://bucket/folder

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -446,8 +446,6 @@ def test_efs_throughput_mode_provisioned_throughput_validator(section_dict, expe
         ({"PerUnitStorageThroughput": 50}, None),
         ({"PerUnitStorageThroughput": 100}, None),
         ({"PerUnitStorageThroughput": 200}, None),
-        ({"PerUnitStorageThroughput": 101}, "Must be one of"),
-        ({"PerUnitStorageThroughput": 1000}, "Must be one of"),
         ({"DailyAutomaticBackupStartTime": ""}, "does not match expected pattern"),
         ({"DailyAutomaticBackupStartTime": "01:00"}, None),
         ({"DailyAutomaticBackupStartTime": "23:00"}, None),

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_1.yaml
@@ -127,7 +127,7 @@ SharedStorage:
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: 3600
-      DeploymentType: PERSISTENT_1  # PERSISTENT_1 | SCRATCH_1 | SCRATCH_2
+      DeploymentType: PERSISTENT_1  # PERSISTENT_1 | PERSISTENT_2 | SCRATCH_1 | SCRATCH_2
       ImportedFileChunkSize: 1024
       ExportPath: String  # s3://bucket/folder
       ImportPath: String  # s3://bucket

--- a/cli/tests/pcluster/validators/test_fsx_validators.py
+++ b/cli/tests/pcluster/validators/test_fsx_validators.py
@@ -93,19 +93,20 @@ def test_fsx_s3_validator(import_path, imported_file_chunk_size, export_path, au
             "SCRATCH_2",
             "9e8a129be-0e46-459d-865b-3a5bf974a22k",
             None,
-            "KMS key id can only be used when deployment type is `PERSISTENT_1'",
+            "KMS key id can only be used when deployment type is one of ['PERSISTENT_1', 'PERSISTENT_2'].",
         ),
         (
             "SCRATCH_1",
             None,
             200,
-            "Per unit storage throughput can only be used when deployment type is `PERSISTENT_1'",
+            "Per unit storage throughput can only be used when deployment type is one of "
+            "['PERSISTENT_1', 'PERSISTENT_2'].",
         ),
         (
             "PERSISTENT_1",
             None,
             None,
-            "Per unit storage throughput must be specified when deployment type is `PERSISTENT_1'",
+            "Per unit storage throughput must be specified when deployment type is PERSISTENT_1",
         ),
     ],
 )
@@ -127,7 +128,7 @@ def test_fsx_persistent_options_validator(deployment_type, kms_key_id, per_unit_
             None,
             None,
             None,
-            "FSx automatic backup features can be used only with 'PERSISTENT_1' file systems",
+            "FSx automatic backup features can be used only with ['PERSISTENT_1', 'PERSISTENT_2'] file systems.",
         ),
         (
             None,
@@ -231,21 +232,22 @@ def test_fsx_backup_options_validator(
             "SCRATCH_1",
             12,
             "READ",
-            "For HDD filesystems, deployment type must be 'PERSISTENT_1'",
+            "For HDD file systems, deployment type must be PERSISTENT_1.",
         ),
         (
             "HDD",
             "PERSISTENT_1",
             50,
             "READ",
-            r"For HDD filesystems, per unit storage throughput can only have the following values: \[12, 40\]",
+            r"For HDD file systems, per unit storage throughput can only have the following values: \[12, 40\]",
         ),
         (
             "SSD",
             "PERSISTENT_1",
             12,
             None,
-            r"For SSD filesystems, per unit storage throughput can only have the following values: \[50, 100, 200\]",
+            "For PERSISTENT_1 SSD file systems, per unit storage throughput can only have the following values:"
+            r" \[50, 100, 200\].",
         ),
         (
             "SSD",
@@ -259,7 +261,7 @@ def test_fsx_backup_options_validator(
             "PERSISTENT_1",
             50,
             "READ",
-            "Drive cache type features can be used only with HDD filesystems",
+            "Drive cache type features can be used only with HDD file systems",
         ),
     ],
 )
@@ -286,7 +288,7 @@ def test_fsx_storage_type_options_validator(
             None,
             None,
             None,
-            "Capacity for FSx SCRATCH_1 filesystem is 1,200 GB, 2,400 GB or increments of 3,600 GB",
+            "Capacity for FSx SCRATCH_1 file systems is 1,200 GB, 2,400 GB or increments of 3,600 GB",
         ),
         (
             3600,
@@ -295,7 +297,7 @@ def test_fsx_storage_type_options_validator(
             None,
             None,
             None,
-            "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+            "Capacity for FSx SCRATCH_2 file systems is 1,200 GB or increments of 2,400 GB",
         ),
         (
             3600,
@@ -304,7 +306,7 @@ def test_fsx_storage_type_options_validator(
             50,
             None,
             None,
-            "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+            "Capacity for FSx PERSISTENT_1 file systems is 1,200 GB or increments of 2,400 GB",
         ),
         (
             3601,
@@ -313,7 +315,7 @@ def test_fsx_storage_type_options_validator(
             50,
             None,
             None,
-            "Capacity for FSx SCRATCH_2 and PERSISTENT_1 filesystems is 1,200 GB or increments of 2,400 GB",
+            "Capacity for FSx PERSISTENT_1 file systems is 1,200 GB or increments of 2,400 GB",
         ),
         (
             None,

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -48,9 +48,9 @@ MAX_MINUTES_TO_WAIT_FOR_BACKUP_COMPLETION = 7
         ("PERSISTENT_1", 200, "NEW_CHANGED", None, None, 1200, 1024, None),
         ("SCRATCH_1", None, "NEW", None, None, 1200, 1024, "LZ4"),
         ("SCRATCH_2", None, "NEW_CHANGED_DELETED", None, None, 1200, 1024, "LZ4"),
-        ("PERSISTENT_1", 200, None, "SSD", None, 1200, 2048, "LZ4"),
         ("PERSISTENT_1", 40, None, "HDD", None, 1800, 512, "LZ4"),
         ("PERSISTENT_1", 12, None, "HDD", "READ", 6000, 1024, "LZ4"),
+        ("PERSISTENT_2", 250, None, "SSD", None, 1200, 2048, "LZ4"),
     ],
 )
 @pytest.mark.usefixtures("os", "instance", "scheduler")

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
@@ -6,10 +6,12 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  {% if bucket_name %}
   Iam:
     S3Access:
       - BucketName: {{ bucket_name }}
         EnableWriteAccess: False
+  {% endif %}
   Imds:
     Secured: {{ imds_secured }}
 Scheduling:
@@ -36,9 +38,11 @@ SharedStorage:
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: {{ storage_capacity }}
+      {% if bucket_name %}
       ImportedFileChunkSize: {{ imported_file_chunk_size }}
       ImportPath: s3://{{ bucket_name }}
       ExportPath: s3://{{ bucket_name }}/export_dir
+      {% endif %}
       WeeklyMaintenanceStartTime: "{{ weekly_maintenance_start_time }}"
       DeploymentType: {{ deployment_type }}
       {% if per_unit_storage_throughput %}


### PR DESCRIPTION
See commit descriptions for details

The valid throughput of persistent 2: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-fsx-filesystem-lustreconfiguration.html#cfn-fsx-filesystem-lustreconfiguration-perunitstoragethroughput

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
