### PR TITLE
 Improve EFS and EBS boto3 calls to reduce pcluster CLI/API running time

### DIFF
--- a/cli/src/pcluster/api/flask_app.py
+++ b/cli/src/pcluster/api/flask_app.py
@@ -23,6 +23,7 @@ from pcluster.api.errors import (
     exception_message,
 )
 from pcluster.api.util import assert_valid_node_js
+from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError, Cache
 
 LOGGER = logging.getLogger(__name__)
@@ -94,6 +95,7 @@ class ParallelClusterFlaskApp:
         def _clear_cache():
             # Cache is meant to be reused only within a single request
             Cache.clear_all()
+            AWSApi.reset()
 
         @self.flask_app.before_request
         def _log_request():  # pylint: disable=unused-variable

--- a/cli/src/pcluster/aws/aws_api.py
+++ b/cli/src/pcluster/aws/aws_api.py
@@ -160,3 +160,8 @@ class AWSApi:
         if not AWSApi._instance or AWSApi._instance.aws_region != os.environ.get("AWS_DEFAULT_REGION"):
             AWSApi._instance = AWSApi()
         return AWSApi._instance
+
+    @staticmethod
+    def reset():
+        """Reset the instance to clear all caches."""
+        AWSApi._instance = None

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -257,6 +257,21 @@ class FsxFileSystemInfo:
         """Return DNSName of the filesystem."""
         return self.file_system_data.get("DNSName")
 
+    @property
+    def file_system_id(self):
+        """Return id of the file system."""
+        return self.file_system_data.get("FileSystemId")
+
+    @property
+    def vpc_id(self):
+        """Return VPC id of the file system."""
+        return self.file_system_data.get("VpcId")
+
+    @property
+    def network_interface_ids(self):
+        """Return network interface ids of the file system."""
+        return self.file_system_data.get("NetworkInterfaceIds")
+
 
 class ImageInfo:
     """Object to store Ec2 Image information, initialized with the describe_image or describe_images in ec2 client."""

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -34,6 +34,8 @@ class Ec2Client(Boto3Client):
     def __init__(self):
         super().__init__("ec2")
         self.additional_instance_types_data = {}
+        self.security_groups_cache = {}
+        self.subnets_cache = {}
 
     @AWSExceptionHandler.handle_client_exception
     @Cache.cached
@@ -67,7 +69,20 @@ class Ec2Client(Boto3Client):
     @AWSExceptionHandler.handle_client_exception
     def describe_subnets(self, subnet_ids):
         """Return a list of subnets."""
-        return list(self._paginate_results(self._client.describe_subnets, SubnetIds=subnet_ids))
+        result = []
+        missed_subnets = []
+        for subnet_id in subnet_ids:
+            cached_data = self.subnets_cache.get(subnet_id)
+            if cached_data:
+                result.append(cached_data)
+            else:
+                missed_subnets.append(subnet_id)
+        if missed_subnets:
+            response = list(self._paginate_results(self._client.describe_subnets, SubnetIds=missed_subnets))
+            for subnet in response:
+                self.subnets_cache[subnet.get("SubnetId")] = subnet
+                result.append(subnet)
+        return result
 
     @AWSExceptionHandler.handle_client_exception
     @Cache.cached
@@ -381,18 +396,33 @@ class Ec2Client(Boto3Client):
     @AWSExceptionHandler.handle_client_exception
     def describe_security_group(self, security_group_id):
         """Describe a single security group."""
-        return self.describe_security_groups([security_group_id]).get("SecurityGroups")[0]
+        return self.describe_security_groups([security_group_id])[0]
 
     @AWSExceptionHandler.handle_client_exception
     def describe_security_groups(self, security_group_ids):
-        """Describe a single security group."""
-        return self._client.describe_security_groups(GroupIds=security_group_ids)
+        """Describe security groups."""
+        result = []
+        missed_security_group_ids = []
+        for security_group_id in security_group_ids:
+            cached_data = self.security_groups_cache.get(security_group_id)
+            if cached_data:
+                result.append(cached_data)
+            else:
+                missed_security_group_ids.append(security_group_id)
+        if missed_security_group_ids:
+            response = list(
+                self._paginate_results(self._client.describe_security_groups, GroupIds=missed_security_group_ids)
+            )
+            for security_group in response:
+                self.security_groups_cache[security_group.get("GroupId")] = security_group
+                result.append(security_group)
+        return result
 
     @AWSExceptionHandler.handle_client_exception
     def describe_network_interfaces(self, network_interface_ids):
         """Describe network interfaces."""
-        return self._client.describe_network_interfaces(NetworkInterfaceIds=network_interface_ids).get(
-            "NetworkInterfaces"
+        return list(
+            self._paginate_results(self._client.describe_network_interfaces, NetworkInterfaceIds=network_interface_ids)
         )
 
     @AWSExceptionHandler.handle_client_exception

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -358,7 +358,7 @@ def _check_in_out_access(security_groups_ids, port, is_cidr_optional):
     in_access = False
     out_access = False
 
-    for sec_group in AWSApi.instance().ec2.describe_security_groups(security_groups_ids).get("SecurityGroups"):
+    for sec_group in AWSApi.instance().ec2.describe_security_groups(security_groups_ids):
 
         # Check all inbound rules
         for rule in sec_group.get("IpPermissions"):
@@ -403,55 +403,75 @@ def _check_sg_rules_for_port(rule, port_to_check):
     return False
 
 
-class FsxNetworkingValidator(Validator):
+class ExistingFsxNetworkingValidator(Validator):
     """
     FSx networking validator.
 
     Validate file system mount point according to the head node subnet.
     """
 
-    def _validate(self, file_system_id, head_node_subnet_id, are_all_security_groups_customized):
+    def _describe_network_interfaces(self, file_systems):
+        all_network_interfaces = []
+        for file_system in file_systems:
+            all_network_interfaces.extend(file_system.network_interface_ids)
+        if all_network_interfaces:
+            response = AWSApi.instance().ec2.describe_network_interfaces(all_network_interfaces)
+            network_interfaces_data = {}
+            for network_interface in response:
+                network_interfaces_data[network_interface["NetworkInterfaceId"]] = network_interface
+            return network_interfaces_data
+        else:
+            return {}
+
+    def _validate(self, file_system_ids, head_node_subnet_id, are_all_security_groups_customized):
         try:
 
             # Check to see if there is any existing mt on the fs
-            file_system = AWSApi.instance().fsx.get_filesystem_info(file_system_id).file_system_data
+            file_systems = AWSApi.instance().fsx.get_file_systems_info(file_system_ids)
 
             vpc_id = AWSApi.instance().ec2.get_subnet_vpc(head_node_subnet_id)
 
-            # Check to see if fs is in the same VPC as the stack
-            if file_system.get("VpcId") != vpc_id:
-                self._add_failure(
-                    "Currently only support using FSx file system that is in the same VPC as the cluster. "
-                    "The file system provided is in {0}.".format(file_system.get("VpcId")),
-                    FailureLevel.ERROR,
-                )
+            network_interfaces_data = self._describe_network_interfaces(file_systems)
 
-            # If there is an existing mt in the az, need to check the inbound and outbound rules of the security groups
-            network_interface_ids = file_system.get("NetworkInterfaceIds")
-            if not network_interface_ids:
-                self._add_failure(
-                    "Unable to validate FSx security groups. The given FSx file system '{0}' doesn't have "
-                    "Elastic Network Interfaces attached to it.".format(file_system_id),
-                    FailureLevel.ERROR,
-                )
-            else:
-                network_interface_responses = AWSApi.instance().ec2.describe_network_interfaces(network_interface_ids)
-
-                fs_access = False
-                network_interfaces = [ni for ni in network_interface_responses if ni.get("VpcId") == vpc_id]
-                for network_interface in network_interfaces:
-                    # Get list of security group IDs
-                    sg_ids = [sg.get("GroupId") for sg in network_interface.get("Groups")]
-                    if _check_in_out_access(sg_ids, port=988, is_cidr_optional=are_all_security_groups_customized):
-                        fs_access = True
-                        break
-                if not fs_access:
+            # Check file systems
+            for file_system in file_systems:
+                # Check to see if fs is in the same VPC as the stack
+                file_system_id = file_system.file_system_id
+                if file_system.vpc_id != vpc_id:
                     self._add_failure(
-                        "The current security group settings on file system '{0}' does not satisfy mounting requirement"
-                        ". The file system must be associated to a security group that allows inbound and outbound "
-                        "TCP traffic through port 988.".format(file_system_id),
+                        "Currently only support using FSx file system that is in the same VPC as the cluster. "
+                        "The file system provided is in {0}.".format(file_system.vpc_id),
                         FailureLevel.ERROR,
                     )
+
+                # If there is an existing mt in the az, check the inbound and outbound rules of the security groups
+                network_interface_ids = file_system.network_interface_ids
+                if not network_interface_ids:
+                    self._add_failure(
+                        f"Unable to validate FSx security groups. The given FSx file system '{file_system_id}'"
+                        " doesn't have Elastic Network Interfaces attached to it.",
+                        FailureLevel.ERROR,
+                    )
+                else:
+                    network_interface_responses = []
+                    for network_interface_id in network_interface_ids:
+                        network_interface_responses.append(network_interfaces_data[network_interface_id])
+
+                    fs_access = False
+                    network_interfaces = [ni for ni in network_interface_responses if ni.get("VpcId") == vpc_id]
+                    for network_interface in network_interfaces:
+                        # Get list of security group IDs
+                        sg_ids = [sg.get("GroupId") for sg in network_interface.get("Groups")]
+                        if _check_in_out_access(sg_ids, port=988, is_cidr_optional=are_all_security_groups_customized):
+                            fs_access = True
+                            break
+                    if not fs_access:
+                        self._add_failure(
+                            f"The current security group settings on file system '{file_system_id}' does not satisfy "
+                            "mounting requirement. The file system must be associated to a security group that allows "
+                            "inbound and outbound TCP traffic through port 988.",
+                            FailureLevel.ERROR,
+                        )
         except AWSClientError as e:
             self._add_failure(str(e), FailureLevel.ERROR)
 
@@ -567,22 +587,22 @@ class EfsIdValidator(Validator):  # TODO add tests
     Validate if there are existing mount target in the head node availability zone
     """
 
-    def _validate(self, efs_id, head_node_avail_zone: str, are_all_security_groups_customized):
-        # Get head node availability zone
-        head_node_target_id = AWSApi.instance().efs.get_efs_mount_target_id(efs_id, head_node_avail_zone)
-        # If there is an existing mt in the az, need to check the inbound and outbound rules of the security groups
-        if head_node_target_id:
-            # Get list of security group IDs of the mount target
-            sg_ids = AWSApi.instance().efs.get_efs_mount_target_security_groups(head_node_target_id)
-            if not _check_in_out_access(sg_ids, port=2049, is_cidr_optional=are_all_security_groups_customized):
-                self._add_failure(
-                    "There is an existing Mount Target {0} in the Availability Zone {1} for EFS {2}, "
-                    "but it does not have a security group that allows inbound and outbound rules to support NFS. "
-                    "Please modify the Mount Target's security group, to allow traffic on port 2049.".format(
-                        head_node_target_id, head_node_avail_zone, efs_id
-                    ),
-                    FailureLevel.ERROR,
-                )
+    def _validate(self, efs_id, avail_zones: set, are_all_security_groups_customized):
+        for avail_zone in avail_zones:
+            head_node_target_id = AWSApi.instance().efs.get_efs_mount_target_id(efs_id, avail_zone)
+            # If there is an existing mt in the az, need to check the inbound and outbound rules of the security groups
+            if head_node_target_id:
+                # Get list of security group IDs of the mount target
+                sg_ids = AWSApi.instance().efs.get_efs_mount_target_security_groups(head_node_target_id)
+                if not _check_in_out_access(sg_ids, port=2049, is_cidr_optional=are_all_security_groups_customized):
+                    self._add_failure(
+                        "There is an existing Mount Target {0} in the Availability Zone {1} for EFS {2}, "
+                        "but it does not have a security group that allows inbound and outbound rules to support NFS. "
+                        "Please modify the Mount Target's security group, to allow traffic on port 2049.".format(
+                            head_node_target_id, avail_zone, efs_id
+                        ),
+                        FailureLevel.ERROR,
+                    )
 
 
 class SharedStorageNameValidator(Validator):

--- a/cli/tests/pcluster/aws/test_fsx.py
+++ b/cli/tests/pcluster/aws/test_fsx.py
@@ -1,0 +1,60 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.aws.aws_api import AWSApi
+from tests.utils import MockedBoto3Request
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    return "pcluster.aws.common.boto3"
+
+
+def get_describe_file_systems_mocked_request(fsxs, lifecycle):
+    return MockedBoto3Request(
+        method="describe_file_systems",
+        response={"FileSystems": [{"FileSystemId": fsx, "Lifecycle": lifecycle} for fsx in fsxs]},
+        expected_params={"FileSystemIds": fsxs},
+    )
+
+
+def test_get_file_systems_info(boto3_stubber):
+    fsx = "fs-12345678"
+    additional_fsx = "fs-23456789"
+    # The first mocked request and the third are about the same fsx. However, the lifecycle of the fsx changes
+    # from CREATING to AVAILABLE. The second mocked request is about another fsx
+    mocked_requests = [
+        get_describe_file_systems_mocked_request([fsx], "CREATING"),
+        get_describe_file_systems_mocked_request([additional_fsx], "CREATING"),
+        get_describe_file_systems_mocked_request([fsx], "AVAILABLE"),
+    ]
+    boto3_stubber("fsx", mocked_requests)
+    assert_that(AWSApi.instance().fsx.get_file_systems_info([fsx])[0].file_system_data["Lifecycle"]).is_equal_to(
+        "CREATING"
+    )
+
+    # Second boto3 call with more fsxs. The fsx already cached should not be included in the boto3 call.
+    response = AWSApi.instance().fsx.get_file_systems_info([fsx, additional_fsx])
+    assert_that(response).is_length(2)
+
+    # Third boto3 call. The result should be from cache even if the lifecycle of the fsx is different
+    assert_that(AWSApi.instance().fsx.get_file_systems_info([fsx])[0].file_system_data["Lifecycle"]).is_equal_to(
+        "CREATING"
+    )
+
+    # Fourth boto3 call after resetting the AWSApi instance. The latest fsx lifecycle should be retrieved from boto3
+    AWSApi.reset()
+    assert_that(AWSApi.instance().fsx.get_file_systems_info([fsx])[0].file_system_data["Lifecycle"]).is_equal_to(
+        "AVAILABLE"
+    )

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -28,8 +28,8 @@ from pcluster.validators.cluster_validators import (
     EfaPlacementGroupValidator,
     EfaSecurityGroupValidator,
     EfaValidator,
+    ExistingFsxNetworkingValidator,
     FsxArchitectureOsValidator,
-    FsxNetworkingValidator,
     HeadNodeImdsValidator,
     HostedZoneValidator,
     InstanceArchitectureCompatibilityValidator,
@@ -701,8 +701,8 @@ def test_fsx_network_validator(
 
     boto3_stubber("ec2", ec2_mocked_requests)
 
-    actual_failures = FsxNetworkingValidator().execute(
-        "fs-0ff8da96d57f3b4e3", "subnet-12345678", are_all_security_groups_customized
+    actual_failures = ExistingFsxNetworkingValidator().execute(
+        ["fs-0ff8da96d57f3b4e3"], "subnet-12345678", are_all_security_groups_customized
     )
     assert_failure_messages(actual_failures, expected_message)
 


### PR DESCRIPTION
Using "Hide Whitespace" to review this PR is helpful

1. Expand EFS mount targets validator to check both head subnet and compute subnets availability zones. Previously, only head node subnet is checked.

2. Add custom caching for boto3 calls that take lists as arguments. The standard @Cache utility is not compatible with functions with lists arguments

3. Collapse some FSx validators to make single calls for multiple file systems

4. There are no good EFS boto3 calls to do similar collapse as FSx

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
* all tests in configs/pcluster3.yaml have been passed

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
