### PR TITLE
Fix budget naming

### DIFF
--- a/cli/src/pcluster/templates/budget_builder.py
+++ b/cli/src/pcluster/templates/budget_builder.py
@@ -1,3 +1,5 @@
+import uuid
+
 from aws_cdk import aws_budgets as budgets
 from aws_cdk.core import Construct
 
@@ -33,7 +35,10 @@ class CostBudgets:
             name = f"{self.cluster_config.cluster_name}-{index}-custom-{self.cluster_config.region}"
 
         budget_data = budgets.CfnBudget.BudgetDataProperty(
-            budget_name=name,
+            # This name will show up on the budget console, so less hash digits = better
+            # The chance of collision (assuming reasonably uniform distribution) is below 0.0001% with 5 hex digits
+            # If it collides, the update will roll back, but that's all
+            budget_name=name + uuid.uuid4().hex[:5],
             budget_type="COST",
             time_unit=budget.time_unit,
             budget_limit=budgets.CfnBudget.SpendProperty(


### PR DESCRIPTION
### Description of changes
* This adds a short hash to the budget name, to avoid problems when updating the budgets. Notification fields cannot be updated without crating a new budget, and creation will fail if two budgets have the same name.

### Tests
* Manual tests (creating and updating budgets).

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
