### PR TITLE
[3.3] Add validator to prevent configs with CapacityReservationId and not InstanceType

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2490,9 +2490,7 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                     self._register_validator(
                         CapacityReservationValidator,
                         capacity_reservation_id=cr_target.capacity_reservation_id,
-                        # ToDo: This validator is only correct for single instance type
-                        #  Add more validators to be check ODCR with flexible instance types
-                        instance_type=compute_resource.instance_types[0],
+                        instance_type=getattr(compute_resource, "instance_type", None),
                         subnet=queue.networking.subnet_ids[0],
                     )
                     self._register_validator(

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -534,7 +534,7 @@ def test_placement_group_validator(
             "us-east-1a",
             "c5.xlarge",
             "us-east-1a",
-            "Capacity reservation .* must has the same instance type as c5.xlarge.",
+            "Capacity reservation .* must have the same instance type as c5.xlarge.",
         ),
         # Wrong availability zone
         (
@@ -550,7 +550,7 @@ def test_placement_group_validator(
             "us-east-1b",
             "c5.xlarge",
             "us-east-1a",
-            "Capacity reservation .* must has the same instance type as c5.xlarge.",
+            "Capacity reservation .* must have the same instance type as c5.xlarge.",
         ),
         (
             "m5.xlarge",
@@ -558,6 +558,20 @@ def test_placement_group_validator(
             "c5.xlarge",
             "us-east-1a",
             "Capacity reservation .* must use the same availability zone as subnet",
+        ),
+        (
+            "m5.xlarge",
+            "us-east-1b",
+            None,
+            "us-east-1a",
+            "The CapacityReservationId parameter can only be used with the InstanceType parameter.",
+        ),
+        (
+            "m5.xlarge",
+            "us-east-1b",
+            "",
+            "us-east-1a",
+            "The CapacityReservationId parameter can only be used with the InstanceType parameter.",
         ),
     ],
 )


### PR DESCRIPTION
Add validator to prevent configs with CapacityReservationId and not InstanceType

If the CapacityReservationId is used, InstanceType is required.

### Description of changes
* See above

### Tests
* Validator updated to only retrieve the InstanceType parameter.
* Unit test updated to reflect this change

### References
* https://quip-amazon.com/kaLSAnnbyR7I/Design-Add-Support-for-On-Demand-Capacity-Reservations-ODCRs-in-Cluster-Configuration-File

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
