### PR TITLE
Improve validation message when a CFN stack is found with the same name as the given image-id

### DIFF
--- a/cli/src/pcluster/models/imagebuilder.py
+++ b/cli/src/pcluster/models/imagebuilder.py
@@ -438,7 +438,8 @@ class ImageBuilder:
 
         if AWSApi.instance().cfn.stack_exists(self.image_id):
             raise ConflictImageBuilderActionError(
-                f"ParallelCluster build infrastructure for image {self.image_id} already exists"
+                f"ParallelCluster build infrastructure for image {self.image_id} "
+                "or a CloudFormation Stack with the same name already exists."
             )
 
     def create(


### PR DESCRIPTION
### Description of changes
ParallelCluster is using the image-id as name for the CloudFormation stack,
so if there is a Cluster or another CFN Stack with the same name the error message will be misleading.

### Tests
Before:
```
$ pcluster build-image --image-id test --image-configuration build-image.yaml 
{
  "message": "ParallelCluster build infrastructure for image test already exists"
}
```
After:
```
$ pcluster build-image --image-id gdrcopy-image-ubuntu --image-configuration build-image.yaml 
{
  "message": "ParallelCluster build infrastructure for image test or a CloudFormation Stack with the same name already exists."
}
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
