### PR TITLE
Add validation of DirectoryService/AdditionalSssdConfigs: emitting a failure when the customer is overriding protected properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ x.x.x
 **ENHANCEMENTS**
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File Systems.
+- Add validation for `DirectoryService/AdditionalSssdConfigs` to fail in case of invalid overrides.
 
 **CHANGES**
 - Remove support for Python 3.6.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -90,6 +90,7 @@ from pcluster.validators.cluster_validators import (
     SharedStorageNameValidator,
 )
 from pcluster.validators.directory_service_validators import (
+    AdditionalSssdConfigsValidator,
     DomainAddrValidator,
     DomainNameValidator,
     LdapTlsReqCertValidator,
@@ -719,6 +720,12 @@ class DirectoryService(Resource):
             )
         if self.ldap_tls_req_cert:
             self._register_validator(LdapTlsReqCertValidator, ldap_tls_reqcert=self.ldap_tls_req_cert)
+        if self.additional_sssd_configs:
+            self._register_validator(
+                AdditionalSssdConfigsValidator,
+                additional_sssd_configs=self.additional_sssd_configs,
+                ldap_access_filter=self.ldap_access_filter,
+            )
 
 
 class ClusterIam(Resource):

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -166,3 +166,6 @@ NODE_BOOTSTRAP_TIMEOUT = 1800
 
 SCHEDULER_PLUGIN_INTERFACE_VERSION = packaging.version.Version("1.0")
 SCHEDULER_PLUGIN_INTERFACE_VERSION_LOW_RANGE = packaging.version.Version("1.0")
+
+# DirectoryService
+DIRECTORY_SERVICE_RESERVED_SETTINGS = {"id_provider": "ldap"}

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -746,6 +746,8 @@ def test_ad_integration(
     _run_user_workloads(users, test_datadir, remote_command_executor)
     logging.info("Testing pcluster update and generate ssh keys for user")
     _check_ssh_key_generation(users[0], remote_command_executor, scheduler_commands, False)
+
+    # Verify access control with ldap access provider.
     updated_config_file = pcluster_config_reader(
         config_file="pcluster.config.update.yaml", benchmarks=benchmarks, **config_params
     )
@@ -759,6 +761,23 @@ def test_ad_integration(
     for user in users:
         logging.info(f"Checking SSH access for user {user.alias}")
         _check_ssh_auth(user=user, expect_success=user.alias != "PclusterUser2")
+
+    # Verify access control with simple access provider.
+    # With this test we also verify that AdditionalSssdConfigs is working properly.
+    updated_config_file = pcluster_config_reader(
+        config_file="pcluster.config.update2.yaml", benchmarks=benchmarks, **config_params
+    )
+    cluster.update(str(updated_config_file), force_update="true")
+    # Reset stateful connection variables after the cluster update
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+    for user in users:
+        user.reset_stateful_connection_objects(remote_command_executor, scheduler_commands_factory)
+    _check_ssh_key_generation(users[1], remote_command_executor, scheduler_commands, True)
+    for user in users:
+        logging.info(f"Checking SSH access for user {user.alias}")
+        _check_ssh_auth(user=user, expect_success=user.alias != "PclusterUser0")
+
     run_system_analyzer(cluster, scheduler_commands_factory, request)
     run_benchmarks(users[0].remote_command_executor(), users[0].scheduler_commands(), diretory_type=directory_type)
 

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
@@ -1,0 +1,54 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ head_node_instance_type }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: compute
+      ComputeResources:
+        - Name: cit
+          InstanceType: {{ compute_instance_type }}
+          MinCount: 2
+          MaxCount: 150
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+Monitoring:
+  Logs:
+    CloudWatch:
+      Enabled: true
+      RetentionInDays: 14
+SharedStorage:
+  - MountDir: /shared
+    Name: fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 2400
+  - MountDir: /ebs
+    Name: ebs
+    StorageType: Ebs
+  - MountDir: /efs
+    Name: efs
+    StorageType: Efs
+DirectoryService:
+  DomainName: {{ ldap_search_base }}
+  DomainAddr: {{ ldap_uri }}
+  PasswordSecretArn: {{ password_secret_arn }}
+  DomainReadOnlyUser: {{ ldap_default_bind_dn }}
+  LdapTlsCaCert: {{ ldap_tls_ca_cert }}
+  LdapTlsReqCert: {{ ldap_tls_req_cert }}
+  GenerateSshKeysForUsers: true
+  AdditionalSssdConfigs:
+    debug_level: "0x1ff"
+    {% if directory_protocol == "ldap" %}
+    ldap_auth_disable_tls_never_use_in_production: True
+    {% endif %}
+    access_provider: simple
+    simple_deny_users: PclusterUser0


### PR DESCRIPTION
### Description of changes
1. Added a validator for `DirectoryService/AdditionalSssdConfigs` that fails when additional properties overrides protected properties with unacceptable values. In particular the validation must fail in the following cases:
  1. `id_provider != ldap`
  2. `access_provider != ldap` when a `DirectoryService/LdapAccessFilter` is specified 

Notice that we decided to not validate the property `ldap_schema` in order to provide customer with highest flexibility in case of on-prem customizations.

### Tests
1. Manually tested cluster creation and update triggering some critical configurations leveraging AdditionalSssdConfigs (e.g. switching from LdapAccessFilter to a simple access filter)
4. Integ test (SimpleAD/MsAD with LDAPS) locally launched
5. [ONGOING] Build&Test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
