### PR TITLE
Add a test to verify the security group attached to the shared EFS/FSxLustre file systems

### DIFF
--- a/cli/tests/pcluster/templates/test_shared_storage.py
+++ b/cli/tests/pcluster/templates/test_shared_storage.py
@@ -1,0 +1,46 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.schemas.cluster_schema import ClusterSchema
+from pcluster.templates.cdk_builder import CDKTemplateBuilder
+from pcluster.utils import load_yaml_dict
+from tests.pcluster.aws.dummy_aws_api import mock_aws_api
+from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket
+
+
+@pytest.mark.parametrize(
+    "config_file_name, resource_logical_name, security_group_property, expected_security_group",
+    [
+        ("efs.config.yaml", "EFS0MTstring", "SecurityGroups", "ComputeSecurityGroup"),
+        ("fsx-lustre.config.yaml", "FSX0", "SecurityGroupIds", "ComputeSecurityGroup"),
+    ],
+)
+def test_shared_storage_security_group(
+    mocker, test_datadir, config_file_name, resource_logical_name, security_group_property, expected_security_group
+):
+    mock_aws_api(mocker)
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    actual_security_group_resource = generated_template["Resources"][resource_logical_name]["Properties"][
+        security_group_property
+    ]
+
+    assert_that(actual_security_group_resource).is_equal_to([{"Ref": expected_security_group}])

--- a/cli/tests/pcluster/templates/test_shared_storage/test_shared_storage_security_group/efs.config.yaml
+++ b/cli/tests/pcluster/templates/test_shared_storage/test_shared_storage_security_group/efs.config.yaml
@@ -1,0 +1,20 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+SharedStorage:
+  - MountDir: /shared/efs1
+    Name: shared-efs1
+    StorageType: Efs

--- a/cli/tests/pcluster/templates/test_shared_storage/test_shared_storage_security_group/fsx-lustre.config.yaml
+++ b/cli/tests/pcluster/templates/test_shared_storage/test_shared_storage_security_group/fsx-lustre.config.yaml
@@ -1,0 +1,22 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+SharedStorage:
+  - MountDir: /shared/fsx1
+    Name: shared-fsx1
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 1200


### PR DESCRIPTION
### Description of changes
Add a test to verify the security group attached to the shared EFS/FSxLustre file systems. In particular, we want to verify that the security group is the compute fleet's.

### Tests
Executed the unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
