### PR TITLE
[Dependencies] Downgrade Slurm to version 21.08.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ CHANGELOG
 - Add support for multiple instance types in the same Compute Resource.
 - Add support for a Name field in PlacementGroup as the preferred naming method.
 - Add support for Networking.PlacementGroup in the SlurmQueues.ComputeResources section
-- Upgrade Slurm to version 22.05.3.
 
 **BUG FIXES**
 - Fix validation of parameter `SharedStorage/EfsSettings`: now validation fails when `FileSystemId` is specified

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1231,7 +1231,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
 def _test_slurm_version(remote_command_executor):
     logging.info("Testing Slurm Version")
     version = remote_command_executor.run_remote_command("sinfo -V").stdout
-    assert_that(version).is_equal_to("slurm 22.05.3")
+    assert_that(version).is_equal_to("slurm 21.08.8-2")
 
 
 def _test_job_dependencies(slurm_commands, region, stack_name, scaledown_idletime):


### PR DESCRIPTION
### Description of changes
Downgrade Slurm to version 21.08.8.
The upgrade to Slurm 22.05.3 can be related to some regressions detected by our integration tests.
Further investigation is needed to root cause the regressions, but in the meantime we want to keep the release safe.

### Tests
* Will be tested in the official pipeline

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>