### PR TITLE
[develop] Add missing policies for lambda update performed through CFN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ x.x.x
 - Changes to FSx for Lustre file systems created by ParallelCluster:
   - Change the default deployment type to `Scratch_2`.
   - Change the Lustre server version to `2.12`.
+- Add `lambda:ListTags` and `lambda:UntagResource` to `ParallelClusterUserRole` used by ParallelCluster API stack for cluster update.
 
 **BUG FIXES**
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -620,6 +620,8 @@ Resources:
               - lambda:AddPermission
               - lambda:RemovePermission
               - lambda:UpdateFunctionConfiguration
+              - lambda:ListTags
+              - lambda:UntagResource
             Resource:
               - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:parallelcluster-*
               - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:pcluster-*

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -362,6 +362,8 @@ Resources:
               - lambda:AddPermission
               - lambda:RemovePermission
               - lambda:UpdateFunctionConfiguration
+              - lambda:ListTags
+              - lambda:UntagResource
             Resource:
               - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:parallelcluster-*
               - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:pcluster-*


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Starting from May 2022, lambda is enforcing the usage of lambda:ListTags, lambda:TagResource, and lambda:UntagResource policies to be able to perform the update of a lambda function deployed through CloudFormation

### Tests
* automated tests already in place

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
