### PR TITLE
[EFA] Improvements on messaging used in the EFA Validator

### DIFF
--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -435,7 +435,7 @@ def _prompt_for_efa(instance_type):
     print(
         "The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). "
         "EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no "
-        "additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html)."
+        "additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html)."
     )
     enable_efa = prompt(f"Enable EFA on {instance_type} (y/n)", validator=lambda x: x in ("y", "n"), default_value="y")
     return enable_efa == "y"

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -309,8 +309,10 @@ class EfaValidator(Validator):
             self._add_failure(f"Instance type '{instance_type}' does not support EFA.", FailureLevel.ERROR)
         if instance_type_supports_efa and not efa_enabled:
             self._add_failure(
-                f"To get results faster with the instance type '{instance_type}' at no additional charge, enable the "
-                "Elastic Fabric Adapter (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html)",
+                f"The EC2 instance selected ({instance_type}) supports enhanced networking capabilities using "
+                "Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of "
+                "inter-node communications at scale on AWS at no additional charge. You can update the cluster's "
+                "configuration to enable EFA (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html)",
                 FailureLevel.WARNING,
             )
         if gdr_support and not efa_enabled:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/output.txt
@@ -34,7 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html).
+The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/output.txt
@@ -34,7 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html).
+The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/output.txt
@@ -34,7 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html).
+The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/output.txt
@@ -34,7 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa.html).
+The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 ERROR: non-existent-test-pg is not an acceptable value for Placement Group name
 Allowed values for VPC ID:

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -207,7 +207,7 @@ def test_schedulable_memory_validator(schedulable_memory, ec2memory, instance_ty
         ("t2.large", True, False, False, "does not support EFA"),
         ("t2.large", False, False, False, None),
         # EFA not enabled for instance type that supports it
-        ("c5n.18xlarge", False, False, True, "at no additional charge, enable the Elastic Fabric Adapter"),
+        ("c5n.18xlarge", False, False, True, "supports enhanced networking capabilities using Elastic Fabric Adapter"),
     ],
 )
 def test_efa_validator(mocker, boto3_stubber, instance_type, efa_enabled, gdr_support, efa_supported, expected_message):


### PR DESCRIPTION


When creating or updating a cluster that has instance-types that support EFA (but EFA is not enabled in the configuration), the user should get a brief but informative validation message about the benefits of enabling EFA


### Description of changes
* To communicate the benefits of EFA more clearly, improvements have been made on the messaging used in the EFA Validator when creating or updating EFA supported instance-types

```
"validationMessages": [
    {
      "level": "WARNING",
      "type": "EfaValidator",
      "message": "The EC2 instance selected (c5n.9xlarge) supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge. You can update the cluster's configuration to enable EFA (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html)"
    }
  ]
```

### Tests
* Unit tests

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
