### PR TITLE
Add validator to prevent using reserved directories as mount dirs

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -170,3 +170,5 @@ SCHEDULER_PLUGIN_INTERFACE_VERSION_LOW_RANGE = packaging.version.Version("1.0")
 
 # DirectoryService
 DIRECTORY_SERVICE_RESERVED_SETTINGS = {"id_provider": "ldap"}
+
+DEFAULT_EPHEMERAL_DIR = "/scratch"

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -248,7 +248,7 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
     )
     fsx_architecture_os_validator.assert_has_calls([call(architecture="x86_64", os="alinux2")])
     duplicate_mount_dir_validator.assert_has_calls(
-        [call(mount_dir_list=["/my/mount/point1", "/my/mount/point2", "/my/mount/point3"])]
+        [call(mount_dir_list=["/my/mount/point1", "/my/mount/point2", "/my/mount/point3", "/scratch"])]
     )
     number_of_storage_validator.assert_has_calls(
         [


### PR DESCRIPTION
Add more detailed check considering the difference between shared storage and local storage:

1. Shared storage directories can not overlap/duplicate with each other.
2. Shared storage directories can not overlap/duplicate with ephemeral storage directories.
3. Ephemeral storage directories can overlap/duplicate with each other, because they are local to compute nodes.

Note this PR always reserves`/scratch` for ephemeral storage, forbidding shared storage from using it. Although only some of the instance types have ephemeral storage. This universal ban will facilitate instance update functionality in the future.


Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
