### PR TITLE
3.x: Add `lambda:TagResource` to API stack

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -612,6 +612,7 @@ Resources:
                   - s3.data-source.lustre.fsx.amazonaws.com
           - Action:
               - lambda:CreateFunction
+              - lambda:TagResource
               - lambda:DeleteFunction
               - lambda:GetFunctionConfiguration
               - lambda:GetFunction
@@ -735,6 +736,7 @@ Resources:
             Effect: Allow
             Action:
               - lambda:CreateFunction
+              - lambda:TagResource
               - lambda:GetFunction
               - lambda:AddPermission
             Resource:

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -354,6 +354,7 @@ Resources:
                   - s3.data-source.lustre.fsx.amazonaws.com
           - Action:
               - lambda:CreateFunction
+              - lambda:TagResource
               - lambda:DeleteFunction
               - lambda:GetFunctionConfiguration
               - lambda:GetFunction
@@ -477,6 +478,7 @@ Resources:
             Effect: Allow
             Action:
               - lambda:CreateFunction
+              - lambda:TagResource
               - lambda:GetFunction
               - lambda:AddPermission
             Resource:


### PR DESCRIPTION
Add lambda:TagsResource to API stack for cluster creation and image creation because Lambda will require an additional lambda:TagResource policy starting from May31 when create Lambda functions with resource tags


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
