### PR TITLE
Allow `apt-get` to upgrade openssh-server in 3.x (#4358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Avoid failing on DescribeCluster when cluster configuration is not available.
+- Fix a hang in upgrading ubuntu via `pcluster build-image` when `Build:UpdateOsPackages:Enabled:true` is set.
 
 3.2.0
 ------

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -119,7 +119,7 @@ phases:
                 while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done
                 flock $(apt-config shell StateDir Dir::State/d | sed -r "s/.*'(.*)\/?'$/\1/")/daily_lock systemctl disable --now apt-daily.timer apt-daily.service apt-daily-upgrade.timer apt-daily-upgrade.service
                 sed "/Update-Package-Lists/s/\"1\"/\"0\"/; /Unattended-Upgrade/s/\"1\"/\"0\"/;" /etc/apt/apt.conf.d/20auto-upgrades > "/etc/apt/apt.conf.d/51pcluster-unattended-upgrades"
-                DEBIAN_FRONTEND=noninteractive apt-get -y update && apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --with-new-pkgs upgrade && apt-get --purge autoremove -y
+                DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --with-new-pkgs upgrade && apt-get --purge autoremove -y
                 apt-get -y install linux-aws linux-headers-aws linux-image-aws
               fi
 


### PR DESCRIPTION
Allow `apt-get` to upgrade openssh-server

This fixes a hang in `pcluster build-image` when `Build:UpdateOsPackages:Enabled:true` is set.

`apt-get upgrade` will prompt for user input during upgrade of `openssh-server` as `/etc/ssh/ssd_config` is locally modified and would be overwritten by package provided file. The proposed patch removes the prompt and chooses to keep the existing configuration file.

I can see this issue pop up on ubuntu-{1804,2004} in pcluster-[3.1.1-3.1.4]. I did not test older releases, but would expect it to occur there do.

