### PR TITLE
Fix Trainium test assertion and region test distribution

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -1,7 +1,7 @@
 ad_integration:
   test_ad_integration.py::test_ad_integration:
     dimensions:
-      - regions: ["us-west-2"]
+      - regions: ["ap-northeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
@@ -491,7 +491,7 @@ schedulers:
         schedulers: ["slurm"]
   test_slurm.py::test_scontrol_reboot:
     dimensions:
-      - regions: ["us-west-2"]
+      - regions: ["us-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/tests/trainium/test_trainium.py
+++ b/tests/integration-tests/tests/trainium/test_trainium.py
@@ -64,4 +64,4 @@ def _test_ccl_two_nodes(test_datadir, remote_command_executor, scheduler_command
     result = remote_command_executor.run_remote_command("cat output-ccl.txt")
 
     print(result.stdout)
-    assert_that(result.stdout).matches(".*CCL(1).*CCL(50).*CCL(99).*CCL(100).*")
+    assert_that(result.stdout).contains("CCL(1)", "CCL(50)", "CCL(99)", "CCL(100)")


### PR DESCRIPTION
### Description of changes
* Fixed assertion in Trainium test
* Redistribute the AD_integration tests to be executed in a region with few tests.
* Moved test_scontrol_reboot to a region that have more t2.micro

### Tests
* Manually tests with sample output

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
