### PR TITLE
Add integration tests for Trainium instances

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -412,39 +412,12 @@ class ClustersFactory:
         :param kwargs: additional parameters to be passed to the pcluster command
         """
         name = cluster.name
-        config = cluster.config_file
         if name in self.__created_clusters:
             raise ValueError("Cluster {0} already exists".format(name))
 
         # create the cluster
-        logging.info("Creating cluster {0} with config {1}".format(name, config))
-        command = [
-            "pcluster",
-            "create-cluster",
-            "--rollback-on-failure",
-            "false",
-            "--cluster-configuration",
-            config,
-            "--cluster-name",
-            name,
-        ]
-        wait = kwargs.pop("wait", True)
-        if wait:
-            command.append("--wait")
-        # TODO Remove the validator suppression below once the plugin scheduler is officially supported
-        if cluster.config["Scheduling"]["Scheduler"] == "plugin":
-            validators_list = ["type:SchedulerValidator"]
-
-            # concatenate validators
-            validator = kwargs.get("suppress_validators")
-            if validator:
-                validators_list.append(validator)
-            kwargs["suppress_validators"] = validators_list
-        for k, val in kwargs.items():
-            if isinstance(val, (list, tuple)):
-                command.extend([f"--{kebab_case(k)}"] + list(map(str, val)))
-            else:
-                command.extend([f"--{kebab_case(k)}", str(val)])
+        logging.info("Creating cluster {0} with config {1}".format(name, cluster.config_file))
+        command, wait = self._build_command(cluster, kwargs)
         try:
             result = run_pcluster_command(command, timeout=7200, raise_on_error=raise_on_error, log_error=log_error)
 
@@ -469,6 +442,40 @@ class ClustersFactory:
                     self.__created_clusters[name] = cluster
             except Exception:
                 pass
+
+    @staticmethod
+    def _build_command(cluster, kwargs):
+        command = [
+            "pcluster",
+            "create-cluster",
+            "--rollback-on-failure",
+            "false",
+            "--cluster-configuration",
+            cluster.config_file,
+            "--cluster-name",
+            cluster.name,
+        ]
+
+        wait = kwargs.pop("wait", True)
+        if wait:
+            command.append("--wait")
+
+        # TODO Remove the validator suppression below once the plugin scheduler is officially supported
+        if cluster.config["Scheduling"]["Scheduler"] == "plugin":
+            validators_list = ["type:SchedulerValidator"]
+            # concatenate validators
+            validator = kwargs.get("suppress_validators")
+            if validator:
+                validators_list.append(validator)
+            kwargs["suppress_validators"] = validators_list
+
+        for k, val in kwargs.items():
+            if isinstance(val, (list, tuple)):
+                command.extend([f"--{kebab_case(k)}"] + list(map(str, val)))
+            else:
+                command.extend([f"--{kebab_case(k)}", str(val)])
+
+        return command, wait
 
     def destroy_cluster(self, name, test_passed):
         """Destroy a created cluster."""

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -431,14 +431,20 @@ class ClustersFactory:
         wait = kwargs.pop("wait", True)
         if wait:
             command.append("--wait")
+        # TODO Remove the validator suppression below once the plugin scheduler is officially supported
+        if cluster.config["Scheduling"]["Scheduler"] == "plugin":
+            validators_list = ["type:SchedulerValidator"]
+
+            # concatenate validators
+            validator = kwargs.get("suppress_validators")
+            if validator:
+                validators_list.append(validator)
+            kwargs["suppress_validators"] = validators_list
         for k, val in kwargs.items():
             if isinstance(val, (list, tuple)):
                 command.extend([f"--{kebab_case(k)}"] + list(map(str, val)))
             else:
                 command.extend([f"--{kebab_case(k)}", str(val)])
-        # TODO Remove the validator suppression below once the plugin scheduler is officially supported
-        if cluster.config["Scheduling"]["Scheduler"] == "plugin":
-            command.extend(["--suppress-validators", "type:SchedulerValidator"])
         try:
             result = run_pcluster_command(command, timeout=7200, raise_on_error=raise_on_error, log_error=log_error)
 

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -265,7 +265,7 @@ efa:
         instances: ["p4d.24xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
-      - regions: ["us-west-2"]
+      - regions: ["eu-west-1"]
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -21,7 +21,7 @@ test-suites:
           instances: ["p4d.24xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]
-        - regions: ["us-west-2"]
+        - regions: ["eu-west-1"]
           instances: ["c6gn.16xlarge"]
           oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
           schedulers: ["slurm"]
@@ -102,3 +102,9 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: {{ common.OSS_GOVCLOUD_ARM }}
           schedulers: ["slurm"]
+  trainium:
+    test_trainium.py::test_trainium:
+      dimensions:
+        - regions: ["us-west-2"]
+          schedulers: ["slurm"]
+          oss: ["alinux2", "ubuntu1804", "ubuntu2004"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -783,8 +783,8 @@ AVAILABILITY_ZONE_OVERRIDES = {
     "us-east-1": ["use1-az6"],
     # some instance type is only supported in use2-az2
     "us-east-2": ["use2-az2"],
-    # c4.xlarge is not supported in usw2-az4
-    "us-west-2": ["usw2-az2", "usw2-az1"],
+    # trn available on usw2-az4
+    "us-west-2": ["usw2-az4"],
     # c5.xlarge is not supported in apse2-az3
     "ap-southeast-2": ["apse2-az1", "apse2-az2"],
     # m6g.xlarge is not supported in apne1-az2

--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -21,7 +21,6 @@ pytest-sugar
 pytest-xdist
 PyYAML
 requests
-requests
 retrying
 troposphere
 untangle

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.update.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.update.config.yaml
@@ -18,7 +18,7 @@ Scheduling:
       ComputeResources:
         - Name: ondemand-i1
           InstanceTypeList:
-            - InstanceType: c4.xlarge
+            - InstanceType: c5.large
         - Name: same-name-diff-queue
           InstanceTypeList:
             - InstanceType: c5.xlarge

--- a/tests/integration-tests/tests/trainium/test_trainium.py
+++ b/tests/integration-tests/tests/trainium/test_trainium.py
@@ -1,0 +1,67 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import boto3
+import pytest
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+
+
+@pytest.mark.usefixtures("os", "scheduler")
+def test_trainium(
+    region,
+    pcluster_config_reader,
+    test_datadir,
+    clusters_factory,
+    s3_bucket_factory,
+    scheduler_commands_factory,
+):
+    # Post-install script to install Neuronx packages
+    bucket_name = s3_bucket_factory()
+    bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+    bucket.upload_file(str(test_datadir / "neuron-installation.sh"), "neuron-installation.sh")
+
+    # FIXME remove suppress_validators after GA
+    cluster_config = pcluster_config_reader(bucket_name=bucket_name)
+    cluster = clusters_factory(cluster_config, suppress_validators="type:InstanceTypeBaseAMICompatibleValidator")
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+
+    # TODO uncomment allreduce test
+    # _test_allreduce_single_node(test_datadir, remote_command_executor, scheduler_commands)
+    _test_ccl_two_nodes(test_datadir, remote_command_executor, scheduler_commands)
+
+
+def _test_allreduce_single_node(test_datadir, remote_command_executor, scheduler_commands):
+    result = scheduler_commands.submit_script(str(test_datadir / "neuron-allreduce.sh"), partition="queue-trn2")
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)
+    result = remote_command_executor.run_remote_command("cat output-allreduce.txt")
+
+    print(result.stdout)
+    assert_that(result.stdout).matches(".*PASSED.*")
+
+
+def _test_ccl_two_nodes(test_datadir, remote_command_executor, scheduler_commands):
+    result = scheduler_commands.submit_script(
+        str(test_datadir / "neuron-ccl.sh"),
+        nodes=2,
+        partition="queue-trn32",
+        other_options="--ntasks-per-node=1 --cpus-per-task=32",
+    )
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)
+    result = remote_command_executor.run_remote_command("cat output-ccl.txt")
+
+    print(result.stdout)
+    assert_that(result.stdout).matches(".*CCL(1).*CCL(50).*CCL(99).*CCL(100).*")

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-allreduce.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-allreduce.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Test the basic functionality of the Neuron component installed in the ParallelCluster AMI
+
+# Print available Neuron packages
+OS="$(grep "^ID=" /etc/os-release | cut -d"=" -f 2 | xargs)"
+case ${OS} in
+  ubuntu)
+    apt list --installed | grep neuron
+    USER=ubuntu
+    ;;
+  amzn)
+    rpm -qa | grep neuron
+    USER=ec2-user
+    ;;
+  *)
+    echo "Unsupported system. Found /etc/os-release ID content: ${OS}"
+    exit 1
+    ;;
+esac
+
+# Create python scripts required for the tests
+cat <<EOF >allreduce_launch.py
+import os
+import torch_xla.core.xla_model as xm
+import torch
+import torch.distributed as dist
+from torch_xla.neuron.distributed import xla_backend
+
+#os.environ["NEURON_RT_LOG_LEVEL"] = "INFO"
+#os.environ["NEURON_RT_LOG_LOCATION"] = "syslog"
+#os.environ["NCCL_DEBUG"] = "ERROR"
+#os.environ["NCCL_DEBUG_SUBSYS"] = "ALL"
+
+
+def _mp_fn():
+    dist.init_process_group('xla')
+    world_size = xm.xrt_world_size()
+    device = xm.xla_device()
+
+    if world_size > 0:
+        ones = torch.ones((2, 3))
+        xones = ones.to(device)
+        print("running all reduce")
+        result = xm.all_reduce(xm.REDUCE_SUM, xones)
+        result_cpu = result.cpu()
+        expected = torch.ones((2,3))*world_size
+        assert expected.allclose(result_cpu)
+        print(result_cpu)
+        print('PASS')
+
+
+if __name__ == '__main__':
+    print(
+        'master_port:{}, master_addr:{}, rank:{}, local_rank:{}, size:{}'.format(
+            os.environ['MASTER_PORT'],
+            os.environ['MASTER_ADDR'],
+            os.environ['RANK'],
+            os.environ['LOCAL_RANK'],
+            os.environ['WORLD_SIZE'],
+        )
+    )
+
+    _mp_fn()
+EOF
+
+
+cat <<'EOF' >test_launch.py
+import os
+import subprocess
+
+
+def test_local_launch_allreduce():
+    # This test launches a two phase launcher, spawns two processes which
+    # in turn launch more processes. This uses pytorch distributed.launch utility along with ptxrt bridge
+    cmd = "torchrun --nproc_per_node=$PROC_PER_NODE --nnodes=1 allreduce_launch.py "
+
+    new_env0 = os.environ.copy()
+    new_env0['PROC_PER_NODE'] = '2'
+
+    proc0 = subprocess.Popen(cmd, env=new_env0, shell=True)
+
+    return_code = proc0.wait()
+    assert return_code == 0
+EOF
+
+# Activate virtual environment created by neuron-installation.sh and run the test
+# We expect to find PASSED word at the end of the output
+source /home/$USER/aws_neuron_venv_pytorch/bin/activate
+pytest test_launch.py -vxs | tee output-allreduce.txt

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-ccl.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-ccl.sh
@@ -47,10 +47,12 @@ else
 fi
 TOTAL_RANK=$(($SLURM_NNODES*32))
 
-# Download file for simulation
-NEFF_FILE=test_nccl_32r_allg_int8_393216/0/file.neff
+# Download file for simulation (64 in the file name corresponds to the number of ranks hardcoded into the file).
+# To use a different number of ranks you need to generate another one:
+# python3 inst-sweep/genneffs_nccl.py -n <total-number-of-ranks> --all --output <output-dir>
+NEFF_FILE=test_nccl_64r_allg_int8_393216/0/file.neff
 if [[ ! -f $NEFF_FILE ]]; then
-  aws s3 cp ${TEMPORARY_ARTIFACTS_BUCKET_PATH}test_nccl_32r_allg_int8_393216_0_file.neff $NEFF_FILE
+  aws s3 cp ${TEMPORARY_ARTIFACTS_BUCKET_PATH}test_nccl_64r_allg_int8_393216_0_file.neff $NEFF_FILE
 fi
 
 # Print eth0 ip

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-ccl.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-ccl.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Test the collective functionality of the Neuron component installed in the ParallelCluster AMI
+# This script can work if submitted through Slurm with the following command:
+# sbatch --nodes=2 --ntasks-per-node=1 --cpus-per-task=32 neuron-ccl.sh
+# or if submitted directly on a single node (SLURM_JOB_NODELIST not set)
+
+cat <<'EOF' >submission-script.sh
+#!/bin/bash
+set -x
+
+# FIXME remove this repo once packages are public available
+TEMPORARY_ARTIFACTS_BUCKET_PATH=s3://aws-parallelcluster-beta/neuron/
+
+# Print available Neuron packages
+OS="$(grep "^ID=" /etc/os-release | cut -d"=" -f 2 | xargs)"
+case ${OS} in
+  ubuntu)
+    apt list --installed | grep neuron
+    ;;
+  amzn)
+    rpm -qa | grep neuron
+    ;;
+  *)
+    echo "Unsupported system. Found /etc/os-release ID content: ${OS}"
+    exit 1
+    ;;
+esac
+
+# Identify node name to set the right START_RANK
+if [ "${SLURM_NNODES:=1}" == "1" ]; then
+  # SLURM_NNODES is not set (no slurm job) or script is executed in a single node
+  START_RANK=0
+  # retrieve first IP of the list
+  HOST_IP=$(hostname -I | cut -d ' ' -f1)
+else
+  # SLURM_JOB_NODELIST is an array, find first and second node of the array and use number to identify first node.
+  NODE_NAME_PREFIX=${SLURM_JOB_NODELIST%-[*}
+  NODE1=$(echo $SLURM_JOB_NODELIST | cut -d'[' -f2 | cut -d'-' -f1)
+  NODE2=$(echo $SLURM_JOB_NODELIST | cut -d'[' -f2 | cut -d'-' -f2 | tr -d ']')
+  HOST_IP=$(scontrol show nodes $NODE_NAME_PREFIX-$NODE1 | grep -oe "NodeAddr=[^ ]*" | cut -d'=' -f2)
+
+  if [ "$(hostname)" == "$NODE_NAME_PREFIX-$NODE1" ]; then
+      START_RANK=0
+  else
+      START_RANK=32
+  fi
+fi
+TOTAL_RANK=$(($SLURM_NNODES*32))
+
+# Download file for simulation
+NEFF_FILE=test_nccl_32r_allg_int8_393216/0/file.neff
+if [[ ! -f $NEFF_FILE ]]; then
+  aws s3 cp ${TEMPORARY_ARTIFACTS_BUCKET_PATH}test_nccl_32r_allg_int8_393216_0_file.neff $NEFF_FILE
+fi
+
+# Export variables required for neuron-bench
+export PATH="/opt/aws/neuron/bin:$PATH"
+# Export variables required for EFA
+export FI_EFA_USE_DEVICE_RDMA=1
+export FI_PROVIDER=efa
+
+NEURON_RT_EXEC_TIMEOUT=10 \
+NEURON_RT_ROOT_COMM_ID=$HOST_IP:33666 \
+LD_LIBRARY_PATH=/opt/aws/neuron/lib:/opt/amazon/efa/lib64 \
+neuron-bench infer --fixed-instance-count 32 --enable-only-throughput --work 1000 \
+  --run-as-cc-neff --minimal-tensor-io --verbose 4 \
+  --cc-world-size $TOTAL_RANK --cc-rank-start $START_RANK \
+  --summary-percentiles=1,50,99,100 \
+  --worker-thread-count 1 $NEFF_FILE | tee output-ccl.txt
+
+EOF
+
+# srun is required to run neuron-bench process on the two nodes
+srun bash submission-script.sh

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-ccl.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-ccl.sh
@@ -53,20 +53,24 @@ if [[ ! -f $NEFF_FILE ]]; then
   aws s3 cp ${TEMPORARY_ARTIFACTS_BUCKET_PATH}test_nccl_32r_allg_int8_393216_0_file.neff $NEFF_FILE
 fi
 
+# Print eth0 ip
+/usr/sbin/ip -br addr show dev eth0 scope global
+
 # Export variables required for neuron-bench
 export PATH="/opt/aws/neuron/bin:$PATH"
 # Export variables required for EFA
 export FI_EFA_USE_DEVICE_RDMA=1
 export FI_PROVIDER=efa
 
+NCCL_DEBUG=trace NCCL_DEBUG_SUBSYS=all NCCL_DEBUG_FILE=$(pwd)/nccl_${SLURM_TASK_PID}.log \
 NEURON_RT_EXEC_TIMEOUT=10 \
 NEURON_RT_ROOT_COMM_ID=$HOST_IP:33666 \
 LD_LIBRARY_PATH=/opt/aws/neuron/lib:/opt/amazon/efa/lib64 \
-neuron-bench infer --fixed-instance-count 32 --enable-only-throughput --work 1000 \
+neuron-bench infer --fixed-instance-count 32 --enable-only-latency --work 1000 \
   --run-as-cc-neff --minimal-tensor-io --verbose 4 \
   --cc-world-size $TOTAL_RANK --cc-rank-start $START_RANK \
   --summary-percentiles=1,50,99,100 \
-  --worker-thread-count 1 $NEFF_FILE | tee output-ccl.txt
+  --warmup none $NEFF_FILE | tee output-ccl.txt
 
 EOF
 

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-installation.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-installation.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# Private Repository Access
+# I manually created a TrainiumPreviewRepository secret and TrainiumPreviewPolicy on 447714826191 account to permit access to Secret below
+# {
+#    "Version": "2012-10-17",
+#    "Statement": [
+#        {
+#            "Effect": "Allow",
+#            "Action": [
+#                "secretsmanager:GetResourcePolicy",
+#                "secretsmanager:GetSecretValue",
+#                "secretsmanager:DescribeSecret",
+#                "secretsmanager:ListSecretVersionIds"
+#            ],
+#            "Resource": [
+#                "arn:aws:secretsmanager:us-east-1:447714826191:secret:TrainiumPreviewRepository-<RANDOM-STRING>"
+#            ]
+#        },
+#        {
+#            "Effect": "Allow",
+#            "Action": "secretsmanager:ListSecrets",
+#            "Resource": "*"
+#        }
+#    ]
+#}
+REPO_USER=$(aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-east-1:447714826191:secret:TrainiumPreviewRepository --region us-east-1 --query 'SecretString' --output text | jq -r '.repository_user')
+REPO_SECRET=$(aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-east-1:447714826191:secret:TrainiumPreviewRepository --region us-east-1 --query 'SecretString' --output text | jq -r '.repository_password')
+REPO_SUFFIX=$(aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-east-1:447714826191:secret:TrainiumPreviewRepository --region us-east-1 --query 'SecretString' --output text | jq -r '.repository_suffix')
+
+TEMPORARY_ARTIFACTS_BUCKET_PATH=s3://aws-parallelcluster-beta/neuron/
+
+
+_ubuntu_installation() {
+  # Configure Linux for Neuron repository updates
+  sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
+deb https://${REPO_USER}:${REPO_SECRET}@apt.${REPO_SUFFIX} focal main
+EOF
+  wget -qO - https://${REPO_USER}:${REPO_SECRET}@apt.${REPO_SUFFIX}/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+
+  # Install packages from S3 --> FIXME they should be installed from configured repository
+  sudo dpkg -i aws-neuronx-devtools-2.5.6.0.deb
+  sudo dpkg -i aws-neuronx-tools-2.5.6.0.deb
+  sudo dpkg -i aws-neuronx-collectives-2.9.47.0-d96ffa967.deb
+  sudo dpkg -i aws-neuronx-runtime-lib-2.9.39.0-21003aa11.deb
+
+  # Install Python venv and activate Python virtual environment to install Neuron pip packages.
+  local OS_VERSION="$(grep "^VERSION_ID=" /etc/os-release | cut -d"=" -f 2 | xargs)"
+  case ${OS_VERSION} in
+      20.04)
+        sudo apt-get install -y python3.8-venv g++
+        python3 -m venv /home/ubuntu/aws_neuron_venv_pytorch
+        ;;
+      18.04)
+        sudo apt-get install -y python3.7-venv g++
+        python3.7 -m venv /home/ubuntu/aws_neuron_venv_pytorch
+        ;;
+      *)
+        echo "Unrecognized VERSION_ID. Found /etc/os-release version content: ${OS_VERSION}"
+        exit 1
+        ;;
+    esac
+}
+
+_rhel_installation() {
+  # Install dkms driver. This is not required, installation is performed at AMI creation time
+  sudo tee /etc/yum.repos.d/neuron.repo > /dev/null <<EOF
+[neuron]
+name=Neuron YUM Repository
+baseurl=https://${REPO_USER}:${REPO_SECRET}@yum.${REPO_SUFFIX}
+enabled=1
+EOF
+  sudo rpm --import https://${REPO_USER}:${REPO_SECRET}@yum.${REPO_SUFFIX}/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB
+
+  # Install packages from S3 --> FIXME they should be installed from configured repository
+  sudo rpm -i aws-neuronx-devtools-2.5.6.0.rpm
+  sudo rpm -i aws-neuronx-tools-2.5.6.0.rpm
+  sudo rpm -i aws-neuronx-collectives-2.9.47.0-d96ffa967.rpm
+  sudo rpm -i aws-neuronx-runtime-lib-2.9.39.0-21003aa11.rpm
+
+  python3 -m venv /home/ec2-user/aws_neuron_venv_pytorch
+}
+
+
+_dkms_ubuntu_installation() {
+  # Install dkms driver. This is not required, installation is performed at AMI creation time
+  sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null <<EOF
+deb https://apt.repos.neuron.amazonaws.com focal main
+EOF
+  wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+
+  sudo apt update
+  sudo apt-get install aws-neuronx-dkms -y
+}
+
+
+_dkms_rhel_installation() {
+  # Install dkms driver. This is not required, installation is performed at AMI creation time
+  sudo tee /etc/yum.repos.d/neuron.repo > /dev/null <<EOF
+[neuron]
+name=Neuron YUM Repository
+baseurl=https://yum.repos.neuron.amazonaws.com
+enabled=1
+EOF
+  sudo rpm --import https://yum.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB
+
+  sudo yum install aws-neuronx-dkms -y
+}
+
+
+function main() {
+  # Download packages from S3 --> FIXME they should be installed from configured repository
+  aws s3 cp ${TEMPORARY_ARTIFACTS_BUCKET_PATH} . --recursive
+
+  local OS="$(grep "^ID=" /etc/os-release | cut -d"=" -f 2 | xargs)"
+  case ${OS} in
+    ubuntu)
+      _dkms_ubuntu_installation  # not needed, installed at AMI creation time
+      _ubuntu_installation
+      USER=ubuntu
+      ;;
+    amzn)
+      _dkms_rhel_installation  # not needed, installed at AMI creation time
+      _rhel_installation
+      USER=ec2-user
+      ;;
+    *)
+      echo "Unsupported system. Found /etc/os-release ID content: ${OS}"
+      exit 1
+      ;;
+  esac
+
+  # Install Python venv and activate Python virtual environment to install Neuron pip packages.
+  source /home/$USER/aws_neuron_venv_pytorch/bin/activate
+  pip3 install -U pip
+  pip3 install pytest
+
+  # Install packages from beta repo --> FIXME they should be installed from official PyPI
+  python3 -m pip config set global.extra-index-url "https://${REPO_USER}:${REPO_SECRET}@pip.${REPO_SUFFIX}"
+  pip3 install torch-neuronx==1.10.2.1.*
+  pip3 install neuronx-cc==2.*
+}
+
+main "${@}"

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-installation.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/neuron-installation.sh
@@ -137,7 +137,7 @@ function main() {
 
   # Install packages from beta repo --> FIXME they should be installed from official PyPI
   python3 -m pip config set global.extra-index-url "https://${REPO_USER}:${REPO_SECRET}@pip.${REPO_SUFFIX}"
-  pip3 install torch-neuronx==1.10.2.1.*
+  pip3 install torch-neuronx==1.11.*
   pip3 install neuronx-cc==2.*
 }
 

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/pcluster.config.yaml
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/pcluster.config.yaml
@@ -1,0 +1,65 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: c5.large
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    # Policy to access to Trainium beta repository info
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::447714826191:policy/TrainiumPreviewPolicy
+    S3Access:
+      - BucketName: {{ bucket_name }}
+      # Needed to download neuronx packages and neff file --> FIXME to be removed once packages are public available
+      - BucketName: aws-parallelcluster-beta
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue-trn32
+      ComputeResources:
+        - Name: compute-resource-trn32
+          InstanceTypeList:
+            - InstanceType: trn1.32xlarge
+          MinCount: 2
+          Efa:
+            Enabled: true
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+        PlacementGroup:
+          Enabled: false
+      CustomActions:
+        OnNodeConfigured:
+          Script: s3://{{ bucket_name }}/neuron-installation.sh
+      Iam:
+        # Policy to access to Trainium beta repository info
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::447714826191:policy/TrainiumPreviewPolicy
+        S3Access:
+          # Needed to download post install script
+          - BucketName: {{ bucket_name }}
+          # Needed to download neuronx packages and neff file --> FIXME to be removed once packages are public available
+          - BucketName: aws-parallelcluster-beta
+    - Name: queue-trn2
+      ComputeResources:
+        - Name: compute-resource-trn2
+          InstanceTypeList:
+            - InstanceType: trn1.2xlarge
+          MinCount: 0  # TODO change to 1 once allreduce test is passing
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      CustomActions:
+        OnNodeConfigured:
+          Script: s3://{{ bucket_name }}/neuron-installation.sh
+      Iam:
+        # Policy to access to Trainium beta repository info
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::447714826191:policy/TrainiumPreviewPolicy
+        S3Access:
+          # Needed to download post install script
+          - BucketName: {{ bucket_name }}
+          # Needed to download neuronx packages and neff file --> FIXME to be removed once packages are public available
+          - BucketName: aws-parallelcluster-beta


### PR DESCRIPTION
### Description of changes
The test configuration is static, with two trn1.32xlarge and one trn1.2xlarge.
We're running allreduce tests in a single instance on trn1.2xlarge and collective test (leveraging EFA) on the two trn1.32xlarge nodes.

Some code is temporary and must be removed after GA:
* Installation of neuronx packages from aws-parallelcluster-beta bucket
* Setup of private repository
* Setup of private PyPI repository
* InstanceTypeBaseAMICompatibleValidator usage

The `neuron-installation.sh` script contains also the instructions to install official neuronx repo
and install dkms driver but they are useless because dkms is already installed in the AMI.

### Tests
* Move tests using c6gn.16xlarge from us-west-2 to eu-west-1 because they are not avail
in the avail zone required for trainium tests.
* Change c4.xlarge to c5.large because it is not available in the avail zone required
for traininum tests.
* Manual test execution of the integ tests for the 3 OSes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
