### PR TITLE
[release-3.2] Backport of changes from integ-release-3.2 and fix to integration tests

### DIFF
--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/recipes/install_cluster_daemons.rb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/recipes/install_cluster_daemons.rb
@@ -22,7 +22,8 @@ bash 'install' do
     set -e
 
     # FIXME: installing from GitHub is discouraged
-    #{node['pcluster']['python_root']}/pip install https://github.com/aws/aws-parallelcluster-node/tarball/refs/heads/develop
+    # FIXME: move node package in the scheduler-plugin artifacts
+    #{node['pcluster']['python_root']}/pip install https://github.com/aws/aws-parallelcluster-node/tarball/refs/heads/release-3.2
   DAEMONS
   not_if "#{node['pcluster']['python_root']}/pip list | grep aws-parallelcluster-node"
 end

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -298,7 +298,7 @@ iam:
 intel_hpc:
   test_intel_hpc.py::test_intel_hpc:
     dimensions:
-      - regions: ["sa-east-1"]
+      - regions: ["us-east-2"]
         instances: ["c5n.18xlarge"]
         oss: ["centos7"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -416,10 +416,12 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
+{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_ONE_PER_DISTRO }}
         schedulers: ["slurm_plugin"]
+{%- endif %}
   test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
     dimensions:
       - regions: ["ap-southeast-2"]
@@ -436,10 +438,12 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_ONE_PER_DISTRO }}
         schedulers: ["slurm"]
+{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
       - regions: ["me-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm_plugin"]
+{%- endif %}
       - regions: [ "us-east-2" ]
         instances: [{{ common.instance("instance_type_1") }}]
         oss: [ "alinux2" ]
@@ -449,13 +453,25 @@ schedulers:
       - regions: ["ca-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "slurm_plugin"]
+        schedulers: ["slurm"]
+{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
+      - regions: ["ca-central-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm_plugin"]
+{%- endif %}
   test_slurm.py::test_slurm_protected_mode:
     dimensions:
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "slurm_plugin"]
+        schedulers: ["slurm"]
+{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
+      - regions: ["eu-west-2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm_plugin"]
+{%- endif %}
   test_slurm.py::test_fast_capacity_failover:
     dimensions:
       - regions: ["ap-east-1"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -149,9 +149,6 @@ createami:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2", "ubuntu2004", "centos7"]
-      - regions: ["us-gov-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1804"]
   test_createami.py::test_kernel4_build_image_run_cluster:
     dimensions:
       - regions: ["eu-west-1"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -1,4 +1,5 @@
 {%- import 'common.jinja2' as common with context -%}
+{%- set SCHEDULER_PLUGIN_TESTS = false -%}
 ---
 scheduler-plugins:
   slurm_plugin:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -13,7 +13,7 @@ test-suites:
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: ["sa-east-1"]
+        - regions: ["us-east-2"]
           instances: ["c5n.18xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -1,10 +1,6 @@
 {%- import 'common.jinja2' as common with context -%}
+{%- set SCHEDULER_PLUGIN_TESTS = false -%}
 ---
-scheduler-plugins:
-  slurm_plugin:
-    scheduler-definition: "../../scheduler_plugins/slurm/utils/upload_artifacts.sh"
-    scheduler-commands: "tests.common.schedulers_common.SlurmCommands"
-    requires-sudo: true
 test-suites:
 {% filter indent(2) %}
 {% include 'common/common.yaml' %}

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -94,8 +94,7 @@ def test_create_imds_secured(
     Test IMDS access with different configurations.
     In particular, it also verifies that IMDS access is preserved on instance reboot.
     """
-    custom_ami = retrieve_latest_ami(region, os, ami_type="pcluster", architecture=architecture)
-    cluster_config = pcluster_config_reader(custom_ami=custom_ami, imds_secured=imds_secured)
+    cluster_config = pcluster_config_reader(imds_secured=imds_secured)
     cluster = clusters_factory(cluster_config, raise_on_error=True)
 
     assert_head_node_is_running(region, cluster)

--- a/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
@@ -1,6 +1,5 @@
 Image:
   Os: {{ os }}
-  CustomAmi: {{ custom_ami }}
 HeadNode:
   InstanceType: {{ instance }}
   Networking:


### PR DESCRIPTION
### Description of changes
* Backport of commit to fix integration tests from integ-release-3.2
* [Remove scheduler_plugin tests from develop config](https://github.com/aws/aws-parallelcluster/commit/a0acc21db25219bac6f1113e4040a62d2082b49d) 
* [Move region for test_efa to us-east-2](https://github.com/aws/aws-parallelcluster/pull/4375/commits/e43a7633d008166e9b072c08980c3f20da4b44ea)

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
