### PR TITLE
[release-2.11] Fix catch exception on HeadObject operation

### DIFF
--- a/cli/src/pcluster/config/validators.py
+++ b/cli/src/pcluster/config/validators.py
@@ -724,6 +724,12 @@ def url_validator(param_key, param_value, pcluster_config):
             warnings.append("{0} {1} {2}".format(param_value, e.code, e.reason))
         except urllib.error.URLError as e:
             warnings.append("{0} {1}".format(param_value, e.reason))
+        except ClientError as e:
+            warnings.append(
+                "Unable to perform HeadObject operation on object URL '{0}': {1}".format(
+                    param_value, e.response.get("Error").get("Message")
+                )
+            )
         except ValueError:
             errors.append(
                 "The value '{0}' used for the parameter '{1}' is not a valid URL".format(param_value, param_key)


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
HeadObject operation failures were not caught.
This patch is adding a warning when it's not possible to perform HeadObject operation on the input object URL

Output is
```
WARNING: The configuration parameter 'template_url' generated the following warnings:
Unable to perform HeadObject operation on object URL 'https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json': Not Found
```

### Tests
already covered

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
