### PR TITLE
Add validation recipe call to image validation

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -399,3 +399,11 @@ phases:
                 fi
                 echo "dpkg test passed"
               fi
+      - name: ChefValidations
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -vx
+
+              cinc-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/parallelcluster/image_dna.json --override-runlist aws-parallelcluster::validations


### PR DESCRIPTION
### Description of changes
* Added call validation recipes to make it easier to access node configuration from ImageBuilder validation steps
* Added recipe to validate MySQL installation

### Tests
* Manually built AMI's to make sure the validation recipe was successfully called from the validation component
* Verified by manual build that MySQL client package installations successfully validated on [Amzn2, Centos7, Ubuntu 1804, Ubuntu 2004] x [x86_64, Arm].

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
