### PR TITLE
[release-2.11] Fix flake8 B2023 warning

### DIFF
--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -2236,7 +2236,7 @@ def make_pcluster_config_mock(mocker, config_dict):
     section_to_mocks = {}
     for section_key, section_dict in config_dict.items():
         section_mock = mocker.MagicMock()
-        section_mock.get_param_value.side_effect = lambda param: section_dict.get(param)
+        section_mock.get_param_value.side_effect = lambda param, section=section_dict: section.get(param)
         section_to_mocks[section_key] = section_mock
 
     pcluster_config_mock = mocker.MagicMock()

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -183,7 +183,8 @@ def get_latest_images(images):
         for _key, value in DISTROS.items():
             ami_filtered_and_sorted = sorted(
                 filter(
-                    lambda ami: "-{0}-".format(value) in ami["Name"] and ami["Architecture"] == architecture,
+                    lambda ami, val=value, arch=architecture: "-{0}-".format(val) in ami["Name"]
+                    and ami["Architecture"] == arch,
                     images["Images"],
                 ),
                 key=lambda ami: ami["CreationDate"],


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
Fix flake8 B023 warning: functions defined inside a loop must not use variables redefined in the loop.
Refs
- https://github.com/PyCQA/flake8-bugbear#list-of-warnings
- https://docs.python-guide.org/writing/gotchas/#late-binding-closures

### Tests
* n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
