### PR TITLE
Integ-tests: Fix test_scheduler_plugin

### DIFF
--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_arm64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_arm64.yaml
@@ -14,7 +14,12 @@
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
-      RootVolume: null
+      RootVolume:
+        Encrypted: true
+        Iops: 3000
+        Size: null
+        Throughput: 125
+        VolumeType: gp3
   CustomActions: null
   CustomSettings: null
   Iam:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_x86_64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_x86_64.yaml
@@ -14,7 +14,12 @@
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
-      RootVolume: null
+      RootVolume:
+        Encrypted: true
+        Iops: 3000
+        Size: null
+        Throughput: 125
+        VolumeType: gp3
   CustomActions: null
   CustomSettings: null
   Iam:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_arm64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_arm64.yaml
@@ -25,7 +25,12 @@
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
-      RootVolume: null
+      RootVolume:
+        Encrypted: true
+        Iops: 3000
+        Size: null
+        Throughput: 125
+        VolumeType: gp3
   CustomActions: null
   CustomSettings: null
   Iam:
@@ -59,7 +64,12 @@
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
-      RootVolume: null
+      RootVolume:
+        Encrypted: true
+        Iops: 3000
+        Size: null
+        Throughput: 125
+        VolumeType: gp3
   CustomActions: null
   CustomSettings: null
   Iam:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_x86_64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_x86_64.yaml
@@ -25,7 +25,12 @@
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
-      RootVolume: null
+      RootVolume:
+        Encrypted: true
+        Iops: 3000
+        Size: null
+        Throughput: 125
+        VolumeType: gp3
   CustomActions: null
   CustomSettings: null
   Iam:
@@ -59,7 +64,12 @@
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
-      RootVolume: null
+      RootVolume:
+        Encrypted: true
+        Iops: 3000
+        Size: null
+        Throughput: 125
+        VolumeType: gp3
   CustomActions: null
   CustomSettings: null
   Iam:


### PR DESCRIPTION
The test failed because of https://github.com/aws/aws-parallelcluster/commit/fbb995d4221b56b62cb8d7edd5ffa91ee643f002. The test checks the cluster configuration file with default values on the head node is as expected. Because the root volume configuration was added to the default in the previous commit. The expected outputs have to be changed accordingly. Adding the default root volume configuration makes sense, because those values are used to configure the root volume.

test_scheduler_plugin was successful after this commit.

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
