### PR TITLE
[develop] Tests for list of InstanceType

### DIFF
--- a/tests/integration-tests/benchmarks/test_scaling_performance/test_scaling_performance/pcluster.config.yaml
+++ b/tests/integration-tests/benchmarks/test_scaling_performance/test_scaling_performance/pcluster.config.yaml
@@ -14,7 +14,8 @@ Scheduling:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MaxCount: {{ scaling_target }}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/benchmarks/test_scheduler_performance/test_scheduler_performance/pcluster.config.yaml
+++ b/tests/integration-tests/benchmarks/test_scheduler_performance/test_scheduler_performance/pcluster.config.yaml
@@ -14,7 +14,8 @@ Scheduling:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MaxCount: {{ scaling_target + 10 }}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -681,6 +681,12 @@ update:
       - regions: ["eu-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
+  test_update.py::test_update_instance_list:
+    dimensions:
+      - regions: ["ap-south-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
   test_update.py::test_queue_parameters_update:
     dimensions:
       - regions: ["ap-south-1"]

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -14,7 +14,8 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: cit
-          InstanceType: {{ compute_instance_type }}
+          InstanceTypeList:
+            - InstanceType: {{ compute_instance_type }}
           MinCount: 2
           MaxCount: 150
       Networking:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
@@ -14,7 +14,8 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: cit
-          InstanceType: {{ compute_instance_type }}
+          InstanceTypeList:
+            - InstanceType: {{ compute_instance_type }}
           MinCount: 2
           MaxCount: 150
       Networking:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -14,7 +14,8 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: cit
-          InstanceType: {{ compute_instance_type }}
+          InstanceTypeList:
+            - InstanceType: {{ compute_instance_type }}
           MinCount: 2
           MaxCount: 150
       Networking:

--- a/tests/integration-tests/tests/arm_pl/test_arm_pl/test_arm_pl/pcluster.config.yaml
+++ b/tests/integration-tests/tests/arm_pl/test_arm_pl/test_arm_pl/pcluster.config.yaml
@@ -18,7 +18,8 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           {% endif %}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_install_args_quotes/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_install_args_quotes/pcluster.config.yaml
@@ -49,7 +49,8 @@ Scheduling:
             - {{ instance }}
           MinvCpus: 1
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
@@ -22,7 +22,8 @@ Scheduling:
           Script: s3://{{ bucket_name }}/failing_post_install.sh
       ComputeResources:
         - Name: compute-i1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.yaml
@@ -24,9 +24,11 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-11
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
         - Name: compute-resource-12
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
     - Name: ondemand2
       Networking:
@@ -34,7 +36,9 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-21
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
         - Name: compute-resource-22
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
@@ -18,7 +18,8 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           {% endif %}
           {% if scheduler == "awsbatch" %}DesiredvCpus:{% else %}MinCount:{% endif %} {{ queue_size }}
       Networking:

--- a/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
@@ -14,7 +14,8 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: compute-i1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
@@ -15,7 +15,8 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: compute-i1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
@@ -15,7 +15,8 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: compute-i1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/pcluster.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/pcluster.config.yaml
@@ -22,5 +22,6 @@ Scheduling:
         InstanceTypes:
           - {{ instance }}
         {% else %}
-        InstanceType: {{ instance }}
+        InstanceTypeList:
+          - InstanceType: {{ instance }}
         {% endif %}

--- a/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
@@ -21,7 +21,8 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           {% endif %}
 Monitoring:
   DetailedMonitoring: true

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
@@ -26,7 +26,8 @@ Scheduling:
           DesiredvCpus: 8
           MaxvCpus: 8
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
@@ -26,7 +26,8 @@ Scheduling:
           DesiredvCpus: 8
           MaxvCpus: 8
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_hit_disable_hyperthreading/pcluster.config.yaml
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_hit_disable_hyperthreading/pcluster.config.yaml
@@ -18,7 +18,8 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-11
           DisableSimultaneousMultithreading: true
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
     - Name: ht-enabled
       Networking:
@@ -27,7 +28,8 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-21
           DisableSimultaneousMultithreading: false
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
 SharedStorage:
   - MountDir: /shared

--- a/tests/integration-tests/tests/dns/test_dns/test_existing_hosted_zone/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dns/test_dns/test_existing_hosted_zone/pcluster.config.yaml
@@ -19,7 +19,8 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand-1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: {{ queue_size }}
 SharedStorage:
   - MountDir: /shared

--- a/tests/integration-tests/tests/dns/test_dns/test_hit_no_cluster_dns_mpi/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dns/test_dns/test_hit_no_cluster_dns_mpi/pcluster.config.yaml
@@ -21,7 +21,8 @@ Scheduling:
           - {{ public_subnet_id }}
       ComputeResources:
         - Name: default-queue-i1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MaxCount: {{ max_queue_size }}
           MinCount: {{ min_queue_size }}
           # initial_count was deprecated. The original config has it set to 1. ToDo Check if using MinCount is a good alternative for the test.

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -11,7 +11,7 @@ HeadNode:
     Secured: {{ imds_secured }}
 {% if instance == "p4d.24xlarge" %}
   Iam:
-    # Needed to use the p4d capacity reservation 
+    # Needed to use the p4d capacity reservation
     AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AmazonEC2FullAccess
     S3Access:
@@ -32,7 +32,8 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: efa-enabled-i1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MaxCount: {{ max_queue_size }}
           MinCount: {{ max_queue_size }}
           DisableSimultaneousMultithreading: true

--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/pcluster.config.yaml
@@ -32,7 +32,8 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: efa-enabled
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 2
           MaxCount: 2
           DisableSimultaneousMultithreading: true

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.yaml
@@ -30,7 +30,8 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           {% endif %}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
@@ -27,7 +27,8 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: {{ min_count }}
           Efa:
             Enabled: false
@@ -42,7 +43,8 @@ Scheduling:
         InstanceRole: {{ compute_instance_role }}
       ComputeResources:
         - Name: compute-resource-0
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: {{ min_count }}
           Efa:
             Enabled: false

--- a/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
@@ -26,7 +26,8 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           Efa:
             Enabled: false
             GdrSupport: false

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
@@ -25,7 +25,8 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           {% endif %}
           MinCount: 2
       Networking:

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
@@ -26,7 +26,8 @@ Scheduling:
             - {{ instance }}
           {% else %}
           InstanceTypeList:
-            - InstanceType: {{ instance }}
+            - InstanceType: c5n.18xlarge
+            - InstanceType: c5n.metal
           {% endif %}
           MinCount: 2
       Networking:

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -32,7 +32,8 @@ Scheduling:
             - {{ instance }}
           MinvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           Efa:
             Enabled: true

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
@@ -32,7 +32,8 @@ Scheduling:
   - Name: queue-0
     ComputeResources:
       - Name: compute-resource-0
-        InstanceType: {{ instance }}
+        InstanceTypeList:
+          - InstanceType: {{ instance }}
         MinCount: 1
         MaxCount: 2
     Networking:

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
@@ -18,7 +18,8 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_existing_eip/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_existing_eip/pcluster.config.yaml
@@ -19,7 +19,8 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           {% endif %}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 4
           MaxvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
@@ -14,7 +14,8 @@ Scheduling:
     - Name: dynamic
       ComputeResources:
         - Name: compute-resource-0
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MaxCount: 5
       Networking:
         PlacementGroup:
@@ -24,7 +25,8 @@ Scheduling:
     - Name: existing
       ComputeResources:
         - Name: compute-resource-1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
       Networking:
         PlacementGroup:
           Id: {{ placement_group }}

--- a/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.yaml
@@ -23,7 +23,8 @@ Scheduling:
           MinvCpus: 4
           MaxvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
@@ -19,7 +19,8 @@ Scheduling:
             - {{ instance }}
           MinvCpus: 1
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 2
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
@@ -21,7 +21,8 @@ Scheduling:
             - {{ instance }}
           MinvCpus: 1
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 2
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.update.yaml
@@ -17,7 +17,8 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 2
     - Name: ondemand2
@@ -26,5 +27,6 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-2
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.yaml
@@ -17,7 +17,8 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 1
     - Name: ondemand2
@@ -26,5 +27,6 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-2
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1

--- a/tests/integration-tests/tests/performance_tests/test_simple/test_simple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_simple/test_simple/pcluster.config.yaml
@@ -25,7 +25,8 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: res-1
-          InstanceType: {{ compute_instance_type }}
+          InstanceTypeList:
+            - InstanceType: {{ compute_instance_type }}
           MinCount: 0
           MaxCount: {{ num_compute_nodes }}
           DisableSimultaneousMultithreading: {{ multithreading_disabled }}

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
@@ -16,7 +16,8 @@ Scheduling:
       CapacityType: ONDEMAND
       ComputeResources:
         - Name: compute-resource-0
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi/pcluster.config.yaml
@@ -16,7 +16,8 @@ Scheduling:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MaxCount: {{ max_queue_size }}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/pcluster.config.yaml
@@ -14,7 +14,8 @@ Scheduling:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_error_handling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_error_handling/pcluster.config.yaml
@@ -22,9 +22,11 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: dummy-1
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
         - Name: ondemand1-i1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
 SharedStorage:
   - MountDir: /shared

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
@@ -18,7 +18,7 @@ Scheduling:
           InstanceType: c5.large
           MinCount: 1
         - Name: ondemand1-i1
-          InstanceType: {{ instance }}
+          InstanceType: { instance }}
 SharedStorage:
   - MountDir: /shared
     Name: name1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot/pcluster.config.yaml
@@ -15,6 +15,7 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: t2micro
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 2
           MaxCount: 4

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.yaml
@@ -22,9 +22,11 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand-i1
-          InstanceType: c4.xlarge
+          InstanceTypeList:
+            - InstanceType: 4.xlarge
         - Name: same-name-diff-queue
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MaxCount: 5
     - Name: gpu
       Networking:
@@ -33,7 +35,8 @@ Scheduling:
       CapacityType: ONDEMAND
       ComputeResources:
         - Name: same-name-diff-queue
-          InstanceType: {{ gpu_instance_type }}
+          InstanceTypeList:
+            - InstanceType: {{ gpu_instance_type }}
           MaxCount: 5
 SharedStorage:
   - MountDir: /shared  # Test comment

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.update.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.update.config.yaml
@@ -17,9 +17,11 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand-i1
-          InstanceType: c4.xlarge
+          InstanceTypeList:
+            - InstanceType: c4.xlarge
         - Name: same-name-diff-queue
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MaxCount: 5
     - Name: gpu
       Networking:
@@ -28,7 +30,8 @@ Scheduling:
       CapacityType: ONDEMAND
       ComputeResources:
         - Name: same-name-diff-queue
-          InstanceType: {{ gpu_instance_type }}
+          InstanceTypeList:
+            - InstanceType: {{ gpu_instance_type }}
           MaxCount: 5
 SharedStorage:
   - MountDir: /shared  # Test comment

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update.yaml
@@ -18,10 +18,12 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
           MinCount: 1
         - Name: ondemand1-i2
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
 SharedStorage:
   - MountDir: /shared
     Name: name1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update_scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update_scheduling.yaml
@@ -18,10 +18,12 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
           MinCount: 0
         - Name: ondemand1-i2
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
 SharedStorage:
   - MountDir: /shared
     Name: name1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.yaml
@@ -15,10 +15,12 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
           MinCount: 1
         - Name: ondemand1-i2
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
 SharedStorage:
   - MountDir: /shared
     Name: name1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
@@ -21,12 +21,15 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
           MinCount: 1
         - Name: ondemand1-i2
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
         - Name: ondemand1-i3
-          InstanceType: c5.4xlarge
+          InstanceTypeList:
+            - InstanceType: c5.4xlarge
           MinCount: 0
           SchedulableMemory: 31400
 SharedStorage:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
@@ -21,13 +21,16 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
           MinCount: 1
           SchedulableMemory: 3000
         - Name: ondemand1-i2
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
         - Name: ondemand1-i3
-          InstanceType: c5.4xlarge
+          InstanceTypeList:
+            - InstanceType: c5.4xlarge
           MinCount: 0
           SchedulableMemory: 31400
 SharedStorage:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
@@ -18,12 +18,15 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
           MinCount: 1
         - Name: ondemand1-i2
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
         - Name: ondemand1-i3
-          InstanceType: c5.4xlarge
+          InstanceTypeList:
+            - InstanceType: c5.4xlarge
           MinCount: 0
 SharedStorage:
   - MountDir: /shared

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_pmix/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_pmix/pcluster.config.yaml
@@ -16,7 +16,8 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand-1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: {{ queue_size }}
 SharedStorage:
   - MountDir: /shared

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
@@ -24,7 +24,8 @@ Scheduling:
           Script: s3://{{ bucket }}/scripts/preinstall.sh
       ComputeResources:
         - Name: broken-static
-          InstanceType: c5.large # instance type has bootstrap failure
+          InstanceTypeList:
+            - InstanceType: c5.large # instance type has bootstrap failure
           MinCount: 2
           MaxCount: 250
       Iam:
@@ -41,10 +42,12 @@ Scheduling:
           Script: s3://{{ bucket }}/scripts/preinstall.sh
       ComputeResources:
         - Name: broken-dynamic
-          InstanceType: c5.large # instance type has bootstrap failure
+          InstanceTypeList:
+            - InstanceType: c5.large # instance type has bootstrap failure
           MaxCount: 250
         - Name: working-static
-          InstanceType: c5.xlarge # instance type works as expected
+          InstanceTypeList:
+            - InstanceType: c5.xlarge # instance type works as expected
           MinCount: 1
           MaxCount: 250
       Iam:
@@ -61,7 +64,8 @@ Scheduling:
           Script: s3://{{ bucket }}/scripts/preinstall.sh
       ComputeResources:
         - Name: normal
-          InstanceType: c5.xlarge # instance type works as expected
+          InstanceTypeList:
+            - InstanceType: c5.xlarge # instance type works as expected
           MinCount: 1
           MaxCount: 250
       Iam:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
@@ -20,7 +20,8 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: broken-static
-          InstanceType: c5.large # instance type has bootstrap failure
+          InstanceTypeList:
+            - InstanceType: c5.large # instance type has bootstrap failure
           MinCount: 3 # Set min_count larger than bootstrap failure threshold (which is 2) to test pcluster stop and start don't treat static nodes as bootstrap failure nodes and not set into protected node
       Iam:
         S3Access:
@@ -32,9 +33,11 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: broken-dynamic
-          InstanceType: c5.large # instance type has bootstrap failure
+          InstanceTypeList:
+            - InstanceType: c5.large # instance type has bootstrap failure
         - Name: working-static
-          InstanceType: c5.xlarge # instance type works as expected
+          InstanceTypeList:
+            - InstanceType: c5.xlarge # instance type works as expected
       Iam:
         S3Access:
           - BucketName: {{ bucket }}
@@ -45,7 +48,8 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: normal
-          InstanceType: c5.xlarge # instance type works as expected
+          InstanceTypeList:
+            - InstanceType: c5.xlarge # instance type works as expected
       Iam:
         S3Access:
           - BucketName: {{ bucket }}

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: broken-static
-          InstanceType: c5.large # instance type has bootstrap failure
+          InstanceTypeList:
+            - InstanceType: c5.large # instance type has bootstrap failure
       Iam:
         S3Access:
           - BucketName: {{ bucket }}
@@ -31,9 +32,11 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: broken-dynamic
-          InstanceType: c5.large # instance type has bootstrap failure
+          InstanceTypeList:
+            - InstanceType: c5.large # instance type has bootstrap failure
         - Name: working-static
-          InstanceType: c5.xlarge # instance type works as expected
+          InstanceTypeList:
+            - InstanceType: c5.xlarge # instance type works as expected
       Iam:
         S3Access:
           - BucketName: {{ bucket }}
@@ -44,7 +47,8 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: normal
-          InstanceType: c5.xlarge # instance type works as expected
+          InstanceTypeList:
+            - InstanceType: c5.xlarge # instance type works as expected
       Iam:
         S3Access:
           - BucketName: {{ bucket }}

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_scaling/pcluster.config.yaml
@@ -22,9 +22,11 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: dummy-1
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
         - Name: ondemand1-i1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 2   # FIXME expecting 3 initial nodes and a min count of 2
     - Name: ondemand2
       Networking:
@@ -32,7 +34,9 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: dummy-2
-          InstanceType: c5.large
+          InstanceTypeList:
+            - InstanceType: c5.large
         - Name: ondemand2-i1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 2

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_update_slurm_reconfigure_race_condition/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_update_slurm_reconfigure_race_condition/pcluster.config.yaml
@@ -17,5 +17,6 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MaxCount: {{ max_count_cr1 }}

--- a/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
+++ b/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
@@ -15,7 +15,8 @@ Scheduling:
       CapacityType: SPOT
       ComputeResources:
         - Name: compute-i1
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: {{ min_count }}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/storage/test_deletion_policy/test_retain_on_deletion/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_deletion_policy/test_retain_on_deletion/pcluster.config.yaml
@@ -23,7 +23,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 1
           DesiredvCpus: 1
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           {% endif %}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -35,7 +35,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -22,7 +22,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 1
           DesiredvCpus: 1
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 30
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
@@ -24,7 +24,8 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           {% endif %}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
@@ -28,7 +28,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster_restore_fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster_restore_fsx.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
@@ -26,7 +26,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multiple_fsx/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multiple_fsx/pcluster.config.yaml
@@ -26,7 +26,8 @@ Scheduling:
           MinvCpus: 1
           DesiredvCpus: 1
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 30
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.yaml
@@ -20,7 +20,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.update.yaml
@@ -23,7 +23,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
@@ -23,7 +23,8 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceType: {{ instance }}
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
       ComputeSettings:
@@ -26,7 +27,8 @@ Scheduling:
     - Name: queue2
       ComputeResources:
         - Name: queue2-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update_drain.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update_drain.yaml
@@ -15,7 +15,8 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
       Networking:
@@ -28,7 +29,8 @@ Scheduling:
     - Name: queue2
       ComputeResources:
         - Name: queue2-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
       ComputeSettings:
@@ -26,7 +27,8 @@ Scheduling:
     - Name: queue2
       ComputeResources:
         - Name: queue2-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.update_drain_without_running_job.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.update_drain_without_running_job.yaml
@@ -15,7 +15,8 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
       Networking:
@@ -28,7 +29,8 @@ Scheduling:
     - Name: queue2
       ComputeResources:
         - Name: queue2-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.update.yaml
@@ -17,11 +17,13 @@ Scheduling:
             Size: 200
       ComputeResources:
         - Name: queue1-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
         - Name: queue1-i2
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.yaml
@@ -13,11 +13,13 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
         - Name: queue1-i2
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.remove.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.remove.yaml
@@ -1,0 +1,21 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      ComputeResources:
+        - Name: queue1-i1
+          InstanceTypeList:
+            - InstanceType: t3.xlarge
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
@@ -1,0 +1,22 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      ComputeResources:
+        - Name: queue1-i1
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
+            - InstanceType: t3.xlarge
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
@@ -1,0 +1,21 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      ComputeResources:
+        - Name: queue1-i1
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -40,14 +40,17 @@ Scheduling:
       CapacityType: SPOT
       ComputeResources:
         - Name: queue1-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 2
           MaxCount: 4
         - Name: queue1-i2
-          InstanceType: c5.2xlarge
+          InstanceTypeList:
+            - InstanceType: c5.2xlarge
           SpotPrice: 2.1
         - Name: queue1-i3
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
       Iam:
         S3Access:
           - BucketName: {{ resource_bucket }}
@@ -79,7 +82,8 @@ Scheduling:
             - DEF
       ComputeResources:
         - Name: queue2-i1
-          InstanceType: c5n.18xlarge
+          InstanceTypeList:
+            - InstanceType: c5n.18xlarge
           MaxCount: 1
           DisableSimultaneousMultithreading: true
           Efa:
@@ -111,12 +115,14 @@ Scheduling:
             - DEF
       ComputeResources:
         - Name: queue3-i1
-          InstanceType: c5n.18xlarge
+          InstanceTypeList:
+            - InstanceType: c5n.18xlarge
           DisableSimultaneousMultithreading: true
           Efa:
             Enabled: true
         - Name: queue3-i2
-          InstanceType: t2.xlarge
+          InstanceTypeList:
+            - InstanceType: t2.xlarge
           DisableSimultaneousMultithreading: true
           Efa:
             Enabled: false

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -34,11 +34,13 @@ Scheduling:
       CapacityType: ONDEMAND
       ComputeResources:
         - Name: queue1-i1
-          InstanceType: c5.xlarge
+          InstanceTypeList:
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
         - Name: queue1-i2
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 1
       Networking:
         SubnetIds:
@@ -56,7 +58,8 @@ Scheduling:
         - Name: queue2-i1
           Efa:
             Enabled: true
-          InstanceType: c5n.18xlarge
+          InstanceTypeList:
+            - InstanceType: c5n.18xlarge
       Iam:
         S3Access:
           - BucketName: {{ resource_bucket }}


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Switch from InstanceType to single instance in InstanceTypeList
  
  All integration tests changed except for the:
  * test_scaling, for which we want to keep testing the same instance launch API
  * test_fast_capacity_failover, for which we use the run_instance override to simulate capacity failure

* Add test for updating instance type list
  
  Test perform cluster update adding and removing instance types from the list, checking that new types are spinned up based on the allocation strategy

* Add instance type for intel_hpc test
  
  This in order to reduce ICE when using c5n.18xlarge
 
### Tests
* added

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
