### PR TITLE
3.x: Do not require Enabled set to true when passing an existing Placement Group Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.1.4
+------
+
+**CHANGES**
+- Do not require `PlacementGroup/Enabled` to be set to `true` when passing an existing `PlacementGroup/Id`.
+
 3.1.3
 ------
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1329,10 +1329,10 @@ class ComputeFleetConstruct(Construct):
             queue_lt_security_groups = get_queue_security_groups_full(self._compute_security_group, queue)
 
             queue_placement_group = None
-            if queue.networking.placement_group and queue.networking.placement_group.enabled:
+            if queue.networking.placement_group:
                 if queue.networking.placement_group.id:
                     queue_placement_group = queue.networking.placement_group.id
-                else:
+                elif queue.networking.placement_group.enabled:
                     queue_placement_group = managed_placement_groups[queue.name].ref
 
             queue_pre_install_action, queue_post_install_action = (None, None)

--- a/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
@@ -27,7 +27,6 @@ Scheduling:
           InstanceType: {{ instance }}
       Networking:
         PlacementGroup:
-          Enabled: true
           Id: {{ placement_group }}
         SubnetIds:
           - {{ private_subnet_id }}


### PR DESCRIPTION
### Description of changes
If `PlacementGroup/Id` is configured it is no longer required to set `PlacementGroup/Enabled` to `True`.

The alternative was to add a validator to require that both `Enabled` and `Id` were set when asking for an existing PG
but we decided to simplify this logic and so providing an `Id` implies that PG is enabled.

### Tests
- Ran modified test_placement_group integration test
- Created cluster with multiple queues and different ODCR and PG configuration, submitted a job in all the queues and verified the ODCR is correctly used. 
- Verified the Placement groups is present in the Launch Template details associated to the queues on which I'm using `PlacementGroup/Id` without `Enabled` set to `true` (before the patch the PG wasn't set).
```yaml
# --- Open ODCR

    - Name: open-cluster-pg  # CR open associated to PG cluster --> result OK, using instances from ODCR (before the patch it wasn't using the CR)
      Networking:
        PlacementGroup:
          Id: "test cluster pg"
        SubnetIds:
        - subnet-xxx
    - Name: open-auto-pg  # CR open, PG automatically created by Pcluster --> result OK, using instances from ODCR
      Networking:
        PlacementGroup:
          Enabled: true
        SubnetIds:
        - subnet-xxx
    - Name: open-no-pg  # CR open, no PG --> result OK, using instances from ODCR
      Networking:
        SubnetIds:
        - subnet-xxx

# --- Targeted ODCR (using run-instances override approach)

    - Name: target-cluster-pg  # CR targeted associated to PG cluster --> result OK, using instances from ODCR (before the patch it wasn't using CR)
      Networking:
        PlacementGroup:
          Id: "test cluster pg"
        SubnetIds:
          - subnet-xxx
    - Name: target-auto-pg  #  CR targeted, PG automatically created by Pcluster --> result OK, using instances from ODCR
      Networking:
        PlacementGroup:
          Enabled: true
        SubnetIds:
        - subnet-xxx
    - Name: target-no-pg  # CR targeted, no PG --> result OK, using instances from ODCR
      Networking:
        SubnetIds:
        - subnet-xxx
```

### References
* Cherry pick of: https://github.com/aws/aws-parallelcluster/pull/3991

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
