### PR TITLE
[FsxS3Access] Fix integration tests by setting a default for FsxS3Buckets parameter

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -75,7 +75,7 @@ Parameters:
       NOTE - The setting is used only when EnableFSxS3Access is set to true. (example arn:aws:s3:::<S3_BUCKET_1>,arn:aws:s3:::<S3_BUCKET_2>)
     Type: String
     Default: ''
-    AllowedPattern: ^((arn:[a-z\-]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/\*]+)?(,arn:[a-z\-]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/\*]+)*)$|^\*$
+    AllowedPattern: ^((arn:[a-z\-\*]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/]+)?(,arn:[a-z\-\*]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/]+)*)$|^\*$
     ConstraintDescription: |
       The list of S3 buckets is incorrectly formatted. The list should have the format: arn:<PARTITION>:s3:<REGION>:<ACCOUNT_ID>:<BUCKET_NAME>[,arn:<PARTITION>:s3:<REGION>:<ACCOUNT_ID>:<BUCKET_NAME>,...]
       Example: arn:aws:s3:::test-bucket-1,arn:aws:s3:::test-bucket-2,arn:aws:s3:::test-bucket-3

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -25,7 +25,7 @@ Parameters:
       When set to true the ParallelCluster API can access, write to the S3 buckets specified in the Filed FsxS3Bucket, it is needed to import/export from/to S3 when creating an FSx filesystem.
       NOTE - setting this to true grants the Lambda function S3 Get*, List* and PutObject privileges on the buckets specified in FsxS3Buckets.
     Type: String
-    Default: false
+    Default: true
     AllowedValues:
       - true
       - false
@@ -35,7 +35,8 @@ Parameters:
       Comma separated list of S3 bucket ARNs, to allow the lambda function to import/export from/to S3 when creating an FSx filesystem.
       NOTE - The setting is used only when EnableFSxS3Access is set to true. (example arn:aws:s3:::<S3_BUCKET_1>,arn:aws:s3:::<S3_BUCKET_2>)
     Type: String
-    AllowedPattern: ^((arn:[a-z\-]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/\*]+)?(,arn:[a-z\-]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/\*]+)*)$|^\*$
+    Default: 'arn:*:s3:::integ-tests-*'
+    AllowedPattern: ^((arn:[a-z\-\*]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/]+)?(,arn:[a-z\-\*]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/]+)*)$|^\*$
     ConstraintDescription: |
       The list of S3 buckets is incorrectly formatted. The list should have the format: arn:<PARTITION>:s3:<REGION>:<ACCOUNT_ID>:<BUCKET_NAME>[,arn:<PARTITION>:s3:<REGION>:<ACCOUNT_ID>:<BUCKET_NAME>,...]
       Example: arn:aws:s3:::test-bucket-1,arn:aws:s3:::test-bucket-2,arn:aws:s3:::test-bucket-3


### PR DESCRIPTION
### Description of changes
- Integration tests are failing due to the FsxS3Buckets parameter missing a default value in the `user-role.cfn` file used during tests
- This commit sets EnableFSxS3Access to true and FsxS3Buckets to an S3 Bucket ARN pattern that matches buckets created for tests

### Tests
* Integration tests
  * Reproduced test failure
```
2022-07-20 09:31:10,558 - ERROR - 73471 - test_pcluster_configure[us-east-1-c5.xlarge-alinux2-slurm] - conftest - Exception raised while executing test_pcluster_configure[us-east-1-c5.xlarge-alinux2-slurm]: An error occurred (ValidationError) when calling the CreateStack operation: Parameters: [FsxS3Buckets] must have values
```
  * Applied changes in this commit
```
Passed | configure/test_pcluster_configure.py::test_pcluster_configure[us-east-1-c5.xlarge-alinux2-slurm]
```

### References
* This fixes integration tests linked to [#4199](https://github.com/aws/aws-parallelcluster/pull/4199)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
