### PR TITLE
Print last hundreds lines of log to console when build image integration test fails and --no-delete preserve imagebuilder stack

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -471,7 +471,11 @@ def images_factory(request):
         return image
 
     yield _image_factory
-    factory.destroy_all_images()
+
+    if not request.config.getoption("no_delete"):
+        factory.destroy_all_images()
+    else:
+        logging.warning("Skipping deletion of CFN image stacks because --no-delete option is set")
 
 
 def _write_config_to_outdir(request, config, config_dir):

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -383,8 +383,10 @@ def build_image_custom_resource(cfn_stacks_factory, region, request):
         return instance_role_arn
 
     yield _custom_resource
-    if stack_name_post_test:
+    if stack_name_post_test and not request.config.getoption("no_delete"):
         cfn_stacks_factory.delete_stack(stack_name_post_test, region)
+    else:
+        logging.warning("Skipping deletion of CFN image stacks because --no-delete option is set")
 
 
 def test_build_image_custom_components(

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -430,6 +430,7 @@ def _test_build_image_success(image):
         logging.info(pcluster_describe_image_result)
     if image.image_status != "BUILD_COMPLETE":
         image.keep_logs = True
+        _keep_recent_logs(image)
     assert_that(image.image_status).is_equal_to("BUILD_COMPLETE")
 
 
@@ -480,5 +481,12 @@ def _test_build_image_failed(image):
 
     if image.image_status == "BUILD_FAILED":
         image.keep_logs = True
-
+        _keep_recent_logs(image)
     assert_that(image.image_status).is_equal_to("BUILD_FAILED")
+
+
+def _keep_recent_logs(image):
+    """Keep several lines of recent log to the console when creating an image fails."""
+    log_stream_name = f"{get_installed_parallelcluster_base_version()}/1"
+    failure_logs = image.get_log_events(log_stream_name, start_from_head=True, query="events[*].message", limit=100)
+    logging.info(f"Image built failed for {image.image_id}, the last 100 lines of the log are: {failure_logs}")


### PR DESCRIPTION
### Description of changes
* Cherry-picking from https://github.com/aws/aws-parallelcluster/pull/4234
* Cherry-picking from https://github.com/aws/aws-parallelcluster/pull/4248

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
