### PR TITLE
Inject additional config settings to new pcluster configure EFA/PG tests

### DIFF
--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -129,6 +129,7 @@ def test_region_without_t2micro(vpc_stack, pcluster_config_reader, key_name, reg
     ],
 )
 def test_efa_and_placement_group(
+    request,
     vpc_stack,
     key_name,
     region,
@@ -179,6 +180,7 @@ def test_efa_and_placement_group(
         efa_config=efa_config,
         placement_group_config=placement_group_config["configuration"],
     )
+    inject_additional_config_settings(config_path, request, region)
     clusters_factory(config_path)
 
 


### PR DESCRIPTION
### Description of changes
We missed to inject `DevSettings` required to find the AMIs not yet published.

The tests were passing because they were using public 3.2.0b2 AMIs and started
to fail when we bumped the version to 3.2.0 because there are no public images for this version.

### Tests
* None

### References
* Tests introduced with: https://github.com/aws/aws-parallelcluster/pull/4153

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
