### PR TITLE
Fix undefined variable name in API client

### DIFF
--- a/api/client/resources/api_client.py.patch
+++ b/api/client/resources/api_client.py.patch
@@ -13,7 +13,7 @@
              return
  
 +        if 'aws.auth.sigv4' in auth_settings:
-+            sigv4_auth(method, self.configuration.host, resource_path, querys, body, headers)
++            sigv4_auth(method, self.configuration.host, resource_path, queries, body, headers)
 +
          for auth in auth_settings:
              auth_setting = self.configuration.auth_settings().get(auth)

--- a/api/client/resources/sigv4_auth.py
+++ b/api/client/resources/sigv4_auth.py
@@ -17,12 +17,12 @@ import botocore
 import json
 
 
-def sigv4_auth(method, host, path, querys, body, headers):
+def sigv4_auth(method, host, path, queries, body, headers):
     "Adds authorization headers for sigv4 to headers parameter."
     endpoint = host.replace('https://', '').replace('http://', '')
     _api_id, _service, region, _domain = endpoint.split('.', maxsplit=3)
 
-    request_parameters = '&'.join([f"{k}={v}" for k, v in querys])
+    request_parameters = '&'.join([f"{k}={v}" for k, v in queries])
     url = f"{host}{path}?{request_parameters}"
 
     session = botocore.session.Session()

--- a/api/client/src/pcluster_client/api_client.py
+++ b/api/client/src/pcluster_client/api_client.py
@@ -635,7 +635,7 @@ class ApiClient(object):
             return
 
         if 'aws.auth.sigv4' in auth_settings:
-            sigv4_auth(method, self.configuration.host, resource_path, querys, body, headers)
+            sigv4_auth(method, self.configuration.host, resource_path, queries, body, headers)
 
         for auth in auth_settings:
             auth_setting = self.configuration.auth_settings().get(auth)

--- a/api/client/src/pcluster_client/sigv4_auth.py
+++ b/api/client/src/pcluster_client/sigv4_auth.py
@@ -17,12 +17,12 @@ import botocore
 import json
 
 
-def sigv4_auth(method, host, path, querys, body, headers):
+def sigv4_auth(method, host, path, queries, body, headers):
     "Adds authorization headers for sigv4 to headers parameter."
     endpoint = host.replace('https://', '').replace('http://', '')
     _api_id, _service, region, _domain = endpoint.split('.', maxsplit=3)
 
-    request_parameters = '&'.join([f"{k}={v}" for k, v in querys])
+    request_parameters = '&'.join([f"{k}={v}" for k, v in queries])
     url = f"{host}{path}?{request_parameters}"
 
     session = botocore.session.Session()


### PR DESCRIPTION
### Description of changes
The upgrade of the openapi generator version performed here https://github.com/aws/aws-parallelcluster/pull/4270 introduced a change in the variable naming that was incompatible with our client patch needed to add sigv4 auth to the client. I updated the patch and applied it with the `./gradlew generatePythonClient` task.