### PR TITLE
Expose internal memory-based scheduling parameters as Chef parameters

### DIFF
--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -213,7 +213,7 @@ DevSettings:
   Cookbook:
     ChefCookbook: https://tests/aws-parallelcluster-cookbook-3.0.tgz
     ExtraChefAttributes: |
-      {"cluster": {"scheduler_slots": "cores"}}
+      {"cluster": {"scheduler_slots": "cores", "slurm_node_reg_mem_percent": 75, "realmemory_to_ec2memory_ratio": 0.95}}
   AwsBatchCliPackage: s3://test/aws-parallelcluster-batch-3.0.tgz
   NodePackage: s3://test/aws-parallelcluster-node-3.0.tgz
   AmiSearchFilters:

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -459,6 +459,12 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm"]
+  test_slurm.py::test_slurm_memory_based_scheduling:
+    dimensions:
+      - regions: ["ap-east-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
 spot:
   test_spot.py::test_spot_default:
     dimensions:

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -475,6 +475,14 @@ class SlurmCommands(SchedulerCommands):
         match = re.search(r"(\s+)= (.*)$", result.stdout)
         return match.group(2)
 
+    def get_node_attribute(self, nodename, attribute):
+        """Get node attribute."""
+        # This method is implemented with `sinfo`, so please refer to the `sinfo` documentation
+        check_attribute_cmd = f"sinfo --noheader --nodes={nodename} -O {attribute}:100"
+        result = self._remote_command_executor.run_remote_command(check_attribute_cmd)
+        match = re.search(r"(\S*)\s*$", result.stdout)
+        return match.group(1)
+
 
 class TorqueCommands(SchedulerCommands):
     """Implement commands for torque scheduler."""

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1532,6 +1532,12 @@ def _test_memory_based_scheduling_enabled_false(
     assert_that(slurm_commands.get_conf_param("SelectTypeParameters")).is_equal_to("CR_CPU")
     assert_that(slurm_commands.get_conf_param("ConstrainRAMSpace")).is_equal_to("no")
 
+    # check default value of node_reg_mem_percent
+    assert_that(slurm_commands.get_conf_param("SlurmctldParameters")).contains("node_reg_mem_percent=75")
+
+    # check values of RealMemory at default settings
+    assert_that(slurm_commands.get_node_attribute("queue1-st-ondemand1-i1-1", "Memory")).is_equal_to("3891")
+
     # TODO: Add functional tests for memory-based scheduling
 
 


### PR DESCRIPTION
### Description of changes
* Allow overriding default values for internal parameters for memory-based scheduling via ExtraChefAttributes in DevSettings
* Add unit tests for custom value of realmemory_to_ec2memory_ratio
* Add validation for realmemory_to_ec2memory_ratio
* Add integration test for node_reg_mem_percent and realmemory_to_ec2memory_ratio

### Tests
* Added and ran integration test for memory-based scheduling in Slurm.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1457

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
