### PR TITLE
Print last hundreds lines of log to console when build image integration test fails

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -430,6 +430,7 @@ def _test_build_image_success(image):
         logging.info(pcluster_describe_image_result)
     if image.image_status != "BUILD_COMPLETE":
         image.keep_logs = True
+        _keep_recent_logs(image)
     assert_that(image.image_status).is_equal_to("BUILD_COMPLETE")
 
 
@@ -480,5 +481,12 @@ def _test_build_image_failed(image):
 
     if image.image_status == "BUILD_FAILED":
         image.keep_logs = True
-
+        _keep_recent_logs(image)
     assert_that(image.image_status).is_equal_to("BUILD_FAILED")
+
+
+def _keep_recent_logs(image):
+    """Keep several lines of recent log to the console when creating an image fails."""
+    log_stream_name = f"{get_installed_parallelcluster_base_version()}/1"
+    failure_logs = image.get_log_events(log_stream_name, start_from_head=True, query="events[*].message", limit=100)
+    logging.info(f"Image built failed for {image.image_id}, the last 100 lines of the log are: {failure_logs}")


### PR DESCRIPTION
### Description of changes
* Print last hundreds lines of log to console when build image integration test fails

### Tests
* Manually test with making test_build_image fail, the error message is:
```
2022-08-02 11:58:01,165 - INFO - 55261 - test_build_image[us-east-1-c5.xlarge-centos7] - utils - Executing command: pcluster get-image-log-events --image-id integ-tests-build-image-smpw88436okp4psh --region us-east-1 --log-stream-name 3.2.0/1 --start-from-head True --query events[*].message --limit 100
2022-08-02 11:58:04,310 - INFO - 55261 - test_build_image[us-east-1-c5.xlarge-centos7] - credential_providers - Restoring credentials {'AWS_ACCESS_KEY_ID': None, 'AWS_SECRET_ACCESS_KEY': None, 'AWS_SESSION_TOKEN': None, 'AWS_PROFILE': None}
2022-08-02 11:58:04,325 - INFO - 55261 - test_build_image[us-east-1-c5.xlarge-centos7] - test_createami - Image built failed for integ-tests-build-image-smpw88436okp4psh, the last 100 lines of the log are: ['Setup: Currently validating document arn:aws:imagebuilder:us-east-1:...:component/parallelclusterimage-c28fada0-1290-11ed-852a-121a417afed9/3.2.0/1', 'Setup: Currently validating document arn:aws:imagebuilder:us-east-1:..:component/parallelclusterimage-tag-c28fada0-1290-11ed-852a-121a417afed9/3.2.0/1', 'Executor: STARTED EXECUTION OF ALL DOCUMENTS', 'Document arn:aws:imagebuilder:us-east-1:..:component/parallelclusterimage-c28fada0-1290-11ed-852a-121a417afed9/3.2.0/1', 'Phase build', 'Step AWSRegion', 'ExecuteBash: STARTED EXECUTION', 'Stdout: us-east-1', 'Stderr: echo us-east-1\n\n', 'CmdExecution: Command execution has been completed', 'CmdExecution: Command execution was completed successfully', 'CmdExecution: Stderr: echo us-east-1\n\n', 'CmdExecution: ExitCode 0', 'ExecuteBash: FINISHED EXECUTION', 'Step PClusterCookbookVersionName', 'ExecuteBash: STARTED EXECUTION', 'Stdout: aws-parallelcluster-cookbook-3.2.0b2', 'Stderr: echo "aws-parallelcluster-cookbook-3.2.0b2"\n\n', 'CmdExecution: Command execution has been completed', 'CmdExecution: Command execution was completed successfully', 'CmdExecution: Stderr: echo "aws-parallelcluster-cookbook-3.2.0b2"\n\n', 'CmdExecution: ExitCode 0', 'ExecuteBash: FINISHED EXECUTION', 'Step CookbookUrl', 'ExecuteBash: STARTED EXECUTION', 'Stdout: https://us-east-1-aws-parallelcluster.s3.us-east-1.amazonaws.com/parallelcluster/3.2.0b2/cookbooks/aws-parallelcluster-cookbook-3.2.0b2.tgz', 'Stderr: COOKBOOK_URL="https://us-east-1-aws-parallelcluster.s3.us-east-1.amazonaws.com/parallelcluster/3.2.0b2/cookbooks/aws-parallelcluster-cookbook-3.2.0b2.tgz"\n[ -n "" ] && COOKBOOK_URL=""\necho "${COOKBOOK_URL}"\n\n', 'CmdExecution: Command execution has been completed', 'CmdExecution: Command execution was completed successfully', 'CmdExecution: Stderr: COOKBOOK_URL="https://us-east-1-aws-parallelcluster.s3.us-east-1.amazonaws.com/parallelcluster/3.2.0b2/cookbooks/aws-parallelcluster-cookbook-3.2.0b2.tgz"\n[ -n "" ] && COOKBOOK_URL=""\necho "${COOKBOOK_URL}"\n\n', 'CmdExecution: ExitCode 0', 'ExecuteBash: FINISHED EXECUTION', 'Step CincUrl', 'ExecuteBash: STARTED EXECUTION', 'Stdout: https://us-east-1-aws-parallelcluster.s3.us-east-1.amazonaws.com/archives/cinc/cinc-install-1.1.0.sh', 'Stderr: CINC_URL="https://us-east-1-aws-parallelcluster.s3.us-east-1.amazonaws.com/archives/cinc/cinc-install-1.1.0.sh"\n[ -n "" ] && CINC_URL=""\necho "${CINC_URL}"\n\n', 'CmdExecution: Command execution has been completed', 'CmdExecution: Command execution was completed successfully', 'CmdExecution: Stderr: CINC_URL="https://us-east-1-aws-parallelcluster.s3.us-east-1.amazonaws.com/archives/cinc/cinc-install-1.1.0.sh"\n[ -n "" ] && CINC_URL=""\necho "${CINC_URL}"\n\n', 'CmdExecution: ExitCode 0', 'ExecuteBash: FINISHED EXECUTION', 'Step OperatingSystemRelease', 'ExecuteBash: STARTED EXECUTION', 'Stdout: centos.7', 'Stderr: FILE=/etc/os-release\nif [ -e ${FILE} ]; then\n  . ${FILE}\n  echo "${ID}${VERSION_ID:+.${VERSION_ID}}"\nelse\n  echo "The file \'${FILE}\' does not exist. Failing build."\n  exit 1\nfi\nNAME="CentOS Linux"\nVERSION="7 (Core)"\nID="centos"\nID_LIKE="rhel fedora"\nVERSION_ID="7"\nPRETTY_NAME="CentOS Linux 7 (Core)"\nANSI_COLOR="0;31"\nCPE_NAME="cpe:/o:centos:centos:7"\nHOME_URL="https://www.centos.org/"\nBUG_REPORT_URL="https://bugs.centos.org/"\n\nCENTOS_MANTISBT_PROJECT="CentOS-7"\nCENTOS_MANTISBT_PROJECT_VERSION="7"\nREDHAT_SUPPORT_PRODUCT="centos"\nREDHAT_SUPPORT_PRODUCT_VERSION="7"\n\n\n', 'CmdExecution: Command execution has been completed', 'CmdExecution: Command execution was completed successfully', 'CmdExecution: Stderr: FILE=/etc/os-release\nif [ -e ${FILE} ]; then\n  . ${FILE}\n  echo "${ID}${VERSION_ID:+.${VERSION_ID}}"\nelse\n  echo "The file \'${FILE}\' does not exist. Failing build."\n  exit 1\nfi\nNAME="CentOS Linux"\nVERSION="7 (Core)"\nID="centos"\nID_LIKE="rhel fedora"\nVERSION_ID="7"\nPRETTY_NAME="CentOS Linux 7 (Core)"\nANSI_COLOR="0;31"\nCPE_NAME="cpe:/o:centos:centos:7"\nHOME_URL="https://www.centos.org/"\nBUG_REPORT_URL="https://bugs.centos.org/"\n\nCENTOS_MANTISBT_PROJECT="CentOS-7"\nCENTOS_MANTISBT_PROJECT_VERSION="7"\nREDHAT_SUPPORT_PRODUCT="centos"\nREDHAT_SUPPORT_PRODUCT_VERSION="7"\n\n\n', 'CmdExecution: ExitCode 0', 'ExecuteBash: FINISHED EXECUTION', 'Step OperatingSystemName', 'ExecuteBash: STARTED EXECUTION', 'Stdout: centos7', 'Stderr: RELEASE=\'centos.7\'\n\nif [ `echo "${RELEASE}" | grep -w \'^amzn\\.2\'` ]; then\n  OS=\'alinux2\'\nelif [ `echo "${RELEASE}" | grep \'^centos\\.7\'` ]; then\n  OS=\'centos7\'\nelif [ `echo "${RELEASE}" | grep \'^ubuntu\\.18\'` ]; then\n  OS=\'ubuntu1804\'\nelif [ `echo "${RELEASE}" | grep \'^ubuntu\\.20\'` ]; then\n  OS=\'ubuntu2004\'\nelse\n  echo "Operating System \'${RELEASE}\' is not supported. Failing build."\n  exit 1\nfi\necho "${RELEASE}" | grep -w \'^amzn\\.2\'\necho "${RELEASE}" | grep \'^centos\\.7\'\n\necho ${OS}\n\n', 'CmdExecution: Command execution has been completed', 'CmdExecution: Command execution was completed successfully', 'CmdExecution: Stderr: RELEASE=\'centos.7\'\n\nif [ `echo "${RELEASE}" | grep -w \'^amzn\\.2\'` ]; then\n  OS=\'alinux2\'\nelif [ `echo "${RELEASE}" | grep \'^centos\\.7\'` ]; then\n  OS=\'centos7\'\nelif [ `echo "${RELEASE}" | grep \'^ubuntu\\.18\'` ]; then\n  OS=\'ubuntu1804\'\nelif [ `echo "${RELEASE}" | grep \'^ubuntu\\.20\'` ]; then\n  OS=\'ubuntu2004\'\nelse\n  echo "Operating System \'${RELEASE}\' is not supported. Failing build."\n  exit 1\nfi\necho "${RELEASE}" | grep -w \'^amzn\\.2\'\necho "${RELEASE}" | grep \'^centos\\.7\'\n\necho ${OS}\n\n', 'CmdExecution: ExitCode 0', 'ExecuteBash: FINISHED EXECUTION', 'Step PlatformName', 'ExecuteBash: STARTED EXECUTION', 'Stdout: RHEL', 'Stderr: OS=\'centos7\'\n\nif [ `echo "${OS}" | grep -E \'^(alinux|centos)\'` ]; then\n  PLATFORM=\'RHEL\'\nelif [ `echo "${OS}" | grep -E \'^ubuntu\'` ]; then\n  PLATFORM=\'DEBIAN\'\nfi\necho "${OS}" | grep -E \'^(alinux|centos)\'\n\necho ${PLATFORM}\n\n', 'CmdExecution: Command execution has been completed', 'CmdExecution: Command execution was completed successfully', 'CmdExecution: Stderr: OS=\'centos7\'\n\nif [ `echo "${OS}" | grep -E \'^(alinux|centos)\'` ]; then\n  PLATFORM=\'RHEL\'\nelif [ `echo "${OS}" | grep -E \'^ubuntu\'` ]; then\n  PLATFORM=\'DEBIAN\'\nfi\necho "${OS}" | grep -E \'^(alinux|centos)\'\n\necho ${PLATFORM}\n\n', 'CmdExecution: ExitCode 0', 'ExecuteBash: FINISHED EXECUTION', 'Step OperatingSystemArchitecture', 'ExecuteBash: STARTED EXECUTION', 'Stdout: x86_64', 'Stderr: ARCH=$(uname -m)\ncase ${ARCH} in\n  \'x86_64\')\n    echo \'x86_64\'\n    ;;\n  \'aarch64\')\n    echo \'arm64\'\n    ;;\n  *)\n    echo "The \'${ARCH}\' architecture is not supported. Failing build."\n    exit 1\n    ;;\nesac\n\n', 'CmdExecution: Command execution has been completed', 'CmdExecution: Command execution was completed successfully', 'CmdExecution: Stderr: ARCH=$(uname -m)\ncase ${ARCH} in\n  \'x86_64\')\n    echo \'x86_64\'\n    ;;\n  \'aarch64\')\n    echo \'arm64\'\n    ;;\n  *)\n    echo "The \'${ARCH}\' architecture is not supported. Failing build."\n    exit 1\n    ;;\nesac\n\n', 'CmdExecution: ExitCode 0', 'ExecuteBash: FINISHED EXECUTION', 'Step IsOperatingSystemSupported', 'ExecuteBash: STARTED EXECUTION', 'Stderr: if [ false == false ]; then\n  RELEASE=\'centos.7\'\n  if [ `echo "${RELEASE}" | grep -Ev \'^(amzn|centos|ubuntu)\'` ]; then\n    echo "This component does not support \'${RELEASE}\'. Failing build."\n    exit 1\n  fi\n\n  # This component only supports aarch64 CPUs on Amazon Linux 2, Ubuntu1804, Ubuntu2004 and Centos7\n  ARCH=$(uname -m)\n  if [[ `echo ${ARCH}` == \'aarch64\' ]]; then\n    if [ `echo "${RELEASE}" | grep -Ev \'^(amzn\\.2|centos\\.7|ubuntu\\.18\\.04|ubuntu\\.20\\.04)\'` ]; then\n      echo "This component does not support \'${RELEASE}\' on ARM64 CPUs. Failing build."\n      exit 1\n    fi\n  fi\nfi\necho "${RELEASE}" | grep -Ev \'^(amzn|centos|ubuntu)\'\necho ${ARCH}\n\n', 'CmdExecution: Command execution has been completed', 'CmdExecution: Command execution was completed successfully', 'CmdExecution: Stderr: if [ false == false ]; then\n  RELEASE=\'centos.7\'\n  if [ `echo "${RELEASE}" | grep -Ev \'^(amzn|centos|ubuntu)\'` ]; then\n    echo "This component does not support \'${RELEASE}\'. Failing build."\n    exit 1\n  fi\n\n  # This component only supports aarch64 CPUs on Amazon Linux 2, Ubuntu1804, Ubuntu2004 and Centos7\n  ARCH=$(uname -m)\n  if [[ `echo ${ARCH}` == \'aarch64\' ]]; then\n    if [ `echo "${RELEASE}" | grep -Ev \'^(amzn\\.2|centos\\.7|ubuntu\\.18\\.04|ubuntu\\.20\\.04)\'` ]; then\n      echo "This component does not support \'${RELEASE}\' on ARM64 CPUs. Failing build."\n      exit 1\n    fi\n  fi\nfi\necho "${RELEASE}" | grep -Ev \'^(amzn|centos|ubuntu)\'\necho ${ARCH}\n\n', 'CmdExecution: ExitCode 0', 'ExecuteBash: FINISHED EXECUTION', 'Step InstallPrerequisite', 'ExecuteBash: STARTED EXECUTION', 'Stdout: Loaded plugins: fastestmirror', 'Stdout: Determining fastest mirrors', 'Stdout:  * base: download.cf.centos.org', 'Stdout:  * extras: download.cf.centos.org', 'Stdout:  * updates: download.cf.centos.org', 'Stdout: Resolving Dependencies', 'Stdout: --> Running transaction check', 'Stdout: ---> Package epel-release.noarch 0:7-11 will be installed', 'Stdout: --> Finished Dependency Resolution', 'Stdout: ', 'Stdout: Dependencies Resolved', 'Stdout: ', 'Stdout: ================================================================================']
2022-08-02 11:58:04,600 - INFO - 55261 - test_build_image[us-east-1-c5.xlarge-centos7] - conftest - Updating failed tests config file tests_outputs/1659464699.904014.out/failed_tests_config.yaml
2022-08-02 11:58:04,600 - INFO - 55261 - test_build_image[us-east-1-c5.xlarge-centos7] - filelock - Lock 4996484960 acquired on tests_outputs/1659464699.904014.out/failed_tests_config.yaml.lock
2022-08-02 11:58:04,602 - INFO - 55261 - test_build_image[us-east-1-c5.xlarge-centos7] - filelock - Lock 4996484960 released on tests_outputs/1659464699.904014.out/failed_tests_config.yaml.lock
2022-08-02 11:58:04,612 - ERROR - 55261 - test_build_image[us-east-1-c5.xlarge-centos7] - conftest - Exception raised while executing test_build_image[us-east-1-c5.xlarge-centos7]: Expected <BUILD_FAILED> to be equal to <BUILD_COMPLETE>, but was not.
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
