### PR TITLE
[develop] backport: Fix integration test failure due to update cluster with pending copied AMI

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -390,6 +390,8 @@ def test_update_compute_ami(region, os, pcluster_config_reader, ami_copy, cluste
         pcluster_ami_id, "-".join(["test", "update", "computenode", generate_random_string()])
     )
 
+    _wait_for_image_available(ec2, pcluster_copy_ami_id)
+
     updated_config_file = pcluster_config_reader(
         config_file="pcluster.config.update.yaml", global_custom_ami=pcluster_ami_id, custom_ami=pcluster_copy_ami_id
     )
@@ -399,6 +401,12 @@ def test_update_compute_ami(region, os, pcluster_config_reader, ami_copy, cluste
     instances = cluster.get_cluster_instance_ids(node_type="Compute")
     logging.info(instances)
     _check_instance_ami_id(ec2, instances, pcluster_copy_ami_id)
+
+
+def _wait_for_image_available(ec2_client, image_id):
+    logging.info(f"Waiting for {image_id} to be available")
+    waiter = ec2_client.get_waiter("image_available")
+    waiter.wait(Filters=[{"Name": "image-id", "Values": [image_id]}], WaiterConfig={"Delay": 60, "MaxAttempts": 10})
 
 
 def _check_instance_ami_id(ec2, instances, expected_queue_ami):
@@ -486,7 +494,8 @@ def test_queue_parameters_update(
         updated_compute_root_volume_size,
         queue_update_strategy,
     )
-
+    ec2 = boto3.client("ec2", region_name=region)
+    _wait_for_image_available(ec2, pcluster_copy_ami_id)
     # test update without setting queue strategy, update will fail
     _test_update_without_queue_strategy(
         pcluster_config_reader, pcluster_ami_id, pcluster_copy_ami_id, cluster, updated_compute_root_volume_size


### PR DESCRIPTION
Add a waiter to wait for the copied AMI to be available before using it to create cluster

Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
