### PR TITLE
Backport fix in integration test for scontrol reboot from develop

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -451,11 +451,14 @@ def test_scontrol_reboot(
     )
 
     # Run job to allocate all nodes and test that allocated nodes can be rebooted
-    slurm_commands.submit_command(
-        command="sleep 150",
-        nodes=4,
-        slots=4,
+    job_id_1 = slurm_commands.submit_command_and_assert_job_accepted(
+        submit_command_args={
+            "command": "sleep 150",
+            "nodes": 4,
+            "slots": 4,
+        }
     )
+    slurm_commands.wait_job_running(job_id_1)
     _test_scontrol_reboot_nodes(
         remote_command_executor,
         slurm_commands,


### PR DESCRIPTION
### Description of changes
* Fix backported from https://github.com/aws/aws-parallelcluster/pull/4217

### References
* https://github.com/aws/aws-parallelcluster/pull/4217

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
