### PR TITLE
Add ODCR to p4d tests

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -217,7 +217,7 @@ efa:
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
         schedulers: ["slurm"]
-      - regions: ["us-west-2"]
+      - regions: ["us-east-1  "]
         instances: ["p4d.24xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/p4d.yaml
+++ b/tests/integration-tests/configs/p4d.yaml
@@ -1,5 +1,5 @@
 {%- import 'common.jinja2' as common -%}
-{%- set regions = ["us-west-2"] -%}
+{%- set regions = ["us-east-1"] -%}
 {%- set instances = ["p4d.24xlarge"] -%}
 
 ---

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -512,12 +512,11 @@ AVAILABILITY_ZONE_OVERRIDES = {
     # c5.xlarge is not supported in use1-az3
     # FSx Lustre file system creation is currently not supported for use1-az3
     # m6g.xlarge is not supported in use1-az2 or use1-az3
-    # p4d.24xlarge is only available on use1-az2
-    "us-east-1": ["use1-az2"],
+    # p4d.24xlarge is only available on use1-az6
+    "us-east-1": ["use1-az6"],
     # some instance type is only supported in use2-az2
     "us-east-2": ["use2-az2"],
     # c4.xlarge is not supported in usw2-az4
-    # p4d.24xlarge is only available on uw2-az2
     "us-west-2": ["usw2-az2"],
     # c5.xlarge is not supported in apse2-az3
     "ap-southeast-2": ["apse2-az1", "apse2-az2"],

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.ini
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/pcluster.config.ini
@@ -11,6 +11,12 @@ vpc_settings = parallelcluster-vpc
 scheduler = {{ scheduler }}
 master_instance_type = {{ head_node_instance }}
 queue_settings = efa-enabled
+{% if instance == "p4d.24xlarge" %}
+# Needed to use the p4d capacity reservation 
+additional_iam_policies = arn:aws:iam::aws:policy/AmazonEC2FullAccess
+post_install = s3://{{ bucket_name }}/run_instance_override.sh
+s3_read_resource = arn:aws:s3:::{{ bucket_name }}/*
+{% endif %}
 
 [queue efa-enabled]
 compute_resource_settings = efa-enabled_i1

--- a/tests/integration-tests/tests/efa/test_efa/test_hit_efa/run_instance_override.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_hit_efa/run_instance_override.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+. "/etc/parallelcluster/cfnconfig"
+
+
+if [[ $cfn_node_type == "MasterServer" ]]; then
+    # Override run_instance attributes
+    cat > /opt/slurm/etc/pcluster/run_instances_overrides.json << 'EOF'
+{
+    "efa-enabled": {
+        "p4d.24xlarge": {
+            "CapacityReservationSpecification": {
+                "CapacityReservationTarget": {
+                    "CapacityReservationId": "cr-0fa65fcdbd597f551"
+                }
+            }
+        }
+    }
+}
+EOF
+fi


### PR DESCRIPTION
### Description of changes
* Add logic to enable the usage of targeted ODCR which require run_instance_override
* Change the AVAILABILITY_ZONE_OVERRIDES the to point to the availability zone in the ODCR

### Tests
* Tests with p4d
* All tests of the changed AVAILABILITY_ZONE_OVERRIDES **us-east-1** 

### References
* https://github.com/aws/aws-parallelcluster/wiki/Launch-instances-with-ODCR-(On-Demand-Capacity-Reservations)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
