### PR TITLE
[DFSM] Use UpdatePolicy.IGNORED for Ebs/Efs/FSxLustreSettings.

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -482,9 +482,9 @@ class SharedStorageSchema(BaseSchema):
         validate=validate.OneOf(["Ebs", FSX_LUSTRE, FSX_OPENZFS, FSX_ONTAP, "Efs"]),
         metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
     )
-    ebs_settings = fields.Nested(EbsSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
-    efs_settings = fields.Nested(EfsSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
-    fsx_lustre_settings = fields.Nested(FsxLustreSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+    ebs_settings = fields.Nested(EbsSettingsSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
+    efs_settings = fields.Nested(EfsSettingsSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
+    fsx_lustre_settings = fields.Nested(FsxLustreSettingsSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
     fsx_open_zfs_settings = fields.Nested(
         FsxOpenZfsSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
     )


### PR DESCRIPTION
### Description of changes
Use `UpdatePolicy.IGNORED` for `Ebs/Efs/FSxLustreSettings`.

We want this update policy because the setting `Ebs/Efs/FSxLustreSettings.DeletionPolicy` supports the updates.
With this change we will support the following update, that we should provide to our users:

From:

```
  - MountDir: /opt/shared/efs/managed/1
    Name: shared-efs-managed-1
    StorageType: Efs
```

to:

```
  - MountDir: /opt/shared/efs/managed/1
    Name: shared-efs-managed-1
    StorageType: Efs
    EfsSettings:
      DeletionPolicy: Retain|Delete
```

### Tests
1. Manually tested the above scenario and that update containing not updatable settings is rejected.
2. Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
