### PR TITLE
[DFSM] Fix cluster configuration used in integration tests: using same instance type for head node and compute nodes.

### DIFF
--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_drain.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_drain.yaml
@@ -21,7 +21,7 @@ Scheduling:
       ComputeResources:
         - Name: queue1-i1
           InstanceTypeList:
-            - InstanceType: c5.xlarge
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 2
       Networking:
@@ -34,7 +34,7 @@ Scheduling:
       ComputeResources:
         - Name: queue2-i1
           InstanceTypeList:
-            - InstanceType: c5.xlarge
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
       ComputeResources:
         - Name: queue1-i1
           InstanceTypeList:
-            - InstanceType: c5.xlarge
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 2
       Networking:
@@ -23,7 +23,7 @@ Scheduling:
       ComputeResources:
         - Name: queue2-i1
           InstanceTypeList:
-            - InstanceType: c5.xlarge
+            - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 2
       Networking:


### PR DESCRIPTION
### Description of changes
Fix cluster configuration used in integration tests: using same instance type for head node and compute nodes.

This change fixes the following error that makes cluster creation fails:

```
The specified compute instance type (c5.xlarge) supports the architectures [\'x86_64\'], none of which are compatible with the architecture supported by the head node instance type (arm64)
```

### Tests
Will be tested directly on the official pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
