### PR TITLE
[IntegrationTests] Use capacity-optimized allocation strategy to reduce InsufficientInstanceCapacity errors

### DIFF
--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
@@ -15,6 +15,10 @@ Scheduling:
   Scheduler: {{ scheduler }}
   {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
     - Name: queue-0
+      {% if scheduler == "slurm" %}
+      AllocationStrategy: capacity-optimized
+      CapacityType: SPOT
+      {% endif %}
       ComputeSettings:
         LocalStorage:
           RootVolume:


### PR DESCRIPTION
### Description of changes
* Some Integration Tests often fail with InsufficientInstanceCapacity Errors
* This commit introduces the use of a `capacity-optimized` allocation strategy for the intel_hpc integration tests

### Tests
* Tested locally

```
INFO - 58518 - test_intel_hpc[eu-west-1-c5n.18xlarge-centos7-slurm] - conftest - Completed test test_intel_hpc[eu-west-1-c5n.18xlarge-centos7-slurm]
INFO - test_runner - All tests completed!
INFO - test_runner - Generating tests report
```

### References
* [Allocation strategies for Spot Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
