### PR TITLE
Trigger fleet stop when budget threshold is reached

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -689,6 +689,18 @@ Resources:
             Resource: '*'
             Effect: Allow
             Sid: CostAllocationTagsUpdateDescribe
+          - Action:
+              - sns:GetTopicAttributes
+              - sns:TagResource
+              - sns:CreateTopic
+              - sns:Subscribe
+              - sns:DeleteTopic
+              - sns:Unsubscribe
+              - sns:SetTopicAttributes
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:sns:${Region}:${AWS::AccountId}:pcluster-BudgetTopic*'
+            Sid: BudgetTriggeredSNS
 
   ### IMAGE ACTIONS POLICIES
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -61,7 +61,7 @@ from pcluster.validators.awsbatch_validators import (
     AwsBatchInstancesArchitectureCompatibilityValidator,
     AwsBatchRegionValidator,
 )
-from pcluster.validators.budget_validators import BudgetFilterTagValidator
+from pcluster.validators.budget_validators import BudgetFilterTagValidator, TriggerFleetStopValidator
 from pcluster.validators.cluster_validators import (
     ArchitectureOsValidator,
     ClusterNameValidator,
@@ -886,10 +886,16 @@ class BudgetSubscriber(Resource):
 class BudgetNotificationWithSubscribers(Resource):
     """Represent the configuration of the NotificationWithSubscribers field of a budget."""
 
-    def __init__(self, notification: BudgetNotification, subscribers: List[BudgetSubscriber] = None):
+    def __init__(
+        self,
+        notification: BudgetNotification,
+        trigger_fleet_stop: bool = None,
+        subscribers: List[BudgetSubscriber] = None,
+    ):
         super().__init__()
         self.notification = notification
         self.subscribers = subscribers
+        self.trigger_fleet_stop = Resource.init_param(trigger_fleet_stop, default=False)
 
 
 class BudgetLimit(Resource):
@@ -924,6 +930,12 @@ class Budget(Resource):
     def _register_validators(self):
         if self.budget_category:
             self._register_validator(BudgetFilterTagValidator, budget_category=self.budget_category)
+            if self.notifications_with_subscribers:
+                self._register_validator(
+                    TriggerFleetStopValidator,
+                    budget_category=self.budget_category,
+                    notifications_with_subscribers=self.notifications_with_subscribers,
+                )
 
 
 class ClusterDevSettings(BaseDevSettings):

--- a/cli/src/pcluster/resources/custom_resources/custom_resources_code/budget_triggered_stop.py
+++ b/cli/src/pcluster/resources/custom_resources/custom_resources_code/budget_triggered_stop.py
@@ -1,0 +1,78 @@
+import datetime
+import os
+import time
+
+import boto3
+from boto3.dynamodb.conditions import Attr
+
+DB_KEY = "COMPUTE_FLEET"
+DB_DATA = "Data"
+
+COMPUTE_FLEET_STATUS_ATTRIBUTE = "status"
+COMPUTE_FLEET_LAST_UPDATED_TIME_ATTRIBUTE = "lastStatusUpdatedTime"
+
+
+def update_item(table, status, current_status):
+    table.update_item(
+        Key={"Id": DB_KEY},
+        UpdateExpression="set #dt.#st=:s, #dt.#lut=:t",
+        ExpressionAttributeNames={
+            "#dt": DB_DATA,
+            "#st": COMPUTE_FLEET_STATUS_ATTRIBUTE,
+            "#lut": COMPUTE_FLEET_LAST_UPDATED_TIME_ATTRIBUTE,
+        },
+        ExpressionAttributeValues={
+            ":s": str(status),
+            ":t": str(datetime.datetime.now(tz=datetime.timezone.utc)),
+        },
+        ConditionExpression=Attr(f"{DB_DATA}.{COMPUTE_FLEET_STATUS_ATTRIBUTE}").eq(str(current_status)),
+    )
+
+
+def update_status_with_last_updated_time(table_name, region, status):
+    try:
+        table = boto3.resource("dynamodb", region_name=region).Table(table_name)
+        current_status = get_dynamo_db_data(table).get(COMPUTE_FLEET_STATUS_ATTRIBUTE)
+        print("Stopping Compute Fleet - Triggered by Budget Threshold.")
+        if current_status == status:
+            return
+        elif current_status in ["RUNNING", "PROTECTED"]:
+            update_item(table, status, current_status)
+        else:
+            raise Exception(f"Could not update compute fleet status from '{current_status}' to {status}.")
+    except Exception as e:
+        raise Exception(f"Failed when updating fleet status with error: {e}")
+
+
+def get_dynamo_db_data(table):
+    try:
+        compute_fleet_item = table.get_item(ConsistentRead=True, Key={"Id": DB_KEY})
+        if not compute_fleet_item or "Item" not in compute_fleet_item:
+            raise Exception("COMPUTE_FLEET data not found in db table")
+        db_data = compute_fleet_item["Item"].get(DB_DATA)
+        return db_data
+    except Exception as e:
+        raise Exception(f"Failed when retrieving data from DynamoDB with error {e}.")
+
+
+def handler(*args, attempt=0):
+    try:
+        if os.environ.get("IS_BATCH") == "TRUE":
+            boto3.client("batch").update_compute_environment(
+                computeEnvironment=os.environ.get("CE_NAME"),
+                state="DISABLED",
+            )
+        else:
+            update_status_with_last_updated_time(
+                os.environ.get("TABLE_NAME"),
+                os.environ.get("AWS_REGION"),
+                "STOP_REQUESTED",
+            )
+
+    except Exception as e:
+        print(f"ERROR: Failed to update compute fleet status, exception: {e}")
+        if attempt < 3:
+            time.sleep(60)
+            handler(*args, attempt=attempt + 1)
+        else:
+            return

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -993,7 +993,7 @@ class BudgetNotificationWithSubscribersSchema(BaseSchema):
         required=True,
         metadata={"update_policy": UpdatePolicy.SUPPORTED},
     )
-
+    trigger_fleet_stop = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     subscribers = fields.Nested(
         BudgetSubscriberSchema,
         required=True,
@@ -1053,6 +1053,7 @@ class BudgetSchema(BaseSchema):
         budget_category = data.get("budget_category")
         cost_filters = data.get("cost_filters")
         queue_name = data.get("queue_name")
+
         if budget_category != "custom" and cost_filters:
             raise ValidationError("CostFilters can only be configured when BudgetCategory is set to custom.")
         if budget_category == "custom" and not cost_filters:

--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -101,7 +101,7 @@ class AwsBatchConstruct(Construct):
         return Stack.of(self).stack_id
 
     def _get_compute_env_prefix(self):
-        return Fn.select(1, Fn.split("compute-environment/", self._compute_env.ref))
+        return Fn.select(1, Fn.split("compute-environment/", self.compute_env.ref))
 
     def _cluster_scoped_iam_path(self):
         """Return a path to be associated IAM roles and instance profiles."""
@@ -125,7 +125,7 @@ class AwsBatchConstruct(Construct):
             self._spot_iam_fleet_role = self._add_spot_fleet_iam_role()
 
         # Batch resources
-        self._compute_env = self._add_compute_env()
+        self.compute_env = self._add_compute_env()
         self._job_queue = self._add_job_queue()
         self._job_role = self._add_job_role()
         self._docker_images_repo = self._add_docker_images_repo()
@@ -190,7 +190,7 @@ class AwsBatchConstruct(Construct):
             priority=1,
             compute_environment_order=[
                 batch.CfnJobQueue.ComputeEnvironmentOrderProperty(
-                    compute_environment=self._compute_env.ref,
+                    compute_environment=self.compute_env.ref,
                     order=1,
                 )
             ],
@@ -821,7 +821,7 @@ class AwsBatchConstruct(Construct):
             self.stack_scope,
             "BatchComputeEnvironmentArn",
             description="Compute Environment created within the cluster.",
-            value=self._compute_env.ref,
+            value=self.compute_env.ref,
         )
         CfnOutput(
             self.stack_scope,

--- a/cli/src/pcluster/templates/budget_builder.py
+++ b/cli/src/pcluster/templates/budget_builder.py
@@ -1,28 +1,54 @@
+from typing import List
+
 from aws_cdk import aws_budgets as budgets
-from aws_cdk.core import Construct
+from aws_cdk import aws_iam as iam
+from aws_cdk import aws_lambda as awslambda
+from aws_cdk import aws_logs as logs
+from aws_cdk import aws_s3 as s3
+from aws_cdk import aws_sns as sns
+from aws_cdk import aws_sns_subscriptions as sns_subscriptions
+from aws_cdk import core
+from aws_cdk.core import Construct, Fn, Stack
 
 from pcluster.config.cluster_config import BaseClusterConfig
+from pcluster.constants import IAM_ROLE_PATH
+from pcluster.models.s3_bucket import S3Bucket
+from pcluster.templates.cdk_builder_utils import (
+    PCLUSTER_LAMBDA_PREFIX,
+    get_cloud_watch_logs_policy_statement,
+    get_cloud_watch_logs_retention_days,
+    get_lambda_log_group_prefix,
+)
 from pcluster.utils import random_alphanumeric
 
 
 class CostBudgets:
     """Create the budgets based on the configuration file."""
 
-    def __init__(self, scope: Construct, cluster_config: BaseClusterConfig):
+    def __init__(
+        self,
+        scope: Construct,
+        cluster_config: BaseClusterConfig,
+        is_batch: bool,
+        create_lambda_role: bool,
+        bucket: S3Bucket,
+    ):
         self.cluster_config = cluster_config
         self.scope = scope
+        self.is_batch = is_batch
+        self.create_lambda_role = create_lambda_role
+        self.sns_arn = None
+        self.bucket = bucket
         self._create_budgets()
 
     def _create_budgets(self):
         """Create the Cfn templates for the list of budgets."""
         budget_list = self.cluster_config.dev_settings.budgets
-        cfn_budget_list = []
+        self.cfn_budget_list = []
 
         for index, budget in enumerate(budget_list):
             cfn_budget = self._add_parameters(budget, index)
-            cfn_budget_list.append(cfn_budget)
-
-        return cfn_budget_list
+            self.cfn_budget_list.append(cfn_budget)
 
     def _add_parameters(self, budget, index):
         """Add each budget's parameters."""
@@ -60,7 +86,7 @@ class CostBudgets:
             ),
         )
         notifications_with_subscribers = (
-            add_budget_notifications(budget) if budget.notifications_with_subscribers else None
+            self._add_budget_notifications(budget) if budget.notifications_with_subscribers else None
         )
         budget_id = f"Budget{str(index)}"
         cfn_budget = budgets.CfnBudget(
@@ -68,27 +94,150 @@ class CostBudgets:
         )
         return cfn_budget
 
+    def _add_budget_notifications(self, budget):
+        """Create the notifications with subscribers for each budget."""
+        notifications_with_subscribers = []
+        for single_notification in budget.notifications_with_subscribers:
+            subscribers = [
+                budgets.CfnBudget.SubscriberProperty(
+                    address=subscriber.address,
+                    subscription_type=subscriber.subscription_type,
+                )
+                for subscriber in single_notification.subscribers
+            ]
 
-def add_budget_notifications(budget):
-    """Create the notifications with subscribers for each budget."""
-    notifications_with_subscribers = []
-    for single_notification in budget.notifications_with_subscribers:
-        notifications_with_subscribers.append(
-            budgets.CfnBudget.NotificationWithSubscribersProperty(
-                notification=budgets.CfnBudget.NotificationProperty(
-                    comparison_operator=single_notification.notification.comparison_operator,
-                    notification_type=single_notification.notification.notification_type,
-                    threshold_type=single_notification.notification.threshold_type,
-                    threshold=single_notification.notification.threshold,
-                ),
-                subscribers=[
+            if single_notification.trigger_fleet_stop:
+                if not self.sns_arn:
+                    self._create_lambda_and_sns()
+                subscribers.append(
                     budgets.CfnBudget.SubscriberProperty(
-                        address=subscriber.address,
-                        subscription_type=subscriber.subscription_type,
+                        address=self.sns_arn,
+                        subscription_type="SNS",
                     )
-                    for subscriber in single_notification.subscribers
-                ],
+                )
+            notifications_with_subscribers.append(
+                budgets.CfnBudget.NotificationWithSubscribersProperty(
+                    notification=budgets.CfnBudget.NotificationProperty(
+                        comparison_operator=single_notification.notification.comparison_operator,
+                        notification_type=single_notification.notification.notification_type,
+                        threshold_type=single_notification.notification.threshold_type,
+                        threshold=single_notification.notification.threshold,
+                    ),
+                    subscribers=subscribers,
+                )
+            )
+        return notifications_with_subscribers
+
+    def _create_lambda_and_sns(self):
+        """Create an sns topic and a lambda function to stop compute fleet when triggered."""
+        topic_name = f"pcluster-BudgetTopic-{self.cluster_config.cluster_name}"
+        self.sns_topic = sns.Topic(
+            self.scope,
+            topic_name,
+            display_name=topic_name,
+            fifo=False,
+            topic_name=topic_name,
+        )
+        self.sns_arn = self.sns_topic.topic_arn
+        self.sns_topic.add_to_resource_policy(
+            iam.PolicyStatement(
+                actions=["SNS:Publish"],
+                effect=iam.Effect.ALLOW,
+                resources=[self.sns_arn],
+                principals=[iam.ServicePrincipal("budgets.amazonaws.com")],
             )
         )
 
-    return notifications_with_subscribers
+        lambda_env = {
+            "TABLE_NAME": self.scope.dynamodb_table_status.ref if not self.is_batch else "NONE",
+            "IS_BATCH": "TRUE" if self.is_batch else "FALSE",
+            "CE_NAME": self.scope.scheduler_resources.compute_env.ref if self.is_batch else "NONE",
+        }
+
+        function_id = "FleetStop"
+        function_name = f"{PCLUSTER_LAMBDA_PREFIX}{function_id}-{self._stack_unique_id()}"
+
+        budget_triggered_lambda_role = None
+
+        if self.create_lambda_role:
+            slurm_policy = iam.PolicyStatement(
+                actions=["dynamodb:GetItem", "dynamodb:UpdateItem"],
+                effect=iam.Effect.ALLOW,
+                resources=[
+                    self.scope.format_arn(
+                        service="dynamodb",
+                        resource="table/parallelcluster-*",
+                        region=self.scope.region,
+                        account=self.scope.account,
+                    ),
+                ],
+                sid="DynamoDbStopFleetPolicy",
+            )
+            batch_policy = iam.PolicyStatement(
+                actions=["batch:UpdateComputeEnvironment"],
+                effect=iam.Effect.ALLOW,
+                resources=["*"],
+                sid="BatchStopComputeEnv",
+            )
+
+            budget_triggered_lambda_role = add_lambda_role(
+                scope=self.scope,
+                function_id=function_id,
+                statements=[
+                    (batch_policy if self.is_batch else slurm_policy),
+                    get_cloud_watch_logs_policy_statement(
+                        resource=self.scope.format_arn(
+                            service="logs",
+                            account=self.scope.account,
+                            region=self.scope.region,
+                            resource=get_lambda_log_group_prefix("FleetStop-*"),
+                        )
+                    ),
+                ],
+            )
+
+        budget_triggered_lambda = awslambda.Function(
+            self.scope,
+            f"{function_id}Function",
+            role=(
+                budget_triggered_lambda_role
+                if self.create_lambda_role
+                else iam.Role.from_role_arn(
+                    self.scope,
+                    "LambdaFunctionsRole",
+                    self.cluster_config.iam.roles.lambda_functions_role,
+                )
+            ),
+            runtime=awslambda.Runtime.PYTHON_3_8,
+            function_name=function_name,
+            code=awslambda.Code.from_bucket(
+                bucket=s3.Bucket.from_bucket_name(self.scope, "LambdaCodeBucket", self.bucket.name),
+                key=f"{self.bucket.artifact_directory}/custom_resources/artifacts.zip",
+            ),
+            handler="budget_triggered_stop.handler",
+            timeout=core.Duration.seconds(600),
+            environment=lambda_env,
+        )
+
+        self.log_group = logs.CfnLogGroup(
+            self.scope,
+            f"{function_id}FunctionLogGroup",
+            log_group_name=f"/aws/lambda/{function_name}",
+            retention_in_days=get_cloud_watch_logs_retention_days(self.cluster_config),
+        )
+
+        self.sns_topic.add_subscription(sns_subscriptions.LambdaSubscription(budget_triggered_lambda))
+
+    def _stack_unique_id(self):
+        return Fn.select(2, Fn.split("/", Stack.of(self.scope).stack_id))
+
+
+def add_lambda_role(scope, function_id: str, statements: List[iam.PolicyStatement]):
+    """Return a CfnRole to be used for a Lambda function."""
+    return iam.Role(
+        scope,
+        f"{function_id}FunctionExecutionRole",
+        path=IAM_ROLE_PATH,
+        assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+        inline_policies={"LambdaPolicy": iam.PolicyDocument(statements=statements)},
+    )

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -292,7 +292,13 @@ class ClusterCdkStack(Stack):
 
         # Budgets
         if self.config.dev_settings and self.config.dev_settings.budgets:
-            self.budgets = CostBudgets(self, self.config)
+            self.budgets = CostBudgets(
+                scope=self,
+                cluster_config=self.config,
+                is_batch=self._condition_is_batch(),
+                create_lambda_role=self._condition_create_lambda_iam_role(),
+                bucket=self.bucket,
+            )
 
     def _add_iam_resources(self):
         head_node_iam_resources = HeadNodeIamResources(

--- a/cli/tests/pcluster/example_configs/awsbatch.full.yaml
+++ b/cli/tests/pcluster/example_configs/awsbatch.full.yaml
@@ -124,6 +124,7 @@ DevSettings:
       NotificationsWithSubscribers:
         - Notification:
             Threshold: 76.0
+          TriggerFleetStop: true
           Subscribers:
             - SubscriptionType: EMAIL
               Address: alias1@amazon.com

--- a/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
+++ b/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
@@ -239,7 +239,7 @@ SharedStorage:
       StorageType: HDD  # HDD | SSD
 Iam:
   Roles:
-    LambdaFunctionsRole: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
+    LambdaFunctionsRole: arn:aws:iam::aws:role/CustomResourcesLambdaRole
 Monitoring:
   DetailedMonitoring: true  # false
   Logs:
@@ -286,6 +286,7 @@ DevSettings:
       NotificationsWithSubscribers:
         - Notification:
             Threshold: 76.0
+          TriggerFleetStop: true
           Subscribers:
             - SubscriptionType: EMAIL
               Address: alias1@amazon.com

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -175,7 +175,7 @@ SharedStorage:
       VolumeId: fsvol-12345678901234567
 Iam:
   Roles:
-    LambdaFunctionsRole: String  # arn:aws:iam::aws:role/CustomResourcesLambdaRole
+    LambdaFunctionsRole: arn:aws:iam::aws:role/CustomResourcesLambdaRole
 Monitoring:
   DetailedMonitoring: true  # false
   Logs:
@@ -234,6 +234,7 @@ DevSettings:
       NotificationsWithSubscribers:
         - Notification:
             Threshold: 76.0
+          TriggerFleetStop: true
           Subscribers:
             - SubscriptionType: EMAIL
               Address: alias1@amazon.com

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -433,6 +433,18 @@ Resources:
             Resource: '*'
             Effect: Allow
             Sid: CostAllocationTagsUpdateDescribe
+          - Action:
+              - sns:GetTopicAttributes
+              - sns:TagResource
+              - sns:CreateTopic
+              - sns:Subscribe
+              - sns:DeleteTopic
+              - sns:Unsubscribe
+              - sns:SetTopicAttributes
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:sns:${Region}:${AWS::AccountId}:pcluster-BudgetTopic*'
+            Sid: BudgetTriggeredSNS
 
   ### IMAGE ACTIONS POLICIES
 
@@ -744,6 +756,11 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:s3:::integ-tests-*
             Effect: Allow
+          - Action:
+              - sns:Publish
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:sns:${Region}:${AWS::AccountId}:pcluster-BudgetTopic*'
 
   ### PERMISSIONS BOUNDARY
 

--- a/tests/integration-tests/tests/budgets/test_budgets/test_update_budget_properties/budget_with_fleet_stop.yaml
+++ b/tests/integration-tests/tests/budgets/test_budgets/test_update_budget_properties/budget_with_fleet_stop.yaml
@@ -1,0 +1,44 @@
+Image:
+  Os: {{ os }}
+Tags:
+  - Key: ConfigFileTag
+    Value: ConfigFileTagValue
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
+    - Name: queue-0
+      ComputeResources:
+        - Name: compute-resource-0
+          {% if scheduler == "awsbatch" %}
+          InstanceTypes:
+            - {{ instance }}
+          MinvCpus: 4
+          DesiredvCpus: 4
+          {% else %}
+          InstanceType: {{ instance }}
+          MinCount: 1
+          {% endif %}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+DevSettings:
+  Budgets:
+    - BudgetCategory: cluster
+      BudgetLimit:
+        Amount: 85.0
+        Unit: USD
+      NotificationsWithSubscribers:
+        - Notification:
+            Threshold: 76.0
+          TriggerFleetStop: true
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: alias1@amazon.com


### PR DESCRIPTION
### Description of changes
* If specified in the configuration file, creates a lambda function subscribed to an SNS topic, which gets triggered if a budget limit is reached. This stops the compute fleet to prevent further costs.

### Testing
* Integration tests added, to make sure the fleet is stopped.
* Unit tests to verify configuration validator.
* Manual testing done by publishing messages to the sns topic (awsBatch and slurm tested).

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
