### PR TITLE
[PCluster Configure] Improve messaging used when requesting to enable EFA

### DIFF
--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -221,7 +221,7 @@ def configure(args):  # noqa: C901
 
                 efa_supported_by_instance_type = instance_type_supports_efa(compute_instance_type)
                 if efa_supported_by_instance_type:
-                    efa_enabled_in_compute_resource = _prompt_for_efa()
+                    efa_enabled_in_compute_resource = _prompt_for_efa(compute_instance_type)
                     if efa_enabled_in_compute_resource:
                         efa_enabled_in_queue = True
             min_cluster_size = DEFAULT_MIN_COUNT
@@ -431,21 +431,20 @@ def _prompt_for_subnet(all_subnets, qualified_subnets, message, default_subnet=N
     return prompt_iterable(message, qualified_subnets, default_value=default_subnet)
 
 
-def _prompt_for_efa():
+def _prompt_for_efa(instance_type):
     print(
-        "To get results faster with the instance selected at no additional charge, enable the "
-        "Elastic Fabric Adapter (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html)"
+        "The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). "
+        "EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no "
+        "additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html)."
     )
-    enable_efa = prompt(
-        "Enable EFA on compute instances (EFA) (y/n)", validator=lambda x: x in ("y", "n"), default_value="y"
-    )
+    enable_efa = prompt(f"Enable EFA on {instance_type} (y/n)", validator=lambda x: x in ("y", "n"), default_value="y")
     return enable_efa == "y"
 
 
 def _prompt_for_placement_group():
     print(
-        "Enabling EFA requires compute instances to be placed within a Placement Group. Specify an existing "
-        "Placement Group name or leave blank for ParallelCluster to create one"
+        "Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing "
+        "Placement Group name or leave it blank for ParallelCluster to create one."
     )
 
     return prompt("Placement Group name", validator=lambda x: x == "" or placement_group_exists(x), default_value="")

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/output.txt
@@ -34,7 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-To get results faster with the instance selected at no additional charge, enable the Elastic Fabric Adapter (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html)
+The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html).
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/output.txt
@@ -34,8 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-To get results faster with the instance selected at no additional charge, enable the Elastic Fabric Adapter (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html)
-Enabling EFA requires compute instances to be placed within a Placement Group. Specify an existing Placement Group name or leave blank for ParallelCluster to create one
+The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html).
+Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/output.txt
@@ -34,8 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-To get results faster with the instance selected at no additional charge, enable the Elastic Fabric Adapter (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html)
-Enabling EFA requires compute instances to be placed within a Placement Group. Specify an existing Placement Group name or leave blank for ParallelCluster to create one
+The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html).
+Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/output.txt
@@ -34,8 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-To get results faster with the instance selected at no additional charge, enable the Elastic Fabric Adapter (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html)
-Enabling EFA requires compute instances to be placed within a Placement Group. Specify an existing Placement Group name or leave blank for ParallelCluster to create one
+The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html).
+Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 ERROR: non-existent-test-pg is not an acceptable value for Placement Group name
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets


### PR DESCRIPTION
### Description of changes
* To communicate more clearly how EFA improves cluster performance, these messaging improvements have been agreed on
* The messaging will be shown when a user selects a compute instance-type that supports EFA during the `pcluster configure` process

### Tests
* Unit Test

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
