### PR TITLE
Add threshold check to benchmark fixture

### DIFF
--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-installation.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-installation.sh
@@ -44,7 +44,10 @@ EOF
 
   # Install packages from S3 --> FIXME they should be installed from configured repository
   DEBS=$(aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-east-1:447714826191:secret:TrainiumPreviewRepository --region us-east-1 --query 'SecretString' --output text | jq -r '.debs')
-  sudo dpkg -i ${DEBS}
+  for DEB in $DEBS
+  do
+    sudo dpkg -i $DEB
+  done
 
   # Install Python venv and activate Python virtual environment to install Neuron pip packages.
   local OS_VERSION="$(grep "^VERSION_ID=" /etc/os-release | cut -d"=" -f 2 | xargs)"
@@ -77,7 +80,10 @@ EOF
 
   # Install packages from S3 --> FIXME they should be installed from configured repository
   RPMS=$(aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-east-1:447714826191:secret:TrainiumPreviewRepository --region us-east-1 --query 'SecretString' --output text | jq -r '.rpms')
-  sudo rpm -i ${RPMS}
+  for RPM in $RPMS
+  do
+    sudo rpm -i $RPM
+  done
 
   python3 -m venv /home/ec2-user/aws_neuron_venv_pytorch
 }


### PR DESCRIPTION
### Description of changes
* Add to the benchmark fixture a flag to check the OSU benchmark result with the result of 32 node cluster of c5n.18xlarge. The method employed sets the threshold to the average plus five times the standard deviation

### Tests
* Manual Tests in test_disable_multithreading

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
