### PR TITLE
[Testing] Make integration tests suppress SchedulerValidator on cluster creation/update when using plugin scheduler

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -86,6 +86,9 @@ class Cluster:
                 command.extend([f"--{kebab_case(k)}"] + list(map(str, val)))
             else:
                 command.extend([f"--{kebab_case(k)}", str(val)])
+        # TODO Remove the validator suppression below once the plugin scheduler is officially supported
+        if self.config["Scheduling"]["Scheduler"] == "plugin":
+            command.append("--suppress-validators type:SchedulerValidator")
         result = run_pcluster_command(command, raise_on_error=raise_on_error, log_error=log_error)
         logging.info("update-cluster response: %s", result.stdout)
         response = json.loads(result.stdout)
@@ -433,6 +436,9 @@ class ClustersFactory:
                 command.extend([f"--{kebab_case(k)}"] + list(map(str, val)))
             else:
                 command.extend([f"--{kebab_case(k)}", str(val)])
+        # TODO Remove the validator suppression below once the plugin scheduler is officially supported
+        if cluster.config["Scheduling"]["Scheduler"] == "plugin":
+            command.append("--suppress-validators type:SchedulerValidator")
         try:
             result = run_pcluster_command(command, timeout=7200, raise_on_error=raise_on_error, log_error=log_error)
 

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
@@ -110,7 +110,7 @@ def test_scheduler_plugin_integration(
         run_as_user=run_as_user,
         plugin_interface_version=SCHEDULER_PLUGIN_INTERFACE_VERSION,
     )
-    cluster = clusters_factory(before_update_cluster_config, suppress_validators="type:SchedulerValidator")
+    cluster = clusters_factory(before_update_cluster_config)
     cluster_config = pcluster_config_reader(
         bucket=bucket_name,
         bucket_key_prefix=s3_bucket_key_prefix,
@@ -600,7 +600,7 @@ def _test_cluster_update(cluster, cluster_config):
     """Test cluster update."""
     cluster.stop()
     _check_fleet_status(cluster, "STOPPED")
-    cluster.update(str(cluster_config), force_update="true", suppress_validators="type:SchedulerValidator")
+    cluster.update(str(cluster_config), force_update="true")
     cluster.start()
     _check_fleet_status(cluster, "RUNNING")
 


### PR DESCRIPTION
### Description of changes
Make integration tests suppress SchedulerValidator on cluster creation/update when using plugin scheduler to make them able to test the scheduler plugin even if not yet officially supported.

This Pr fixes some regressions introduced in https://github.com/aws/aws-parallelcluster/pull/4149

### Tests
Will be validated by integration tests on pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
