### PR TITLE
[3.3] Add validation between Placement Groups (PG) and On Demand Capacity Reservations (ODCRs)

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -122,6 +122,7 @@ from pcluster.validators.ec2_validators import (
     InstanceTypeMemoryInfoValidator,
     InstanceTypeValidator,
     KeyPairValidator,
+    PlacementGroupCapacityReservationValidator,
     PlacementGroupNamingValidator,
 )
 from pcluster.validators.fsx_validators import (
@@ -2472,11 +2473,14 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                     self._register_validator(
                         CapacityReservationResourceGroupValidator,
                         capacity_reservation_resource_group_arn=cr_target.capacity_reservation_resource_group_arn,
-                        # ToDo: This validator is only correct for single instance type
-                        #  Add more validators to be check ODCR with flexible instance types
-                        instance_type=compute_resource.instance_types[0],
+                        instance_types=compute_resource.instance_types,
                         subnet=queue.networking.subnet_ids[0],
                     )
+                self._register_validator(
+                    PlacementGroupCapacityReservationValidator,
+                    queue=queue,
+                    compute_resource=compute_resource,
+                )
 
     @property
     def _capacity_reservation_targets(self):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -966,7 +966,7 @@ class CapacityReservationTargetSchema(BaseSchema):
         return CapacityReservationTarget(**data)
 
     @validates_schema
-    def no_coexist_instance_type_flexibility(self, data, **kwargs):
+    def no_coexist_id_and_group_arn(self, data, **kwargs):
         """Validate that 'capacity_reservation_id' and 'capacity_reservation_resource_group_arn' do not co-exist."""
         if self.fields_coexist(
             data,

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -8,9 +8,12 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Dict, List
+
 from pcluster import imagebuilder_utils
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError
+from pcluster.utils import get_resource_name_from_resource_arn
 from pcluster.validators.common import FailureLevel, Validator
 
 
@@ -189,27 +192,106 @@ class CapacityReservationValidator(Validator):
                 )
 
 
+def get_capacity_reservations(capacity_reservation_resource_group_arn):
+    capacity_reservation_ids = AWSApi.instance().resource_groups.get_capacity_reservation_ids_from_group_resources(
+        capacity_reservation_resource_group_arn
+    )
+    return AWSApi.instance().ec2.describe_capacity_reservations(capacity_reservation_ids)
+
+
+def capacity_reservation_matches_instance(capacity_reservation: Dict, instance_type: str, subnet: str) -> bool:
+    return capacity_reservation["InstanceType"] == instance_type and capacity_reservation[
+        "AvailabilityZone"
+    ] == AWSApi.instance().ec2.get_subnet_avail_zone(subnet)
+
+
 class CapacityReservationResourceGroupValidator(Validator):
     """Validate at least one capacity reservation in the resource group can be used with the instance and subnet."""
 
-    def _validate(self, capacity_reservation_resource_group_arn: str, instance_type: str, subnet: str):
+    def _validate(self, capacity_reservation_resource_group_arn: str, instance_types: List[str], subnet: str):
         if capacity_reservation_resource_group_arn:
-            capacity_reservation_ids = (
-                AWSApi.instance().resource_groups.get_capacity_reservation_ids_from_group_resources(
-                    capacity_reservation_resource_group_arn
-                )
-            )
-            capacity_reservations = AWSApi.instance().ec2.describe_capacity_reservations(capacity_reservation_ids)
-            found_qualified_capacity_reservation = False
-            for capacity_reservation in capacity_reservations:
-                if capacity_reservation["InstanceType"] == instance_type and capacity_reservation[
-                    "AvailabilityZone"
-                ] == AWSApi.instance().ec2.get_subnet_avail_zone(subnet):
-                    found_qualified_capacity_reservation = True
-                    break
-            if not found_qualified_capacity_reservation:
+            capacity_reservations = get_capacity_reservations(capacity_reservation_resource_group_arn)
+            for instance_type in instance_types:
+                found_qualified_capacity_reservation = False
+                for capacity_reservation in capacity_reservations:
+                    if capacity_reservation_matches_instance(capacity_reservation, instance_type, subnet):
+                        found_qualified_capacity_reservation = True
+                        break
+                if not found_qualified_capacity_reservation:
+                    self._add_failure(
+                        f"Capacity reservation resource group {capacity_reservation_resource_group_arn} must have at "
+                        f"least one capacity reservation for {instance_type} in the same availability zone as subnet"
+                        f" {subnet}.",
+                        FailureLevel.ERROR,
+                    )
+
+
+class PlacementGroupCapacityReservationValidator(Validator):
+    """Validate the placement group is compatible with the capacity reservation target."""
+
+    def _validate_chosen_pg(self, queue, compute_resource, odcr_list, chosen_pg):
+        pg_match, open_or_targeted = False, False
+        for instance_type in compute_resource.instance_types:
+            for odcr in odcr_list:
+                if capacity_reservation_matches_instance(
+                    capacity_reservation=odcr, instance_type=instance_type, subnet=queue.networking.subnet_ids[0]
+                ):
+                    odcr_pg = get_resource_name_from_resource_arn(odcr.get("PlacementGroupArn", None))
+                    if odcr_pg:
+                        if odcr_pg == chosen_pg:
+                            pg_match = True
+                    else:
+                        open_or_targeted = True
+            if not (pg_match or open_or_targeted):
                 self._add_failure(
-                    f"Capacity reservation resource group {capacity_reservation_resource_group_arn} must have at least "
-                    f"one capacity reservation for {instance_type} in the same availability zone as subnet {subnet}.",
+                    f"The placement group provided '{chosen_pg}' does not match any placement group in the set of "
+                    f"target PG/ODCRs and there are no open or targeted '{instance_type}' ODCRs included.",
                     FailureLevel.ERROR,
                 )
+            elif open_or_targeted:
+                self._add_failure(
+                    "When using an open or targeted capacity reservation with an unrelated placement group, "
+                    "insufficient capacity errors may occur due to placement constraints outside of the "
+                    "reservation even if the capacity reservation has remaining capacity. Please consider either "
+                    "not using a placement group for the compute resource or creating a new capacity reservation "
+                    "in a related placement group.",
+                    FailureLevel.WARNING,
+                )
+
+    def _validate_no_pg(self, queue, compute_resource, odcr_list):
+        for instance_type in compute_resource.instance_types:
+            odcr_without_pg = False
+            for odcr in odcr_list:
+                odcr_pg = (
+                    get_resource_name_from_resource_arn(odcr["PlacementGroupArn"])
+                    if "PlacementGroupArn" in odcr
+                    else None
+                )
+                if not odcr_pg and capacity_reservation_matches_instance(
+                    capacity_reservation=odcr, instance_type=instance_type, subnet=queue.networking.subnet_ids[0]
+                ):
+                    odcr_without_pg = True
+            if not odcr_without_pg:
+                self._add_failure(
+                    f"There are no open or targeted ODCRs that match the instance_type '{instance_type}' "
+                    f"and no placement group provided. Please either provide a placement group or add an ODCR that "
+                    f"does not target a placement group and targets the instance type.",
+                    FailureLevel.ERROR,
+                )
+
+    def _validate(self, queue, compute_resource):
+        chosen_pg = queue.get_placement_group_key_for_compute_resource(compute_resource)[0]
+        odcr = compute_resource.capacity_reservation_target or queue.capacity_reservation_target
+        odcr_id = odcr.capacity_reservation_id if odcr else None
+        odcr_arn = odcr.capacity_reservation_resource_group_arn if odcr else None
+        odcr_list = (
+            AWSApi.instance().ec2.describe_capacity_reservations([odcr_id])
+            if odcr_id
+            else get_capacity_reservations(odcr_arn)
+        )
+        if chosen_pg:
+            self._validate_chosen_pg(
+                queue=queue, compute_resource=compute_resource, odcr_list=odcr_list, chosen_pg=chosen_pg
+            )
+        else:
+            self._validate_no_pg(queue=queue, compute_resource=compute_resource, odcr_list=odcr_list)

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -13,7 +13,15 @@ import pytest
 
 from pcluster.aws.aws_resources import ImageInfo, InstanceTypeInfo
 from pcluster.aws.common import AWSClientError
-from pcluster.config.cluster_config import CapacityType, PlacementGroup
+from pcluster.config.cluster_config import (
+    CapacityReservationTarget,
+    CapacityType,
+    PlacementGroup,
+    SlurmComputeResource,
+    SlurmComputeResourceNetworking,
+    SlurmQueue,
+    SlurmQueueNetworking,
+)
 from pcluster.validators.ec2_validators import (
     AmiOsCompatibleValidator,
     CapacityReservationResourceGroupValidator,
@@ -23,6 +31,7 @@ from pcluster.validators.ec2_validators import (
     InstanceTypeMemoryInfoValidator,
     InstanceTypeValidator,
     KeyPairValidator,
+    PlacementGroupCapacityReservationValidator,
     PlacementGroupNamingValidator,
 )
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
@@ -630,6 +639,133 @@ def test_capacity_reservation_resource_group_validator(
         return_value=desired_availability_zone,
     )
     actual_failures = CapacityReservationResourceGroupValidator().execute(
-        capacity_reservation_resource_group_arn="skip_dummy", instance_type=desired_instance_type, subnet="subnet-123"
+        capacity_reservation_resource_group_arn="skip_dummy",
+        instance_types=[desired_instance_type],
+        subnet="subnet-123",
     )
     assert_failure_messages(actual_failures, expected_message)
+
+
+mock_compute_resources = [
+    SlurmComputeResource(
+        instance_type="mock-type",
+        name="test1",
+        networking=SlurmComputeResourceNetworking(placement_group=PlacementGroup(implied=True)),
+        capacity_reservation_target=CapacityReservationTarget(capacity_reservation_id="cr-123"),
+    ),
+    SlurmComputeResource(
+        instance_type="mock-type",
+        name="test2",
+        networking=SlurmComputeResourceNetworking(placement_group=PlacementGroup(enabled=True)),
+        capacity_reservation_target=CapacityReservationTarget(capacity_reservation_id="cr-123"),
+    ),
+    SlurmComputeResource(
+        instance_type="mock-type-3",
+        name="test3",
+        networking=SlurmComputeResourceNetworking(placement_group=PlacementGroup(enabled=False)),
+        capacity_reservation_target=CapacityReservationTarget(capacity_reservation_id="cr-123"),
+    ),
+    SlurmComputeResource(
+        instance_type="mock-type",
+        name="test4",
+        networking=SlurmComputeResourceNetworking(placement_group=PlacementGroup(name="test")),
+        capacity_reservation_target=CapacityReservationTarget(capacity_reservation_id="cr-321"),
+    ),
+]
+
+mock_odcrs = [
+    {
+        "CapacityReservationId": "cr-123",
+        "InstanceType": "mock-type",
+        "AvailabilityZone": "mock-zone",
+    },
+    {
+        "CapacityReservationId": "cr-321",
+        "InstanceType": "mock-type",
+        "AvailabilityZone": "mock-zone",
+        "PlacementGroupArn": "fail-arn",
+    },
+]
+
+
+@pytest.mark.parametrize(
+    "queue, compute_resource, odcr_list, expected_message",
+    [
+        (
+            SlurmQueue(
+                name="mock-queue-1",
+                networking=SlurmQueueNetworking(
+                    subnet_ids=["mock-subnet-1"], placement_group=PlacementGroup(enabled=False)
+                ),
+                compute_resources=mock_compute_resources,
+            ),
+            mock_compute_resources[0],
+            mock_odcrs[:2],
+            None,
+        ),
+        (
+            SlurmQueue(
+                name="mock-queue-2",
+                networking=SlurmQueueNetworking(
+                    subnet_ids=["mock-subnet-2"], placement_group=PlacementGroup(enabled=False)
+                ),
+                compute_resources=mock_compute_resources,
+            ),
+            mock_compute_resources[1],
+            mock_odcrs[:2],
+            "When using an open or targeted capacity reservation with an unrelated placement group, "
+            "insufficient capacity errors may occur due to placement constraints outside of the "
+            "reservation even if the capacity reservation has remaining capacity. Please consider either "
+            "not using a placement group for the compute resource or creating a new capacity reservation "
+            "in a related placement group.",
+        ),
+        (
+            SlurmQueue(
+                name="mock-queue-3",
+                networking=SlurmQueueNetworking(
+                    subnet_ids=["mock-subnet-3"], placement_group=PlacementGroup(enabled=False)
+                ),
+                compute_resources=mock_compute_resources,
+            ),
+            mock_compute_resources[3],
+            mock_odcrs[1:2],
+            "The placement group provided 'test' does not match any placement group in the set of target PG/ODCRs and "
+            "there are no open or targeted 'mock-type' ODCRs included.",
+        ),
+        (
+            SlurmQueue(
+                name="mock-queue-4",
+                networking=SlurmQueueNetworking(
+                    subnet_ids=["mock-subnet-4"], placement_group=PlacementGroup(enabled=False)
+                ),
+                compute_resources=mock_compute_resources,
+            ),
+            mock_compute_resources[2],
+            mock_odcrs[1:2],
+            "There are no open or targeted ODCRs that match the instance_type 'mock-type-3' "
+            "and no placement group provided. Please either provide a placement group or add an ODCR that "
+            "does not target a placement group and targets the instance type.",
+        ),
+    ],
+)
+def test_placement_group_capacity_reservation_validator(
+    mocker,
+    queue,
+    compute_resource,
+    odcr_list,
+    expected_message,
+):
+    mock_aws_api(mocker)
+    desired_availability_zone = "mock-zone"
+    mocker.patch(
+        "pcluster.aws.ec2.Ec2Client.describe_capacity_reservations",
+        side_effect=lambda capacity_reservation_ids: odcr_list,
+    )
+    mocker.patch(
+        "pcluster.aws.ec2.Ec2Client.get_subnet_avail_zone",
+        return_value=desired_availability_zone,
+    )
+    actual_failure = PlacementGroupCapacityReservationValidator().execute(
+        queue=queue, compute_resource=compute_resource
+    )
+    assert_failure_messages(actual_failure, expected_message)

--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -21,7 +21,7 @@ Before executing integration tests it is required to install all the Python depe
 In order to do that simply run the following commands:
 ```bash
 cd tests/integration-tests
-pip install -r tests/integration-tests/requirements.txt
+pip install -r requirements.txt
 ```
 
 After that you can run the CLI by simply executing the following
@@ -182,7 +182,7 @@ Executing the command will run an integration testing suite with the following f
 Each test contained in the suite can be parametrized, at submission time, across four different dimensions: regions,
 instances, operating systems and schedulers. These dimensions allow to dynamically customize the combination of cluster
 parameters that need to be validated by the scheduler. Some tests, due to the specific feature they are validating,
-might not be compatible with the entire set of available dimensions. 
+might not be compatible with the entire set of available dimensions.
 
 In order to specify what tests to execute and the dimensions to select there are two different possibilities:
 1. The recommended approach consists into passing to the `test_runner` a YAML configuration file that declares the tests
@@ -193,7 +193,7 @@ In order to specify what tests to execute and the dimensions to select there are
 
 When executing the `test_runner` CLI, the `--tests-config` argument can be used to specify a configuration file
 containing the list of tests that need to be executed. The configuration file is a YAML document, with optionally Jinja
-templating directives, that needs to comply with the following schema: 
+templating directives, that needs to comply with the following schema:
 https://github.com/aws/aws-parallelcluster/tree/develop/tests/integration-tests/framework/tests_configuration/config_schema.yaml
 
 Here is an example of a tests suite definition file:
@@ -241,8 +241,8 @@ test-suites:
           schedulers: ["slurm"]
 ```
 
-As shown in the example above, the configuration file groups tests by the name of the package where these are defined. 
-For each test function, identified by the test module and the function name, an array of dimensions are specified in 
+As shown in the example above, the configuration file groups tests by the name of the package where these are defined.
+For each test function, identified by the test module and the function name, an array of dimensions are specified in
 order to define how this specific test is parametrized. Each element of the dimensions array generates a parametrization
 of the selected test function which consist in the combination of all defined dimensions. For example the
 cloudwatch_logging suite defined above will produce the following parametrization:
@@ -255,11 +255,11 @@ cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[ca-centra
 cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[ca-central-1-c5.xlarge-alinux2-slurm]
 cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[eu-west-1-m6g.xlarge-alinux2-slurm]
 ```
-  
+
 Jinja directives can be used to simplify the declaration of the tests suites.
 
 Some tox commands are offered in order to simplify the generation and validation of such configuration files:
-* ` tox -e validate-test-configs` can be executed to validate all configuration files defined in the 
+* ` tox -e validate-test-configs` can be executed to validate all configuration files defined in the
   `tests/integration-tests/configs` directory. The directory or the specific file to validate can be also selected
   with the additional arguments: `--tests-configs-dir` and `--tests-config-file`
   (e.g. tox -e validate-test-configs -- --tests-config-file configs/develop.yaml)
@@ -267,7 +267,7 @@ Some tox commands are offered in order to simplify the generation and validation
   with the list of all available files. The config file is generated in the `tests/integration-tests/configs` directory.
 
 #### Using CLI options
- 
+
 The following options can be used to control the parametrization of test cases:
 * `-r REGIONS [REGIONS ...], --regions REGIONS [REGIONS ...]`: AWS region where tests are executed.
 * `-i INSTANCES [INSTANCES ...], --instances INSTANCES [INSTANCES ...]`: AWS instances under test.
@@ -374,10 +374,10 @@ in the cluster config then the value in the config is used.
 
 ### Re-use clusters and vpc clusters
 
-When developing integration tests, it can be helpful to re-use a cluster between tests. 
-This is easily accomplished with the use of the `--vpc-stack` and `--cluster` flags. 
+When developing integration tests, it can be helpful to re-use a cluster between tests.
+This is easily accomplished with the use of the `--vpc-stack` and `--cluster` flags.
 
-If you're starting from scratch, run the test with the `--no-delete` flag. 
+If you're starting from scratch, run the test with the `--no-delete` flag.
 This preserves any stacks created for the test:
 
 ```bash
@@ -396,28 +396,28 @@ python -m test_runner \
   --no-delete
 ```
 
-Keep in mind, the cluster you pass can have different `scheduler`, `os` or other features 
+Keep in mind, the cluster you pass can have different `scheduler`, `os` or other features
 than what is specified in the test. This can break the tests in unexpected ways. Be mindful.
 
 ## Cross Account Integration Tests
-If you want to distribute integration tests across multiple accounts you can make use of the `--credential` flag. 
-This is useful to overcome restrictions related to account limits and be compliant with a multi-region, multi-account 
+If you want to distribute integration tests across multiple accounts you can make use of the `--credential` flag.
+This is useful to overcome restrictions related to account limits and be compliant with a multi-region, multi-account
 setup.
 
-When the `--credential` flag is specified and STS assume-role call is made in order to fetch temporary credentials to 
-be used to run tests in a specific region. 
+When the `--credential` flag is specified and STS assume-role call is made in order to fetch temporary credentials to
+be used to run tests in a specific region.
 
-The `--credential` flag is in the form `<region>,<endpoint_url>,<ARN>,<external_id>` and needs to be specified for each 
-region you want to use with an STS assumed role (that usually means for every region you want to have in a separate 
+The `--credential` flag is in the form `<region>,<endpoint_url>,<ARN>,<external_id>` and needs to be specified for each
+region you want to use with an STS assumed role (that usually means for every region you want to have in a separate
 account).
 
- * `region` is the region you want to test with an assumed STS role (which is in the target account where you want to 
+ * `region` is the region you want to test with an assumed STS role (which is in the target account where you want to
  launch the integration tests)
  * `endpoint_url` is the STS endpoint url of the main account to be called in order to assume the delegation role
  * `ARN` is the ARN of the delegation role in the optin region account to be assumed by the main account
- * `external_id` is the external ID of the delegation role  
+ * `external_id` is the external ID of the delegation role
 
-By default, the delegation role lifetime is one hour. Mind that if you are planning to launch tests that last 
+By default, the delegation role lifetime is one hour. Mind that if you are planning to launch tests that last
 more than one hour.
 
 ## Write Integration Tests
@@ -843,7 +843,7 @@ test-suites:
 ```
 The definition above means the `osu_allreduce` and `osu_alltoall` will run in `eu-west-1`. You can extend the list under `benchmarks` or each parameters to get various combinations
 
-6. Use `--benchmarks` option to run performance tests. Performance tests are disabled by default due to the high resource utilization involved with their execution. 
+6. Use `--benchmarks` option to run performance tests. Performance tests are disabled by default due to the high resource utilization involved with their execution.
 
 In conclusion, the performance test will run for a test only if:
 1. The test calls the `run_benchmark` fixture
@@ -895,7 +895,7 @@ def run_benchmarks(request, mpi_variants, test_datadir, instance, os, region, be
 
 ### Troubleshooting and fixes
 
-* `IdentityFile` option in `ssh/config` will trigger a `str has no attribute extend` bug in the `fabric` package. 
+* `IdentityFile` option in `ssh/config` will trigger a `str has no attribute extend` bug in the `fabric` package.
 Please remove `IdentityFile` option from `ssh/config` before running the testing framework
 
 
@@ -914,10 +914,10 @@ scheduler-plugins:
 
 `scheduler-plugin` defines an entry for each scheduler plugin you intend to enable in tests.
 For each scheduler plugin you can specify the following fields:
-* `scheduler-definition`: this can be a S3 or HTTPs URL pointing to the scheduler plugin definition. Alternatively, 
+* `scheduler-definition`: this can be a S3 or HTTPs URL pointing to the scheduler plugin definition. Alternatively,
   it can be the path (relative or absolute) to the upload_artifacts.sh script. If the path is relative, it's relative to
   integration tests suite root folder. The upload_artifacts.sh script is in charge to upload the scheduler-definition
-  into a given bucket, that will be created and passed by the test suite. 
+  into a given bucket, that will be created and passed by the test suite.
 * `scheduler-commands`: this is the path to a Python class implementing the scheduler commands interface
   defined in `tests.common.schedulers_common.SchedulerCommands`.
 * `requires-sudo`: this needs to be set to true in case the scheduler plugin requires sudo privileges.
@@ -1010,7 +1010,7 @@ def run_system_analyzer(cluster, scheduler_commands_factory, request, partition=
 
 The nodeJS `diff2html` generates a html file from a diff which helps to compare the differences.
 Compare result from different node type (head, compute) can create misleading results: it is suggested to compare the
-same node type (e.g. head with head) 
+same node type (e.g. head with head)
 Below an example on how compare system analysis results :
 ```bash
 npm install -g diff2html

--- a/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_odcr/odcr.config.yaml
+++ b/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_odcr/odcr.config.yaml
@@ -1,0 +1,79 @@
+Region: us-west-2
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: c7g.4xlarge
+  Networking:
+    SubnetId: subnet-020f39e1a8eb1c972
+  Ssh:
+    KeyName: ndry-hpc
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: q-pg-en-cr-name-odcr-id
+      ComputeResources:
+        - Name: pg-name-odcr-id-open
+          InstanceType: c6gn.xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Name: 'cr-named-odcr-open'
+          CapacityReservationTarget:
+            CapacityReservationId: 'cr-0265ef5d5cacbbc22'
+        - Name: pg-name-odcr-id-target
+          InstanceType: m6g.xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Name: 'cr-named-odcr-target'
+          CapacityReservationTarget:
+            CapacityReservationId: 'cr-012def4f1628883fa'
+        - Name: pg-name-odcr-id-right-pg
+          InstanceType: c7g.xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Name: 'q-enabled-cr-named'
+          CapacityReservationTarget:
+            CapacityReservationId: 'cr-01df19e7c8c6b8566'
+        - Name: pg-name-odcr-id-wrong-pg
+          InstanceType: c7g.xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Name: 'cr-named-wrong-pg'
+          CapacityReservationTarget:
+            CapacityReservationId: 'cr-04331967645330fbe'
+      Networking:
+        SubnetIds:
+          - subnet-0bfcd29fad2404485
+        PlacementGroup:
+          Enabled: true
+      CapacityReservationTarget:
+        CapacityReservationId: 'cr-0573660fb76478d13'
+    - Name: q-pg-en-cr-name-odcr-arn
+      ComputeResources:
+        - Name: pg-omit-odcr-arn
+          InstanceType: c6gn.xlarge
+          MinCount: 1
+          MaxCount: 10
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: 'arn:aws:resource-groups:us-west-2:944054287730:group/odcr-grp'
+        - Name: pg-name-odcr-arn
+          InstanceType: c6g.xlarge
+          MinCount: 1
+          MaxCount: 10
+          Networking:
+            PlacementGroup:
+              Name: 'q-enabled-cr-named'
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: 'arn:aws:resource-groups:us-west-2:944054287730:group/odcr-grp'
+      Networking:
+        SubnetIds:
+          - subnet-0bfcd29fad2404485
+      CapacityReservationTarget:
+        CapacityReservationId: 'cr-0573660fb76478d13'


### PR DESCRIPTION
Add validation between Placement Groups (PG) and On Demand Capacity Reservations (ODCRs)

Provides validation functions to ensure the PG supplied for each compute resource is compatible with the ODCR or group of ODCRs also provided for that resource.

If the PG is provided, there must either be an open, targeted, or PG/ODCR that matches

IF the PG is omitted, there must be an open or targeted ODCR that matches

Signed-off-by: Ryan Anderson <ndry@amazon.com>


### Description of changes
* See above

### Tests
* Manual tests for different combinations of PG and ODCR
* Unit tests for some failure scenarios and successful ones, not comprehensive

### References
* https://quip-amazon.com/kaLSAnnbyR7I/Design-Add-Support-for-On-Demand-Capacity-Reservations-ODCRs-in-Cluster-Configuration-File

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
