### PR TITLE
Add support for Slurm memory-based scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ x.x.x
   - Change the default deployment type to `Scratch_2`.
   - Change the Lustre server version to `2.12`.
 - Add `lambda:ListTags` and `lambda:UntagResource` to `ParallelClusterUserRole` used by ParallelCluster API stack for cluster update.
+- Add new configuration parameter `Scheduling/SlurmSettings/EnableMemoryBasedScheduling` to configure memory-based
+  scheduling in Slurm.
 
 **BUG FIXES**
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1772,13 +1772,21 @@ class Dns(Resource):
 class SlurmSettings(Resource):
     """Represent the Slurm settings."""
 
-    def __init__(self, scaledown_idletime: int = None, dns: Dns = None, queue_update_strategy: str = None, **kwargs):
+    def __init__(
+        self,
+        scaledown_idletime: int = None,
+        dns: Dns = None,
+        queue_update_strategy: str = None,
+        enable_memory_based_scheduling: bool = None,
+        **kwargs,
+    ):
         super().__init__()
         self.scaledown_idletime = Resource.init_param(scaledown_idletime, default=10)
         self.dns = dns or Dns(implied=True)
         self.queue_update_strategy = Resource.init_param(
             queue_update_strategy, default=QueueUpdateStrategy.COMPUTE_FLEET_STOP.value
         )
+        self.enable_memory_based_scheduling = Resource.init_param(enable_memory_based_scheduling, default=False)
 
 
 class QueueUpdateStrategy(Enum):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1252,6 +1252,7 @@ class SlurmSettingsSchema(BaseSchema):
         validate=validate.OneOf([strategy.value for strategy in QueueUpdateStrategy]),
         metadata={"update_policy": UpdatePolicy.IGNORED},
     )
+    enable_memory_based_scheduling = fields.Bool(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -54,6 +54,7 @@ Scheduling:
     Dns:
       DisableManagedDns: true
       UseEc2Hostnames: true
+    EnableMemoryBasedScheduling: false
   SlurmQueues:
     - Name: queue1
       CapacityType: ONDEMAND

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -469,6 +469,12 @@ class SlurmCommands(SchedulerCommands):
         """Get node info."""
         return self._remote_command_executor.run_remote_command("scontrol show nodes {0}".format(nodename))
 
+    def get_conf_param(self, param):
+        """Get value of configuration parameter."""
+        result = self._remote_command_executor.run_remote_command("scontrol show config | grep {0}".format(param))
+        match = re.search(r"(\s+)= (.*)$", result.stdout)
+        return match.group(2)
+
 
 class TorqueCommands(SchedulerCommands):
     """Implement commands for torque scheduler."""

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update_scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update_scheduling.yaml
@@ -1,0 +1,30 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    EnableMemoryBasedScheduling: true
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: ondemand1-i1
+          InstanceType: c5.large
+          MinCount: 1
+        - Name: ondemand1-i2
+          InstanceType: {{ instance }}
+SharedStorage:
+  - MountDir: /shared
+    Name: name1
+    StorageType: Ebs

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
@@ -1,0 +1,28 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: ondemand1-i1
+          InstanceType: c5.large
+          MinCount: 1
+        - Name: ondemand1-i2
+          InstanceType: {{ instance }}
+SharedStorage:
+  - MountDir: /shared
+    Name: name1
+    StorageType: Ebs


### PR DESCRIPTION
### Description of changes
* First implementation of Slurm memory-based scheduling configuration via ParallelCluster:
    * Expose a new `EnableMemoryBasedScheduling` boolean parameter to users under `Scheduling/SlurmSettings`;
    * Add default `RealMemory` value for all compute nodes and `node_reg_mem_percent` by default;
    * Change `SelectTypeParameters` and `ConstrainRAMSpace` if `EnableMemoryBasedScheduling` is `true` (these parameters have been moved to slurm include conf files controlled by ParallelCluster);
* Link to impacted open issues:
    * [#2198 ](https://github.com/aws/aws-parallelcluster/issues/2198)

### Tests
* Performed tests:
    * Manual and automated tests for cluster creation with new configuration option
    * Manual and automated tests for cluster update by changing the new option
    * Basic manual tests for the Slurm memory-scheduling functionality
* Describe the added/modified tests:
    * Modify and add unit tests that check the configuration files generations
    * Add basic integration tests for cluster creation and updatability with the new configuration parameter `EnableMemoryBasedScheduling`.

### References
* Link to related PRs in other packages (i.e. cookbook, node):
    * https://github.com/aws/aws-parallelcluster/pull/4091
    * https://github.com/aws/aws-parallelcluster-cookbook/pull/1450

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change. -> TODO

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
