### PR TITLE
Avoid failing on DescribeCluster when cluster configuration is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+3.2.1
+-----
+
+**BUG FIXES**
+- Avoid failing on DescribeCluster when cluster configuration is not available.
+
 3.2.0
 ------
 

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -688,7 +688,7 @@ class TestDescribeCluster:
                         },
                     ],
                     "version": get_installed_version(),
-                    "scheduler": {"type": "plugin", "metadata": {"name": "my_scheduler", "version": "1.0.0"}},
+                    "scheduler": {"type": "plugin"},
                 },
             ),
             (
@@ -800,13 +800,17 @@ class TestDescribeCluster:
             mocker.patch(
                 "pcluster.models.cluster.Cluster.config_presigned_url", new_callable=mocker.PropertyMock
             ).return_value = "presigned-url"
+            config_mock = mocker.patch("pcluster.models.cluster.Cluster.config", new_callable=mocker.PropertyMock)
+            config_mock.return_value.scheduling.settings.scheduler_definition.metadata = metadata
+            config_mock.return_value.scheduling.scheduler = scheduler
         else:
             mocker.patch(
                 "pcluster.models.cluster.Cluster.config_presigned_url", new_callable=mocker.PropertyMock
             ).side_effect = ClusterActionError("failed")
-        config_mock = mocker.patch("pcluster.models.cluster.Cluster.config", new_callable=mocker.PropertyMock)
-        config_mock.return_value.scheduling.settings.scheduler_definition.metadata = metadata
-        config_mock.return_value.scheduling.scheduler = scheduler
+            mocker.patch(
+                "pcluster.models.cluster.Cluster.config", new_callable=mocker.PropertyMock
+            ).side_effect = ClusterActionError("failed")
+
         response = self._send_test_request(client)
 
         with soft_assertions():


### PR DESCRIPTION
Signed-off-by: Francesco De Martino <fdm@amazon.com>
Signed-off-by: Hanwen <hanwenli@amazon.com>


### Description of changes
This PR is cherry-picked from https://github.com/aws/aws-parallelcluster/pull/4298

### Tests
* Covered by unit test
* Manually deleted cluster config for an existing cluster and executed a describe-cluster
Here is the response, the url is still constructed but the config is not available (this reverts to the old behavior <3.2.0 for now):
```
pcluster describe-cluster --cluster-name clusterdemo
{
  "creationTime": "2022-09-09T13:28:49.499Z",
  "headNode": {
    "launchTime": "2022-09-09T13:31:58.000Z",
    "instanceId": "i-06e9e38e629abafe2",
    "publicIpAddress": "44.200.9.144",
    "instanceType": "t3.xlarge",
    "state": "running",
    "privateIpAddress": "192.168.39.76"
  },
  "version": "3.2.0",
  "clusterConfiguration": {
    "url": "https://parallelcluster-801a8468adc5cb29-v1-do-not-delete.s3.amazonaws.com/parallelcluster/3.2.0/clusters/clusterdemo-uxfnuziju6iehdsb/configs/cluster-config.yaml?versionId=ekS3Wd4td9Gg0MsrYhh5pYe7zCiIYQDf&AWSAccessKeyId=ASIA5RSIY6NYY4M24GZK&Signature=KP%2BvAOI%2FnvtBdx2X%2FAAPB%2B573%2Fs%3D&x-amz-security-token=IQoJb3JpZ2luX2VjEK7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJGMEQCIHFEesolQL%2F2JSN3tEWWGySbgd1FiZBDIFjHN4B4MSiSAiATo8iw7Ind8u64eX9CR3keycP%2F%2BRB18ERdVFQ%2BeXcBGyqfAghHEAEaDDkzMTA4Njc5MTUzNyIMne5yVr2MnWg%2BNKc9KvwBiqsCxWeZKk%2BCWotqY0bV836SuA9XBH367BU8Kz80kHl3fsOPtR6tBQGDMJq5s4AeLMMwYBvW5GlAiZ8UkzhZwfxxG1Yy20RSncxD5O1Y6hNS5jmWtarfRrM5HfteJOyUM7aYQspUeEx9%2FXEUP665yG4vah0bXta4Vd%2Bjp2Tk1eL7QmNBq9%2BWkfAO6tYpGO3f%2Bkx0H2ppxSlAJvY6YHA0e32rkKAd8aE6KMnVZeDtZvTLxXKxQ9bo4zRRnLMdlP1Z%2FYO7laF5s%2FM1NlQZeJgKBaCSmsOQwz00Hy0nku8oOCG4TWxXg%2BzA3cdnf6nTnB9mMF32DsM8ndQcDCAuMIP%2F7JgGOp4B%2BsOY3xFVFVExviefXJ12MTn4m0nHGgSqBdoqYyZU7oTu%2BifObXFaxBMc%2Bqg1lCd0VoWJg%2BG4FJJej4%2FPTRmNOXrQuodkjT9JMeiI9oDGCvQCSpArNoGFN%2B1K6jhuhKN47y0jgV4Od9M6HVAe9YkEwSnCjylKZxVHL8NmrT%2FnQ1TLpCeM%2F1PHHXETy3HEg8MRHYNJtyjcT%2BCsgsAqqr8%3D&Expires=1662736637"
  },
  "tags": [
    {
      "value": "3.2.0",
      "key": "parallelcluster:version"
    },
    {
      "value": "clusterdemo",
      "key": "parallelcluster:cluster-name"
    }
  ],
  "cloudFormationStackStatus": "CREATE_COMPLETE",
  "clusterName": "clusterdemo",
  "computeFleetStatus": "RUNNING",
  "cloudformationStackArn": "arn:aws:cloudformation:us-east-1:931086791537:stack/clusterdemo/569bb320-3043-11ed-93b4-1226258378df",
  "lastUpdatedTime": "2022-09-09T13:28:49.499Z",
  "region": "us-east-1",
  "clusterStatus": "CREATE_COMPLETE",
  "scheduler": {
    "type": "slurm"
  }
}
```
Here is the relevant lines in logs:
```
2022-09-09 07:17:17,101 - INFO - common.py:134:_log_boto3_calls() - Executing boto3 call: region=us-east-1, service=s3, operation=GetObject, params={'Bucket': 'parallelcluster-801a8468adc5cb29-v1-do-not-delete', 'Key': 'parallelcluster/3.2.0/clusters/clusterdemo-uxfnuziju6iehdsb/configs/cluster-config.yaml', 'VersionId': 'ekS3Wd4td9Gg0MsrYhh5pYe7zCiIYQDf'}
2022-09-09 07:17:17,137 - ERROR - common.py:107:wrapper() - Encountered error when performing boto3 call in get_object: The specified version does not exist.
2022-09-09 07:17:17,137 - WARNING - cluster.py:1212:get_plugin_metadata() - Unable to retrieve scheduler metadata from cluster configuration.
```

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

