### PR TITLE
[integration tests] Make AD integration tests create directories with random unique names to avoid collision when using a single VPC

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -32,7 +32,7 @@ from paramiko import RSAKey
 from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
 from time_utils import seconds
-from utils import generate_stack_name
+from utils import generate_stack_name, random_alphanumeric
 
 from tests.ad_integration.cluster_user import ClusterUser
 from tests.common.osu_common import compile_osu, run_osu_benchmarks
@@ -196,7 +196,7 @@ def _create_directory_stack(cfn_stacks_factory, request, directory_type, test_re
     )
     ad_admin_password = "".join(random.choices(string.ascii_letters + string.digits, k=60))
     ad_user_password = "".join(random.choices(string.ascii_letters + string.digits, k=60))
-    ad_domain_name = f"{directory_type.lower()}.multiuser.pcluster"
+    ad_domain_name = f"{directory_type.lower()}.{random_alphanumeric(size=10)}.multiuser.pcluster"
     ad_domain_short_name = "NET"
     ad_base_search = _get_ldap_base_search(ad_domain_name)
     if directory_type == "SimpleAD":
@@ -394,7 +394,8 @@ def directory_factory(request, cfn_stacks_factory, vpc_stacks, store_secret_in_s
             nlb_stack_name = created_directory_stacks.get(region, {}).get("nlb")
             logging.info("Using NLB stack named %s created by another test", nlb_stack_name)
         else:
-            common_name = f"{directory_type.lower()}.multiuser.pcluster"
+            directory_stack_outputs = get_infra_stack_outputs(directory_stack_name)
+            common_name = directory_stack_outputs.get("DomainName")
             certificate_arn, certificate = _generate_certificate(common_name)
             certificate_secret_arn = store_secret_in_secret_manager(region, secret_binary=certificate)
             created_certificates[region] = certificate_arn


### PR DESCRIPTION
**Cherry-picked from https://github.com/aws/aws-parallelcluster/pull/3982**

### Changes
Make AD integration tests create directories with random unique names to to avoid collision when using a single VPC

### Tests
Tested in https://github.com/aws/aws-parallelcluster/pull/3982

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
