### PR TITLE
[3.3] Create an update policy for managed placement groups

### DIFF
--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -22,7 +22,7 @@ from pcluster.schemas.common_schema import BaseSchema
 # Represents a single parameter change in a ConfigPatch instance
 Change = namedtuple("Change", ["path", "key", "old_value", "new_value", "update_policy", "is_list"])
 
-# Patch for deepcopy bug - Issue10076 in Pyhton < 3.7
+# Patch for deepcopy bug - Issue10076 in Python < 3.7
 # see https://bugs.python.org/issue10076
 # see https://docs.python.org/3/whatsnew/3.7.html#re
 if sys.version_info <= (3, 7):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -637,9 +637,9 @@ class HeadNodeNetworkingSchema(BaseNetworkingSchema):
 class PlacementGroupSchema(BaseSchema):
     """Represent the schema of placement group."""
 
-    enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
-    id = fields.Str(metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
-    name = fields.Str(metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
+    enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP})
+    id = fields.Str(metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP})
+    name = fields.Str(metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP})
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -663,7 +663,7 @@ class SlurmQueueNetworkingSchema(QueueNetworkingSchema):
     """Represent the schema of the Networking, child of slurm Queue."""
 
     placement_group = fields.Nested(
-        PlacementGroupSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
+        PlacementGroupSchema, metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP}
     )
     proxy = fields.Nested(QueueProxySchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY})
 
@@ -1138,7 +1138,7 @@ class SlurmComputeResourceNetworkingSchema(BaseSchema):
     """Represent the Networking schema of the Slurm ComputeResource."""
 
     placement_group = fields.Nested(
-        PlacementGroupSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
+        PlacementGroupSchema, metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP}
     )
 
     @post_load
@@ -1168,7 +1168,7 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
         CapacityReservationTargetSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
     )
     networking = fields.Nested(
-        SlurmComputeResourceNetworkingSchema, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
+        SlurmComputeResourceNetworkingSchema, metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP}
     )
 
     @validates_schema


### PR DESCRIPTION
### Description of changes
Managed placement group deletion requires the compute fleet to be stopped. The update policy for placement groups and all of the parameters within needs to check for deletion when updating the cluster.  Also, the networking section of the compute resource only contains placement group, so that section follows this policy as well.

Signed-off-by: Ryan Anderson <ndry@amazon.com>

### Tests
* Manual tests for update policy
* Unit tests added for update policy related to managed placement groups
* The relevant pcluster 3 integration tests are passing with these changes

### References
* https://quip-amazon.com/kaLSAnnbyR7I/Design-Add-Support-for-On-Demand-Capacity-Reservations-ODCRs-in-Cluster-Configuration-File

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
