### PR TITLE
[integration tests] Remove switch-user from SSM command that creates directory users

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -259,7 +259,7 @@ Resources:
             name: addAdUser
             inputs:
               runCommand:
-                - "su - {{ ad_admin_user }} /usr/local/bin/add_a_number_of_users.sh {% raw %}{{ DirectoryId }} {{ NumUsersToCreate }}{% endraw %} "
+                - "bash /usr/local/bin/add_a_number_of_users.sh {% raw %}{{ DirectoryId }} {{ NumUsersToCreate }}{% endraw %} "
       DocumentType: Command
       TargetType: /AWS::EC2::Instance
 Outputs:


### PR DESCRIPTION
**Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/3983**

### Changes
1. Remove switch-user from SSM command that creates directory users. Such a switch-user is not required and it may be a point of failures during integration tests.

### Tests
Tested in https://github.com/aws/aws-parallelcluster/pull/3983

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
