### PR TITLE
[Testing] Fix integration tests executing Fabtests by disabling PlacementGroups when running on p4d.24xlarge using ODCR

### DIFF
--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/pcluster.config.yaml
@@ -27,7 +27,7 @@ Scheduling:
     - Name: q1
       Networking:
         PlacementGroup:
-          Enabled: true
+          Enabled: {% if instance != "p4d.24xlarge" %}true{% else %}false{% endif %}
         SubnetIds:
           - {{ private_subnet_id }}
       ComputeResources:


### PR DESCRIPTION
### Description of changes
Fix integration tests executing Fabtests by disabling PlacementGroups when running on p4d.24xlarge using ODCR.
Verified on a failed execution that the failure root cause was the usage of PlacementGroup when ODCR is used.

### Tests
Will be tested on dev pipeline where the ODCR is defined.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
