### PR TITLE
Wip/devel/mem sched expose realmemory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ x.x.x
 - Show `requested_value` and `current_value` values in the change set when adding or removing a section.
 - Add new configuration parameter `Scheduling/SlurmSettings/EnableMemoryBasedScheduling` to configure memory-based
   scheduling in Slurm.
+  - Add new configuration parameter to override default value of schedulable memory on compute nodes.
 
 **CHANGES**
 - Remove support for Python 3.6.

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -243,7 +243,8 @@ class InstanceTypeInfo:
         return supported_classes
 
     def ec2memory_size_in_mib(self):
-        return self.instance_type_data.get("MemoryInfo").get("SizeInMiB")
+        """Return the amount of memory in MiB."""
+        return self.instance_type_data.get("MemoryInfo", {}).get("SizeInMiB")
 
 
 class FsxFileSystemInfo:

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -242,6 +242,9 @@ class InstanceTypeInfo:
             supported_classes.append("ondemand")
         return supported_classes
 
+    def ec2memory_size_in_mib(self):
+        return self.instance_type_data.get("MemoryInfo").get("SizeInMiB")
+
 
 class FsxFileSystemInfo:
     """Data object wrapping the result of a describe_file_systems call."""

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -90,6 +90,7 @@ from pcluster.validators.cluster_validators import (
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
     RegionValidator,
+    SchedulableMemoryValidator,
     SchedulerOsValidator,
     SharedStorageMountDirValidator,
     SharedStorageNameValidator,
@@ -1590,6 +1591,7 @@ class SlurmComputeResource(BaseComputeResource):
         spot_price: float = None,
         efa: Efa = None,
         disable_simultaneous_multithreading: bool = None,
+        schedulable_memory: int = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -1602,6 +1604,7 @@ class SlurmComputeResource(BaseComputeResource):
         )
         self.__instance_type_info = None
         self.efa = efa or Efa(enabled=False, implied=True)
+        self.schedulable_memory = Resource.init_param(schedulable_memory)
 
     @property
     def instance_type_info(self) -> InstanceTypeInfo:
@@ -1621,6 +1624,12 @@ class SlurmComputeResource(BaseComputeResource):
             instance_type=self.instance_type,
             efa_enabled=self.efa.enabled,
             gdr_support=self.efa.gdr_support,
+        )
+        self._register_validator(
+            SchedulableMemoryValidator,
+            schedulable_memory=self.schedulable_memory,
+            ec2memory=self._instance_type_info.ec2memory_size_in_mib(),
+            instance_type=self.instance_type,
         )
 
     @property

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1095,6 +1095,7 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
     )
     efa = fields.Nested(EfaSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
     disable_simultaneous_multithreading = fields.Bool(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    schedulable_memory = fields.Int(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1095,7 +1095,7 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
     )
     efa = fields.Nested(EfaSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
     disable_simultaneous_multithreading = fields.Bool(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
-    schedulable_memory = fields.Int(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    schedulable_memory = fields.Int(metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -192,18 +192,25 @@ class SchedulableMemoryValidator(Validator):
         if schedulable_memory is not None:
             if schedulable_memory < 1:
                 self._add_failure("SchedulableMemory must be at least 1 MiB.", FailureLevel.ERROR)
-            if schedulable_memory > ec2memory:
+            if ec2memory is None:
                 self._add_failure(
-                    f"SchedulableMemory cannot be larger than EC2 Memory for selected instance type "
-                    f"{instance_type} ({ec2memory} MiB).",
-                    FailureLevel.ERROR,
-                )
-            if schedulable_memory < math.floor(0.95 * ec2memory):
-                self._add_failure(
-                    f"SchedulableMemory was set lower than 95% of EC2 Memory for selected instance type "
-                    f"{instance_type} ({ec2memory} MiB).",
+                    f"SchedulableMemory was set but EC2 memory is not available for selected instance type "
+                    f"{instance_type}. Defaulting to 1 MiB.",
                     FailureLevel.WARNING,
                 )
+            else:
+                if schedulable_memory > ec2memory:
+                    self._add_failure(
+                        f"SchedulableMemory cannot be larger than EC2 Memory for selected instance type "
+                        f"{instance_type} ({ec2memory} MiB).",
+                        FailureLevel.ERROR,
+                    )
+                if schedulable_memory < math.floor(0.95 * ec2memory):
+                    self._add_failure(
+                        f"SchedulableMemory was set lower than 95% of EC2 Memory for selected instance type "
+                        f"{instance_type} ({ec2memory} MiB).",
+                        FailureLevel.INFO,
+                    )
 
 
 class ArchitectureOsValidator(Validator):

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -189,9 +189,9 @@ class SchedulableMemoryValidator(Validator):
     """Validate SchedulableMemory parameter passed by user."""
 
     def _validate(self, schedulable_memory, ec2memory, instance_type):
-        if schedulable_memory != None:
+        if schedulable_memory is not None:
             if schedulable_memory < 1:
-                self._add_failure(f"SchedulableMemory must be at least 1 MiB.", FailureLevel.ERROR)
+                self._add_failure("SchedulableMemory must be at least 1 MiB.", FailureLevel.ERROR)
             if schedulable_memory > ec2memory:
                 self._add_failure(
                     f"SchedulableMemory cannot be larger than EC2 Memory for selected instance type "

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -8,6 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import math
 import re
 from abc import ABC
 from enum import Enum
@@ -182,6 +183,27 @@ class EfaOsArchitectureValidator(Validator):
             self._add_failure(
                 f"EFA is currently not supported on {os} for {architecture} architecture.", FailureLevel.ERROR
             )
+
+
+class SchedulableMemoryValidator(Validator):
+    """Validate SchedulableMemory parameter passed by user."""
+
+    def _validate(self, schedulable_memory, ec2memory, instance_type):
+        if schedulable_memory != None:
+            if schedulable_memory < 1:
+                self._add_failure(f"SchedulableMemory must be at least 1 MiB.", FailureLevel.ERROR)
+            if schedulable_memory > ec2memory:
+                self._add_failure(
+                    f"SchedulableMemory cannot be larger than EC2 Memory for selected instance type "
+                    f"{instance_type} ({ec2memory} MiB).",
+                    FailureLevel.ERROR,
+                )
+            if schedulable_memory < math.floor(0.95 * ec2memory):
+                self._add_failure(
+                    f"SchedulableMemory was set lower than 95% of EC2 Memory for selected instance type "
+                    f"{instance_type} ({ec2memory} MiB).",
+                    FailureLevel.WARNING,
+                )
 
 
 class ArchitectureOsValidator(Validator):

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -37,6 +37,7 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
         supported_architectures=None,
         efa_supported=False,
         ebs_optimized=False,
+        ec2memory_size_in_mib=4096,
     ):
         super().__init__(instance_type_data={})
         self._gpu_count = gpu_count
@@ -47,6 +48,7 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
         self._efa_supported = efa_supported
         self._instance_type = instance_type
         self._ebs_optimized = ebs_optimized
+        self._ec2memory_size_in_mib = ec2memory_size_in_mib
 
     def gpu_count(self):
         return self._gpu_count
@@ -71,6 +73,9 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
 
     def is_ebs_optimized(self):
         return self._ebs_optimized
+
+    def ec2memory_size_in_mib(self):
+        return self._ec2memory_size_in_mib
 
 
 class _DummyAWSApi(AWSApi):

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -41,6 +41,7 @@ from pcluster.validators.cluster_validators import (
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
     RegionValidator,
+    SchedulableMemoryValidator,
     SchedulerOsValidator,
     SharedStorageMountDirValidator,
     SharedStorageNameValidator,
@@ -153,6 +154,32 @@ def test_max_count_validator(resource_name, resources_length, max_length, expect
     actual_failures = MaxCountValidator().execute(
         resource_name=resource_name, resources_length=resources_length, max_length=max_length
     )
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "schedulable_memory, ec2memory, instance_type, expected_message",
+    [
+        (3500, 3600, "dummy_instance_type", None),
+        (0, 3600, "dummy_instance_type", "SchedulableMemory must be at least 1 MiB."),
+        (
+            3700,
+            3600,
+            "dummy_instance_type",
+            "SchedulableMemory cannot be larger than EC2 Memory for selected "
+            "instance type dummy_instance_type (3600 MiB).",
+        ),
+        (
+            3000,
+            3600,
+            "dummy_instance_type",
+            "SchedulableMemory was set lower than 95% of EC2 Memory for selected "
+            "instance type dummy_instance_type (3600 MiB).",
+        ),
+    ],
+)
+def test_schedulable_memory_validator(schedulable_memory, ec2memory, instance_type, expected_message):
+    actual_failures = SchedulableMemoryValidator().execute(schedulable_memory, ec2memory, instance_type)
     assert_failure_messages(actual_failures, expected_message)
 
 

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -164,6 +164,13 @@ def test_max_count_validator(resource_name, resources_length, max_length, expect
         (0, 3600, "dummy_instance_type", "SchedulableMemory must be at least 1 MiB."),
         (
             3700,
+            None,
+            "dummy_instance_type",
+            "SchedulableMemory was set but EC2 memory is not available for selected "
+            "instance type dummy_instance_type. Defaulting to 1 MiB.",
+        ),
+        (
+            3700,
             3600,
             "dummy_instance_type",
             "SchedulableMemory cannot be larger than EC2 Memory for selected "

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1537,6 +1537,7 @@ def _test_memory_based_scheduling_enabled_false(
 
     # check values of RealMemory at default settings
     assert_that(slurm_commands.get_node_attribute("queue1-st-ondemand1-i1-1", "Memory")).is_equal_to("3891")
+    assert_that(slurm_commands.get_node_attribute("queue1-dy-ondemand1-i3-1", "Memory")).is_equal_to("31129")
 
     # TODO: Add functional tests for memory-based scheduling
 
@@ -1553,4 +1554,6 @@ def _test_memory_based_scheduling_enabled_true(
     assert_that(slurm_commands.get_conf_param("SelectTypeParameters")).is_equal_to("CR_CPU_MEMORY")
     assert_that(slurm_commands.get_conf_param("ConstrainRAMSpace")).is_equal_to("yes")
 
+    # check RealMemory overridden via config file parameter
+    assert_that(slurm_commands.get_node_attribute("queue1-dy-ondemand1-i3-1", "Memory")).is_equal_to("31400")
     # TODO: Add functional tests for memory-based scheduling

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update_scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update_scheduling.yaml
@@ -24,6 +24,10 @@ Scheduling:
           MinCount: 1
         - Name: ondemand1-i2
           InstanceType: {{ instance }}
+        - Name: ondemand1-i3
+          InstanceType: c5.4xlarge
+          MinCount: 0
+          SchedulableMemory: 31400
 SharedStorage:
   - MountDir: /shared
     Name: name1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
@@ -22,6 +22,9 @@ Scheduling:
           MinCount: 1
         - Name: ondemand1-i2
           InstanceType: {{ instance }}
+        - Name: ondemand1-i3
+          InstanceType: c5.4xlarge
+          MinCount: 0
 SharedStorage:
   - MountDir: /shared
     Name: name1


### PR DESCRIPTION
### Description of changes
* Expose `SchedulableMemory` in the Compute Resource definition to allow the override of `RealMemory` with a user-defined parameter in the cluster configuration file.
* It relates to https://github.com/aws/aws-parallelcluster/issues/2198

### Tests
* Manual test of the validation of the `SchedulableMemory` parameter
* Manual and automatic unit and integration test for the override of `RealMemory` via `SchedulableMemory`
* Manual test of the update of `RealMemory` via new definition of `SchedulableMemory` and `QueueUpdateStrategy=DRAIN` while jobs run on the nodes impacted by the parameter update
* Manual test that `RealMemory` defaults to 1 if `EnableMemoryBasedScheduling` is `false` and there are no memory-info in the instance_type_data (even if `SchedulableMemory` is provided)

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1460

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
