### PR TITLE
Add validator for DirectoryService/PasswordSecretArn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ x.x.x
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File Systems.
 - Add support for FSx Lustre Persistent_2 deployment type.
+- Add validation for `DirectoryService/PasswordSecretArn` to fail in case the secret does not exist.
 
 **CHANGES**
 - Remove support for Python 3.6.

--- a/cli/src/pcluster/aws/aws_api.py
+++ b/cli/src/pcluster/aws/aws_api.py
@@ -23,6 +23,7 @@ from pcluster.aws.logs import LogsClient
 from pcluster.aws.route53 import Route53Client
 from pcluster.aws.s3 import S3Client
 from pcluster.aws.s3_resource import S3Resource
+from pcluster.aws.secretsmanager import SecretsManagerClient
 from pcluster.aws.sts import StsClient
 
 
@@ -55,6 +56,7 @@ class AWSApi:
         self._ddb_resource = None
         self._logs = None
         self._route53 = None
+        self._secretsmanager = None
 
     @property
     def cfn(self):
@@ -153,6 +155,13 @@ class AWSApi:
         if not self._route53:
             self._route53 = Route53Client()
         return self._route53
+
+    @property
+    def secretsmanager(self):
+        """Secrets Manager client."""
+        if not self._secretsmanager:
+            self._secretsmanager = SecretsManagerClient()
+        return self._secretsmanager
 
     @staticmethod
     def instance():

--- a/cli/src/pcluster/aws/secretsmanager.py
+++ b/cli/src/pcluster/aws/secretsmanager.py
@@ -1,0 +1,29 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from pcluster.aws.common import AWSExceptionHandler, Boto3Client, Cache
+
+
+class SecretsManagerClient(Boto3Client):
+    """SecretsManager Boto3 client."""
+
+    def __init__(self):
+        super().__init__("secretsmanager")
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def describe_secret(self, secret_arn):
+        """
+        Describe the Secret.
+
+        :param secret_arn: Secret ARN.
+        :return: secret info
+        """
+        self._client.describe_secret(SecretId=secret_arn)

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -96,6 +96,7 @@ from pcluster.validators.directory_service_validators import (
     DomainAddrValidator,
     DomainNameValidator,
     LdapTlsReqCertValidator,
+    PasswordSecretArnValidator,
 )
 from pcluster.validators.ebs_validators import (
     EbsVolumeIopsValidator,
@@ -720,6 +721,8 @@ class DirectoryService(Resource):
             self._register_validator(
                 DomainAddrValidator, domain_addr=self.domain_addr, additional_sssd_configs=self.additional_sssd_configs
             )
+        if self.password_secret_arn:
+            self._register_validator(PasswordSecretArnValidator, password_secret_arn=self.password_secret_arn)
         if self.ldap_tls_req_cert:
             self._register_validator(LdapTlsReqCertValidator, ldap_tls_reqcert=self.ldap_tls_req_cert)
         if self.additional_sssd_configs:

--- a/cli/tests/pcluster/validators/utils.py
+++ b/cli/tests/pcluster/validators/utils.py
@@ -12,6 +12,8 @@ import re
 
 from assertpy import assert_that
 
+from pcluster.validators.common import FailureLevel
+
 
 def assert_failure_messages(actual_failures, expected_messages):
     """Check failure messages."""
@@ -27,4 +29,17 @@ def assert_failure_messages(actual_failures, expected_messages):
             assert_that(res).is_true()
     else:
         print(actual_failures)
+        assert_that(actual_failures).is_empty()
+
+
+def assert_failure_level(actual_failures, expected_failure_level):
+    """Check failure level."""
+    if expected_failure_level == FailureLevel.ERROR:
+        at_least_one_error = any(actual_failure.level == FailureLevel.ERROR for actual_failure in actual_failures)
+        assert_that(at_least_one_error).is_true()
+    elif expected_failure_level == FailureLevel.WARNING:
+        no_errors = all(actual_failure.level != FailureLevel.ERROR for actual_failure in actual_failures)
+        at_least_one_warning = any(actual_failure.level == FailureLevel.WARNING for actual_failure in actual_failures)
+        assert_that(no_errors and at_least_one_warning).is_true()
+    else:
         assert_that(actual_failures).is_empty()


### PR DESCRIPTION
### Description of changes
Add validator for DirectoryService/PasswordSecretArn. The validation logic works as follows:

If the user policy has the permission to verify that the secret exists and the secret actually exists, the validation succeedsa and the creation/update proceeds.

If the user policy have the permission to verify that the secret exists and the secret does not actually exist, the following error is returned and the creation/update is blocked:

```
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "PasswordSecretArnValidator",
      "message": "Secrets Manager can't find the specified secret."
    }
  ],
  "message": "Invalid cluster configuration."
}
```

If the user policy does not have the permission to verify that the secret exists, the following warning is returned and the creation/update proceeds:

```
"validationMessages": [
    {
      "level": "WARNING",
      "type": "PasswordSecretArnValidator",
      "message": "Cannot validate PasswordSecretArn due to lack of permissions. Please refer to ParallelCluster official documentation for more information."
    }
  ]
```

### Tests
1. Manual tests:
    1. User policy having `secretmanager:DescribeSecret` and the secret exists, the validation is ok;
    2. User policy having `secretmanager:DescribeSecret` and the secret does not exist, the validation fails with error;
    3. User policy missing `secretmanager:DescribeSecret` and the secret exists, the warning is emitted about missing validation and the creation will succeed.
    4. User policy missing `secretmanager:DescribeSecret` and the secret does not exist, the warning is emitted about missing validation and the creation will fail.
2. Unit tests;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
