### PR TITLE
[3.3][DFSM] Move head node tags from launch template to instance definition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 **CHANGES**
 - Remove support for Python 3.6 in aws-parallelcluster-batch-cli.
 - Upgrade Python and NodeJS versions in API infrastructure, API Docker container and cluster Lambda resources.
+- Move head node tags from launch template to instance definition to avoid head node replacement on tags updates.
 
 3.2.0
 ------

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -830,13 +830,6 @@ class ClusterCdkStack(Stack):
                 ),
                 tag_specifications=[
                     ec2.CfnLaunchTemplate.TagSpecificationProperty(
-                        resource_type="instance",
-                        tags=get_default_instance_tags(
-                            self._stack_name, self.config, head_node, "HeadNode", self.shared_storage_infos
-                        )
-                        + get_custom_tags(self.config),
-                    ),
-                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
                         resource_type="volume",
                         tags=get_default_volume_tags(self._stack_name, "HeadNode") + get_custom_tags(self.config),
                     ),
@@ -1110,6 +1103,10 @@ class ClusterCdkStack(Stack):
                 launch_template_id=head_node_launch_template.ref,
                 version=head_node_launch_template.attr_latest_version_number,
             ),
+            tags=get_default_instance_tags(
+                self._stack_name, self.config, head_node, "HeadNode", self.shared_storage_infos
+            )
+            + get_custom_tags(self.config),
         )
         if not self._condition_is_batch():
             head_node_instance.node.add_dependency(self.compute_fleet_resources)


### PR DESCRIPTION
### Description of changes
Moved head node tags from head node launch template to head node instance definition. This  change is required by Dynamic File systems Mount (DFSM) in order to not trigger head node replacement on file systems changes.

Added unit tests that verifies tags in head node launch template and instance definition.

### Tests
1. Unit tests
2. Created a cluster and verified that the head node has the expected tags. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
