### PR TITLE
Make SharedStorageMountDirValidator accept /scratch and improve error message

### DIFF
--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -205,6 +205,10 @@ class InstanceTypeInfo:
 
         return vcpus
 
+    def instance_storage_supported(self) -> bool:
+        """Indicate whether instance storage is supported."""
+        return self.instance_type_data.get("InstanceStorageSupported")
+
     def supported_architecture(self):
         """Return the list of supported architectures."""
         supported_architectures = self.instance_type_data.get("ProcessorInfo").get("SupportedArchitectures")

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -77,6 +77,11 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
     def ec2memory_size_in_mib(self):
         return self._ec2memory_size_in_mib
 
+    def instance_storage_supported(self):
+        # There are more instance types supporting instance storage.
+        # But for the simplicity of the mock, only c5d is considered.
+        return True if self._instance_type.startswith("c5d") else False
+
 
 class _DummyAWSApi(AWSApi):
     def __init__(self):
@@ -262,6 +267,4 @@ def mock_aws_api(mocker, mock_instance_type_info=True):
     """Mock AWS Api."""
     mocker.patch("pcluster.aws.aws_api.AWSApi.instance", return_value=_DummyAWSApi())
     if mock_instance_type_info:
-        mocker.patch(
-            "pcluster.aws.ec2.Ec2Client.get_instance_type_info", return_value=_DummyInstanceTypeInfo("t2.micro")
-        )
+        mocker.patch("pcluster.aws.ec2.Ec2Client.get_instance_type_info", side_effect=_DummyInstanceTypeInfo)

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -224,14 +224,14 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
         any_order=True,
     )
     key_pair_validator.assert_has_calls([call(key_name="ec2-key-name")])
-    instance_type_validator.assert_has_calls([call(instance_type="t2.micro")])
+    instance_type_validator.assert_has_calls([call(instance_type="c5d.xlarge")])
     instance_type_base_ami_compatible_validator.assert_has_calls(
         [
-            call(instance_type="t2.micro", image="ami-12345678"),
+            call(instance_type="c5d.xlarge", image="ami-12345678"),
             call(instance_type="c5.2xlarge", image="ami-12345678"),
             call(instance_type="c4.2xlarge", image="ami-12345678"),
             call(instance_type="c5.4xlarge", image="ami-12345678"),
-            call(instance_type="c4.4xlarge", image="ami-12345678"),
+            call(instance_type="c5d.xlarge", image="ami-12345678"),
         ],
         any_order=True,
     )
@@ -251,7 +251,7 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
             call(instance_type="c5.2xlarge", architecture="x86_64"),
             call(instance_type="c4.2xlarge", architecture="x86_64"),
             call(instance_type="c5.4xlarge", architecture="x86_64"),
-            call(instance_type="c4.4xlarge", architecture="x86_64"),
+            call(instance_type="c5d.xlarge", architecture="x86_64"),
         ]
     )
 
@@ -263,11 +263,12 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
     fsx_architecture_os_validator.assert_has_calls([call(architecture="x86_64", os="alinux2")])
     # Scratch mount directories are retrieved from a set. So the order of them is not guaranteed.
     # The first item in call_args is regular args, the second item is keyword args.
-    mount_dir_list = duplicate_mount_dir_validator.call_args[1]["mount_dir_list"]
-    mount_dir_list.sort()
-    assert_that(mount_dir_list).is_equal_to(
-        ["/my/mount/point1", "/my/mount/point2", "/my/mount/point3", "/scratch", "/scratch_head"]
-    )
+    shared_mount_dir_list = duplicate_mount_dir_validator.call_args[1]["shared_mount_dir_list"]
+    shared_mount_dir_list.sort()
+    assert_that(shared_mount_dir_list).is_equal_to(["/my/mount/point1", "/my/mount/point2", "/my/mount/point3"])
+    local_mount_dir_list = duplicate_mount_dir_validator.call_args[1]["local_mount_dir_list"]
+    local_mount_dir_list.sort()
+    assert_that(local_mount_dir_list).is_equal_to(["/scratch", "/scratch_head"])
     number_of_storage_validator.assert_has_calls(
         [
             call(storage_type="EBS", max_number=5, storage_count=1),

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -263,12 +263,19 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
     fsx_architecture_os_validator.assert_has_calls([call(architecture="x86_64", os="alinux2")])
     # Scratch mount directories are retrieved from a set. So the order of them is not guaranteed.
     # The first item in call_args is regular args, the second item is keyword args.
-    shared_mount_dir_list = duplicate_mount_dir_validator.call_args[1]["shared_mount_dir_list"]
-    shared_mount_dir_list.sort()
-    assert_that(shared_mount_dir_list).is_equal_to(["/my/mount/point1", "/my/mount/point2", "/my/mount/point3"])
-    local_mount_dir_list = duplicate_mount_dir_validator.call_args[1]["local_mount_dir_list"]
-    local_mount_dir_list.sort()
-    assert_that(local_mount_dir_list).is_equal_to(["/scratch", "/scratch_head"])
+    shared_storage_name_mount_dir_tuple_list = duplicate_mount_dir_validator.call_args[1][
+        "shared_storage_name_mount_dir_tuple_list"
+    ]
+    shared_storage_name_mount_dir_tuple_list.sort(key=lambda tup: tup[1])
+    assert_that(shared_storage_name_mount_dir_tuple_list).is_equal_to(
+        [("name1", "/my/mount/point1"), ("name2", "/my/mount/point2"), ("name3", "/my/mount/point3")]
+    )
+    local_mount_dir_instance_types_dict = duplicate_mount_dir_validator.call_args[1][
+        "local_mount_dir_instance_types_dict"
+    ]
+    assert_that(local_mount_dir_instance_types_dict).is_equal_to(
+        {"/scratch": {"c5d.xlarge"}, "/scratch_head": {"c5d.xlarge"}}
+    )
     number_of_storage_validator.assert_has_calls(
         [
             call(storage_type="EBS", max_number=5, storage_count=1),

--- a/cli/tests/pcluster/validators/test_all_validators/test_validators_are_called_with_correct_argument/slurm.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_validators_are_called_with_correct_argument/slurm.yaml
@@ -2,7 +2,7 @@ Image:
   Os: alinux2
   CustomAmi: ami-12345678
 HeadNode:
-  InstanceType: t2.micro
+  InstanceType: c5d.xlarge
   Networking:
     SubnetId: subnet-12345678
   Ssh:
@@ -31,7 +31,7 @@ Scheduling:
           InstanceType: c5.4xlarge
           MaxCount: 5
         - Name: compute_resource2
-          InstanceType: c4.4xlarge
+          InstanceType: c5d.xlarge
 SharedStorage:
   - MountDir: /my/mount/point1
     Name: name1

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -827,32 +827,48 @@ def test_fsx_architecture_os_validator(architecture, os, expected_message):
 
 
 @pytest.mark.parametrize(
-    "mount_dir_list, expected_message",
+    "shared_mount_dir_list, local_mount_dir_list, expected_message",
     [
         (
             ["dir1"],
+            [],
             None,
         ),
         (
             ["dir1", "dir2"],
+            [],
             None,
         ),
         (
             ["dir1", "dir2", "dir3"],
+            [],
             None,
         ),
         (
             ["dir1", "dir1", "dir2"],
+            [],
             "Mount directory dir1 cannot be specified for multiple file systems",
         ),
         (
             ["dir1", "dir2", "dir3", "dir2", "dir1"],
+            [],
             "Mount directories dir2, dir1 cannot be specified for multiple file systems",
+        ),
+        (
+            ["dir1", "dir2", "/scratch"],
+            [],
+            None,
+        ),
+        (
+            ["dir1", "dir2", "/scratch"],
+            ["/scratch"],
+            "Ephemeral drive mount directory `/scratch` is overwritten by shared storage mount directory. "
+            "Please consider changing either directory to avoid the overwrite.",
         ),
     ],
 )
-def test_duplicate_mount_dir_validator(mount_dir_list, expected_message):
-    actual_failures = DuplicateMountDirValidator().execute(mount_dir_list)
+def test_duplicate_mount_dir_validator(shared_mount_dir_list, local_mount_dir_list, expected_message):
+    actual_failures = DuplicateMountDirValidator().execute(shared_mount_dir_list, local_mount_dir_list)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -939,7 +955,6 @@ def test_shared_storage_name_validator(name, expected_message):
         ("shared", None),
         ("/shared", None),
         ("home", "mount directory .* is reserved"),
-        ("/scratch", "mount directory .* is reserved"),
     ],
 )
 def test_shared_storage_mount_dir_validator(mount_dir, expected_message):

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -82,9 +82,14 @@ def test_ebs_snapshot(
     assert_that(result.stdout.strip()).is_equal_to("hello world")
 
 
-@pytest.mark.usefixtures("instance")
-def test_ebs_multiple(scheduler, pcluster_config_reader, clusters_factory, region, os, scheduler_commands_factory):
+def test_ebs_multiple(
+    scheduler, instance, pcluster_config_reader, clusters_factory, region, os, scheduler_commands_factory
+):
     mount_dirs = ["/ebs_mount_dir_{0}".format(i) for i in range(0, 5)]
+    if not utils.get_instance_info(instance)["InstanceStorageSupported"]:
+        # If the instance type does not support instance store, mount an EBS to /scratch to make sure our code allows it
+        mount_dirs[0] = "/scratch"
+
     volume_sizes = [15 + 5 * i for i in range(0, 5)]
 
     # for volume type sc1 and st1, the minimum volume sizes are 500G


### PR DESCRIPTION
### Description of changes
This is an amendament of https://github.com/aws/aws-parallelcluster/pull/3981.
See commit descriptions for details

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
The unit test has been improved to test the logic. 
`test_ebs_multiple` is improved to test `/scratch` used by a shared EBS on instances without instance store

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
