### PR TITLE
Disable awsbatch integration tests

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -39,10 +39,11 @@ cloudwatch_logging:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: {{ common.SCHEDULERS_TRAD }}
-      - regions: ["us-gov-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda 
+#      - regions: ["us-gov-east-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
       # 2) run the test for all x86 OSes with slurm
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -66,10 +67,11 @@ configure:
         schedulers: ["slurm"]
       # Do not run on ARM + Batch
       # pcluster configure always picks optimal and Batch does not support ARM for optimal for now
-      - regions: ["us-gov-west-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda       
+#      - regions: ["us-gov-west-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
   test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
     dimensions:
       - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
@@ -145,15 +147,16 @@ dcv:
         {{- common.OSS_COMMERCIAL_ARM.append("ubuntu2004") or "" }}
         schedulers: ["slurm"]
       # DCV on Batch
-      - regions: ["us-east-1"]
-        instances: ["g4dn.2xlarge"]
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
-      # DCV on Batch + ARM
-      - regions: ["us-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+#      - regions: ["us-east-1"]
+#        instances: ["g4dn.2xlarge"]
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
+#      # DCV on Batch + ARM
+#      - regions: ["us-east-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
       # DCV in cn regions and non GPU enabled instance
       - regions: ["cn-northwest-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -239,11 +242,11 @@ iam:
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "awsbatch"]
+        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
   test_iam.py::test_iam_roles:
     dimensions:
       - regions: ["us-east-2"]
-        schedulers: ["awsbatch", "slurm"]
+        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
         oss: ["alinux2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
   test_iam.py::test_s3_read_write_resource:
@@ -251,7 +254,7 @@ iam:
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "awsbatch"]
+        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
 intel_hpc:
   test_intel_hpc.py::test_intel_hpc:
     dimensions:
@@ -281,27 +284,30 @@ networking:
       - regions: ["ap-northeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "awsbatch"]
+        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+
   test_security_groups.py::test_additional_sg_and_ssh_from:
     dimensions:
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
-      - regions: ["eu-north-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda        
+#      - regions: ["eu-north-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
   test_security_groups.py::test_overwrite_sg:
     dimensions:
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
-      - regions: ["eu-north-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda   
+#      - regions: ["eu-north-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
   test_placement_group.py::test_existing_placement_group_in_cluster:
     dimensions:
       - regions: ["af-south-1"]
@@ -338,20 +344,21 @@ scaling:
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
 schedulers:
-  test_awsbatch.py::test_awsbatch:
-    dimensions:
-      - regions: ["eu-north-1", "us-gov-west-1", "cn-north-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
-      - regions: ["ap-southeast-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
-      - regions: ["ap-northeast-1"]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda   
+#  test_awsbatch.py::test_awsbatch:
+#    dimensions:
+#      - regions: ["eu-north-1", "us-gov-west-1", "cn-north-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
+#      - regions: ["ap-southeast-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
+#      - regions: ["ap-northeast-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
   test_slurm.py::test_slurm:
     dimensions:
       - regions: ["us-east-2"]
@@ -437,7 +444,7 @@ storage:
       - regions: ["us-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "awsbatch"]
+        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
   test_efs.py::test_efs_same_az:
     dimensions:
       - regions: ["ap-northeast-1"]
@@ -448,16 +455,17 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_CHINA_X86 }}
         schedulers: ["slurm"]
-      - regions: ["ap-northeast-1", "cn-north-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_BATCH }}
-        schedulers: ["awsbatch"]
-  test_efs.py::test_existing_efs:
-    dimensions:
-      - regions: ["ap-northeast-2"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+#      - regions: ["ap-northeast-1", "cn-north-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: {{ common.OSS_BATCH }}
+#        schedulers: ["awsbatch"]
+#  test_efs.py::test_existing_efs:
+#    dimensions:
+#      - regions: ["ap-northeast-2"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
       - regions: ["ap-northeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
@@ -478,10 +486,11 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_GOVCLOUD_X86 }}
         schedulers: ["slurm"]
-      - regions: ["ap-south-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_BATCH }}
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+#      - regions: ["ap-south-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: {{ common.OSS_BATCH }}
+#        schedulers: ["awsbatch"]
   test_ebs.py::test_default_ebs:
     dimensions:
       - regions: ["cn-northwest-1"]
@@ -490,10 +499,11 @@ storage:
         schedulers: ["slurm"]
   test_ebs.py::test_ebs_multiple:
     dimensions:
-      - regions: ["eu-west-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+#      - regions: ["eu-west-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
       - regions: ["eu-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"]
@@ -534,13 +544,14 @@ tags:
       - regions: ["ap-southeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "awsbatch"]
+        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
 update:
-  test_update.py::test_update_awsbatch:
-    dimensions:
-      - regions: ["eu-south-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+#  test_update.py::test_update_awsbatch:
+#    dimensions:
+#      - regions: ["eu-south-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
   test_update.py::test_update_slurm:
     dimensions:
       - regions: ["eu-west-1"]
@@ -552,4 +563,4 @@ resource_bucket:
       - regions: ["ap-southeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "awsbatch"]
+        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda


### PR DESCRIPTION
### Description of changes
* Awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
