### PR TITLE
[develop] Add validator for accelerator manufacturer

### DIFF
--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -8,9 +8,6 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-import json
-import logging
-
 from pcluster.constants import (
     LUSTRE,
     OPENZFS,
@@ -25,8 +22,6 @@ from pcluster.constants import (
     PCLUSTER_VERSION_TAG,
     SUPPORTED_ARCHITECTURES,
 )
-
-LOGGER = logging.getLogger(__name__)
 
 
 class StackInfo:
@@ -183,17 +178,7 @@ class InstanceTypeInfo:
         gpu_manufacturers = list({gpu.get("Manufacturer", "") for gpu in gpu_info.get("Gpus", [])})
 
         # Only one GPU manufacturer is associated with each Instance Type's GPU
-        manufacturer = gpu_manufacturers[0] if gpu_manufacturers else ""
-        if manufacturer.upper() != "NVIDIA":
-            LOGGER.warning(
-                "ParallelCluster currently offers native support for NVIDIA manufactured GPUs only. "
-                "InstanceType (%s) GPU Info: %s. "
-                "Please make sure to use a custom AMI with the appropriate drivers in order to leverage "
-                "GPUs functionalities",
-                self.instance_type(),
-                json.dumps(gpu_info),
-            )
-        return manufacturer
+        return gpu_manufacturers[0] if gpu_manufacturers else ""
 
     def inference_accelerator_manufacturer(self) -> str:
         """Return the Inference Accelerator Manufacturer supported by this instance type."""
@@ -202,19 +187,8 @@ class InstanceTypeInfo:
         inference_accelerator_manufacturers = list(
             {accelerator.get("Manufacturer", "") for accelerator in inference_accelerator_info.get("Accelerators", [])}
         )
+
         # Only one accelerator manufacturer is associated with each Instance Type's accelerator
-
-        accelerator_manufacturer = inference_accelerator_manufacturers[0] if inference_accelerator_manufacturers else ""
-        if accelerator_manufacturer.upper() != "AWS":
-            LOGGER.warning(
-                "ParallelCluster currently offers native support for 'AWS' manufactured Inference Accelerators only. "
-                "InstanceType (%s) accelerator info: %s. "
-                "Please make sure to use a custom AMI with the appropriate drivers in order to leverage the "
-                "accelerators functionalities.",
-                self.instance_type(),
-                json.dumps(inference_accelerator_info),
-            )
-
         return inference_accelerator_manufacturers[0] if inference_accelerator_manufacturers else ""
 
     def inference_accelerator_count(self):

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -119,6 +119,7 @@ from pcluster.validators.ec2_validators import (
     CapacityReservationResourceGroupValidator,
     CapacityReservationValidator,
     CapacityTypeValidator,
+    InstanceTypeAcceleratorManufacturerValidator,
     InstanceTypeBaseAMICompatibleValidator,
     InstanceTypeMemoryInfoValidator,
     InstanceTypeValidator,
@@ -2655,6 +2656,12 @@ class SlurmClusterConfig(CommonSchedulerClusterConfig):
                             instance_type=instance_type,
                             instance_type_data=instance_types_data[instance_type],
                         )
+                for instance_type in compute_resource.instance_types:
+                    self._register_validator(
+                        InstanceTypeAcceleratorManufacturerValidator,
+                        instance_type=instance_type,
+                        instance_type_data=instance_types_data[instance_type],
+                    )
                 if isinstance(compute_resource, SlurmFlexibleComputeResource):
                     validator_args = dict(
                         queue_name=queue.name,

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -236,7 +236,6 @@ def test_init_from_instance_type(mocker, caplog):
     g4ad_instance_info = AWSApi.instance().ec2.get_instance_type_info("g4ad.16xlarge")
     assert_that(g4ad_instance_info.gpu_count()).is_equal_to(0)
     assert_that(g4ad_instance_info.gpu_manufacturer()).is_equal_to("AMD")
-    assert_that(caplog.text).matches("offers native support for NVIDIA manufactured GPUs only.")
     assert_that(g4ad_instance_info.max_network_interface_count()).is_equal_to(1)
     assert_that(g4ad_instance_info.default_threads_per_core()).is_equal_to(2)
     assert_that(g4ad_instance_info.vcpus_count()).is_equal_to(64)

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -161,6 +161,9 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     instance_type_base_ami_compatible_validator = mocker.patch(
         ec2_validators + ".InstanceTypeBaseAMICompatibleValidator._validate", return_value=[]
     )
+    instance_type_accelerator_manufacturer_validator = mocker.patch(
+        ec2_validators + ".InstanceTypeAcceleratorManufacturerValidator._validate", return_value=[]
+    )
 
     networking_validators = validators_path + ".networking_validators"
     security_groups_validator = mocker.patch(
@@ -320,6 +323,7 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     ebs_volume_size_snapshot_validator.assert_called()
     shared_ebs_volume_id_validator.assert_called()
     fsx_persistent_options_validator.assert_called()
+    instance_type_accelerator_manufacturer_validator.assert_called()
 
 
 def test_scheduler_plugin_all_validators_are_called(test_datadir, mocker):
@@ -379,6 +383,7 @@ def test_scheduler_plugin_all_validators_are_called(test_datadir, mocker):
                 "MixedSecurityGroupOverwriteValidator",
                 "HostedZoneValidator",
                 "InstanceTypeMemoryInfoValidator",
+                "InstanceTypeAcceleratorManufacturerValidator",
                 "CapacityReservationValidator",
                 "CapacityReservationResourceGroupValidator",
                 "DatabaseUriValidator",

--- a/cli/tests/pcluster/validators/test_instance_type_list_validators.py
+++ b/cli/tests/pcluster/validators/test_instance_type_list_validators.py
@@ -12,7 +12,6 @@ from enum import Enum
 from typing import Dict, List
 
 import pytest
-from assertpy import assert_that
 
 from pcluster.aws.aws_resources import InstanceTypeInfo
 from pcluster.config.cluster_config import AllocationStrategy, CapacityType
@@ -99,7 +98,7 @@ def test_instance_type_list_cpu_validator(
 
 
 @pytest.mark.parametrize(
-    "compute_resource_name, instance_types_info, expected_message, logger_message",
+    "compute_resource_name, instance_types_info, expected_message",
     [
         # Instance Types should have the same number of GPUs
         (
@@ -135,7 +134,6 @@ def test_instance_type_list_cpu_validator(
             },
             "Instance types listed under Compute Resource TestComputeResource must have the same number of GPUs ({"
             "'g4dn.xlarge': 1, 'g5.xlarge': 2}).",
-            "",
         ),
         (
             "TestComputeResource",
@@ -167,7 +165,6 @@ def test_instance_type_list_cpu_validator(
                 ),
             },
             "",
-            "",
         ),
         # Instance Types should have the same number of Accelerators
         (
@@ -192,7 +189,6 @@ def test_instance_type_list_cpu_validator(
             },
             "Instance types listed under Compute Resource TestComputeResource must have the same number of Inference "
             "Accelerators ({'inf1.6xlarge': 4, 'inf1.2xlarge': 1}).",
-            "",
         ),
         (
             "TestComputeResource",
@@ -212,7 +208,6 @@ def test_instance_type_list_cpu_validator(
                     }
                 ),
             },
-            "",
             "",
         ),
         # Instance Types should have the same GPU manufacturer
@@ -249,8 +244,6 @@ def test_instance_type_list_cpu_validator(
             },
             "Instance types listed under Compute Resource TestComputeResource must have the same GPU manufacturer ({"
             "'g4dn.xlarge': 'NVIDIA', 'g5.xlarge': 'OtherGPUManufacturers'}).",
-            "offers native support for NVIDIA manufactured GPUs only.* GPU Info: .*Please "
-            "make sure to use a custom AMI",
         ),
         (
             "TestComputeResource",
@@ -282,7 +275,6 @@ def test_instance_type_list_cpu_validator(
                 ),
             },
             "",
-            "",
         ),
         # Instance Types should have the same Accelerator Manufacturer (Inferentia)
         (
@@ -307,8 +299,6 @@ def test_instance_type_list_cpu_validator(
             },
             "Instance types listed under Compute Resource TestComputeResource must have the same inference "
             "accelerator manufacturer ({'inf1.6xlarge': 'AWS', 'inf1.2xlarge': 'NotAWS'}).",
-            "offers native support for 'AWS' manufactured Inference Accelerators only.* accelerator info: .*Please "
-            "make sure to use a custom AMI",
         ),
         (
             "TestComputeResource",
@@ -329,20 +319,15 @@ def test_instance_type_list_cpu_validator(
                 ),
             },
             "",
-            "",
         ),
     ],
 )
-def test_instance_type_list_accelerators_validator(
-    compute_resource_name, instance_types_info, expected_message, logger_message, caplog
-):
+def test_instance_type_list_accelerators_validator(compute_resource_name, instance_types_info, expected_message):
     actual_failures = InstanceTypeListAcceleratorsValidator().execute(
         compute_resource_name,
         instance_types_info,
     )
     assert_failure_messages(actual_failures, expected_message)
-    if logger_message:
-        assert_that(caplog.text).matches(logger_message)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Add validator for accelerator manufacturer, so that when a not supported one is selected, a warning message is returned.

e.g. using `dl1.24xlarge` and `g4ad.16xlarge`

CLI output:

```
    {
      "level": "WARNING",
      "type": "InstanceTypeAcceleratorManufacturerValidator",
      "message": "The GPU manufacturer 'Habana' for instance type 'dl1.24xlarge' is not supported. Please make sure to use a custom AMI with the appropriate drivers in order to leverage GPUs functionalities"
    },
    {
      "level": "WARNING",
      "type": "InstanceTypeAcceleratorManufacturerValidator",
      "message": "The GPU manufacturer 'AMD' for instance type 'g4ad.16xlarge' is not supported. Please make sure to use a custom AMI with the appropriate drivers in order to leverage GPUs functionalities"
    }
  ],
  "message": "Invalid cluster configuration."
}
```

PCluster CLI log:
```
2022-10-05 14:27:27,985 - WARNING - ec2_validators.py:46:_validate() - ParallelCluster offers native support for NVIDIA manufactured GPUs only. InstanceType (dl1.24xlarge) GPU Info: {"Gpus": [{"Name": "Gaudi HL-205", "Manufacturer": "Habana", "Count": 8, "MemoryInfo": {"SizeInMiB": 32768}}], "TotalGpuMemoryInMiB": 262144}. Please make sure to use a custom AMI with the appropriate drivers in order to leverage GPUs functionalities
2022-10-05 14:27:27,986 - WARNING - ec2_validators.py:46:_validate() - ParallelCluster offers native support for NVIDIA manufactured GPUs only. InstanceType (g4ad.16xlarge) GPU Info: {"Gpus": [{"Name": "Radeon Pro V520", "Manufacturer": "AMD", "Count": 4, "MemoryInfo": {"SizeInMiB": 8192}}], "TotalGpuMemoryInMiB": 32768}. Please make sure to use a custom AMI with the appropriate drivers in order to leverage GPUs functionalities
```

### Tests
unit tests added

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
