### PR TITLE
[ParallelCluster-API] Remove extra ECS policy actions used by the ECS Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ CHANGELOG
 - Fix default for disable validate and test components when building custom AMI. The default was to disable those components, but it wasn't effective.
 - Handle corner case in the scaling logic when instance is just launched and the describe instances API doesn't report yet all the EC2 info.
 - Dropped validation that would prevent ARM instance type to be used when `DisableSimultaneousMultithreading` was set to true.
-- Add missing policies for EcrImageDeletionLambda and ImageBuilderInstance roles that were causing failure when upgrading ParallelCluster API from one version to another.
+- Fix resource pattern used for the ListImagePipelineImages Action in the EcrImageDeletionLambdaRole. This is causing a stack update failure when upgrading ParallelCluster API from one version to another.
 - Add missing permissions needed to import/export from S3 when using FSx for Lustre via ParallelCluster API.
 
 3.1.4

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -1019,17 +1019,6 @@ Resources:
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
         - !Sub arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds
-      Policies:
-        - PolicyName: ImageBuilderCustomPolicy
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action: ecs:RegisterContainerInstance
-                Resource: !Sub arn:${AWS::Partition}:ecs:*:${AWS::AccountId}:cluster/*
-              - Effect: Allow
-                Action: ecs:DiscoverPollEndpoint
-                Resource: "*"
       AssumeRolePolicyDocument:
         Statement:
           - Action:


### PR DESCRIPTION
### Description of changes
- The ECS Agent is missing `RegisterContainerInstance` and `DiscoverPollEndpoint` actions resulting in regular failures being recorded in CloudTrail
- The missing actions do not affect ParallelCluster API creation and update
- This created a red-herring when debugging the ParallelCluster API Upgrade issue described in [PR #4194](https://github.com/aws/aws-parallelcluster/pull/4194)
- This commit removes the ECS Agent related policy/actions since they do not seem to impact the ParallelCluster API functionality

### Tests
* Manual tests
  * Created the API (3.1.4) and attempted to upgrade to 3.2.x --> Stack Update Failed
    * EcrImageRemover Error in CloudFormation
  * Created the API (3.1.4) with an API template with the changes in this commit
    * Attempted to upgrade to 3.2.x --> Stack updated Succeeded

### References
* Related to previous PR ([#4194](https://github.com/aws/aws-parallelcluster/pull/4194)) in which the ImageBuilderInstance Role had API Errors that were unrelated to the CloudFormation Stack Update

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
