### PR TITLE
[Testing] Fix integration tests executing Fabtests

### DIFF
--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/install-fabtests.sh
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/install-fabtests.sh
@@ -3,22 +3,28 @@ set -ex
 
 # Installs Fabtests suite from GitHub.
 # Usage: install-fabtests.sh [FABTESTS_DIR]
-# Example: install-fabtests.sh /home/ec2-user/shared/fabtests
+# Example: install-fabtests.sh /shared/fabtests
 
 FABTESTS_DIR="$1"
 
-FABTESTS_REPO="https://github.com/ofiwg/libfabric.git"  # TODO Replace with released tarball v1.16.0 once available
+FABTESTS_REPO="https://github.com/ofiwg/libfabric.git"
+# TODO We should target the release 1.16.0 instead of a commit.
+# We must fix this once that version will be released.
+FABTESTS_COMMIT="840a4a93ccf576b950dfd15d979cbf5f06e9c64b"
 FABTESTS_SOURCES_DIR="$FABTESTS_DIR/sources"
 LIBFABRIC_DIR="/opt/amazon/efa"
+CUDA_DIR="/usr/local/cuda"
 
 echo "[INFO] Installing Fabtests in $FABTESTS_DIR"
 rm -rf $FABTESTS_DIR
 mkdir -p $FABTESTS_SOURCES_DIR
 cd $FABTESTS_SOURCES_DIR
 git clone $FABTESTS_REPO
-cd libfabric/fabtests
+cd libfabric
+git reset --hard $FABTESTS_COMMIT
+cd fabtests
 ./autogen.sh
-./configure --with-libfabric=$LIBFABRIC_DIR --prefix=$FABTESTS_DIR && make -j 32 && make install
+./configure --with-libfabric=$LIBFABRIC_DIR --with-cuda=$CUDA_DIR --prefix=$FABTESTS_DIR && make -j 32 && make install
 python3 -m pip install -r $FABTESTS_SOURCES_DIR/libfabric/fabtests/pytest/requirements.txt
 python3 -m pip install pyyaml # TODO This is required but it is missing in the above requirements.txt
 echo "[INFO] Fabtests installed in $FABTESTS_DIR"

--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/run-fabtests.sh
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/run-fabtests.sh
@@ -10,7 +10,7 @@ set -ex
 # /shared/fabtests/outputs/fabtests.log \
 # /shared/fabtests/outputs/fabtests.report \
 # q1-st-g4dn8xl-efa-1 q1-st-g4dn8xl-efa-2 \
-# rdm_tagged_bw,rdm_tagged_pingpong \
+# rdm_tagged_bw,rdm_tagged_pingpong,runt \
 # enable-gdr
 
 FABTESTS_DIR="$1"
@@ -35,7 +35,7 @@ COMPUTE_IP_1=$(host $COMPUTE_NODE_1 | cut -d ' ' -f 4)
 COMPUTE_IP_2=$(host $COMPUTE_NODE_2 | cut -d ' ' -f 4)
 TEST_EXPRESSION=${TEST_CASES//,/ or }
 TEST_ENVIRONMENT_OPTION=""
-[[ "$TEST_OPTIONS" == *"enable-gdr"* ]] && TEST_ENVIRONMENT_OPTION="-E FI_EFA_USE_DEVICE_RDMA=1"
+[[ "$TEST_OPTIONS" == *"enable-gdr"* ]] && TEST_ENVIRONMENT_OPTION="-E \"FI_EFA_USE_DEVICE_RDMA=1\""
 
 mkdir -p $(dirname $PID_FILE)
 mkdir -p $(dirname $LOG_FILE)
@@ -47,7 +47,7 @@ python3 $FABTESTS_RUNNER \
   --expression "$TEST_EXPRESSION" \
   --timeout $FABTESTS_TIMEOUT \
   --junit-xml $REPORT_FILE \
-  $TEST_ENVIRONMENT_OPTION $COMPUTE_IP_1 $COMPUTE_IP_2 > $LOG_FILE 2>&1 &
+  -v $TEST_ENVIRONMENT_OPTION $COMPUTE_IP_1 $COMPUTE_IP_2 > $LOG_FILE 2>&1 &
 
 echo $! > $PID_FILE
 


### PR DESCRIPTION
### Description of changes
Fix integration tests executing Fabtests by:
- configuring the test suite to be run with CUDA support
- cloning the suite targeting a stable commit
- applying minor fixes to the execution script: increased logs verbosity and injecting envars more safely.

### Tests
Tested in dev account on p4d.24xlarge.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
