### PR TITLE
[Test] Make AWSBatchCommands.submit_command accept partition argument even if unused

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -147,7 +147,7 @@ class AWSBatchCommands(SchedulerCommands):
         assert_that(match).is_not_none()
         return match.group(1)
 
-    def submit_command(self, command, nodes=1, slots=None):  # noqa: D102
+    def submit_command(self, command, nodes=1, slots=None, partition=None):  # noqa: D102
         return self._remote_command_executor.run_remote_command('echo "{0}" | awsbsub -n {1}'.format(command, nodes))
 
     def submit_script(self, script, script_args=None, nodes=1, additional_files=None, slots=None):  # noqa: D102


### PR DESCRIPTION
### Description of changes
Make `AWSBatchCommands.submit_command` accept `partition` argument, even if unused.
We need to add it even if unused to align `AWSBatchCommands.submit_command` to `SlurmCommands.submit_command()` and thus avoid branches in our test logic.

This change fix the following  error in storage related tests:

```
E       TypeError: submit_command() got an unexpected keyword argument 'partition'

...

scheduler_commands = <tests.common.schedulers_common.AWSBatchCommands object at 0x7f8ff995df60>
```

The above error started showing up today, after the merge of 42bb16def6e4ef67ecb9f994c43b2396644d1f9a

### Tests
1. Locally tested `test_efs.py::test_multiple_efs` with scheduler `awsbatch`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
