### PR TITLE
[DFSM] Make security group rules attached to file systems have a DeletionPolicy that is consistent with the DeletionPolicy set for the file systems

### DIFF
--- a/cli/tests/pcluster/templates/test_shared_storage.py
+++ b/cli/tests/pcluster/templates/test_shared_storage.py
@@ -92,6 +92,7 @@ def test_shared_storage_efs(mocker, test_datadir, config_file_name, storage_name
     assert_that(mount_target_sg["DeletionPolicy"]).is_equal_to(deletion_policy)
 
     for sg in ["HeadNodeSecurityGroup", "ComputeSecurityGroup", mount_target_sg_name]:
+        rule_deletion_policy = deletion_policy if sg == mount_target_sg_name else None
         assert_sg_rule(
             generated_template,
             mount_target_sg_name,
@@ -99,6 +100,7 @@ def test_shared_storage_efs(mocker, test_datadir, config_file_name, storage_name
             protocol="-1",
             port_range=[0, 65535],
             target_sg=sg,
+            deletion_policy=rule_deletion_policy,
         )
         assert_sg_rule(
             generated_template,
@@ -107,6 +109,7 @@ def test_shared_storage_efs(mocker, test_datadir, config_file_name, storage_name
             protocol="-1",
             port_range=[0, 65535],
             target_sg=sg,
+            deletion_policy=rule_deletion_policy,
         )
 
 
@@ -143,6 +146,7 @@ def test_shared_storage_fsx(mocker, test_datadir, config_file_name, storage_name
     assert_that(file_system_sg["DeletionPolicy"]).is_equal_to(deletion_policy)
 
     for sg in ["HeadNodeSecurityGroup", "ComputeSecurityGroup", file_system_sg_name]:
+        rule_deletion_policy = deletion_policy if sg == file_system_sg_name else None
         assert_sg_rule(
             generated_template,
             file_system_sg_name,
@@ -150,6 +154,7 @@ def test_shared_storage_fsx(mocker, test_datadir, config_file_name, storage_name
             protocol="-1",
             port_range=[0, 65535],
             target_sg=sg,
+            deletion_policy=rule_deletion_policy,
         )
         assert_sg_rule(
             generated_template,
@@ -158,11 +163,18 @@ def test_shared_storage_fsx(mocker, test_datadir, config_file_name, storage_name
             protocol="-1",
             port_range=[0, 65535],
             target_sg=sg,
+            deletion_policy=rule_deletion_policy,
         )
 
 
 def assert_sg_rule(
-    generated_template: dict, sg_name: str, rule_type: str, protocol: str, port_range: list, target_sg: str
+    generated_template: dict,
+    sg_name: str,
+    rule_type: str,
+    protocol: str,
+    port_range: list,
+    target_sg: str,
+    deletion_policy: str,
 ):
     constants = {
         "ingress": {"resource_type": "AWS::EC2::SecurityGroupIngress", "sg_field": "SourceSecurityGroupId"},
@@ -171,6 +183,7 @@ def assert_sg_rule(
     sg_rules = get_resources(
         generated_template,
         type=constants[rule_type]["resource_type"],
+        deletion_policy=deletion_policy,
         properties={
             "GroupId": {"Ref": sg_name},
             "IpProtocol": protocol,

--- a/cli/tests/pcluster/utils.py
+++ b/cli/tests/pcluster/utils.py
@@ -29,12 +29,15 @@ def load_cluster_model_from_yaml(config_file_name, test_datadir=None):
     return input_yaml, cluster
 
 
-def get_resources(generated_template: dict, name: str = None, type: str = None, properties: dict = None):
+def get_resources(
+    generated_template: dict, name: str = None, type: str = None, properties: dict = None, deletion_policy: str = None
+):
     return dict(
         (res_name, res_value)
         for res_name, res_value in generated_template.get("Resources", {}).items()
         if (name is None or res_name == name)
         and (type is None or res_value.get("Type") == type)
+        and (deletion_policy is None or res_value.get("DeletionPolicy") == deletion_policy)
         and (
             properties is None
             or all(


### PR DESCRIPTION
### Description of changes
Make security group rules attached to file systems have a DeletionPolicy that is consistent with the DeletionPolicy set for the file systems.

#### Assumptions
The SG attached to a EFS/FSx file system must have the following rules:
1. allow traffic within itself
2. allow traffic with the head node
3. allow traffic with the compute node

#### User Experience without this change
If the user wants to _retain_ the file system, then the following resources are retained:
1. file system
2. SG attached to the file system

All the above rules will be deleted. 
That's correct for rules 2 and 3 because the lifecycle of the file system is now decoupled from the cluster. 
That's not correct for rule 1, because its lifecycle should be coupled with the file system lifecycle.

#### User Experience with this change
If the user wants to _retain_ the file system, then the following resources are retained:
1. file system
2. SG attached to the file system
3. Rule 1

Rules 2 and 3 will be deleted (as it currently is).

### Tests
1. Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
