### PR TITLE
[ParallelCluster-API] Add missing policies for EcrImageDeletionLambda and ImageBuilderInstance Roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ CHANGELOG
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.
 - Handle corner case in the scaling logic when instance is just launched and the describe instances API doesn't report yet all the EC2 info.
 - Dropped validation that would prevent ARM instance type to be used when `DisableSimultaneousMultithreading` was set to true.
+- Add missing policies for EcrImageDeletionLambda and ImageBuilderInstance roles that were causing failure when upgrading ParallelCluster API from one version to another.
 
 3.1.4
 ------

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -964,6 +964,17 @@ Resources:
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
         - !Sub arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds
+      Policies:
+        - PolicyName: ImageBuilderCustomPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: ecs:RegisterContainerInstance
+                Resource: !Sub arn:${AWS::Partition}:ecs:*:${AWS::AccountId}:cluster/*
+              - Effect: Allow
+                Action: ecs:DiscoverPollEndpoint
+                Resource: "*"
       AssumeRolePolicyDocument:
         Statement:
           - Action:
@@ -1263,7 +1274,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - imagebuilder:ListImagePipelineImages
-                Resource: !Ref EcrImagePipeline
+                Resource: !Sub
+                  - arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:image-pipeline/ecrimagepipeline-*${StackIdSuffix}*
+                  - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
               - Effect: Allow
                 Action:
                   - imagebuilder:DeleteImage


### PR DESCRIPTION
### Description of changes
* CloudFormation Stack upgrade of the ParallelCluster API fails for ECRImage and ECRImageRemover resources due to missing actions and policies.
* This commit adds the missing policies & actions to the corresponding roles

### Tests
* Manually tested by:
  * Reproducing the issue with existing API template
  * Applying the fixes in this commit
  * Upgrading the API Version using `aws cloudformation update-stack` as instructed in the [ParallelCluster API Docs](https://docs.aws.amazon.com/parallelcluster/latest/ug/api-reference-v3.html#api-reference-update-v3)
  * Confirmed the cluster is successfully updated

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
