### PR TITLE
updating links for the getting started guide to point to version 3 si…

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ You can view the running compute hosts:
 $ sinfo
 ```
 
-For more information on any of these steps see the [Getting Started Guide](https://docs.aws.amazon.com/parallelcluster/latest/ug/getting_started.html).
+For more information on any of these steps see the [Getting Started Guide](https://docs.aws.amazon.com/parallelcluster/latest/ug/install-v3.html).
 
 Documentation
 -------------
 
 We've been working hard to greatly improve the [Documentation](https://docs.aws.amazon.com/parallelcluster/latest/ug/), it's now published in 10 languages, one of the many benefits of being hosted on AWS Docs. Of most interest to new users is
-the [Getting Started Guide](https://docs.aws.amazon.com/parallelcluster/latest/ug/getting_started.html).
+the [Getting Started Guide](https://docs.aws.amazon.com/parallelcluster/latest/ug/install-v3.html).
 
 If you have changes you would like to see in the docs, please either submit feedback using the feedback link at the bottom
 of each page or create an issue or pull request for the project at:


### PR DESCRIPTION

### Description of changes
I am creating this PR to commit up changes to the documentation links for the getting started guide.  Its been setup now with the v3 links of parallelcluster and not v2 links in my change.

### Tests
* No tests were needed


### Checklist
- [ x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ x] Check all commits' messages are clear, describing what and why vs how.
- [ x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
