### PR TITLE
Enable back integ tests on AWSBatch

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -39,11 +39,10 @@ cloudwatch_logging:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: {{ common.SCHEDULERS_TRAD }}
-# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda 
-#      - regions: ["us-gov-east-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
+      - regions: ["us-gov-east-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
       # 2) run the test for all x86 OSes with slurm
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -67,11 +66,10 @@ configure:
         schedulers: ["slurm"]
       # Do not run on ARM + Batch
       # pcluster configure always picks optimal and Batch does not support ARM for optimal for now
-# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda       
-#      - regions: ["us-gov-west-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
+      - regions: ["us-gov-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
   test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
     dimensions:
       - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
@@ -147,16 +145,15 @@ dcv:
         {{- common.OSS_COMMERCIAL_ARM.append("ubuntu2004") or "" }}
         schedulers: ["slurm"]
       # DCV on Batch
-# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
-#      - regions: ["us-east-1"]
-#        instances: ["g4dn.2xlarge"]
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
-#      # DCV on Batch + ARM
-#      - regions: ["us-east-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
+      - regions: ["us-east-1"]
+        instances: ["g4dn.2xlarge"]
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
+      # DCV on Batch + ARM
+      - regions: ["us-east-1"]
+        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
       # DCV in cn regions and non GPU enabled instance
       - regions: ["cn-northwest-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -242,11 +239,11 @@ iam:
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+        schedulers: ["slurm", "awsbatch"]
   test_iam.py::test_iam_roles:
     dimensions:
       - regions: ["us-east-2"]
-        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+        schedulers: ["awsbatch", "slurm"]
         oss: ["alinux2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
   test_iam.py::test_s3_read_write_resource:
@@ -254,7 +251,7 @@ iam:
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+        schedulers: ["slurm", "awsbatch"]
 intel_hpc:
   test_intel_hpc.py::test_intel_hpc:
     dimensions:
@@ -284,30 +281,27 @@ networking:
       - regions: ["ap-northeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
-
+        schedulers: ["slurm", "awsbatch"]
   test_security_groups.py::test_additional_sg_and_ssh_from:
     dimensions:
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
-# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda        
-#      - regions: ["eu-north-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
+      - regions: ["eu-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
   test_security_groups.py::test_overwrite_sg:
     dimensions:
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
-# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda   
-#      - regions: ["eu-north-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
+      - regions: ["eu-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
   test_placement_group.py::test_existing_placement_group_in_cluster:
     dimensions:
       - regions: ["af-south-1"]
@@ -344,21 +338,20 @@ scaling:
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
 schedulers:
-# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda   
-#  test_awsbatch.py::test_awsbatch:
-#    dimensions:
-#      - regions: ["eu-north-1", "us-gov-west-1", "cn-north-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
-#      - regions: ["ap-southeast-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
-#      - regions: ["ap-northeast-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
+  test_awsbatch.py::test_awsbatch:
+    dimensions:
+      - regions: ["eu-north-1", "us-gov-west-1", "cn-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
+      - regions: ["ap-southeast-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
+      - regions: ["ap-northeast-1"]
+        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
   test_slurm.py::test_slurm:
     dimensions:
       - regions: ["us-east-2"]
@@ -444,7 +437,7 @@ storage:
       - regions: ["us-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+        schedulers: ["slurm", "awsbatch"]
   test_efs.py::test_efs_same_az:
     dimensions:
       - regions: ["ap-northeast-1"]
@@ -455,17 +448,16 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_CHINA_X86 }}
         schedulers: ["slurm"]
-# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
-#      - regions: ["ap-northeast-1", "cn-north-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: {{ common.OSS_BATCH }}
-#        schedulers: ["awsbatch"]
-#  test_efs.py::test_existing_efs:
-#    dimensions:
-#      - regions: ["ap-northeast-2"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
+      - regions: ["ap-northeast-1", "cn-north-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: {{ common.OSS_BATCH }}
+        schedulers: ["awsbatch"]
+  test_efs.py::test_existing_efs:
+    dimensions:
+      - regions: ["ap-northeast-2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
       - regions: ["ap-northeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
@@ -486,11 +478,10 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_GOVCLOUD_X86 }}
         schedulers: ["slurm"]
-# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
-#      - regions: ["ap-south-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: {{ common.OSS_BATCH }}
-#        schedulers: ["awsbatch"]
+      - regions: ["ap-south-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: {{ common.OSS_BATCH }}
+        schedulers: ["awsbatch"]
   test_ebs.py::test_default_ebs:
     dimensions:
       - regions: ["cn-northwest-1"]
@@ -499,11 +490,10 @@ storage:
         schedulers: ["slurm"]
   test_ebs.py::test_ebs_multiple:
     dimensions:
-# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
-#      - regions: ["eu-west-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["awsbatch"]
+      - regions: ["eu-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["awsbatch"]
       - regions: ["eu-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"]
@@ -544,14 +534,13 @@ tags:
       - regions: ["ap-southeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+        schedulers: ["slurm", "awsbatch"]
 update:
-# awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
-#  test_update.py::test_update_awsbatch:
-#    dimensions:
-#      - regions: ["eu-south-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
+  test_update.py::test_update_awsbatch:
+    dimensions:
+      - regions: ["eu-south-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
   test_update.py::test_update_slurm:
     dimensions:
       - regions: ["eu-west-1"]
@@ -563,4 +552,4 @@ resource_bucket:
       - regions: ["ap-southeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm"] # awsbatch temporarily disabled due to deprecation of Python 3.6 runtime in AWS Lambda
+        schedulers: ["slurm", "awsbatch"]

--- a/tests/integration-tests/tests/configure/test_pcluster_configure/test_pcluster_configure_avoid_bad_subnets/pcluster.config.ini
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure/test_pcluster_configure_avoid_bad_subnets/pcluster.config.ini
@@ -10,6 +10,7 @@ key_name = {{ key_name }}
 vpc_settings = default
 scheduler = slurm
 master_instance_type = t2.micro
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc default]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.ini
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.ini
@@ -21,6 +21,7 @@ maintain_initial_size = true
 {% endif %}
 dcv_settings = test
 shared_dir = {{ shared_dir }}
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.ini
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.ini
@@ -12,6 +12,7 @@ additional_iam_policies = {{ iam_policies }}
 master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 base_os = {{ os }}
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/HIT.ini
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/HIT.ini
@@ -13,6 +13,7 @@ base_os = {{ os }}
 queue_settings = compute
 ec2_iam_role = {{ ec2_iam_role }}
 iam_lambda_role = {{ iam_lambda_role }}
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/SIT.ini
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/SIT.ini
@@ -20,6 +20,7 @@ desired_vcpus = 1
 initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.ini
+++ b/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.ini
@@ -13,6 +13,7 @@ compute_instance_type = {{ instance }}
 base_os = {{ os }}
 s3_read_resource = arn:aws:s3:::{{ bucket }}/read_only/*
 s3_read_write_resource = arn:aws:s3:::{{ bucket }}/read_and_write/*
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.ini
+++ b/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.ini
@@ -16,6 +16,7 @@ max_queue_size = 1
 {% if scheduler != "awsbatch" %}
 maintain_initial_size = true
 {% endif %}
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.ini
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.ini
@@ -18,6 +18,7 @@ desired_vcpus = 1
 initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.ini
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.ini
@@ -20,6 +20,7 @@ maintain_initial_size = true
 {% endif %}
 efs_settings = parallelcluster-efs
 fsx_settings = parallelcluster-fsx
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.ini
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.ini
@@ -19,3 +19,4 @@ master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 min_vcpus=1
 cluster_resource_bucket = {{ resource_bucket }}
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
@@ -15,9 +15,10 @@ compute_instance_type = {{ instance }}
 min_vcpus = 4
 desired_vcpus = 8
 max_vcpus = 40
-# EFS is integrated in order to exercise the mount_efs.sh script called from the	
+# EFS is integrated in order to exercise the mount_efs.sh script called from the
 # entry point of the docker image generated when the scheduler is awsbatch.
 efs_settings = custom_efs
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.ini
@@ -19,6 +19,7 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 ebs_settings = ebs1, ebs2, ebs3, ebs4, ebs5
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.ini
@@ -19,6 +19,7 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 efs_settings = efs
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/storage/test_efs/test_existing_efs/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_efs/test_existing_efs/pcluster.config.ini
@@ -19,6 +19,7 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 efs_settings = efs
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.ini
@@ -19,6 +19,7 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 raid_settings = raid_type0
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.ini
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.ini
@@ -19,6 +19,7 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 tags = {{ tags }}
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.ini
@@ -16,6 +16,7 @@ max_vcpus = 3
 cluster_type = spot
 spot_bid_percentage = 35
 tags = {"key": "value3", "key2": "value2"}
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.ini
@@ -16,6 +16,7 @@ max_vcpus = 4
 cluster_type = spot
 spot_bid_percentage = 70
 tags = {"key": "value3", "key2": "value2"}
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Enable back integration tests on AWSBatch, that were disabled in https://github.com/aws/aws-parallelcluster/commit/daea2e3f93472ca041ae84c5a1cb0de3e4683fc1
Uses the workaround in https://github.com/aws/aws-parallelcluster/wiki/(2.11.7-and-earlier)-Cluster-creation-fails-with-awsbatch-scheduler

### Tests
already covered

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
