### PR TITLE
Add timeout to run_system_analyzer utility function

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -255,7 +255,7 @@ def run_system_analyzer(cluster, scheduler_commands_factory, request, partition=
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
 
     logging.info(f"Retrieve head node system information for test: {request.node.name}")
-    result = remote_command_executor.run_remote_script(SYSTEM_ANALYZER_SCRIPT, args=[head_node_dir])
+    result = remote_command_executor.run_remote_script(SYSTEM_ANALYZER_SCRIPT, args=[head_node_dir], timeout=180)
     logging.debug(f"result.failed={result.failed}")
     logging.debug(f"result.stdout={result.stdout}")
     logging.info(
@@ -275,7 +275,7 @@ def run_system_analyzer(cluster, scheduler_commands_factory, request, partition=
         SYSTEM_ANALYZER_SCRIPT, script_args=[compute_node_shared_dir], partition=partition
     )
     job_id = scheduler_commands.assert_job_submitted(result.stdout)
-    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.wait_job_completed(job_id, timeout=180)
     scheduler_commands.assert_job_succeeded(job_id)
     logging.info(
         "Copy results from remote cluster into: "


### PR DESCRIPTION
Signed-off-by: Francesco Giordano <giordafr@amazon.it>


### Description of changes
* Add timeout of 600 seconds on the scripts called by run_system_analyzer utility function

### Tests
* Manual tested

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
