### PR TITLE
[develop] Specify role name in cfn-init call

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -645,32 +645,38 @@ class Iam(Resource):
             arns.append(policy.policy)
         return arns
 
-    def _extract_roles_from_instance_profile(self, instance_profile_name) -> List[str]:
-        """Return the ARNs of the IAM roles attached to the given instance profile."""
-        return [
-            role.get("Arn")
-            for role in (
-                AWSApi.instance().iam.get_instance_profile(instance_profile_name).get("InstanceProfile").get("Roles")
-            )
-        ]
+    @staticmethod
+    def _extract_role_from_instance_profile(instance_profile_name) -> str:
+        """Return the ARN of the IAM role attached to the given instance profile.
+
+        An instance profile can contain only one IAM role
+        see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
+        """
+        return (
+            AWSApi.instance()
+            .iam.get_instance_profile(instance_profile_name)
+            .get("InstanceProfile")
+            .get("Roles")[0]
+            .get("Arn")
+        )
 
     @property
-    def instance_role_arns(self) -> List[str]:
+    def instance_role_arn(self) -> str:
         """
-        Get unique collection of ARNs of IAM roles underlying instance profile.
+        Get IAM role of underlying instance profile.
 
-        self.instance_role is used if it's specified. Otherwise the roles contained within self.instance_profile are
+        self.instance_role is used if it's specified. Otherwise the role contained within self.instance_profile is
         used. It's assumed that self.instance_profile and self.instance_role cannot both be specified.
         """
         if self.instance_role:
-            instance_role_arns = {self.instance_role}
+            instance_role_arn = self.instance_role
         elif self.instance_profile:
-            instance_role_arns = set(
-                self._extract_roles_from_instance_profile(get_resource_name_from_resource_arn(self.instance_profile))
+            instance_role_arn = self._extract_role_from_instance_profile(
+                get_resource_name_from_resource_arn(self.instance_profile)
             )
         else:
-            instance_role_arns = {}
-        return list(instance_role_arns)
+            instance_role_arn = ""
+        return instance_role_arn
 
     def _register_validators(self):
         if self.instance_role:

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -77,7 +77,7 @@ function vendor_cookbook
 # deploy config files
 export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin
 cd /tmp
-cfn-init -s ${AWS::StackName} -v -c deployFiles -r HeadNodeLaunchTemplate --region ${AWS::Region}
+cfn-init -s ${AWS::StackName} -v -c deployFiles -r HeadNodeLaunchTemplate --region ${AWS::Region} --role ${HeadNodeInstanceRole}
 wait_condition_handle_presigned_url=$(cat /tmp/wait_condition_handle.txt)
 
 custom_cookbook=${CustomChefCookbook}
@@ -112,7 +112,7 @@ if [ "${!custom_cookbook}" != "NONE" ]; then
 fi
 
 # Call CloudFormation
-cfn-init -s ${AWS::StackName} -v -c default -r HeadNodeLaunchTemplate --region ${AWS::Region} || error_exit 'Failed to run cfn-init. If --norollback was specified, check /var/log/cfn-init.log and /var/log/cloud-init-output.log.'
+cfn-init -s ${AWS::StackName} -v -c default -r HeadNodeLaunchTemplate --region ${AWS::Region} --role ${HeadNodeInstanceRole} || error_exit 'Failed to run cfn-init. If --norollback was specified, check /var/log/cfn-init.log and /var/log/cloud-init-output.log.'
 cfn-signal --exit-code=0 --reason="HeadNode setup complete" "${!wait_condition_handle_presigned_url}"
 # End of file
 --==BOUNDARY==

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -94,7 +94,7 @@ from pcluster.templates.cdk_builder_utils import (
 )
 from pcluster.templates.cw_dashboard_builder import CWDashboardConstruct
 from pcluster.templates.slurm_builder import SlurmConstruct
-from pcluster.utils import get_attr, join_shell_args
+from pcluster.utils import get_attr, get_resource_name_from_resource_arn, join_shell_args
 
 StorageInfo = namedtuple("StorageInfo", ["id", "config"])
 
@@ -793,6 +793,8 @@ class ClusterCdkStack(Stack):
                 )
             )
 
+        head_node_role_name = self._get_head_node_role_name(head_node)
+
         # Head node Launch Template
         head_node_launch_template = ec2.CfnLaunchTemplate(
             self,
@@ -813,7 +815,7 @@ class ClusterCdkStack(Stack):
                 user_data=Fn.base64(
                     Fn.sub(
                         get_user_data_content("../resources/head_node/user_data.sh"),
-                        {**get_common_user_data_env(head_node, self.config)},
+                        {**get_common_user_data_env(head_node, self.config, head_node_role_name)},
                     )
                 ),
                 tag_specifications=[
@@ -983,11 +985,15 @@ class ClusterCdkStack(Stack):
                                 "triggers=post.update\n"
                                 "path=Resources.HeadNodeLaunchTemplate.Metadata.AWS::CloudFormation::Init\n"
                                 "action=PATH=/usr/local/bin:/bin:/usr/bin:/opt/aws/bin; "
-                                "cfn-init -v --stack ${StackName} "
-                                "--resource HeadNodeLaunchTemplate --configsets update --region ${Region}\n"
+                                "cfn-init -v --stack ${StackName} --resource HeadNodeLaunchTemplate "
+                                "--configsets update --region ${Region} --role ${HeadNodeInstanceRole}\n"
                                 "runas=root\n"
                             ),
-                            {"StackName": self._stack_name, "Region": self.region},
+                            {
+                                "StackName": self._stack_name,
+                                "Region": self.region,
+                                "HeadNodeInstanceRole": head_node_role_name,
+                            },
                         ),
                         "mode": "000400",
                         "owner": "root",
@@ -1098,6 +1104,16 @@ class ClusterCdkStack(Stack):
             head_node_instance.add_depends_on(self.scheduler_plugin_stack)
 
         return head_node_instance
+
+    def _get_head_node_role_name(self, head_node) -> str:
+        # Retrieve HeadNode role name
+        custom_instance_role_arn = head_node.iam.instance_role_arn
+        if custom_instance_role_arn:
+            # Case when custom instance profile or role is passed as input
+            return get_resource_name_from_resource_arn(custom_instance_role_arn)
+        else:
+            # Case when managed instance role is created
+            return self._managed_head_node_instance_role.ref
 
     def _get_launch_templates_config(self):
         if not self.compute_fleet_resources:

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -14,10 +14,12 @@ from datetime import datetime
 import pytest
 import yaml
 from assertpy import assert_that
+from aws_cdk.core import App
 from freezegun import freeze_time
 
 from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
+from pcluster.templates.cluster_stack import ClusterCdkStack
 from pcluster.utils import load_json_dict, load_yaml_dict
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket, mock_bucket
@@ -240,3 +242,38 @@ def _get_cfn_init_file_content(template, resource, file):
     content_separator = content_join[0]
     content_elements = content_join[1]
     return content_separator.join(str(elem) for elem in content_elements)
+
+
+@pytest.mark.parametrize(
+    "custom_iam, expected_role_name, managed",
+    [
+        ({"InstanceProfile": "arn:aws:iam::1234567890:instance-profile/MyCustomProfile"}, "MyCustomProfile", False),
+        ({"InstanceRole": "arn:aws:iam::1234567890:role/MyCustomRole"}, "MyCustomRole", False),
+        (None, "${Token[TOKEN.", True),
+    ],
+)
+def test_get_head_node_role_name(mocker, test_datadir, custom_iam, expected_role_name, managed):
+    mock_aws_api(mocker)
+    get_instance_profile_mock = mocker.patch(
+        "pcluster.aws.iam.IamClient.get_instance_profile",
+        return_value={"InstanceProfile": {"Roles": [{"Arn": f"arn:aws:iam::1234567890:role/{expected_role_name}"}]}},
+    )
+    input_yaml = load_yaml_dict(test_datadir / "config.yaml")
+    if custom_iam:
+        input_yaml["HeadNode"]["Iam"] = custom_iam
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+    head_node = cluster_config.head_node
+
+    cluster_stack = ClusterCdkStack(App(), "fake-output-file", "stack-name", cluster_config, dummy_cluster_bucket())
+    head_node_role = cluster_stack._get_head_node_role_name(head_node)
+
+    if managed:
+        assert_that(head_node_role).starts_with(expected_role_name)
+    else:
+        assert_that(head_node_role).is_equal_to(expected_role_name)
+
+    if "Profile" in expected_role_name:
+        assert_that(get_instance_profile_mock.call_count).is_equal_to(2)
+    else:
+        get_instance_profile_mock.assert_not_called()

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_get_head_node_role_name/config.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_get_head_node_role_name/config.yaml
@@ -1,0 +1,16 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
This allows to be able to create HeadNode outside Cloudformation scope, because by default, if no credentials are specified, CloudFormation checks for stack membership and limits the scope of the cfn-init call to the stack that the instance belongs to.

This is useful in case HeadNode instance created by Cloudformation is terminated, to be able to create a new one using the HeadNode LaunchTemplate.

### Tests


### References
* n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
