### PR TITLE
[FsxS3Access] Add missing permissions needed to import/export from S3 when using Fsx for Lustre via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ CHANGELOG
 - Handle corner case in the scaling logic when instance is just launched and the describe instances API doesn't report yet all the EC2 info.
 - Dropped validation that would prevent ARM instance type to be used when `DisableSimultaneousMultithreading` was set to true.
 - Add missing policies for EcrImageDeletionLambda and ImageBuilderInstance roles that were causing failure when upgrading ParallelCluster API from one version to another.
+- Add missing permissions needed to import/export from S3 when using FSx for Lustre via ParallelCluster API.
 
 3.1.4
 ------

--- a/api/infrastructure/deploy-api.sh
+++ b/api/infrastructure/deploy-api.sh
@@ -68,6 +68,16 @@ case $key in
     shift # past argument
     shift # past value
     ;;
+    --enable-fsx-s3-access)
+    export ENABLE_FSX_S3_ACCESS=$2
+    shift # past argument
+    shift # past value
+    ;;
+    --fsx-s3-buckets)
+    export FSX_S3_BUCKETS=$2
+    shift # past argument
+    shift # past value
+    ;;
     *)    # unknown option
     echo "$usage" >&2
     exit 1

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -59,6 +59,27 @@ Parameters:
       - true
       - false
 
+  EnableFSxS3Access:
+    Description: |
+      When set to true the ParallelCluster API can access, write to the S3 buckets specified in the Filed FsxS3Bucket, it is needed to import/export from/to S3 when creating an FSx filesystem.
+      NOTE - setting this to true grants the Lambda function S3 Get*, List* and PutObject privileges on the buckets specified in FsxS3Buckets.
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+
+  FsxS3Buckets:
+    Description: |
+      Comma separated list of S3 bucket ARNs, to allow the lambda function to import/export from/to S3 when creating an FSx filesystem.
+      NOTE - The setting is used only when EnableFSxS3Access is set to true. (example arn:aws:s3:::<S3_BUCKET_1>,arn:aws:s3:::<S3_BUCKET_2>)
+    Type: String
+    Default: ''
+    AllowedPattern: ^((arn:[a-z\-]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/\*]+)?(,arn:[a-z\-]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/\*]+)*)$|^\*$
+    ConstraintDescription: |
+      The list of S3 buckets is incorrectly formatted. The list should have the format: arn:<PARTITION>:s3:<REGION>:<ACCOUNT_ID>:<BUCKET_NAME>[,arn:<PARTITION>:s3:<REGION>:<ACCOUNT_ID>:<BUCKET_NAME>,...]
+      Example: arn:aws:s3:::test-bucket-1,arn:aws:s3:::test-bucket-2,arn:aws:s3:::test-bucket-3
+
   PermissionsBoundaryPolicy:
     Description: |
       ARN of a IAM policy to use as PermissionsBoundary for all IAM resources created by ParallelCluster API.
@@ -155,6 +176,10 @@ Conditions:
     Fn::And:
       - !Not [!Equals [!Ref ImageBuilderVpcId, ""]]
       - !Not [!Equals [!Ref ImageBuilderSubnetId, ""]]
+  EnableFSxS3AccessCondition: !And
+    - !Equals [!Ref EnableFSxS3Access, true]
+    - !Condition CreateIamResources
+  UseAllBucketsForFSxS3: !Equals [!Ref FsxS3Buckets, "*"]
 
 Resources:
 
@@ -458,6 +483,36 @@ Resources:
                   aws:RequestedRegion:
                     - !Ref Region
             Sid: ECS
+
+  FSxS3AccessPolicy:
+    Type: AWS::IAM::Policy
+    Condition: EnableFSxS3AccessCondition
+    Properties:
+      PolicyName: FSxS3AccessPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - iam:CreateServiceLinkedRole
+              - iam:AttachRolePolicy
+              - iam:PutRolePolicy
+            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/s3.data-source.lustre.fsx.amazonaws.com/*
+            Effect: Allow
+            Sid: FSxS3PoliciesAttach
+          - Action:
+              - s3:Get*
+              - s3:List*
+              - s3:PutObject
+            Resource: !Split
+              - ","
+              - !If
+                - UseAllBucketsForFSxS3
+                - "*"
+                - !Sub ["${FsxS3Buckets},${FsxS3BucketsObjects}", FsxS3BucketsObjects: !Join ["/*,", !Split [",", !Sub "${FsxS3Buckets}/*"]]]
+            Effect: Allow
+            Sid: EnableFSxS3Access
+      Roles:
+        - !Ref ParallelClusterUserRole
 
   ParallelClusterClusterPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -20,12 +20,35 @@ Parameters:
     AllowedValues:
       - true
       - false
+  EnableFSxS3Access:
+    Description: |
+      When set to true the ParallelCluster API can access, write to the S3 buckets specified in the Filed FsxS3Bucket, it is needed to import/export from/to S3 when creating an FSx filesystem.
+      NOTE - setting this to true grants the Lambda function S3 Get*, List* and PutObject privileges on the buckets specified in FsxS3Buckets.
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+
+  FsxS3Buckets:
+    Description: |
+      Comma separated list of S3 bucket ARNs, to allow the lambda function to import/export from/to S3 when creating an FSx filesystem.
+      NOTE - The setting is used only when EnableFSxS3Access is set to true. (example arn:aws:s3:::<S3_BUCKET_1>,arn:aws:s3:::<S3_BUCKET_2>)
+    Type: String
+    AllowedPattern: ^((arn:[a-z\-]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/\*]+)?(,arn:[a-z\-]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/\*]+)*)$|^\*$
+    ConstraintDescription: |
+      The list of S3 buckets is incorrectly formatted. The list should have the format: arn:<PARTITION>:s3:<REGION>:<ACCOUNT_ID>:<BUCKET_NAME>[,arn:<PARTITION>:s3:<REGION>:<ACCOUNT_ID>:<BUCKET_NAME>,...]
+      Example: arn:aws:s3:::test-bucket-1,arn:aws:s3:::test-bucket-2,arn:aws:s3:::test-bucket-3
 
 Conditions:
   EnableIamPolicy: !Equals [!Ref EnableIamAdminAccess, true]
   EnablePermissionsBoundary: !Equals [!Ref EnablePermissionsBoundary, true]
   IsMultiRegion: !Equals [!Ref Region, '*']
   CreateIamResources: !Equals [true, true]  # to keep aligned the resources in the API stack
+  EnableFSxS3AccessCondition: !And
+    - !Equals [!Ref EnableFSxS3Access, true]
+    - !Condition CreateIamResources
+  UseAllBucketsForFSxS3: !Equals [!Ref FsxS3Buckets, "*"]
 
 Resources:
 
@@ -200,6 +223,36 @@ Resources:
                   aws:RequestedRegion:
                     - !Ref Region
             Sid: ECS
+
+  FSxS3AccessPolicy:
+    Type: AWS::IAM::Policy
+    Condition: EnableFSxS3AccessCondition
+    Properties:
+      PolicyName: FSxS3AccessPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - iam:CreateServiceLinkedRole
+              - iam:AttachRolePolicy
+              - iam:PutRolePolicy
+            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/s3.data-source.lustre.fsx.amazonaws.com/*
+            Effect: Allow
+            Sid: FSxS3PoliciesAttach
+          - Action:
+              - s3:Get*
+              - s3:List*
+              - s3:PutObject
+            Resource: !Split
+              - ","
+              - !If
+                - UseAllBucketsForFSxS3
+                - "*"
+                - !Sub ["${FsxS3Buckets},${FsxS3BucketsObjects}", FsxS3BucketsObjects: !Join ["/*,", !Split [",", !Sub "${FsxS3Buckets}/*"]]]
+            Effect: Allow
+            Sid: EnableFSxS3Access
+      Roles:
+        - !Ref ParallelClusterUserRole
 
   ParallelClusterClusterPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
### Description of changes
- Creation of a cluster with FsxLuster storage via ParallelCluster API fails due to the user role missing some permissions needed to import/export from S3.
- This commit creates an inline-policy with the needed permissions and associates it with the user role.
- The inline-policy is only created if the API stack is created with certain parameters (EnableFSxS3Access and FsxS3Buckets).

### Tests
* Manually tested by first reproducing the error through API Gateway
* Applied the changes in this commit to a copy of the current CFN Template
* Recreated the API and verified that the `FSxS3AccessPolicy` is created and associated with the `ParallelClusterUserRole`
* Made an API request using API Gateway to create a cluster
* Got a 202 OK response status with these results

```
{
  "cluster": {
    "cloudformationStackArn": "<STACK_ARN>",
    "cloudformationStackStatus": "CREATE_IN_PROGRESS",
    "clusterName": "<CLUSTER_NAME>",
    "clusterStatus": "CREATE_IN_PROGRESS",
    "region": "eu-west-1",
    "version": "3.1.4"
  }
}
```

### References
* [CloudFormation Conditions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-condition.html)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
