### PR TITLE
Integ-tests: only use simple protocol when running NCCL test

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
@@ -13,5 +13,6 @@ mpirun \
 -x RDMAV_FORK_SAFE=1 \
 -x NCCL_ALGO=ring \
 -x NCCL_DEBUG=WARNING \
+-x NCCL_PROTO=simple \
 --mca pml ^cm --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 --bind-to none \
 /shared/openmpi/nccl-tests-2.10.0/build/all_reduce_perf -b 8 -e 1G -f 2 -g 1 -c 1 -n 100 > /shared/nccl_tests.out


### PR DESCRIPTION
This change is done to fix test_efa test on p4d. It is done according to the doc: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl-base.html#nccl-start-base-test

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
* test_efa test on p4d+alinux2 has been passed

### References
The test_efa test on p4d started to fail since https://github.com/aws/aws-parallelcluster-cookbook/pull/1477

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
