### PR TITLE
Fix test_update

### DIFF
--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -153,7 +153,7 @@ SharedStorage:
     Name: fsx
     StorageType: FsxLustre
     FsxLustreSettings:
-      StorageCapacity: 3600
+      StorageCapacity: 2400
       WeeklyMaintenanceStartTime: "3:02:30"
 Monitoring:
   DetailedMonitoring: false

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -94,7 +94,7 @@ SharedStorage:
     Name: fsx
     StorageType: FsxLustre
     FsxLustreSettings:
-      StorageCapacity: 3600
+      StorageCapacity: 2400
 #     WeeklyMaintenanceStartTime: "3:02:30" #Initially not set
 Monitoring:
   DetailedMonitoring: false


### PR DESCRIPTION
After changing the default FSx Lustre to Scratch_2 with https://github.com/aws/aws-parallelcluster/pull/3977, the test started to fail. The storage capacity 3.6TB specified is only supported by Scratch_1. Scratch_2 requires 1.2, 2.4, 4.8, 7.2 ...

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
test_update has been passed after this PR

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
