### PR TITLE
Avoid failing on DescribeCluster when cluster configuration is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
 - Fix validation of parameter `SharedStorage/EfsSettings`: now validation fails when `FileSystemId` is specified 
   along with other `SharedStorage/EfsSettings` parameters, whereas it was previously ignoring them.
 - Fix cluster update when changing the order of SharedStorage together with other changes in the configuration.
+- Avoid failing on DescribeCluster when cluster configuration is not available.
 
 3.2.0
 ------

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -686,7 +686,7 @@ class TestDescribeCluster:
                         },
                     ],
                     "version": get_installed_version(),
-                    "scheduler": {"type": "plugin", "metadata": {"name": "my_scheduler", "version": "1.0.0"}},
+                    "scheduler": {"type": "plugin"},
                 },
             ),
             (
@@ -798,13 +798,17 @@ class TestDescribeCluster:
             mocker.patch(
                 "pcluster.models.cluster.Cluster.config_presigned_url", new_callable=mocker.PropertyMock
             ).return_value = "presigned-url"
+            config_mock = mocker.patch("pcluster.models.cluster.Cluster.config", new_callable=mocker.PropertyMock)
+            config_mock.return_value.scheduling.settings.scheduler_definition.metadata = metadata
+            config_mock.return_value.scheduling.scheduler = scheduler
         else:
             mocker.patch(
                 "pcluster.models.cluster.Cluster.config_presigned_url", new_callable=mocker.PropertyMock
             ).side_effect = ClusterActionError("failed")
-        config_mock = mocker.patch("pcluster.models.cluster.Cluster.config", new_callable=mocker.PropertyMock)
-        config_mock.return_value.scheduling.settings.scheduler_definition.metadata = metadata
-        config_mock.return_value.scheduling.scheduler = scheduler
+            mocker.patch(
+                "pcluster.models.cluster.Cluster.config", new_callable=mocker.PropertyMock
+            ).side_effect = ClusterActionError("failed")
+
         response = self._send_test_request(client)
 
         with soft_assertions():


### PR DESCRIPTION
### Description of changes
When a describe-cluster is executed and the cluster configuration file is not available (e.g. when a cluster fails creation and rolls back) we should not fail. This issue was apparently introduced when we added scheduler info to the describe-cluster response in 3.2.0, see https://github.com/aws/aws-parallelcluster/commit/220c9051eeeabbc51a6ea80edb9ba7c66af87395. Scheduler metadata field is optional and simply needs to be omitted when unavailable.

### Tests
* Covered by unit test
* Manually deleted cluster config for an existing cluster and executed a describe-cluster
Here is the response, the url is still constructed but the config is not available (this reverts to the old behavior <3.2.0 for now):
```
{
  "creationTime": "2022-08-29T07:56:50.406Z",
  "headNode": {
    "launchTime": "2022-08-29T07:59:42.000Z",
    "instanceId": "i-05dcb5ee601446a5a",
    "instanceType": "c5.xlarge",
    "state": "running",
    "privateIpAddress": "192.168.83.193"
  },
  "version": "3.2.0",
  "clusterConfiguration": {
    "url": "https://parallelcluster-7c5da9a0e3915ce6-v1-do-not-delete.s3.eu-west-1.amazonaws.com/parallelcluster/3.2.0/clusters/no-public-ip-2-410v2vuqt9dxb5q6/configs/cluster-config.yaml?versionId=ZTQ53sf4TGpyD__1Xv3mYCYovQ94E9lW&AWSAccessKeyId=ASIAZQQTMX44FNXEO3WP&Signature=K9MHefKxlzg%2BCe0UPER1GKQaZBQ%3D&x-amz-security-token=IQoJb3JpZ2luX2VjEKD%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIQDeUv4CTPlUIgpmiGnvGZvhNUGJGLohssewH2VP5OV%2BZAIgS%2FqwDEFXLmZJMwT%2FUjI5G8AnEQyHQgT1q1Ovn%2FzdRQUqmgIIKRADGgw2NTM5NDk0NTIwODgiDGeLh8UFc0fhXjG1dyr3AYB9d8jdcgNiPZxF%2FHZsR9YOa1JqVbfdApGhgU4i%2B1t5tXrntjB3TEiRvLB%2BxbO8QO03NYLcmDJTY7Wg%2BTUIXqwKps%2BQ7h%2F2On1AIBNyvcRUwNr9vxWbG6EMcdzpgohNhTvO5ky9e%2B66Dc9hmwvn%2BvDYhFC37H6N6hh3XHL35DGeXROy8v4hSJXt1ASoS1rEvOC4b9hZyvlLxuZw25TZZ%2BZg%2BeOYgyZuhG79Xiqy%2FsaTDFOOCPl%2FY9h58xO9T9mSnPBszyslw5yQEEGPEQTUpYW7RiWu%2FxrkG8QJ1tOiDlulVR9LqagTEMRiHTzDQOC6ojgpv4Sh54Uw8NOxmAY6nQElaBVyYyvCiSuO15xa4pgxYIgO20Vmzblzc%2FO3kWLeNkzHEjJDboEAQ6b4JCegf%2FwZKu57YhVIolBD%2B9IW49QMjHeZ3Us8NUd6vMm4PQP2kZkwS1TQ8jpid23hwqzRlZcNBNpXg%2FH6Ses%2BvmZ8Rxgv3yVQ82iHc74k6Y%2BuPHSSG7dPh0XAD3ePNhNzdHYVueiQSBeozhvOSnCzUCrS&Expires=1661765138"
  },
  "tags": [
    {
      "value": "3.2.0",
      "key": "parallelcluster:version"
    },
    {
      "value": "no-public-ip-2",
      "key": "parallelcluster:cluster-name"
    }
  ],
  "cloudFormationStackStatus": "CREATE_COMPLETE",
  "clusterName": "no-public-ip-2",
  "computeFleetStatus": "RUNNING",
  "cloudformationStackArn": "arn:aws:cloudformation:eu-west-1:653949452088:stack/no-public-ip-2/235a1500-2770-11ed-99c6-0ac454c07325",
  "lastUpdatedTime": "2022-08-29T07:56:50.406Z",
  "region": "eu-west-1",
  "clusterStatus": "CREATE_COMPLETE",
  "scheduler": {
    "type": "slurm"
  }
}
```
Here is the relevant lines in logs:
```
2022-08-29 10:24:00,822 - INFO - common.py:134:_log_boto3_calls() - Executing boto3 call: region=eu-west-1, service=s3, operation=GetObject, params={'Bucket': 'parallelcluster-7c5da9a0e3915ce6-v1-do-not-delete', 'Key': 'parallelcluster/3.2.0/clusters/no-public-ip-2-410v2vuqt9dxb5q6/configs/cluster-config.yaml', 'VersionId': 'ZTQ53sf4TGpyD__1Xv3mYCYovQ94E9lW'}
2022-08-29 10:24:00,886 - ERROR - common.py:107:wrapper() - Encountered error when performing boto3 call in get_object: The specified version does not exist.
2022-08-29 10:24:00,886 - WARNING - cluster.py:1212:get_plugin_metadata() - Unable to retrieve scheduler metadata from cluster configuration.
```

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
