### PR TITLE
Fix test_ad_integration test

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -101,10 +101,10 @@ def get_ad_config_param_vals(
 
 
 def get_fsx_config_param_vals(fsx_factory, svm_factory):
-    fsx_ontap_fs_ids = create_fsx_ontap(fsx_factory, num=1)
-    fsx_ontap_volume_ids = [volume_id for _, volume_id in svm_factory(fsx_ontap_fs_ids)]
-    fsx_open_zfs_volume_ids = create_fsx_open_zfs(fsx_factory, num=1)
-    return {"fsx_ontap_volume_id": fsx_ontap_volume_ids[0], "fsx_open_zfs_volume_id": fsx_open_zfs_volume_ids[0]}
+    fsx_ontap_fs_id = create_fsx_ontap(fsx_factory, num=1)[0]
+    fsx_ontap_volume_id = svm_factory(fsx_ontap_fs_id)[0]
+    fsx_open_zfs_volume_id = create_fsx_open_zfs(fsx_factory, num=1)[0]
+    return {"fsx_ontap_volume_id": fsx_ontap_volume_id, "fsx_open_zfs_volume_id": fsx_open_zfs_volume_id}
 
 
 def _add_file_to_zip(zip_file, path, arcname):


### PR DESCRIPTION
The test failed because we change the definition of some fixture fixtures in https://github.com/aws/aws-parallelcluster/commit/15c34a4a7fde44e5dc2f32d73692a96831d8a80e. However, we forgot to change the usage of the fixtures in the AD integration test

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
