### PR TITLE
[develop] Switch from InstanceType to single instance in InstanceTypeList

### DIFF
--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -210,7 +210,9 @@ def configure(args):  # noqa: C901
                         default_value=default_instance_type,
                     )
                     if compute_instance_type not in [
-                        compute_resource["InstanceType"] for compute_resource in compute_resources
+                        instances["InstanceType"]
+                        for compute_resource in compute_resources
+                        for instances in compute_resource["InstanceTypeList"]
                     ]:
                         break
                     print(
@@ -245,7 +247,7 @@ def configure(args):  # noqa: C901
             else:
                 compute_resource = {
                     "Name": compute_resource_name,
-                    "InstanceType": compute_instance_type,
+                    "InstanceTypeList": [{"InstanceType": compute_instance_type}],
                     "MinCount": min_cluster_size,
                     "MaxCount": max_cluster_size,
                 }

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: c5n18xlarge
-          InstanceType: c5n.18xlarge
+          InstanceTypeList:
+            - InstanceType: c5n.18xlarge
           MinCount: 0
           MaxCount: 10
           Efa:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_efa_not_supported/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_efa_not_supported/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: c5n18xlarge
-          InstanceType: c5n.18xlarge
+          InstanceTypeList:
+            - InstanceType: c5n.18xlarge
           MinCount: 0
           MaxCount: 10
       Networking:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: c5n18xlarge
-          InstanceType: c5n.18xlarge
+          InstanceTypeList:
+            - InstanceType: c5n.18xlarge
           MinCount: 0
           MaxCount: 10
           Efa:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: c5n18xlarge
-          InstanceType: c5n.18xlarge
+          InstanceTypeList:
+            - InstanceType: c5n.18xlarge
           MinCount: 0
           MaxCount: 10
           Efa:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: c5n18xlarge
-          InstanceType: c5n.18xlarge
+          InstanceTypeList:
+            - InstanceType: c5n.18xlarge
           MinCount: 0
           MaxCount: 10
           Efa:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 10
       Networking:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14
       Networking:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 10
       Networking:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14
       Networking:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14
       Networking:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14
       Networking:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14
       Networking:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14
       Networking:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/pcluster.config.yaml
@@ -13,7 +13,8 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceType: t2.micro
+          InstanceTypeList:
+            - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14
       Networking:


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Use `InstanceTypeList` with single instance instead of `InstanceType` when running the pcluster configure wizard.

### Tests
unit tests changed accordingly

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
