### PR TITLE
Fix test_error_handling integration test

### DIFF
--- a/tests/integration-tests/tests/common/hit_common.py
+++ b/tests/integration-tests/tests/common/hit_common.py
@@ -67,9 +67,16 @@ def assert_compute_node_states(scheduler_commands, compute_nodes, expected_state
         assert_that(expected_states).contains(node_states.get(node))
 
 
-@retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))
-def wait_for_compute_nodes_states(scheduler_commands, compute_nodes, expected_states):
-    assert_compute_node_states(scheduler_commands, compute_nodes, expected_states)
+def wait_for_compute_nodes_states(
+    scheduler_commands,
+    compute_nodes,
+    expected_states,
+    wait_fixed_secs=20,
+    stop_max_delay_secs=300,
+):
+    retry(wait_fixed=seconds(wait_fixed_secs), stop_max_delay=seconds(stop_max_delay_secs))(assert_compute_node_states)(
+        scheduler_commands, compute_nodes, expected_states
+    )
 
 
 def assert_compute_node_reasons(scheduler_commands, compute_nodes, expected_reason):


### PR DESCRIPTION
### Description of changes
* Fix test_error_handling integration test
* Allow test_error_handling integration test to wait longer for a compute node to be terminated by computemgtd
* Extend wait_for_compute_nodes_states to wait for a custom amount of time

### Tests
* Manually ran the test_error_handling integration test
* Changed the duration of some waiting functions in test_error_handling to be able to wait a custom amount of time.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
