### PR TITLE
[develop] new QueueUpdateStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ x.x.x
 ------
 
 **ENHANCEMENTS**
+- Add new configuration parameter `Scheduling/SlurmSettings/QueueUpdateStrategy` to allow cluster update when
+  `SlurmQueues` configuration changes don't impact Slurm scheduler configuration.
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File Systems.
 - Add support for FSx Lustre Persistent_2 deployment type.

--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -55,6 +55,7 @@ from pcluster.api.models import (
 from pcluster.api.util import assert_valid_node_js
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import StackNotFoundError
+from pcluster.config.config_patch import ConfigPatch
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.models.cluster import (
     Cluster,
@@ -420,7 +421,7 @@ def _analyze_changes(changes):
     key_indexes = {key: index for index, key in enumerate(changes[0])}
 
     for row in changes[1:]:
-        parameter = _get_yaml_path(row[key_indexes["param_path"]], row[key_indexes["parameter"]])
+        parameter = ConfigPatch.build_config_param_path(row[key_indexes["param_path"]], row[key_indexes["parameter"]])
         new_value = row[key_indexes["new value"]]
         old_value = row[key_indexes["old value"]]
         check_result = row[key_indexes["check"]]
@@ -440,16 +441,3 @@ def _create_message(failure_reason, action_needed):
     if action_needed:
         message = f"{message}. {action_needed}" if message else action_needed
     return message or "Error during update"
-
-
-def _get_yaml_path(path, parameter):
-    """Compose the parameter path following the YAML Path standard.
-
-    Standard: https://github.com/wwkimball/yamlpath/wiki/Segments-of-a-YAML-Path#yaml-path-standard
-    """
-    yaml_path = []
-    if path:
-        yaml_path.extend(path)
-    if parameter:
-        yaml_path.append(parameter)
-    return ".".join(yaml_path)

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1682,10 +1682,20 @@ class Dns(Resource):
 class SlurmSettings(Resource):
     """Represent the Slurm settings."""
 
-    def __init__(self, scaledown_idletime: int = None, dns: Dns = None, **kwargs):
+    def __init__(self, scaledown_idletime: int = None, dns: Dns = None, queue_update_strategy: str = None, **kwargs):
         super().__init__()
         self.scaledown_idletime = Resource.init_param(scaledown_idletime, default=10)
         self.dns = dns or Dns(implied=True)
+        self.queue_update_strategy = Resource.init_param(
+            queue_update_strategy, default=QueueUpdateStrategy.COMPUTE_FLEET_STOP.value
+        )
+
+
+class QueueUpdateStrategy(Enum):
+    """Enum to identify the update strategy supported by the queue."""
+
+    DRAIN = "DRAIN"
+    COMPUTE_FLEET_STOP = "COMPUTE_FLEET_STOP"
 
 
 class SlurmScheduling(Resource):

--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -191,7 +191,6 @@ class ConfigPatch:
         # Then, compare all non visited base sections vs target config.
         for base_nested_section in base_section.get(data_key, []):
             if not base_nested_section.get("visited", False):
-                update_key_value = base_nested_section.get(update_key)
                 self.changes.append(
                     Change(
                         param_path,

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -26,12 +26,14 @@ class UpdatePolicy:
     def __init__(
         self,
         base_policy=None,
+        name=None,
         level=None,
         fail_reason=None,
         action_needed=None,
         condition_checker=None,
         print_succeeded=True,
     ):
+        self.name = None
         self.fail_reason = None
         self.action_needed = None
         self.condition_checker = None
@@ -39,11 +41,14 @@ class UpdatePolicy:
         self.level = 0
 
         if base_policy:
+            self.name = base_policy.name
             self.fail_reason = base_policy.fail_reason
             self.action_needed = base_policy.action_needed
             self.condition_checker = base_policy.condition_checker
             self.level = base_policy.level
 
+        if name:
+            self.name = name
         if level:
             self.level = level
         if fail_reason:
@@ -122,6 +127,7 @@ UpdatePolicy.ACTIONS_NEEDED = {
 
 # Update is ignored
 UpdatePolicy.IGNORED = UpdatePolicy(
+    name="IGNORED",
     level=-10,
     fail_reason="-",
     condition_checker=(lambda change, patch: True),
@@ -130,10 +136,13 @@ UpdatePolicy.IGNORED = UpdatePolicy(
 )
 
 # Update supported
-UpdatePolicy.SUPPORTED = UpdatePolicy(level=0, fail_reason="-", condition_checker=(lambda change, patch: True))
+UpdatePolicy.SUPPORTED = UpdatePolicy(
+    name="SUPPORTED", level=0, fail_reason="-", condition_checker=(lambda change, patch: True)
+)
 
 # Checks resize of max_vcpus in Batch Compute Environment
 UpdatePolicy.AWSBATCH_CE_MAX_RESIZE = UpdatePolicy(
+    name="AWSBATCH_CE_MAX_RESIZE",
     level=1,
     fail_reason=lambda change, patch: "Max vCPUs can not be lower than the current Desired vCPUs ({0})".format(
         patch.cluster.get_running_capacity()
@@ -145,6 +154,7 @@ UpdatePolicy.AWSBATCH_CE_MAX_RESIZE = UpdatePolicy(
 
 # Checks resize of max_count
 UpdatePolicy.MAX_COUNT = UpdatePolicy(
+    name="MAX_COUNT",
     level=1,
     fail_reason=lambda change, patch: "Shrinking a queue requires the compute fleet to be stopped first",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
@@ -155,6 +165,7 @@ UpdatePolicy.MAX_COUNT = UpdatePolicy(
 
 # Update supported only with all compute nodes down
 UpdatePolicy.COMPUTE_FLEET_STOP = UpdatePolicy(
+    name="COMPUTE_FLEET_STOP",
     level=10,
     fail_reason="All compute nodes must be stopped",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
@@ -163,6 +174,7 @@ UpdatePolicy.COMPUTE_FLEET_STOP = UpdatePolicy(
 
 # Update supported only with head node down
 UpdatePolicy.HEAD_NODE_STOP = UpdatePolicy(
+    name="HEAD_NODE_STOP",
     level=20,
     fail_reason="To perform this update action, the head node must be in a stopped state",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
@@ -173,6 +185,7 @@ UpdatePolicy.HEAD_NODE_STOP = UpdatePolicy(
 # No bucket specified when create, no bucket specified when update: Display no diff, proceed with update
 # For all other cases: Display diff and block, value will not be updated even if forced
 UpdatePolicy.READ_ONLY_RESOURCE_BUCKET = UpdatePolicy(
+    name="READ_ONLY_RESOURCE_BUCKET",
     level=30,
     fail_reason=lambda change, patch: (
         "'{0}' parameter is a read only parameter that cannot be updated. "
@@ -189,6 +202,7 @@ UpdatePolicy.READ_ONLY_RESOURCE_BUCKET = UpdatePolicy(
 # update policy instead of UNKNOWN to pass unit tests.
 #
 UpdatePolicy.UNKNOWN = UpdatePolicy(
+    name="UNKNOWN",
     level=100,
     fail_reason="Update currently not supported",
     action_needed="Restore the previous parameter value for the unsupported changes.",
@@ -196,6 +210,7 @@ UpdatePolicy.UNKNOWN = UpdatePolicy(
 
 # Update not supported
 UpdatePolicy.UNSUPPORTED = UpdatePolicy(
+    name="UNSUPPORTED",
     level=1000,
     fail_reason=lambda change, patch: (f"Update actions are not currently supported for the '{change.key}' parameter"),
     action_needed=lambda change, patch: (

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -120,6 +120,7 @@ PCLUSTER_S3_ARTIFACTS_DICT = {
     "instance_types_data_name": "instance-types-data.json",
     "custom_artifacts_name": "artifacts.zip",
     "scheduler_resources_name": "scheduler_resources.zip",
+    "change_set_name": "change-set.json",
 }
 
 PCLUSTER_TAG_VALUE_REGEX = r"^([\w\+\-\=\.\_\:\@/]{0,256})$"

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1639,7 +1639,7 @@ class SchedulingSchema(BaseSchema):
         metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
     # Slurm schema
-    slurm_settings = fields.Nested(SlurmSettingsSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    slurm_settings = fields.Nested(SlurmSettingsSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
     slurm_queues = fields.Nested(
         SlurmQueueSchema,
         many=True,

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1197,7 +1197,7 @@ class SlurmSettingsSchema(BaseSchema):
     """Represent the schema of the Scheduling Settings."""
 
     scaledown_idletime = fields.Int(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
-    dns = fields.Nested(DnsSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    dns = fields.Nested(DnsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     queue_update_strategy = fields.Str(
         validate=validate.OneOf([strategy.value for strategy in QueueUpdateStrategy]),
         metadata={"update_policy": UpdatePolicy.IGNORED},

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -899,7 +899,10 @@ class ClusterCdkStack(Stack):
                         self.bucket.artifact_directory, PCLUSTER_S3_ARTIFACTS_DICT.get("config_name")
                     ),
                     "cluster_config_version": self.config.config_version,
-                    "instance_types_data_s3_key": f"{self.bucket.artifact_directory}/configs/instance-types-data.json",
+                    "change_set_s3_key": f"{self.bucket.artifact_directory}/configs/"
+                    f"{PCLUSTER_S3_ARTIFACTS_DICT.get('change_set_name')}",
+                    "instance_types_data_s3_key": f"{self.bucket.artifact_directory}/configs/"
+                    f"{PCLUSTER_S3_ARTIFACTS_DICT.get('instance_types_data_name')}",
                     "custom_node_package": self.config.custom_node_package or "",
                     "custom_awsbatchcli_package": self.config.custom_aws_batch_cli_package or "",
                     "head_node_imds_secured": str(self.config.head_node.imds.secured).lower(),

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -400,6 +400,9 @@ def _test_less_target_sections(base_conf, target_conf):
     # add new section + param in the base conf so that it appears as removed in the target conf
     base_conf["Scheduling"].update({"SlurmSettings": {"ScaledownIdletime": 30}})
     base_conf["Scheduling"]["SlurmSettings"].update({"QueueUpdateStrategy": QueueUpdateStrategy.DRAIN.value})
+    base_conf["Scheduling"]["SlurmQueues"][0].update(
+        {"Iam": {"AdditionalIamPolicies": [{"Policy": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"}]}}
+    )
 
     # add new param in the base conf so that it appears as removed in the target conf
     base_conf["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MinCount"] = 1
@@ -439,11 +442,19 @@ def _test_less_target_sections(base_conf, target_conf):
                 is_list=False,
             ),
             Change(
-                ["Scheduling"],
-                "SlurmSettings",
-                {"ScaledownIdletime": 30, "QueueUpdateStrategy": QueueUpdateStrategy.DRAIN.value},
-                "-",
-                UpdatePolicy.SUPPORTED,
+                ["Scheduling", "SlurmSettings"],
+                "QueueUpdateStrategy",
+                QueueUpdateStrategy.DRAIN.value,
+                None,
+                UpdatePolicy.IGNORED,
+                is_list=False,
+            ),
+            Change(
+                ["Scheduling", "SlurmSettings"],
+                "ScaledownIdletime",
+                30,
+                None,
+                UpdatePolicy.COMPUTE_FLEET_STOP,
                 is_list=False,
             ),
             Change(
@@ -452,6 +463,14 @@ def _test_less_target_sections(base_conf, target_conf):
                 1,
                 None,
                 UpdatePolicy.COMPUTE_FLEET_STOP,
+                is_list=False,
+            ),
+            Change(
+                ["Scheduling", "SlurmQueues[queue1]"],
+                "Iam",
+                {"AdditionalIamPolicies": [{"Policy": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"}]},
+                "-",
+                UpdatePolicy.SUPPORTED,
                 is_list=False,
             ),
         ],
@@ -487,6 +506,9 @@ def _test_more_target_sections(base_conf, target_conf):
     target_conf["Scheduling"]["SlurmSettings"].update(
         {"QueueUpdateStrategy": QueueUpdateStrategy.COMPUTE_FLEET_STOP.value}
     )
+    target_conf["Scheduling"]["SlurmQueues"][0].update(
+        {"Iam": {"AdditionalIamPolicies": [{"Policy": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"}]}}
+    )
 
     # add new param in the target conf
     target_conf["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MinCount"] = 1
@@ -520,11 +542,19 @@ def _test_more_target_sections(base_conf, target_conf):
                 is_list=False,
             ),
             Change(
-                ["Scheduling"],
-                "SlurmSettings",
-                "-",
-                {"ScaledownIdletime": 30, "QueueUpdateStrategy": QueueUpdateStrategy.COMPUTE_FLEET_STOP.value},
-                UpdatePolicy.SUPPORTED,
+                ["Scheduling", "SlurmSettings"],
+                "ScaledownIdletime",
+                None,
+                30,
+                UpdatePolicy.COMPUTE_FLEET_STOP,
+                is_list=False,
+            ),
+            Change(
+                ["Scheduling", "SlurmSettings"],
+                "QueueUpdateStrategy",
+                None,
+                QueueUpdateStrategy.COMPUTE_FLEET_STOP.value,
+                UpdatePolicy.IGNORED,
                 is_list=False,
             ),
             Change(
@@ -533,6 +563,14 @@ def _test_more_target_sections(base_conf, target_conf):
                 None,
                 1,
                 UpdatePolicy.COMPUTE_FLEET_STOP,
+                is_list=False,
+            ),
+            Change(
+                ["Scheduling", "SlurmQueues[queue1]"],
+                "Iam",
+                "-",
+                {"AdditionalIamPolicies": [{"Policy": "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"}]},
+                UpdatePolicy.SUPPORTED,
                 is_list=False,
             ),
         ],

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -314,6 +314,7 @@ def _test_less_target_sections(base_conf, target_conf):
                 None,
                 UpdatePolicy(
                     UpdatePolicy.UNSUPPORTED,
+                    name="UNSUPPORTED",
                     fail_reason=(
                         "Shared Storage cannot be added or removed during a 'pcluster update-cluster' operation"
                     ),

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -14,6 +14,7 @@ import shutil
 import pytest
 from assertpy import assert_that
 
+from pcluster.config.cluster_config import QueueUpdateStrategy
 from pcluster.config.config_patch import Change, ConfigPatch
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.schemas.cluster_schema import ClusterSchema
@@ -57,12 +58,12 @@ def _compare_changes(changes, expected_changes):
     def _compare_change(source, target):
         is_old_value_equal = (
             source.old_value["Name"] == target.old_value["Name"]
-            if isinstance(source.old_value, dict)
+            if isinstance(source.old_value, dict) and "Name" in source.old_value
             else source.old_value == target.old_value
         )
         is_new_value_equal = (
             source.new_value["Name"] == target.new_value["Name"]
-            if isinstance(source.new_value, dict)
+            if isinstance(source.new_value, dict) and "Name" in source.new_value
             else source.new_value == target.new_value
         )
 
@@ -76,8 +77,17 @@ def _compare_changes(changes, expected_changes):
             and source.is_list == target.is_list
         )
 
-    sorted_changes = sorted(changes, key=lambda change: change.key)
-    sorted_expected_changes = sorted(expected_changes, key=lambda change: change.key)
+    def _sorting_func(change):
+        if change.is_list:
+            if isinstance(change.new_value, dict):
+                return change.new_value["Name"]
+            else:
+                return "-"
+        else:
+            return change.key
+
+    sorted_changes = sorted(changes, key=_sorting_func)
+    sorted_expected_changes = sorted(expected_changes, key=_sorting_func)
 
     assert_that(
         all([_compare_change(source, target) for source, target in zip(sorted_changes, sorted_expected_changes)])
@@ -133,7 +143,7 @@ def _compare_changes(changes, expected_changes):
             "CustomAmi",
             "ami-12345678",
             "ami-1234567a",
-            UpdatePolicy.COMPUTE_FLEET_STOP,
+            UpdatePolicy.QUEUE_UPDATE_STRATEGY,
             False,
             id="change queue custom ami",
         ),
@@ -183,9 +193,9 @@ def _compare_changes(changes, expected_changes):
             "InstanceProfile",
             "arn:aws:iam::aws:instance-profile/InstanceProfileone",
             "arn:aws:iam::aws:instance-profile/InstanceProfiletwo",
-            UpdatePolicy.SUPPORTED,
+            UpdatePolicy.COMPUTE_FLEET_STOP,
             False,
-            id="change queue insatnce profile",
+            id="change queue instance profile",
         ),
     ],
 )
@@ -270,7 +280,7 @@ def test_multiple_param_changes(mocker, pcluster_config_reader, test_datadir):
             "SubnetIds",
             ["subnet-12345678"],
             ["subnet-1234567a"],
-            UpdatePolicy.COMPUTE_FLEET_STOP,
+            UpdatePolicy.QUEUE_UPDATE_STRATEGY,
             is_list=False,
         ),
         Change(
@@ -291,11 +301,108 @@ def _test_equal_configs(base_conf, target_conf):
     _check_patch(base_conf, target_conf, [], UpdatePolicy.SUPPORTED)
 
 
+def _test_compute_resources(base_conf, target_conf):
+    # simulate removal of compute resource, by adding new one in the base conf
+    base_conf["Scheduling"]["SlurmQueues"][0]["ComputeResources"].append(
+        {"Name": "compute-removed", "InstanceType": "c5.9xlarge", "MaxCount": 20}
+    )
+
+    # add new compute resource
+    target_conf["Scheduling"]["SlurmQueues"][0]["ComputeResources"].append(
+        {"Name": "new-compute", "InstanceType": "c5.large", "MinCount": 1}
+    )
+
+    # The patch must show multiple differences
+    _check_patch(
+        base_conf,
+        target_conf,
+        [
+            Change(
+                ["Scheduling", "SlurmQueues[queue1]"],
+                "ComputeResources",
+                {"Name": "compute-removed", "InstanceType": "c5.9xlarge", "MaxCount": 20},
+                None,
+                UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+                is_list=True,
+            ),
+            Change(
+                ["Scheduling", "SlurmQueues[queue1]"],
+                "ComputeResources",
+                None,
+                {"Name": "new-compute", "InstanceType": "c5.large", "MinCount": 1},
+                UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+                is_list=True,
+            ),
+        ],
+        UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+    )
+
+
+def _test_queues(base_conf, target_conf):
+    # simulate removal of queue, by adding new one in the base conf
+    base_conf["Scheduling"]["SlurmQueues"].append(
+        {
+            "Name": "queue-removed",
+            "Networking": {"SubnetIds": "subnet-12345678"},
+            "ComputeResources": {"Name": "compute-removed", "InstanceType": "c5.9xlarge"},
+        }
+    )
+
+    # add new queue
+    target_conf["Scheduling"]["SlurmQueues"].append(
+        {
+            "Name": "new-queue",
+            "Networking": {"SubnetIds": "subnet-987654321"},
+            "ComputeResources": {"Name": "new-compute", "InstanceType": "c5.xlarge"},
+        }
+    )
+
+    # The patch must show multiple differences
+    _check_patch(
+        base_conf,
+        target_conf,
+        [
+            Change(
+                ["Scheduling"],
+                "SlurmQueues",
+                {
+                    "Name": "queue-removed",
+                    "Networking": {"SubnetIds": "subnet-12345678"},
+                    "ComputeResources": {"Name": "compute-removed", "InstanceType": "c5.9xlarge"},
+                },
+                None,
+                UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+                is_list=True,
+            ),
+            Change(
+                ["Scheduling"],
+                "SlurmQueues",
+                None,
+                {
+                    "Name": "new-queue",
+                    "Networking": {"SubnetIds": "subnet-987654321"},
+                    "ComputeResources": {"Name": "new-compute", "InstanceType": "c5.xlarge"},
+                },
+                UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+                is_list=True,
+            ),
+        ],
+        UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE,
+    )
+
+
 def _test_less_target_sections(base_conf, target_conf):
     # Remove an ebs section in the target conf
     assert_that(_get_storage_by_name(target_conf, "ebs1")).is_not_none()
     _remove_storage_by_name(target_conf, "ebs1")
     assert_that(_get_storage_by_name(target_conf, "ebs1")).is_none()
+
+    # add new section + param in the base conf so that it appears as removed in the target conf
+    base_conf["Scheduling"].update({"SlurmSettings": {"ScaledownIdletime": 30}})
+    base_conf["Scheduling"]["SlurmSettings"].update({"QueueUpdateStrategy": QueueUpdateStrategy.DRAIN.value})
+
+    # add new param in the base conf so that it appears as removed in the target conf
+    base_conf["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MinCount"] = 1
 
     # update some values in the target config for the remaining ebs
     target_conf["SharedStorage"][0]["MountDir"] = "vol1"
@@ -331,6 +438,22 @@ def _test_less_target_sections(base_conf, target_conf):
                 UpdatePolicy.UNSUPPORTED,
                 is_list=False,
             ),
+            Change(
+                ["Scheduling"],
+                "SlurmSettings",
+                {"ScaledownIdletime": 30, "QueueUpdateStrategy": QueueUpdateStrategy.DRAIN.value},
+                "-",
+                UpdatePolicy.SUPPORTED,
+                is_list=False,
+            ),
+            Change(
+                ["Scheduling", "SlurmQueues[queue1]", "ComputeResources[compute-resource1]"],
+                "MinCount",
+                1,
+                None,
+                UpdatePolicy.COMPUTE_FLEET_STOP,
+                is_list=False,
+            ),
         ],
         UpdatePolicy.UNSUPPORTED,
     )
@@ -359,6 +482,15 @@ def _test_more_target_sections(base_conf, target_conf):
     target_storage["EbsSettings"]["Iops"] = 20
     target_storage["EbsSettings"]["VolumeType"] = "gp2"
 
+    # add new section + param in the target conf
+    target_conf["Scheduling"].update({"SlurmSettings": {"ScaledownIdletime": 30}})
+    target_conf["Scheduling"]["SlurmSettings"].update(
+        {"QueueUpdateStrategy": QueueUpdateStrategy.COMPUTE_FLEET_STOP.value}
+    )
+
+    # add new param in the target conf
+    target_conf["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MinCount"] = 1
+
     # The patch must show multiple differences: changes for EBS settings and one for missing ebs section in base conf
     _check_patch(
         base_conf,
@@ -385,6 +517,22 @@ def _test_more_target_sections(base_conf, target_conf):
                 "gp3",
                 "gp2",
                 UpdatePolicy.UNSUPPORTED,
+                is_list=False,
+            ),
+            Change(
+                ["Scheduling"],
+                "SlurmSettings",
+                "-",
+                {"ScaledownIdletime": 30, "QueueUpdateStrategy": QueueUpdateStrategy.COMPUTE_FLEET_STOP.value},
+                UpdatePolicy.SUPPORTED,
+                is_list=False,
+            ),
+            Change(
+                ["Scheduling", "SlurmQueues[queue1]", "ComputeResources[compute-resource1]"],
+                "MinCount",
+                None,
+                1,
+                UpdatePolicy.COMPUTE_FLEET_STOP,
                 is_list=False,
             ),
         ],
@@ -458,6 +606,8 @@ def _test_different_names(base_conf, target_conf):
         _test_incompatible_ebs_sections,
         _test_equal_configs,
         _test_different_names,
+        _test_compute_resources,
+        _test_queues,
     ],
 )
 def test_adaptation(mocker, test_datadir, pcluster_config_reader, test):

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -691,7 +691,7 @@ def test_patch_check_cluster_resource_bucket(
 ):
     mock_aws_api(mocker)
     expected_message_rows = [
-        ["param_path", "parameter", "old value", "new value", "check", "reason", "action_needed"],
+        ["param_path", "parameter", "old value", "new value", "check", "reason", "action_needed", "update_policy"],
         # ec2_iam_role is to make sure other parameters are not affected by cluster_resource_bucket custom logic
         [
             ["HeadNode", "Iam"],
@@ -701,6 +701,7 @@ def test_patch_check_cluster_resource_bucket(
             "SUCCEEDED",
             "-",
             None,
+            UpdatePolicy.SUPPORTED.name,
         ],
     ]
     if expected_error_row:
@@ -717,6 +718,7 @@ def test_patch_check_cluster_resource_bucket(
                 )
             ),
             f"Restore the value of parameter 'CustomS3Bucket' to '{old_bucket_name}'",
+            UpdatePolicy.READ_ONLY_RESOURCE_BUCKET.name,
         ]
         expected_message_rows.append(error_message_row)
     src_dict = {"cluster_resource_bucket": old_bucket_name, "ec2_iam_role": "arn:aws:iam::aws:role/some_old_role"}

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -11,6 +11,7 @@
 import pytest
 from assertpy import assert_that
 
+from pcluster.config.cluster_config import QueueUpdateStrategy
 from pcluster.config.update_policy import UpdatePolicy
 from tests.pcluster.test_utils import dummy_cluster
 
@@ -42,3 +43,363 @@ def test_max_count_policy(mocker, is_fleet_stopped, old_max, new_max, expected_r
 
     assert_that(UpdatePolicy.MAX_COUNT.condition_checker(change_mock, patch_mock)).is_equal_to(expected_result)
     cluster_has_running_capacity_mock.assert_called()
+
+
+@pytest.mark.parametrize(
+    "is_fleet_stopped, key, path, old_value, new_value, update_strategy, expected_result",
+    [
+        pytest.param(
+            True,
+            "CustomAmi",
+            ["Scheduling", "SlurmQueues[queue1]", "Image"],
+            None,
+            "ami-123456789",
+            None,
+            True,
+            id="stopped fleet and custom AMI set",
+        ),
+        pytest.param(
+            True,
+            "CustomAmi",
+            ["Scheduling", "SlurmQueues[queue1]", "Image"],
+            "ami-123456789",
+            None,
+            None,
+            True,
+            id="stopped fleet and custom AMI unset",
+        ),
+        pytest.param(
+            False,
+            "CustomAmi",
+            ["Scheduling", "SlurmQueues[queue1]", "Image"],
+            None,
+            "ami-123456789",
+            None,
+            False,
+            id="running fleet and custom AMI set with no update strategy set",
+        ),
+        pytest.param(
+            False,
+            "CustomAmi",
+            ["Scheduling", "SlurmQueues[queue1]", "Image"],
+            "ami-987654321",
+            "ami-123456789",
+            None,
+            False,
+            id="running fleet and custom AMI change with no update strategy set",
+        ),
+        pytest.param(
+            False,
+            "CustomAmi",
+            ["Scheduling", "SlurmQueues[queue1]", "Image"],
+            "ami-987654321",
+            "ami-123456789",
+            QueueUpdateStrategy.COMPUTE_FLEET_STOP.value,
+            False,
+            id="running fleet and custom AMI change with update strategy COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "CustomAmi",
+            ["Scheduling", "SlurmQueues[queue1]", "Image"],
+            None,
+            "ami-123456789",
+            QueueUpdateStrategy.DRAIN.value,
+            True,
+            id="running fleet and custom AMI set with update strategy DRAIN",
+        ),
+        pytest.param(
+            False,
+            "CustomAmi",
+            ["Scheduling", "SlurmQueues[queue1]", "Image"],
+            "ami-123456789",
+            None,
+            QueueUpdateStrategy.DRAIN.value,
+            True,
+            id="running fleet and custom AMI unset with update strategy DRAIN",
+        ),
+        pytest.param(
+            False,
+            "GenerateSshKeysForUsers",
+            ["DirectoryService"],
+            None,
+            True,
+            QueueUpdateStrategy.DRAIN.value,
+            False,
+            id="running fleet with change outside SlurmQueues which requires COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "GenerateSshKeysForUsers",
+            ["DirectoryService"],
+            False,
+            None,
+            QueueUpdateStrategy.DRAIN.value,
+            False,
+            id="running fleet with change outside SlurmQueues which requires COMPUTE_FLEET_STOP",
+        ),
+        pytest.param(
+            False,
+            "GenerateSshKeysForUsers",
+            ["DirectoryService"],
+            True,
+            False,
+            QueueUpdateStrategy.DRAIN.value,
+            False,
+            id="running fleet with change outside SlurmQueues which requires COMPUTE_FLEET_STOP",
+        ),
+    ],
+)
+def test_queue_update_strategy_condition_checker(
+    mocker, is_fleet_stopped, key, path, old_value, new_value, update_strategy, expected_result
+):
+    cluster = dummy_cluster()
+    cluster_has_running_capacity_mock = mocker.patch.object(
+        cluster, "has_running_capacity", return_value=not is_fleet_stopped
+    )
+
+    patch_mock = mocker.MagicMock()
+    patch_mock.cluster = cluster
+    patch_mock.target_config = (
+        {"Scheduling": {"SlurmSettings": {"QueueUpdateStrategy": update_strategy}}}
+        if update_strategy
+        else {"Scheduling": {"SlurmSettings": {}}}
+    )
+    change_mock = mocker.MagicMock()
+    change_mock.path = path
+    change_mock.key = key
+    change_mock.old_value = old_value
+    change_mock.new_value = new_value
+
+    assert_that(UpdatePolicy.QUEUE_UPDATE_STRATEGY.condition_checker(change_mock, patch_mock)).is_equal_to(
+        expected_result
+    )
+    cluster_has_running_capacity_mock.assert_called()
+
+
+@pytest.mark.parametrize(
+    "is_fleet_stopped, key, path, old_value, new_value, expected_result",
+    [
+        pytest.param(
+            True,
+            "SlurmQueues",
+            ["Scheduling"],
+            None,
+            {
+                "Name": "queue-added",
+                "Networking": {"SubnetIds": "subnet-12345678"},
+                "ComputeResources": {"Name": "compute-added", "InstanceType": "c5.9xlarge"},
+            },
+            True,
+            id="stopped fleet and queue is added",
+        ),
+        pytest.param(
+            True,
+            "SlurmQueues",
+            ["Scheduling"],
+            {
+                "Name": "queue-removed",
+                "Networking": {"SubnetIds": "subnet-12345678"},
+                "ComputeResources": {"Name": "compute-removed", "InstanceType": "c5.9xlarge"},
+            },
+            None,
+            True,
+            id="stopped fleet and queue is removed",
+        ),
+        pytest.param(
+            True,
+            "ComputeResources",
+            ["Scheduling", "SlurmQueues[queue1]"],
+            None,
+            {"Name": "compute-added", "InstanceType": "c5.large", "MinCount": 1},
+            True,
+            id="stopped fleet and compute is added",
+        ),
+        pytest.param(
+            True,
+            "ComputeResources",
+            ["Scheduling", "SlurmQueues[queue1]"],
+            {"Name": "compute-removed", "InstanceType": "c5.large", "MinCount": 1},
+            None,
+            True,
+            id="stopped fleet and compute is removed",
+        ),
+        pytest.param(
+            False,
+            "SlurmQueues",
+            ["Scheduling"],
+            None,
+            {
+                "Name": "queue-added",
+                "Networking": {"SubnetIds": "subnet-12345678"},
+                "ComputeResources": {"Name": "compute-added", "InstanceType": "c5.9xlarge"},
+            },
+            True,
+            id="running fleet and queue is added",
+        ),
+        pytest.param(
+            False,
+            "SlurmQueues",
+            ["Scheduling"],
+            {
+                "Name": "queue-removed",
+                "Networking": {"SubnetIds": "subnet-12345678"},
+                "ComputeResources": {"Name": "compute-removed", "InstanceType": "c5.9xlarge"},
+            },
+            None,
+            False,
+            id="running fleet and queue is removed",
+        ),
+        pytest.param(
+            False,
+            "ComputeResources",
+            ["Scheduling", "SlurmQueues[queue1]"],
+            None,
+            {"Name": "compute-added", "InstanceType": "c5.large", "MinCount": 1},
+            True,
+            id="running fleet and compute is added",
+        ),
+        pytest.param(
+            False,
+            "ComputeResources",
+            ["Scheduling", "SlurmQueues[queue1]"],
+            {"Name": "compute-removed", "InstanceType": "c5.large", "MinCount": 1},
+            None,
+            False,
+            id="running fleet and compute is removed",
+        ),
+    ],
+)
+def test_compute_fleet_stop_on_remove_condition_checker(
+    mocker, is_fleet_stopped, key, path, old_value, new_value, expected_result
+):
+    cluster = dummy_cluster()
+    cluster_has_running_capacity_mock = mocker.patch.object(
+        cluster, "has_running_capacity", return_value=not is_fleet_stopped
+    )
+
+    patch_mock = mocker.MagicMock()
+    patch_mock.cluster = cluster
+
+    change_mock = mocker.MagicMock()
+    change_mock.path = path
+    change_mock.key = key
+    change_mock.old_value = old_value
+    change_mock.new_value = new_value
+
+    assert_that(UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE.condition_checker(change_mock, patch_mock)).is_equal_to(
+        expected_result
+    )
+    cluster_has_running_capacity_mock.assert_called()
+
+
+@pytest.mark.parametrize(
+    "key, path, old_value, new_value, expected_fail_reason, expected_actions_needed",
+    [
+        pytest.param(
+            "CustomAmi",
+            ["Scheduling", "SlurmQueues[queue6]", "Image"],
+            None,
+            "ami-123456789",
+            "All compute nodes must be stopped or QueueUpdateStrategy must be set",
+            "Stop the compute fleet with the pcluster update-compute-fleet command, "
+            "or set QueueUpdateStrategy in the configuration used for the 'update-cluster' operation",
+            id="change within SlurmQueues",
+        ),
+    ],
+)
+def test_queue_update_strategy_fail_reason_and_actions_needed(
+    mocker, key, path, old_value, new_value, expected_fail_reason, expected_actions_needed
+):
+    cluster = dummy_cluster()
+    patch_mock = mocker.MagicMock()
+    patch_mock.cluster = cluster
+    change_mock = mocker.MagicMock()
+    change_mock.path = path
+    change_mock.key = key
+    change_mock.old_value = old_value
+    change_mock.new_value = new_value
+
+    assert_that(UpdatePolicy.QUEUE_UPDATE_STRATEGY.fail_reason(change_mock, patch_mock)).is_equal_to(
+        expected_fail_reason
+    )
+    assert_that(UpdatePolicy.QUEUE_UPDATE_STRATEGY.action_needed(change_mock, patch_mock)).is_equal_to(
+        expected_actions_needed
+    )
+
+
+@pytest.mark.parametrize(
+    "key, path, old_value, new_value, expected_fail_reason, expected_actions_needed",
+    [
+        pytest.param(
+            "SlurmQueues",
+            ["Scheduling"],
+            {
+                "Name": "queue-removed",
+                "Networking": {"SubnetIds": "subnet-12345678"},
+                "ComputeResources": {"Name": "compute-removed", "InstanceType": "c5.9xlarge"},
+            },
+            None,
+            "All compute nodes must be stopped",
+            "Stop the compute fleet with the pcluster update-compute-fleet command",
+            id="remove a Slurm queue",
+        ),
+    ],
+)
+def test_compute_fleet_stop_on_remove_fail_reason_and_actions_needed(
+    mocker, key, path, old_value, new_value, expected_fail_reason, expected_actions_needed
+):
+    cluster = dummy_cluster()
+    patch_mock = mocker.MagicMock()
+    patch_mock.cluster = cluster
+    change_mock = mocker.MagicMock()
+    change_mock.path = path
+    change_mock.key = key
+    change_mock.old_value = old_value
+    change_mock.new_value = new_value
+
+    assert_that(UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE.fail_reason).is_equal_to(expected_fail_reason)
+    assert_that(UpdatePolicy.COMPUTE_FLEET_STOP_ON_REMOVE.action_needed(change_mock, patch_mock)).is_equal_to(
+        expected_actions_needed
+    )
+
+
+@pytest.mark.parametrize(
+    "key, path, old_value, new_value, expected_fail_reason, expected_actions_needed",
+    [
+        pytest.param(
+            "MinCount",
+            ["Scheduling", "SlurmQueues[queue6]", "ComputeResources[compute6]"],
+            0,
+            None,
+            "All compute nodes must be stopped",
+            "Stop the compute fleet with the pcluster update-compute-fleet command",
+            id="change within SlurmQueues",
+        ),
+        pytest.param(
+            "GenerateSshKeysForUsers",
+            ["DirectoryService"],
+            None,
+            True,
+            "All compute nodes must be stopped",
+            "Stop the compute fleet with the pcluster update-compute-fleet command",
+            id="change outside SlurmQueues",
+        ),
+    ],
+)
+def test_compute_fleet_stop_fail_reason_and_actions_needed(
+    mocker, key, path, old_value, new_value, expected_fail_reason, expected_actions_needed
+):
+    cluster = dummy_cluster()
+    patch_mock = mocker.MagicMock()
+    patch_mock.cluster = cluster
+    change_mock = mocker.MagicMock()
+    change_mock.path = path
+    change_mock.key = key
+    change_mock.old_value = old_value
+    change_mock.new_value = new_value
+
+    assert_that(UpdatePolicy.COMPUTE_FLEET_STOP.fail_reason).is_equal_to(expected_fail_reason)
+    assert_that(UpdatePolicy.COMPUTE_FLEET_STOP.action_needed(change_mock, patch_mock)).is_equal_to(
+        expected_actions_needed
+    )

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
@@ -3,6 +3,7 @@
     "base_os": "alinux2",
     "cluster_config_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/cluster-config-with-implied-values.yaml",
     "cluster_config_version": "",
+    "change_set_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/change-set.json",
     "cluster_s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
     "cluster_user": "ec2-user",
     "custom_awsbatchcli_package": "",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/scheduler-plugin-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/scheduler-plugin-imds-secured-true.head-node.dna.json
@@ -3,6 +3,7 @@
     "base_os": "alinux2",
     "cluster_config_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/cluster-config-with-implied-values.yaml",
     "cluster_config_version": "",
+    "change_set_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/change-set.json",
     "cluster_s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
     "cluster_user": "ec2-user",
     "custom_awsbatchcli_package": "",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
@@ -3,6 +3,7 @@
     "base_os": "alinux2",
     "cluster_config_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/cluster-config-with-implied-values.yaml",
     "cluster_config_version": "",
+    "change_set_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/change-set.json",
     "cluster_s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
     "cluster_user": "ec2-user",
     "custom_awsbatchcli_package": "",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
@@ -3,6 +3,7 @@
     "base_os": "alinux2",
     "cluster_config_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/cluster-config-with-implied-values.yaml",
     "cluster_config_version": "",
+    "change_set_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/change-set.json",
     "cluster_s3_bucket": "parallelcluster-a69601b5ee1fc2f2-v1-do-not-delete",
     "cluster_user": "ec2-user",
     "custom_awsbatchcli_package": "",


### PR DESCRIPTION
### Description of changes
* Add new parameter QueueUpdateStrategy

  This parameter is meant to be used as update policy override for the parameters under the SlurmQueue section which by default require a COMPUTE_FLEET_STOP for the update of their value. The parameter change doesn't impact Slurm configuration.

  Possible values for QueueUpdateStrategy
  * COMPUTE_FLEET_STOP - it keeps the same behaviour as of today
  * DRAIN - will replace nodes using a DRAIN strategy, i.e. nodes will be put in DRAINING and replaced only when jobs running on them terminate. The new value of the parameter changed during the update, will be applied to the new nodes.
  
  With this change, other two new policies are added.
  * QUEUE_UPDATE_STRATEGY - it's the new policy overridable by the QueueUpdateStrategy parameter
  * COMPUTE_FLEET_STOP_ON_REMOVE - it supports the addition of new section while requires the compute fleet stop on section removal. This is the policy set for queue and compute resource sections

  Example when a param with the new QUEUE_UPDATE_STRATEGY policy is changed, without setting the QueueUpdateStrategy configuration:

```
{
  "message": "Update failure",
  "updateValidationErrors": [
    {
      "parameter": "Scheduling.SlurmQueues[compute1].Image",
      "requestedValue": "-",
      "message": "All compute nodes must be stopped or QueueUpdateStrategy must be set. Stop the compute fleet with the pcluster update-compute-fleet command or set QueueUpdateStrategy in the configuration used for the 'update-cluster' operation",
      "currentValue": {
        "CustomAmi": "ami-06d5e4d193b95991d"
      }
    }
  ],
  "changeSet": [
    {
      "parameter": "Scheduling.SlurmQueues[compute1].Image",
      "requestedValue": "-",
      "currentValue": {
        "CustomAmi": "ami-06d5e4d193b95991d"
      }
    }
  ]
}
```

  Before the change it was
```
{
  "message": "Update failure",
  "updateValidationErrors": [
    {
      "parameter": "Scheduling.SlurmQueues[compute1].Image",
      "requestedValue": "-",
      "message": "All compute nodes must be stopped. Stop the compute fleet with the pcluster update-compute-fleet command",
      "currentValue": {
        "CustomAmi": "ami-06d5e4d193b95991d"
      }
    }
  ],
  "changeSet": [
    {
      "parameter": "Scheduling.SlurmQueues[compute1].Image",
      "requestedValue": "-",
      "currentValue": {
        "CustomAmi": "ami-06d5e4d193b95991d"
      }
    }
  ]
}
```

* Add change set file into S3 bucket during cluster update

  Upload a json file containing the change set to be performed during an update.
  The important part is that it will bring information about the update policies of all the changed parameters.
  This information is then consumed during the update by the update replacement logic.
  The file is in the form:
```
{
  "changeSet": [
    {
      "parameter": "Scheduling.SlurmQueues[compute2].ComputeResources[compute2-i1].MinCount",
      "requestedValue": 0,
      "currentValue": 1,
      "updatePolicy": "COMPUTE_FLEET_STOP"
    }
  ]
}
```

* Fix policy for Dns section

  All parameters under DNS section have update policy UNSUPPORTED, hence also the parent section should be UNSUPPORTED.

* Add name to instance of UpdatePolicy class

  This is useful for debugging purposes, to be able to know the name of the policy from an instance of the class

* Enable traversing of config comparison

  Currently, the configuration comparison stops as soon as a new parameter is found in the new configuration.
  With this patch, the comparison goes further when the update policy is IGNORED, traversing also the children of the new parameter when this is a section.
  This change allows to be able to ignore the update policy of a section and have the updatability depending on the policies of its children.
  
  Example: changing config from
```
Scheduling:
  SlurmQueues:
    [...]
```
  to
```
Scheduling:
  SlurmSettings:
    ScaledownIdletime: 12
  SlurmQueues:
    [...]
```

  the output of update-cluster changes from
```
{
  "message": "Update failure",
  "updateValidationErrors": [
    {
      "parameter": "Scheduling.SlurmSettings",
      "requestedValue": {
        "ScaledownIdletime": 12
      },
      "message": "All compute nodes must be stopped. Stop the compute fleet with the pcluster update-compute-fleet command",
      "currentValue": "-"
    }
  ],
  "changeSet": [
    {
      "parameter": "Scheduling.SlurmSettings",
      "requestedValue": {
        "ScaledownIdletime": 12
      },
      "currentValue": "-"
    }
  ]
}
```
to
```
{
  "message": "Update failure",
  "updateValidationErrors": [
    {
      "parameter": "Scheduling.SlurmSettings.ScaledownIdletime",
      "requestedValue": 12,
      "message": "All compute nodes must be stopped. Stop the compute fleet with the pcluster update-compute-fleet command"
    }
  ],
  "changeSet": [
    {
      "parameter": "Scheduling.SlurmSettings.ScaledownIdletime",
      "requestedValue": 12
    }
  ]
}
```
  which is consistent to the output showed when adding a single parameter under a section that already exist

### Tests
* added unit tests

### References
* n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
