### PR TITLE
[SharedStorage] Fix EfsSettings schema validation: fail when FileSystemId is specified together with other parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ CHANGELOG
 - Upgrade Python and NodeJS versions in API infrastructure, API Docker container and cluster Lambda resources.
 - Move head node tags from launch template to instance definition to avoid head node replacement on tags updates.
 
+**BUG FIXES**
+- Fix validation of parameter `SharedStorage/EfsSettings`: now validation fails when `FileSystemId` is specified along with other `SharedStorage/EfsSettings` parameters.
+
 3.2.0
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ CHANGELOG
 - Move head node tags from launch template to instance definition to avoid head node replacement on tags updates.
 
 **BUG FIXES**
-- Fix validation of parameter `SharedStorage/EfsSettings`: now validation fails when `FileSystemId` is specified along with other `SharedStorage/EfsSettings` parameters.
+- Fix validation of parameter `SharedStorage/EfsSettings`: now validation fails when `FileSystemId` is specified 
+  along with other `SharedStorage/EfsSettings` parameters, whereas it was previously ignoring them.
 
 3.2.0
 ------

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -41,6 +41,12 @@ NAME_REGEX = r"^[a-z][a-z0-9\-]*$"
 
 EFA_UNSUPPORTED_ARCHITECTURES_OSES = {"x86_64": [], "arm64": ["centos7"]}
 
+EFS_MESSAGES = {
+    "errors": {
+        "ignored_param_with_efs_fs_id": "{efs_param} cannot be specified when an existing EFS file system is used.",
+    }
+}
+
 FSX_SUPPORTED_ARCHITECTURES_OSES = {
     "x86_64": SUPPORTED_OSES,
     "arm64": ["ubuntu1804", "ubuntu2004", "alinux2", "centos7"],

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -61,7 +61,7 @@ FSX_MESSAGES = {
         "compute instance type and/or custom AMI configurations.",
         "unsupported_backup_param": "When restoring an FSx Lustre file system from backup, '{name}' "
         "cannot be specified.",
-        "ignored_param_with_fsx_fs_id": "{fsx_param} is ignored when an existing Lustre file system is specified.",
+        "ignored_param_with_fsx_fs_id": "{fsx_param} cannot be specified when an existing Lustre file system is used.",
     }
 }
 

--- a/cli/tests/pcluster/example_configs/awsbatch.full.yaml
+++ b/cli/tests/pcluster/example_configs/awsbatch.full.yaml
@@ -86,7 +86,6 @@ SharedStorage:
       PerformanceMode: maxIO  # generalPurpose | maxIO
       ThroughputMode: provisioned  # bursting | provisioned
       ProvisionedThroughput: 1024
-      FileSystemId: fs-12345678
 Iam:
   Roles:
     LambdaFunctionsRole: arn:aws:iam::aws:role/CustomResourcesLambdaRole

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -339,6 +339,20 @@ def test_efs_validator(section_dict, expected_message):
 @pytest.mark.parametrize(
     "section_dict, expected_message",
     [
+        ({"FileSystemId": "fs-12345678901234567"}, None),
+        (
+            {"FileSystemId": "fs-12345678901234567", "Encrypted": "True"},
+            "encrypted cannot be specified when an existing EFS file system is used",
+        ),
+    ],
+)
+def test_efs_validate_file_system_id_ignored_parameters(section_dict, expected_message):
+    _validate_and_assert_error(EfsSettingsSchema(), section_dict, expected_message, partial=False)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_message",
+    [
         (
             {"ThroughputMode": "bursting", "ProvisionedThroughput": 1024},
             "When specifying provisioned throughput, the throughput mode must be set to provisioned",

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -374,7 +374,7 @@ def test_efs_throughput_mode_provisioned_throughput_validator(section_dict, expe
         ({"FileSystemId": "fs-0123456789abcdef0"}, None),
         (
             {"FileSystemId": "fs-0123456789abcdef0", "StorageCapacity": 3600},
-            "storage_capacity is ignored when an existing Lustre file system is specified",
+            "storage_capacity cannot be specified when an existing Lustre file system is used",
         ),
         (
             {


### PR DESCRIPTION
### Description of changes
1. Fix validation for parameter `EfsSettings`: now it fails when `FileSystemId` is specified together with other parameters.
This is a bug because the user should not be able to set any `EfsSettings` parameters other than `FileSystemId`, when `FileSystemId` is specified. Currently without this change, we succeed the cluster creation giving precedence to `FileSystemId` and ignoring the other parameters.
1. Fix error message returned by `FsxLustreSettings` validation when `FileSystemId` is specified together with other parameters.

### Tests
1. Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
