### PR TITLE
[CLI] Verify that there are no duplicate instance types in an InstanceTypeList

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -18,6 +18,7 @@ import copy
 import hashlib
 import logging
 import re
+from typing import List
 from urllib.request import urlopen
 
 import yaml
@@ -1158,6 +1159,19 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
             **kwargs,
         ):
             raise ValidationError("A Compute Resource needs to specify either InstanceType or InstanceTypeList.")
+
+    @validates("instance_type_list")
+    def no_duplicate_instance_types(self, flexible_instance_types: List[FlexibleInstanceType]):
+        """Verify that there are no duplicates in an InstanceTypeList."""
+        instance_types = set()
+        for flexible_instance_type in flexible_instance_types:
+            instance_type_name = flexible_instance_type.instance_type
+            if instance_type_name in instance_types:
+                raise ValidationError(
+                    f"Duplicate instance type ({instance_type_name}) detected. An InstanceTypeList should not have "
+                    f"duplicate instance types. "
+                )
+            instance_types.add(instance_type_name)
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -393,6 +393,24 @@ def test_scheduling_schema(mocker, config_dict, failure_message):
             },
             "A Compute Resource needs to specify either InstanceType or InstanceTypeList.",
         ),
+        # InstanceTypeList in a Compute Resource should not have duplicate instance types
+        (
+            {
+                "Name": "DuplicateInstanceTypes",
+                "ComputeResources": [
+                    {
+                        "Name": "compute_resource1",
+                        "InstanceTypeList": [
+                            {"InstanceType": "c4.2xlarge"},
+                            {"InstanceType": "c5.xlarge"},
+                            {"InstanceType": "c5a.xlarge"},
+                            {"InstanceType": "c4.2xlarge"},
+                        ],
+                    },
+                ],
+            },
+            "Duplicate instance type \\(c4.2xlarge\\) detected.",
+        ),
     ],
 )
 def test_slurm_flexible_queue(mocker, config_dict, failure_message):


### PR DESCRIPTION
### Description of changes
* CreateFleet API does not allow duplicate instance types in the overrides parameter
```
(InvalidFleetConfig) when calling the CreateFleet operation: The fleet configuration contains duplicate instance pools.
```
* This commit adds a validation check to detect duplicate instance types in the cluster configuration's InstanceTypeList

### Tests
* Unit test: Shows a validation error for an InstanceTypeList with duplicate instance types

### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
