### PR TITLE
[AWSBatch] Fix entrypoint.sh to use /home/.pcluster to generate hostfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ x.x.x
 **BUG FIXES**
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.
 - Fix the ability to export cluster's logs when using `export-cluster-logs` command with the `--filters` option.
+- Fix AWS Batch Docker entrypoint to use `/home` shared directory to coordinate Multi-node-Parallel job execution.
 
 3.1.3
 ------

--- a/cli/src/pcluster/resources/batch/docker/scripts/entrypoint.sh
+++ b/cli/src/pcluster/resources/batch/docker/scripts/entrypoint.sh
@@ -13,6 +13,13 @@ eval $(ssh-agent -s) && ssh-add ${SSHDIR}/id_rsa
 echo "Mounting /home..."
 /parallelcluster/bin/mount_nfs.sh "${PCLUSTER_HEAD_NODE_IP}" "/home"
 
+# create if not exists hidden pcluster folder
+PCLUSTER_HIDDEN_FOLDER="/home/.pcluster/"
+if [ ! -d "${PCLUSTER_HIDDEN_FOLDER}" ]; then
+  echo "Creating ${PCLUSTER_HIDDEN_FOLDER}"
+  mkdir "${PCLUSTER_HIDDEN_FOLDER}"
+fi
+
 echo "Mounting shared file system..."
 ebs_shared_dirs=$(echo "${PCLUSTER_SHARED_DIRS}" | tr "," " ")
 
@@ -25,7 +32,6 @@ do
 done
 
 ebs_arr=($ebs_shared_dirs)
-first_ebs_shared_dir=${ebs_arr[0]}
 
 # mount EFS via nfs
 IFS=',' read -r -a efs_ids <<< "${PCLUSTER_EFS_FS_IDS}"
@@ -41,7 +47,7 @@ fi
 
 # create hostfile if mnp job
 if [ -n "${AWS_BATCH_JOB_NUM_NODES}" ]; then
-  /parallelcluster/bin/generate_hostfile.sh "${first_ebs_shared_dir}" "${HOME}"
+  /parallelcluster/bin/generate_hostfile.sh "${PCLUSTER_HIDDEN_FOLDER}" "${HOME}"
 fi
 
 # run the user's script

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -385,12 +385,14 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
-      - regions: ["ap-southeast-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
       - regions: ["ap-northeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
+  test_awsbatch.py::test_awsbatch_defaults:
+    dimensions:
+      - regions: ["eu-north-1", "us-gov-west-1", "cn-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
   test_slurm.py::test_slurm:

--- a/tests/integration-tests/tests/schedulers/test_awsbatch.py
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch.py
@@ -19,29 +19,41 @@ from tests.common.scaling_common import get_batch_ce_max_size, get_batch_ce_min_
 from tests.common.schedulers_common import AWSBatchCommands
 
 
-@pytest.mark.batch_dockerfile_deps
+@pytest.mark.batch_dockerfile_deps  # specifies that the test is executed to verify dockerfile deps for released version
 @pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_awsbatch(pcluster_config_reader, clusters_factory, test_datadir, caplog, region):
-    """
-    Test all AWS Batch related features.
+    """Test all AWS Batch related features with shared storage."""
+    _test_awsbatch_common(pcluster_config_reader, clusters_factory, test_datadir, caplog, region, vcpus_check=True)
 
-    Grouped all tests in a single function so that cluster can be reused for all of them.
-    """
+
+@pytest.mark.usefixtures("region", "os", "instance", "scheduler")
+def test_awsbatch_defaults(pcluster_config_reader, clusters_factory, test_datadir, caplog, region):
+    """Test all AWS Batch related features with default parameters."""
+    _test_awsbatch_common(
+        pcluster_config_reader, clusters_factory, test_datadir, caplog, region, script="test_simple_job.sh"
+    )
+
+
+def _test_awsbatch_common(
+    pcluster_config_reader, clusters_factory, test_datadir, caplog, region, script="test_mpi_job.sh", vcpus_check=False
+):
+    """Grouped all tests in a single function so that cluster can be reused for all of them."""
     caplog.set_level(logging.DEBUG)  # Needed for checks in _assert_compute_instance_type_validation_successful
     cluster_config = pcluster_config_reader()
     cluster = clusters_factory(cluster_config)
     _assert_compute_instance_type_validation_successful(caplog)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
-    min_vcpus = cluster.config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["MinvCpus"]
-    max_vcpus = cluster.config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["MaxvCpus"]
-    assert_that(get_batch_ce_min_size(cluster.cfn_name, region)).is_equal_to(int(min_vcpus))
-    assert_that(get_batch_ce_max_size(cluster.cfn_name, region)).is_equal_to(int(max_vcpus))
+    if vcpus_check:
+        min_vcpus = cluster.config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["MinvCpus"]
+        max_vcpus = cluster.config["Scheduling"]["AwsBatchQueues"][0]["ComputeResources"][0]["MaxvCpus"]
+        assert_that(get_batch_ce_min_size(cluster.cfn_name, region)).is_equal_to(int(min_vcpus))
+        assert_that(get_batch_ce_max_size(cluster.cfn_name, region)).is_equal_to(int(max_vcpus))
 
     timeout = 120 if region.startswith("cn-") else 60  # Longer timeout in china regions due to less reliable networking
     _test_simple_job_submission(remote_command_executor, test_datadir, timeout)
     _test_array_submission(remote_command_executor)
-    _test_mnp_submission(remote_command_executor, test_datadir)
+    _test_mnp_submission(remote_command_executor, test_datadir, script=script)
     _test_job_kill(remote_command_executor, timeout)
 
 
@@ -75,12 +87,12 @@ def _test_array_submission(remote_command_executor):
     _test_job_submission(remote_command_executor, "awsbsub --vcpus 1 --memory 128 -a 4 sleep 1", children_number=4)
 
 
-def _test_mnp_submission(remote_command_executor, test_datadir):
+def _test_mnp_submission(remote_command_executor, test_datadir, script):
     logging.info("Testing MNP submission with MPI job.")
     _test_job_submission(
         remote_command_executor,
-        "awsbsub --vcpus 1 --memory 128 -n 4 -cf test_mpi_job.sh",
-        additional_files=[str(test_datadir / "test_mpi_job.sh")],
+        f"awsbsub --vcpus 1 --memory 128 -n 4 -cf {script}",
+        additional_files=[str(test_datadir / script)],
         children_number=4,
     )
 

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch_defaults/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch_defaults/pcluster.config.yaml
@@ -1,0 +1,21 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: False
+Scheduling:
+  Scheduler: awsbatch
+  AwsBatchQueues:
+    - Name: ondemand1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: compute-resource-11
+          InstanceTypes:
+            - optimal

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch_defaults/test_simple_job.sh
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch_defaults/test_simple_job.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+echo "Executing Test Script"
+exit 0


### PR DESCRIPTION
### Description of changes
* Cherry pick from https://github.com/aws/aws-parallelcluster/pull/4008
* Only for AWSBatch fix entrypoint.sh to use /home/.pcluster to generate hostfiles instead of relying on a shared EBS from the cluster config
* Add integration tests

### Tests
* Manual Tests
* Run automated build and integration tests 
* Created new integration tests to test awsbatch scheduler with defaults


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
