### PR TITLE
Add linux kernel to UpdateOS for Debian platforms

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -120,7 +120,7 @@ phases:
                 flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)\/?'$/\1/")/daily_lock systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service
                 sed "/Update-Package-Lists/s/\"1\"/\"0\"/; /Unattended-Upgrade/s/\"1\"/\"0\"/;" /etc/apt/apt.conf.d/20auto-upgrades > "/etc/apt/apt.conf.d/51pcluster-unattended-upgrades"
                 DEBIAN_FRONTEND=noninteractive apt-get -y update && apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --with-new-pkgs upgrade && apt-get --purge autoremove -y
-                apt-get -y install linux-aws linux-headers-aws
+                apt-get -y install linux-aws linux-headers-aws linux-image-aws
               fi
 
       - name: KeepSSM


### PR DESCRIPTION
### Description of changes
* Add the linux-image-aws package to the list of kernel packages to be upgraded in UpdateOS for Debian (Ubuntu) platforms
* This helps understanding potential issues due to kernel packages being held on the OS.

### Tests
* Manual tests with the kernel upgrade procedure.

### References
- https://github.com/aws/aws-parallelcluster/pull/4267

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.