### PR TITLE
[FIT] Add integration test for create-fleet and run-instances overrides

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -495,6 +495,12 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004"]
         schedulers: ["slurm"]
+  test_slurm.py::test_slurm_overrides:
+    dimensions:
+      - regions: ["me-south-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["ubuntu2004"]
+        schedulers: ["slurm"]
 spot:
   test_spot.py::test_spot_default:
     dimensions:

--- a/tests/integration-tests/tags_utils.py
+++ b/tests/integration-tests/tags_utils.py
@@ -81,9 +81,9 @@ def get_compute_node_root_volume_tags(cluster, os):
     return get_tags_for_volume(root_volume_id, cluster.region)
 
 
-def get_compute_node_tags(cluster):
+def get_compute_node_tags(cluster, queue_name=None):
     """Return the given cluster's compute node's tags."""
-    compute_nodes = cluster.get_cluster_instance_ids(node_type="Compute")
+    compute_nodes = cluster.get_cluster_instance_ids(node_type="Compute", queue_name=queue_name)
     assert_that(compute_nodes).is_length(1)
     return get_ec2_instance_tags(compute_nodes[0], cluster.region)
 

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -65,6 +65,13 @@ def assert_no_msg_in_logs(remote_command_executor, log_files, log_msg):
         assert_that(log).does_not_contain(message)
 
 
+def assert_msg_in_log(remote_command_executor, log_file, message):
+    """Assert message is in log_file."""
+    __tracebackhide__ = True
+    log = remote_command_executor.run_remote_command(f"sudo cat {log_file}", hide=True).stdout
+    assert_that(log).contains(message)
+
+
 def assert_errors_in_logs(remote_command_executor, log_files, expected_errors):
     # assert every expected error exists in at least one of the log files
     __tracebackhide__ = True

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_overrides/launch_override.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_overrides/launch_override.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -ex
+. "/etc/parallelcluster/cfnconfig"
+
+
+if [[ $cfn_node_type == "HeadNode" ]]; then
+    # Override create_fleet attributes
+    cat > /opt/slurm/etc/pcluster/create_fleet_overrides.json << 'EOF'
+{
+    "fleet": {
+        "fleet-1": {
+            "TagSpecifications": [
+                 {
+                    "ResourceType": "instance",
+                    "Tags": [
+                        {
+                            "Key": "overridefleet",
+                            "Value": "overridefleet"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+EOF
+
+    # Override run_instances attributes
+    cat > /opt/slurm/etc/pcluster/run_instances_overrides.json << 'EOF'
+{
+    "single": {
+        "single-1": {
+            "TagSpecifications": [
+                 {
+                    "ResourceType": "instance",
+                    "Tags": [
+                        {
+                            "Key": "overridesingle",
+                            "Value": "overridesingle"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+EOF
+fi

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_overrides/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_overrides/pcluster.config.yaml
@@ -1,0 +1,32 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket_name }}
+  CustomActions:
+    OnNodeConfigured:
+      Script: s3://{{ bucket_name }}/launch_override.sh
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: fleet
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: fleet-1
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
+    - Name: single
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: single-1
+          InstanceType: {{ instance }}


### PR DESCRIPTION
### Description of changes
* The test is adding explicit tags to the instances through the run-instances/create-fleet override setting and verifying they are correctly set to the instances.

### Tests
* Manually verified the run-instances-override.json file is loaded correctly and instances are tagged.
* Executed integration tests locally.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
