### PR TITLE
[Scheduler Plugin] Add validator to disable Scheduler Plugin

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -93,6 +93,7 @@ from pcluster.validators.cluster_validators import (
     RootVolumeSizeValidator,
     SchedulableMemoryValidator,
     SchedulerOsValidator,
+    SchedulerValidator,
     SharedStorageMountDirValidator,
     SharedStorageNameValidator,
 )
@@ -1176,6 +1177,7 @@ class BaseClusterConfig(Resource):
         if self.custom_s3_bucket:
             self._register_validator(S3BucketValidator, bucket=self.custom_s3_bucket)
             self._register_validator(S3BucketRegionValidator, bucket=self.custom_s3_bucket, region=self.region)
+        self._register_validator(SchedulerValidator, scheduler=self.scheduling.scheduler)
         self._register_validator(SchedulerOsValidator, scheduler=self.scheduling.scheduler, os=self.image.os)
         self._register_validator(
             HeadNodeImdsValidator, imds_secured=self.head_node.imds.secured, scheduler=self.scheduling.scheduler

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -29,6 +29,7 @@ from pcluster.constants import (
     SCHEDULERS_SUPPORTING_IMDS_SECURED,
     SUPPORTED_OSES,
     SUPPORTED_REGIONS,
+    SUPPORTED_SCHEDULERS,
 )
 from pcluster.utils import get_installed_version, get_supported_os_for_architecture, get_supported_os_for_scheduler
 from pcluster.validators.common import FailureLevel, Validator
@@ -1121,5 +1122,16 @@ class HostedZoneValidator(Validator):
                     f"longer than {CLUSTER_NAME_AND_CUSTOM_DOMAIN_NAME_MAX_LENGTH} character, "
                     f"current length is {total_length}"
                 ),
+                FailureLevel.ERROR,
+            )
+
+
+class SchedulerValidator(Validator):
+    """Validate that only supported schedulers are specified."""
+
+    def _validate(self, scheduler):
+        if scheduler not in SUPPORTED_SCHEDULERS:
+            self._add_failure(
+                f"{scheduler} scheduler is not supported. Supported schedulers are: {', '.join(SUPPORTED_SCHEDULERS)}.",
                 FailureLevel.ERROR,
             )

--- a/cli/tests/pcluster/validators/test_scheduling_validators.py
+++ b/cli/tests/pcluster/validators/test_scheduling_validators.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pcluster.constants import SUPPORTED_SCHEDULERS
+from pcluster.validators.cluster_validators import SchedulerValidator
+from pcluster.validators.common import FailureLevel
+from tests.pcluster.validators.utils import assert_failure_level, assert_failure_messages
+
+
+@pytest.mark.parametrize(
+    "scheduler, expected_failure_level, expected_message",
+    [
+        ("slurm", None, None),
+        ("awsbatch", None, None),
+        (
+            "plugin",
+            FailureLevel.ERROR,
+            f"plugin scheduler is not supported. Supported schedulers are: {', '.join(SUPPORTED_SCHEDULERS)}.",
+        ),
+    ],
+)
+def test_scheduler_validator(scheduler, expected_failure_level, expected_message):
+    actual_failures = SchedulerValidator().execute(scheduler=scheduler)
+    assert_failure_level(actual_failures, expected_failure_level)
+    assert_failure_messages(actual_failures, expected_message)

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
@@ -110,7 +110,7 @@ def test_scheduler_plugin_integration(
         run_as_user=run_as_user,
         plugin_interface_version=SCHEDULER_PLUGIN_INTERFACE_VERSION,
     )
-    cluster = clusters_factory(before_update_cluster_config)
+    cluster = clusters_factory(before_update_cluster_config, suppress_validators="type:SchedulerValidator")
     cluster_config = pcluster_config_reader(
         bucket=bucket_name,
         bucket_key_prefix=s3_bucket_key_prefix,
@@ -600,7 +600,7 @@ def _test_cluster_update(cluster, cluster_config):
     """Test cluster update."""
     cluster.stop()
     _check_fleet_status(cluster, "STOPPED")
-    cluster.update(str(cluster_config), force_update="true")
+    cluster.update(str(cluster_config), force_update="true", suppress_validators="type:SchedulerValidator")
     cluster.start()
     _check_fleet_status(cluster, "RUNNING")
 


### PR DESCRIPTION
### Description of changes
Add validator to disable Scheduler Plugin.

#### Examples of usage
See below the behaviour of the validator when using the following config:

```
...
Scheduling:
  Scheduler: plugin
...
```

```
pcluster create-cluster --region eu-west-1 --cluster-configuration /Users/mgiacomo/workplace/MGIACOMO-AWSParallelCluster/cluster-config/scheduler_plugin/config.yaml --cluster-name test-plugin-v1 --rollback-on-failure false --dryrun true
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "SchedulerValidator",
      "message": "plugin scheduler is not supported. Supported schedulers are: slurm,awsbatch."
    }
  ],
  "message": "Invalid cluster configuration."
}
```

```
pcluster create-cluster --region eu-west-1 --cluster-configuration /Users/mgiacomo/workplace/MGIACOMO-AWSParallelCluster/cluster-config/scheduler_plugin/config.yaml --cluster-name test-plugin-v1 --rollback-on-failure false --dryrun true --suppress-validators type:SchedulerValidator
{
  "message": "Request would have succeeded, but DryRun flag is set."
}
```

### Tests
1. Unit Tests covering the new validator.
2. All existing unit tests succeeded, but some on api due to an unrelated issue.
3. Manual tests proving that there are no regressions.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
