### PR TITLE
`[cli/setup]` Update setup to reduce warnings in python3.10.

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -11,7 +11,7 @@
 
 import os
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 
 def readme():
@@ -65,7 +65,7 @@ setup(
     url="https://github.com/aws/aws-parallelcluster",
     license="Apache License 2.0",
     package_dir={"": "src"},
-    packages=find_packages("src"),
+    packages=find_namespace_packages("src"),
     python_requires=">=3.7",
     install_requires=REQUIRES,
     extras_require={


### PR DESCRIPTION
### Description of changes
* Update the setup.py to retrieve packages using the `find_namespace_packages` function for python 3.10

### Tests
* Manually ran `tox -e build` on both python3.8 and python3.10

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
