### PR TITLE
Add tests for build-image with kernel 4 images

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -143,6 +143,12 @@ createami:
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"]
+  test_createami.py::test_kernel4_build_image_run_cluster:
+    dimensions:
+      - regions: ["eu-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        schedulers: ["awsbatch", "slurm"]
+        oss: ["alinux2"]
   test_createami.py::test_build_image_custom_components:
     dimensions:
       - regions: ["ap-southeast-2"]

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -49,6 +49,10 @@ OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
     "ubuntu2004": {"name": "Deep Learning AMI GPU CUDA * (Ubuntu 20.04)*", "owners": ["amazon"]},
 }
 
+OS_TO_KERNEL4_AMI_NAME_OWNER_MAP = {
+    "alinux2": {"name": "amzn2-ami-hvm-*.*.*.*-*-gp2", "owners": ["amazon"]},
+}
+
 # Get official pcluster AMIs or get from dev account
 PCLUSTER_AMI_OWNERS = ["amazon", "self"]
 # Pcluster AMIs are latest ParallelCluster official AMIs that align with cli version
@@ -63,6 +67,7 @@ AMI_TYPE_DICT = {
     "official": OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP,
     "remarkable": OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP,
     "pcluster": OS_TO_PCLUSTER_AMI_NAME_OWNER_MAP,
+    "kernel4": OS_TO_KERNEL4_AMI_NAME_OWNER_MAP,
 }
 
 

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -29,7 +29,7 @@ LOGGER = logging.getLogger(__name__)
 SYSTEM_ANALYZER_SCRIPT = pathlib.Path(__file__).parent / "data/system-analyzer.sh"
 
 OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
-    "alinux2": {"name": "amzn2-ami-hvm-*.*.*.*-*-gp2", "owners": ["amazon"]},
+    "alinux2": {"name": "amzn2-ami-kernel-5.10-hvm-*.*.*.*-*-gp2", "owners": ["amazon"]},
     "centos7": {"name": "CentOS 7.*", "owners": ["125523088429"]},
     "ubuntu1804": {
         "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-*-server-*",

--- a/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/image.config.yaml
@@ -1,0 +1,3 @@
+Build:
+    InstanceType: {{ instance }}
+    ParentImage: {{ parent_image }}

--- a/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/pcluster.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/pcluster.config.yaml
@@ -1,0 +1,26 @@
+Image:
+  Os: {{ os }}
+  CustomAmi: {{ custom_ami }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: False
+Scheduling:
+  Scheduler: {{ scheduler }}
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
+  - Name: queue1
+    Networking:
+      SubnetIds:
+        - {{ private_subnet_id }}
+    ComputeResources:
+      - Name: compute-resource1
+        {% if scheduler == "awsbatch" %}
+        InstanceTypes:
+          - {{ instance }}
+        {% else %}
+        InstanceType: {{ instance }}
+        {% endif %}


### PR DESCRIPTION
### Description of changes
* Since the base ami for Amazon Linux are based on kernel 5.10, this test verifies that the build-image still work with Amazon Linux based on kernel 4
* Add tests to build kernel 4 images from image-build and test the newly created images with a cluster

### Tests
* Manual tested with:
  * slurm and awsbatch scheduler
  * eu-west-1
  * INSTANCES_DEFAULT_X86
* Running on automated tests

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
