### PR TITLE
Fix DeviceIndex to not exceed MaximumNetworkInterfaces

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1371,11 +1371,11 @@ class ComputeFleetConstruct(Construct):
                 subnet_id=queue.networking.subnet_ids[0],
             )
         ]
-        for device_index in range(1, compute_resource.max_network_interface_count):
+        for network_interface_index in range(1, compute_resource.max_network_interface_count):
             compute_lt_nw_interfaces.append(
                 ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
-                    device_index=device_index,
-                    network_card_index=device_index,
+                    device_index=1,
+                    network_card_index=network_interface_index,
                     interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
                     groups=queue_lt_security_groups,
                     subnet_id=queue.networking.subnet_ids[0],


### PR DESCRIPTION
Fix value of device_index to 1 to ensure that the value do not exceed MaximumNetworkInterfaces causing termination of the instance after a successful run-instances. This avoid issues when the number of `NetworkCards` is greater than the `MaximumNetworkInterfaces`. Sample of `describe-instance-types` output on an instance that would be impacted by the former logic:
```
                "NetworkCards": [
                    {
                        "NetworkCardIndex": 0,
                        "NetworkPerformance": "1 Gigabit",
                        "MaximumNetworkInterfaces": 2
                    },
                    {
                        "NetworkCardIndex": 1,
                        "NetworkPerformance": "1 Gigabit",
                        "MaximumNetworkInterfaces": 2
                    },
                    {
                        "NetworkCardIndex": 2,
                        "NetworkPerformance": "1 Gigabit",
                        "MaximumNetworkInterfaces": 2
                    },
                    {
                        "NetworkCardIndex": 3,
                        "NetworkPerformance": "1 Gigabit",
                        "MaximumNetworkInterfaces": 2
                    }
                ]
```

Signed-off-by: Francesco Giordano <giordafr@amazon.it>

### Tests
* Created a cluster manually

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
