### PR TITLE
[3.3] Update PG/ODCR validator to only check if the cr_target exists and account for no id or arn

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2499,11 +2499,13 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                         instance_types=compute_resource.instance_types,
                         subnet=queue.networking.subnet_ids[0],
                     )
-                self._register_validator(
-                    PlacementGroupCapacityReservationValidator,
-                    queue=queue,
-                    compute_resource=compute_resource,
-                )
+                    self._register_validator(
+                        PlacementGroupCapacityReservationValidator,
+                        placement_group=queue.get_placement_group_key_for_compute_resource(compute_resource)[0],
+                        odcr=cr_target,
+                        subnet=queue.networking.subnet_ids[0],
+                        instance_types=compute_resource.instance_types,
+                    )
 
     @property
     def _capacity_reservation_targets(self):

--- a/cli/tests/pcluster/validators/test_all_validators/test_scheduler_plugin_all_validators_are_called/scheduler_plugin_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_scheduler_plugin_all_validators_are_called/scheduler_plugin_1.yaml
@@ -185,6 +185,12 @@ Scheduling:
           Efa:
             Enabled: true
             GdrSupport: false
+        - Name: pg-omit-odcr-arn
+          InstanceType: c6gn.xlarge
+          MinCount: 1
+          MaxCount: 10
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: 'arn:aws:resource-groups:us-west-2:944054287730:group/odcr-grp'
       Iam:
         InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
       Image:


### PR DESCRIPTION
Update PG/ODCR validator to only check if the cr_target exists and account for no id or arn

Also, refactors the validator to use a smaller set of data


### Description of changes
* See above

### Tests
* Manually created a cluster that uses this validation in several ways, only id, only arn, no id or arn

### References
* https://quip-amazon.com/kaLSAnnbyR7I/Design-Add-Support-for-On-Demand-Capacity-Reservations-ODCRs-in-Cluster-Configuration-File

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
