### PR TITLE
Upgrade smithy to 1.22.0 and fix lambda definitions

### DIFF
--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -66,13 +66,13 @@ paths:
       tags:
         - Cluster Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     post:
       description: Create a managed cluster in a given region.
       operationId: CreateCluster
@@ -166,13 +166,13 @@ paths:
       tags:
         - Cluster Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}:
     delete:
       description: Initiate the deletion of a cluster.
@@ -232,13 +232,13 @@ paths:
       tags:
         - Cluster Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     get:
       description: Get detailed information about an existing cluster.
       operationId: DescribeCluster
@@ -297,13 +297,13 @@ paths:
       tags:
         - Cluster Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     put:
       description: Update a cluster managed in a given region.
       operationId: UpdateCluster
@@ -411,13 +411,13 @@ paths:
       tags:
         - Cluster Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}/computefleet:
     get:
       description: Describe the status of the compute fleet.
@@ -477,13 +477,13 @@ paths:
       tags:
         - Cluster ComputeFleet
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     patch:
       description: Update the status of the cluster compute fleet.
       operationId: UpdateComputeFleet
@@ -548,13 +548,13 @@ paths:
       tags:
         - Cluster ComputeFleet
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}/instances:
     delete:
       description: Initiate the forced termination of all cluster compute nodes. Does not work with AWS Batch clusters.
@@ -617,13 +617,13 @@ paths:
       tags:
         - Cluster Instances
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     get:
       description: Describe the instances belonging to a given cluster.
       operationId: DescribeClusterInstances
@@ -693,13 +693,13 @@ paths:
       tags:
         - Cluster Instances
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}/logstreams:
     get:
       description: Retrieve the list of log streams associated with a cluster.
@@ -784,13 +784,13 @@ paths:
       tags:
         - Cluster Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}/logstreams/{logStreamName}:
     get:
       description: Retrieve the events associated with a log stream.
@@ -892,13 +892,13 @@ paths:
       tags:
         - Cluster Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}/stackevents:
     get:
       description: Retrieve the events associated with the stack for a given cluster.
@@ -964,13 +964,13 @@ paths:
       tags:
         - Cluster Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/custom:
     get:
       description: Retrieve the list of existing custom images.
@@ -1028,13 +1028,13 @@ paths:
       tags:
         - Image Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     post:
       description: Create a custom ParallelCluster image in a given region.
       operationId: BuildImage
@@ -1128,13 +1128,13 @@ paths:
       tags:
         - Image Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/custom/{imageId}:
     delete:
       description: Initiate the deletion of the custom ParallelCluster image.
@@ -1201,13 +1201,13 @@ paths:
       tags:
         - Image Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     get:
       description: Get detailed information about an existing image.
       operationId: DescribeImage
@@ -1266,13 +1266,13 @@ paths:
       tags:
         - Image Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/custom/{imageId}/logstreams:
     get:
       description: Retrieve the list of log streams associated with an image.
@@ -1338,13 +1338,13 @@ paths:
       tags:
         - Image Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/custom/{imageId}/logstreams/{logStreamName}:
     get:
       description: Retrieve the events associated with an image build.
@@ -1446,13 +1446,13 @@ paths:
       tags:
         - Image Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/custom/{imageId}/stackevents:
     get:
       description: Retrieve the events associated with the stack for a given image build.
@@ -1518,13 +1518,13 @@ paths:
       tags:
         - Image Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/official:
     get:
       description: List Official ParallelCluster AMIs.
@@ -1582,13 +1582,13 @@ paths:
       tags:
         - Image Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
 components:
   schemas:
     AmiInfo:

--- a/api/spec/smithy/build.gradle.kts
+++ b/api/spec/smithy/build.gradle.kts
@@ -10,17 +10,17 @@ repositories {
 
 buildscript {
     dependencies {
-        classpath("software.amazon.smithy:smithy-openapi:1.16.2")
-        classpath("software.amazon.smithy:smithy-aws-traits:1.16.2")
-        classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:1.16.2")
+        classpath("software.amazon.smithy:smithy-openapi:1.22.0")
+        classpath("software.amazon.smithy:smithy-aws-traits:1.22.0")
+        classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:1.22.0")
     }
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-aws-apigateway-traits:1.16.2")
-    implementation("software.amazon.smithy:smithy-aws-traits:1.16.2")
-    implementation("software.amazon.smithy:smithy-model:1.16.2")
-    implementation("software.amazon.smithy:smithy-linters:1.16.2")
+    implementation("software.amazon.smithy:smithy-aws-apigateway-traits:1.22.0")
+    implementation("software.amazon.smithy:smithy-aws-traits:1.22.0")
+    implementation("software.amazon.smithy:smithy-model:1.22.0")
+    implementation("software.amazon.smithy:smithy-linters:1.22.0")
 }
 
 tasks["jar"].enabled = false

--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -228,7 +228,7 @@ def configure(args):  # noqa: C901
             max_cluster_size = int(
                 prompt(
                     "Maximum {0}".format(size_name),
-                    validator=lambda x: str(x).isdigit() and int(x) >= min_cluster_size,  # pylint: disable=W0640
+                    validator=lambda x, ms=min_cluster_size: str(x).isdigit() and int(x) >= ms,  # pylint: disable=W0640
                     default_value=DEFAULT_MAX_COUNT,
                 )
             )

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -200,7 +200,7 @@ def get_latest_images(images):
         for _key, value in DISTROS.items():
             ami_filtered_and_sorted = sorted(
                 filter(
-                    lambda ami: "-{0}-".format(value) in ami["Name"] and ami["Architecture"] == architecture,
+                    lambda ami, v=value, a=architecture: "-{0}-".format(v) in ami["Name"] and ami["Architecture"] == a,
                     images["Images"],
                 ),
                 key=lambda ami: ami["CreationDate"],


### PR DESCRIPTION
### Description of changes
1. Upgrade smithy to 1.22.0
2. Make lambda function definition bind loop variable

### Tests
1. Built the API definition with the new version of Smithy produces safe diffs in `api/spec/openapi/ParallelCluster.openapi.yaml`
2. Simple variable replacement does not requiring further testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
