### PR TITLE
Improve ExistingFsxNetworkingValidator Validator

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1221,27 +1221,28 @@ class BaseClusterConfig(Resource):
                 resource_name="Shared Storage IDs",
             )
 
-            existing_fsx = []
+            existing_fsx = set()
             for storage in self.shared_storage:
                 self._register_validator(SharedStorageNameValidator, name=storage.name)
                 self._register_validator(SharedStorageMountDirValidator, mount_dir=storage.mount_dir)
-                if isinstance(storage, BaseSharedFsx):
+                if isinstance(storage, SharedFsxLustre):
                     if storage.file_system_id:
                         existing_storage_count["fsx"] += 1
-                        existing_fsx.append(storage.file_system_id)
+                        existing_fsx.add(storage.file_system_id)
                     else:
                         new_storage_count["fsx"] += 1
                     self._register_validator(
                         FsxArchitectureOsValidator, architecture=self.head_node.architecture, os=self.image.os
                     )
-                if isinstance(storage, (ExistingFsxOpenZfs, ExistingFsxOntap)):
-                    existing_fsx.append(storage.file_system_id)
-                if isinstance(storage, SharedEbs):
+                elif isinstance(storage, (ExistingFsxOpenZfs, ExistingFsxOntap)):
+                    existing_storage_count["fsx"] += 1
+                    existing_fsx.add(storage.file_system_id)
+                elif isinstance(storage, SharedEbs):
                     if storage.raid:
                         new_storage_count["raid"] += 1
                     else:
                         ebs_count += 1
-                if isinstance(storage, SharedEfs):
+                elif isinstance(storage, SharedEfs):
                     if storage.file_system_id:
                         existing_storage_count["efs"] += 1
                         self._register_validator(
@@ -1254,7 +1255,7 @@ class BaseClusterConfig(Resource):
                         new_storage_count["efs"] += 1
             self._register_validator(
                 ExistingFsxNetworkingValidator,
-                file_system_ids=existing_fsx,
+                file_system_ids=list(existing_fsx),
                 head_node_subnet_id=self.head_node.networking.subnet_id,
                 are_all_security_groups_customized=self.are_all_security_groups_customized,
             )

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -65,11 +65,11 @@ FSX_VOLUME_ID_REGEX = r"^fsvol-[0-9a-f]{17}$"
 
 FSX_PORTS = {
     # Lustre Security group: https://docs.aws.amazon.com/fsx/latest/LustreGuide/limit-access-security-groups.html
-    LUSTRE: [988],
+    LUSTRE: {"tcp": [988]},
     # OpenZFS Security group: https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/limit-access-security-groups.html
-    OPENZFS: [111, 2049, 20001, 20002, 20003],
+    OPENZFS: {"tcp": [111, 2049, 20001, 20002, 20003], "udp": [111, 2049, 20001, 20002, 20003]},
     # Ontap Security group: https://docs.aws.amazon.com/fsx/latest/ONTAPGuide/limit-access-security-groups.html
-    ONTAP: [111, 635, 2049, 4046],
+    ONTAP: {"tcp": [111, 635, 2049, 4046], "udp": [111, 635, 2049, 4046]},
 }
 
 EBS_VOLUME_TYPE_IOPS_DEFAULT = {


### PR DESCRIPTION
1. Only display one error message if multiple ports of a single file system are absent
2. Improve the validator to check UDP protocol when necessary. This was not implementated because we had no time
3. Refactor the code avoid function too complex code linters error

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
Tests in config/pcluster3.yaml have been passed
Manually tested the validator works as expected when the ports are not completed

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
