### PR TITLE
3.x: Add integ-test for queue paramter update

### DIFF
--- a/tests/integration-tests/tests/common/hit_common.py
+++ b/tests/integration-tests/tests/common/hit_common.py
@@ -61,6 +61,11 @@ def assert_compute_node_states(scheduler_commands, compute_nodes, expected_state
         assert_that(expected_states).contains(node_states.get(node))
 
 
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))
+def wait_for_compute_nodes_states(scheduler_commands, compute_nodes, expected_states):
+    assert_compute_node_states(scheduler_commands, compute_nodes, expected_states)
+
+
 def assert_compute_node_reasons(scheduler_commands, compute_nodes, expected_reason):
     for node in compute_nodes:
         node_info = scheduler_commands.get_nodes_info(node)

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update.yaml
@@ -1,0 +1,36 @@
+Image:
+  Os: {{ os }}
+  CustomAmi: {{ global_custom_ami }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      ComputeResources:
+        - Name: queue1-i1
+          InstanceType: c5.xlarge
+          MinCount: 1
+          MaxCount: 2
+      ComputeSettings:
+        LocalStorage:
+          RootVolume:
+            Size: {{ updated_compute_root_volume_size }}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+    - Name: queue2
+      ComputeResources:
+        - Name: queue2-i1
+          InstanceType: c5.xlarge
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Image:
+        CustomAmi: {{ custom_ami }}

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update_drain.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update_drain.yaml
@@ -1,0 +1,38 @@
+Image:
+  Os: {{ os }}
+  CustomAmi: {{ global_custom_ami }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  SlurmSettings:
+    QueueUpdateStrategy: DRAIN
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      ComputeResources:
+        - Name: queue1-i1
+          InstanceType: c5.xlarge
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeSettings:
+        LocalStorage:
+          RootVolume:
+            Size: {{ updated_compute_root_volume_size }}
+    - Name: queue2
+      ComputeResources:
+        - Name: queue2-i1
+          InstanceType: c5.xlarge
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Image:
+        CustomAmi: {{ custom_ami }}

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.yaml
@@ -1,0 +1,34 @@
+Image:
+  Os: {{ os }}
+  CustomAmi: {{ global_custom_ami }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      ComputeResources:
+        - Name: queue1-i1
+          InstanceType: c5.xlarge
+          MinCount: 1
+          MaxCount: 2
+      ComputeSettings:
+        LocalStorage:
+          RootVolume:
+            Size: {{ initial_compute_root_volume_size }}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+    - Name: queue2
+      ComputeResources:
+        - Name: queue2-i1
+          InstanceType: c5.xlarge
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.update_drain_without_running_job.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.update_drain_without_running_job.yaml
@@ -1,0 +1,36 @@
+Image:
+  Os: {{ os }}
+  CustomAmi: {{ global_custom_ami }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  SlurmSettings:
+    QueueUpdateStrategy: DRAIN
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      ComputeResources:
+        - Name: queue1-i1
+          InstanceType: c5.xlarge
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeSettings:
+          LocalStorage:
+            RootVolume:
+              Size: {{ updated_compute_root_volume_size }}
+    - Name: queue2
+      ComputeResources:
+        - Name: queue2-i1
+          InstanceType: c5.xlarge
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}


### PR DESCRIPTION
Test update queue ami with drain strategy, nodes in update queue will be drain, jobs in other queues are not disrrupted.

Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
