### PR TITLE
Fix `export-cluster-logs` command filter option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ x.x.x
 
 **BUG FIXES**
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.
+- Fix the ability to export cluster's logs when using `export-cluster-logs` command with the `--filters` option.
 
 3.1.3
 ------

--- a/cli/src/pcluster/cli/commands/cluster_logs.py
+++ b/cli/src/pcluster/cli/commands/cluster_logs.py
@@ -76,7 +76,7 @@ class ExportClusterLogsCommand(ExportLogsCommand, CliCommand):
             keep_s3_objects=args.keep_s3_objects,
             start_time=args.start_time,
             end_time=args.end_time,
-            filters=" ".join(args.filters) if args.filters else None,
+            filters=args.filters,
             output_file=output_file,
         )
         LOGGER.debug("Cluster's logs exported correctly to %s", url)

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -935,7 +935,7 @@ class Cluster:
         keep_s3_objects: bool = False,
         start_time: datetime = None,
         end_time: datetime = None,
-        filters: str = None,
+        filters: List[str] = None,
         output_file: str = None,
     ):
         """
@@ -948,7 +948,7 @@ class Cluster:
         :param keep_s3_objects: Keep the exported objects exports to S3. The default behavior is to delete them
         :param start_time: Start time of interval of interest for log events. ISO 8601 format: YYYY-MM-DDThh:mm:ssTZD
         :param end_time: End time of interval of interest for log events. ISO 8601 format: YYYY-MM-DDThh:mm:ssTZD
-        :param filters: Filters in the format Name=name,Values=value1,value2
+        :param filters: Filters in the format ["Name=name,Values=value1,value2"]
                Accepted filters are: private_dns_name, node_type==HeadNode
         """
         # check stack

--- a/cli/src/pcluster/models/cluster_resources.py
+++ b/cli/src/pcluster/models/cluster_resources.py
@@ -167,7 +167,7 @@ class ExportClusterLogsFiltersParser(ClusterLogsFiltersParser):
         log_group_name: str,
         start_time: datetime.datetime = None,
         end_time: datetime.datetime = None,
-        filters: str = None,
+        filters: List[str] = None,
     ):
         super().__init__(head_node, filters)
         self.time_parser = LogGroupTimeFiltersParser(log_group_name, start_time, end_time)

--- a/cli/tests/pcluster/cli/test_export_cluster_logs.py
+++ b/cli/tests/pcluster/cli/test_export_cluster_logs.py
@@ -41,6 +41,7 @@ class TestExportClusterLogsCommand:
         [
             ({"filters": ["Name=wrong,Value=test"]}, "filters parameter must be in the form"),
             ({"filters": ["private-dns-name=test"]}, "filters parameter must be in the form"),
+            ({"filters": "private-dns-name=test"}, "filters parameter must be in the form"),
         ],
     )
     def test_invalid_args(self, args, error_message, run_cli, capsys):
@@ -109,6 +110,7 @@ class TestExportClusterLogsCommand:
             "filters": None,
             "start_time": None,
             "end_time": None,
+            "filters": None,
         }
         expected_params.update(args)
         expected_params.update(
@@ -116,6 +118,7 @@ class TestExportClusterLogsCommand:
                 "output_file": args.get("output_file") and os.path.realpath(args.get("output_file")),
                 "start_time": args.get("start_time") and to_utc_datetime(args["start_time"]),
                 "end_time": args.get("end_time") and to_utc_datetime(args["end_time"]),
+                "filters": [args.get("filters")] if args.get("filters") else None,
             }
         )
         export_logs_mock.assert_called_with(**expected_params)

--- a/cli/tests/pcluster/models/test_cluster_resources.py
+++ b/cli/tests/pcluster/models/test_cluster_resources.py
@@ -39,6 +39,11 @@ class TestClusterLogsFiltersParser:
                 ["Name=private-dns-name,Values=ip-10-10-10-10,ip-10-10-10-11"],
                 "Filter .* doesn't accept comma separated strings as value",
             ),
+            (
+                "Name=private-dns-name,Values=ip-10-10-10-10,ip-10-10-10-11",
+                "Invalid filters Name=private-dns-name,Values=ip-10-10-10-10,ip-10-10-10-11. "
+                "They must be in the form Name=...,Values=",
+            ),
         ],
     )
     def test_initialization_error(self, mock_head_node, filters, expected_error):

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -226,13 +226,15 @@ class Cluster:
         instances = self.describe_cluster_instances(node_type=node_type, queue_name=queue_name)
         return [instance["instanceId"] for instance in instances]
 
-    def export_logs(self, bucket, output_file=None, bucket_prefix=None):
+    def export_logs(self, bucket, output_file=None, bucket_prefix=None, filters=None):
         """Run pcluster export-cluster-logs and return the result."""
         cmd_args = ["pcluster", "export-cluster-logs", "--cluster-name", self.name, "--bucket", bucket]
         if output_file:
             cmd_args += ["--output-file", output_file]
         if bucket_prefix:
             cmd_args += ["--bucket-prefix", bucket_prefix]
+        if filters:
+            cmd_args += ["--filters", filters]
         try:
             result = run_pcluster_command(cmd_args, log_error=False)
             response = json.loads(result.stdout)

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -277,9 +277,27 @@ def _test_pcluster_compute_fleet(cluster, expected_num_nodes):
     check_status(cluster, "CREATE_COMPLETE", "running", "RUNNING")
 
 
+def _test_export_log_files_are_expected(cluster, bucket_name, instance_ids, bucket_prefix, filters=None):
+    # test with a prefix and an output file
+    with tempfile.TemporaryDirectory() as tempdir:
+        output_file = f"{tempdir}/testfile.tar.gz"
+        ret = cluster.export_logs(
+            bucket=bucket_name, output_file=output_file, bucket_prefix=bucket_prefix, filters=filters
+        )
+        assert_that(ret["path"]).is_equal_to(output_file)
+
+        with tarfile.open(output_file) as archive:
+            filenames = {logfile.name for logfile in archive}
+
+            # check there are the logs of all the instances and cfn logs
+            for file_expected in set(instance_ids) | {f"{cluster.name}-cfn-events"}:
+                assert_that(any(file_expected in filename for filename in filenames)).is_true()
+
+
 def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster):
     """Test pcluster export-cluster-logs functionality."""
     instance_ids = cluster.get_cluster_instance_ids()
+    headnode_instance_id = cluster.get_cluster_instance_ids(node_type="HeadNode")
 
     logging.info("Testing that pcluster export-cluster-logs is working as expected")
     bucket_name = s3_bucket_factory()
@@ -305,20 +323,14 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster):
         ],
     }
     boto3.client("s3").put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(bucket_policy))
-
     # test with a prefix and an output file
-    with tempfile.TemporaryDirectory() as tempdir:
-        output_file = f"{tempdir}/testfile.tar.gz"
-        bucket_prefix = "test_prefix"
-        ret = cluster.export_logs(bucket=bucket_name, output_file=output_file, bucket_prefix=bucket_prefix)
-        assert_that(ret["path"]).is_equal_to(output_file)
+    bucket_prefix = "test_prefix"
+    _test_export_log_files_are_expected(cluster, bucket_name, instance_ids, bucket_prefix)
 
-        with tarfile.open(output_file) as archive:
-            filenames = {logfile.name for logfile in archive}
-
-            # check there are the logs of all the instances and cfn logs
-            for file_expected in set(instance_ids) | {f"{cluster.name}-cfn-events"}:
-                assert_that(any(file_expected in filename for filename in filenames)).is_true()
+    # test export-cluster-logs with filter option
+    _test_export_log_files_are_expected(
+        cluster, bucket_name, headnode_instance_id, bucket_prefix, filters="Name=node-type,Values=HeadNode"
+    )
 
     # check bucket_prefix folder has been removed from S3
     bucket_cleaned_up = False


### PR DESCRIPTION
### Description of changes
Fix the filter option of `export-cluster-logs`, the problem is that input type of filters is not consistent in class ClusterLogsFiltersParser and class ExportClusterLogsFiltersParser

Before the fix, the error message is:
pcluster export-cluster-logs -n slurm-memory --bucket test-bucket --filters "Name=node-type,Values=HeadNode"

ERROR: Unable to export cluster's logs.
Unexpected error when exporting cluster's logs: Invalid filters Name=node-type,Values=HeadNode. They must be in the form Name=...,Values=...

### Tests
* Add unit test
* Manually test

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
