### PR TITLE
[integ-tests-2.11.7] Disable awsbatch tests in aws-us-gov and aws-cn

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -39,10 +39,11 @@ cloudwatch_logging:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: {{ common.SCHEDULERS_TRAD }}
-      - regions: ["us-gov-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled because of https://github.com/aws/aws-parallelcluster/issues/4229
+#      - regions: ["us-gov-east-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
       # 2) run the test for all x86 OSes with slurm
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -66,10 +67,11 @@ configure:
         schedulers: ["slurm"]
       # Do not run on ARM + Batch
       # pcluster configure always picks optimal and Batch does not support ARM for optimal for now
-      - regions: ["us-gov-west-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
+# awsbatch temporarily disabled because of https://github.com/aws/aws-parallelcluster/issues/4229
+#      - regions: ["us-gov-west-1"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["awsbatch"]
   test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
     dimensions:
       - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
@@ -340,7 +342,7 @@ scaling:
 schedulers:
   test_awsbatch.py::test_awsbatch:
     dimensions:
-      - regions: ["eu-north-1", "us-gov-west-1", "cn-north-1"]
+      - regions: ["eu-north-1"] # "us-gov-west-1", "cn-north-1"] # awsbatch temporarily disabled because of https://github.com/aws/aws-parallelcluster/issues/4229
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
@@ -448,7 +450,7 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_CHINA_X86 }}
         schedulers: ["slurm"]
-      - regions: ["ap-northeast-1", "cn-north-1"]
+      - regions: ["ap-northeast-1"] # "cn-north-1" # awsbatch temporarily disabled because of https://github.com/aws/aws-parallelcluster/issues/4229
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_BATCH }}
         schedulers: ["awsbatch"]


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
This because the workaround was only published in aws and requires fix in release branch (https://github.com/aws/aws-parallelcluster/pull/4242) that will be published only with new patch release

### Tests
n/a

### References
n/a

### Checklist
- [n/a] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [n/a] Check all commits' messages are clear, describing what and why vs how.
- [n/a] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [n/a] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
