### PR TITLE
Pin smithy-cli version used to build API spec

### DIFF
--- a/api/spec/smithy/build.gradle.kts
+++ b/api/spec/smithy/build.gradle.kts
@@ -10,6 +10,7 @@ repositories {
 
 buildscript {
     dependencies {
+        classpath("software.amazon.smithy:smithy-cli:1.22.0")
         classpath("software.amazon.smithy:smithy-openapi:1.22.0")
         classpath("software.amazon.smithy:smithy-aws-traits:1.22.0")
         classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:1.22.0")


### PR DESCRIPTION
This prevents the build from breaking when a new Smithy version is released

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
