### PR TITLE
Fix slurm_plugin tests by using node package from 3.2

### DIFF
--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/recipes/install_cluster_daemons.rb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/recipes/install_cluster_daemons.rb
@@ -22,7 +22,8 @@ bash 'install' do
     set -e
 
     # FIXME: installing from GitHub is discouraged
-    #{node['pcluster']['python_root']}/pip install https://github.com/aws/aws-parallelcluster-node/tarball/refs/heads/develop
+    # FIXME: move node package in the scheduler-plugin artifacts
+    #{node['pcluster']['python_root']}/pip install https://github.com/aws/aws-parallelcluster-node/tarball/refs/heads/release-3.2
   DAEMONS
   not_if "#{node['pcluster']['python_root']}/pip list | grep aws-parallelcluster-node"
 end


### PR DESCRIPTION
In develop the node package has a behaviour incompatible with scheduler plugin (BYOS).
