### PR TITLE
[Testing] Add integration tests to verify EFA using fabtests

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -29,6 +29,12 @@ test-suites:
           instances: [{{ common.instance("instance_type_1") }}]
           oss: [ "alinux2", "centos7", "ubuntu2004" ]
           schedulers: [ "slurm" ]
+    test_fabric.py::test_fabric:
+      dimensions:
+        - regions: [ "us-east-1" ]
+          instances: [ "p4d.24xlarge" ]
+          oss: [ "alinux2" ]
+          schedulers: [ "slurm" ]
   # need to duplicate api section because test_official_images works only after release
   pcluster_api:
     test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -133,6 +133,7 @@ class RemoteCommandExecutor:
         timeout=None,
         run_as_root=False,
         login_shell=True,
+        pty=True,
     ):
         """
         Execute a script remotely on the cluster head node.
@@ -145,7 +146,8 @@ class RemoteCommandExecutor:
         :param hide: do not print command output to the local stdout
         :param timeout: interrupt connection after N seconds, default of None = no timeout
         :param run_as_root: boolean; if True 'sudo' is prepended to the command used to run the script
-        :login_shell: boolean; passed to run_remote_command
+        :param login_shell: boolean; passed to run_remote_command
+        :param pty: if True, uses pty to execute commands; default is True.
         :return: result of the execution.
         """
         script_name = os.path.basename(script_file)
@@ -162,6 +164,7 @@ class RemoteCommandExecutor:
             hide=hide,
             timeout=timeout,
             login_shell=login_shell,
+            pty=pty,
         )
 
     def _copy_additional_files(self, files):

--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -26,3 +26,4 @@ retrying
 troposphere
 untangle
 psutil
+xmltodict

--- a/tests/integration-tests/tests/efa/test_fabric.py
+++ b/tests/integration-tests/tests/efa/test_fabric.py
@@ -1,0 +1,110 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+
+import boto3
+import xmltodict
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+
+from tests.common.assertions import assert_no_errors_in_logs
+from tests.common.utils import run_system_analyzer
+from tests.performance_tests.common import read_remote_file, wait_process_completion
+
+FABTESTS_BASIC_TESTS = ["rdm_tagged_bw", "rdm_tagged_pingpong"]
+
+FABTESTS_GDRCOPY_TESTS = ["runt"]
+
+
+def test_fabric(
+    os,
+    region,
+    scheduler,
+    instance,
+    pcluster_config_reader,
+    clusters_factory,
+    test_datadir,
+    scheduler_commands_factory,
+    request,
+    s3_bucket_factory,
+):
+    """
+    Test tha EFA is working according to Fabtests, that is the official libfabric test suite.
+    See https://github.com/ofiwg/libfabric/tree/main/fabtests
+    """
+
+    # Bootstrap script to use p4d targeted ODCR
+    bucket_name = ""
+    if instance == "p4d.24xlarge":
+        bucket_name = s3_bucket_factory()
+        bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+        bucket.upload_file(str(test_datadir / "run_instance_override.sh"), "run_instance_override.sh")
+
+    cluster_config = pcluster_config_reader(
+        bucket_name=bucket_name,
+    )
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    run_system_analyzer(cluster, scheduler_commands_factory, request, partition="q1")
+
+    fabtests_report = _execute_fabtests(remote_command_executor, test_datadir, instance)
+
+    num_tests = int(fabtests_report.get("testsuites", {}).get("testsuite", {}).get("@tests", None))
+    num_failures = int(fabtests_report.get("testsuites", {}).get("testsuite", {}).get("@failures", None))
+
+    assert_that(num_tests, description="Cannot read number of tests from Fabtests report").is_not_none()
+    assert_that(num_failures, description="Cannot read number of failures from Fabtests report").is_not_none()
+
+    if num_failures > 0:
+        logging.info(f"Fabtests report:\n{fabtests_report}")
+
+    assert_that(num_failures, description=f"{num_failures}/{num_tests} libfabric tests are failing").is_equal_to(0)
+    assert_no_errors_in_logs(remote_command_executor, scheduler)
+
+
+def _execute_fabtests(remote_command_executor, test_datadir, instance):
+    fabtests_dir = "/shared/fabtests"
+    fabtests_pid_file = f"{fabtests_dir}/outputs/fabtests.pid"
+    fabtests_log_file = f"{fabtests_dir}/outputs/fabtests.log"
+    fabtests_report_file = f"{fabtests_dir}/outputs/fabtests.report"
+
+    logging.info("Installing Fabtests")
+    remote_command_executor.run_remote_script(
+        str(test_datadir / "install-fabtests.sh"), args=[fabtests_dir], timeout=600
+    )
+
+    logging.info("Running Fabtests")
+    test_cases = FABTESTS_BASIC_TESTS + FABTESTS_GDRCOPY_TESTS if instance == "p4d.24xlarge" else FABTESTS_BASIC_TESTS
+    remote_command_executor.run_remote_script(
+        str(test_datadir / "run-fabtests.sh"),
+        args=[
+            fabtests_dir,
+            fabtests_pid_file,
+            fabtests_log_file,
+            fabtests_report_file,
+            "q1-st-efa-enabled-1",
+            "q1-st-efa-enabled-2",
+            ",".join(test_cases),
+            "enable-gdr" if instance == "p4d.24xlarge" else "skip-gdr",
+        ],
+        timeout=60,
+        pty=False,
+    )
+
+    pid = read_remote_file(remote_command_executor, fabtests_pid_file)
+
+    wait_process_completion(remote_command_executor, pid)
+
+    logging.info("Retrieving Fabtests report")
+    report_content = read_remote_file(remote_command_executor, fabtests_report_file)
+    return xmltodict.parse(report_content)

--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/install-fabtests.sh
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/install-fabtests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -ex
+
+# Installs Fabtests suite from GitHub.
+# Usage: install-fabtests.sh [FABTESTS_DIR]
+# Example: install-fabtests.sh /home/ec2-user/shared/fabtests
+
+FABTESTS_DIR="$1"
+
+FABTESTS_REPO="https://github.com/ofiwg/libfabric.git"  # TODO Replace with released tarball v1.16.0 once available
+FABTESTS_SOURCES_DIR="$FABTESTS_DIR/sources"
+LIBFABRIC_DIR="/opt/amazon/efa"
+
+echo "[INFO] Installing Fabtests in $FABTESTS_DIR"
+rm -rf $FABTESTS_DIR
+mkdir -p $FABTESTS_SOURCES_DIR
+cd $FABTESTS_SOURCES_DIR
+git clone $FABTESTS_REPO
+cd libfabric/fabtests
+./autogen.sh
+./configure --with-libfabric=$LIBFABRIC_DIR --prefix=$FABTESTS_DIR && make -j 32 && make install
+python3 -m pip install -r $FABTESTS_SOURCES_DIR/libfabric/fabtests/pytest/requirements.txt
+python3 -m pip install pyyaml # TODO This is required but it is missing in the above requirements.txt
+echo "[INFO] Fabtests installed in $FABTESTS_DIR"

--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/pcluster.config.yaml
@@ -1,0 +1,44 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: c5n.9xlarge
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+    {% if instance == "p4d.24xlarge" %}ElasticIp: true{% endif %}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+{% if instance == "p4d.24xlarge" %}
+  Iam:
+    # Needed to use the p4d capacity reservation
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonEC2FullAccess
+    S3Access:
+      - BucketName: {{ bucket_name }}
+        EnableWriteAccess: false
+  CustomActions:
+    OnNodeConfigured:
+      Script: s3://{{ bucket_name }}/run_instance_override.sh
+{% endif %}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: q1
+      Networking:
+        PlacementGroup:
+          Enabled: true
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: efa-enabled
+          InstanceType: {{ instance }}
+          MinCount: 2
+          MaxCount: 2
+          DisableSimultaneousMultithreading: true
+          Efa:
+            Enabled: true
+SharedStorage:
+  - MountDir: /shared
+    Name: shared-ebs-1
+    StorageType: Ebs

--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/run-fabtests.sh
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/run-fabtests.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -ex
+
+# Executes Fabtests suite.
+# Usage: run-fabtests.sh [FABTESTS_DIR] [PID_FILE] [LOG_FILE] [REPORT_FILE] [COMPUTE_NODE_1] [COMPUTE_NODE_2] [TEST_CASES] [TEST_OPTIONS]
+# Example:
+# run-fabtests.sh \
+# /shared/fabtests \
+# /shared/fabtests/outputs/fabtests.pid \
+# /shared/fabtests/outputs/fabtests.log \
+# /shared/fabtests/outputs/fabtests.report \
+# q1-st-g4dn8xl-efa-1 q1-st-g4dn8xl-efa-2 \
+# rdm_tagged_bw,rdm_tagged_pingpong \
+# enable-gdr
+
+FABTESTS_DIR="$1"
+PID_FILE="$2"
+LOG_FILE="$3"
+REPORT_FILE="$4"
+COMPUTE_NODE_1="$5"
+COMPUTE_NODE_2="$6"
+TEST_CASES="$7"
+TEST_OPTIONS="$8"
+
+echo "[INFO] Starting Fabtests ($FABTESTS_DIR) using compute nodes $COMPUTE_NODE_1 and $COMPUTE_NODE_2: $TEST_CASES"
+echo "[INFO] Fabtests will use the following test environment options: $TEST_OPTIONS"
+echo "[INFO] Fabtests pid will be stored in $PID_FILE"
+echo "[INFO] Fabtests logs will be stored in $LOG_FILE"
+echo "[INFO] Fabtests report will be stored in $REPORT_FILE"
+
+FABTESTS_BIN_DIR="$FABTESTS_DIR/bin"
+FABTESTS_RUNNER="$FABTESTS_BIN_DIR/runfabtests.py"
+FABTESTS_TIMEOUT="300" # Timeout for each test
+COMPUTE_IP_1=$(host $COMPUTE_NODE_1 | cut -d ' ' -f 4)
+COMPUTE_IP_2=$(host $COMPUTE_NODE_2 | cut -d ' ' -f 4)
+TEST_EXPRESSION=${TEST_CASES//,/ or }
+TEST_ENVIRONMENT_OPTION=""
+[[ "$TEST_OPTIONS" == *"enable-gdr"* ]] && TEST_ENVIRONMENT_OPTION="-E FI_EFA_USE_DEVICE_RDMA=1"
+
+mkdir -p $(dirname $PID_FILE)
+mkdir -p $(dirname $LOG_FILE)
+mkdir -p $(dirname $REPORT_FILE)
+
+python3 $FABTESTS_RUNNER \
+  -b efa \
+  -p "$FABTESTS_BIN_DIR" \
+  --expression "$TEST_EXPRESSION" \
+  --timeout $FABTESTS_TIMEOUT \
+  --junit-xml $REPORT_FILE \
+  $TEST_ENVIRONMENT_OPTION $COMPUTE_IP_1 $COMPUTE_IP_2 > $LOG_FILE 2>&1 &
+
+echo $! > $PID_FILE
+
+echo "[INFO] Fabtests launched"

--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/run_instance_override.sh
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/run_instance_override.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+. "/etc/parallelcluster/cfnconfig"
+
+
+if [[ $cfn_node_type == "HeadNode" ]]; then
+    # Override run_instance attributes
+    cat > /opt/slurm/etc/pcluster/run_instances_overrides.json << 'EOF'
+{
+    "q1": {
+        "efa-enabled": {
+            "CapacityReservationSpecification": {
+                "CapacityReservationTarget": {
+                    "CapacityReservationId": "cr-0fa65fcdbd597f551"
+                }
+            }
+        }
+    }
+}
+EOF
+fi


### PR DESCRIPTION
### Description of changes
Add integration tests to verify EFA using [fabtests](https://github.com/ofiwg/libfabric/tree/main/fabtests), which is the official  integration testing suite for libfabric.

The minimum subset of valuable tests considered in this change has been suggested by EFA engineer.

### Tests
1. Tests launched locally succeeded with instances c5n.9xlarge (cannot use p4d.24xlarge)
2. Tests will be verified with p4d.24xlarge on dev pipeline

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
