### PR TITLE
[Testing] Make multiple-nics integration tests use reserved capacity when running p4d.24xlarge instances.

### DIFF
--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -9,6 +9,18 @@ HeadNode:
     KeyName: {{ key_name }}
   Imds:
     Secured: {{ imds_secured }}
+{% if instance == "p4d.24xlarge" %}
+  Iam:
+    # Needed to use the p4d capacity reservation
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonEC2FullAccess
+    S3Access:
+      - BucketName: {{ bucket_name }}
+        EnableWriteAccess: false
+  CustomActions:
+    OnNodeConfigured:
+      Script: s3://{{ bucket_name }}/run_instance_override.sh
+{% endif %}
 Scheduling:
   Scheduler: {{ scheduler }}
   {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/run_instance_override.sh
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/run_instance_override.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+. "/etc/parallelcluster/cfnconfig"
+
+
+if [[ $cfn_node_type == "HeadNode" ]]; then
+    # Override run_instance attributes
+    cat > /opt/slurm/etc/pcluster/run_instances_overrides.json << 'EOF'
+{
+    "queue-0": {
+        "compute-resource-0": {
+            "CapacityReservationSpecification": {
+                "CapacityReservationTarget": {
+                    "CapacityReservationId": "cr-0fa65fcdbd597f551"
+                }
+            }
+        }
+    }
+}
+EOF
+fi


### PR DESCRIPTION
### Description of changes
Make multiple-nics integration tests use reserved capacity when running p4d.24xlarge instances.
In particular, I've adopted the same approach we currently have in place for EFA tests.

### Tests
Tests will be executed on dev pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
