### PR TITLE
integ-tests: remove assert_no_error_in_log from test_efa

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -20,7 +20,6 @@ from jinja2 import Environment, FileSystemLoader
 from remote_command_executor import RemoteCommandExecutor
 from utils import get_compute_nodes_instance_ids
 
-from tests.common.assertions import assert_no_errors_in_logs
 from tests.common.mpi_common import _test_mpi
 from tests.common.schedulers_common import get_scheduler_commands
 from tests.common.utils import fetch_instance_slots, run_system_analyzer
@@ -81,8 +80,6 @@ def test_sit_efa(
         _test_osu_benchmarks_multiple_bandwidth(
             remote_command_executor, scheduler_commands, test_datadir, slots_per_instance
         )
-
-    assert_no_errors_in_logs(remote_command_executor, scheduler)
 
 
 @pytest.mark.regions(["us-east-1"])
@@ -175,8 +172,6 @@ def test_hit_efa(
 
     if instance == "p4d.24xlarge" and os != "centos7":
         _test_nccl_benchmarks(remote_command_executor, test_datadir, "openmpi", scheduler_commands)
-
-    assert_no_errors_in_logs(remote_command_executor, scheduler)
 
 
 def _test_efa_installation(scheduler_commands, remote_command_executor, efa_installed=True, partition=None):


### PR DESCRIPTION
### Description of changes
Remove the check `assert_no_error_in_log` in `test_efa` because sometimes there are insufficient capacity isse during launching instances, but instances are eventually able to launch to run the job. In this case, we don't want to fail the test because of temporary insufficient capacity issue.

Also, this is not the test where we want to validate our scaling or node management logic, test_no_error_in_log is already in slurm test. The test_efa will failed if it can not scale even without the log assertion

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
