### PR TITLE
Update issue templates adding AWS support link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_2.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_2.md
@@ -2,10 +2,13 @@
 name: Bug report for ParallelCluster 2.x.x
 about: Detailed report for issues with ParallelCluster 2.x.x
 title: ''
-labels: '2.x'
+labels: 2.x
 assignees: ''
 
 ---
+
+If you have an active AWS support contract, please open a case with AWS Premium Support team using the below documentation to report the issue:
+https://docs.aws.amazon.com/awssupport/latest/user/case-management.html
 
 Before submitting a new issue, please search through open [GitHub Issues](https://github.com/aws/aws-parallelcluster/issues) and check out the [troubleshooting documentation](https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting.html).
 

--- a/.github/ISSUE_TEMPLATE/bug_report_3.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_3.md
@@ -2,10 +2,13 @@
 name: Bug report for ParallelCluster 3.x.x
 about: Detailed report for issues with ParallelCluster 3.x.x
 title: ''
-labels: '3.x'
+labels: 3.x
 assignees: ''
 
 ---
+
+If you have an active AWS support contract, please open a case with AWS Premium Support team using the below documentation to report the issue:
+https://docs.aws.amazon.com/awssupport/latest/user/case-management.html
 
 Before submitting a new issue, please search through open [GitHub Issues](https://github.com/aws/aws-parallelcluster/issues) and check out the [troubleshooting documentation](https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html).
 

--- a/.github/ISSUE_TEMPLATE/internal_ticket_replica.md
+++ b/.github/ISSUE_TEMPLATE/internal_ticket_replica.md
@@ -1,8 +1,8 @@
 ---
 name: Known Issue Report
-about: 'Report known issues on github'
+about: Report known issues on github
 title: ''
-labels: 'known-issue-report'
+labels: ''
 assignees: ''
 
 ---


### PR DESCRIPTION
Highlight that if users have an active AWS support contract, they can open a case with AWS Premium Support team.