### PR TITLE
integ-tests: fix VPC endpoints of secrets manager in China

### DIFF
--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -256,7 +256,7 @@ def enable_vpc_endpoints(vpc_stack, region, cfn_stacks_factory, request):
         ),
         VPCEndpointConfig(
             name="SecretsManager",
-            service_name=prefix + f"com.amazonaws.{region}.secretsmanager",
+            service_name=f"com.amazonaws.{region}.secretsmanager",
             type=VPCEndpointConfig.EndpointType.INTERFACE,
             enable_private_dns=True,
         ),


### PR DESCRIPTION
The service name of secrets manager does not have .cn prefix. The bug was introduced by https://github.com/aws/aws-parallelcluster/pull/3767

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
