### PR TITLE
Move OSU benchmark to run only in develop branch

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -228,7 +228,8 @@ efa:
   test_efa.py::test_efa:
     dimensions:
       - regions: ["sa-east-1"]
-        instances: ["c5n.18xlarge"]
+        # Changed to not trigger Osu benchmark
+        instances: ["c5n.9xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
       - regions: ["us-east-1"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -27,6 +27,14 @@ test-suites:
         - regions: ["sa-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
+  # Moved here from common to run only on develop branch
+  efa:
+    test_efa.py::test_efa:
+      dimensions:
+        - regions: [ "sa-east-1" ]
+          instances: [ "c5n.18xlarge" ]
+          oss: [ "alinux2" ]
+          schedulers: [ "slurm" ]
   scaling:
     # FixMe: MPI tests configs are duplications of the test in common.yaml.
     # The duplications are necessary because the scaling section here overwrites the scaling section in common.yaml.


### PR DESCRIPTION
### Description of changes
* Move OSU benchmark to run only in develop branch

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
