### PR TITLE
[integ-tests-2.11.7]Temporarily disabling build-image tests in us-gov region

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -102,9 +102,6 @@ createami:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2", "ubuntu1804"] # temporary disable FPGA AMI since there is not enough free space on root partition
-      - regions: ["us-gov-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1804"] # alinux2 temporarily disabled due to incompatible device name
   test_createami.py::test_createami_post_install:
     dimensions:
       - regions: ["ap-southeast-2"]


### PR DESCRIPTION
### Description of changes
* Temporarily disabling build-image tests in us-gov region due to DLAMI not available in GovCloud
