### PR TITLE
Added support for rebooting compute nodes via Slurm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ x.x.x
   - Add new configuration parameter to override default value of schedulable memory on compute nodes.
 - Prompt user to enable EFA for supported instance types when using `pcluster configure` wizard.
 - Change default EBS volume types from gp2 to gp3 in both the root and additional volumes.
+- Add support for rebooting compute nodes via Slurm.
 
 **CHANGES**
 - Remove support for Python 3.6.


### PR DESCRIPTION
### Description of changes
* Added support for rebooting compute nodes via Slurm without having clustermgtd marking nodes as unhealthy during the reboot.

### Tests
* Manual tests with `scontrol reboot` and `scontrol reboot asap` with both static and dynamic nodes.
* Manual tests with `scontrol update Node=<> State=POWER_DOWN_ASAP`.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1463
* https://github.com/aws/aws-parallelcluster-node/pull/416

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
