### PR TITLE
[integ-tests-2.11.7] Fix test execution due to scheduler value not passed

### DIFF
--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.ini
@@ -16,9 +16,7 @@ max_vcpus = 3
 cluster_type = spot
 spot_bid_percentage = 35
 tags = {"key": "value3", "key2": "value2"}
-{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
-{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.ini
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.ini
@@ -16,9 +16,7 @@ max_vcpus = 4
 cluster_type = spot
 spot_bid_percentage = 70
 tags = {"key": "value3", "key2": "value2"}
-{% if scheduler == "awsbatch" %}
 template_url = https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/2.11.7/aws-parallelcluster-2.11.7.cfn.json
-{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
In the "test_update_awsbatch" test, the scheduler value is not set, since this test has a fixed dimension set to "awsbatch"

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
