### PR TITLE
Add fsx policy to import/export from S3

### DIFF
--- a/api/infrastructure/deploy-api.sh
+++ b/api/infrastructure/deploy-api.sh
@@ -68,6 +68,16 @@ case $key in
     shift # past argument
     shift # past value
     ;;
+    --enable-fsx-s3-access)
+    export ENABLE_FSX_S3_ACCESS=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --fsx-s3-buckets)
+    export FSX_S3_BUCKETS=$2
+    shift # past argument
+    shift # past value
+    ;;
     *)    # unknown option
     echo "$usage" >&2
     exit 1

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -59,6 +59,16 @@ Parameters:
       - true
       - false
 
+  EnableS3FullAccess:
+    Description: |
+      When set to true the ParallelCluster API can access, write all the S3 buckets, it is needed to import/export from/to S3 when creating an FSx filesystem.
+      WARNING - setting this to true grants to the Lambda function S3 Get*, List* and PutObject privileges on all the buckets.
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+
   PermissionsBoundaryPolicy:
     Description: |
       ARN of a IAM policy to use as PermissionsBoundary for all IAM resources created by ParallelCluster API.
@@ -610,6 +620,21 @@ Resources:
                 iam:AWSServiceName:
                   - fsx.amazonaws.com
                   - s3.data-source.lustre.fsx.amazonaws.com
+          - Action:
+              - iam:CreateServiceLinkedRole
+              - iam:AttachRolePolicy
+              - iam:PutRolePolicy
+            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/s3.data-source.lustre.fsx.amazonaws.com/*
+            Effect: Allow
+            Sid: FSxS3PoliciesAttach
+          - Action:
+              - s3:Get*
+              - s3:List*
+              - s3:PutObject
+            Resource: '*'
+            Effect: Allow
+            Condition: !Equals [!Ref EnableS3FullAccess, true]
+            Sid: FSxS3FullAccess
           - Action:
               - lambda:CreateFunction
               - lambda:TagResource

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -59,15 +59,22 @@ Parameters:
       - true
       - false
 
-  EnableS3FullAccess:
+  EnableFSxS3Access:
     Description: |
-      When set to true the ParallelCluster API can access, write all the S3 buckets, it is needed to import/export from/to S3 when creating an FSx filesystem.
-      WARNING - setting this to true grants to the Lambda function S3 Get*, List* and PutObject privileges on all the buckets.
+      When set to true the ParallelCluster API can access, write to the S3 buckets specified in the Filed FsxS3Bucket, it is needed to import/export from/to S3 when creating an FSx filesystem.
+      WARNING - setting this to true grants to the Lambda function S3 Get*, List* and PutObject privileges on the buckets specified in FsxS3Buckets.
     Type: String
     Default: false
     AllowedValues:
       - true
       - false
+
+  FsxS3Buckets:
+    Description: |
+      Comma separated arn of the S3 buckets, to allow the lambda function to import/export from/to S3 when creating an FSx filesystem.
+      WARNING - The setting is used only when EnableFSxS3Access is set to true. (example arn:aws:s3:::<S3_BUCKET_1>,arn:aws:s3:::<S3_BUCKET_2>)
+    Type: String
+    AllowedPattern: ^arn:aws:s3:[a-z0-9\-]*:([0-9]{12})*:.+
 
   PermissionsBoundaryPolicy:
     Description: |
@@ -165,6 +172,7 @@ Conditions:
     Fn::And:
       - !Not [!Equals [!Ref ImageBuilderVpcId, ""]]
       - !Not [!Equals [!Ref ImageBuilderSubnetId, ""]]
+  EnableFSxS3AccessCondition: !Equals [!Ref EnableFSxS3Access, true]
 
 Resources:
 
@@ -631,10 +639,10 @@ Resources:
               - s3:Get*
               - s3:List*
               - s3:PutObject
-            Resource: '*'
+            Resource: !Split [",", !Ref FsxS3Buckets]
             Effect: Allow
-            Condition: !Equals [!Ref EnableS3FullAccess, true]
-            Sid: FSxS3FullAccess
+            Condition: EnableFSxS3AccessCondition
+            Sid: EnableFSxS3Access
           - Action:
               - lambda:CreateFunction
               - lambda:TagResource

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -353,6 +353,18 @@ Resources:
                   - fsx.amazonaws.com
                   - s3.data-source.lustre.fsx.amazonaws.com
           - Action:
+              - iam:CreateServiceLinkedRole
+              - iam:AttachRolePolicy
+              - iam:PutRolePolicy
+            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/s3.data-source.lustre.fsx.amazonaws.com/*
+            Effect: Allow
+          - Action:
+              - s3:Get*
+              - s3:List*
+              - s3:PutObject
+            Resource: '*'
+            Effect: Allow
+          - Action:
               - lambda:CreateFunction
               - lambda:TagResource
               - lambda:DeleteFunction


### PR DESCRIPTION
### Description of changes
* Add to API user role the policies to import/export data from S3
* Add to tests the same policies

### Tests
* Run integration tests on fsx

### References
* https://docs.aws.amazon.com/fsx/latest/LustreGuide/create-dra-linked-data-repo.html
* https://docs.aws.amazon.com/fsx/latest/LustreGuide/setting-up.html#fsx-adding-permissions-s3


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
