### PR TITLE
[Testing] Fix integration tests covering multiple NICS by disabling PlacementGroups when running on p4d.24xlarge using ODCR

### DIFF
--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -42,7 +42,7 @@ Scheduling:
           - {{ private_subnet_id }}
         {% if scheduler != "awsbatch" %}
         PlacementGroup:
-          Enabled: true
+          Enabled: {% if instance != "p4d.24xlarge" %}true{% else %}false{% endif %}
         {% endif %}
 SharedStorage:
   - MountDir: /shared


### PR DESCRIPTION
### Description of changes
Fix integration tests covering multiple NICS by disabling PlacementGroups when running on p4d.24xlarge using ODCR.
Verified on a failed execution that the failure root cause was the usage of PlacementGroup when ODCR is used.

### Tests
Will be tested on dev pipeline where the ODCR is defined.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
