### PR TITLE
Add a template to create a serverless database

### DIFF
--- a/cloudformation/database/serverless-database.yaml
+++ b/cloudformation/database/serverless-database.yaml
@@ -1,0 +1,344 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  This template is provided as part of a tutorial on how to enable Slurm Accounting using Parallel Cluster.
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Database Cluster Configuration"
+        Parameters:
+          - ClusterAdmin
+          - AdminPasswordSecretName
+          - AdminPasswordSecretString
+          - MinCapacity
+          - MaxCapacity
+      - Label:
+          default: "Network Configuration"
+        Parameters:
+          - Vpc
+          - DatabaseClusterSubnetOne
+          - DatabaseClusterSubnetTwo
+    ParameterLabels:
+      Vpc:
+        default: "Which VPC should the database cluster be created in?"
+      ClusterAdmin:
+        default: "What should the database administrator user name be?"
+      AdminPasswordSecretName:
+        default: "What should the name of the secret containing the administrator password be?"
+      AdminPasswordSecretString:
+        default: "What should the administrator password be?"
+      MinCapacity:
+        default: "What should the minimum scaling capacity of the database cluster be?"
+      MaxCapacity:
+        default: "What should the maximum scaling capacity of the database cluster be?"
+      DatabaseClusterSubnetOne:
+        default: "What is the first subnet the database cluster should be deployed in?"
+      DatabaseClusterSubnetTwo:
+        default: "What is the second subnet the database cluster should be deployed in?"
+Parameters:
+  AdminPasswordSecretName:
+    Description: Name of then Secrets Manager secret for the database cluster administrator password.
+    Type: String
+    MinLength: 2
+    MaxLength: 1024
+  AdminPasswordSecretString:
+    Description: Password for the database cluster administrator (leave BLANK to import the password from Secrets Manager).
+    Type: String
+    NoEcho: true
+    # Only allow 'Medium' or better strength passwords according to https://dev.mysql.com/doc/refman/8.0/en/validate-password.html
+    AllowedPattern: (?=^.{8,}$)(?=.*\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[^\w\s])^.*|^$
+    ConstraintDescription: Password must be BLANK or at least 8 characters with at least one uppercase letter, one lower case letter, one numeric digit, and one special (non-alphanumeric) character.
+    Default: ""
+  ClusterAdmin:
+    Description: Database cluster administrator user name.
+    Type: String
+    Default: clusteradmin
+    MinLength: 3
+    MaxLength: 64
+  Vpc:
+    Description: VPC ID to create the database cluster in (leave BLANK to create a new one).
+    Type: String
+    # Type: AWS::EC2::VPC::Id
+    Default: ""
+  DatabaseClusterSubnetOne:
+    Description: Subnet ID of the first subnet (leave BLANK to create).
+    Type: String
+    # Type: AWS::EC2::Subnet::Id
+    Default: ""
+  DatabaseClusterSubnetTwo:
+    Description: Subnet ID of the second subnet (leave BLANK to create). This subnet should be in different availability zone from the first subnet.
+    Type: String
+    # Type: AWS::EC2::Subnet::Id
+    Default: ""
+  MinCapacity:
+    Description: Minimum scaling capacity for the database cluster. Must be less than or equal to MaxCapacity.
+    Type: Number
+    Default: 1
+    AllowedValues:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+  MaxCapacity:
+    Description: Maximum scaling capacity for the database cluster. Must be greater than or equal to MinCapacity
+    Type: Number
+    Default: 4
+    AllowedValues:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
+      - 256
+Transform: AWS::Serverless-2016-10-31
+Conditions:
+  CreateVPC: !Equals [!Ref Vpc, '']
+  CreateSubnets: !Or [!Condition CreateVPC, !Equals [!Ref DatabaseClusterSubnetOne, ''], !Equals [!Ref DatabaseClusterSubnetTwo, '']]
+  CreateAdminSecret: !Not [!Equals [!Ref AdminPasswordSecretString, '']]
+Rules:
+  EmptyVpcAssertions:
+    RuleCondition: !Equals
+      - !Ref Vpc
+      - ''
+    Assertions:
+      - Assert: !Equals
+          - !Ref DatabaseClusterSubnetOne
+          - ''
+        AssertDescription: DatabaseClusterSubnetOne must be empty if Vpc is not provided.
+      - Assert: !Equals
+          - !Ref DatabaseClusterSubnetTwo
+          - ''
+        AssertDescription: DatabaseClusterSubnetTwo must be empty if Vpc is not provided.
+Resources:
+  #
+  # Optional Networking
+  #
+  ServerlessDatabaseClusterVpc:
+    Type: 'AWS::EC2::VPC'
+    Condition: CreateVPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: ServerlessDatabaseClusterVPC
+        - Key: 'parallel-cluster:accounting'
+          Value: vpc
+  ServerlessDatabaseClusterSubnet1:
+    Type: 'AWS::EC2::Subnet'
+    Condition: CreateSubnets
+    Properties:
+      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+      AvailabilityZone: !Sub ${AWS::Region}a
+      CidrBlock: 10.0.128.0/24
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: ServerlessDatabaseClusterSubnet1
+        - Key: 'parallel-cluster:accounting'
+          Value: !Sub cluster-subnet-${AWS::Region}a
+  ServerlessDatabaseClusterSubnet1RouteTable:
+    Type: 'AWS::EC2::RouteTable'
+    Condition: CreateSubnets
+    Properties:
+      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+      Tags:
+        - Key: Name
+          Value: ServerlessDatabaseClusterSubnet1
+        - Key: 'parallel-cluster:accounting'
+          Value: !Sub cluster-subnet-${AWS::Region}a
+  ServerlessDatabaseClusterSubnet1RouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Condition: CreateSubnets
+    Properties:
+      RouteTableId: !Ref ServerlessDatabaseClusterSubnet1RouteTable
+      SubnetId: !Ref ServerlessDatabaseClusterSubnet1
+  ServerlessDatabaseClusterSubnet2:
+    Type: 'AWS::EC2::Subnet'
+    Condition: CreateSubnets
+    Properties:
+      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+      AvailabilityZone: !Sub ${AWS::Region}b
+      CidrBlock: 10.0.129.0/24
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: ServerlessDatabaseClusterSubnet2
+        - Key: 'parallel-cluster:accounting'
+          Value: !Sub cluster-subnet-${AWS::Region}b
+  ServerlessDatabaseClusterSubnet2RouteTable:
+    Type: 'AWS::EC2::RouteTable'
+    Condition: CreateSubnets
+    Properties:
+      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+      Tags:
+        - Key: Name
+          Value: ServerlessDatabaseClusterSubnet2
+        - Key: 'parallel-cluster:accounting'
+          Value: !Sub cluster-subnet-${AWS::Region}b
+  ServerlessDatabaseClusterSubnet2RouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Condition: CreateSubnets
+    Properties:
+      RouteTableId: !Ref ServerlessDatabaseClusterSubnet2RouteTable
+      SubnetId: !Ref ServerlessDatabaseClusterSubnet2
+
+  #
+  # Database Cluster
+  #
+  ServerlessDatabaseClusterParameterGroup:
+    Type: 'AWS::RDS::DBClusterParameterGroup'
+    Properties:
+      Description: Cluster parameter group for aurora-mysql5.7
+      Family: aurora-mysql5.7
+      Parameters:
+        require_secure_transport: 'ON'
+        innodb_lock_wait_timeout: '900'
+      Tags:
+        - Key: 'parallel-cluster:accounting'
+          Value: rds-parameter-group
+  ServerlessDatabaseClusterSubnetGroup:
+    Type: 'AWS::RDS::DBSubnetGroup'
+    Properties:
+      DBSubnetGroupDescription: !Sub Subnets for ServerlessDatabaseCluster-${AWS::Region} database
+      SubnetIds:
+        - !If [CreateSubnets, !Ref ServerlessDatabaseClusterSubnet1, !Ref DatabaseClusterSubnetOne]
+        - !If [CreateSubnets, !Ref ServerlessDatabaseClusterSubnet2, !Ref DatabaseClusterSubnetTwo]
+      Tags:
+        - Key: 'parallel-cluster:accounting'
+          Value: subnet-group
+  ServerlessDatabaseClusterSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: RDS security group
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic by default
+          IpProtocol: '-1'
+      Tags:
+        - Key: 'parallel-cluster:accounting'
+          Value: database-security-group
+      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+  ServerlessDatabaseClusterSecurityGroupInboundRule:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      IpProtocol: tcp
+      Description: Allow incoming connections from client security group
+      FromPort: !GetAtt
+        - ServerlessDatabaseCluster
+        - Endpoint.Port
+      GroupId: !GetAtt
+        - ServerlessDatabaseClusterSecurityGroup
+        - GroupId
+      SourceSecurityGroupId: !GetAtt
+        - ServerlessClusterDatabaseClientSecurityGroup
+        - GroupId
+      ToPort: !GetAtt
+        - ServerlessDatabaseCluster
+        - Endpoint.Port
+  ServerlessDatabaseClusterAdminSecret:
+    Type: 'AWS::SecretsManager::Secret'
+    Condition: CreateAdminSecret
+    Properties:
+      Description: 'Serverless Database Cluster Administrator Password'
+      Name: !Ref AdminPasswordSecretName
+      SecretString: !Ref AdminPasswordSecretString
+  ServerlessDatabaseCluster:
+    Type: 'AWS::RDS::DBCluster'
+    Properties:
+      Engine: aurora-mysql
+      CopyTagsToSnapshot: true
+      DBClusterParameterGroupName: !Ref ServerlessDatabaseClusterParameterGroup
+      DBSubnetGroupName: !Ref ServerlessDatabaseClusterSubnetGroup
+      EnableHttpEndpoint: false
+      EngineMode: serverless
+      MasterUsername: !Ref ClusterAdmin
+      MasterUserPassword: !If
+        - CreateAdminSecret
+        - !Ref AdminPasswordSecretString
+        - !Sub '{{resolve:secretsmanager:${AdminPasswordSecretName}:SecretString:::}}'
+      ScalingConfiguration:
+        AutoPause: true
+        MaxCapacity: !Ref MaxCapacity
+        MinCapacity: !Ref MinCapacity
+        SecondsUntilAutoPause: 600
+      StorageEncrypted: true
+      Tags:
+        - Key: 'parallel-cluster:accounting'
+          Value: database-cluster
+      VpcSecurityGroupIds:
+        - !GetAtt
+          - ServerlessDatabaseClusterSecurityGroup
+          - GroupId
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  ServerlessClusterDatabaseClientSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: Security Group to allow connection to Serverless DB Cluster
+      Tags:
+        - Key: 'parallel-cluster:accounting'
+          Value: client-security-group
+      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+  ServerlessClusterDatabaseClientSecurityGroupOutboundRule:
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    Properties:
+      GroupId: !GetAtt
+        - ServerlessClusterDatabaseClientSecurityGroup
+        - GroupId
+      IpProtocol: tcp
+      Description: Allow incoming connections from PCluster
+      DestinationSecurityGroupId: !GetAtt
+        - ServerlessDatabaseClusterSecurityGroup
+        - GroupId
+      FromPort: !GetAtt
+        - ServerlessDatabaseCluster
+        - Endpoint.Port
+      ToPort: !GetAtt
+        - ServerlessDatabaseCluster
+        - Endpoint.Port
+Outputs:
+  parallelclusterdatabasehost:
+    Value: !GetAtt
+      - ServerlessDatabaseCluster
+      - Endpoint.Address
+    Export:
+      Name: !Sub 'parallel-cluster:accounting:database:hostname:${AWS::StackName}'
+  parallelclusterdatabaseport:
+    Value: !GetAtt
+      - ServerlessDatabaseCluster
+      - Endpoint.Port
+    Export:
+      Name: !Sub 'parallel-cluster:accounting:database:port:${AWS::StackName}'
+  parallelclusterdatabaseadminuser:
+    Value: !Ref ClusterAdmin
+    Export:
+      Name: !Sub 'parallel-cluster:accounting:database:admin-user:${AWS::StackName}'
+  parallelclusterdatabasesecretname:
+    Value: !Ref AdminPasswordSecretName
+    Export:
+      Name: !Sub 'parallel-cluster:accounting:database:secret:name:${AWS::StackName}'
+  parallelclusterdatabasesecretarn:
+    Value: !If [CreateAdminSecret, !Ref ServerlessDatabaseClusterAdminSecret, 'external']
+    Export:
+      Name: !Sub 'parallel-cluster:accounting:database:secret:arn:${AWS::StackName}'
+  parallelclusterdatabasevpc:
+    Value: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+    Export:
+      Name: !Sub 'parallel-cluster:accounting:vpc:${AWS::StackName}'
+  parallelclusterdatabaseclient:
+    Value: !GetAtt
+      - ServerlessClusterDatabaseClientSecurityGroup
+      - GroupId
+    Export:
+      Name: !Sub 'parallel-cluster:accounting:database:client:security-group:${AWS::StackName}'


### PR DESCRIPTION
### Description of changes
* Add a 'tutorial' level CloudFormation template for creating a serverless database cluster.


### Tests
* Deployed into an existing VPC
* Created a cluster with accounting enabled
* Verified connection from head node with 'sacctmgr list users -Pn'
* Verified connection from head node by creating a job with sbatch and then executing 'sacct -j <job id>'
* Deployed stack without existing VPC

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
