### PR TITLE
Adds AWS Budgets support to the configuration file

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -5,7 +5,7 @@ jinja2~=3.0
 marshmallow~=3.10
 aws-cdk.core~=1.137
 aws-cdk.aws-batch~=1.137
-aws-cdk.aws-budgets
+aws-cdk.aws-budgets~=1.137
 aws_cdk.aws-cloudwatch~=1.137
 aws-cdk.aws-codebuild~=1.137
 aws-cdk.aws-dynamodb~=1.137

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -5,6 +5,7 @@ jinja2~=3.0
 marshmallow~=3.10
 aws-cdk.core~=1.137
 aws-cdk.aws-batch~=1.137
+aws-cdk.aws-budgets
 aws_cdk.aws-cloudwatch~=1.137
 aws-cdk.aws-codebuild~=1.137
 aws-cdk.aws-dynamodb~=1.137

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -31,6 +31,7 @@ REQUIRES = [
     "marshmallow~=3.10",
     "aws-cdk.core~=" + CDK_VERSION,
     "aws-cdk.aws-batch~=" + CDK_VERSION,
+    "aws-cdk.aws-budgets~=" + CDK_VERSION,
     "aws_cdk.aws-cloudwatch~=" + CDK_VERSION,
     "aws-cdk.aws-codebuild~=" + CDK_VERSION,
     "aws-cdk.aws-dynamodb~=" + CDK_VERSION,

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -861,9 +861,9 @@ class BudgetNotification(Resource):
 
     def __init__(
         self,
+        threshold: float,
         notification_type: str = None,
         comparison_operator: str = None,
-        threshold: int = None,
         threshold_type: str = None,
     ):
         super().__init__()
@@ -876,7 +876,7 @@ class BudgetNotification(Resource):
 class BudgetSubscriber(Resource):
     """Represent the configuration of an individual subscriber of a budget notification."""
 
-    def __init__(self, subscription_type: str = None, address: str = None):
+    def __init__(self, address: str, subscription_type: str = None):
         super().__init__()
         self.subscription_type = Resource.init_param(subscription_type, default="EMAIL")
         self.address = Resource.init_param(address)
@@ -885,7 +885,7 @@ class BudgetSubscriber(Resource):
 class BudgetNotificationWithSubscribers(Resource):
     """Represent the configuration of the NotificationWithSubscribers field of a budget."""
 
-    def __init__(self, notification: BudgetNotification = None, subscribers: List[BudgetSubscriber] = None):
+    def __init__(self, notification: BudgetNotification, subscribers: List[BudgetSubscriber] = None):
         super().__init__()
         self.notification = notification
         self.subscribers = subscribers
@@ -894,10 +894,10 @@ class BudgetNotificationWithSubscribers(Resource):
 class BudgetLimit(Resource):
     """Represent the configuration of a budget limit."""
 
-    def __init__(self, amount: int = None, unit: str = None):
+    def __init__(self, amount: float, unit: str):
         super().__init__()
         self.amount = Resource.init_param(amount)
-        self.unit = Resource.init_param(unit, default="USD")
+        self.unit = Resource.init_param(unit)
 
 
 class Budget(Resource):
@@ -905,9 +905,9 @@ class Budget(Resource):
 
     def __init__(
         self,
-        budget_category: str = None,
+        budget_category: str,
+        budget_limit: BudgetLimit,
         queue_name: str = None,
-        budget_limit: BudgetLimit = None,
         cost_filters: Dict = None,
         time_unit: str = None,
         notifications_with_subscribers: List[BudgetNotificationWithSubscribers] = None,

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -878,7 +878,7 @@ class BudgetSubscriber(Resource):
 
     def __init__(self, subscription_type: str = None, address: str = None):
         super().__init__()
-        self.subscription_type = Resource.init_param(subscription_type)
+        self.subscription_type = Resource.init_param(subscription_type, default="EMAIL")
         self.address = Resource.init_param(address)
 
 
@@ -905,7 +905,6 @@ class Budget(Resource):
 
     def __init__(
         self,
-        budget_name: str = None,
         budget_category: str = None,
         queue_name: str = None,
         budget_limit: BudgetLimit = None,
@@ -914,7 +913,6 @@ class Budget(Resource):
         notifications_with_subscribers: List[BudgetNotificationWithSubscribers] = None,
     ):
         super().__init__()
-        self.budget_name = Resource.init_param(budget_name)
         self.budget_category = Resource.init_param(budget_category)
         self.queue_name = Resource.init_param(queue_name, default=None)
         self.budget_limit = Resource.init_param(budget_limit)

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -861,14 +861,16 @@ class BudgetNotification(Resource):
 
     def __init__(
         self,
-        notification_type: str = "ACTUAL",
-        comparison_operator: str = "GREATER_THAN",
+        notification_type: str = None,
+        comparison_operator: str = None,
         threshold: int = None,
+        threshold_type: str = None,
     ):
         super().__init__()
-        self.notification_type = Resource.init_param(notification_type)
-        self.comparison_operator = Resource.init_param(comparison_operator)
+        self.notification_type = Resource.init_param(notification_type, default="ACTUAL")
+        self.comparison_operator = Resource.init_param(comparison_operator, default="GREATER_THAN")
         self.threshold = Resource.init_param(threshold)
+        self.threshold_type = Resource.init_param(threshold_type, default="ABSOLUTE_VALUE")
 
 
 class BudgetSubscriber(Resource):
@@ -883,10 +885,10 @@ class BudgetSubscriber(Resource):
 class BudgetNotificationWithSubscribers(Resource):
     """Represent the configuration of the NotificationWithSubscribers field of a budget."""
 
-    def __int__(self, notification: BudgetNotification = None, subscribers: List[BudgetSubscriber] = None):
+    def __init__(self, notification: BudgetNotification = None, subscribers: List[BudgetSubscriber] = None):
         super().__init__()
-        self.notification = Resource.init_param(notification)
-        self.subscribers = Resource.init_param(subscribers)
+        self.notification = notification
+        self.subscribers = subscribers
 
 
 class BudgetLimit(Resource):
@@ -910,17 +912,6 @@ class Budget(Resource):
         cost_filters: Dict = None,
         time_unit: str = None,
         notifications_with_subscribers: List[BudgetNotificationWithSubscribers] = None,
-        include_credit: bool = None,
-        include_discount: bool = None,
-        include_other_subscription: bool = None,
-        include_recurring: bool = None,
-        include_refund: bool = None,
-        include_subscription: bool = None,
-        include_support: bool = None,
-        include_tax: bool = None,
-        include_up_front: bool = None,
-        use_amortized: bool = None,
-        use_blended: bool = None,
     ):
         super().__init__()
         self.budget_name = Resource.init_param(budget_name)
@@ -929,18 +920,7 @@ class Budget(Resource):
         self.budget_limit = Resource.init_param(budget_limit)
         self.cost_filters = Resource.init_param(cost_filters, default=None)
         self.time_unit = Resource.init_param(time_unit, default="MONTHLY")
-        self.notifications_with_subscribers = Resource.init_param(notifications_with_subscribers)
-        self.include_credit = Resource.init_param(include_credit, default=True)
-        self.include_discount = Resource.init_param(include_discount, default=True)
-        self.include_other_subscription = Resource.init_param(include_other_subscription, default=True)
-        self.include_recurring = Resource.init_param(include_recurring, default=True)
-        self.include_refund = Resource.init_param(include_refund, default=True)
-        self.include_subscription = Resource.init_param(include_subscription, default=True)
-        self.include_support = Resource.init_param(include_support, default=True)
-        self.include_tax = Resource.init_param(include_tax, default=True)
-        self.include_up_front = Resource.init_param(include_up_front, default=True)
-        self.use_amortized = Resource.init_param(use_amortized, default=True)
-        self.use_blended = Resource.init_param(use_blended, default=False)
+        self.notifications_with_subscribers = notifications_with_subscribers
 
 
 class ClusterDevSettings(BaseDevSettings):

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -864,9 +864,8 @@ class BudgetNotification(Resource):
         notification_type: str = "ACTUAL",
         comparison_operator: str = "GREATER_THAN",
         threshold: int = None,
-        **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__()
         self.notification_type = Resource.init_param(notification_type)
         self.comparison_operator = Resource.init_param(comparison_operator)
         self.threshold = Resource.init_param(threshold)
@@ -875,8 +874,8 @@ class BudgetNotification(Resource):
 class BudgetSubscriber(Resource):
     """Represent the configuration of an individual subscriber of a budget notification."""
 
-    def __init__(self, subscription_type: str = None, address: str = None, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, subscription_type: str = None, address: str = None):
+        super().__init__()
         self.subscription_type = Resource.init_param(subscription_type)
         self.address = Resource.init_param(address)
 
@@ -884,8 +883,8 @@ class BudgetSubscriber(Resource):
 class BudgetNotificationWithSubscribers(Resource):
     """Represent the configuration of the NotificationWithSubscribers field of a budget."""
 
-    def __int__(self, notification: BudgetNotification = None, subscribers: List[BudgetSubscriber] = None, **kwargs):
-        super().__init__(**kwargs)
+    def __int__(self, notification: BudgetNotification = None, subscribers: List[BudgetSubscriber] = None):
+        super().__init__()
         self.notification = Resource.init_param(notification)
         self.subscribers = Resource.init_param(subscribers)
 
@@ -893,10 +892,10 @@ class BudgetNotificationWithSubscribers(Resource):
 class BudgetLimit(Resource):
     """Represent the configuration of a budget limit."""
 
-    def __init__(self, amount: int = None, unit: str = None, **kwargs):
-        super.__init(**kwargs)
+    def __init__(self, amount: int = None, unit: str = None):
+        super().__init__()
         self.amount = Resource.init_param(amount)
-        self.unit = Resource.init_param(unit)
+        self.unit = Resource.init_param(unit, default="USD")
 
 
 class Budget(Resource):
@@ -907,27 +906,41 @@ class Budget(Resource):
         budget_name: str = None,
         budget_category: str = None,
         queue_name: str = None,
-        # cost_filter...
         budget_limit: BudgetLimit = None,
-        time_unit: str = "MONTHLY",
+        cost_filters: Dict = None,
+        time_unit: str = None,
         notifications_with_subscribers: List[BudgetNotificationWithSubscribers] = None,
-        **kwargs,
+        include_credit: bool = None,
+        include_discount: bool = None,
+        include_other_subscription: bool = None,
+        include_recurring: bool = None,
+        include_refund: bool = None,
+        include_subscription: bool = None,
+        include_support: bool = None,
+        include_tax: bool = None,
+        include_up_front: bool = None,
+        use_amortized: bool = None,
+        use_blended: bool = None,
     ):
-        super.__init__(**kwargs)
+        super().__init__()
         self.budget_name = Resource.init_param(budget_name)
         self.budget_category = Resource.init_param(budget_category)
-        self.queue_name = Resource.init_param(queue_name)
+        self.queue_name = Resource.init_param(queue_name, default=None)
         self.budget_limit = Resource.init_param(budget_limit)
-        self.time_unit = Resource.init_param(time_unit)
+        self.cost_filters = Resource.init_param(cost_filters, default=None)
+        self.time_unit = Resource.init_param(time_unit, default="MONTHLY")
         self.notifications_with_subscribers = Resource.init_param(notifications_with_subscribers)
-
-
-class Budgets(Resource):
-    """Represents the configuration of the list of budgets."""
-
-    def __init__(self, budgets: List[Budget] = None, **kwargs):
-        super.__init__(**kwargs)
-        self.budgets = Resource.init_param(budgets)
+        self.include_credit = Resource.init_param(include_credit, default=True)
+        self.include_discount = Resource.init_param(include_discount, default=True)
+        self.include_other_subscription = Resource.init_param(include_other_subscription, default=True)
+        self.include_recurring = Resource.init_param(include_recurring, default=True)
+        self.include_refund = Resource.init_param(include_refund, default=True)
+        self.include_subscription = Resource.init_param(include_subscription, default=True)
+        self.include_support = Resource.init_param(include_support, default=True)
+        self.include_tax = Resource.init_param(include_tax, default=True)
+        self.include_up_front = Resource.init_param(include_up_front, default=True)
+        self.use_amortized = Resource.init_param(use_amortized, default=True)
+        self.use_blended = Resource.init_param(use_blended, default=False)
 
 
 class ClusterDevSettings(BaseDevSettings):
@@ -939,6 +952,7 @@ class ClusterDevSettings(BaseDevSettings):
         ami_search_filters: AmiSearchFilters = None,
         instance_types_data: str = None,
         timeouts: Timeouts = None,
+        budgets: List[Budget] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -946,6 +960,7 @@ class ClusterDevSettings(BaseDevSettings):
         self.ami_search_filters = Resource.init_param(ami_search_filters)
         self.instance_types_data = Resource.init_param(instance_types_data)
         self.timeouts = Resource.init_param(timeouts)
+        self.budgets = Resource.init_param(budgets)
 
     def _register_validators(self):
         super()._register_validators()

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -856,6 +856,80 @@ class Timeouts(Resource):
         )
 
 
+class BudgetNotification(Resource):
+    """Represent the configuration of each notification under the NotificationsWithSubscribers field of a budget."""
+
+    def __init__(
+        self,
+        notification_type: str = "ACTUAL",
+        comparison_operator: str = "GREATER_THAN",
+        threshold: int = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.notification_type = Resource.init_param(notification_type)
+        self.comparison_operator = Resource.init_param(comparison_operator)
+        self.threshold = Resource.init_param(threshold)
+
+
+class BudgetSubscriber(Resource):
+    """Represent the configuration of an individual subscriber of a budget notification."""
+
+    def __init__(self, subscription_type: str = None, address: str = None, **kwargs):
+        super().__init__(**kwargs)
+        self.subscription_type = Resource.init_param(subscription_type)
+        self.address = Resource.init_param(address)
+
+
+class BudgetNotificationWithSubscribers(Resource):
+    """Represent the configuration of the NotificationWithSubscribers field of a budget."""
+
+    def __int__(self, notification: BudgetNotification = None, subscribers: List[BudgetSubscriber] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.notification = Resource.init_param(notification)
+        self.subscribers = Resource.init_param(subscribers)
+
+
+class BudgetLimit(Resource):
+    """Represent the configuration of a budget limit."""
+
+    def __init__(self, amount: int = None, unit: str = None, **kwargs):
+        super.__init(**kwargs)
+        self.amount = Resource.init_param(amount)
+        self.unit = Resource.init_param(unit)
+
+
+class Budget(Resource):
+    """Represent the configuration of a Budget."""
+
+    def __init__(
+        self,
+        budget_name: str = None,
+        budget_category: str = None,
+        queue_name: str = None,
+        # cost_filter...
+        budget_limit: BudgetLimit = None,
+        time_unit: str = "MONTHLY",
+        notifications_with_subscribers: List[BudgetNotificationWithSubscribers] = None,
+        **kwargs,
+    ):
+        super.__init__(**kwargs)
+        self.budget_name = Resource.init_param(budget_name)
+        self.budget_category = Resource.init_param(budget_category)
+        self.queue_name = Resource.init_param(queue_name)
+        self.budget_limit = Resource.init_param(budget_limit)
+        self.time_unit = Resource.init_param(time_unit)
+        self.notifications_with_subscribers = Resource.init_param(notifications_with_subscribers)
+
+
+class Budgets(Resource):
+    """Represents the configuration of the list of budgets."""
+
+    def __init__(self, budgets: List[Budget] = None, **kwargs):
+        super.__init__(**kwargs)
+        self.budgets = Resource.init_param(budgets)
+
+
 class ClusterDevSettings(BaseDevSettings):
     """Represent the dev settings configuration."""
 

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -435,8 +435,9 @@ class Cluster:
 
     @staticmethod
     def _load_additional_instance_type_data(cluster_config_dict):
-        if "DevSettings" in cluster_config_dict:
-            instance_types_data = cluster_config_dict["DevSettings"].get("InstanceTypesData")
+        # This is before validation, so DevSettings may be {NoneType} but still be a key in the dict
+        if cluster_config_dict.get("DevSettings"):
+            instance_types_data = cluster_config_dict.get("DevSettings").get("InstanceTypesData")
             if instance_types_data:
                 # Set additional instance types data in AWSApi. Schema load will use the information.
                 AWSApi.instance().ec2.additional_instance_types_data = json.loads(instance_types_data)

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -39,7 +39,6 @@ from pcluster.config.cluster_config import (
     BudgetLimit,
     BudgetNotification,
     BudgetNotificationWithSubscribers,
-    Budgets,
     BudgetSubscriber,
     CapacityType,
     CloudWatchDashboards,
@@ -992,7 +991,9 @@ class BudgetSchema(BaseSchema):
         fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED}),
         metadata={"update_policy": UpdatePolicy.SUPPORTED},
     )
-    # cost_filter / need to figure out how to create the custom filter field
+
+    cost_filters = fields.Dict(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+
     budget_limit = fields.Nested(BudgetLimitSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     time_unit = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     notifications_with_subscribers = fields.List(
@@ -1000,24 +1001,23 @@ class BudgetSchema(BaseSchema):
         metadata={"update_policy": UpdatePolicy.SUPPORTED},
     )
 
+    # Cost-type fields
+    include_credit = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    include_discount = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    include_other_subscription = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    include_recurring = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    include_refund = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    include_subscription = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    include_support = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    include_tax = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    include_up_front = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    use_amortized = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    use_blended = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+
     @post_load
     def make_resource(self, data, **kwargs):
         """Generate resource."""
         return Budget(**data)
-
-
-class BudgetsSchema(BaseSchema):
-    """Represents the schema of the list of Bugets."""
-
-    budgets = fields.List(
-        fields.Nested(BudgetSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED}),
-        metadata={"update_policy": UpdatePolicy.SUPPORTED},
-    )
-
-    @post_load
-    def make_resource(self, data, **kwargs):
-        """Create resource."""
-        return Budgets(**data)
 
 
 class ClusterDevSettingsSchema(BaseDevSettingsSchema):
@@ -1027,6 +1027,11 @@ class ClusterDevSettingsSchema(BaseDevSettingsSchema):
     ami_search_filters = fields.Nested(AmiSearchFiltersSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     instance_types_data = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     timeouts = fields.Nested(TimeoutsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    budgets = fields.List(
+        fields.Nested(BudgetSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED}),
+        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    )
+
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -35,6 +35,12 @@ from pcluster.config.cluster_config import (
     AwsBatchQueueNetworking,
     AwsBatchScheduling,
     AwsBatchSettings,
+    Budget,
+    BudgetLimit,
+    BudgetNotification,
+    BudgetNotificationWithSubscribers,
+    Budgets,
+    BudgetSubscriber,
     CapacityType,
     CloudWatchDashboards,
     CloudWatchLogs,
@@ -923,6 +929,95 @@ class TimeoutsSchema(BaseSchema):
     def make_resource(self, data, **kwargs):
         """Generate resource."""
         return Timeouts(**data)
+
+
+class BudgetNotificationSchema(BaseSchema):
+    """Represent the schema of each notification under the NotificationsWithSubscribers field of a budget."""
+
+    notification_type = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    comparison_operator = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    threshold = fields.Int(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return BudgetNotification(**data)
+
+
+class BudgetSubscriberSchema(BaseSchema):
+    """Represent the schema of an individual subscriber of a budget notification."""
+
+    subscription_type = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    address = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return BudgetSubscriber(**data)
+
+
+class BudgetNotificationWithSubscribersSchema(BaseSchema):
+    """Represent the schema of the NotificationsWithSubscriber field of a budget."""
+
+    notification = fields.Nested(BudgetNotificationSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    subscribers = fields.List(
+        fields.Nested(BudgetSubscriberSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED}),
+        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    )
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return BudgetNotificationWithSubscribers(**data)
+
+
+class BudgetLimitSchema(BaseSchema):
+    """Represent the schema of the BudgetLimit field of a budget."""
+
+    amount = fields.Int(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    unit = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return BudgetLimit(**data)
+
+
+class BudgetSchema(BaseSchema):
+    """Represent the schema of an aws budget."""
+
+    budget_name = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    budget_category = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    queue_name = fields.List(
+        fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED}),
+        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    )
+    # cost_filter / need to figure out how to create the custom filter field
+    budget_limit = fields.Nested(BudgetLimitSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    time_unit = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    notifications_with_subscribers = fields.List(
+        fields.Nested(BudgetNotificationWithSubscribersSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED}),
+        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    )
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return Budget(**data)
+
+
+class BudgetsSchema(BaseSchema):
+    """Represents the schema of the list of Bugets."""
+
+    budgets = fields.List(
+        fields.Nested(BudgetSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED}),
+        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    )
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Create resource."""
+        return Budgets(**data)
 
 
 class ClusterDevSettingsSchema(BaseDevSettingsSchema):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -936,6 +936,7 @@ class BudgetNotificationSchema(BaseSchema):
     notification_type = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     comparison_operator = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     threshold = fields.Int(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    threshold_type = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -959,9 +960,10 @@ class BudgetNotificationWithSubscribersSchema(BaseSchema):
     """Represent the schema of the NotificationsWithSubscriber field of a budget."""
 
     notification = fields.Nested(BudgetNotificationSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    subscribers = fields.List(
-        fields.Nested(BudgetSubscriberSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED}),
-        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    subscribers = fields.Nested(
+        BudgetSubscriberSchema,
+        many=True,
+        metadata={"update_policy": UpdatePolicy.SUPPORTED, "update_key": "Name"},
     )
 
     @post_load
@@ -987,32 +989,17 @@ class BudgetSchema(BaseSchema):
 
     budget_name = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     budget_category = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    queue_name = fields.List(
-        fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED}),
-        metadata={"update_policy": UpdatePolicy.SUPPORTED},
-    )
+    queue_name = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     cost_filters = fields.Dict(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     budget_limit = fields.Nested(BudgetLimitSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     time_unit = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    notifications_with_subscribers = fields.List(
-        fields.Nested(BudgetNotificationWithSubscribersSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED}),
-        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    notifications_with_subscribers = fields.Nested(
+        BudgetNotificationWithSubscribersSchema,
+        many=True,
+        metadata={"update_policy": UpdatePolicy.SUPPORTED, "update_key": "Name"},
     )
-
-    # Cost-type fields
-    include_credit = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    include_discount = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    include_other_subscription = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    include_recurring = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    include_refund = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    include_subscription = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    include_support = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    include_tax = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    include_up_front = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    use_amortized = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    use_blended = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -1027,11 +1014,11 @@ class ClusterDevSettingsSchema(BaseDevSettingsSchema):
     ami_search_filters = fields.Nested(AmiSearchFiltersSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     instance_types_data = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     timeouts = fields.Nested(TimeoutsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    budgets = fields.List(
-        fields.Nested(BudgetSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED}),
-        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    budgets = fields.Nested(
+        BudgetSchema,
+        many=True,
+        metadata={"update_policy": UpdatePolicy.SUPPORTED, "update_key": "Name"},
     )
-
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/budget_builder.py
+++ b/cli/src/pcluster/templates/budget_builder.py
@@ -10,62 +10,75 @@ class CostBudgets:
     def __init__(self, scope: Construct, cluster_config: BaseClusterConfig):
         self.cluster_config = cluster_config
         self.scope = scope
+        self._create_budgets()
 
-    def create_budgets(self):
+    def _create_budgets(self):
         """Create the Cfn templates for the list of budgets."""
         budget_list = self.cluster_config.dev_settings.budgets
         cfn_budget_list = []
+
         for index, budget in enumerate(budget_list):
-
-            budget_data = budgets.CfnBudget.BudgetDataProperty(
-                budget_name=f"CfnBudget{self.cluster_config.cluster_name}" + str(index),
-                budget_type="COST",
-                time_unit=budget.time_unit,
-                budget_limit=budgets.CfnBudget.SpendProperty(
-                    amount=budget.budget_limit.amount,
-                    unit=budget.budget_limit.unit,
-                ),
-                cost_filters=(
-                    budget.cost_filters
-                    if budget.budget_category == "custom"
-                    else (
-                        {"TagKeyValue": [f"user:parallelcluster:cluster-name${self.cluster_config.cluster_name}"]}
-                        if budget.budget_category == "cluster"
-                        else ({"TagKeyValue": [f"user:parallelcluster:queue-name${budget.queue_name}"]})
-                    )
-                ),
-            )
-
-            notifications_with_subscribers = None
-
-            if budget.notifications_with_subscribers is not None:
-
-                notifications_with_subscribers = []
-
-                for single_notification in budget.notifications_with_subscribers:
-                    notifications_with_subscribers.append(
-                        budgets.CfnBudget.NotificationWithSubscribersProperty(
-                            notification=budgets.CfnBudget.NotificationProperty(
-                                comparison_operator=single_notification.notification.comparison_operator,
-                                notification_type=single_notification.notification.notification_type,
-                                threshold_type=single_notification.notification.threshold_type,
-                                threshold=single_notification.notification.threshold,
-                            ),
-                            subscribers=[
-                                budgets.CfnBudget.SubscriberProperty(
-                                    address=subscriber.address,
-                                    subscription_type=subscriber.subscription_type,
-                                )
-                                for subscriber in single_notification.subscribers
-                            ],
-                        )
-                    )
-
-            budget_id = f"CfnBudget{self.cluster_config.cluster_name}" + str(index)
-            cfn_budget = budgets.CfnBudget(
-                self.scope, budget_id, budget=budget_data, notifications_with_subscribers=notifications_with_subscribers
-            )
-
+            cfn_budget = self._add_parameters(budget, index)
             cfn_budget_list.append(cfn_budget)
 
         return cfn_budget_list
+
+    def _add_parameters(self, budget, index):
+        """Add each budget's parameters."""
+        if budget.budget_category == "queue":
+            name = f"{self.cluster_config.cluster_name}-{index}-{budget.queue_name}-{self.cluster_config.region}"
+        elif budget.budget_category == "cluster":
+            name = f"{self.cluster_config.cluster_name}-{index}-{self.cluster_config.region}"
+        else:
+            name = f"{self.cluster_config.cluster_name}-{index}-custom-{self.cluster_config.region}"
+
+        budget_data = budgets.CfnBudget.BudgetDataProperty(
+            budget_name=name,
+            budget_type="COST",
+            time_unit=budget.time_unit,
+            budget_limit=budgets.CfnBudget.SpendProperty(
+                amount=budget.budget_limit.amount, unit=budget.budget_limit.unit
+            ),
+            cost_filters=(
+                budget.cost_filters
+                if budget.budget_category == "custom"
+                else (
+                    {"TagKeyValue": [f"user:parallelcluster:cluster-name${self.cluster_config.cluster_name}"]}
+                    if budget.budget_category == "cluster"
+                    else ({"TagKeyValue": [f"user:parallelcluster:queue-name${budget.queue_name}"]})
+                )
+            ),
+        )
+        notifications_with_subscribers = (
+            add_budget_notifications(budget) if budget.notifications_with_subscribers else None
+        )
+        budget_id = f"Budget{str(index)}"
+        cfn_budget = budgets.CfnBudget(
+            self.scope, budget_id, budget=budget_data, notifications_with_subscribers=notifications_with_subscribers
+        )
+        return cfn_budget
+
+
+def add_budget_notifications(budget):
+    """Create the notifications with subscribers for each budget."""
+    notifications_with_subscribers = []
+    for single_notification in budget.notifications_with_subscribers:
+        notifications_with_subscribers.append(
+            budgets.CfnBudget.NotificationWithSubscribersProperty(
+                notification=budgets.CfnBudget.NotificationProperty(
+                    comparison_operator=single_notification.notification.comparison_operator,
+                    notification_type=single_notification.notification.notification_type,
+                    threshold_type=single_notification.notification.threshold_type,
+                    threshold=single_notification.notification.threshold,
+                ),
+                subscribers=[
+                    budgets.CfnBudget.SubscriberProperty(
+                        address=subscriber.address,
+                        subscription_type=subscriber.subscription_type,
+                    )
+                    for subscriber in single_notification.subscribers
+                ],
+            )
+        )
+
+    return notifications_with_subscribers

--- a/cli/src/pcluster/templates/budget_builder.py
+++ b/cli/src/pcluster/templates/budget_builder.py
@@ -5,19 +5,20 @@ from pcluster.config.cluster_config import BaseClusterConfig
 
 
 class CostBudgets:
-    """Creates the budgets based on the configuration file"""
+    """Create the budgets based on the configuration file."""
 
     def __init__(self, scope: Construct, cluster_config: BaseClusterConfig):
         self.cluster_config = cluster_config
         self.scope = scope
 
     def create_budgets(self):
+        """Create the Cfn templates for the list of budgets."""
         budget_list = self.cluster_config.dev_settings.budgets
         cfn_budget_list = []
         for index, budget in enumerate(budget_list):
 
             budget_data = budgets.CfnBudget.BudgetDataProperty(
-                budget_name=budget.budget_name,
+                budget_name=f"CfnBudget{self.cluster_config.cluster_name}" + str(index),
                 budget_type="COST",
                 time_unit=budget.time_unit,
                 budget_limit=budgets.CfnBudget.SpendProperty(

--- a/cli/src/pcluster/templates/budget_builder.py
+++ b/cli/src/pcluster/templates/budget_builder.py
@@ -24,29 +24,15 @@ class CostBudgets:
                     amount=budget.budget_limit.amount,
                     unit=budget.budget_limit.unit,
                 ),
-
-                cost_types=budgets.CfnBudget.CostTypesProperty(
-                    include_credit=budget.include_credit,
-                    include_discount=budget.include_discount,
-                    include_other_subscription=budget.include_other_subscription,
-                    include_recurring=budget.include_recurring,
-                    include_refund=budget.include_refund,
-                    include_subscription=budget.include_subscription,
-                    include_support=budget.include_support,
-                    include_tax=budget.include_tax,
-                    include_upfront=budget.include_up_front,
-                    use_amortized=budget.use_amortized,
-                    use_blended=budget.use_blended,
-                ),
-
                 cost_filters=(
-                    budget.cost_filters if budget.budget_category == 'custom' else (
-                        {"TagKeyValue": [f'user:parallelcluster:cluster-name${self.cluster_config.cluster_name}']}
-                        if budget.budget_category == 'cluster' else (
-                            {"TagKeyValue": [f"user:parallelcluster:queue-name${budget.queue_name}"]}
-                        )
+                    budget.cost_filters
+                    if budget.budget_category == "custom"
+                    else (
+                        {"TagKeyValue": [f"user:parallelcluster:cluster-name${self.cluster_config.cluster_name}"]}
+                        if budget.budget_category == "cluster"
+                        else ({"TagKeyValue": [f"user:parallelcluster:queue-name${budget.queue_name}"]})
                     )
-                )
+                ),
             )
 
             notifications_with_subscribers = None
@@ -59,9 +45,10 @@ class CostBudgets:
                     notifications_with_subscribers.append(
                         budgets.CfnBudget.NotificationWithSubscribersProperty(
                             notification=budgets.CfnBudget.NotificationProperty(
-                                comparison_operator=single_notification.comparison_operator,
-                                notification_type=single_notification.notification_type,
-                                threshold_type=single_notification.threshold_type,
+                                comparison_operator=single_notification.notification.comparison_operator,
+                                notification_type=single_notification.notification.notification_type,
+                                threshold_type=single_notification.notification.threshold_type,
+                                threshold=single_notification.notification.threshold,
                             ),
                             subscribers=[
                                 budgets.CfnBudget.SubscriberProperty(
@@ -73,7 +60,7 @@ class CostBudgets:
                         )
                     )
 
-            budget_id = f"CfnBudget-cluster:{self.cluster_config.cluster_name}" + str(index)
+            budget_id = f"CfnBudget{self.cluster_config.cluster_name}" + str(index)
             cfn_budget = budgets.CfnBudget(
                 self.scope, budget_id, budget=budget_data, notifications_with_subscribers=notifications_with_subscribers
             )

--- a/cli/src/pcluster/templates/budget_builder.py
+++ b/cli/src/pcluster/templates/budget_builder.py
@@ -1,0 +1,83 @@
+from aws_cdk import aws_budgets as budgets
+from aws_cdk.core import Construct
+
+from pcluster.config.cluster_config import BaseClusterConfig
+
+
+class CostBudgets:
+    """Creates the budgets based on the configuration file"""
+
+    def __init__(self, scope: Construct, cluster_config: BaseClusterConfig):
+        self.cluster_config = cluster_config
+        self.scope = scope
+
+    def create_budgets(self):
+        budget_list = self.cluster_config.dev_settings.budgets
+        cfn_budget_list = []
+        for index, budget in enumerate(budget_list):
+
+            budget_data = budgets.CfnBudget.BudgetDataProperty(
+                budget_name=budget.budget_name,
+                budget_type="COST",
+                time_unit=budget.time_unit,
+                budget_limit=budgets.CfnBudget.SpendProperty(
+                    amount=budget.budget_limit.amount,
+                    unit=budget.budget_limit.unit,
+                ),
+
+                cost_types=budgets.CfnBudget.CostTypesProperty(
+                    include_credit=budget.include_credit,
+                    include_discount=budget.include_discount,
+                    include_other_subscription=budget.include_other_subscription,
+                    include_recurring=budget.include_recurring,
+                    include_refund=budget.include_refund,
+                    include_subscription=budget.include_subscription,
+                    include_support=budget.include_support,
+                    include_tax=budget.include_tax,
+                    include_upfront=budget.include_up_front,
+                    use_amortized=budget.use_amortized,
+                    use_blended=budget.use_blended,
+                ),
+
+                cost_filters=(
+                    budget.cost_filters if budget.budget_category == 'custom' else (
+                        {"TagKeyValue": [f'user:parallelcluster:cluster-name${self.cluster_config.cluster_name}']}
+                        if budget.budget_category == 'cluster' else (
+                            {"TagKeyValue": [f"user:parallelcluster:queue-name${budget.queue_name}"]}
+                        )
+                    )
+                )
+            )
+
+            notifications_with_subscribers = None
+
+            if budget.notifications_with_subscribers is not None:
+
+                notifications_with_subscribers = []
+
+                for single_notification in budget.notifications_with_subscribers:
+                    notifications_with_subscribers.append(
+                        budgets.CfnBudget.NotificationWithSubscribersProperty(
+                            notification=budgets.CfnBudget.NotificationProperty(
+                                comparison_operator=single_notification.comparison_operator,
+                                notification_type=single_notification.notification_type,
+                                threshold_type=single_notification.threshold_type,
+                            ),
+                            subscribers=[
+                                budgets.CfnBudget.SubscriberProperty(
+                                    address=subscriber.address,
+                                    subscription_type=subscriber.subscription_type,
+                                )
+                                for subscriber in single_notification.subscribers
+                            ],
+                        )
+                    )
+
+            budget_id = f"CfnBudget-cluster:{self.cluster_config.cluster_name}" + str(index)
+            cfn_budget = budgets.CfnBudget(
+                self.scope, budget_id, budget=budget_data, notifications_with_subscribers=notifications_with_subscribers
+            )
+
+            cfn_budget_list.append(cfn_budget)
+
+        return cfn_budget_list

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -71,6 +71,7 @@ from pcluster.constants import (
 )
 from pcluster.models.s3_bucket import S3Bucket
 from pcluster.templates.awsbatch_builder import AwsBatchConstruct
+from pcluster.templates.budget_builder import CostBudgets
 from pcluster.templates.cdk_builder_utils import (
     ComputeNodeIamResources,
     HeadNodeIamResources,
@@ -97,7 +98,6 @@ from pcluster.templates.cdk_builder_utils import (
     to_comma_separated_string,
 )
 from pcluster.templates.cw_dashboard_builder import CWDashboardConstruct
-from pcluster.templates.budget_builder import CostBudgets
 from pcluster.templates.slurm_builder import SlurmConstruct
 from pcluster.utils import get_attr, join_shell_args
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -292,8 +292,7 @@ class ClusterCdkStack(Stack):
 
         # Budgets
         if self.config.dev_settings and self.config.dev_settings.budgets:
-            cost_budgets = CostBudgets(self, self.config)
-            self.budget_list = cost_budgets.create_budgets()
+            self.budgets = CostBudgets(self, self.config)
 
     def _add_iam_resources(self):
         head_node_iam_resources = HeadNodeIamResources(

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -97,6 +97,7 @@ from pcluster.templates.cdk_builder_utils import (
     to_comma_separated_string,
 )
 from pcluster.templates.cw_dashboard_builder import CWDashboardConstruct
+from pcluster.templates.budget_builder import CostBudgets
 from pcluster.templates.slurm_builder import SlurmConstruct
 from pcluster.utils import get_attr, join_shell_args
 
@@ -288,6 +289,11 @@ class ClusterCdkStack(Stack):
                 shared_storage_infos=self.shared_storage_infos,
                 cw_log_group_name=self.log_group.log_group_name if self.config.is_cw_logging_enabled else None,
             )
+
+        # Budgets
+        if self.config.dev_settings and self.config.dev_settings.budgets:
+            cost_budgets = CostBudgets(self, self.config)
+            self.budget_list = cost_budgets.create_budgets()
 
     def _add_iam_resources(self):
         head_node_iam_resources = HeadNodeIamResources(

--- a/cli/tests/pcluster/example_configs/awsbatch.full.yaml
+++ b/cli/tests/pcluster/example_configs/awsbatch.full.yaml
@@ -116,3 +116,62 @@ DevSettings:
   NodePackage: https://nodepackage.url
   Timeouts:
     HeadNodeBootstrapTimeout: 1000  # Default 1800 (seconds)
+  Budgets:
+    - BudgetCategory: cluster
+      BudgetLimit:
+        Amount: 85.0
+        Unit: USD
+      NotificationsWithSubscribers:
+        - Notification:
+            Threshold: 76.0
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias1@amazon.com
+        - Notification:
+            Threshold: 40.0
+            NotificationType: FORECASTED
+            ThresholdType: PERCENTAGE
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias2@amazon.com
+    - BudgetCategory: queue
+      QueueName: queue1
+      BudgetLimit:
+        Amount: 45.0
+        Unit: USD
+      NotificationsWithSubscribers:
+        - Notification:
+            Threshold: 34.0
+            ComparisonOperator: LESS_THAN
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias1@amazon.com
+        - Notification:
+            Threshold: 45.0
+            NotificationType: FORECASTED
+            ThresholdType: PERCENTAGE
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias2@amazon.com
+    - BudgetCategory: custom
+      BudgetLimit:
+        Amount: 65.0
+        Unit: USD
+      CostFilters:
+        TagKeyValue:
+          - user:parallelcluster:node-type$Compute
+      NotificationsWithSubscribers:
+        - Notification:
+            Threshold: 40.0
+            ComparisonOperator: EQUAL_TO
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias1@amazon.com
+        - Notification:
+            Threshold: 65.0
+            NotificationType: FORECASTED
+            ThresholdType: PERCENTAGE
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias2@amazon.com
+

--- a/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
+++ b/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
@@ -278,3 +278,61 @@ DevSettings:
   Timeouts:
     HeadNodeBootstrapTimeout: 1201  # Default 1800 (seconds)
     ComputeNodeBootstrapTimeout: 1001  # Default 1800 (seconds)
+  Budgets:
+    - BudgetCategory: cluster
+      BudgetLimit:
+        Amount: 85.0
+        Unit: USD
+      NotificationsWithSubscribers:
+        - Notification:
+            Threshold: 76.0
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias1@amazon.com
+        - Notification:
+            Threshold: 40.0
+            NotificationType: FORECASTED
+            ThresholdType: PERCENTAGE
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias2@amazon.com
+    - BudgetCategory: queue
+      QueueName: queue1
+      BudgetLimit:
+        Amount: 45.0
+        Unit: USD
+      NotificationsWithSubscribers:
+        - Notification:
+            Threshold: 34.0
+            ComparisonOperator: LESS_THAN
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias1@amazon.com
+        - Notification:
+            Threshold: 45.0
+            NotificationType: FORECASTED
+            ThresholdType: PERCENTAGE
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias2@amazon.com
+    - BudgetCategory: custom
+      BudgetLimit:
+        Amount: 65.0
+        Unit: USD
+      CostFilters:
+        TagKeyValue:
+          - user:parallelcluster:node-type$Compute
+      NotificationsWithSubscribers:
+        - Notification:
+            Threshold: 40.0
+            ComparisonOperator: EQUAL_TO
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias1@amazon.com
+        - Notification:
+            Threshold: 65.0
+            NotificationType: FORECASTED
+            ThresholdType: PERCENTAGE
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias2@amazon.com

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -226,3 +226,61 @@ DevSettings:
   Timeouts:
     HeadNodeBootstrapTimeout: 1201  # Default 1800 (seconds)
     ComputeNodeBootstrapTimeout: 1001  # Default 1800 (seconds)
+  Budgets:
+    - BudgetCategory: cluster
+      BudgetLimit:
+        Amount: 85.0
+        Unit: USD
+      NotificationsWithSubscribers:
+        - Notification:
+            Threshold: 76.0
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias1@amazon.com
+        - Notification:
+            Threshold: 40.0
+            NotificationType: FORECASTED
+            ThresholdType: PERCENTAGE
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias2@amazon.com
+    - BudgetCategory: queue
+      QueueName: queue1
+      BudgetLimit:
+        Amount: 45.0
+        Unit: USD
+      NotificationsWithSubscribers:
+        - Notification:
+            Threshold: 34.0
+            ComparisonOperator: LESS_THAN
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias1@amazon.com
+        - Notification:
+            Threshold: 45.0
+            NotificationType: FORECASTED
+            ThresholdType: PERCENTAGE
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias2@amazon.com
+    - BudgetCategory: custom
+      BudgetLimit:
+        Amount: 65.0
+        Unit: USD
+      CostFilters:
+        TagKeyValue:
+          - user:parallelcluster:node-type$Compute
+      NotificationsWithSubscribers:
+        - Notification:
+            Threshold: 40.0
+            ComparisonOperator: EQUAL_TO
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias1@amazon.com
+        - Notification:
+            Threshold: 65.0
+            NotificationType: FORECASTED
+            ThresholdType: PERCENTAGE
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias2@amazon.com

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -614,25 +614,28 @@ def test_password_secret_arn_validator(password_secret_arn, expected_message):
         ("ACTUAL", "EQUAL", 200, None, "Must be one of"),
         ("Actual", None, 100, None, "Must be one of"),
         (None, None, 150, "ABSOLUTE", "Must be one of"),
-        (None, None, None, None, "Field may not be null"),
         ("FORECASTED", "EQUAL_TO", 100, "PERCENTAGE", None),
         (None, "GREATER_THAN", 200, "ABSOLUTE_VALUE", None),
         (None, "LESS_THAN", 2, None, None),
     ],
 )
-def test_budget_notification_schema(
+def test_budget_notification_schema_validators(
     notification_type,
     comparison_operator,
     threshold,
     threshold_type,
     expected_message,
 ):
-    section_dict = {
-        "NotificationType": notification_type,
-        "ComparisonOperator": comparison_operator,
-        "Threshold": threshold,
-        "ThresholdType": threshold_type,
-    }
+    section_dict = {}
+    if notification_type:
+        section_dict["NotificationType"] = notification_type
+    if comparison_operator:
+        section_dict["ComparisonOperator"] = comparison_operator
+    if threshold:
+        section_dict["Threshold"] = threshold
+    if threshold_type:
+        section_dict["ThresholdType"] = threshold_type
+
     _validate_and_assert_error(BudgetNotificationSchema(), section_dict, expected_message)
 
 
@@ -643,14 +646,14 @@ def test_budget_notification_schema(
         ("EMAIL", "alias@amazon.com", None),
         ("SNS", "arn:aws:sns:us-east-1:444455556666:MyTopic", None),
         ("GMAIL", "email@gmail.com", "Must be one of"),
-        (None, None, "Field may not be null"),
     ],
 )
-def test_budget_subscriber_schema(subscription_type, address, expected_message):
-    section_dict = {
-        "Address": address,
-        "SubscriptionType": subscription_type,
-    }
+def test_budget_subscriber_schema_validators(subscription_type, address, expected_message):
+    section_dict = {}
+    if address:
+        section_dict["Address"] = address
+    if subscription_type:
+        section_dict["SubscriptionType"] = subscription_type
     _validate_and_assert_error(BudgetSubscriberSchema(), section_dict, expected_message)
 
 
@@ -658,16 +661,15 @@ def test_budget_subscriber_schema(subscription_type, address, expected_message):
     "amount, unit, expected_message",
     [
         (120, "USD", None),
-        (100, None, None),
-        (None, None, "Field may not be null"),
-        (None, "BRP", "Field may not be null"),
+        (100, "GBP", None),
     ],
 )
-def test_budget_limit_schema(amount, unit, expected_message):
-    section_dict = {
-        "Amount": amount,
-        "Unit": unit,
-    }
+def test_budget_limit_schema_validators(amount, unit, expected_message):
+    section_dict = {}
+    if amount:
+        section_dict["Amount"] = amount
+    if unit:
+        section_dict["Unit"] = unit
     _validate_and_assert_error(BudgetLimitSchema(), section_dict, expected_message)
 
 
@@ -675,15 +677,14 @@ def test_budget_limit_schema(amount, unit, expected_message):
     "budget_category, budget_limit, time_unit, queue_name, cost_filters, expected_message",
     [
         ("cluster", {"Amount": 100, "Unit": "USD"}, "MONTHLY", None, None, None),
-        ("queue", {"Amount": 150}, "ANNUALLY", "queue1", None, None),
-        ("custom", {"Amount": 200}, "QUARTERLY", None, {"TagKeyValue": "user:customTag$hpc"}, None),
-        ("cluster", {"Amount": 300}, None, None, None, None),
-        ("cluster", None, None, None, None, "Field may not be null"),
-        ("wrongValue", {"Amount": 100}, None, None, None, "Must be one of"),
-        ("cluster", {"Amount": 100}, "DAILY", None, None, "Must be one of"),
+        ("queue", {"Amount": 150, "Unit": "GBP"}, "ANNUALLY", "queue1", None, None),
+        ("custom", {"Amount": 200, "Unit": "USD"}, "QUARTERLY", None, {"TagKeyValue": "user:customTag$hpc"}, None),
+        ("cluster", {"Amount": 300, "Unit": "USD"}, None, None, None, None),
+        ("wrongValue", {"Amount": 100, "Unit": "USD"}, None, None, None, "Must be one of"),
+        ("cluster", {"Amount": 100, "Unit": "USD"}, "DAILY", None, None, "Must be one of"),
     ],
 )
-def test_budget_schema(
+def test_budget_schema_validators(
     budget_category,
     budget_limit,
     time_unit,
@@ -691,11 +692,16 @@ def test_budget_schema(
     cost_filters,
     expected_message,
 ):
-    section_dict = {
-        "BudgetCategory": budget_category,
-        "BudgetLimit": budget_limit,
-        "TimeUnit": time_unit,
-        "QueueName": queue_name,
-        "CostFilters": cost_filters,
-    }
+    section_dict = {}
+    if budget_category:
+        section_dict["BudgetCategory"] = budget_category
+    if budget_limit:
+        section_dict["BudgetLimit"] = budget_limit
+    if time_unit:
+        section_dict["TimeUnit"] = time_unit
+    if queue_name:
+        section_dict["QueueName"] = queue_name
+    if cost_filters:
+        section_dict["CostFilters"] = cost_filters
+
     _validate_and_assert_error(BudgetSchema(), section_dict, expected_message)


### PR DESCRIPTION
### Description of changes
* This adds the necessary budget fields schema and configuration classes, and creates a budget builder file, for the Cfn template.
* Added basic field validation to the schema and unit tests to ensure they are working correctly.

### Tests
* Manual testing (creating clusters and updating configuration after creation)
  * Creating cluster without budget and adding it after creation
  * Creating cluster with a budget, then changing budget category / properties
  * Creating a cluster with a budget, then deleting the budget
* Unit test to check basic validation of the budget schema

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
