### PR TITLE
Drop Python 3.6 in batch-cli and upgrade Python runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,17 +102,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         name:
-          - Python 3.6 AWS Batch CLI Tests
           - Python 3.7 AWS Batch CLI Tests
           - Python 3.8 AWS Batch CLI Tests
           - Python 3.9 AWS Batch CLI Tests
-          - Python 3.8 AWS Batch CLI Tests Coverage
+          - Python 3.10 AWS Batch CLI Tests
+          - Python 3.10 AWS Batch CLI Tests Coverage
           - Code Checks AWS Batch CLI
         include:
-          - name: Python 3.6 AWS Batch CLI Tests
-            python: 3.6
-            toxdir: awsbatch-cli
-            toxenv: py36-nocov
           - name: Python 3.7 AWS Batch CLI Tests
             python: 3.7
             toxdir: awsbatch-cli
@@ -125,12 +121,16 @@ jobs:
             python: 3.9
             toxdir: awsbatch-cli
             toxenv: py39-nocov
-          - name: Python 3.8 AWS Batch CLI Tests Coverage
-            python: 3.8
+          - name: Python 3.10 AWS Batch CLI Tests
+            python: '3.10'
             toxdir: awsbatch-cli
-            toxenv: py38-cov
+            toxenv: py310-nocov
+          - name: Python 3.10 AWS Batch CLI Tests Coverage
+            python: '3.10'
+            toxdir: awsbatch-cli
+            toxenv: py310-cov
           - name: Code Checks AWS Batch CLI
-            python: 3.9
+            python: '3.10'
             toxdir: awsbatch-cli
             toxenv: code-linters
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
           - Python 3.7 Tests
           - Python 3.8 Tests
           - Python 3.9 Tests
-          - Python 3.8 Tests Coverage
+          - Python 3.10 Tests
+          - Python 3.10 Tests Coverage
           - Code Checks
           - CLI CloudFormation Templates Checks
           - API CloudFormation Templates Checks
@@ -59,24 +60,28 @@ jobs:
             python: 3.9
             toxdir: cli
             toxenv: py39-nocov
-          - name: Python 3.8 Tests Coverage
-            python: 3.8
+          - name: Python 3.10 Tests
+            python: '3.10'
             toxdir: cli
-            toxenv: py38-cov
+            toxenv: py310-nocov
+          - name: Python 3.10 Tests Coverage
+            python: '3.10'
+            toxdir: cli
+            toxenv: py310-cov
           - name: Code Checks
-            python: 3.9
+            python: '3.10'
             toxdir: cli
             toxenv: code-linters
           - name: CLI CloudFormation Templates Checks
-            python: 3.8
+            python: '3.10'
             toxdir: cli
             toxenv: cfn-format-check,cfn-lint,cfn-tests
           - name: API CloudFormation Templates Checks
-            python: 3.8
+            python: '3.10'
             toxdir: api
             toxenv: cfn-lint
           - name: Integration Tests Config Checks
-            python: 3.8
+            python: '3.10'
             toxdir: tests/integration-tests
             toxenv: validate-test-configs
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.x.x
+-----
+
+**CHANGES**
+- Remove support for Python 3.6 in aws-parallelcluster-batch-cli.
+
 3.2.0
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 **CHANGES**
 - Remove support for Python 3.6 in aws-parallelcluster-batch-cli.
+- Upgrade Python and NodeJS versions in API infrastructure, API Docker container and cluster Lambda resources.
 
 3.2.0
 ------

--- a/api/docker/awslambda/Dockerfile
+++ b/api/docker/awslambda/Dockerfile
@@ -1,5 +1,5 @@
 ### Stage 1: creates the wheel package from the pcluster source
-FROM public.ecr.aws/lambda/python:3.8 AS build_pcluster
+FROM public.ecr.aws/lambda/python:3.9 AS build_pcluster
 
 RUN python -m pip install --upgrade setuptools wheel pip
 COPY src ./cli/src
@@ -7,10 +7,10 @@ COPY setup.py MANIFEST.in README ./cli/
 RUN cd cli && python setup.py bdist_wheel
 
 ### Stage 2: prepares the AWS Lambda environment
-FROM public.ecr.aws/lambda/python:3.8 AS pcluster_lambda
+FROM public.ecr.aws/lambda/python:3.9 AS pcluster_lambda
 
 # Copy the node runtime
-COPY --from=public.ecr.aws/lambda/nodejs:14 /var/lang/bin/node /var/lang/bin
+COPY --from=public.ecr.aws/lambda/nodejs:16 /var/lang/bin/node /var/lang/bin
 # Copy the aws-parallelcluster wheel package
 COPY --from=build_pcluster /var/task/cli/dist/* ./dist/
 # Install aws-parallelcluster

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -1152,7 +1152,7 @@ Resources:
                     client.update_function_code(FunctionName=function_to_update, ImageUri=uri, Publish=True)
 
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.9
       Role: !GetAtt UpdateParallelClusterLambdaRole.Arn
       Environment:
         Variables:
@@ -1275,7 +1275,7 @@ Resources:
               cfnresponse.send(event, context, response_status, response_data, physical_resource_id, reason)
 
       Handler: index.handler
-      Runtime: python3.7
+      Runtime: python3.9
       Role: !GetAtt EcrImageDeletionLambdaRole.Arn
 
   EcrImageDeletionLambdaLogGroup:

--- a/awsbatch-cli/setup.py
+++ b/awsbatch-cli/setup.py
@@ -39,7 +39,7 @@ setup(
     license="Apache License 2.0",
     package_dir={"": "src"},
     packages=find_packages("src"),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=REQUIRES,
     entry_points={
         "console_scripts": [
@@ -64,7 +64,6 @@ setup(
         "Environment :: Console",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 toxworkdir=../.tox
 envlist =
-    py{36,37,38,39}-{cov,nocov}
+    py{37,38,39,310}-{cov,nocov}
     code-linters
 
 # Default testenv. Used to run tests on all python versions.

--- a/cli/src/pcluster/api/controllers/cluster_logs_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_logs_controller.py
@@ -115,7 +115,7 @@ def get_cluster_log_events(
         raise BadRequestException(f"CloudWatch logging is not enabled for cluster {cluster.name}.")
 
     log_events = cluster.get_log_events(
-        log_stream_name,
+        log_stream_name=log_stream_name,
         start_time=start_dt,
         end_time=end_dt,
         start_from_head=start_from_head,

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -762,7 +762,7 @@ class PclusterLambdaConstruct(Construct):
             handler=f"{handler_func}.handler",
             memory_size=128,
             role=execution_role,
-            runtime="python3.8",
+            runtime="python3.9",
             timeout=timeout,
         )
 

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -774,7 +774,7 @@ class ImageBuilderCdkStack(Stack):
             handler="delete_image_stack.handler",
             memory_size=128,
             role=execution_role,
-            runtime="python3.8",
+            runtime="python3.9",
             timeout=900,
             environment=lambda_env,
             tags=build_tags,

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -238,8 +238,10 @@ def run_cli(mocker, capsys):
 def assert_out_err(capsys):
     def _assert_out_err(expected_out, expected_err):
         out_err = capsys.readouterr()
+        # In Python 3.10 ArgParse renamed the 'optional arguments' section in the helper to 'option'
+        expected_out_alternative = expected_out.replace("options", "optional arguments")
         with soft_assertions():
-            assert_that(out_err.out.strip()).contains(expected_out)
+            assert_that(out_err.out.strip()).is_in(expected_out, expected_out_alternative)
             assert_that(out_err.err.strip()).contains(expected_err)
 
     return _assert_out_err

--- a/cli/tests/pcluster/api/controllers/test_cluster_logs_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_logs_controller.py
@@ -103,7 +103,6 @@ class TestGetClusterLogEvents:
 
         get_log_events_mock = mocker.patch(
             "pcluster.models.cluster.Cluster.get_log_events",
-            auto_spec=True,
             return_value=mock_log_stream,
         )
 
@@ -114,13 +113,14 @@ class TestGetClusterLogEvents:
         )
 
         expected_args = {
+            "log_stream_name": log_stream_name,
             "start_time": start_time and to_utc_datetime(start_time),
             "end_time": end_time and to_utc_datetime(end_time),
             "limit": limit,
             "start_from_head": start_from_head,
             "next_token": next_token,
         }
-        get_log_events_mock.assert_called_with(log_stream_name, **expected_args)
+        get_log_events_mock.assert_called_with(**expected_args)
 
         expected = {
             "events": [
@@ -246,7 +246,7 @@ class TestGetClusterStackEvents:
 
         validate_cluster = mocker.patch(
             "pcluster.api.controllers.cluster_logs_controller.validate_cluster",
-            auto_spec=True,
+            autospec=True,
             return_value=True,
         )
 
@@ -376,7 +376,6 @@ class TestListClusterLogStreams:
 
         mocker.patch(
             "pcluster.models.cluster.Cluster.head_node_instance",
-            auto_spec=True,
             new_callable=mocker.PropertyMock,
             return_value=MockHeadNode(),
         )

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -155,9 +155,7 @@ Scheduling:
         region,
         rollback_on_failure,
     ):
-        cluster_create_mock = mocker.patch(
-            "pcluster.models.cluster.Cluster.create", auto_spec=True, return_value=("id", errors)
-        )
+        cluster_create_mock = mocker.patch("pcluster.models.cluster.Cluster.create", return_value=("id", errors))
 
         response = self._send_test_request(
             client,
@@ -199,7 +197,7 @@ Scheduling:
 
     @pytest.mark.parametrize("errors", [([]), ([ValidationResult("message", FailureLevel.WARNING, "type")])])
     def test_dryrun(self, client, mocker, errors):
-        mocker.patch("pcluster.models.cluster.Cluster.validate_create_request", auto_spec=True, return_value=(errors))
+        mocker.patch("pcluster.models.cluster.Cluster.validate_create_request", return_value=(errors))
 
         create_cluster_request_content = {"clusterName": "cluster", "clusterConfiguration": self.CONFIG}
 
@@ -401,7 +399,7 @@ Scheduling:
         ],
     )
     def test_cluster_action_error(self, client, mocker, error_type, error_code):
-        mocker.patch("pcluster.models.cluster.Cluster.create", auto_spec=True, side_effect=error_type("error message"))
+        mocker.patch("pcluster.models.cluster.Cluster.create", autospec=True, side_effect=error_type("error message"))
 
         response = self._send_test_request(
             client,
@@ -476,7 +474,7 @@ class TestDeleteCluster:
     )
     def test_successful_request(self, mocker, client, cfn_stack_data, expected_response):
         mocker.patch("pcluster.aws.cfn.CfnClient.describe_stack", return_value=cfn_stack_data)
-        cluster_delete_mock = mocker.patch("pcluster.models.cluster.Cluster.delete", auto_spec=True)
+        cluster_delete_mock = mocker.patch("pcluster.models.cluster.Cluster.delete")
         response = self._send_test_request(client)
 
         with soft_assertions():
@@ -547,7 +545,7 @@ class TestDeleteCluster:
     )
     def test_cluster_action_error(self, client, mocker, error_type, error_code):
         mocker.patch("pcluster.aws.cfn.CfnClient.describe_stack", return_value=cfn_describe_stack_mock_response())
-        mocker.patch("pcluster.models.cluster.Cluster.delete", auto_spec=True, side_effect=error_type("error message"))
+        mocker.patch("pcluster.models.cluster.Cluster.delete", autospec=True, side_effect=error_type("error message"))
 
         response = self._send_test_request(client)
 
@@ -1200,9 +1198,7 @@ class TestUpdateCluster:
         ]
         stack_data = cfn_describe_stack_mock_response()
         mocker.patch("pcluster.aws.cfn.CfnClient.describe_stack", return_value=stack_data)
-        cluster_update_mock = mocker.patch(
-            "pcluster.models.cluster.Cluster.update", auto_spec=True, return_value=(change_set, errors)
-        )
+        cluster_update_mock = mocker.patch("pcluster.models.cluster.Cluster.update", return_value=(change_set, errors))
 
         response = self._send_test_request(
             client,
@@ -1265,7 +1261,7 @@ class TestUpdateCluster:
         ]
         mocker.patch(
             "pcluster.models.cluster.Cluster.validate_update_request",
-            auto_spec=True,
+            autospec=True,
             return_value=(None, changes, errors),
         )
 
@@ -1683,7 +1679,7 @@ class TestUpdateCluster:
         else:
             error = error_type("error message")
 
-        mocker.patch("pcluster.models.cluster.Cluster.update", auto_spec=True, side_effect=error)
+        mocker.patch("pcluster.models.cluster.Cluster.update", autospec=True, side_effect=error)
 
         response = self._send_test_request(
             client, update_cluster_request_content={"clusterConfiguration": self.CONFIG}, cluster_name="clusterName"

--- a/cli/tests/pcluster/api/controllers/test_image_logs_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_logs_controller.py
@@ -103,7 +103,6 @@ class TestGetImageLogEvents:
 
         get_log_events_mock = mocker.patch(
             "pcluster.models.imagebuilder.ImageBuilder.get_log_events",
-            auto_spec=True,
             return_value=mock_log_stream,
         )
 
@@ -172,7 +171,7 @@ class TestGetImageLogEvents:
         err_msg = "The specified %s doesn't exist." % ("log stream" if image_exists else "log group")
         mocker.patch(
             "pcluster.aws.logs.LogsClient.get_log_events",
-            auto_spec=True,
+            autospec=True,
             side_effect=AWSClientError("get_log_events", err_msg, 404),
         )
         response = self._send_test_request(client, "image", "logstream", "us-east-2", None, None, None, None, None)
@@ -403,7 +402,7 @@ class TestListImageLogStreams:
         mock_image_stack(image_id="image", stack_exists=image_stack_found)
         mocker.patch(
             "pcluster.models.imagebuilder.ImageBuilder.get_log_events",
-            auto_spec=True,
+            autospec=True,
             side_effect=AWSClientError("get_log_events", err_msg, 404),
         )
         response = self._send_test_request(client, "image", "us-east-1", None)

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -508,7 +508,6 @@ class TestBuildImage:
     ):
         mocked_call = mocker.patch(
             "pcluster.models.imagebuilder.ImageBuilder.create",
-            auto_spec=True,
             return_value=suppressed_validation_errors,
         )
         mocker.patch(

--- a/cli/tests/pcluster/cli/test_build_image/TestBuildImageCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_build_image/TestBuildImageCommand/test_helper/pcluster-help.txt
@@ -8,7 +8,7 @@ usage: pcluster build-image [-h]
 
 Create a custom ParallelCluster image in a given region.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --suppress-validators SUPPRESS_VALIDATORS [SUPPRESS_VALIDATORS ...]
                         Identifies one or more config validators to suppress.

--- a/cli/tests/pcluster/cli/test_configure/TestConfigureCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_configure/TestConfigureCommand/test_helper/pcluster-help.txt
@@ -2,7 +2,7 @@ usage: pcluster configure [-h] [--debug] [-r REGION] -c CONFIG
 
 Start the AWS ParallelCluster configuration.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
   -r REGION, --region REGION

--- a/cli/tests/pcluster/cli/test_create_cluster/TestCreateClusterCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_create_cluster/TestCreateClusterCommand/test_helper/pcluster-help.txt
@@ -8,7 +8,7 @@ usage: pcluster create-cluster [-h] [-r REGION]
 
 Create a managed cluster in a given region.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -r REGION, --region REGION
                         AWS Region that the operation corresponds to.

--- a/cli/tests/pcluster/cli/test_dcv_connect/TestDcvConnectCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_dcv_connect/TestDcvConnectCommand/test_helper/pcluster-help.txt
@@ -4,7 +4,7 @@ usage: pcluster dcv-connect [-h] [--debug] [-r REGION] -n CLUSTER_NAME
 Permits to connect to the head node through an interactive session by using
 NICE DCV.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
   -r REGION, --region REGION

--- a/cli/tests/pcluster/cli/test_delete_cluster/TestDeleteClusterCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_delete_cluster/TestDeleteClusterCommand/test_helper/pcluster-help.txt
@@ -3,7 +3,7 @@ usage: pcluster delete-cluster [-h] -n CLUSTER_NAME [-r REGION] [--debug]
 
 Initiate the deletion of a cluster.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster

--- a/cli/tests/pcluster/cli/test_delete_cluster_instances/TestDeleteClusterInstancesCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_delete_cluster_instances/TestDeleteClusterInstancesCommand/test_helper/pcluster-help.txt
@@ -5,7 +5,7 @@ usage: pcluster delete-cluster-instances [-h] -n CLUSTER_NAME [-r REGION]
 Initiate the forced termination of all cluster compute nodes. Does not work
 with AWS Batch clusters.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster

--- a/cli/tests/pcluster/cli/test_delete_image/TestDeleteImageCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_delete_image/TestDeleteImageCommand/test_helper/pcluster-help.txt
@@ -3,7 +3,7 @@ usage: pcluster delete-image [-h] -i IMAGE_ID [-r REGION] [--force FORCE]
 
 Initiate the deletion of the custom ParallelCluster image.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -i IMAGE_ID, --image-id IMAGE_ID
                         Id of the image.

--- a/cli/tests/pcluster/cli/test_describe_cluster/TestDescribeClusterCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_describe_cluster/TestDescribeClusterCommand/test_helper/pcluster-help.txt
@@ -3,7 +3,7 @@ usage: pcluster describe-cluster [-h] -n CLUSTER_NAME [-r REGION] [--debug]
 
 Get detailed information about an existing cluster.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster

--- a/cli/tests/pcluster/cli/test_describe_cluster_instances/TestDescribeClusterInstancesCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_describe_cluster_instances/TestDescribeClusterInstancesCommand/test_helper/pcluster-help.txt
@@ -6,7 +6,7 @@ usage: pcluster describe-cluster-instances [-h] -n CLUSTER_NAME [-r REGION]
 
 Describe the instances belonging to a given cluster.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster

--- a/cli/tests/pcluster/cli/test_describe_compute_fleet/TestDescribeComputeFleetCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_describe_compute_fleet/TestDescribeComputeFleetCommand/test_helper/pcluster-help.txt
@@ -3,7 +3,7 @@ usage: pcluster describe-compute-fleet [-h] -n CLUSTER_NAME [-r REGION]
 
 Describe the status of the compute fleet.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster

--- a/cli/tests/pcluster/cli/test_describe_image/TestDescribeImageCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_describe_image/TestDescribeImageCommand/test_helper/pcluster-help.txt
@@ -3,7 +3,7 @@ usage: pcluster describe-image [-h] -i IMAGE_ID [-r REGION] [--debug]
 
 Get detailed information about an existing image.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -i IMAGE_ID, --image-id IMAGE_ID
                         Id of the image.

--- a/cli/tests/pcluster/cli/test_entrypoint/TestParallelClusterCli/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_entrypoint/TestParallelClusterCli/test_helper/pcluster-help.txt
@@ -5,7 +5,7 @@ usage: pcluster [-h]
 pcluster is the AWS ParallelCluster CLI and permits launching and management
 of HPC clusters in the AWS cloud.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
 
 COMMANDS:

--- a/cli/tests/pcluster/cli/test_export_cluster_logs/TestExportClusterLogsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_export_cluster_logs/TestExportClusterLogsCommand/test_helper/pcluster-help.txt
@@ -10,7 +10,7 @@ usage: pcluster export-cluster-logs [-h] [--debug] [-r REGION] -n CLUSTER_NAME
 Export the logs of the cluster to a local tar.gz archive by passing through an
 Amazon S3 Bucket.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
   -r REGION, --region REGION

--- a/cli/tests/pcluster/cli/test_export_image_logs/TestExportImageLogsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_export_image_logs/TestExportImageLogsCommand/test_helper/pcluster-help.txt
@@ -9,7 +9,7 @@ usage: pcluster export-image-logs [-h] [--debug] [-r REGION]
 Export the logs of the image builder stack to a local tar.gz archive by
 passing through an Amazon S3 Bucket.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
   -r REGION, --region REGION

--- a/cli/tests/pcluster/cli/test_get_cluster_log_events.py
+++ b/cli/tests/pcluster/cli/test_get_cluster_log_events.py
@@ -135,13 +135,14 @@ class TestGetClusterLogEventsCommand:
 
         # verify arguments
         kwargs = {
+            "log_stream_name": "log-stream-name",
             "start_time": args.get("start_time", None) and to_utc_datetime(args["start_time"]),
             "end_time": args.get("end_time", None) and to_utc_datetime(args["end_time"]),
             "start_from_head": True if args.get("start_from_head", None) else None,
             "limit": int(args["limit"]) if args.get("limit", None) else None,
             "next_token": args.get("next_token", None),
         }
-        get_cluster_log_events_mock.assert_called_with("log-stream-name", **kwargs)
+        get_cluster_log_events_mock.assert_called_with(**kwargs)
 
     @staticmethod
     def _build_cli_args(args):

--- a/cli/tests/pcluster/cli/test_get_cluster_log_events/TestGetClusterLogEventsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_get_cluster_log_events/TestGetClusterLogEventsCommand/test_helper/pcluster-help.txt
@@ -9,7 +9,7 @@ usage: pcluster get-cluster-log-events [-h] -n CLUSTER_NAME --log-stream-name
 
 Retrieve the events associated with a log stream.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster

--- a/cli/tests/pcluster/cli/test_get_cluster_stack_events/TestGetClusterStackEventsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_get_cluster_stack_events/TestGetClusterStackEventsCommand/test_helper/pcluster-help.txt
@@ -4,7 +4,7 @@ usage: pcluster get-cluster-stack-events [-h] -n CLUSTER_NAME [-r REGION]
 
 Retrieve the events associated with the stack for a given cluster.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster

--- a/cli/tests/pcluster/cli/test_get_image_log_events/TestGetImageLogEventsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_get_image_log_events/TestGetImageLogEventsCommand/test_helper/pcluster-help.txt
@@ -8,7 +8,7 @@ usage: pcluster get-image-log-events [-h] -i IMAGE_ID --log-stream-name
 
 Retrieve the events associated with an image build.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -i IMAGE_ID, --image-id IMAGE_ID
                         Id of the image.

--- a/cli/tests/pcluster/cli/test_get_image_stack_events/TestGetImageStackEventsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_get_image_stack_events/TestGetImageStackEventsCommand/test_helper/pcluster-help.txt
@@ -4,7 +4,7 @@ usage: pcluster get-image-stack-events [-h] -i IMAGE_ID [-r REGION]
 
 Retrieve the events associated with the stack for a given image build.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -i IMAGE_ID, --image-id IMAGE_ID
                         Id of the image.

--- a/cli/tests/pcluster/cli/test_list_cluster_log_streams/TestListClusterLogStreamsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_list_cluster_log_streams/TestListClusterLogStreamsCommand/test_helper/pcluster-help.txt
@@ -5,7 +5,7 @@ usage: pcluster list-cluster-log-streams [-h] -n CLUSTER_NAME [-r REGION]
 
 Retrieve the list of log streams associated with a cluster.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster

--- a/cli/tests/pcluster/cli/test_list_cluster_logs/TestListClusterLogsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_list_cluster_logs/TestListClusterLogsCommand/test_helper/pcluster-help.txt
@@ -9,7 +9,7 @@ List the log streams associated to a cluster.
 positional arguments:
   cluster_name          List the logs of the cluster name provided here.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
   -r {af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-south-1,ap-southeast-1,ap-southeast-2,ca-central-1,cn-north-1,cn-northwest-1,eu-central-1,eu-north-1,eu-south-1,eu-west-1,eu-west-2,eu-west-3,me-south-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-1,us-west-2}, --region {af-south-1,ap-east-1,ap-northeast-1,ap-northeast-2,ap-south-1,ap-southeast-1,ap-southeast-2,ca-central-1,cn-north-1,cn-northwest-1,eu-central-1,eu-north-1,eu-south-1,eu-west-1,eu-west-2,eu-west-3,me-south-1,sa-east-1,us-east-1,us-east-2,us-gov-east-1,us-gov-west-1,us-west-1,us-west-2}

--- a/cli/tests/pcluster/cli/test_list_clusters/TestListClustersCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_list_clusters/TestListClustersCommand/test_helper/pcluster-help.txt
@@ -4,7 +4,7 @@ usage: pcluster list-clusters [-h] [-r REGION] [--next-token NEXT_TOKEN]
 
 Retrieve the list of existing clusters.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -r REGION, --region REGION
                         List clusters deployed to a given AWS Region.

--- a/cli/tests/pcluster/cli/test_list_image_log_streams/TestListImageLogStreamsCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_list_image_log_streams/TestListImageLogStreamsCommand/test_helper/pcluster-help.txt
@@ -4,7 +4,7 @@ usage: pcluster list-image-log-streams [-h] -i IMAGE_ID [-r REGION]
 
 Retrieve the list of log streams associated with an image.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -i IMAGE_ID, --image-id IMAGE_ID
                         Id of the image.

--- a/cli/tests/pcluster/cli/test_list_images/TestListImagesCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_list_images/TestListImagesCommand/test_helper/pcluster-help.txt
@@ -4,7 +4,7 @@ usage: pcluster list-images [-h] [-r REGION] [--next-token NEXT_TOKEN]
 
 Retrieve the list of existing custom images.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -r REGION, --region REGION
                         List images built in a given AWS Region.

--- a/cli/tests/pcluster/cli/test_list_official_images/TestListOfficialImagesCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_list_official_images/TestListOfficialImagesCommand/test_helper/pcluster-help.txt
@@ -4,7 +4,7 @@ usage: pcluster list-official-images [-h] [-r REGION] [--os OS]
 
 List Official ParallelCluster AMIs.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -r REGION, --region REGION
                         AWS Region that the operation corresponds to.

--- a/cli/tests/pcluster/cli/test_ssh/TestSshCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_ssh/TestSshCommand/test_helper/pcluster-help.txt
@@ -3,7 +3,7 @@ usage: pcluster ssh [-h] [--debug] [-r REGION] -n CLUSTER_NAME
 
 Run ssh command with the cluster username and IP address pre-populated. Arbitrary arguments are appended to the end of the ssh command.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --debug               Turn on debug logging.
   -r REGION, --region REGION

--- a/cli/tests/pcluster/cli/test_update_cluster/TestUpdateClusterCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_update_cluster/TestUpdateClusterCommand/test_helper/pcluster-help.txt
@@ -7,7 +7,7 @@ usage: pcluster update-cluster [-h] -n CLUSTER_NAME
 
 Update a cluster managed in a given region.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster

--- a/cli/tests/pcluster/cli/test_update_compute_fleet/TestUpdateComputeFleetCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_update_compute_fleet/TestUpdateComputeFleetCommand/test_helper/pcluster-help.txt
@@ -4,7 +4,7 @@ usage: pcluster update-compute-fleet [-h] -n CLUSTER_NAME [-r REGION] --status
 
 Update the status of the cluster compute fleet.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -n CLUSTER_NAME, --cluster-name CLUSTER_NAME
                         Name of the cluster

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 toxworkdir=../.tox
 envlist =
-    py{36,37,38,39,310}-{cov,nocov}
+    py{37,38,39,310}-{cov,nocov}
     code-linters
     cfn-{tests,lint,format-check}
 

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 toxworkdir=../.tox
 envlist =
-    py{36,37,38,39}-{cov,nocov}
+    py{36,37,38,39,310}-{cov,nocov}
     code-linters
     cfn-{tests,lint,format-check}
 


### PR DESCRIPTION
### Description of changes
* Add tests for Python 3.10 in aws-parallelcluster package
* move support for Python 3.6 and add Python 3.10 tests in aws-paralelcluster-batch-cli
* Bump Python and nodejs versions in API Dockerfile and infra template
* Bump Python version for Lambda functions in cluster templates

### Tests
* Unit tests
* Locally built API docker container

### References
* https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
