### PR TITLE
Change installation path of cfn-bootstrap

### DIFF
--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -76,6 +76,9 @@ function vendor_cookbook
 
 # deploy config files
 export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin
+# Load ParallelCluster environment variables
+[ -f /etc/profile.d/pcluster.sh ] && . /etc/profile.d/pcluster.sh
+
 cd /tmp
 cfn-init -s ${AWS::StackName} -v -c deployFiles -r HeadNodeLaunchTemplate --region ${AWS::Region}
 wait_condition_handle_presigned_url=$(cat /tmp/wait_condition_handle.txt)

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -114,17 +114,6 @@ phases:
 
                echo ${!PLATFORM}
 
-      # Get Cfn Bootstrap Url
-      - name: CfnBootstrapUrl
-        action: ExecuteBash
-        inputs:
-          commands:
-            - |
-              set -v
-              BUCKET="s3.amazonaws.com"
-              [[ ${AWS::Region} =~ ^cn- ]] && BUCKET="s3.cn-north-1.amazonaws.com.cn/cn-north-1-aws-parallelcluster"
-              echo "https://${!BUCKET}/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
-
       # Get input base AMI Architecture
       - name: OperatingSystemArchitecture
         action: ExecuteBash
@@ -256,19 +245,6 @@ phases:
               echo "Calling chef-client with /etc/parallelcluster/image_dna.json"
               cat /etc/parallelcluster/image_dna.json
               cinc-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/parallelcluster/image_dna.json --override-runlist aws-parallelcluster::default
-
-      - name: InstallCfnBootstrap
-        action: ExecuteBash
-        inputs:
-          commands:
-            - |
-              set -v
-              OS='{{ build.OperatingSystemName.outputs.stdout }}'
-
-              if [[ ${!OS} =~ ^(centos7|ubuntu(18|20)04)$ ]]; then
-                curl --retry 3 -L -o /tmp/aws-cfn-bootstrap-latest.tar.gz {{ build.CfnBootstrapUrl.outputs.stdout }}
-                pip3 install /tmp/aws-cfn-bootstrap-latest.tar.gz
-              fi
 
       - name: CreateBootstrapFile
         action: CreateFile

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1001,6 +1001,7 @@ class ClusterCdkStack(Stack):
                                 "triggers=post.update\n"
                                 "path=Resources.HeadNodeLaunchTemplate.Metadata.AWS::CloudFormation::Init\n"
                                 "action=PATH=/usr/local/bin:/bin:/usr/bin:/opt/aws/bin; "
+                                ". /etc/profile.d/pcluster.sh; "
                                 "cfn-init -v --stack ${StackName} "
                                 "--resource HeadNodeLaunchTemplate --configsets update --region ${Region}\n"
                                 "runas=root\n"
@@ -1077,6 +1078,7 @@ class ClusterCdkStack(Stack):
                 "commands": {
                     "chef": {
                         "command": (
+                            ". /etc/profile.d/pcluster.sh; "
                             "cinc-client --local-mode --config /etc/chef/client.rb --log_level info"
                             " --logfile /var/log/chef-client.log --force-formatter --no-color"
                             " --chef-zero-port 8889 --json-attributes /etc/chef/dna.json"


### PR DESCRIPTION
### Description of changes
* Change the installation path to be in a virtualenv
* Creation of the profile file pcluster.sh to automatically include the cfn-bootstrap binary in the path

### Tests
* Automated image build and integration tests

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
