### PR TITLE
Support mounting existing FSx for Ontap and OpenZFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ x.x.x
   `SlurmQueues` configuration changes don't impact Slurm scheduler configuration.
 - Add support for multiple Elastic File Systems.
 - Add support for multiple FSx File Systems.
+- Add support for attaching existing FSx for Ontap and FSx for OpenZFS File Systems.
 - Add support for FSx Lustre Persistent_2 deployment type.
 - Show `requested_value` and `current_value` values in the change set when adding or removing a section.
 

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -11,6 +11,8 @@
 import logging
 
 from pcluster.constants import (
+    LUSTRE,
+    OPENZFS,
     PCLUSTER_IMAGE_BUILD_LOG_TAG,
     PCLUSTER_IMAGE_CONFIG_TAG,
     PCLUSTER_IMAGE_ID_TAG,
@@ -248,14 +250,25 @@ class FsxFileSystemInfo:
         self.file_system_data = file_system_data
 
     @property
+    def file_system_type(self):
+        """Return the type of FSx file system (LUSTRE, WINDOWS, ONTAP, or OPENZFS). WINDOWS is not supported."""
+        return self.file_system_data.get("FileSystemType")
+
+    @property
     def mount_name(self):
-        """Return MountName of the filesystem."""
-        return self.file_system_data.get("LustreConfiguration").get("MountName")
+        """Return MountName of the FSx Lustre file system."""
+        return (
+            self.file_system_data.get("LustreConfiguration").get("MountName") if self.file_system_type == LUSTRE else ""
+        )
 
     @property
     def dns_name(self):
-        """Return DNSName of the filesystem."""
-        return self.file_system_data.get("DNSName")
+        """
+        Return DNSName of the file system.
+
+        Lustre, OpenZFS have DNS name on file systems. Ontap has DNS name on storage virtual machines.
+        """
+        return self.file_system_data.get("DNSName") if self.file_system_type in [LUSTRE, OPENZFS] else ""
 
     @property
     def file_system_id(self):

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -52,6 +52,26 @@ AWSBATCH_CLI_REQUIREMENTS = "aws-parallelcluster-awsbatch-cli<2.0.0"
 FSX_SSD_THROUGHPUT = {"PERSISTENT_1": [50, 100, 200], "PERSISTENT_2": [125, 250, 500, 1000]}
 FSX_HDD_THROUGHPUT = [12, 40]
 
+LUSTRE = "LUSTRE"
+OPENZFS = "OPENZFS"
+ONTAP = "ONTAP"
+
+FSX_LUSTRE = "FsxLustre"
+FSX_OPENZFS = "FsxOpenZfs"
+FSX_ONTAP = "FsxOntap"
+
+# https://docs.aws.amazon.com/fsx/latest/APIReference/API_DescribeVolumes.html#FSx-DescribeVolumes-request-VolumeIds.
+FSX_VOLUME_ID_REGEX = r"^fsvol-[0-9a-f]{17}$"
+
+FSX_PORTS = {
+    # Lustre Security group: https://docs.aws.amazon.com/fsx/latest/LustreGuide/limit-access-security-groups.html
+    LUSTRE: [988],
+    # OpenZFS Security group: https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/limit-access-security-groups.html
+    OPENZFS: [111, 2049, 20001, 20002, 20003],
+    # Ontap Security group: https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/limit-access-security-groups.html
+    ONTAP: [111, 635, 2049, 4046],
+}
+
 EBS_VOLUME_TYPE_IOPS_DEFAULT = {
     "io1": 100,
     "io2": 100,

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -69,6 +69,8 @@ write_files:
           "fsx_fs_ids": "${FSXIds}",
           "fsx_mount_names": "${FSXMountNames}",
           "fsx_dns_names": "${FSXDNSNames}",
+          "fsx_volume_junction_paths": "${FSXVolumeJunctionPaths}",
+          "fsx_fs_types": "${FSXFileSystemTypes}",
           "fsx_shared_dirs": "${FSXSharedDirs}",
           "scheduler": "${Scheduler}",
           "disable_hyperthreading_manually": "${DisableHyperThreadingManually}",

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -49,6 +49,8 @@ from pcluster.config.cluster_config import (
     Dns,
     Efa,
     EphemeralVolume,
+    ExistingFsxOntap,
+    ExistingFsxOpenZfs,
     HeadNode,
     HeadNodeImage,
     HeadNodeNetworking,
@@ -91,7 +93,7 @@ from pcluster.config.cluster_config import (
     SchedulerPluginUser,
     SharedEbs,
     SharedEfs,
-    SharedFsx,
+    SharedFsxLustre,
     SlurmClusterConfig,
     SlurmComputeResource,
     SlurmQueue,
@@ -107,6 +109,13 @@ from pcluster.constants import (
     DELETION_POLICIES,
     DELETION_POLICIES_WITH_SNAPSHOT,
     EBS_VOLUME_SIZE_DEFAULT,
+    FSX_LUSTRE,
+    FSX_ONTAP,
+    FSX_OPENZFS,
+    FSX_VOLUME_ID_REGEX,
+    LUSTRE,
+    ONTAP,
+    OPENZFS,
     SCHEDULER_PLUGIN_MAX_NUMBER_OF_USERS,
     SUPPORTED_OSES,
 )
@@ -429,6 +438,22 @@ class FsxLustreSettingsSchema(BaseSchema):
                 raise ValidationError(message=messages)
 
 
+class FsxOpenZfsSettingsSchema(BaseSchema):
+    """Represent the FSX OpenZFS schema."""
+
+    volume_id = fields.Str(
+        validate=validate.Regexp(FSX_VOLUME_ID_REGEX), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
+    )
+
+
+class FsxOntapSettingsSchema(BaseSchema):
+    """Represent the FSX Ontap schema."""
+
+    volume_id = fields.Str(
+        validate=validate.Regexp(FSX_VOLUME_ID_REGEX), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
+    )
+
+
 class SharedStorageSchema(BaseSchema):
     """Represent the generic SharedStorage schema."""
 
@@ -438,17 +463,25 @@ class SharedStorageSchema(BaseSchema):
     name = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     storage_type = fields.Str(
         required=True,
-        validate=validate.OneOf(["Ebs", "FsxLustre", "Efs"]),
+        validate=validate.OneOf(["Ebs", FSX_LUSTRE, FSX_OPENZFS, FSX_ONTAP, "Efs"]),
         metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
     ebs_settings = fields.Nested(EbsSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     efs_settings = fields.Nested(EfsSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     fsx_lustre_settings = fields.Nested(FsxLustreSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+    fsx_open_zfs_settings = fields.Nested(
+        FsxOpenZfsSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
+    )
+    fsx_ontap_settings = fields.Nested(FsxOntapSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 
     @validates_schema
     def no_coexist_storage_settings(self, data, **kwargs):
         """Validate that *_settings for different storage types do not co-exist."""
-        if self.fields_coexist(data, ["ebs_settings", "efs_settings", "fsx_lustre_settings"], **kwargs):
+        if self.fields_coexist(
+            data,
+            ["ebs_settings", "efs_settings", "fsx_lustre_settings", "fsx_open_zfs_settings", "fsx_ontap_settings"],
+            **kwargs,
+        ):
             raise ValidationError("Multiple *Settings sections cannot be specified in the SharedStorage items.")
 
     @validates_schema
@@ -457,7 +490,9 @@ class SharedStorageSchema(BaseSchema):
         for storage_type, settings in [
             ("Ebs", "ebs_settings"),
             ("Efs", "efs_settings"),
-            ("FsxLustre", "fsx_lustre_settings"),
+            (FSX_LUSTRE, "fsx_lustre_settings"),
+            (FSX_OPENZFS, "fsx_open_zfs_settings"),
+            (FSX_ONTAP, "fsx_ontap_settings"),
         ]:
             # Verify the settings section is associated to the right storage type
             if data.get(settings, None) and storage_type != data.get("storage_type"):
@@ -472,16 +507,24 @@ class SharedStorageSchema(BaseSchema):
         storage_type = data.get("storage_type")
         shared_volume_attributes = {"mount_dir": data.get("mount_dir"), "name": data.get("name")}
         settings = (
-            data.get("efs_settings", None) or data.get("fsx_lustre_settings", None) or data.get("ebs_settings", None)
+            data.get("efs_settings", None)
+            or data.get("ebs_settings", None)
+            or data.get("fsx_lustre_settings", None)
+            or data.get("fsx_open_zfs_settings", None)
+            or data.get("fsx_ontap_settings", None)
         )
         if settings:
             shared_volume_attributes.update(**settings)
         if storage_type == "Efs":
             return SharedEfs(**shared_volume_attributes)
-        elif storage_type == "FsxLustre":
-            return SharedFsx(**shared_volume_attributes)
         elif storage_type == "Ebs":
             return SharedEbs(**shared_volume_attributes)
+        elif storage_type == FSX_LUSTRE:
+            return SharedFsxLustre(**shared_volume_attributes)
+        elif storage_type == FSX_OPENZFS:
+            return ExistingFsxOpenZfs(**shared_volume_attributes)
+        elif storage_type == FSX_ONTAP:
+            return ExistingFsxOntap(**shared_volume_attributes)
         return None
 
     @pre_dump
@@ -492,14 +535,17 @@ class SharedStorageSchema(BaseSchema):
         if adapted_data.shared_storage_type == "efs":
             storage_type = "efs"
         elif adapted_data.shared_storage_type == "fsx":
-            storage_type = "fsx_lustre"
+            mapping = {LUSTRE: "fsx_lustre", OPENZFS: "fsx_open_zfs", ONTAP: "fsx_ontap"}
+            storage_type = mapping.get(adapted_data.file_system_type)
         else:  # "raid", "ebs"
             storage_type = "ebs"
         setattr(adapted_data, f"{storage_type}_settings", copy.copy(adapted_data))
         # Restore storage type attribute
-        adapted_data.storage_type = (
-            "FsxLustre" if adapted_data.shared_storage_type == "fsx" else storage_type.capitalize()
-        )
+        if adapted_data.shared_storage_type == "fsx":
+            mapping = {LUSTRE: FSX_LUSTRE, OPENZFS: FSX_OPENZFS, ONTAP: FSX_ONTAP}
+            adapted_data.storage_type = mapping.get(adapted_data.file_system_type)
+        else:
+            adapted_data.storage_type = storage_type.capitalize()
         return adapted_data
 
     @validates("mount_dir")

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -44,11 +44,14 @@ from aws_cdk.core import (
 from pcluster.aws.aws_api import AWSApi
 from pcluster.config.cluster_config import (
     AwsBatchClusterConfig,
+    BaseSharedFsx,
     CapacityType,
+    ExistingFsxOntap,
+    ExistingFsxOpenZfs,
     SchedulerPluginQueue,
     SharedEbs,
     SharedEfs,
-    SharedFsx,
+    SharedFsxLustre,
     SharedStorageType,
     SlurmClusterConfig,
     SlurmQueue,
@@ -57,6 +60,7 @@ from pcluster.constants import (
     CW_LOG_GROUP_NAME_PREFIX,
     CW_LOGS_CFN_PARAM_NAME,
     DEFAULT_EPHEMERAL_DIR,
+    LUSTRE,
     NODE_BOOTSTRAP_TIMEOUT,
     OS_MAPPING,
     PCLUSTER_CLUSTER_NAME_TAG,
@@ -604,17 +608,20 @@ class ClusterCdkStack(Stack):
             storage_list.extend(self._add_raid_volume(cfn_resource_id, storage))
         self.shared_storage_mount_dirs[storage.shared_storage_type].append(storage.mount_dir)
 
-    def _add_fsx_storage(self, id: str, shared_fsx: SharedFsx):
+    def _add_fsx_storage(self, id: str, shared_fsx: BaseSharedFsx):
         """Add specific Cfn Resources to map the FSX storage."""
         fsx_id = shared_fsx.file_system_id
+        mount_name = ""
+        dns_name = ""
+        volume_junction_path = ""
         if fsx_id:
-            # Initialize DNSName and MountName for existing filesystem, if any
-            self.shared_storage_attributes[shared_fsx.shared_storage_type]["MountNames"].append(
-                shared_fsx.existing_mount_name
-            )
-            self.shared_storage_attributes[shared_fsx.shared_storage_type]["DNSNames"].append(
-                shared_fsx.existing_dns_name
-            )
+            dns_name = shared_fsx.existing_dns_name
+            if isinstance(shared_fsx, ExistingFsxOntap):
+                volume_junction_path = shared_fsx.junction_path
+            if isinstance(shared_fsx, ExistingFsxOpenZfs):
+                volume_junction_path = shared_fsx.volume_path
+            if isinstance(shared_fsx, SharedFsxLustre):
+                mount_name = shared_fsx.existing_mount_name
         else:
             # Drive cache type must be set for HDD (Either "NONE" or "READ"), and must not be set for SDD (None).
             drive_cache_type = None
@@ -643,7 +650,7 @@ class ClusterCdkStack(Stack):
                 ),
                 backup_id=shared_fsx.backup_id,
                 kms_key_id=shared_fsx.kms_key_id,
-                file_system_type="LUSTRE",
+                file_system_type=LUSTRE,
                 storage_type=shared_fsx.fsx_storage_type,
                 subnet_ids=self.config.compute_subnet_ids,
                 security_group_ids=self._get_compute_security_groups(),
@@ -651,12 +658,17 @@ class ClusterCdkStack(Stack):
                 tags=[CfnTag(key="Name", value=shared_fsx.name)],
             )
             fsx_id = fsx_resource.ref
-            # Get MountName for new filesystem
-            self.shared_storage_attributes[shared_fsx.shared_storage_type]["MountNames"].append(
-                fsx_resource.attr_lustre_mount_name
-            )
-            # DNSName cannot be retrieved from CFN and will be generated in cookbook
-            self.shared_storage_attributes[shared_fsx.shared_storage_type]["DNSNames"].append("")
+            # Get MountName for new filesystem. DNSName cannot be retrieved from CFN and will be generated in cookbook
+            mount_name = fsx_resource.attr_lustre_mount_name
+
+        self.shared_storage_attributes[shared_fsx.shared_storage_type]["DNSNames"].append(dns_name)
+        self.shared_storage_attributes[shared_fsx.shared_storage_type]["MountNames"].append(mount_name)
+        self.shared_storage_attributes[shared_fsx.shared_storage_type]["VolumeJunctionPaths"].append(
+            volume_junction_path
+        )
+        self.shared_storage_attributes[shared_fsx.shared_storage_type]["FileSystemTypes"].append(
+            shared_fsx.file_system_type
+        )
 
         return fsx_id
 
@@ -876,6 +888,12 @@ class ClusterCdkStack(Stack):
                     ),
                     "fsx_dns_names": to_comma_separated_string(
                         self.shared_storage_attributes[SharedStorageType.FSX]["DNSNames"]
+                    ),
+                    "fsx_volume_junction_paths": to_comma_separated_string(
+                        self.shared_storage_attributes[SharedStorageType.FSX]["VolumeJunctionPaths"]
+                    ),
+                    "fsx_fs_types": to_comma_separated_string(
+                        self.shared_storage_attributes[SharedStorageType.FSX]["FileSystemTypes"]
                     ),
                     "fsx_shared_dirs": to_comma_separated_string(self.shared_storage_mount_dirs[SharedStorageType.FSX]),
                     "volume": get_shared_storage_ids_by_type(self.shared_storage_infos, SharedStorageType.EBS),
@@ -1439,6 +1457,12 @@ class ComputeFleetConstruct(Construct):
                                 ),
                                 "FSXDNSNames": to_comma_separated_string(
                                     self._shared_storage_attributes[SharedStorageType.FSX]["DNSNames"]
+                                ),
+                                "FSXVolumeJunctionPaths": to_comma_separated_string(
+                                    self._shared_storage_attributes[SharedStorageType.FSX]["VolumeJunctionPaths"]
+                                ),
+                                "FSXFileSystemTypes": to_comma_separated_string(
+                                    self._shared_storage_attributes[SharedStorageType.FSX]["FileSystemTypes"]
                                 ),
                                 "FSXSharedDirs": to_comma_separated_string(
                                     self._shared_storage_mount_dirs[SharedStorageType.FSX]

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -11,7 +11,7 @@
 import os
 
 from pcluster.aws.aws_api import AWSApi
-from pcluster.aws.aws_resources import InstanceTypeInfo
+from pcluster.aws.aws_resources import FsxFileSystemInfo, InstanceTypeInfo
 from pcluster.aws.cfn import CfnClient
 from pcluster.aws.dynamo import DynamoResource
 from pcluster.aws.ec2 import Ec2Client
@@ -155,6 +155,41 @@ class _DummyFSxClient(FSxClient):
                 "MountName": "dummy-fsx-mount-name",
             },
         }
+
+    def describe_volumes(self, volume_ids):
+        """Describe FSx volumes."""
+        result = []
+        for volume_id in volume_ids:
+            result.append(
+                {
+                    "FileSystemId": "fs-12345678123456789",
+                    "VolumeId": volume_id,
+                    "OntapConfiguration": {"StorageVirtualMachineId": "svm-123", "JunctionPath": "/vol1"},
+                    "OpenZFSConfiguration": {"VolumePath": "/fsx"},
+                }
+            )
+        return result
+
+    def get_file_systems_info(self, fsx_fs_ids):
+        result = []
+        for file_system_id in fsx_fs_ids:
+            result.append(
+                FsxFileSystemInfo(
+                    {
+                        "FileSystemType": "LUSTRE",
+                        "LustreConfiguration": {"MountName": "abcdef"},
+                        "FileSystemId": file_system_id,
+                    }
+                )
+            )
+        return result
+
+    def describe_storage_virtual_machines(self, storage_virtual_machine_ids):
+        """Describe storage virtual machines."""
+        result = []
+        for _ in storage_virtual_machine_ids:
+            result.append({"Endpoints": {"Nfs": {"DNSName": "abcd"}}})
+        return result
 
 
 class _DummyS3Client(S3Client):

--- a/cli/tests/pcluster/config/dummy_cluster_config.py
+++ b/cli/tests/pcluster/config/dummy_cluster_config.py
@@ -39,7 +39,7 @@ from pcluster.config.cluster_config import (
     SchedulerPluginSettings,
     SharedEbs,
     SharedEfs,
-    SharedFsx,
+    SharedFsxLustre,
     SlurmClusterConfig,
     SlurmComputeResource,
     SlurmQueue,
@@ -262,7 +262,7 @@ def dummy_scheduler_plugin_cluster_config(mocker):
 
 def dummy_fsx(file_system_id=None, mount_dir="/shared", name="name"):
     """Generate dummy fsx."""
-    return SharedFsx(
+    return SharedFsxLustre(
         mount_dir=mount_dir,
         name=name,
         file_system_id=file_system_id,

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -161,6 +161,16 @@ SharedStorage:
       AutoImportPolicy: NEW  # NEW | NEW_CHANGED | NEW_CHANGED_DELETED
       DriveCacheType: READ  # READ
       StorageType: HDD  # HDD | SSD
+  - MountDir: /my/mount/point4
+    Name: name4
+    StorageType: FsxOpenZfs
+    FsxOpenZfsSettings:
+      VolumeId: fsvol-12345678901234567
+  - MountDir: /my/mount/point5
+    Name: name5
+    StorageType: FsxOntap
+    FsxOntapSettings:
+      VolumeId: fsvol-12345678901234567
 Iam:
   Roles:
     LambdaFunctionsRole: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/awsbatch-imds-secured-false.head-node.dna.json
@@ -22,6 +22,8 @@
     "fsx_fs_ids": "",
     "fsx_mount_names": "",
     "fsx_shared_dirs": "",
+    "fsx_fs_types": "",
+    "fsx_volume_junction_paths": "",
     "head_node_imds_secured": "false",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",
     "log_group_name": "/aws/parallelcluster/clustername-202101010101",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/scheduler-plugin-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/scheduler-plugin-imds-secured-true.head-node.dna.json
@@ -22,6 +22,8 @@
     "fsx_fs_ids": "",
     "fsx_mount_names": "",
     "fsx_shared_dirs": "",
+    "fsx_fs_types": "",
+    "fsx_volume_junction_paths": "",
     "head_node_imds_secured": "true",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",
     "log_group_name": "/aws/parallelcluster/clustername-202101010101",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-false.head-node.dna.json
@@ -24,6 +24,8 @@
     "fsx_fs_ids": "",
     "fsx_mount_names": "",
     "fsx_shared_dirs": "",
+    "fsx_fs_types": "",
+    "fsx_volume_junction_paths": "",
     "head_node_imds_secured": "false",
     "hosted_zone": "{'Ref': 'Route53HostedZone'}",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/slurm-imds-secured-true.head-node.dna.json
@@ -24,6 +24,8 @@
     "fsx_fs_ids": "",
     "fsx_mount_names": "",
     "fsx_shared_dirs": "",
+    "fsx_fs_types": "",
+    "fsx_volume_junction_paths": "",
     "head_node_imds_secured": "true",
     "hosted_zone": "{'Ref': 'Route53HostedZone'}",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
@@ -60,12 +60,24 @@ SharedStorage:
     StorageType: Ebs
     EbsSettings:
       Size: 35
-  - MountDir: fsx
+  - MountDir: fsx1
     Name: myfsx
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: 1200
       DeploymentType: SCRATCH_2
+  - MountDir: fsx2
+    Name: existingopenzfs
+    StorageType: FsxOpenZfs
+    FsxOpenZfsSettings:
+      FileSystemId: {{ fsx_open_zfs_fs_id }}
+  - MountDir: fsx3
+    Name: existingontap
+    StorageType: FsxOntap
+    FsxOntapSettings:
+      FileSystemId: {{ fsx_ontap_fs_id }}
+      StorageVirtualMachineId: {{ fsx_ontap_svm_id }}
+      VolumeJunctionPath: /vol1
 {% if os == "centos7" and architechture=="x86_64"%}
 AdditionalPackages:
   IntelSoftware:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multiple_fsx/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multiple_fsx/pcluster.config.yaml
@@ -34,7 +34,7 @@ Scheduling:
         SubnetIds:
           - {{ private_subnet_id }}
 SharedStorage:
-  - MountDir: {{ mount_dirs[0] }}
+  - MountDir: {{ fsx_lustre_mount_dirs[0] }}
     Name: fsx1
     StorageType: FsxLustre
     FsxLustreSettings:
@@ -43,10 +43,24 @@ SharedStorage:
       ExportPath: s3://{{ bucket_name }}/export_dir
       DeploymentType: PERSISTENT_1
       PerUnitStorageThroughput: 200
-  {% for fsx_fs_id in existing_fsx_fs_ids %}
-  - MountDir: {{ mount_dirs[loop.index] }} # the index of mount dirs starts from the second item. Because the first is used for the new FSx.
+  {% for fsx_fs_id in existing_fsx_lustre_fs_ids %}
+  - MountDir: {{ fsx_lustre_mount_dirs[loop.index] }} # the index of mount dirs starts from the second item. Because the first is used for the new FSx.
     Name: existingfsx{{ loop.index-1 }}
     StorageType: FsxLustre
     FsxLustreSettings:
       FileSystemId: {{ fsx_fs_id }}
+  {% endfor %}
+  {% for fsx_open_zfs_volume_id in fsx_open_zfs_volume_ids %}
+  - MountDir: {{ fsx_open_zfs_mount_dirs[loop.index-1] }}
+    Name: existingopenzfs{{ loop.index-1 }}
+    StorageType: FsxOpenZfs
+    FsxOpenZfsSettings:
+      VolumeId: {{ fsx_open_zfs_volume_id }}
+  {% endfor %}
+  {% for fsx_ontap_volume_id in fsx_ontap_volume_ids %}
+  - MountDir: {{ fsx_ontap_mount_dirs[loop.index-1] }}
+    Name: existingontap{{ loop.index-1 }}
+    StorageType: FsxOntap
+    FsxOntapSettings:
+      VolumeId: {{ fsx_ontap_volume_id }}
   {% endfor %}


### PR DESCRIPTION
1. Add section of FsxOntap and FsxOpenZfs settings in configuration file:
```
SharedStorage:
  - MountDir: /my/mount/point1
    Name: name1
    StorageType: FsxOpenZfs
    FsxOpenZfsSettings:
      VolumeId: fsvol-12345678901234567
  - MountDir: /my/mount/point2
    Name: name2
    StorageType: FsxOntap
    FsxOntapSettings:
      VolumeId: fsvol-12345678901234567
```
2. Use class inheritance in cluster_config.py for FSx for Lustre, Optap, OpenZFS
3. Pass two more attributes to cookbook:
`fsx_volume_junction_paths`: It is a comma separated list. There are strings between the comma if it is FSx for Ontap and OpenZFS. There is empty if it is FSx for Lustre.
`fsx_fs_types`: It is a comma separated list. It tells the cookbook what mount method to use according to the file system (Lustre, Ontap, OpenZFS)
4. Improve FSx security group validator to check different ports for different file system
5. Improve integration test to test the new file system. Move fsx_factory to conftest, so it can be reused by other tests

Test:
Manual tests are done with test_ad_integration and test_cluster_in_no_internet_subnet

Signed-off-by: Hanwen <hanwenli@amazon.com>


### Tests
Improved test_multiple_fsx tests to check Ontap and OpenZFS,
Manual tests are done with test_ad_integration and test_cluster_in_no_internet_subnet

### References
* This PR works together with https://github.com/aws/aws-parallelcluster-cookbook/pull/1446

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
