### PR TITLE
Change default lustre version and deployment type of FSx and lower limit of multiple EFS and FSx to 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ x.x.x
 - Remove support for Python 3.6.
 - Upgrade Slurm to version 21.08.7.
 - Do not require `PlacementGroup/Enabled` to be set to `true` when passing an existing `PlacementGroup/Id`.
+- Changes to FSx for Lustre file systems created by ParallelCluster:
+  - Change the default deployment type to `Scrach_2`.
+  - Change the lustre server version to `2.12`.
 
 **BUG FIXES**
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ x.x.x
 - Upgrade Slurm to version 21.08.7.
 - Do not require `PlacementGroup/Enabled` to be set to `true` when passing an existing `PlacementGroup/Id`.
 - Changes to FSx for Lustre file systems created by ParallelCluster:
-  - Change the default deployment type to `Scrach_2`.
-  - Change the lustre server version to `2.12`.
+  - Change the default deployment type to `Scratch_2`.
+  - Change the Lustre server version to `2.12`.
 
 **BUG FIXES**
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -325,7 +325,7 @@ class SharedFsx(Resource):
         self.shared_storage_type = SharedStorageType.FSX
         self.storage_capacity = Resource.init_param(storage_capacity)
         self.fsx_storage_type = Resource.init_param(fsx_storage_type)
-        self.deployment_type = Resource.init_param(deployment_type)
+        self.deployment_type = Resource.init_param(deployment_type, default="SCRATCH_2")
         self.data_compression_type = Resource.init_param(data_compression_type)
         self.export_path = Resource.init_param(export_path)
         self.import_path = Resource.init_param(import_path)

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -67,7 +67,7 @@ MAX_NUMBER_OF_COMPUTE_RESOURCES = 5
 
 MAX_EBS_COUNT = 5
 MAX_NEW_STORAGE_COUNT = {"efs": 1, "fsx": 1, "raid": 1}
-MAX_EXISTING_STORAGE_COUNT = {"efs": 50, "fsx": 50, "raid": 0}
+MAX_EXISTING_STORAGE_COUNT = {"efs": 20, "fsx": 20, "raid": 0}
 
 COOKBOOK_PACKAGES_VERSIONS = {
     "parallelcluster": "3.2.0",

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -647,6 +647,7 @@ class ClusterCdkStack(Stack):
                 storage_type=shared_fsx.fsx_storage_type,
                 subnet_ids=self.config.compute_subnet_ids,
                 security_group_ids=self._get_compute_security_groups(),
+                file_system_type_version="2.12",
                 tags=[CfnTag(key="Name", value=shared_fsx.name)],
             )
             fsx_id = fsx_resource.ref

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -257,8 +257,8 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
     number_of_storage_validator.assert_has_calls(
         [
             call(storage_type="EBS", max_number=5, storage_count=1),
-            call(storage_type="existing EFS", max_number=50, storage_count=0),
-            call(storage_type="existing FSX", max_number=50, storage_count=0),
+            call(storage_type="existing EFS", max_number=20, storage_count=0),
+            call(storage_type="existing FSX", max_number=20, storage_count=0),
             call(storage_type="new EFS", max_number=1, storage_count=1),
             call(storage_type="new FSX", max_number=1, storage_count=1),
             call(storage_type="new RAID", max_number=1, storage_count=0),


### PR DESCRIPTION
ParallelCluster CLI and API validation for 50 EFS takes too long. 50 EFS takes 50 seconds, while the timeout for ParallelCluster API is 30 seconds Therefore, we lower the limit to 20.

### Tests
all tests in test_fsx_lustre have been passed

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
