### PR TITLE
Add ODCR to p4d test

### DIFF
--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -180,11 +180,11 @@ class Resource(ABC):
 
     def _nested_resources(self):
         nested_resources = []
-        for attr, value in self.__dict__.items():
+        for _, value in self.__dict__.items():
             if isinstance(value, Resource):
                 nested_resources.append(value)
             if isinstance(value, list) and value:
-                nested_resources.extend(item for item in self.__getattribute__(attr) if isinstance(item, Resource))
+                nested_resources.extend(item for item in value if isinstance(item, Resource))
         return nested_resources
 
     def validate(self, suppressors: List[ValidatorSuppressor] = None) -> List[ValidationResult]:

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -704,7 +704,10 @@ Resources:
           - Action:
               - iam:AttachRolePolicy
               - iam:DetachRolePolicy
-            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
+            Resource: 
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
+              # Needed to enable capacity reservation access without creating a custom policy in tests
+              - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonEC2FullAccess
             Effect: Allow
           # Required to use KMS encryption key in tests
           - Action:

--- a/tests/integration-tests/configs/ad_integration.yaml
+++ b/tests/integration-tests/configs/ad_integration.yaml
@@ -4,7 +4,7 @@ test-suites:
   ad_integration:
     test_ad_integration.py::test_ad_integration:
       dimensions:
-        - regions: ["us-east-1"]
+        - regions: ["us-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2", "ubuntu2004"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -231,7 +231,7 @@ efa:
         instances: ["c5n.18xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
-      - regions: ["us-west-2"]
+      - regions: ["us-east-1"]
         instances: ["p4d.24xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
@@ -591,7 +591,7 @@ update:
 # multiple_nics:
 #   test_multiple_nics.py::test_multiple_nics:
 #     dimensions:
-#       - regions: ["us-west-2"]
+#       - regions: ["us-east-1"]
 #         instances: ["p4d.24xlarge"]
 #         oss: {{ common.OSS_COMMERCIAL_X86 }}
 #         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/p4d.yaml
+++ b/tests/integration-tests/configs/p4d.yaml
@@ -1,5 +1,5 @@
 {%- import 'common.jinja2' as common -%}
-{%- set regions = ["us-west-2"] -%}
+{%- set regions = ["us-east-1"] -%}
 {%- set instances = ["p4d.24xlarge"] -%}
 
 ---

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -698,12 +698,12 @@ def parameterized_cfn_stacks_factory(request):
 AVAILABILITY_ZONE_OVERRIDES = {
     # c5.xlarge is not supported in use1-az3
     # FSx Lustre file system creation is currently not supported for use1-az3
-    "us-east-1": ["use1-az1", "use1-az2"],
+    # p4d.24xlarge targeted ODCR is only available on use1-az6
+    "us-east-1": ["use1-az6"],
     # some instance type is only supported in use2-az2
     "us-east-2": ["use2-az2"],
     # c4.xlarge is not supported in usw2-az4
-    # p4d.24xlarge is only available on uw2-az2
-    "us-west-2": ["usw2-az2"],
+    "us-west-2": ["usw2-az2", "usw2-az1"],
     # c5.xlarge is not supported in apse2-az3
     "ap-southeast-2": ["apse2-az1", "apse2-az2"],
     # m6g.xlarge is not supported in apne1-az2

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -9,6 +9,18 @@ HeadNode:
     KeyName: {{ key_name }}
   Imds:
     Secured: {{ imds_secured }}
+{% if instance == "p4d.24xlarge" %}
+  Iam:
+    # Needed to use the p4d capacity reservation 
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonEC2FullAccess
+    S3Access:
+      - BucketName: {{ bucket_name }}
+        EnableWriteAccess: false
+  CustomActions:
+    OnNodeConfigured:
+      Script: s3://{{ bucket_name }}/run_instance_override.sh
+{% endif %}
 Scheduling:
   Scheduler: {{ scheduler }}
   SlurmQueues:

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/run_instance_override.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/run_instance_override.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+. "/etc/parallelcluster/cfnconfig"
+
+
+if [[ $cfn_node_type == "HeadNode" ]]; then
+    # Override run_instance attributes
+    cat > /opt/slurm/etc/pcluster/run_instances_overrides.json << 'EOF'
+{
+    "efa-enabled": {
+        "efa-enabled-i1": {
+            "CapacityReservationSpecification": {
+                "CapacityReservationTarget": {
+                    "CapacityReservationId": "cr-0fa65fcdbd597f551"
+                }
+            }
+        }
+    }
+}
+EOF
+fi


### PR DESCRIPTION
### Description of changes
* Add logic to enable the usage of targeted ODCR which require run_instance_override
* Change the AVAILABILITY_ZONE_OVERRIDES the to point to the availability zone in the ODCR
* Change the AVAILABILITY_ZONE_OVERRIDES the to have one more AZ for us-west-2 to move some tests from us-east-1

### Tests
* Tests with p4d
* All tests of the changed AVAILABILITY_ZONE_OVERRIDES **us-east-1** 
* All tests of the changed AVAILABILITY_ZONE_OVERRIDES **us-west-2** 

### References
* https://github.com/aws/aws-parallelcluster/wiki/Launch-instances-with-ODCR-(On-Demand-Capacity-Reservations)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
