### PR TITLE
Not require PlacementGroup/Enabled to be set to true when using PlacementGroup/Id with EFA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ x.x.x
   - Change the Lustre server version to `2.12`.
 - Add `lambda:ListTags` and `lambda:UntagResource` to `ParallelClusterUserRole` used by ParallelCluster API stack for cluster update.
 - Add `parallelcluster:cluster-name` tag to all resources created by ParallelCluster.
+- Do not allow setting `PlacementGroup/Id` when `PlacementGroup/Enabled` is explicitly set to `false`.
 
 **BUG FIXES**
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -536,7 +536,7 @@ class PlacementGroup(Resource):
         self.id = Resource.init_param(id)
 
     def _register_validators(self):
-        self._register_validator(PlacementGroupIdValidator, placement_group_id=self.id)
+        self._register_validator(PlacementGroupIdValidator, placement_group=self)
 
 
 class _QueueNetworking(_BaseNetworking):
@@ -1747,9 +1747,7 @@ class SlurmQueue(_CommonQueue):
             self._register_validator(
                 EfaPlacementGroupValidator,
                 efa_enabled=compute_resource.efa.enabled,
-                placement_group_enabled=self.networking.placement_group and self.networking.placement_group.enabled,
-                placement_group_config_implicit=self.networking.placement_group is None
-                or self.networking.placement_group.is_implied("enabled"),
+                placement_group=self.networking.placement_group,
             )
 
     @property

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1324,7 +1324,9 @@ class ComputeFleetConstruct(Construct):
 
             queue_placement_group = None
             if queue.networking.placement_group:
-                if queue.networking.placement_group.id:
+                if queue.networking.placement_group.id and (
+                    queue.networking.placement_group.enabled or queue.networking.placement_group.is_implied("enabled")
+                ):  # Do not use `PlacementGroup/Id` when `PlacementGroup/Enabled` is explicitly set to `false`
                     queue_placement_group = queue.networking.placement_group.id
                 elif queue.networking.placement_group.enabled:
                     queue_placement_group = managed_placement_groups[queue.name].ref

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -288,7 +288,13 @@ class EfaValidator(Validator):
 class EfaPlacementGroupValidator(Validator):
     """Validate placement group if EFA is enabled."""
 
-    def _validate(self, efa_enabled, placement_group_enabled, placement_group_config_implicit):
+    def _validate(self, efa_enabled, placement_group):
+        placement_group_enabled = placement_group and (
+            placement_group.enabled or (placement_group.id and placement_group.is_implied("enabled"))
+        )
+        placement_group_config_implicit = placement_group is None or (
+            placement_group.is_implied("enabled") and placement_group.id is None
+        )
         if efa_enabled and placement_group_config_implicit:
             self._add_failure(
                 "The placement group for EFA-enabled compute resources must be explicit. "

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -102,12 +102,20 @@ class KeyPairValidator(Validator):
 class PlacementGroupIdValidator(Validator):  # TODO: add tests
     """Placement group id validator."""
 
-    def _validate(self, placement_group_id: str):
-        if placement_group_id:
-            try:
-                AWSApi.instance().ec2.describe_placement_group(placement_group_id)
-            except AWSClientError as e:
-                self._add_failure(str(e), FailureLevel.ERROR)
+    def _validate(self, placement_group):
+        if placement_group.id:
+            if not placement_group.is_implied("enabled") and not placement_group.enabled:
+                self._add_failure(
+                    "PlacementGroup Id can not be set when setting 'Enabled: false' in queue's "
+                    "networking section. Please remove PlacementGroup Id if you don't want"
+                    " to use PlacementGroup.",
+                    FailureLevel.ERROR,
+                )
+            else:
+                try:
+                    AWSApi.instance().ec2.describe_placement_group(placement_group.id)
+                except AWSClientError as e:
+                    self._add_failure(str(e), FailureLevel.ERROR)
 
 
 class CapacityTypeValidator(Validator):


### PR DESCRIPTION
### Description of changes
* Do not require PlacementGroup/Enabled to be set to true when passing an existing PlacementGroup/Id. Fixed EfaPlacementGroupValidator to not required PlacementGroup/Enabled to be set to true when using PlacementGroup/Id with EFA enabled

### Tests
* unit test
* manual test
  * Ok:
Enabled=true
Id=1234
  * Ok:
Id=1234
  * Error:
Enabled=false
Id=1234
  * Ok:
Enabled=false
#Id=1234
  * Suppress validator, id is not used
Enabled=false
Id=1234
### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
