### PR TITLE
Fix budget cost filtering

### DIFF
--- a/cli/src/pcluster/templates/budget_builder.py
+++ b/cli/src/pcluster/templates/budget_builder.py
@@ -48,7 +48,14 @@ class CostBudgets:
                 else (
                     {"TagKeyValue": [f"user:parallelcluster:cluster-name${self.cluster_config.cluster_name}"]}
                     if budget.budget_category == "cluster"
-                    else ({"TagKeyValue": [f"user:parallelcluster:queue-name${budget.queue_name}"]})
+                    else (
+                        {
+                            "TagKeyValue": [
+                                f"user:parallelcluster:queue-name${budget.queue_name}",
+                                f"user:parallelcluster:cluster-name${self.cluster_config.cluster_name}",
+                            ]
+                        }
+                    )
                 )
             ),
         )


### PR DESCRIPTION

### Description of changes
* Includes the cluster name in the cost filter for queue budgets, to guarantee that costs from other clusters' queues with the same same don't get included.

### Tests
* Manually verified created budget filters on the budget console.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
