### PR TITLE
Add custom metric filters for common scaling errors to default cloudwatch dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+**ENHANCEMENTS**
+- Introducing error metrics to cloudwatch dashboard
+  - Include configuration option to enable/disable
+
 3.2.0
 ------
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2301,6 +2301,14 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                     architecture=self.head_node.architecture,
                 )
 
+    @property
+    def do_compute_nodes_have_custom_actions(self):
+        """Return True if any queues have custom scripts."""
+        for queue in self.scheduling.queues:
+            if queue.custom_actions:
+                return True
+        return False
+
 
 class SchedulerPluginClusterConfig(CommonSchedulerClusterConfig):
     """Represent the full Scheduler Plugin Cluster configuration."""

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -621,9 +621,10 @@ class CloudWatchLogs(Resource):
 class CloudWatchDashboards(Resource):
     """Represent the CloudWatch Dashboard."""
 
-    def __init__(self, enabled: bool = None, **kwargs):
+    def __init__(self, enabled: bool = None, enable_error_metrics: bool = None, **kwargs):
         super().__init__(**kwargs)
         self.enabled = Resource.init_param(enabled, default=CW_DASHBOARD_ENABLED_DEFAULT)
+        self.enable_error_metrics = Resource.init_param(enable_error_metrics, default=True)
 
 
 class Logs(Resource):
@@ -1445,12 +1446,17 @@ class BaseClusterConfig(Resource):
 
     @property
     def is_cw_dashboard_enabled(self):
-        """Return True if CloudWatch Dashboard is enabled."""
+        """Return True if custom errors are enabled."""
         return (
             self.monitoring.dashboards.cloud_watch.enabled
             if self.monitoring and self.monitoring.dashboards and self.monitoring.dashboards.cloud_watch
             else False
         )
+
+    @property
+    def are_custom_errors_enabled(self):
+        """Return True if CloudWatch Dashboard is enabled."""
+        return self.monitoring.dashboards.cloud_watch.enable_error_metrics
 
     @property
     def is_dcv_enabled(self):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -723,6 +723,7 @@ class CloudWatchDashboardsSchema(BaseSchema):
     """Represent the schema of the CloudWatchDashboards section."""
 
     enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    enable_error_metrics = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -287,6 +287,7 @@ class ClusterCdkStack(Stack):
                 head_node_instance=self.head_node_instance,
                 shared_storage_infos=self.shared_storage_infos,
                 cw_log_group_name=self.log_group.log_group_name if self.config.is_cw_logging_enabled else None,
+                cw_log_group=self.log_group,
             )
 
     def _add_iam_resources(self):

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -144,7 +144,8 @@ class CWDashboardConstruct(Construct):
         # Head Node logs add custom metrics if cw_log and metrics are enabled
         if self.config.is_cw_logging_enabled:
             self._add_cw_log()
-            self.add_custom_error_metrics()
+            if self.config.are_custom_errors_enabled:
+                self.add_custom_error_metrics()
 
     def _update_coord(self, d_x, d_y):
         """Calculate coordinates for the new graph."""

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -12,9 +12,15 @@ from collections import defaultdict, namedtuple
 
 from aws_cdk import aws_cloudwatch as cloudwatch
 from aws_cdk import aws_ec2 as ec2
-from aws_cdk.core import Construct, Stack
+from aws_cdk import aws_logs as logs
+from aws_cdk.core import Construct, Duration, Stack
 
-from pcluster.config.cluster_config import BaseClusterConfig, SharedFsxLustre, SharedStorageType
+from pcluster.config.cluster_config import (
+    BaseClusterConfig,
+    CommonSchedulerClusterConfig,
+    SharedFsxLustre,
+    SharedStorageType,
+)
 
 MAX_WIDTH = 24
 
@@ -28,6 +34,7 @@ class Coord:
 
 
 _PclusterMetric = namedtuple("_PclusterMetric", ["title", "metrics", "supported_vol_types"])
+_CustomMetricFilter = namedtuple("MetricFilter", ["metric_name", "filter_pattern"])
 _Filter = namedtuple("new_filter", ["pattern", "param"])
 _CWLogWidget = namedtuple(
     "_CWLogWidget",
@@ -51,6 +58,7 @@ class CWDashboardConstruct(Construct):
         head_node_instance: ec2.CfnInstance,
         shared_storage_infos: dict,
         cw_log_group_name: str,
+        cw_log_group: logs.CfnLogGroup,
     ):
         super().__init__(scope, id)
         self.stack_scope = scope
@@ -59,6 +67,7 @@ class CWDashboardConstruct(Construct):
         self.head_node_instance = head_node_instance
         self.shared_storage_infos = shared_storage_infos
         self.cw_log_group_name = cw_log_group_name
+        self.cw_log_group = cw_log_group
 
         self.dashboard_name = self.stack_name + "-" + self._stack_region
         self.coord = Coord(x_value=0, y_value=0)
@@ -132,9 +141,10 @@ class CWDashboardConstruct(Construct):
         if len(self.shared_storage_infos[SharedStorageType.FSX]) > 0:
             self._add_fsx_metrics_graphs()
 
-        # Head Node logs, if CW Logs are enabled
+        # Head Node logs add custom metrics if cw_log and metrics are enabled
         if self.config.is_cw_logging_enabled:
             self._add_cw_log()
+            self.add_custom_error_metrics()
 
     def _update_coord(self, d_x, d_y):
         """Calculate coordinates for the new graph."""
@@ -171,15 +181,29 @@ class CWDashboardConstruct(Construct):
         self.cloudwatch_dashboard.add_widgets(text_widget)
         self._update_coord_after_section(d_y=1)
 
-    def _generate_graph_widget(self, title, metric_list):
+    def _generate_graph_widget(self, title, metric_list, error_label):
         """Generate a graph widget and update the coordinates."""
-        widget = cloudwatch.GraphWidget(
-            title=title,
-            left=metric_list,
-            region=self._stack_region,
-            width=self.graph_width,
-            height=self.graph_height,
-        )
+        if error_label:
+            widget = cloudwatch.GraphWidget(
+                title=title,
+                left=metric_list,
+                region=self._stack_region,
+                width=self.graph_width,
+                height=self.graph_height,
+                left_annotations=[
+                    cloudwatch.HorizontalAnnotation(
+                        value=1, label="github.com/aws/aws-parallelcluster/wiki#known-issues-"
+                    ),
+                ],
+            )
+        else:
+            widget = cloudwatch.GraphWidget(
+                title=title,
+                left=metric_list,
+                region=self._stack_region,
+                width=self.graph_width,
+                height=self.graph_height,
+            )
         widget.position(x=self.coord.x_value, y=self.coord.y_value)
         self._update_coord(self.graph_width, self.graph_height)
         return widget
@@ -215,9 +239,131 @@ class CWDashboardConstruct(Construct):
                     metric_list.append(cloudwatch_metric)
 
             if len(metric_list) > 0:  # Add the metrics only if there exist support volumes for it
-                graph_widget = self._generate_graph_widget(metric_condition_params.title, metric_list)
+                graph_widget = self._generate_graph_widget(metric_condition_params.title, metric_list, False)
                 widgets_list.append(graph_widget)
         return widgets_list
+
+    def custom_pcluster_metric_filter(self, metric_name, filter_pattern, custom_namespace):
+        """Adding custom metric filter from named tuple."""
+        metric_filter = logs.CfnMetricFilter(
+            scope=self.stack_scope,
+            id=metric_name + " Filter",
+            filter_pattern=filter_pattern,
+            log_group_name=self.cw_log_group_name,
+            metric_transformations=[
+                logs.CfnMetricFilter.MetricTransformationProperty(
+                    metric_namespace=custom_namespace,
+                    metric_name=metric_name,
+                    metric_value="1",
+                    default_value=0,
+                )
+            ],
+        )
+        metric_filter.add_depends_on(self.cw_log_group)
+        return metric_filter
+
+    def add_custom_error_metrics(self):
+        """Create custom error metric filter and outputs to cloudwatch graph."""
+        jobs_not_starting_errors = [
+            _CustomMetricFilter(
+                metric_name="Mismatch between IAM Group",
+                filter_pattern="?UnauthorizedOperation ?AccessDeniedException",
+            ),
+            _CustomMetricFilter(
+                metric_name="AMI larger than root volume",
+                filter_pattern="InvalidBlockDeviceMapping",
+            ),
+            _CustomMetricFilter(
+                metric_name="Vcpu limit",
+                filter_pattern="VcpuLimitExceeded",
+            ),
+            _CustomMetricFilter(
+                metric_name="Volume Limit",
+                filter_pattern="?VolumeLimitExceeded ?InsufficientVolumeCapacity",
+            ),
+            _CustomMetricFilter(
+                metric_name="Node Capacity Insufficient",
+                filter_pattern="?InsufficientInstanceCapacity ?InsufficientHostCapacity "
+                "?InsufficientReservedInstanceCapacity ?InsufficientCapacity",
+            ),
+        ]
+
+        custom_script_errors = [
+            _CustomMetricFilter(
+                metric_name="Cannot retrieve custom script",
+                filter_pattern="error occurred 403 when calling the HeadObject operation Forbidden",
+            ),
+            _CustomMetricFilter(
+                metric_name="Error With Custom Script",
+                filter_pattern="Failed to run bootstrap recipes",
+            ),
+            _CustomMetricFilter(
+                metric_name="Script Timeout",
+                filter_pattern="WARNING Node bootstrap error Resume timeout "
+                "expires state DOWN CLOUD POWERED DOWN NOT RESPONDING",
+            ),
+        ]
+
+        compute_node_events = [
+            _CustomMetricFilter(
+                metric_name="Terminated EC2 compute node before job submission ",
+                filter_pattern="WARNING Node state check no corresponding instance in EC2 for node",
+            ),
+            _CustomMetricFilter(
+                metric_name="EC2 Health Check",
+                filter_pattern="Nodes not responding setting DOWN",
+            ),
+            _CustomMetricFilter(
+                metric_name="EC2 Maintenance Events",
+                filter_pattern="Setting nodes failing health check type ec2_health_check to DRAIN",
+            ),
+            _CustomMetricFilter(
+                metric_name="Slurm Health Check Failure",
+                filter_pattern="Performing actions for health check type scheduled_events_check",
+            ),
+        ]
+
+        other_potential_issues = [
+            _CustomMetricFilter(
+                metric_name="Errors and Warnings",
+                filter_pattern="?error ?Error ?ERROR ?WARNING ?Warning ?warning",
+            ),
+        ]
+
+        error_metric_dict = {
+            "Other Error and Warning Messages": other_potential_issues,
+            "Jobs Not Starting Errors": jobs_not_starting_errors,
+            "Unexpected EC2 Termination": compute_node_events,
+        }
+
+        if self.config.head_node.custom_actions or (
+            isinstance(self.config, CommonSchedulerClusterConfig) and self.config.do_compute_nodes_have_custom_actions
+        ):
+            error_metric_dict.update({"Custom Script Errors": custom_script_errors})
+
+        self._add_text_widget("## Metrics for Common Errors")
+        custom_namespace = "ParallelCluster/Errors/" + self.config.cluster_name
+        widgets_list = []
+        for title, metric_filters in error_metric_dict.items():
+            metric_list = []
+            for new_filter in metric_filters:
+                self.custom_pcluster_metric_filter(
+                    metric_name=new_filter.metric_name,
+                    filter_pattern=new_filter.filter_pattern,
+                    custom_namespace=custom_namespace,
+                )
+                cloudwatch_metric = cloudwatch.Metric(
+                    namespace=custom_namespace,
+                    metric_name=new_filter.metric_name,
+                    period=Duration.minutes(1),
+                    statistic="Sum",
+                )
+                metric_list.append(cloudwatch_metric)
+            graph_widget = self._generate_graph_widget(title, metric_list, True)
+            widgets_list.append(graph_widget)
+
+        self.cloudwatch_dashboard.add_widgets(*widgets_list)
+        self._update_coord_after_section(self.graph_height)
 
     def _add_storage_widgets(self, metrics, storages_list, namespace, dimension_name):
         widgets_list = []
@@ -231,7 +377,7 @@ class CWDashboardConstruct(Construct):
                         dimensions_map={dimension_name: storage.id},
                     )
                     metric_list.append(cloudwatch_metric)
-            graph_widget = self._generate_graph_widget(metrics_param.title, metric_list)
+            graph_widget = self._generate_graph_widget(metrics_param.title, metric_list, False)
             widgets_list.append(graph_widget)
         return widgets_list
 
@@ -283,7 +429,7 @@ class CWDashboardConstruct(Construct):
                     metric_list.append(cloudwatch_metric)
         widgets_list = []
         for title, metric_list in metric_graphs.items():
-            widgets_list.append(self._generate_graph_widget(title, metric_list))
+            widgets_list.append(self._generate_graph_widget(title, metric_list, False))
         return widgets_list
 
     def _add_head_node_instance_metrics_graphs(self):
@@ -303,7 +449,7 @@ class CWDashboardConstruct(Construct):
         widgets_list = []
         for metrics_param in ec2_metrics:
             metrics_list = self._generate_ec2_metrics_list(metrics_param.metrics)
-            graph_widget = self._generate_graph_widget(metrics_param.title, metrics_list)
+            graph_widget = self._generate_graph_widget(metrics_param.title, metrics_list, False)
             widgets_list.append(graph_widget)
         self.cloudwatch_dashboard.add_widgets(*widgets_list)
         self._update_coord_after_section(self.graph_height)

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -186,6 +186,7 @@ Monitoring:
   Dashboards:
     CloudWatch:
       Enabled: true  # true
+      EnableErrorMetrics: true
 AdditionalPackages:
   IntelSoftware:
     IntelHpcPlatform: false

--- a/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
@@ -31,3 +31,4 @@ Monitoring:
   Dashboards:
     CloudWatch:
       Enabled: {{ dashboard_enabled }}
+      EnableErrorMetrics: {{ enabled_error_metrics }}


### PR DESCRIPTION
### Description of changes
* Improved visibility of known errors from ParallelCluster daemons by adding custom metricFilters for specified common errors 
* Added graph widgets to visualize new metrics as shown in the image below
* Added configuration template option to enable or disable metrics and automated checks to ensure metrics that do not apply to a user's template are included 

![image](https://user-images.githubusercontent.com/78058716/179066062-8176b8c0-f1f7-4f8a-a291-519715120590.png)

### Tests
* Passed Intellij unit tests
* Added integration test for configuration option "EnableErrorMetrics"
* Manual testing was done for each error metric, the function and "do_compute_nodes_have_custom_actions"


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
