### PR TITLE
cherry-pick: Fix export-cluster-logs command filter option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ CHANGELOG
 **CHANGES**
 - Do not require `PlacementGroup/Enabled` to be set to `true` when passing an existing `PlacementGroup/Id`.
 
+**BUG FIXES**
+- Fix the ability to export cluster's logs when using `export-cluster-logs` command with the `--filters` option.
+
 3.1.3
 ------
 

--- a/cli/src/pcluster/cli/commands/cluster_logs.py
+++ b/cli/src/pcluster/cli/commands/cluster_logs.py
@@ -76,7 +76,7 @@ class ExportClusterLogsCommand(ExportLogsCommand, CliCommand):
             keep_s3_objects=args.keep_s3_objects,
             start_time=args.start_time,
             end_time=args.end_time,
-            filters=" ".join(args.filters) if args.filters else None,
+            filters=args.filters,
             output_file=output_file,
         )
         LOGGER.debug("Cluster's logs exported correctly to %s", url)

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -906,7 +906,7 @@ class Cluster:
         keep_s3_objects: bool = False,
         start_time: datetime = None,
         end_time: datetime = None,
-        filters: str = None,
+        filters: List[str] = None,
         output_file: str = None,
     ):
         """
@@ -919,7 +919,7 @@ class Cluster:
         :param keep_s3_objects: Keep the exported objects exports to S3. The default behavior is to delete them
         :param start_time: Start time of interval of interest for log events. ISO 8601 format: YYYY-MM-DDThh:mm:ssTZD
         :param end_time: End time of interval of interest for log events. ISO 8601 format: YYYY-MM-DDThh:mm:ssTZD
-        :param filters: Filters in the format Name=name,Values=value1,value2
+        :param filters: Filters in the format ["Name=name,Values=value1,value2"]
                Accepted filters are: private_dns_name, node_type==HeadNode
         """
         # check stack

--- a/cli/src/pcluster/models/cluster_resources.py
+++ b/cli/src/pcluster/models/cluster_resources.py
@@ -167,7 +167,7 @@ class ExportClusterLogsFiltersParser(ClusterLogsFiltersParser):
         log_group_name: str,
         start_time: datetime.datetime = None,
         end_time: datetime.datetime = None,
-        filters: str = None,
+        filters: List[str] = None,
     ):
         super().__init__(head_node, filters)
         self.time_parser = LogGroupTimeFiltersParser(log_group_name, start_time, end_time)

--- a/cli/tests/pcluster/cli/test_export_cluster_logs.py
+++ b/cli/tests/pcluster/cli/test_export_cluster_logs.py
@@ -41,6 +41,7 @@ class TestExportClusterLogsCommand:
         [
             ({"filters": ["Name=wrong,Value=test"]}, "filters parameter must be in the form"),
             ({"filters": ["private-dns-name=test"]}, "filters parameter must be in the form"),
+            ({"filters": "private-dns-name=test"}, "filters parameter must be in the form"),
         ],
     )
     def test_invalid_args(self, args, error_message, run_cli, capsys):
@@ -116,6 +117,7 @@ class TestExportClusterLogsCommand:
                 "output_file": args.get("output_file") and os.path.realpath(args.get("output_file")),
                 "start_time": args.get("start_time") and to_utc_datetime(args["start_time"]),
                 "end_time": args.get("end_time") and to_utc_datetime(args["end_time"]),
+                "filters": [args.get("filters")] if args.get("filters") else None,
             }
         )
         export_logs_mock.assert_called_with(**expected_params)

--- a/cli/tests/pcluster/models/test_cluster_resources.py
+++ b/cli/tests/pcluster/models/test_cluster_resources.py
@@ -39,6 +39,11 @@ class TestClusterLogsFiltersParser:
                 ["Name=private-dns-name,Values=ip-10-10-10-10,ip-10-10-10-11"],
                 "Filter .* doesn't accept comma separated strings as value",
             ),
+            (
+                "Name=private-dns-name,Values=ip-10-10-10-10,ip-10-10-10-11",
+                "Invalid filters Name=private-dns-name,Values=ip-10-10-10-10,ip-10-10-10-11. "
+                "They must be in the form Name=...,Values=",
+            ),
         ],
     )
     def test_initialization_error(self, mock_head_node, filters, expected_error):

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -226,13 +226,15 @@ class Cluster:
         instances = self.describe_cluster_instances(node_type=node_type, queue_name=queue_name)
         return [instance["instanceId"] for instance in instances]
 
-    def export_logs(self, bucket, output_file=None, bucket_prefix=None):
+    def export_logs(self, bucket, output_file=None, bucket_prefix=None, filters=None):
         """Run pcluster export-cluster-logs and return the result."""
         cmd_args = ["pcluster", "export-cluster-logs", "--cluster-name", self.name, "--bucket", bucket]
         if output_file:
             cmd_args += ["--output-file", output_file]
         if bucket_prefix:
             cmd_args += ["--bucket-prefix", bucket_prefix]
+        if filters:
+            cmd_args += ["--filters", filters]
         try:
             result = run_pcluster_command(cmd_args, log_error=False)
             response = json.loads(result.stdout)


### PR DESCRIPTION
### Description of changes
* Include https://github.com/aws/aws-parallelcluster/pull/4013 and https://github.com/aws/aws-parallelcluster/pull/4017/files

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
