### PR TITLE
[3.2.x] Add Name field to PlacementGroup for Scheduling.SlurmQueues.Networking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ assets/
 report.html
 tests_outputs/
 .python-version
+test.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
       - id: trailing-whitespace
@@ -37,7 +37,7 @@ repos:
         args: ['-rc', '-w 120', '--settings-path=cli/.isort.cfg']
 
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.6.0
     hooks:
       - id: black
         args: ['-l 120']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
 **ENHANCEMENTS**
-- Add new configuration parameter `DeletionPolicy` for EFs and FSx for Lustre shared storage 
+- Add new configuration parameter `DeletionPolicy` for EFs and FSx for Lustre shared storage
   to support storage retention on deletion.
 
 **CHANGES**
@@ -14,9 +14,10 @@ CHANGELOG
 - Move head node tags from Launch Template to instance definition to avoid head node replacement on tags updates.
 - Disable Multithreading through script executed by cloud-init and not through CpuOptions set into Launch Template.
 - Add support for multiple instance types in the same Compute Resource.
+- Add support for a Name field in PlacementGroup as the preferred naming method.
 
 **BUG FIXES**
-- Fix validation of parameter `SharedStorage/EfsSettings`: now validation fails when `FileSystemId` is specified 
+- Fix validation of parameter `SharedStorage/EfsSettings`: now validation fails when `FileSystemId` is specified
   along with other `SharedStorage/EfsSettings` parameters, whereas it was previously ignoring them.
 - Fix cluster update when changing the order of SharedStorage together with other changes in the configuration.
 
@@ -73,7 +74,7 @@ CHANGELOG
 - Fix file handle leak in `computemgtd`.
 - Fix race condition that was sporadically causing launched instances to be immediately terminated because not available yet in EC2 DescribeInstances response
 - Fix support for `DisableSimultaneousMultithreading` parameter on instance types with Arm processors.
-- Fix ParallelCluster API stack update failure when upgrading from a previus version. Add resource pattern used for the `ListImagePipelineImages` action in the `EcrImageDeletionLambdaRole`. 
+- Fix ParallelCluster API stack update failure when upgrading from a previus version. Add resource pattern used for the `ListImagePipelineImages` action in the `EcrImageDeletionLambdaRole`.
 - Fix ParallelCluster API adding missing permissions needed to import/export from S3 when creating an FSx for Lustre storage.
 
 3.1.4

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -119,7 +119,7 @@ from pcluster.validators.ec2_validators import (
     InstanceTypeMemoryInfoValidator,
     InstanceTypeValidator,
     KeyPairValidator,
-    PlacementGroupIdValidator,
+    PlacementGroupNamingValidator,
 )
 from pcluster.validators.fsx_validators import (
     FsxAutoImportValidator,
@@ -539,13 +539,14 @@ class HeadNodeNetworking(_BaseNetworking):
 class PlacementGroup(Resource):
     """Represent the placement group for the Queue networking."""
 
-    def __init__(self, enabled: bool = None, id: str = None):
+    def __init__(self, enabled: bool = None, name: str = None, id: str = None):
         super().__init__()
         self.enabled = Resource.init_param(enabled, default=False)
-        self.id = Resource.init_param(id)
+        self.name = Resource.init_param(name)
+        self.id = Resource.init_param(id)  # Duplicate of name
 
     def _register_validators(self):
-        self._register_validator(PlacementGroupIdValidator, placement_group=self)
+        self._register_validator(PlacementGroupNamingValidator, placement_group=self)
 
 
 class _QueueNetworking(_BaseNetworking):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -630,6 +630,7 @@ class PlacementGroupSchema(BaseSchema):
 
     enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
     id = fields.Str(metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
+    name = fields.Str(metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1367,7 +1367,7 @@ class ComputeFleetConstruct(Construct):
             if (
                 queue.networking.placement_group
                 and queue.networking.placement_group.enabled
-                and not queue.networking.placement_group.id
+                and not (queue.networking.placement_group.id or queue.networking.placement_group.name)
             ):
                 managed_placement_groups[queue.name] = ec2.CfnPlacementGroup(
                     self, f"PlacementGroup{create_hash_suffix(queue.name)}", strategy="cluster"
@@ -1382,10 +1382,10 @@ class ComputeFleetConstruct(Construct):
 
             queue_placement_group = None
             if queue.networking.placement_group:
-                if queue.networking.placement_group.id and (
+                if (queue.networking.placement_group.id or queue.networking.placement_group.name) and (
                     queue.networking.placement_group.enabled or queue.networking.placement_group.is_implied("enabled")
-                ):  # Do not use `PlacementGroup/Id` when `PlacementGroup/Enabled` is explicitly set to `false`
-                    queue_placement_group = queue.networking.placement_group.id
+                ):
+                    queue_placement_group = queue.networking.placement_group.name or queue.networking.placement_group.id
                 elif queue.networking.placement_group.enabled:
                     queue_placement_group = managed_placement_groups[queue.name].ref
 

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -99,21 +99,27 @@ class KeyPairValidator(Validator):
             )
 
 
-class PlacementGroupIdValidator(Validator):  # TODO: add tests
-    """Placement group id validator."""
+class PlacementGroupNamingValidator(Validator):  # TODO: add tests
+    """Placement group naming validator."""
 
     def _validate(self, placement_group):
-        if placement_group.id:
+        if placement_group.id and placement_group.name:
+            self._add_failure(
+                "PlacementGroup Id cannot be set when setting PlacementGroup Name.  Please "
+                "set either Id or Name but not both.",
+                FailureLevel.ERROR,
+            )
+        identifier = placement_group.name or placement_group.id
+        if identifier:
             if not placement_group.is_implied("enabled") and not placement_group.enabled:
                 self._add_failure(
-                    "PlacementGroup Id can not be set when setting 'Enabled: false' in queue's "
-                    "networking section. Please remove PlacementGroup Id if you don't want"
-                    " to use PlacementGroup.",
+                    "The PlacementGroup feature must be enabled (Enabled: true) in order "
+                    "to assign a Name or Id parameter",
                     FailureLevel.ERROR,
                 )
             else:
                 try:
-                    AWSApi.instance().ec2.describe_placement_group(placement_group.id)
+                    AWSApi.instance().ec2.describe_placement_group(identifier)
                 except AWSClientError as e:
                     self._add_failure(str(e), FailureLevel.ERROR)
 

--- a/cli/tests/requirements.txt
+++ b/cli/tests/requirements.txt
@@ -1,6 +1,8 @@
 assertpy
+aws-lambda-powertools
 freezegun
 jinja2
+munch
 pytest
 pytest-cov
 pytest-datadir
@@ -8,4 +10,3 @@ pytest-html
 pytest-mock
 pytest-xdist
 recordclass
-munch


### PR DESCRIPTION
Signed-off-by: Ryan Anderson <ndry@amazon.com>


### Description of changes
* Updating the PlacementGroup section under Scheduling.SlurmQueues.Networking to include the name field.
* Both Name and Id serve the same purpose and both will coexist for backward compatibility within the major version.
* The documentation will only refer to Name after this update is released.

### Tests
* Added tests associated with the new field validation and conflicts with the existing Id field validation
* Ran local CLI unit tests and all associated with the placement group validation are passing

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
