### PR TITLE
Do not execute test_awsbatch_defaults when checking dockerfile deps

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_awsbatch.py
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch.py
@@ -19,14 +19,13 @@ from tests.common.scaling_common import get_batch_ce_max_size, get_batch_ce_min_
 from tests.common.schedulers_common import AWSBatchCommands
 
 
-@pytest.mark.batch_dockerfile_deps
+@pytest.mark.batch_dockerfile_deps  # specifies that the test is executed to verify dockerfile deps for released version
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
 def test_awsbatch(pcluster_config_reader, clusters_factory, test_datadir, caplog, region):
     """Test all AWS Batch related features with shared storage."""
     _test_awsbatch_common(pcluster_config_reader, clusters_factory, test_datadir, caplog, region, vcpus_check=True)
 
 
-@pytest.mark.batch_dockerfile_deps
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
 def test_awsbatch_defaults(pcluster_config_reader, clusters_factory, test_datadir, caplog, region):
     """Test all AWS Batch related features with default parameters."""


### PR DESCRIPTION
### Description of changes
* Do not execute test_awsbatch_defaults when checking dockerfile deps

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
