### PR TITLE
Fix cluster update when changing the order of SharedStorage 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 **BUG FIXES**
 - Fix validation of parameter `SharedStorage/EfsSettings`: now validation fails when `FileSystemId` is specified 
   along with other `SharedStorage/EfsSettings` parameters, whereas it was previously ignoring them.
+- Fix cluster update when changing the order of SharedStorage together with other changes in the configuration.
 
 3.2.0
 ------

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -597,7 +597,7 @@ class ClusterCdkStack(Stack):
     def _add_shared_storage(self, storage):
         """Add specific Cfn Resources to map the shared storage and store the output filesystem id."""
         storage_list = self.shared_storage_infos[storage.shared_storage_type]
-        cfn_resource_id = "{0}{1}".format(storage.shared_storage_type.name, len(storage_list))
+        cfn_resource_id = "{0}{1}".format(storage.shared_storage_type.name, create_hash_suffix(storage.name))
         if storage.shared_storage_type == SharedStorageType.FSX:
             storage_list.append(StorageInfo(self._add_fsx_storage(cfn_resource_id, storage), storage))
         elif storage.shared_storage_type == SharedStorageType.EBS:

--- a/cli/tests/pcluster/templates/test_shared_storage.py
+++ b/cli/tests/pcluster/templates/test_shared_storage.py
@@ -22,8 +22,8 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket
 @pytest.mark.parametrize(
     "config_file_name, resource_logical_name, security_group_property, expected_security_group",
     [
-        ("efs.config.yaml", "EFS0MTstring", "SecurityGroups", "ComputeSecurityGroup"),
-        ("fsx-lustre.config.yaml", "FSX0", "SecurityGroupIds", "ComputeSecurityGroup"),
+        ("efs.config.yaml", "EFS8d3a330efcad8cd3MTstring", "SecurityGroups", "ComputeSecurityGroup"),
+        ("fsx-lustre.config.yaml", "FSX0c14c0b8f045af82", "SecurityGroupIds", "ComputeSecurityGroup"),
     ],
 )
 def test_shared_storage_security_group(

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -126,6 +126,16 @@ Scheduling:
         PlacementGroup:
           Enabled: false
 SharedStorage:
+  - MountDir: raid
+    StorageType: Ebs
+    Name: raid
+    EbsSettings:
+      VolumeType: gp3
+      Iops: 3200
+      Throughput: 130
+      Raid:
+        Type: 0
+        NumberOfVolumes: 2
   - MountDir: shared
     Name: ebs
     StorageType: Ebs
@@ -139,16 +149,6 @@ SharedStorage:
     EfsSettings:
       ThroughputMode: provisioned
       ProvisionedThroughput: 1024
-  - MountDir: raid
-    StorageType: Ebs
-    Name: raid
-    EbsSettings:
-      VolumeType: gp3
-      Iops: 3200
-      Throughput: 130
-      Raid:
-        Type: 0
-        NumberOfVolumes: 2
   - MountDir: fsx
     Name: fsx
     StorageType: FsxLustre


### PR DESCRIPTION
### Description of changes
* Before the fix, update the cluster with changing the orders of multiple shared storages will fail with shared storages replacement. This is because the logical ID of the shared storages are determined by the order in which they appear.
With the fix, changing ShareStorage orders during update will work. The logical ID of the shared storages will be decided by the shared storage name.

### Tests
* Manually test with create and update cluster with switching share storage order.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
