### PR TITLE
Make volume id in OpenZFS and Ontap as required parameters

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -442,7 +442,9 @@ class FsxOpenZfsSettingsSchema(BaseSchema):
     """Represent the FSX OpenZFS schema."""
 
     volume_id = fields.Str(
-        validate=validate.Regexp(FSX_VOLUME_ID_REGEX), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
+        required=True,
+        validate=validate.Regexp(FSX_VOLUME_ID_REGEX),
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
 
 
@@ -450,7 +452,9 @@ class FsxOntapSettingsSchema(BaseSchema):
     """Represent the FSX Ontap schema."""
 
     volume_id = fields.Str(
-        validate=validate.Regexp(FSX_VOLUME_ID_REGEX), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
+        required=True,
+        validate=validate.Regexp(FSX_VOLUME_ID_REGEX),
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
 
 


### PR DESCRIPTION
The volume id is required to mount OpenZFS and Ontap

Signed-off-by: Hanwen <hanwenli@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
