### PR TITLE
[integ-tests-3.2.0] Disable slurm_plugin and build-image tests in GovCloud 

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -153,9 +153,6 @@ createami:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2", "ubuntu2004", "centos7"]
-      - regions: ["us-gov-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1804"]
   test_createami.py::test_kernel4_build_image_run_cluster:
     dimensions:
       - regions: ["eu-west-1"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -420,10 +420,12 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
+{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_ONE_PER_DISTRO }}
         schedulers: ["slurm_plugin"]
+{%- endif %}
   test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
     dimensions:
       - regions: ["ap-southeast-2"]
@@ -440,10 +442,12 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_ONE_PER_DISTRO }}
         schedulers: ["slurm"]
+{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
       - regions: ["me-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm_plugin"]
+{%- endif %}
       - regions: [ "us-east-2" ]
         instances: [{{ common.instance("instance_type_1") }}]
         oss: [ "alinux2" ]
@@ -453,13 +457,25 @@ schedulers:
       - regions: ["ca-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "slurm_plugin"]
+        schedulers: ["slurm"]
+{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
+      - regions: ["ca-central-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm_plugin"]
+{%- endif %}
   test_slurm.py::test_slurm_protected_mode:
     dimensions:
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "slurm_plugin"]
+        schedulers: ["slurm"]
+{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
+      - regions: ["eu-west-2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm_plugin"]
+{%- endif %}
   test_slurm.py::test_fast_capacity_failover:
     dimensions:
       - regions: ["ap-east-1"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -1,10 +1,6 @@
 {%- import 'common.jinja2' as common with context -%}
+{%- set SCHEDULER_PLUGIN_TESTS = false -%}
 ---
-scheduler-plugins:
-  slurm_plugin:
-    scheduler-definition: "../../scheduler_plugins/slurm/utils/upload_artifacts.sh"
-    scheduler-commands: "tests.common.schedulers_common.SlurmCommands"
-    requires-sudo: true
 test-suites:
 {% filter indent(2) %}
 {% include 'common/common.yaml' %}


### PR DESCRIPTION
### Description of changes
* Disabling slurm_plugin tests in released config since the feature is still in development
* Disabling build-image tests in GovCloud due to unavailability of DLAMI. The functionality is still covered by the same test in  "eu-west-3" region

### Tests
* `python -m test_runner --reports html junitxml json --key-name "fdm-jenkins" --key-path /Users/fdm/.ssh/fdm-jenkins.pem --tests-config configs/develop.yaml --sequential -n 1 --dry-run`
* `python -m test_runner --reports html junitxml json --key-name "fdm-jenkins" --key-path /Users/fdm/.ssh/fdm-jenkins.pem --tests-config configs/released.yaml --sequential -n 1 --dry-run`

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
