### PR TITLE
Allow for extra partition config values

### DIFF
--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster_queue_partition.conf
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/files/default/head_node_slurm/slurm/templates/slurm_parallelcluster_queue_partition.conf
@@ -33,6 +33,6 @@ NodeSet={{ queue_name }}_nodes Nodes=
     {{- "," if not loop.last else "" -}}
     {% endfor %}
 
-PartitionName={{ queue_name }} Nodes={{ queue_name }}_nodes MaxTime=INFINITE State=UP{% if is_default_queue %} Default=YES{% endif %}
+PartitionName={{ queue_name }} Nodes={{ queue_name }}_nodes MaxTime=INFINITE State=UP{% if is_default_queue %} Default=YES{% endif %} {% for key, value in queue_config.get('PartitionExtraConfig').items() %}{{ key }}={{ value }} {% endfor %}
 
 {% endif %}


### PR DESCRIPTION
This would let other values be configured for the partition 

### Description of changes

This change would allow extra Slurm partition configuration values to be set in the parallel cluster
config file. There are quite a few options that can be set for a partition, but there's no easy path
for configuring these currently. For example, we want to set DefaultTime for the queue. Here's
a reference: https://slurm.schedmd.com/slurm.conf.html#lbAI

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
