### PR TITLE
Add validation of DirectoryService/AdditionalSssdConfigs: emitting a failure when the customer is overriding protected properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ CHANGELOG
 - Execute SSH key creation alongside with the creation of HOME directory, i.e.
   during SSH login, when switching to another user and when executing a command as another user.
 - Add support for both FQDN and LDAP Distinguished Names in the configuration parameter `DirectoryService/DomainName`. The new validator now checks both the syntaxes.
-- New `update_directory_service_password.sh` script deployed on the head node supports the manual update of the Active Directory password in the SSSD configuration. 
+- New `update_directory_service_password.sh` script deployed on the head node supports the manual update of the Active Directory password in the SSSD configuration.
   The password is retrieved by the AWS Secrets Manager as from the cluster configuration.
 - Add support to deploy API infrastructure in environments without a default VPC.
+- Add validation for `DirectoryService/AdditionalSssdConfigs` to fail in case of invalid overrides.
 
 **CHANGES**
 - Disable deeper C-States in x86_64 official AMIs and AMIs created through `build-image` command, to guarantee high performance and low latency.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -83,6 +83,7 @@ from pcluster.validators.cluster_validators import (
     SharedStorageNameValidator,
 )
 from pcluster.validators.directory_service_validators import (
+    AdditionalSssdConfigsValidator,
     DomainAddrValidator,
     DomainNameValidator,
     LdapTlsReqCertValidator,
@@ -709,6 +710,12 @@ class DirectoryService(Resource):
             )
         if self.ldap_tls_req_cert:
             self._register_validator(LdapTlsReqCertValidator, ldap_tls_reqcert=self.ldap_tls_req_cert)
+        if self.additional_sssd_configs:
+            self._register_validator(
+                AdditionalSssdConfigsValidator,
+                additional_sssd_configs=self.additional_sssd_configs,
+                ldap_access_filter=self.ldap_access_filter,
+            )
 
 
 class ClusterIam(Resource):

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -156,3 +156,6 @@ SCHEDULER_PLUGIN_MAX_NUMBER_OF_USERS = 10
 # see https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html
 NODEJS_MIN_VERSION = "10.13.0"
 NODEJS_INCOMPATIBLE_VERSION_RANGE = ["13.0.0", "13.6.0"]
+
+# DirectoryService
+DIRECTORY_SERVICE_RESERVED_SETTINGS = {"id_provider": "ldap"}

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
@@ -1,0 +1,54 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ head_node_instance_type }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: compute
+      ComputeResources:
+        - Name: cit
+          InstanceType: {{ compute_instance_type }}
+          MinCount: 2
+          MaxCount: 150
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+Monitoring:
+  Logs:
+    CloudWatch:
+      Enabled: true
+      RetentionInDays: 14
+SharedStorage:
+  - MountDir: /shared
+    Name: fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 2400
+  - MountDir: /ebs
+    Name: ebs
+    StorageType: Ebs
+  - MountDir: /efs
+    Name: efs
+    StorageType: Efs
+DirectoryService:
+  DomainName: {{ ldap_search_base }}
+  DomainAddr: {{ ldap_uri }}
+  PasswordSecretArn: {{ password_secret_arn }}
+  DomainReadOnlyUser: {{ ldap_default_bind_dn }}
+  LdapTlsCaCert: {{ ldap_tls_ca_cert }}
+  LdapTlsReqCert: {{ ldap_tls_req_cert }}
+  GenerateSshKeysForUsers: true
+  AdditionalSssdConfigs:
+    debug_level: "0x1ff"
+    {% if directory_protocol == "ldap" %}
+    ldap_auth_disable_tls_never_use_in_production: True
+    {% endif %}
+    access_provider: simple
+    simple_deny_users: PclusterUser0


### PR DESCRIPTION
**CHERRY-PICKED FROM: https://github.com/aws/aws-parallelcluster/pull/3961**

### Description of changes
1. Added a validator for `DirectoryService/AdditionalSssdConfigs` that fails when additional properties overrides protected properties with unacceptable values. In particular the validation must fail in the following cases:
  1. `id_provider != ldap`
  2. `access_provider != ldap` when a `DirectoryService/LdapAccessFilter` is specified 

Notice that we decided to not validate the property `ldap_schema` in order to provide customer with highest flexibility in case of on-prem customizations.

### Tests
1. The change has been tested in the original PR, btw I will execute a build&test before merging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
