### PR TITLE
[2.x]Upgrade Python runtime used by Lambda functions in AWS Batch integration to python3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.x.x
+-----
+**CHANGES**
+Upgrade Python runtime used by Lambda functions in AWS Batch integration to python3.9.
+
 2.11.7
 -----
 

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -866,7 +866,7 @@
             }
           ]
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Timeout": 60
       }
     },
@@ -1026,7 +1026,7 @@
             }
           ]
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Timeout": 60
       },
       "DependsOn": "DockerBuildWaitHandle"


### PR DESCRIPTION
### Description of changes
* Upgrade Python runtime used by Lambda functions in AWS Batch integration to python3.9

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
