### PR TITLE
Cherry-pick: fix issue in integration test for scontrol reboot

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -451,11 +451,14 @@ def test_scontrol_reboot(
     )
 
     # Run job to allocate all nodes and test that allocated nodes can be rebooted
-    slurm_commands.submit_command(
-        command="sleep 150",
-        nodes=4,
-        slots=4,
+    job_id_1 = slurm_commands.submit_command_and_assert_job_accepted(
+        submit_command_args={
+            "command": "sleep 150",
+            "nodes": 4,
+            "slots": 4,
+        }
     )
+    slurm_commands.wait_job_running(job_id_1)
     _test_scontrol_reboot_nodes(
         remote_command_executor,
         slurm_commands,


### PR DESCRIPTION
Wait for job to start before asserting that nodes are in allocated state

Signed-off-by: Jacopo De Amicis <jdamicis@amazon.it>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
