### PR TITLE
Multi-AZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ x.x.x
 - Add support for multiple FSx File Systems.
 - Add support for FSx Lustre Persistent_2 deployment type.
 - Show `requested_value` and `current_value` values in the change set when adding or removing a section.
+- Support for different availibility zones per Slurm partition.
 
 **CHANGES**
 - Remove support for Python 3.6.

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1701,19 +1701,6 @@ class SchedulingSchema(BaseSchema):
                     f"Scheduling > *Queues section is not appropriate to the Scheduler: {configured_scheduler}."
                 )
 
-    @validates_schema
-    def same_subnet_in_different_queues(self, data, **kwargs):
-        """Validate subnet_ids configured in different queues are the same."""
-        if "slurm_queues" in data or "scheduler_queues" in data:
-            queues = "slurm_queues" if "slurm_queues" in data else "scheduler_queues"
-
-            def _queue_has_subnet_ids(queue):
-                return queue.networking and queue.networking.subnet_ids
-
-            subnet_ids = {tuple(set(q.networking.subnet_ids)) for q in data[queues] if _queue_has_subnet_ids(q)}
-            if len(subnet_ids) > 1:
-                raise ValidationError("The SubnetIds used for all of the queues should be the same.")
-
     @post_load
     def make_resource(self, data, **kwargs):
         """Generate the right type of scheduling according to the child type (Slurm vs AwsBatch vs Custom)."""

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -47,6 +47,15 @@ class SubnetsValidator(Validator):
                         FailureLevel.ERROR,
                     )
 
+            # warn if subnets are not in the same AZ
+            azs = {subnet.get("AvailabilityZone") for subnet in subnets}
+            if len(azs) > 1:
+                self._add_failure(
+                    f"Subnets in multiple Availibility Zones {azs} may result in data transfer charges. "
+                    + "Please review the EC2 docs: https://aws.amazon.com/ec2/pricing/on-demand/#Data_Transfer",
+                    FailureLevel.WARNING,
+                )
+
             # Check for DNS support in the VPC
             if not AWSApi.instance().ec2.is_enable_dns_support(vpc_id):
                 self._add_failure(f"DNS Support is not enabled in the VPC {vpc_id}.", FailureLevel.ERROR)

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -273,23 +273,6 @@ def dummy_slurm_compute_resource(name, instance_type):
             },
             None,
         ),
-        (
-            {
-                "Scheduler": "slurm",
-                "SlurmQueues": [
-                    dummy_slurm_queue(),
-                    {
-                        "Name": "queue2",
-                        "Networking": {"SubnetIds": ["subnet-00000000"]},
-                        "ComputeResources": [
-                            {"Name": "compute_resource3", "InstanceType": "c5.2xlarge", "MaxCount": 5},
-                            {"Name": "compute_resource4", "InstanceType": "c4.2xlarge"},
-                        ],
-                    },
-                ],
-            },
-            "The SubnetIds used for all of the queues should be the same",
-        ),
         (  # maximum slurm queue length
             {
                 "Scheduler": "slurm",


### PR DESCRIPTION
Enable using a separate Availability Zone per-partition. Warn about cross AZ charges if multiple-AZ's are specified.

This enables users to use multiple availability zones. This is part of https://github.com/aws/aws-parallelcluster/issues/3576

Signed-off-by: Sean Smith <seaam@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
