### PR TITLE
Add validator for MemoryInfo from EC2 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ x.x.x
 - Add support for attaching existing FSx for Ontap and FSx for OpenZFS File Systems.
 - Add support for FSx Lustre Persistent_2 deployment type.
 - Show `requested_value` and `current_value` values in the change set when adding or removing a section.
+- Add new configuration parameter `Scheduling/SlurmSettings/EnableMemoryBasedScheduling` to configure memory-based
+  scheduling in Slurm.
 
 **CHANGES**
 - Remove support for Python 3.6.
@@ -22,8 +24,6 @@ x.x.x
   - Change the Lustre server version to `2.12`.
 - Add `lambda:ListTags` and `lambda:UntagResource` to `ParallelClusterUserRole` used by ParallelCluster API stack for cluster update.
 - Add `parallelcluster:cluster-name` tag to all resources created by ParallelCluster.
-- Add new configuration parameter `Scheduling/SlurmSettings/EnableMemoryBasedScheduling` to configure memory-based
-  scheduling in Slurm.
 
 **BUG FIXES**
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -113,6 +113,7 @@ from pcluster.validators.ec2_validators import (
     AmiOsCompatibleValidator,
     CapacityTypeValidator,
     InstanceTypeBaseAMICompatibleValidator,
+    InstanceTypeMemoryInfoValidator,
     InstanceTypeValidator,
     KeyPairValidator,
     PlacementGroupIdValidator,
@@ -2317,6 +2318,7 @@ class SlurmClusterConfig(BaseClusterConfig):
             )
 
         checked_images = []
+        instance_types_data = self.get_instance_types_data()
 
         for queue in self.scheduling.queues:
             self._register_validator(
@@ -2347,6 +2349,12 @@ class SlurmClusterConfig(BaseClusterConfig):
                     os=self.image.os,
                     architecture=self.head_node.architecture,
                 )
+                if self.scheduling.settings.enable_memory_based_scheduling:
+                    self._register_validator(
+                        InstanceTypeMemoryInfoValidator,
+                        instance_type=compute_resource.instance_type,
+                        instance_type_data=instance_types_data[compute_resource.instance_type],
+                    )
 
     @property
     def image_dict(self):

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -26,6 +26,22 @@ class InstanceTypeValidator(Validator):
             self._add_failure(f"The instance type '{instance_type}' is not supported.", FailureLevel.ERROR)
 
 
+class InstanceTypeMemoryInfoValidator(Validator):
+    """
+    EC2 Instance Type MemoryInfo validator.
+
+    Verify that EC2 provides the necessary memory information about an instance type.
+    """
+
+    def _validate(self, instance_type: str, instance_type_data: dict):
+        size_in_mib = instance_type_data.get("MemoryInfo", {}).get("SizeInMiB")
+        if size_in_mib is None:
+            self._add_failure(
+                f"EC2 does not provide memory information for instance type '{instance_type}'.",
+                FailureLevel.ERROR,
+            )
+
+
 class InstanceTypeBaseAMICompatibleValidator(Validator):
     """EC2 Instance type and base ami compatibility validator."""
 

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -38,6 +38,7 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
         efa_supported=False,
         ebs_optimized=False,
     ):
+        super().__init__(instance_type_data={})
         self._gpu_count = gpu_count
         self._max_network_interface_count = interfaces_count
         self._default_threads_per_core = default_threads_per_core

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -80,6 +80,9 @@ def test_all_validators_are_called(test_datadir, mocker):
         "pcluster.config.cluster_config.BaseClusterConfig.head_node_ami",
         new_callable=PropertyMock(return_value="ami-12345678"),
     )
+    mocker.patch(
+        "pcluster.config.cluster_config.SlurmClusterConfig.get_instance_types_data",
+    )
     mock_aws_api(mocker)
 
     # Need to load two configuration files to execute all validators because there are mutually exclusive parameters.

--- a/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_2.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_all_validators_are_called/slurm_2.yaml
@@ -9,6 +9,8 @@ HeadNode:
     AllowedIps: 1.2.3.4/32
 Scheduling:
   Scheduler: slurm
+  SlurmSettings:
+    EnableMemoryBasedScheduling: true
   SlurmQueues:
     - Name: queue1
       CapacityType: ONDEMAND

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -18,6 +18,7 @@ from pcluster.validators.ec2_validators import (
     AmiOsCompatibleValidator,
     CapacityTypeValidator,
     InstanceTypeBaseAMICompatibleValidator,
+    InstanceTypeMemoryInfoValidator,
     InstanceTypeValidator,
     KeyPairValidator,
 )
@@ -33,6 +34,183 @@ def test_instance_type_validator(mocker, instance_type, expected_message):
     mocker.patch("pcluster.aws.ec2.Ec2Client.list_instance_types", return_value=["t2.micro", "c4.xlarge"])
 
     actual_failures = InstanceTypeValidator().execute(instance_type)
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "instance_type, instance_type_data, expected_message",
+    [
+        (
+            "t2.medium",
+            {
+                "InstanceType": "t2.medium",
+                "CurrentGeneration": True,
+                "FreeTierEligible": False,
+                "SupportedUsageClasses": ["on-demand", "spot"],
+                "SupportedRootDeviceTypes": ["ebs"],
+                "SupportedVirtualizationTypes": ["hvm"],
+                "BareMetal": False,
+                "Hypervisor": "xen",
+                "ProcessorInfo": {
+                    "SupportedArchitectures": ["i386", "x86_64"],
+                    "SustainedClockSpeedInGhz": 2.3,
+                },
+                "VCpuInfo": {
+                    "DefaultVCpus": 2,
+                    "DefaultCores": 2,
+                    "DefaultThreadsPerCore": 1,
+                },
+                "MemoryInfo": {"SizeInMiB": 4096},
+                "InstanceStorageSupported": False,
+                "EbsInfo": {
+                    "EbsOptimizedSupport": "unsupported",
+                    "EncryptionSupport": "supported",
+                    "NvmeSupport": "unsupported",
+                },
+                "NetworkInfo": {
+                    "NetworkPerformance": "Low to Moderate",
+                    "MaximumNetworkInterfaces": 3,
+                    "MaximumNetworkCards": 1,
+                    "DefaultNetworkCardIndex": 0,
+                    "NetworkCards": [
+                        {
+                            "NetworkCardIndex": 0,
+                            "NetworkPerformance": "Low to Moderate",
+                            "MaximumNetworkInterfaces": 3,
+                        },
+                    ],
+                    "Ipv4AddressesPerInterface": 6,
+                    "Ipv6AddressesPerInterface": 6,
+                    "Ipv6Supported": True,
+                    "EnaSupport": "unsupported",
+                    "EfaSupported": False,
+                    "EncryptionInTransitSupported": False,
+                },
+                "PlacementGroupInfo": {"SupportedStrategies": ["partition", "spread"]},
+                "HibernationSupported": True,
+                "BurstablePerformanceSupported": True,
+                "DedicatedHostsSupported": False,
+                "AutoRecoverySupported": True,
+                "SupportedBootModes": ["legacy-bios"],
+            },
+            None,
+        ),
+        (
+            "t2.medium",
+            {
+                "InstanceType": "t2.medium",
+                "CurrentGeneration": True,
+                "FreeTierEligible": False,
+                "SupportedUsageClasses": ["on-demand", "spot"],
+                "SupportedRootDeviceTypes": ["ebs"],
+                "SupportedVirtualizationTypes": ["hvm"],
+                "BareMetal": False,
+                "Hypervisor": "xen",
+                "ProcessorInfo": {
+                    "SupportedArchitectures": ["i386", "x86_64"],
+                    "SustainedClockSpeedInGhz": 2.3,
+                },
+                "VCpuInfo": {
+                    "DefaultVCpus": 2,
+                    "DefaultCores": 2,
+                    "DefaultThreadsPerCore": 1,
+                },
+                "InstanceStorageSupported": False,
+                "EbsInfo": {
+                    "EbsOptimizedSupport": "unsupported",
+                    "EncryptionSupport": "supported",
+                    "NvmeSupport": "unsupported",
+                },
+                "NetworkInfo": {
+                    "NetworkPerformance": "Low to Moderate",
+                    "MaximumNetworkInterfaces": 3,
+                    "MaximumNetworkCards": 1,
+                    "DefaultNetworkCardIndex": 0,
+                    "NetworkCards": [
+                        {
+                            "NetworkCardIndex": 0,
+                            "NetworkPerformance": "Low to Moderate",
+                            "MaximumNetworkInterfaces": 3,
+                        },
+                    ],
+                    "Ipv4AddressesPerInterface": 6,
+                    "Ipv6AddressesPerInterface": 6,
+                    "Ipv6Supported": True,
+                    "EnaSupport": "unsupported",
+                    "EfaSupported": False,
+                    "EncryptionInTransitSupported": False,
+                },
+                "PlacementGroupInfo": {"SupportedStrategies": ["partition", "spread"]},
+                "HibernationSupported": True,
+                "BurstablePerformanceSupported": True,
+                "DedicatedHostsSupported": False,
+                "AutoRecoverySupported": True,
+                "SupportedBootModes": ["legacy-bios"],
+            },
+            "EC2 does not provide memory information for instance type 't2.medium'.",
+        ),
+        (
+            "t2.medium",
+            {
+                "InstanceType": "t2.medium",
+                "CurrentGeneration": True,
+                "FreeTierEligible": False,
+                "SupportedUsageClasses": ["on-demand", "spot"],
+                "SupportedRootDeviceTypes": ["ebs"],
+                "SupportedVirtualizationTypes": ["hvm"],
+                "BareMetal": False,
+                "Hypervisor": "xen",
+                "ProcessorInfo": {
+                    "SupportedArchitectures": ["i386", "x86_64"],
+                    "SustainedClockSpeedInGhz": 2.3,
+                },
+                "VCpuInfo": {
+                    "DefaultVCpus": 2,
+                    "DefaultCores": 2,
+                    "DefaultThreadsPerCore": 1,
+                },
+                "MemoryInfo": {},
+                "InstanceStorageSupported": False,
+                "EbsInfo": {
+                    "EbsOptimizedSupport": "unsupported",
+                    "EncryptionSupport": "supported",
+                    "NvmeSupport": "unsupported",
+                },
+                "NetworkInfo": {
+                    "NetworkPerformance": "Low to Moderate",
+                    "MaximumNetworkInterfaces": 3,
+                    "MaximumNetworkCards": 1,
+                    "DefaultNetworkCardIndex": 0,
+                    "NetworkCards": [
+                        {
+                            "NetworkCardIndex": 0,
+                            "NetworkPerformance": "Low to Moderate",
+                            "MaximumNetworkInterfaces": 3,
+                        },
+                    ],
+                    "Ipv4AddressesPerInterface": 6,
+                    "Ipv6AddressesPerInterface": 6,
+                    "Ipv6Supported": True,
+                    "EnaSupport": "unsupported",
+                    "EfaSupported": False,
+                    "EncryptionInTransitSupported": False,
+                },
+                "PlacementGroupInfo": {"SupportedStrategies": ["partition", "spread"]},
+                "HibernationSupported": True,
+                "BurstablePerformanceSupported": True,
+                "DedicatedHostsSupported": False,
+                "AutoRecoverySupported": True,
+                "SupportedBootModes": ["legacy-bios"],
+            },
+            "EC2 does not provide memory information for instance type 't2.medium'.",
+        ),
+    ],
+)
+def test_instance_type_memory_info_validator(mocker, instance_type, instance_type_data, expected_message):
+    mock_aws_api(mocker)
+    mocker.patch("pcluster.aws.ec2.Ec2Client.list_instance_types", return_value=["t2.medium"])
+
+    actual_failures = InstanceTypeMemoryInfoValidator().execute(instance_type, instance_type_data)
     assert_failure_messages(actual_failures, expected_message)
 
 


### PR DESCRIPTION
Prevent cluster creation/update if memory information is not available from EC2 API

Signed-off-by: Jacopo De Amicis <jdamicis@amazon.it>


### Description of changes
* Add validator to throw error in case EC2 does not provide the instance memory information when Slurm memory-based scheduling is enabled.

### Tests
* Manually tested validator at cluster creation and cluster update time.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1455

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
