### PR TITLE
Change Slurm version number to 21.08.8-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ x.x.x
 
 **CHANGES**
 - Remove support for Python 3.6.
+- Upgrade Slurm to version 21.08.8-2.
+- Do not require `PlacementGroup/Enabled` to be set to `true` when passing an existing `PlacementGroup/Id`.
 - Changes to FSx for Lustre file systems created by ParallelCluster:
   - Change the default deployment type to `Scratch_2`.
   - Change the Lustre server version to `2.12`.

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -968,7 +968,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
 def _test_slurm_version(remote_command_executor):
     logging.info("Testing Slurm Version")
     version = remote_command_executor.run_remote_command("sinfo -V").stdout
-    assert_that(version).is_equal_to("slurm 21.08.8")
+    assert_that(version).is_equal_to("slurm 21.08.8-2")
 
 
 def _test_job_dependencies(slurm_commands, region, stack_name, scaledown_idletime):


### PR DESCRIPTION
Signed-off-by: Jacopo De Amicis <jdamicis@amazon.it>


### Description of changes
* Change Slurm version number to 21.08.8-2.
* Fix Slurm version integration test with correct Slurm version number.

### Tests
* Will be tested directly on pipeline

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
