### PR TITLE
Move test_ad_integration to eu-west-1 to void error with fsx in ap-northeast-1c

### DIFF
--- a/tests/integration-tests/configs/ad_integration.yaml
+++ b/tests/integration-tests/configs/ad_integration.yaml
@@ -4,7 +4,7 @@ test-suites:
   ad_integration:
     test_ad_integration.py::test_ad_integration:
       dimensions:
-        - regions: ["us-west-2"]
+        - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2", "ubuntu2004"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -1,10 +1,6 @@
 ad_integration:
   test_ad_integration.py::test_ad_integration:
     dimensions:
-      - regions: ["ap-northeast-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["centos7"]
-        schedulers: ["slurm"]
       - regions: [ "ap-southeast-1" ]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
@@ -20,7 +16,7 @@ ad_integration:
         schedulers: ["slurm"]
       - regions: ["eu-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2004", "centos7"]
         schedulers: ["slurm"]
 arm_pl:
   test_arm_pl.py::test_arm_pl:


### PR DESCRIPTION
### Description of changes
* Moved tests for AD integration in eu-west-1 to avoid error with FSx in ap-northeast-1c

### References
* https://github.com/aws/aws-parallelcluster/pull/4339

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
