### PR TITLE
[3.3] Add validation for the Capacity Reservation Resource Group to be created from the cli

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -736,6 +736,7 @@ Resources:
             Sid: CloudWatchLogs
           - Action:
               - resource-groups:ListGroupResources
+              - resource-groups:GetGroupConfiguration
             Resource: '*'
             Effect: Allow
             Sid: ResourceGroupRead

--- a/cli/src/pcluster/aws/resource_groups.py
+++ b/cli/src/pcluster/aws/resource_groups.py
@@ -33,3 +33,9 @@ class ResourceGroupsClient(Boto3Client):
                     ).group("reservation_id")
                 )
         return capacity_reservation_ids
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def get_group_configuration(self, group):
+        """Return the group config or throw an exception if not a Service Linked Group."""
+        return self._client.get_group_configuration(Group=group)

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -476,6 +476,7 @@ Resources:
             Sid: CloudWatchLogs
           - Action:
               - resource-groups:ListGroupResources
+              - resource-groups:GetGroupConfiguration
             Resource: '*'
             Effect: Allow
             Sid: ResourceGroupRead
@@ -764,7 +765,7 @@ Resources:
           - Action:
               - iam:AttachRolePolicy
               - iam:DetachRolePolicy
-            Resource: 
+            Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
               # Needed to enable capacity reservation access without creating a custom policy in tests
               - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonEC2FullAccess

--- a/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_odcr/odcr.config.yaml
+++ b/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_odcr/odcr.config.yaml
@@ -39,15 +39,6 @@ Scheduling:
               Name: 'q-enabled-cr-named'
           CapacityReservationTarget:
             CapacityReservationId: 'cr-01df19e7c8c6b8566'
-        - Name: pg-name-odcr-id-wrong-pg
-          InstanceType: c7g.xlarge
-          MinCount: 1
-          MaxCount: 10
-          Networking:
-            PlacementGroup:
-              Name: 'cr-named-wrong-pg'
-          CapacityReservationTarget:
-            CapacityReservationId: 'cr-04331967645330fbe'
       Networking:
         SubnetIds:
           - subnet-0bfcd29fad2404485
@@ -58,7 +49,8 @@ Scheduling:
     - Name: q-pg-en-cr-name-odcr-arn
       ComputeResources:
         - Name: pg-omit-odcr-arn
-          InstanceType: c6gn.xlarge
+          InstanceTypeList:
+            - InstanceType: c6gn.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
@@ -72,8 +64,15 @@ Scheduling:
               Name: 'q-enabled-cr-named'
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: 'arn:aws:resource-groups:us-west-2:944054287730:group/odcr-grp'
+        - Name: pg-omit-odcr
+          InstanceTypeList:
+            - InstanceType: c6gn.xlarge
+          MinCount: 1
+          MaxCount: 10
+        - Name: pg-omit-odcr-b
+          InstanceType: c6gn.xlarge
+          MinCount: 1
+          MaxCount: 10
       Networking:
         SubnetIds:
           - subnet-0bfcd29fad2404485
-      CapacityReservationTarget:
-        CapacityReservationId: 'cr-0573660fb76478d13'


### PR DESCRIPTION
Add validation for the Capacity Reservation Resource Group to be created from the cli

Service Linked Groups (SLG) are required in order to use Capacity Reservation Resource Groups when launching instances.  SLGs can only be created from the CLI or API even though Tag Based or Stack Based Resource Groups can be created from the console.  Parallel Cluster thus requires that all Capacity Reservation Resource Groups are SLGs created from the CLI.

Also remove unnecessary compute resource mocks from unit test

Signed-off-by: Ryan Anderson <ndry@amazon.com>


### Description of changes
* See above

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
