### PR TITLE
[integ-tests-2.11.7]Enable workaround only for AWSBatch case

### DIFF
--- a/tests/integration-tests/tests/configure/test_pcluster_configure/test_pcluster_configure_avoid_bad_subnets/pcluster.config.ini
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure/test_pcluster_configure_avoid_bad_subnets/pcluster.config.ini
@@ -10,7 +10,9 @@ key_name = {{ key_name }}
 vpc_settings = default
 scheduler = slurm
 master_instance_type = t2.micro
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc default]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.ini
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.ini
@@ -21,7 +21,9 @@ maintain_initial_size = true
 {% endif %}
 dcv_settings = test
 shared_dir = {{ shared_dir }}
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.ini
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.ini
@@ -12,7 +12,9 @@ additional_iam_policies = {{ iam_policies }}
 master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 base_os = {{ os }}
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/HIT.ini
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/HIT.ini
@@ -13,7 +13,9 @@ base_os = {{ os }}
 queue_settings = compute
 ec2_iam_role = {{ ec2_iam_role }}
 iam_lambda_role = {{ iam_lambda_role }}
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/SIT.ini
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/SIT.ini
@@ -20,7 +20,9 @@ desired_vcpus = 1
 initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.ini
+++ b/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.ini
@@ -13,7 +13,9 @@ compute_instance_type = {{ instance }}
 base_os = {{ os }}
 s3_read_resource = arn:aws:s3:::{{ bucket }}/read_only/*
 s3_read_write_resource = arn:aws:s3:::{{ bucket }}/read_and_write/*
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.ini
+++ b/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.ini
@@ -16,7 +16,9 @@ max_queue_size = 1
 {% if scheduler != "awsbatch" %}
 maintain_initial_size = true
 {% endif %}
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.ini
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.ini
@@ -18,7 +18,9 @@ desired_vcpus = 1
 initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.ini
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.ini
@@ -20,7 +20,9 @@ maintain_initial_size = true
 {% endif %}
 efs_settings = parallelcluster-efs
 fsx_settings = parallelcluster-fsx
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.ini
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.ini
@@ -19,4 +19,6 @@ master_instance_type = {{ instance }}
 compute_instance_type = {{ instance }}
 min_vcpus=1
 cluster_resource_bucket = {{ resource_bucket }}
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.ini
@@ -18,7 +18,9 @@ max_vcpus = 40
 # EFS is integrated in order to exercise the mount_efs.sh script called from the
 # entry point of the docker image generated when the scheduler is awsbatch.
 efs_settings = custom_efs
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.ini
@@ -19,7 +19,9 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 ebs_settings = ebs1, ebs2, ebs3, ebs4, ebs5
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.ini
@@ -19,7 +19,9 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 efs_settings = efs
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.ini
@@ -19,7 +19,9 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 efs_settings = efs
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/storage/test_efs/test_existing_efs/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_efs/test_existing_efs/pcluster.config.ini
@@ -19,7 +19,9 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 efs_settings = efs
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.ini
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.ini
@@ -19,7 +19,9 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 raid_settings = raid_type0
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.ini
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.ini
@@ -19,7 +19,9 @@ initial_queue_size = 1
 maintain_initial_size = true
 {% endif %}
 tags = {{ tags }}
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.ini
@@ -16,7 +16,9 @@ max_vcpus = 3
 cluster_type = spot
 spot_bid_percentage = 35
 tags = {"key": "value3", "key2": "value2"}
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.ini
@@ -16,7 +16,9 @@ max_vcpus = 4
 cluster_type = spot
 spot_bid_percentage = 70
 tags = {"key": "value3", "key2": "value2"}
+{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
Workaround is https://github.com/aws/aws-parallelcluster/wiki/(2.11.7-and-earlier)-Cluster-creation-fails-with-awsbatch-scheduler
This to avoid tests to fail in aws-us-gov and aws-cn when using scheduler != awsbatch

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
