### PR TITLE
Add termination protection feature

### DIFF
--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -80,6 +80,7 @@ def create_cluster(
     validation_failure_level: str = None,
     dryrun: bool = None,
     rollback_on_failure: bool = None,
+    enable_termination_protection: bool = False,
 ) -> CreateClusterResponseContent:
     """
     Create a managed cluster in a given region.
@@ -98,6 +99,8 @@ def create_cluster(
     :param rollback_on_failure: When set it automatically initiates a cluster stack rollback on failures.
     (Defaults to &#39;true&#39;.)
     :type rollback_on_failure: bool
+    :param enable_termination_protection: When set, enables termination protection for the cluster stack
+    :type enable_termination_protection: bool
     """
     assert_valid_node_js()
     # Set defaults
@@ -127,6 +130,7 @@ def create_cluster(
             disable_rollback=not rollback_on_failure,
             validator_suppressors=get_validator_suppressors(suppress_validators),
             validation_failure_level=FailureLevel[validation_failure_level],
+            enable_termination_protection=enable_termination_protection,
         )
 
         return CreateClusterResponseContent(

--- a/cli/src/pcluster/api/pcluster_api.py
+++ b/cli/src/pcluster/api/pcluster_api.py
@@ -150,6 +150,7 @@ class PclusterApi:
         disable_rollback: bool = False,
         suppress_validators: bool = False,
         validation_failure_level: FailureLevel = FailureLevel.ERROR,
+        enable_termination_protection: bool = False,
     ):
         """
         Load cluster model from cluster_config and create stack.
@@ -160,6 +161,7 @@ class PclusterApi:
         :param disable_rollback: Disable rollback in case of failures
         :param suppress_validators: Disable validator execution
         :param validation_failure_level: Min validation level that will cause the creation to fail
+        :param enable_termination_protection: Termination protection for the Cfn stack
         """
         try:
             # Generate model from config dict and validate
@@ -172,7 +174,12 @@ class PclusterApi:
             # check cluster existence
             if AWSApi.instance().cfn.stack_exists(cluster.stack_name):
                 raise Exception(f"Cluster {cluster.name} already exists")
-            cluster.create(disable_rollback, validator_suppressors, validation_failure_level)
+            cluster.create(
+                disable_rollback,
+                validator_suppressors,
+                validation_failure_level,
+                enable_termination_protection=enable_termination_protection,
+            )
             return ClusterInfo(cluster.stack)
         except ConfigValidationError as e:
             return ApiFailure(str(e), validation_failures=e.validation_failures)

--- a/cli/src/pcluster/aws/cfn.py
+++ b/cli/src/pcluster/aws/cfn.py
@@ -27,7 +27,14 @@ class CfnClient(Boto3Client):
         super().__init__("cloudformation")
 
     @AWSExceptionHandler.handle_client_exception
-    def create_stack(self, stack_name: str, disable_rollback: bool, tags: list, template_body: str):
+    def create_stack(
+        self,
+        stack_name: str,
+        disable_rollback: bool,
+        tags: list,
+        template_body: str,
+        enable_termination_protection: bool = False,
+    ):
         """Create CFN stack by using the given template."""
         return self._client.create_stack(
             StackName=stack_name,
@@ -35,6 +42,7 @@ class CfnClient(Boto3Client):
             Capabilities=["CAPABILITY_IAM"],
             DisableRollback=disable_rollback,
             Tags=tags,
+            EnableTerminationProtection=enable_termination_protection,
         )
 
     @AWSExceptionHandler.handle_client_exception
@@ -45,6 +53,7 @@ class CfnClient(Boto3Client):
         tags: list,
         template_url: str,
         capabilities: str = "CAPABILITY_IAM",
+        enable_termination_protection: bool = False,
     ):
         """Create CFN stack by using the given template url."""
         return self._client.create_stack(
@@ -53,6 +62,7 @@ class CfnClient(Boto3Client):
             Capabilities=[capabilities],
             DisableRollback=disable_rollback,
             Tags=tags,
+            EnableTerminationProtection=enable_termination_protection,
         )
 
     @AWSExceptionHandler.handle_client_exception

--- a/cli/src/pcluster/cli/middleware.py
+++ b/cli/src/pcluster/cli/middleware.py
@@ -46,6 +46,11 @@ def add_additional_args(parser_map):
     calling the underlying function for the situation where they are not a part
     of the specification.
     """
+    parser_map["create-cluster"].add_argument(
+        "--enable-termination-protection",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     parser_map["create-cluster"].add_argument("--wait", action="store_true", help=argparse.SUPPRESS)
     parser_map["delete-cluster"].add_argument("--wait", action="store_true", help=argparse.SUPPRESS)
     parser_map["update-cluster"].add_argument("--wait", action="store_true", help=argparse.SUPPRESS)

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -338,6 +338,7 @@ class Cluster:
         disable_rollback: bool = False,
         validator_suppressors: Set[ValidatorSuppressor] = None,
         validation_failure_level: FailureLevel = FailureLevel.ERROR,
+        enable_termination_protection: bool = False,
     ) -> Tuple[Optional[str], List]:
         """
         Create cluster.
@@ -360,7 +361,10 @@ class Cluster:
             # Create template if not provided by the user
             if not (self.config.dev_settings and self.config.dev_settings.cluster_template):
                 self.template_body = CDKTemplateBuilder().build_cluster_template(
-                    cluster_config=self.config, bucket=self.bucket, stack_name=self.stack_name
+                    cluster_config=self.config,
+                    bucket=self.bucket,
+                    stack_name=self.stack_name,
+                    enable_termination_protection=enable_termination_protection,
                 )
 
             # upload cluster artifacts and generated template
@@ -374,6 +378,7 @@ class Cluster:
                 ),
                 disable_rollback=disable_rollback,
                 tags=self._get_cfn_tags(),
+                enable_termination_protection=enable_termination_protection,
             )
 
             return creation_result.get("StackId"), suppressed_validation_failures

--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -26,7 +26,11 @@ class CDKTemplateBuilder:
 
     @staticmethod
     def build_cluster_template(
-        cluster_config: BaseClusterConfig, bucket: S3Bucket, stack_name: str, log_group_name: str = None
+        cluster_config: BaseClusterConfig,
+        bucket: S3Bucket,
+        stack_name: str,
+        log_group_name: str = None,
+        enable_termination_protection: bool = False,
     ):
         """Build template for the given cluster and return as output in Yaml format."""
         from aws_cdk.core import App  # pylint: disable=C0415
@@ -36,7 +40,15 @@ class CDKTemplateBuilder:
         with tempfile.TemporaryDirectory() as tempdir:
             output_file = str(stack_name)
             app = App(outdir=str(tempdir))
-            ClusterCdkStack(app, output_file, stack_name, cluster_config, bucket, log_group_name)
+            ClusterCdkStack(
+                app,
+                output_file,
+                stack_name,
+                cluster_config,
+                bucket,
+                log_group_name,
+                termination_protection=enable_termination_protection,
+            )
             app.synth()
             generated_template = load_yaml_dict(os.path.join(tempdir, f"{output_file}.template.json"))
 

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -425,7 +425,10 @@ class ClustersFactory:
             "--cluster-name",
             name,
         ]
+        termination_protection = kwargs.pop("--enable-termination-protection", False)
         wait = kwargs.pop("wait", True)
+        if termination_protection:
+            command.append("--enable-termination-protection")
         if wait:
             command.append("--wait")
         for k, val in kwargs.items():


### PR DESCRIPTION
### Description of changes
* User can now include the flag --enable-termination-protection when running create-cluster, so that the cluster stack has termination protection.



### Tests
* Manual testing: created clusters with and without the flag, checked cloudformation, and ran delete-cluster for both. The one without the flag was deleted, while the cluster with the flag could not be deleted.


### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
