### PR TITLE
[integ-tests-3.2.0] Fix test_create_imds_secured test

### DIFF
--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -94,8 +94,7 @@ def test_create_imds_secured(
     Test IMDS access with different configurations.
     In particular, it also verifies that IMDS access is preserved on instance reboot.
     """
-    custom_ami = retrieve_latest_ami(region, os, ami_type="pcluster", architecture=architecture)
-    cluster_config = pcluster_config_reader(custom_ami=custom_ami, imds_secured=imds_secured)
+    cluster_config = pcluster_config_reader(imds_secured=imds_secured)
     cluster = clusters_factory(cluster_config, raise_on_error=True)
 
     assert_head_node_is_running(region, cluster)

--- a/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
@@ -1,6 +1,5 @@
 Image:
   Os: {{ os }}
-  CustomAmi: {{ custom_ami }}
 HeadNode:
   InstanceType: {{ instance }}
   Networking:


### PR DESCRIPTION
### Description of changes
The test was mistakenly using a custom AMI and not the official ones

### Tests
Executed integration tests

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
