### PR TITLE
integ-test: Fix test_scheduler_plugin failed by ODCR PRs

### DIFF
--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_arm64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_arm64.yaml
@@ -1,4 +1,5 @@
 - CapacityType: ONDEMAND
+  CapacityReservationTarget: null
   ComputeResources:
     - CustomSettings: null
       DisableSimultaneousMultithreading: false
@@ -11,6 +12,12 @@
       Name: c1
       SchedulableMemory: null
       SpotPrice: null
+      CapacityReservationTarget: null
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
@@ -32,7 +39,10 @@
   Networking:
     AdditionalSecurityGroups: null
     AssignPublicIp: null
-    PlacementGroup: null
+    PlacementGroup:
+      Enabled: null
+      Id: null
+      Name: null
     Proxy: null
     SecurityGroups: null
     SubnetIds:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_x86_64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_x86_64.yaml
@@ -1,4 +1,5 @@
 - CapacityType: ONDEMAND
+  CapacityReservationTarget: null
   ComputeResources:
     - CustomSettings: null
       DisableSimultaneousMultithreading: false
@@ -11,6 +12,12 @@
       Name: c1
       SchedulableMemory: null
       SpotPrice: null
+      CapacityReservationTarget: null
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
@@ -32,7 +39,10 @@
   Networking:
     AdditionalSecurityGroups: null
     AssignPublicIp: null
-    PlacementGroup: null
+    PlacementGroup:
+      Enabled: null
+      Id: null
+      Name: null
     Proxy: null
     SecurityGroups: null
     SubnetIds:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_arm64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_arm64.yaml
@@ -1,4 +1,5 @@
 - CapacityType: ONDEMAND
+  CapacityReservationTarget: null
   ComputeResources:
     - CustomSettings: null
       DisableSimultaneousMultithreading: false
@@ -11,6 +12,12 @@
       Name: c1
       SchedulableMemory: null
       SpotPrice: null
+      CapacityReservationTarget: null
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
     - CustomSettings: null
       DisableSimultaneousMultithreading: false
       Efa:
@@ -22,6 +29,12 @@
       Name: c2
       SchedulableMemory: null
       SpotPrice: null
+      CapacityReservationTarget: null
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
@@ -43,12 +56,16 @@
   Networking:
     AdditionalSecurityGroups: null
     AssignPublicIp: null
-    PlacementGroup: null
+    PlacementGroup:
+      Enabled: null
+      Id: null
+      Name: null
     Proxy: null
     SecurityGroups: null
     SubnetIds:
       - subnet-123
 - CapacityType: ONDEMAND
+  CapacityReservationTarget: null
   ComputeResources:
     - CustomSettings: null
       DisableSimultaneousMultithreading: false
@@ -61,6 +78,12 @@
       Name: c1
       SchedulableMemory: null
       SpotPrice: null
+      CapacityReservationTarget: null
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
@@ -82,7 +105,10 @@
   Networking:
     AdditionalSecurityGroups: null
     AssignPublicIp: null
-    PlacementGroup: null
+    PlacementGroup:
+      Enabled: null
+      Id: null
+      Name: null
     Proxy: null
     SecurityGroups: null
     SubnetIds:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_x86_64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_x86_64.yaml
@@ -1,4 +1,5 @@
 - CapacityType: ONDEMAND
+  CapacityReservationTarget: null
   ComputeResources:
     - CustomSettings: null
       DisableSimultaneousMultithreading: false
@@ -11,6 +12,12 @@
       Name: c1
       SchedulableMemory: null
       SpotPrice: null
+      CapacityReservationTarget: null
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
     - CustomSettings: null
       DisableSimultaneousMultithreading: false
       Efa:
@@ -22,6 +29,12 @@
       Name: c2
       SchedulableMemory: null
       SpotPrice: null
+      CapacityReservationTarget: null
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
@@ -43,12 +56,16 @@
   Networking:
     AdditionalSecurityGroups: null
     AssignPublicIp: null
-    PlacementGroup: null
+    PlacementGroup:
+      Enabled: null
+      Id: null
+      Name: null
     Proxy: null
     SecurityGroups: null
     SubnetIds:
       - subnet-123
 - CapacityType: ONDEMAND
+  CapacityReservationTarget: null
   ComputeResources:
     - CustomSettings: null
       DisableSimultaneousMultithreading: false
@@ -61,6 +78,12 @@
       Name: c1
       SchedulableMemory: null
       SpotPrice: null
+      CapacityReservationTarget: null
+      Networking:
+        PlacementGroup:
+          Enabled: null
+          Id: null
+          Name: null
   ComputeSettings:
     LocalStorage:
       EphemeralVolume: null
@@ -82,7 +105,10 @@
   Networking:
     AdditionalSecurityGroups: null
     AssignPublicIp: null
-    PlacementGroup: null
+    PlacementGroup:
+      Enabled: null
+      Id: null
+      Name: null
     Proxy: null
     SecurityGroups: null
     SubnetIds:


### PR DESCRIPTION
test_scheduler_plugin checks cluster configuration file to be the same as expected. We added ODCR section in https://github.com/aws/aws-parallelcluster/pull/4295 and Placement Group section in Compute Resource https://github.com/aws/aws-parallelcluster/pull/4330 in cluster configuration file. Therefore, the expected cluster configuration file should be changed accordingly

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
Tests from the following definition have been passed

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
