### PR TITLE
[integ-tests] Extend system-analyzer.sh to include /etc/passwd content

### DIFF
--- a/tests/integration-tests/tests/common/data/system-analyzer.sh
+++ b/tests/integration-tests/tests/common/data/system-analyzer.sh
@@ -151,7 +151,6 @@ function main() {
     exit $?
   fi
 
-
   # Check if path exist
   if [ -d "${1}" ]; then
     log "Directory ${1} exists."
@@ -212,6 +211,10 @@ function main() {
   _network_info "${TEMP_DIR}"
 
   _save_imds_info "${TEMP_DIR}"
+
+  # Save users info
+  log "Save /etc/passwd content"
+  cp /etc/passwd "${TEMP_DIR}/passwd"
 
   # Create the archive
   log "Create the archive"


### PR DESCRIPTION
### Description of changes
I'm extending the `system-analyzer.sh` script, that is running at the end of the tests or that can be run manually on a running cluster.
The change to include `/etc/passwd` in the output is useful to run it in a running cluster and understand if the UIDs of the users are not aligned between head node and compute node.

This might happen for example when using the "Custom AMI at runtime" approach for ParallelCluster 2.x,
on which the new compute nodes might be not aligned with the head node.

### Tests
* Tested manual execution of the script
```
$ sudo bash system-analyzer2.sh /tmp/test
Wed Jul  6 16:01:14 UTC 2022 - system-analyzer - INFO - START
...
Wed Jul  6 16:01:17 UTC 2022 - system-analyzer - INFO - Save /etc/passwd content
Wed Jul  6 16:01:17 UTC 2022 - system-analyzer - INFO - Create the archive
Wed Jul  6 16:01:17 UTC 2022 - system-analyzer - INFO - DONE

$ ls /tmp/test/
system-information.tar.gz

$ tar -xzf /tmp/test/system-information.tar.gz
$ cat system-information/passwd
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
...
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
