### PR TITLE
[CLI] Improve messaging used for CapacityType/AllocationStrategy Validation

### DIFF
--- a/cli/src/pcluster/validators/instance_type_list_validators.py
+++ b/cli/src/pcluster/validators/instance_type_list_validators.py
@@ -225,8 +225,9 @@ class InstanceTypeListAllocationStrategyValidator(Validator, _FlexibleInstanceTy
             and allocation_strategy != cluster_config.AllocationStrategy.LOWEST_PRICE
         ):
             self._add_failure(
-                f"Compute Resource {compute_resource_name} is using an OnDemand CapacityType. OnDemand CapacityType "
-                f"can only use '{cluster_config.AllocationStrategy.LOWEST_PRICE.value}' allocation strategy.",
+                f"Compute Resource {compute_resource_name} is using an OnDemand CapacityType but the Allocation "
+                f"Strategy specified is {allocation_strategy.value}. OnDemand CapacityType can only use '"
+                f"{cluster_config.AllocationStrategy.LOWEST_PRICE.value}' allocation strategy.",
                 FailureLevel.ERROR,
             )
 

--- a/cli/tests/pcluster/validators/test_instance_type_list_validators.py
+++ b/cli/tests/pcluster/validators/test_instance_type_list_validators.py
@@ -467,8 +467,8 @@ def test_instance_type_list_networking_validator(
             "TestComputeResource",
             CapacityType.ONDEMAND,
             AllocationStrategy.CAPACITY_OPTIMIZED,
-            "Compute Resource TestComputeResource is using an OnDemand CapacityType. OnDemand CapacityType can only "
-            "use 'lowest-price' allocation strategy.",
+            "Compute Resource TestComputeResource is using an OnDemand CapacityType but the Allocation Strategy "
+            "specified is capacity-optimized. OnDemand CapacityType can only use 'lowest-price' allocation strategy.",
         ),
         ("TestComputeResource", CapacityType.ONDEMAND, AllocationStrategy.LOWEST_PRICE, ""),
     ],


### PR DESCRIPTION
### Description of changes
* Mention the allocation strategy being used when reporting that OnDemand CapacityType cannot. be linked to an allocation strategy other than `lower-price`

### Tests
* Automated Unit Test

### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
