### PR TITLE
[integ-tests-2.11.7] Fix on AWSBatch tests

### DIFF
--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -724,6 +724,12 @@ def url_validator(param_key, param_value, pcluster_config):
             warnings.append("{0} {1} {2}".format(param_value, e.code, e.reason))
         except urllib.error.URLError as e:
             warnings.append("{0} {1}".format(param_value, e.reason))
+        except ClientError as e:
+            warnings.append(
+                "Unable to perform HeadObject operation on object URL '{0}': {1}".format(
+                    param_value, e.response.get("Error").get("Message")
+                )
+            )
         except ValueError:
             errors.append(
                 "The value '{0}' used for the parameter '{1}' is not a valid URL".format(param_value, param_key)

--- a/cli/tests/pcluster/config/test_validators.py
+++ b/cli/tests/pcluster/config/test_validators.py
@@ -2236,7 +2236,7 @@ def make_pcluster_config_mock(mocker, config_dict):
     section_to_mocks = {}
     for section_key, section_dict in config_dict.items():
         section_mock = mocker.MagicMock()
-        section_mock.get_param_value.side_effect = lambda param: section_dict.get(param)
+        section_mock.get_param_value.side_effect = lambda param, section=section_dict: section.get(param)
         section_to_mocks[section_key] = section_mock
 
     pcluster_config_mock = mocker.MagicMock()

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.ini
@@ -19,6 +19,7 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 efs_settings = efs
+template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -183,7 +183,8 @@ def get_latest_images(images):
         for _key, value in DISTROS.items():
             ami_filtered_and_sorted = sorted(
                 filter(
-                    lambda ami: "-{0}-".format(value) in ami["Name"] and ami["Architecture"] == architecture,
+                    lambda ami, val=value, arch=architecture: "-{0}-".format(val) in ami["Name"]
+                    and ami["Architecture"] == arch,
                     images["Images"],
                 ),
                 key=lambda ami: ami["CreationDate"],


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Enable back integration tests on AWSBatch, that were disabled in https://github.com/aws/aws-parallelcluster/commit/daea2e3f93472ca041ae84c5a1cb0de3e4683fc1
Uses the workaround in https://github.com/aws/aws-parallelcluster/wiki/(2.11.7-and-earlier)-Cluster-creation-fails-with-awsbatch-scheduler

This test was missed in https://github.com/aws/aws-parallelcluster/pull/4238

* Fix catch exception on HeadObject operation

HeadObject operation failures were not caught.
This patch is adding a warning when it's not possible to perform HeadObject operation on the input object URL

Output is
```
WARNING: The configuration parameter 'template_url' generated the following warnings:
Unable to perform HeadObject operation on object URL 'https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json': Not Found
```

### Tests
already covered

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
