### PR TITLE
Upgrade Slurm to version 21.08.7

### DIFF
--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/attributes/default.rb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/attributes/default.rb
@@ -23,9 +23,9 @@ default['pcluster']['instance_types_data_path'] = ENV['PCLUSTER_INSTANCE_TYPES_D
 default['pcluster']['node_type'] = ENV['PCLUSTER_NODE_TYPE']
 default['pcluster']['python_root'] = ENV['PCLUSTER_PYTHON_ROOT']
 
-default['slurm']['version'] = '21-08-6-1'
+default['slurm']['version'] = '21-08-7-1'
 default['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['slurm']['version']}.tar.gz"
-default['slurm']['sha1'] = '61c24d0dc89981112710cca571fcd0a2bdefb879'
+default['slurm']['sha1'] = '318c261d40dd6d946b150d557e9f107e32b0b8a4'
 default['slurm']['user'] = 'slurm-user'
 default['slurm']['group'] = node['slurm']['user']
 default['slurm']['install_dir'] = "#{node['pcluster']['shared_dir']}/slurm"


### PR DESCRIPTION
### Description of changes
* Upgrade Slurm to version 21.08.7 in scheduler plugin. Version and checksum taken from https://github.com/aws/aws-parallelcluster/pull/3985
* Changelog not updated because it was actually updated in the first incomplete change towards the upgrade in https://github.com/aws/aws-parallelcluster/pull/3985

### Tests
Changes tested in https://github.com/aws/aws-parallelcluster/pull/3985

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
