### PR TITLE
[3.x] Validate capacity reservation if capacity reservation target is specified on compute resource or queue

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2459,8 +2459,8 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                 )
                 # The validation below has to be in cluster config class instead of queue class
                 # to make sure the subnet APIs are cached by previous validations.
-                if compute_resource.capacity_reservation_target:
-                    cr_target = compute_resource.capacity_reservation_target
+                cr_target = compute_resource.capacity_reservation_target or queue.capacity_reservation_target
+                if cr_target:
                     self._register_validator(
                         CapacityReservationValidator,
                         capacity_reservation_id=cr_target.capacity_reservation_id,


### PR DESCRIPTION
This was a bug from https://github.com/aws/aws-parallelcluster/pull/4295. The validation was only executed if capacity reservation target is specified on compute resource

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
