### PR TITLE
Fix code style error after Pylint 2.14

### DIFF
--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -180,11 +180,11 @@ class Resource(ABC):
 
     def _nested_resources(self):
         nested_resources = []
-        for attr, value in self.__dict__.items():
+        for _, value in self.__dict__.items():
             if isinstance(value, Resource):
                 nested_resources.append(value)
             if isinstance(value, list) and value:
-                nested_resources.extend(item for item in self.__getattribute__(attr) if isinstance(item, Resource))
+                nested_resources.extend(item for item in value if isinstance(item, Resource))
         return nested_resources
 
     def validate(self, suppressors: List[ValidatorSuppressor] = None) -> List[ValidationResult]:


### PR DESCRIPTION
Solving Pylint error: 
```
************* Module src.pcluster.config.common
src/pcluster/config/common.py:187:57: C2801: Unnecessarily calls dunder method __getattribute__. Access attribute directly or use getattr built-in function. (unnecessary-dunder-call)
```

Even without the Pylint, we know in the code that the value is already retrieved from the __dict__. So it was unnecessary to use `__getattribute__` again

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
