### PR TITLE
[develop] Fix default for disable test and validate components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ x.x.x
 **BUG FIXES**
 - Fix build-image stack in `DELETE_FAILED` after image built successful, due to new EC2ImageBuilder policies.
 - Fix the configuration parameter `DirectoryService/DomainAddr` conversion to `ldap_uri` SSSD property when it contains multiples domain addresses.
+- Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.
 
 3.1.2
 ------

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -496,8 +496,8 @@ class ImageBuilderCdkStack(Stack):
 
         disable_validate_and_test_component = (
             self.config.dev_settings.disable_validate_and_test
-            if self.config.dev_settings and self.config.dev_settings.disable_validate_and_test
-            else False
+            if self.config.dev_settings and isinstance(self.config.dev_settings.disable_validate_and_test, bool)
+            else True
         )
         if not disable_pcluster_component and not disable_validate_and_test_component:
             validate_component_resource = imagebuilder.CfnComponent(

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -1246,6 +1246,449 @@ def test_imagebuilder_instance_role(
                                         },
                                     },
                                     {
+                                        "Action": "imagebuilder:DeleteImageRecipe",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":imagebuilder:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":image-recipe/parallelclusterimage-my-image/*",
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "imagebuilder:DeleteDistributionConfiguration",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":imagebuilder:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":distribution-configuration/parallelclusterimage-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": [
+                                            "imagebuilder:DeleteImage",
+                                            "imagebuilder:GetImage",
+                                            "imagebuilder:CancelImageCreation",
+                                        ],
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":imagebuilder:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":image/parallelclusterimage-my-image/*",
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "cloudformation:DeleteStack",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":cloudformation:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":stack/My-Image/",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "ec2:CreateTags",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":ec2:",
+                                                    {"Ref": "AWS::Region"},
+                                                    "::image/*",
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "tag:TagResources",
+                                        "Effect": "Allow",
+                                        "Resource": "*",
+                                    },
+                                    {
+                                        "Action": ["iam:DetachRolePolicy", "iam:DeleteRole", "iam:DeleteRolePolicy"],
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":iam::",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":role/parallelcluster/" "ParallelClusterImageCleanup-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": ["lambda:DeleteFunction", "lambda:RemovePermission"],
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":lambda:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":function:ParallelClusterImage-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "logs:DeleteLogGroup",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":logs:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":log-group:/aws/lambda/ParallelClusterImage-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                    ":*",
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "iam:RemoveRoleFromInstanceProfile",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":iam::",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":instance-profile/parallelcluster/ParallelClusterImage-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": ["iam:DetachRolePolicy", "iam:DeleteRolePolicy"],
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":iam::",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":role/parallelcluster/ParallelClusterImage-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": [
+                                            "SNS:GetTopicAttributes",
+                                            "SNS:DeleteTopic",
+                                            "SNS:Unsubscribe",
+                                        ],
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":sns:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":ParallelClusterImage-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                ],
+                                "Version": "2012-10-17",
+                            },
+                            "PolicyName": "LambdaCleanupPolicy",
+                        }
+                    ],
+                    "Tags": [
+                        {
+                            "Key": "parallelcluster:image_id",
+                            "Value": "My-Image",
+                        },
+                        {
+                            "Key": "parallelcluster:image_name",
+                            "Value": "My-Image",
+                        },
+                    ],
+                },
+            },
+            {"Fn::GetAtt": ["DeleteStackFunctionExecutionRole", "Arn"]},
+        ),
+        (
+            {
+                "imagebuilder": {
+                    "build": {
+                        "parent_image": "ami-0185634c5a8a37250",
+                        "instance_type": "c5.xlarge",
+                        "components": [
+                            {"type": "script", "value": "s3://test/post_install.sh"},
+                            {"type": "script", "value": "s3://test/post_install2.sh"},
+                        ],
+                        "update_os_packages": {"enabled": True},
+                    },
+                    "dev_settings": {
+                        "disable_validate_and_test": False,
+                    },
+                }
+            },
+            {
+                "Architecture": "x86_64",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "VolumeSize": 50,
+                        },
+                    }
+                ],
+            },
+            {
+                "Type": "AWS::IAM::Role",
+                "Properties": {
+                    "RoleName": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                "ParallelClusterImageCleanup-",
+                                {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                            ],
+                        ]
+                    },
+                    "AssumeRolePolicyDocument": {
+                        "Statement": [
+                            {
+                                "Action": "sts:AssumeRole",
+                                "Effect": "Allow",
+                                "Principal": {"Service": "lambda.amazonaws.com"},
+                            }
+                        ],
+                        "Version": "2012-10-17",
+                    },
+                    "ManagedPolicyArns": [
+                        {"Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"},
+                    ],
+                    "Path": "/parallelcluster/",
+                    "Policies": [
+                        {
+                            "PolicyDocument": {
+                                "Statement": [
+                                    {
+                                        "Action": "iam:DeleteRole",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":iam::",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":role/parallelcluster/ParallelClusterImage-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "iam:DeleteInstanceProfile",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":iam::",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":instance-profile/parallelcluster/ParallelClusterImage-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "imagebuilder:DeleteInfrastructureConfiguration",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":imagebuilder:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":infrastructure-configuration/parallelclusterimage-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "imagebuilder:DeleteComponent",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":imagebuilder:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":component/parallelclusterimage-updateos-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                    "/*",
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "imagebuilder:DeleteComponent",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":imagebuilder:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":component/parallelclusterimage-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                    "/*",
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "imagebuilder:DeleteComponent",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":imagebuilder:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":component/parallelclusterimage-tag-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                    "/*",
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "imagebuilder:DeleteComponent",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":imagebuilder:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":component/parallelclusterimage-script-0-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                    "/*",
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "Action": "imagebuilder:DeleteComponent",
+                                        "Effect": "Allow",
+                                        "Resource": {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "arn:",
+                                                    {"Ref": "AWS::Partition"},
+                                                    ":imagebuilder:",
+                                                    {"Ref": "AWS::Region"},
+                                                    ":",
+                                                    {"Ref": "AWS::AccountId"},
+                                                    ":component/parallelclusterimage-script-1-",
+                                                    {"Fn::Select": [2, {"Fn::Split": ["/", {"Ref": "AWS::StackId"}]}]},
+                                                    "/*",
+                                                ],
+                                            ]
+                                        },
+                                    },
+                                    {
                                         "Action": "imagebuilder:DeleteComponent",
                                         "Effect": "Allow",
                                         "Resource": {
@@ -1612,8 +2055,6 @@ def test_imagebuilder_lambda_execution_role(
                 {"ComponentArn": {"Ref": "ParallelClusterTagComponent"}},
                 {"ComponentArn": "arn:aws:imagebuilder:us-east-1:aws:component/apache-tomcat-9-linux/1.0.0"},
                 {"ComponentArn": "arn:aws:imagebuilder:us-east-1:aws:component/amazon-cloudwatch-agent-linux/1.0.0"},
-                {"ComponentArn": {"Ref": "ParallelClusterValidateComponent"}},
-                {"ComponentArn": {"Ref": "ParallelClusterTestComponent"}},
             ],
         ),
         (
@@ -1654,8 +2095,6 @@ def test_imagebuilder_lambda_execution_role(
                 {"ComponentArn": {"Ref": "ParallelClusterTagComponent"}},
                 {"ComponentArn": "arn:aws:imagebuilder:us-east-1:aws:component/apache-tomcat-9-linux/1.0.0"},
                 {"ComponentArn": "arn:aws:imagebuilder:us-east-1:aws:component/amazon-cloudwatch-agent-linux/1.0.0"},
-                {"ComponentArn": {"Ref": "ParallelClusterValidateComponent"}},
-                {"ComponentArn": {"Ref": "ParallelClusterTestComponent"}},
             ],
         ),
         (
@@ -1695,8 +2134,6 @@ def test_imagebuilder_lambda_execution_role(
                 {"ComponentArn": "arn:aws:imagebuilder:us-east-1:aws:component/apache-tomcat-9-linux/1.0.0"},
                 {"ComponentArn": {"Ref": "ScriptComponent0"}},
                 {"ComponentArn": {"Ref": "ScriptComponent1"}},
-                {"ComponentArn": {"Ref": "ParallelClusterValidateComponent"}},
-                {"ComponentArn": {"Ref": "ParallelClusterTestComponent"}},
             ],
         ),
         (
@@ -1760,7 +2197,7 @@ def test_imagebuilder_lambda_execution_role(
                         ],
                     },
                     "dev_settings": {
-                        "disable_validate_and_test": True,
+                        "disable_validate_and_test": False,
                     },
                 }
             },
@@ -1780,6 +2217,8 @@ def test_imagebuilder_lambda_execution_role(
                 {"ComponentArn": {"Ref": "ParallelClusterTagComponent"}},
                 {"ComponentArn": "arn:aws:imagebuilder:us-east-1:aws:component/apache-tomcat-9-linux/1.0.0"},
                 {"ComponentArn": "arn:aws:imagebuilder:us-east-1:aws:component/amazon-cloudwatch-agent-linux/1.0.0"},
+                {"ComponentArn": {"Ref": "ParallelClusterValidateComponent"}},
+                {"ComponentArn": {"Ref": "ParallelClusterTestComponent"}},
             ],
         ),
     ],


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Fix default for disable test and validate components when building custom image
The default is DisableValidateAndTest=True, but it wasn't being honored when creating the Cfn template.
Improved unit tests to better cover this case.

### Tests
* Covered by unit tests

### References
* n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
