### PR TITLE
Fix test_fsx_lustre_backup

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -350,7 +350,9 @@ class SharedFsxLustre(BaseSharedFsx):
         super().__init__(**kwargs)
         self.storage_capacity = Resource.init_param(storage_capacity)
         self.fsx_storage_type = Resource.init_param(fsx_storage_type)
-        self.deployment_type = Resource.init_param(deployment_type, default="SCRATCH_2")
+        self.deployment_type = Resource.init_param(
+            deployment_type, default="SCRATCH_2" if backup_id is None and file_system_id is None else None
+        )
         self.data_compression_type = Resource.init_param(data_compression_type)
         self.export_path = Resource.init_param(export_path)
         self.import_path = Resource.init_param(import_path)
@@ -366,6 +368,7 @@ class SharedFsxLustre(BaseSharedFsx):
         self.auto_import_policy = Resource.init_param(auto_import_policy)
         self.drive_cache_type = Resource.init_param(drive_cache_type)
         self.file_system_type = LUSTRE
+        self.file_system_type_version = "2.12" if backup_id is None and file_system_id is None else None
 
     def _register_validators(self):
         super()._register_validators()

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -654,7 +654,7 @@ class ClusterCdkStack(Stack):
                 storage_type=shared_fsx.fsx_storage_type,
                 subnet_ids=self.config.compute_subnet_ids,
                 security_group_ids=self._get_compute_security_groups(),
-                file_system_type_version="2.12",
+                file_system_type_version=shared_fsx.file_system_type_version,
                 tags=[CfnTag(key="Name", value=shared_fsx.name)],
             )
             fsx_id = fsx_resource.ref


### PR DESCRIPTION
With this commit https://github.com/aws/aws-parallelcluster/commit/271aba696ae9e7154582a859624928c74d5d8167, we added the default lustre deployment type `SCRATCH_2` and Lustre server version`2.12.

However, if backup id is specified, those defaults shouldn't be specified because the Lustre file system configuration will be created according to the backup configuration.

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
