### PR TITLE
Fix bug in shared mount directory list

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1206,10 +1206,6 @@ class BaseClusterConfig(Resource):
         if self.shared_storage:
             for storage in self.shared_storage:
                 mount_dir_list.append(storage.mount_dir)
-
-        if self.head_node.local_storage.ephemeral_volume:
-            mount_dir_list.append(self.head_node.local_storage.ephemeral_volume.mount_dir)
-
         return mount_dir_list
 
     @property

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -247,8 +247,12 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
         [call(kms_key_id="1234abcd-12ab-34cd-56ef-1234567890ab", encrypted=True)]
     )
     fsx_architecture_os_validator.assert_has_calls([call(architecture="x86_64", os="alinux2")])
-    duplicate_mount_dir_validator.assert_has_calls(
-        [call(mount_dir_list=["/my/mount/point1", "/my/mount/point2", "/my/mount/point3", "/scratch"])]
+    # Scratch mount directories are retrieved from a set. So the order of them is not guaranteed.
+    # The first item in call_args is regular args, the second item is keyword args.
+    mount_dir_list = duplicate_mount_dir_validator.call_args[1]["mount_dir_list"]
+    mount_dir_list.sort()
+    assert_that(mount_dir_list).is_equal_to(
+        ["/my/mount/point1", "/my/mount/point2", "/my/mount/point3", "/scratch", "/scratch_head"]
     )
     number_of_storage_validator.assert_has_calls(
         [

--- a/cli/tests/pcluster/validators/test_all_validators/test_validators_are_called_with_correct_argument/slurm.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_validators_are_called_with_correct_argument/slurm.yaml
@@ -7,6 +7,9 @@ HeadNode:
     SubnetId: subnet-12345678
   Ssh:
     KeyName: ec2-key-name
+  LocalStorage:
+    EphemeralVolume:
+      MountDir: /scratch_head
 Scheduling:
   Scheduler: slurm
   SlurmQueues:


### PR DESCRIPTION
The list should only contain directories from shared storage. There is another property `local_mount_dir_set` to collect the set of local mount directories.

Signed-off-by: Hanwen <hanwenli@amazon.com>

### References
This PR fixes a bug in https://github.com/aws/aws-parallelcluster/pull/3981

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
