### PR TITLE
3.3 Add the Networking section to SlurmQueues.ComputeResources including only PlacementGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
 - Disable Multithreading through script executed by cloud-init and not through CpuOptions set into Launch Template.
 - Add support for multiple instance types in the same Compute Resource.
 - Add support for a Name field in PlacementGroup as the preferred naming method.
+- Add support for Networking.PlacementGroup in the SlurmQueues.ComputeResources section
 
 **BUG FIXES**
 - Fix validation of parameter `SharedStorage/EfsSettings`: now validation fails when `FileSystemId` is specified

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -518,8 +518,8 @@ class Proxy(Resource):
 class _BaseNetworking(Resource):
     """Represent the networking configuration shared by head node and compute node."""
 
-    def __init__(self, security_groups: List[str] = None, additional_security_groups: List[str] = None):
-        super().__init__()
+    def __init__(self, security_groups: List[str] = None, additional_security_groups: List[str] = None, **kwargs):
+        super().__init__(**kwargs)
         self.security_groups = Resource.init_param(security_groups)
         self.additional_security_groups = Resource.init_param(additional_security_groups)
 
@@ -548,16 +548,34 @@ class HeadNodeNetworking(_BaseNetworking):
 
 
 class PlacementGroup(Resource):
-    """Represent the placement group for the Queue networking."""
+    """Represent the placement group for networking."""
 
-    def __init__(self, enabled: bool = None, name: str = None, id: str = None):
-        super().__init__()
-        self.enabled = Resource.init_param(enabled, default=False)
+    def __init__(self, enabled: bool = None, name: str = None, id: str = None, **kwargs):
+        super().__init__(**kwargs)
+        self.enabled = Resource.init_param(enabled)
         self.name = Resource.init_param(name)
         self.id = Resource.init_param(id)  # Duplicate of name
 
     def _register_validators(self):
         self._register_validator(PlacementGroupNamingValidator, placement_group=self)
+
+    @property
+    def is_enabled_and_unassigned(self) -> bool:
+        """Check if the PlacementGroup is enabled without a name or id."""
+        return not (self.id or self.name) and self.enabled
+
+    @property
+    def assignment(self) -> str:
+        """Check if the placement group has a name or id and get it, preferring the name if it exists."""
+        return self.name or self.id
+
+
+class SlurmComputeResourceNetworking(Resource):
+    """Represent the networking configuration for the compute resource."""
+
+    def __init__(self, placement_group: PlacementGroup = None, **kwargs):
+        super().__init__(**kwargs)
+        self.placement_group = placement_group or PlacementGroup(implied=True)
 
 
 class _QueueNetworking(_BaseNetworking):
@@ -574,7 +592,7 @@ class SlurmQueueNetworking(_QueueNetworking):
 
     def __init__(self, placement_group: PlacementGroup = None, proxy: Proxy = None, **kwargs):
         super().__init__(**kwargs)
-        self.placement_group = placement_group
+        self.placement_group = placement_group or PlacementGroup(implied=True)
         self.proxy = proxy
 
 
@@ -1623,6 +1641,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         disable_simultaneous_multithreading: bool = None,
         schedulable_memory: int = None,
         capacity_reservation_target: CapacityReservationTarget = None,
+        networking: SlurmComputeResourceNetworking = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -1637,6 +1656,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         self.capacity_reservation_target = capacity_reservation_target
         self._instance_types_with_instance_storage = []
         self._instance_type_info_map = {}
+        self.networking = networking or SlurmComputeResourceNetworking(implied=True)
 
     @staticmethod
     def fetch_instance_type_info(instance_type) -> InstanceTypeInfo:
@@ -1792,11 +1812,25 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
         return self.disable_simultaneous_multithreading and self.instance_type_info.default_threads_per_core() > 1
 
 
+class SchedulerPluginComputeResource(SlurmComputeResource):
+    """Represent the Scheduler Plugin Compute Resource."""
+
+    def __init__(
+        self,
+        custom_settings: Dict = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.custom_settings = custom_settings
+
+
 class _CommonQueue(BaseQueue):
     """Represent the Common Queue resource between Slurm and Scheduler Plugin."""
 
     def __init__(
         self,
+        compute_resources: List[Union[_BaseSlurmComputeResource, SchedulerPluginComputeResource]],
+        networking: Union[SlurmQueueNetworking, SchedulerPluginQueueNetworking],
         compute_settings: ComputeSettings = None,
         custom_actions: CustomActions = None,
         iam: Iam = None,
@@ -1810,6 +1844,8 @@ class _CommonQueue(BaseQueue):
         self.iam = iam or Iam(implied=True)
         self.image = image
         self.capacity_reservation_target = capacity_reservation_target
+        self.compute_resources = compute_resources
+        self.networking = networking
 
     @property
     def instance_role(self):
@@ -1829,6 +1865,43 @@ class _CommonQueue(BaseQueue):
         else:
             return None
 
+    def get_managed_placement_group_keys(self) -> List[str]:
+        managed_placement_group_keys = []
+        for resource in self.compute_resources:
+            chosen_pg = (
+                resource.networking.placement_group
+                if not resource.networking.placement_group.implied
+                else self.networking.placement_group
+            )
+            if chosen_pg.is_enabled_and_unassigned:
+                managed_placement_group_keys.append(f"{self.name}-{resource.name}")
+        return managed_placement_group_keys
+
+    def get_placement_group_key_for_compute_resource(
+        self, compute_resource: Union[_BaseSlurmComputeResource, SchedulerPluginComputeResource]
+    ) -> (str, bool):
+        # prefer compute level groups over queue level groups
+        placement_group_key, managed = None, None
+        cr_pg = compute_resource.networking.placement_group
+        if cr_pg.assignment:
+            placement_group_key, managed = cr_pg.assignment, False
+        elif cr_pg.enabled:
+            placement_group_key, managed = f"{self.name}-{compute_resource.name}", True
+        elif cr_pg.enabled is False:
+            placement_group_key, managed = None, False
+        elif self.networking.placement_group.assignment:
+            placement_group_key, managed = self.networking.placement_group.assignment, False
+        elif self.networking.placement_group.enabled:
+            placement_group_key, managed = f"{self.name}-{compute_resource.name}", True
+        return placement_group_key, managed
+
+    def is_placement_group_disabled_for_compute_resource(self, compute_resource_pg_enabled: bool) -> bool:
+        return (
+            compute_resource_pg_enabled is False
+            or self.networking.placement_group.enabled is False
+            and compute_resource_pg_enabled is None
+        )
+
 
 class AllocationStrategy(Enum):
     """Define supported allocation strategies."""
@@ -1842,15 +1915,13 @@ class SlurmQueue(_CommonQueue):
 
     def __init__(
         self,
-        compute_resources: List[_BaseSlurmComputeResource],
-        networking: SlurmQueueNetworking,
         allocation_strategy: str = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.compute_resources = compute_resources
-        self.networking = networking
-        if any(isinstance(compute_resource, SlurmFlexibleComputeResource) for compute_resource in compute_resources):
+        if any(
+            isinstance(compute_resource, SlurmFlexibleComputeResource) for compute_resource in self.compute_resources
+        ):
             self.allocation_strategy = (
                 AllocationStrategy[to_snake_case(allocation_strategy).upper()]
                 if allocation_strategy
@@ -1896,7 +1967,10 @@ class SlurmQueue(_CommonQueue):
             self._register_validator(
                 EfaPlacementGroupValidator,
                 efa_enabled=compute_resource.efa.enabled,
-                placement_group=self.networking.placement_group,
+                placement_group_key=self.get_placement_group_key_for_compute_resource(compute_resource)[0],
+                placement_group_disabled=self.is_placement_group_disabled_for_compute_resource(
+                    compute_resource.networking.placement_group.enabled
+                ),
             )
             for instance_type in compute_resource.instance_types:
                 self._register_validator(
@@ -1967,31 +2041,15 @@ class SlurmScheduling(Resource):
         )
 
 
-class SchedulerPluginComputeResource(SlurmComputeResource):
-    """Represent the Scheduler Plugin Compute Resource."""
-
-    def __init__(
-        self,
-        custom_settings: Dict = None,
-        **kwargs,
-    ):
-        super().__init__(**kwargs)
-        self.custom_settings = custom_settings
-
-
 class SchedulerPluginQueue(_CommonQueue):
     """Represent the Scheduler Plugin queue."""
 
     def __init__(
         self,
-        compute_resources: List[SchedulerPluginComputeResource],
-        networking: SchedulerPluginQueueNetworking,
         custom_settings: Dict = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.compute_resources = compute_resources
-        self.networking = networking
         self.custom_settings = custom_settings
 
     def _register_validators(self):
@@ -2014,7 +2072,10 @@ class SchedulerPluginQueue(_CommonQueue):
             self._register_validator(
                 EfaPlacementGroupValidator,
                 efa_enabled=compute_resource.efa.enabled,
-                placement_group=self.networking.placement_group,
+                placement_group_key=self.get_placement_group_key_for_compute_resource(compute_resource)[0],
+                placement_group_disabled=self.is_placement_group_disabled_for_compute_resource(
+                    compute_resource.networking.placement_group.enabled
+                ),
             )
 
     @property

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -100,6 +100,7 @@ from pcluster.config.cluster_config import (
     SharedFsxLustre,
     SlurmClusterConfig,
     SlurmComputeResource,
+    SlurmComputeResourceNetworking,
     SlurmFlexibleComputeResource,
     SlurmQueue,
     SlurmQueueNetworking,
@@ -1128,6 +1129,19 @@ class _ComputeResourceSchema(BaseSchema):
     name = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 
 
+class SlurmComputeResourceNetworkingSchema(BaseSchema):
+    """Represent the Networking schema of the Slurm ComputeResource."""
+
+    placement_group = fields.Nested(
+        PlacementGroupSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
+    )
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return SlurmComputeResourceNetworking(**data)
+
+
 class SlurmComputeResourceSchema(_ComputeResourceSchema):
     """Represent the schema of the Slurm ComputeResource."""
 
@@ -1147,6 +1161,9 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
     schedulable_memory = fields.Int(metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
     capacity_reservation_target = fields.Nested(
         CapacityReservationTargetSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
+    )
+    networking = fields.Nested(
+        SlurmComputeResourceNetworkingSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
     )
 
     @validates_schema

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -64,7 +64,7 @@ class BaseSchema(Schema):
 
     def on_bind_field(self, field_name, field_obj):
         """
-        Bind PascalCase in the config with with snake_case in Python.
+        Bind PascalCase in the config with snake_case in Python.
 
         For example, subnet_id in the code is automatically bind with SubnetId in the config file.
         The bind can be overwritten by specifying data_key.
@@ -76,11 +76,11 @@ class BaseSchema(Schema):
     @staticmethod
     def fields_coexist(data, field_list, one_required=False, **kwargs):
         """
-        Check if at least two fields in the filed lists co-exist in the schema.
+        Check if at least two fields in the field list co-exist in the schema.
 
         :param data: data to be checked
         :param field_list: list including the name of the fields to check
-        :param one_required: True if one of the field is required to be existed
+        :param one_required: True if one of the fields is required to exist
         :return: True if one and only one field is not None
         """
         if kwargs.get("partial"):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1364,47 +1364,39 @@ class ComputeFleetConstruct(Construct):
     def _add_placement_groups(self) -> Dict[str, ec2.CfnPlacementGroup]:
         managed_placement_groups = {}
         for queue in self._config.scheduling.queues:
-            if (
-                queue.networking.placement_group
-                and queue.networking.placement_group.enabled
-                and not (queue.networking.placement_group.id or queue.networking.placement_group.name)
-            ):
-                managed_placement_groups[queue.name] = ec2.CfnPlacementGroup(
-                    self, f"PlacementGroup{create_hash_suffix(queue.name)}", strategy="cluster"
+            for key in queue.get_managed_placement_group_keys():
+                managed_placement_groups[key] = ec2.CfnPlacementGroup(
+                    self,
+                    f"PlacementGroup{create_hash_suffix(key)}",
+                    strategy="cluster",
                 )
         return managed_placement_groups
+
+    @staticmethod
+    def _get_placement_group_for_compute_resource(queue, managed_placement_groups, compute_resource) -> str:
+        placement_group_key, managed = queue.get_placement_group_key_for_compute_resource(compute_resource)
+        return managed_placement_groups[placement_group_key].ref if managed else placement_group_key
 
     def _add_launch_templates(self, managed_placement_groups, instance_profiles):
         compute_launch_templates = {}
         for queue in self._config.scheduling.queues:
             compute_launch_templates[queue.name] = {}
             queue_lt_security_groups = get_queue_security_groups_full(self._compute_security_group, queue)
-
-            queue_placement_group = None
-            if queue.networking.placement_group:
-                if (queue.networking.placement_group.id or queue.networking.placement_group.name) and (
-                    queue.networking.placement_group.enabled or queue.networking.placement_group.is_implied("enabled")
-                ):
-                    queue_placement_group = queue.networking.placement_group.name or queue.networking.placement_group.id
-                elif queue.networking.placement_group.enabled:
-                    queue_placement_group = managed_placement_groups[queue.name].ref
-
             queue_pre_install_action, queue_post_install_action = (None, None)
             if queue.custom_actions:
                 queue_pre_install_action = queue.custom_actions.on_node_start
                 queue_post_install_action = queue.custom_actions.on_node_configured
 
-            for compute_resource in queue.compute_resources:
-                launch_template = self._add_compute_resource_launch_template(
+            for resource in queue.compute_resources:
+                compute_launch_templates[queue.name][resource.name] = self._add_compute_resource_launch_template(
                     queue,
-                    compute_resource,
+                    resource,
                     queue_pre_install_action,
                     queue_post_install_action,
                     queue_lt_security_groups,
-                    queue_placement_group,
+                    self._get_placement_group_for_compute_resource(queue, managed_placement_groups, resource),
                     instance_profiles,
                 )
-                compute_launch_templates[queue.name][compute_resource.name] = launch_template
         return compute_launch_templates
 
     def _add_compute_resource_launch_template(
@@ -1414,7 +1406,7 @@ class ComputeFleetConstruct(Construct):
         queue_pre_install_action,
         queue_post_install_action,
         queue_lt_security_groups,
-        queue_placement_group,
+        placement_group,
         instance_profiles,
     ):
         # LT network interfaces
@@ -1479,7 +1471,7 @@ class ComputeFleetConstruct(Construct):
                 ),
                 # key_name=,
                 network_interfaces=compute_lt_nw_interfaces,
-                placement=ec2.CfnLaunchTemplate.PlacementProperty(group_name=queue_placement_group),
+                placement=ec2.CfnLaunchTemplate.PlacementProperty(group_name=placement_group),
                 image_id=self._config.image_dict[queue.name],
                 iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(
                     name=instance_profiles[queue.name]

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -315,23 +315,17 @@ class EfaValidator(Validator):
 class EfaPlacementGroupValidator(Validator):
     """Validate placement group if EFA is enabled."""
 
-    def _validate(self, efa_enabled, placement_group):
-        placement_group_enabled = placement_group and (
-            placement_group.enabled or (placement_group.id and placement_group.is_implied("enabled"))
-        )
-        placement_group_config_implicit = placement_group is None or (
-            placement_group.is_implied("enabled") and placement_group.id is None
-        )
-        if efa_enabled and placement_group_config_implicit:
+    def _validate(self, efa_enabled: bool, placement_group_key: str, placement_group_disabled: bool):
+        if efa_enabled and placement_group_disabled:
+            self._add_failure(
+                "You may see better performance using a placement group for the queue.", FailureLevel.WARNING
+            )
+        elif efa_enabled and placement_group_key is None:
             self._add_failure(
                 "The placement group for EFA-enabled compute resources must be explicit. "
                 "You may see better performance using a placement group, but if you don't wish to use one please add "
                 "'Enabled: false' to the compute resource's configuration section.",
                 FailureLevel.ERROR,
-            )
-        elif efa_enabled and not placement_group_enabled:
-            self._add_failure(
-                "You may see better performance using a placement group for the queue.", FailureLevel.WARNING
             )
 
 

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -99,7 +99,7 @@ class KeyPairValidator(Validator):
             )
 
 
-class PlacementGroupNamingValidator(Validator):  # TODO: add tests
+class PlacementGroupNamingValidator(Validator):
     """Placement group naming validator."""
 
     def _validate(self, placement_group):
@@ -111,10 +111,12 @@ class PlacementGroupNamingValidator(Validator):  # TODO: add tests
             )
         identifier = placement_group.name or placement_group.id
         if identifier:
-            if not placement_group.is_implied("enabled") and not placement_group.enabled:
+            if placement_group.enabled is False:
                 self._add_failure(
                     "The PlacementGroup feature must be enabled (Enabled: true) in order "
-                    "to assign a Name or Id parameter",
+                    "to assign a Name or Id parameter.  Please either remove the Name/Id parameter to disable the "
+                    "feature, set Enabled: true to enable it, or remove the Enabled parameter to imply it is enabled "
+                    "with the Name/Id given",
                     FailureLevel.ERROR,
                 )
             else:

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -470,7 +470,10 @@ def test_compute_ami_os_compatible_validator(mocker, image_id, os, ami_info, exp
                 ]
             },
             None,
-            "The PlacementGroup feature must be enabled (Enabled: true) in order to assign a Name or Id parameter",
+            "The PlacementGroup feature must be enabled (Enabled: true) in order "
+            "to assign a Name or Id parameter.  Please either remove the Name/Id parameter to disable the "
+            "feature, set Enabled: true to enable it, or remove the Enabled parameter to imply it is enabled "
+            "with the Name/Id given",
         ),
         (
             PlacementGroup(enabled=False, name="test"),
@@ -480,7 +483,10 @@ def test_compute_ami_os_compatible_validator(mocker, image_id, os, ami_info, exp
                 ]
             },
             None,
-            "The PlacementGroup feature must be enabled (Enabled: true) in order to assign a Name or Id parameter",
+            "The PlacementGroup feature must be enabled (Enabled: true) in order "
+            "to assign a Name or Id parameter.  Please either remove the Name/Id parameter to disable the "
+            "feature, set Enabled: true to enable it, or remove the Enabled parameter to imply it is enabled "
+            "with the Name/Id given",
         ),
         (
             PlacementGroup(enabled=True, id="test", name="test2"),

--- a/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pg.config.yaml
+++ b/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pg.config.yaml
@@ -1,0 +1,138 @@
+Region: us-west-2
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: c7g.4xlarge
+  Networking:
+    SubnetId: subnet-020f39e1a8eb1c972
+  Ssh:
+    KeyName: ndry-hpc
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: q-pg-enabled
+      ComputeResources:
+        - Name: cr-pg-enabled
+          InstanceType: c6gn.xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Enabled: true
+        - Name: cr-pg-disabled
+          InstanceType: c6g.xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Enabled: false
+        - Name: cr-pg-named
+          InstanceType: m6g.xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Name: 'q-enabled-cr-named'
+        - Name: cr-pg-omitted
+          InstanceType: c7g.xlarge
+          MinCount: 1
+          MaxCount: 10
+      Networking:
+        SubnetIds:
+          - subnet-0bfcd29fad2404485
+        PlacementGroup:
+          Enabled: true
+    - Name: q-pg-disabled
+      ComputeResources:
+        - Name: cr-pg-enabled
+          InstanceType: c6gn.2xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Enabled: true
+        - Name: cr-pg-disabled
+          InstanceType: c6g.2xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Enabled: false
+        - Name: cr-pg-named
+          InstanceType: m6g.2xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Name: 'q-disabled-cr-named'
+        - Name: cr-pg-omitted
+          InstanceType: c7g.2xlarge
+          MinCount: 1
+          MaxCount: 10
+      Networking:
+        SubnetIds:
+          - subnet-0bfcd29fad2404485
+        PlacementGroup:
+          Enabled: false
+    - Name: q-pg-named
+      ComputeResources:
+        - Name: cr-pg-enabled
+          InstanceType: c6gn.8xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Enabled: true
+        - Name: cr-pg-disabled
+          InstanceType: c6g.8xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Enabled: false
+        - Name: cr-pg-named
+          InstanceType: m6g.8xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Name: 'q-named-cr-named'
+        - Name: cr-pg-omitted
+          InstanceType: c7g.large
+          MinCount: 1
+          MaxCount: 10
+      Networking:
+        SubnetIds:
+          - subnet-0bfcd29fad2404485
+        PlacementGroup:
+          Name: 'q-named'
+    - Name: q-pg-omitted
+      ComputeResources:
+        - Name: cr-pg-enabled
+          InstanceType: c6gn.12xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Enabled: true
+        - Name: cr-pg-disabled
+          InstanceType: c6g.12xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Enabled: false
+        - Name: cr-pg-named
+          InstanceType: m6g.12xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Name: 'q-omitted-cr-named'
+        - Name: cr-pg-omitted
+          InstanceType: c7g.medium
+          MinCount: 1
+          MaxCount: 10
+      Networking:
+        SubnetIds:
+          - subnet-0bfcd29fad2404485


### PR DESCRIPTION
This change allows for creating configs that include placement groups for specific compute resources.  It changes the way Queue level placement groups are configured as well.  This aligns better with AWS EC2 placement group guidance to reduce insufficient capacity errors.  Parallel cluster managed placement groups will no longer be created to include multiple compute resources.

If enabled at the queue level and not assigned a name, every compute resource will get a separate parallel cluster managed placement group.

If enabled and assigned a name at the queue level, there will be a single placement group for all compute resources in the queue.

If enabled at the compute resource level and not assigned a name, this config will override the queue level config and that resource will get its own managed placement group.

If enabled at the compute resource level and assigned a name, this config will override the queue level config and that resource will use the assigned placement group.

Signed-off-by: Ryan Anderson <ndry@amazon.com>


### Description of changes
* See above

### Tests
* Unit tests for logic in cluster config
* Unit tests updated for validators

### References
* https://quip-amazon.com/kaLSAnnbyR7I/Design-Add-Support-for-On-Demand-Capacity-Reservations-ODCRs-in-Cluster-Configuration-File

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
