### PR TITLE
[ad integration] Fix integration tests: using the correct variable for head node instance type and setting max count equal to the first update.

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: {{ head_node_instance_type }}
+  InstanceType: {{ instance }}
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:
@@ -16,7 +16,7 @@ Scheduling:
         - Name: cit
           InstanceType: {{ compute_instance_type }}
           MinCount: 2
-          MaxCount: 150
+          MaxCount: 3000
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}


### PR DESCRIPTION
### Description of changes
Fix integration tests: using the correct variable for head node instance type and setting max count equal to the first update.
The correct variable for head node instance type is `instance`: the bug was introduced by a recent cherry-pick from develop, where the variable has different name.
The correct value for max compute count is `3000`, which may seem pretty high, but it must be aligned to the first update.

### Tests
1. Launched test locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
