### PR TITLE
[3.x] Integ-tests: Change the number of EFS and FSx used in the integration tests benchmark

### DIFF
--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -90,7 +90,7 @@ def test_multiple_efs(
     existing_efs_mount_dirs = []
     if request.config.getoption("benchmarks") and os == "alinux2":
         # Only create more EFS when benchmarks are specified. Limiting OS to reduce cost of too many file systems
-        num_existing_efs = 50
+        num_existing_efs = 20
     else:
         num_existing_efs = 2
     existing_efs_ids = efs_stack_factory(num_existing_efs)

--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -277,7 +277,7 @@ def test_multiple_fsx(
     num_existing_fsx_open_zfs_volumes = 2 if partition == "aws" else 0  # China and GovCloud do not have OpenZFS.
     if request.config.getoption("benchmarks") and os == "alinux2":
         # Only create more FSx when benchmarks are specified. Limiting OS to reduce cost of too many file systems
-        num_existing_fsx = 50
+        num_existing_fsx = 20
     else:
         # Minimal total existing FSx is the number of Ontap and OpenZFS plus one existing FSx Lustre
         num_existing_fsx = num_existing_fsx_ontap_volumes + num_existing_fsx_open_zfs_volumes + 1


### PR DESCRIPTION
We lowered the limit of the number of EFS and FSx https://github.com/aws/aws-parallelcluster/pull/3977 but forgot to change the test

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
