### PR TITLE
Add integ tests configuration file to be used for new instance types support

### DIFF
--- a/tests/integration-tests/configs/new_instance_types.yaml
+++ b/tests/integration-tests/configs/new_instance_types.yaml
@@ -1,0 +1,100 @@
+{%- import 'common.jinja2' as common -%}
+{%- set REGION = ["##PLACEHOLDER##"] -%}
+{%- set NEW_INSTANCE_TYPES = ["##PLACEHOLDER##"] -%}
+---
+test-suites:
+  scaling:
+    test_mpi.py::test_mpi:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+  schedulers:
+    test_slurm.py::test_slurm:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+    test_slurm.py::test_slurm_pmix:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: ["ubuntu2004"]
+          schedulers: ["slurm"]
+    test_awsbatch.py::test_awsbatch:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: ["alinux2"]
+          schedulers: ["awsbatch"]
+  storage:
+    test_fsx_lustre.py::test_fsx_lustre:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: [ "slurm" ]
+    test_efs.py::test_efs_compute_az:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+    test_ebs.py::test_ebs_single:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: ["centos7"]
+          schedulers: ["slurm"]
+    # Ephemeral test requires instance type with instance store
+    test_ephemeral.py::test_head_node_stop:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+  dcv:
+    # Useful on GPU enabled instances
+    test_dcv.py::test_dcv_configuration:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+  efa:
+    test_efa.py::test_efa:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
+          schedulers: ["slurm"]
+  configure:
+    test_pcluster_configure.py::test_pcluster_configure:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: {{ common.OSS_ONE_PER_DISTRO }}
+          schedulers: ["slurm"]
+  networking:
+    test_cluster_networking.py::test_cluster_in_private_subnet:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: ["ubuntu1804"]
+          schedulers: ["slurm"]
+    # Useful for instances with multiple network interfaces
+    test_multi_cidr.py::test_multi_cidr:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+  spot:
+    test_spot.py::test_spot_default:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ NEW_INSTANCE_TYPES }}
+          oss: ["centos7"]
+          schedulers: ["slurm"]


### PR DESCRIPTION
This new configuration file can be used to verify that all the main features are working as expected in the new instance type.

The enabled tests are:
* scaling and schedulers
* storages: FSx for Lustre, EFS and EBS
* dcv: to verify GPU capabilities
* configure: to verify the new instance type is accepted by the configure command
* networking: be sure the cluster works in a private subnet and a specific multi-cidr tests
* spot

Some tests can only be executed on specific instance types:
* multi-cidr: for instance types with multiple network interfaces
* ephemeral: can be executed for instances with instance store


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
