### PR TITLE
Partially reverting 'Minor fix to xdist_session_fixture'

### DIFF
--- a/tests/integration-tests/framework/fixture_utils.py
+++ b/tests/integration-tests/framework/fixture_utils.py
@@ -177,8 +177,10 @@ def xdist_session_fixture(**pytest_fixture_args):
     """
 
     def _xdist_session_fixture_decorator(func):
-        @functools.wraps(func)
         @pytest.fixture(scope="session", **pytest_fixture_args)
+        # FIXME: if wraps is after fixture then request is not automatically injected.
+        # If fixture is after wraps inter fixture dependencies are not resolved
+        @functools.wraps(func)
         def _xdist_session_fixture(request, *args, **kwargs):
             base_dir = f"{request.config.getoption('output_dir', '')}/tmp/shared_fixtures"
             os.makedirs(base_dir, exist_ok=True)


### PR DESCRIPTION
If wraps is after fixture then request argument is not automatically injected because the wrapped function signature matches the signature of the function annotated with xdist_session_fixture.
If fixture is after wraps inter fixture dependencies are not resolved.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
