### PR TITLE
[integration tests] Remove switch-user from SSM command that creates directory users

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -262,7 +262,7 @@ Resources:
             name: addAdUser
             inputs:
               runCommand:
-                - "su - {{ ad_admin_user }} /usr/local/bin/add_a_number_of_users.sh {% raw %}{{ DirectoryId }} {{ NumUsersToCreate }}{% endraw %} "
+                - "bash /usr/local/bin/add_a_number_of_users.sh {% raw %}{{ DirectoryId }} {{ NumUsersToCreate }}{% endraw %} "
       DocumentType: Command
       TargetType: /AWS::EC2::Instance
 Outputs:


### PR DESCRIPTION
### Changes
1. Remove switch-user from SSM command that creates directory users. Such a switch-user is not required and it may be a point of failures during integration tests.

### Tests
1. Locally launched AD tests succeeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
