### PR TITLE
[Validation] Removed validation of `DisableSimultaneousMultithreading` and adapted disabling logic accordingly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ CHANGELOG
 **BUG FIXES**
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.
 - Handle corner case in the scaling logic when instance is just launched and the describe instances API doesn't report yet all the EC2 info.
+- Dropped validation that would prevent ARM instance type to be used when `DisableSimultaneousMultithreading` was set to true.
 
 3.1.4
 ------

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -224,10 +224,9 @@ class InstanceTypeInfo:
         return self.instance_type_data.get("InstanceType")
 
     def is_cpu_options_supported_in_lt(self):
-        """Check whether hyperthreading can be disabled via CPU options."""
-        # If default threads per core is 1, HT doesn't need to be disabled
+        """Check whether CPUOptions can be set in launch template."""
         # When CpuOptions is not supported, valid threads per core can't be found in vcpu info
-        return self.default_threads_per_core() > 1 and 1 in self.valid_threads_per_core()
+        return len(self.valid_threads_per_core()) != 0
 
     def is_ebs_optimized(self):
         """Check whether the instance has optimized EBS support."""

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -159,23 +159,6 @@ class ComputeResourceSizeValidator(Validator):
             self._add_failure("Max count must be greater than or equal to min count.", FailureLevel.ERROR)
 
 
-class DisableSimultaneousMultithreadingArchitectureValidator(Validator):
-    """
-    Simultaneous Multithreading architecture validator.
-
-    Validate Simultaneous Multithreading and architecture combination.
-    """
-
-    def _validate(self, disable_simultaneous_multithreading, architecture: str):
-        supported_architectures = ["x86_64"]
-        if disable_simultaneous_multithreading and architecture not in supported_architectures:
-            self._add_failure(
-                "Disabling simultaneous multithreading is only supported on instance types that support "
-                "these architectures: {0}.".format(", ".join(supported_architectures)),
-                FailureLevel.ERROR,
-            )
-
-
 class EfaOsArchitectureValidator(Validator):
     """OS and architecture combination validator if EFA is enabled."""
 

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -32,7 +32,6 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
         instance_type,
         gpu_count=0,
         interfaces_count=1,
-        default_threads_per_core=1,
         vcpus=1,
         supported_architectures=None,
         efa_supported=False,
@@ -42,7 +41,6 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
         super().__init__(instance_type_data={})
         self._gpu_count = gpu_count
         self._max_network_interface_count = interfaces_count
-        self._default_threads_per_core = default_threads_per_core
         self._vcpus = vcpus
         self._supported_architectures = supported_architectures if supported_architectures else ["x86_64"]
         self._efa_supported = efa_supported
@@ -57,7 +55,14 @@ class _DummyInstanceTypeInfo(InstanceTypeInfo):
         return self._max_network_interface_count
 
     def default_threads_per_core(self):
-        return self._default_threads_per_core
+        # There are more instance types, but for the simplicity of the mock,
+        # we consider only t2 as having one thread per core.
+        return 1 if self._instance_type.startswith("t2") else 2
+
+    def valid_threads_per_core(self):
+        # There are more instance types, but for the simplicity of the mock,
+        # we consider only t2 as not reporting valid threads per core.
+        return [] if self._instance_type.startswith("t2") else [1, 2]
 
     def vcpus_count(self):
         return self._vcpus

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -115,9 +115,6 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
     compute_resource_size_validator = mocker.patch(
         cluster_validators + ".ComputeResourceSizeValidator._validate", return_value=[]
     )
-    disable_simultaneous_multithreading_architecture_validator = mocker.patch(
-        cluster_validators + ".DisableSimultaneousMultithreadingArchitectureValidator._validate", return_value=[]
-    )
     architecture_os_validator = mocker.patch(cluster_validators + ".ArchitectureOsValidator._validate", return_value=[])
     instance_architecture_compatibility_validator = mocker.patch(
         cluster_validators + ".InstanceArchitectureCompatibilityValidator._validate", return_value=[]
@@ -219,7 +216,7 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
         [
             call(max_length=10, resource_name="SlurmQueues", resources_length=2),
             call(max_length=5, resource_name="ComputeResources", resources_length=2),
-            call(max_length=5, resource_name="ComputeResources", resources_length=2),
+            call(max_length=5, resource_name="ComputeResources", resources_length=3),
         ],
         any_order=True,
     )
@@ -228,10 +225,11 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
     instance_type_base_ami_compatible_validator.assert_has_calls(
         [
             call(instance_type="c5d.xlarge", image="ami-12345678"),
-            call(instance_type="c5.2xlarge", image="ami-12345678"),
+            call(instance_type="t2.large", image="ami-12345678"),
             call(instance_type="c4.2xlarge", image="ami-12345678"),
             call(instance_type="c5.4xlarge", image="ami-12345678"),
             call(instance_type="c5d.xlarge", image="ami-12345678"),
+            call(instance_type="t2.large", image="ami-12345678"),
         ],
         any_order=True,
     )
@@ -239,19 +237,16 @@ def test_validators_are_called_with_correct_argument(test_datadir, mocker):
     security_groups_validator.assert_has_calls(
         [call(security_group_ids=None), call(security_group_ids=None)], any_order=True
     )
-    # Defaults of disable_simultaneous_multithreading=False
-    disable_simultaneous_multithreading_architecture_validator.assert_has_calls(
-        [call(disable_simultaneous_multithreading=False, architecture="x86_64")] * 5
-    )
     architecture_os_validator.assert_has_calls(
         [call(os="alinux2", architecture="x86_64", custom_ami="ami-12345678", ami_search_filters=None)]
     )
     instance_architecture_compatibility_validator.assert_has_calls(
         [
-            call(instance_type="c5.2xlarge", architecture="x86_64"),
+            call(instance_type="t2.large", architecture="x86_64"),
             call(instance_type="c4.2xlarge", architecture="x86_64"),
             call(instance_type="c5.4xlarge", architecture="x86_64"),
             call(instance_type="c5d.xlarge", architecture="x86_64"),
+            call(instance_type="t2.large", architecture="x86_64"),
         ]
     )
 

--- a/cli/tests/pcluster/validators/test_all_validators/test_validators_are_called_with_correct_argument/slurm.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_validators_are_called_with_correct_argument/slurm.yaml
@@ -19,7 +19,7 @@ Scheduling:
           - subnet-23456789
       ComputeResources:
         - Name: compute_resource1
-          InstanceType: c5.2xlarge
+          InstanceType: t2.large
         - Name: compute_resource2
           InstanceType: c4.2xlarge
     - Name: queue2
@@ -30,8 +30,13 @@ Scheduling:
         - Name: compute_resource1
           InstanceType: c5.4xlarge
           MaxCount: 5
+          DisableSimultaneousMultithreading: true
         - Name: compute_resource2
           InstanceType: c5d.xlarge
+          DisableSimultaneousMultithreading: false
+        - Name: compute_resource3
+          InstanceType: t2.large
+          DisableSimultaneousMultithreading: true
 SharedStorage:
   - MountDir: /my/mount/point1
     Name: name1

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -22,7 +22,6 @@ from pcluster.validators.cluster_validators import (
     ClusterNameValidator,
     ComputeResourceSizeValidator,
     DcvValidator,
-    DisableSimultaneousMultithreadingArchitectureValidator,
     DuplicateMountDirValidator,
     EfaOsArchitectureValidator,
     EfaPlacementGroupValidator,
@@ -399,29 +398,6 @@ def test_efa_security_group_validator(
 
 
 # ---------------- Architecture Validators ---------------- #
-
-
-@pytest.mark.parametrize(
-    "disable_simultaneous_multithreading, architecture, expected_message",
-    [
-        (True, "x86_64", None),
-        (False, "x86_64", None),
-        (
-            True,
-            "arm64",
-            "Disabling simultaneous multithreading is only supported"
-            " on instance types that support these architectures",
-        ),
-        (False, "arm64", None),
-    ],
-)
-def test_disable_simultaneous_multithreading_architecture_validator(
-    disable_simultaneous_multithreading, architecture, expected_message
-):
-    actual_failures = DisableSimultaneousMultithreadingArchitectureValidator().execute(
-        disable_simultaneous_multithreading, architecture
-    )
-    assert_failure_messages(actual_failures, expected_message)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -51,10 +51,8 @@ def test_efa(
 
     if architecture == "x86_64":
         head_node_instance = "c5.18xlarge"
-        multithreading_disabled = True
     else:
         head_node_instance = "c6g.16xlarge"
-        multithreading_disabled = False
 
     # Post-install script to use P4d targeted ODCR
     bucket_name = ""
@@ -63,12 +61,11 @@ def test_efa(
         bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
         bucket.upload_file(str(test_datadir / "run_instance_override.sh"), "run_instance_override.sh")
 
-    slots_per_instance = fetch_instance_slots(region, instance, multithreading_disabled=multithreading_disabled)
+    slots_per_instance = fetch_instance_slots(region, instance, multithreading_disabled=True)
     cluster_config = pcluster_config_reader(
         max_queue_size=max_queue_size,
         head_node_instance=head_node_instance,
         bucket_name=bucket_name,
-        multithreading_disabled=multithreading_disabled,
     )
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -35,7 +35,7 @@ Scheduling:
           InstanceType: {{ instance }}
           MaxCount: {{ max_queue_size }}
           MinCount: {{ max_queue_size }}
-          DisableSimultaneousMultithreading: {{ multithreading_disabled }}
+          DisableSimultaneousMultithreading: true
           Efa:
             Enabled: true
             {% if instance == "p4d.24xlarge" %}GdrSupport: true{% endif %}


### PR DESCRIPTION
### Description of changes
1. Removed validation of `DisableSimultaneousMultithreading` in order to allow the disablement of multi-threading on all instances supporting it or to skip it on instances not supporting it.
2. Adapted internal logic to select disablement via CpuOptions or manually

Proved via scripting that single-threading can be set via `CpuOptions` for all instances having 1 within `VcpuInfo.ValidThreadsPerCore`, even if they have `VcpuInfo.DefaultThreadsPerCore=1` and regardless the supported architecture is `x86_64` or `arm64`.

1. DefaultThreadsPerCore > 1 AND ValidThreadsPerCore contains 1 => multi-threading must be disabled via CpuOptions
1. DefaultThreadsPerCore > 1 AND ValidThreadsPerCore not reported => multi-threading must be disabled manually
1. DefaultThreadsPerCore = 1 AND ValidThreadsPerCore contains 1 => nothing to do
1. DefaultThreadsPerCore = 1 AND ValidThreadsPerCore not reported => nothing to do

### Tests
1. Unit tests succeeded
3. Verified that the criteria to select the instances supporting the single threading via CpuOptions is correct by setting it for every instance types in DUB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
