### PR TITLE
[Tags] Add TODOS related to cluster tags

### DIFF
--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -137,10 +137,16 @@ class TagSchema(BaseSchema):
     """Represent the schema of Tag section."""
 
     key = fields.Str(
-        required=True, validate=validate.Length(max=128), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
+        # TODO Tags can be updated with policy QUEUE_UPDATE_STRATEGY
+        required=True,
+        validate=validate.Length(max=128),
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
     value = fields.Str(
-        required=True, validate=validate.Length(max=256), metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
+        # TODO Tags can be updated with policy QUEUE_UPDATE_STRATEGY
+        required=True,
+        validate=validate.Length(max=256),
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
 
     @post_load

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -252,6 +252,9 @@ def _get_cfn_init_file_content(template, resource, file):
             {
                 "parallelcluster:cluster-name": "clustername",
                 "parallelcluster:node-type": "HeadNode",
+                # TODO The tag 'parallelcluster:version' is actually included within head node volume tags,
+                #  but some refactoring is required to check it within this test.
+                # "parallelcluster:version": "[0-9\\.A-Za-z]+",
                 "String": "String",
                 "two": "two22",
             },
@@ -262,6 +265,9 @@ def _get_cfn_init_file_content(template, resource, file):
             {
                 "parallelcluster:cluster-name": "clustername",
                 "parallelcluster:node-type": "HeadNode",
+                # TODO The tag 'parallelcluster:version' is actually included within head node volume tags,
+                #  but some refactoring is required to check it within this test.
+                # "parallelcluster:version": "[0-9\\.A-Za-z]+",
                 "String": "String",
                 "two": "two22",
             },
@@ -272,6 +278,9 @@ def _get_cfn_init_file_content(template, resource, file):
             {
                 "parallelcluster:cluster-name": "clustername",
                 "parallelcluster:node-type": "HeadNode",
+                # TODO The tag 'parallelcluster:version' is actually included within head node volume tags,
+                #  but some refactoring is required to check it within this test.
+                # "parallelcluster:version": "[0-9\\.A-Za-z]+",
                 "String": "String",
                 "two": "two22",
             },
@@ -319,6 +328,9 @@ def test_head_node_tags_from_launch_template(mocker, config_file_name, expected_
                 "parallelcluster:attributes": "centos7, slurm, [0-9\\.A-Za-z]+, x86_64",
                 "parallelcluster:filesystem": "efs=1, multiebs=1, raid=0, fsx=3",
                 "parallelcluster:networking": "EFA=NONE",
+                # TODO The tag 'parallelcluster:version' is actually included within head node volume tags,
+                #  but some refactoring is required to check it within this test.
+                # "parallelcluster:version": "[0-9\\.A-Za-z]+",
                 "String": "String",
                 "two": "two22",
             },
@@ -332,6 +344,9 @@ def test_head_node_tags_from_launch_template(mocker, config_file_name, expected_
                 "parallelcluster:attributes": "alinux2, awsbatch, [0-9\\.A-Za-z]+, x86_64",
                 "parallelcluster:filesystem": "efs=1, multiebs=0, raid=2, fsx=0",
                 "parallelcluster:networking": "EFA=NONE",
+                # TODO The tag 'parallelcluster:version' is actually included within head node volume tags,
+                #  but some refactoring is required to check it within this test.
+                # "parallelcluster:version": "[0-9\\.A-Za-z]+",
                 "String": "String",
                 "two": "two22",
             },
@@ -345,6 +360,9 @@ def test_head_node_tags_from_launch_template(mocker, config_file_name, expected_
                 "parallelcluster:attributes": "centos7, plugin, [0-9\\.A-Za-z]+, x86_64",
                 "parallelcluster:filesystem": "efs=1, multiebs=1, raid=0, fsx=1",
                 "parallelcluster:networking": "EFA=NONE",
+                # TODO The tag 'parallelcluster:version' is actually included within head node volume tags,
+                #  but some refactoring is required to check it within this test.
+                # "parallelcluster:version": "[0-9\\.A-Za-z]+",
                 "String": "String",
                 "two": "two22",
             },


### PR DESCRIPTION
### Description of changes
Add todos related to tags, as follow ups from https://github.com/aws/aws-parallelcluster/pull/4247/files

### Tests
Not needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
