### PR TITLE
[PCluster Configure] Add integration tests for enabling EFA through the pcluster configure wizard

### DIFF
--- a/tests/integration-tests/configs/common.jinja2
+++ b/tests/integration-tests/configs/common.jinja2
@@ -15,6 +15,8 @@
 {%- set INSTANCES_DEFAULT_X86 = ["c5.xlarge"] -%}
 {%- set INSTANCES_DEFAULT_ARM = ["m6g.xlarge"] -%} # m6g.xlarge is not supported in af-south-1, eu-south-1, eu-west-3, me-south-1
 {%- set INSTANCES_DEFAULT = ["c5.xlarge", "m6g.xlarge"] -%}
+{%- set INSTANCES_EFA_SUPPORTED_X86 = ["c5n.9xlarge"] -%}
+{%- set INSTANCES_EFA_UNSUPPORTED_X86 = ["t2.micro"] -%}
 
 {%- macro instance(instance_key) -%}
     {%- if additional_instance_types_map -%}

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -110,6 +110,19 @@ configure:
         - regions: ["eu-north-1"] # must be regions that do not have t2.micro
           oss: ["centos7"]
           schedulers: ["slurm"]
+  test_pcluster_configure.py::test_efa_and_placement_group:
+    dimensions:
+      - regions: ["us-east-1"]
+        instances: {{ common.INSTANCES_EFA_SUPPORTED_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
+  test_pcluster_configure.py::test_efa_unsupported:
+    dimensions:
+      - regions: ["us-east-1"]
+        instances: {{ common.INSTANCES_EFA_UNSUPPORTED_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
+
 create:
   test_create.py::test_create_wrong_os:
     dimensions:


### PR DESCRIPTION


### Description of changes
* The `pcluster configure` command now includes prompts to enable EFA for supported instance-types
* These tests check to confirm if the wizard is able to generate the expected configuration file as well as successfully create a cluster with the same configuration

### Tests
* User is prompted to enable EFA for supported instance-type
* User is prompted to either provide an existing PlacementGroup or let PCluster create one for them
* A configuration file with expected properties is generated
* The configuration file can be used to successfully create a cluster

Result | Test | Duration | 
-- | -- | -- |
Passed | configure/test_pcluster_configure.py::test_efa_and_placement_group[us-east-1-c5n.9xlarge-alinux2-slurm-n-efa_config2-none] | 464.64 |  
Passed | configure/test_pcluster_configure.py::test_efa_and_placement_group[us-east-1-c5n.9xlarge-alinux2-slurm-y-efa_config0-default] | 492.55 |  
Passed | configure/test_pcluster_configure.py::test_efa_and_placement_group[us-east-1-c5n.9xlarge-alinux2-slurm-y-efa_config1-custom] | 466.77



### References
* [Prompt user to enable EFA for supported instance-types when using the pcluster configure wizard](https://github.com/aws/aws-parallelcluster/pull/4118)
* [ParallelCluster EFA](https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
