### PR TITLE
Make cinc use local trusted CA certificates (3.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG
 - Fix cluster update when changing the order of SharedStorage together with other changes in the configuration.
 - Avoid failing on DescribeCluster when cluster configuration is not available.
 - Fix `UpdateParallelClusterLambdaRole` in the ParallelCluster API to upload logs to CloudWatch.
+- Fix Cinc not using the local CA certificates bundle when installing packages before any cookbooks are executed.
 
 3.2.0
 ------

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -197,7 +197,22 @@ phases:
           commands:
             - |
               set -v
+              PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+
+              if [[ ${!PLATFORM} == RHEL ]]; then
+                CA_CERTS_FILE=/etc/ssl/certs/ca-bundle.crt
+                yum -y upgrade ca-certificates
+              elif [[ ${!PLATFORM} == DEBIAN ]]; then
+                CA_CERTS_FILE=/etc/ssl/certs/ca-certificates.crt
+                apt-get -y --only-upgrade install ca-certificates
+              fi
+
               curl --retry 3 -L {{ build.CincUrl.outputs.stdout }} | bash -s -- -v {{ ChefVersion }}
+
+              if [[ -e ${!CA_CERTS_FILE} ]]; then
+                ln -sf ${!CA_CERTS_FILE} /opt/cinc/embedded/ssl/certs/cacert.pem
+              fi
+
               /opt/cinc/embedded/bin/gem install --no-document berkshelf:{{ BerkshelfVersion }}
 
       # Download and vendor Cookbook


### PR DESCRIPTION
This makes sure that cinc can install required ruby gem right from the start when third-party CA certificates are needed to reach the internet, e.g., when MITM proxy is doing SSL inspection of traffic.

### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

See #4316 

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

Running `tox` with or without these changes did not change test results. No new tests written.

Tested the creation of a ParallelCluster with `build-image` and an Amazon Linux 2 parent image and it worked with the config file shown in #4316 whereas it was not working with the 3.2.0 release.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

https://github.com/aws/aws-parallelcluster-cookbook/pull/1144

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
