### PR TITLE
[AWSBatch] Fix entrypoint.sh to use /home/.pcluster to generate hostfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Fix the ability to export cluster's logs when using `export-cluster-logs` command with the `--filters` option.
+- Fix AWS Batch Docker entrypoint to use `/home` shared directory to coordinate Multi-node-Parallel job execution.
 
 3.1.3
 ------

--- a/cli/src/pcluster/resources/batch/docker/scripts/entrypoint.sh
+++ b/cli/src/pcluster/resources/batch/docker/scripts/entrypoint.sh
@@ -13,6 +13,13 @@ eval $(ssh-agent -s) && ssh-add ${SSHDIR}/id_rsa
 echo "Mounting /home..."
 /parallelcluster/bin/mount_nfs.sh "${PCLUSTER_HEAD_NODE_IP}" "/home"
 
+# create if not exists hidden pcluster folder
+PCLUSTER_HIDDEN_FOLDER="/home/.pcluster/"
+if [ ! -d "${PCLUSTER_HIDDEN_FOLDER}" ]; then
+  echo "Creating ${PCLUSTER_HIDDEN_FOLDER}"
+  mkdir "${PCLUSTER_HIDDEN_FOLDER}"
+fi
+
 echo "Mounting shared file system..."
 ebs_shared_dirs=$(echo "${PCLUSTER_SHARED_DIRS}" | tr "," " ")
 
@@ -25,7 +32,6 @@ do
 done
 
 ebs_arr=($ebs_shared_dirs)
-first_ebs_shared_dir=${ebs_arr[0]}
 
 # mount EFS via nfs
 if [[ "${PCLUSTER_EFS_FS_ID}" != "NONE" ]] && [[ ! -z "${PCLUSTER_AWS_REGION}" ]] && [[ "${PCLUSTER_EFS_SHARED_DIR}" != "NONE" ]]; then
@@ -39,7 +45,7 @@ fi
 
 # create hostfile if mnp job
 if [ -n "${AWS_BATCH_JOB_NUM_NODES}" ]; then
-  /parallelcluster/bin/generate_hostfile.sh "${first_ebs_shared_dir}" "${HOME}"
+  /parallelcluster/bin/generate_hostfile.sh "${PCLUSTER_HIDDEN_FOLDER}" "${HOME}"
 fi
 
 # run the user's script

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -369,12 +369,14 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
-      - regions: ["ap-southeast-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
       - regions: ["ap-northeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
+  test_awsbatch.py::test_awsbatch_defaults:
+    dimensions:
+      - regions: ["eu-north-1", "us-gov-west-1", "cn-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
   test_slurm.py::test_slurm:

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch_defaults/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch_defaults/pcluster.config.yaml
@@ -1,0 +1,21 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: False
+Scheduling:
+  Scheduler: awsbatch
+  AwsBatchQueues:
+    - Name: ondemand1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: compute-resource-11
+          InstanceTypes:
+            - optimal

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch_defaults/test_simple_job.sh
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch_defaults/test_simple_job.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+echo "Executing Test Script"
+exit 0


### PR DESCRIPTION
### Description of changes
* Only for AWSBatch fix entrypoint.sh to use /home/.pcluster to generate hostfiles instead of relying on a shared EBS from the cluster config
* Add integration tests

### Tests
* Manual Tests
* Run automated build and integration tests 
* Created new integration tests to test awsbatch scheduler with defaults


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
