### PR TITLE
[release-2.11] Increase sts credentials duration to 4h

### DIFF
--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -339,7 +339,10 @@ def _retrieve_sts_credential(credential_endpoint, credential_arn, credential_ext
 
     sts = boto3.client("sts", region_name=endpoint_region, endpoint_url=credential_endpoint)
     assumed_role_object = sts.assume_role(
-        RoleArn=credential_arn, ExternalId=credential_external_id, RoleSessionName=region + "_integration_tests_session"
+        RoleArn=credential_arn,
+        ExternalId=credential_external_id,
+        RoleSessionName=region + "_integration_tests_session",
+        DurationSeconds=14400,
     )
     aws_credentials = assumed_role_object["Credentials"]
 


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Increase sts credentials duration from 1h to 4h. This is needed to avoid credentials to expire while executing long running tests

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
