### PR TITLE
Changed integration tests accordingly after changing share storages logical id to be hash of volume name

### DIFF
--- a/tests/integration-tests/tags_utils.py
+++ b/tests/integration-tests/tags_utils.py
@@ -13,7 +13,7 @@ import logging
 
 import boto3
 from assertpy import assert_that
-from utils import get_root_volume_id
+from utils import create_hash_suffix, get_root_volume_id
 
 
 def convert_tags_dicts_to_tags_list(tags_dicts):
@@ -93,7 +93,7 @@ def get_ebs_volume_tags(volume_id, region):
     return boto3.client("ec2", region_name=region).describe_volumes(VolumeIds=[volume_id]).get("Volumes")[0].get("Tags")
 
 
-def get_shared_volume_tags(cluster):
+def get_shared_volume_tags(cluster, volume_name):
     """Return the given cluster's EBS volume's tags."""
-    shared_volume = cluster.cfn_resources.get("EBS0")
+    shared_volume = cluster.cfn_resources.get(f"EBS{create_hash_suffix(volume_name)}")
     return get_ebs_volume_tags(shared_volume, cluster.region)

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
@@ -31,11 +31,11 @@ Scheduling:
           # to test the managed sg allow access from the custom sg
 SharedStorage:
   - MountDir: efs
-    Name: efs
+    Name: {{ efs_name }}
     StorageType: Efs
   {% if scheduler != "awsbatch" %}
   - MountDir: fsx
-    Name: fsx
+    Name: {{ fsx_name }}
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: 1200

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
@@ -31,11 +31,11 @@ Scheduling:
           - {{ vpc_security_group_id }}
 SharedStorage:
   - MountDir: efs
-    Name: efs
+    Name: {{ efs_name }}
     StorageType: Efs
   {% if scheduler != "awsbatch" %}
   - MountDir: fsx
-    Name: fsx
+    Name: {{ fsx_name }}
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: 1200

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
@@ -99,6 +99,7 @@ def test_scheduler_plugin_integration(
     run_as_user = OS_MAPPING[os]
     # Create cluster
     another_instance_type = ANOTHER_INSTANCE_TYPE_BY_ARCH[architecture]
+    volume_name = "name1"
     before_update_cluster_config = pcluster_config_reader(
         config_file="pcluster.config.before_update.yaml",
         bucket=bucket_name,
@@ -109,6 +110,7 @@ def test_scheduler_plugin_integration(
         account_id=account_id,
         run_as_user=run_as_user,
         plugin_interface_version=SCHEDULER_PLUGIN_INTERFACE_VERSION,
+        volume_name=volume_name,
     )
     cluster = clusters_factory(before_update_cluster_config)
     cluster_config = pcluster_config_reader(
@@ -121,6 +123,7 @@ def test_scheduler_plugin_integration(
         run_as_user=run_as_user,
         compute_node_bootstrap_timeout=compute_node_bootstrap_timeout,
         plugin_interface_version=SCHEDULER_PLUGIN_INTERFACE_VERSION,
+        volume_name=volume_name,
     )
     # Command executor
     command_executor = RemoteCommandExecutor(cluster)
@@ -193,7 +196,7 @@ def test_scheduler_plugin_integration(
     # Test custom log files in Monitoring configuration
     _test_custom_log(cluster, os)
     # Test scheduler plugin tags
-    _test_tags(cluster, os)
+    _test_tags(cluster, os, volume_name)
     # Test get or update compute fleet_status_script
     _test_update_compute_fleet_status_script(command_executor)
     # Test invoke scheduler plugin event handler script
@@ -457,7 +460,7 @@ def _test_cluster_config(request, region, command_executor, cluster_config, rend
         )
 
 
-def _test_tags(cluster, os):
+def _test_tags(cluster, os, volume_name):
     scheduler_plugin_tags = {"SchedulerPluginTag": "SchedulerPluginTagValue"}
     config_file_tags = {"ConfigFileTag": "ConfigFileTagValue"}
 
@@ -487,6 +490,7 @@ def _test_tags(cluster, os):
         {
             "resource": "Shared EBS Volume",
             "tag_getter": get_shared_volume_tags,
+            "tag_getter_kwargs": {"cluster": cluster, "volume_name": volume_name},
         },
     ]
     for test_case in test_cases:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.before_update.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.before_update.yaml
@@ -112,7 +112,7 @@ Scheduling:
           - {{ private_subnet_id }}
 SharedStorage:
   - MountDir: /shared
-    Name: name1
+    Name: {{ volume_name}}
     StorageType: Ebs
 Tags:
   - Key: ConfigFileTag

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.yaml
@@ -122,7 +122,7 @@ Scheduling:
           - {{ private_subnet_id }}
 SharedStorage:
   - MountDir: /shared
-    Name: name1
+    Name: {{ volume_name }}
     StorageType: Ebs
 Tags:
   - Key: ConfigFileTag

--- a/tests/integration-tests/tests/storage/test_deletion_policy.py
+++ b/tests/integration-tests/tests/storage/test_deletion_policy.py
@@ -15,16 +15,17 @@ import boto3
 import pytest
 from assertpy import assert_that
 from botocore.exceptions import ClientError
-from utils import get_compute_nodes_instance_ids, get_root_volume_id, get_stack_id_tag_filter
+from utils import create_hash_suffix, get_compute_nodes_instance_ids, get_root_volume_id, get_stack_id_tag_filter
 
 
 @pytest.mark.usefixtures("instance", "scheduler")
 def test_retain_on_deletion(pcluster_config_reader, clusters_factory, region, os):
-    cluster_config = pcluster_config_reader()
+    ebs_name = "ebs0"
+    cluster_config = pcluster_config_reader(ebs_name=ebs_name)
     cluster = clusters_factory(cluster_config)
 
     stack_arn = cluster.cfn_stack_arn
-    retained_volume = cluster.cfn_resources["EBS0"]
+    retained_volume = cluster.cfn_resources[f"EBS{create_hash_suffix(ebs_name)}"]
     head_node_root_volume = get_root_volume_id(cluster.head_node_instance_id, region, os)
     compute_node_instance_ids = get_compute_nodes_instance_ids(cluster.name, region)
     logging.info("Checking at least one compute node is running")

--- a/tests/integration-tests/tests/storage/test_deletion_policy/test_retain_on_deletion/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_deletion_policy/test_retain_on_deletion/pcluster.config.yaml
@@ -31,7 +31,7 @@ Scheduling:
           - {{ private_subnet_id }}
 SharedStorage:
   - MountDir: /ebs1
-    Name: ebs0
+    Name: {{ ebs_name }}
     StorageType: Ebs
     EbsSettings:
       DeletionPolicy: Retain

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.update.yaml
@@ -31,5 +31,5 @@ Scheduling:
           - {{ private_subnet_id }}
 SharedStorage:
   - MountDir: /shared
-    Name: name1
+    Name: {{ volume_name }}
     StorageType: Ebs

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
@@ -31,5 +31,5 @@ Scheduling:
           - {{ private_subnet_id }}
 SharedStorage:
   - MountDir: /shared
-    Name: name1
+    Name: {{ volume_name }}
     StorageType: Ebs

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -18,6 +18,7 @@ import shlex
 import socket
 import string
 import subprocess
+from hashlib import sha1
 
 import boto3
 from assertpy import assert_that
@@ -498,3 +499,12 @@ def scheduler_plugin_definition_uploader(upload_script_path, bucket, key_prefix,
     except Exception as e:
         logging.error("Failed when uploading scheduler plugin artifacts", e)
         raise
+
+
+def create_hash_suffix(string_to_hash: str):
+    """Create 16digit hash string."""
+    return (
+        string_to_hash
+        if string_to_hash == "HeadNode"
+        else sha1(string_to_hash.encode("utf-8")).hexdigest()[:16].capitalize()  # nosec nosemgrep
+    )


### PR DESCRIPTION
After changing share storage logical Ids to be the hash of the name, integration tests need to be changed accordingly. The logical Id of the volumes are not longer EBS0, FSX1, EFS0...

Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
