### PR TITLE
Explain benefits of enabling EFA during cluster creation/update

### DIFF
--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -279,7 +279,9 @@ class EfaValidator(Validator):
             self._add_failure(f"Instance type '{instance_type}' does not support EFA.", FailureLevel.ERROR)
         if instance_type_supports_efa and not efa_enabled:
             self._add_failure(
-                f"Instance type '{instance_type}' supports EFA, but it is not enabled.", FailureLevel.WARNING
+                f"To get results faster with the instance type '{instance_type}' at no additional charge, enable the "
+                "Elastic Fabric Adapter (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html)",
+                FailureLevel.WARNING,
             )
         if gdr_support and not efa_enabled:
             self._add_failure("The EFA GDR Support can be used only if EFA is enabled.", FailureLevel.ERROR)

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -172,7 +172,7 @@ def test_max_count_validator(resource_name, resources_length, max_length, expect
         ("t2.large", True, False, False, "does not support EFA"),
         ("t2.large", False, False, False, None),
         # EFA not enabled for instance type that supports it
-        ("c5n.18xlarge", False, False, True, "supports EFA, but it is not enabled"),
+        ("c5n.18xlarge", False, False, True, "at no additional charge, enable the Elastic Fabric Adapter"),
     ],
 )
 def test_efa_validator(mocker, boto3_stubber, instance_type, efa_enabled, gdr_support, efa_supported, expected_message):


### PR DESCRIPTION
### Description of changes
- Clusters with instance-types that support EFA (but EFA is not enabled) print out a warning validation message during creation or update
- This commit improves the warning validation message to explain the benefits and the lack of impact on cost to the customer

### Tests
* Modified existing unit test

### References
* [AWS EFA](https://aws.amazon.com/hpc/efa/#:~:text=EFA%20is%20available%20as%20an%20optional%20EC2%20networking%20feature%20that%20you%20can%20enable%20on%20any%20supported%20EC2%20instance%20at%20no%20additional%20cost)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
