### PR TITLE
Exclude CDK version 1.153.0 cause it introduced a breaking change

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -21,7 +21,7 @@ def readme():
 
 
 VERSION = "3.2.0"
-CDK_VERSION = "1.137"
+CDK_VERSION = "1.137,!=1.153.0"
 REQUIRES = [
     "setuptools",
     "boto3>=1.16.14",


### PR DESCRIPTION
### Description of changes
* CDK version 1.153.0 introduced a breaking change to the aws-imagebuilder library which then got rolled back in 1.153.1.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
