### PR TITLE
3.x Add integration tests for Slurm Accounting

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -501,6 +501,18 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004"]
         schedulers: ["slurm"]
+  test_slurm_accounting.py::test_slurm_accounting:
+    dimensions:
+      - regions: ["us-east-1", "ap-south-1"]
+        instances:  {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2", "ubuntu2004"]
+        schedulers: ["slurm"]
+  test_slurm_accounting.py::test_slurm_accounting_disabled_to_enabled_update:
+    dimensions:
+      - regions: ["us-west-2"]
+        instances:  {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["centos7", "ubuntu1804"]
+        schedulers: ["slurm"]
 spot:
   test_spot.py::test_spot_default:
     dimensions:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -161,6 +161,10 @@ def pytest_addoption(parser):
         help="Name of CFN stack providing NLB to enable use of LDAPS with a Simple AD directory when testing AD "
         "integration feature.",
     )
+    parser.addoption(
+        "--slurm-database-stack-name",
+        help="Name of CFN stack providing database stack to be used for testing Slurm accounting feature.",
+    )
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -83,6 +83,7 @@ TEST_DEFAULTS = {
     "iam_user_role_stack_name": None,
     "directory_stack_name": None,
     "ldaps_nlb_stack_name": None,
+    "slurm_database_stack_name": None,
 }
 
 
@@ -369,6 +370,11 @@ def _init_argparser():
         "integration feature.",
         default=TEST_DEFAULTS.get("ldaps_nlb_stack_name"),
     )
+    debug_group.add_argument(
+        "--slurm-database-stack-name",
+        help="Name of CFN stack providing database stack to be used for testing Slurm accounting feature.",
+        default=TEST_DEFAULTS.get("slurm_database_stack_name"),
+    )
 
     return parser
 
@@ -558,6 +564,9 @@ def _set_custom_stack_args(args, pytest_args):
 
     if args.ldaps_nlb_stack_name:
         pytest_args.extend(["--ldaps-nlb-stack-name", args.ldaps_nlb_stack_name])
+
+    if args.slurm_database_stack_name:
+        pytest_args.extend(["--slurm-database-stack-name", args.slurm_database_stack_name])
 
 
 def _set_api_args(args, pytest_args):

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -495,14 +495,16 @@ class SlurmCommands(SchedulerCommands):
         command = f"sudo -i scontrol reboot {asap_string} {nodename}"
         self._remote_command_executor.run_remote_command(command)
 
-    def get_users(self, fields=("user", "account", "adminlevel", "coordinators", "defaultaccount", "defaultwckey")):
+    def get_accounting_users(
+        self, fields=("user", "account", "adminlevel", "coordinators", "defaultaccount", "defaultwckey")
+    ):
         """Return a list of scheduler user accounts as a list of dicts."""
         users = self._remote_command_executor.run_remote_command(
             f"sacctmgr list users -nP Format={','.join(fields)}"
         ).stdout
         return (dict(zip(fields, columns)) for columns in SlurmCommands._split_accounting_results(users))
 
-    def get_records_for_job(
+    def get_accounting_job_records(
         self, job_id, fields=("jobid", "jobname", "partition", "account", "alloccpus", "state", "exitcode")
     ):
         """Return job steps of {job_id} as a series of dicts."""

--- a/tests/integration-tests/tests/schedulers/conftest.py
+++ b/tests/integration-tests/tests/schedulers/conftest.py
@@ -1,0 +1,93 @@
+import logging
+import random
+import string
+from collections import defaultdict
+
+import pytest
+from cfn_stacks_factory import CfnStack
+from utils import generate_stack_name
+
+
+def _create_database_stack(cfn_stacks_factory, request, region, vpc_stack):
+    database_stack_name = generate_stack_name(
+        "integ-tests-slurm-accounting", request.config.getoption("stackname_suffix")
+    )
+
+    database_stack_template_path = "../../cloudformation/database/serverless-database.yaml"
+    logging.info("Creating stack %s", database_stack_name)
+
+    admin_password = "".join(
+        [
+            *random.choices(string.ascii_uppercase, k=6),
+            # "&*\\",
+            *random.choices("!$%^()_+", k=4),
+            *random.choices(string.digits, k=4),
+            *random.choices(string.ascii_lowercase, k=6),
+        ]
+    )
+
+    with open(database_stack_template_path) as database_template:
+        stack_parameters = [
+            {"ParameterKey": "Vpc", "ParameterValue": vpc_stack.cfn_outputs["VpcId"]},
+            {"ParameterKey": "AdminPasswordSecretString", "ParameterValue": admin_password},
+            {"ParameterKey": "Subnet1CidrBlock", "ParameterValue": "192.168.8.0/23"},
+            {"ParameterKey": "Subnet2CidrBlock", "ParameterValue": "192.168.4.0/23"},
+        ]
+        database_stack = CfnStack(
+            name=database_stack_name,
+            region=region,
+            template=database_template.read(),
+            parameters=stack_parameters,
+            capabilities=["CAPABILITY_AUTO_EXPAND"],
+        )
+    cfn_stacks_factory.create_stack(database_stack)
+    logging.info("Creation of stack %s complete", database_stack_name)
+
+    return database_stack
+
+
+@pytest.fixture(scope="package")
+def database_factory(request, cfn_stacks_factory, vpc_stacks):
+    created_database_stacks = defaultdict(dict)
+
+    logging.info("Setting up database_factory fixture")
+
+    def _database_factory(
+        existing_database_stack_name,
+        test_resources_dir,
+        region,
+    ):
+        if existing_database_stack_name:
+            logging.info("Using pre-existing database stack named %s", existing_database_stack_name)
+            return existing_database_stack_name
+
+        if not created_database_stacks.get(region, {}).get("default"):
+            logging.info("Creating default database stack")
+            database_stack = _create_database_stack(cfn_stacks_factory, request, region, vpc_stacks[region])
+            created_database_stacks[region]["default"] = database_stack.name
+
+        logging.info("Using database stack %s", created_database_stacks.get(region, {}).get("default"))
+        return created_database_stacks.get(region, {}).get("default")
+
+    yield _database_factory
+
+    for region, stack_dict in created_database_stacks.items():
+        stack_name = stack_dict["default"]
+        if request.config.getoption("no_delete"):
+            logging.info(
+                "Not deleting database stack %s in region %s because --no-delete option was specified",
+                stack_name,
+                region,
+            )
+        else:
+            logging.info(
+                "Deleting database stack %s in region %s",
+                stack_name,
+                region,
+            )
+            cfn_stacks_factory.delete_stack(stack_name, region)
+
+
+@pytest.fixture(scope="function")
+def test_resources_dir(datadir):
+    return datadir / "resources"

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
@@ -1,0 +1,177 @@
+import logging
+import re
+
+import boto3
+import pytest
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+from retrying import retry
+
+from tests.cloudwatch_logging import cloudwatch_logging_boto3_utils as cw_utils
+
+STARTED_PATTERN = re.compile(r".*slurmdbd version [\d.]+ started")
+
+
+def get_infra_stack_outputs(stack_name):
+    cfn = boto3.client("cloudformation")
+    return {
+        entry.get("OutputKey"): entry.get("OutputValue")
+        for entry in cfn.describe_stacks(StackName=stack_name)["Stacks"][0]["Outputs"]
+    }
+
+
+def _get_slurm_database_config_parameters(database_stack_outputs):
+    return {
+        "database_host": database_stack_outputs.get("DatabaseHost"),
+        "database_admin_user": database_stack_outputs.get("DatabaseAdminUser"),
+        "database_secret_arn": database_stack_outputs.get("DatabaseSecretArn"),
+        "database_client_security_group": database_stack_outputs.get("DatabaseClientSecurityGroup"),
+    }
+
+
+def _get_expected_users(remote_command_executor, test_resources_dir):
+    users = remote_command_executor.run_remote_script(str(test_resources_dir / "get_accounting_users.sh")).stdout
+    for user in users.splitlines():
+        logging.info("  Expected User: %s", user)
+    return users.splitlines()
+
+
+def _is_accounting_enabled(remote_command_executor):
+    return remote_command_executor.run_remote_command("sacct", raise_on_error=False).ok
+
+
+def _test_slurmdb_users(remote_command_executor, scheduler_commands, test_resources_dir):
+    logging.info("Testing Slurm Accounting Users")
+    expected_users = _get_expected_users(remote_command_executor, test_resources_dir)
+    users = list(scheduler_commands.get_users())
+    assert_that(users).is_length(len(expected_users))
+    for user in users:
+        logging.info("  User: %s", user)
+        assert_that(user.get("user")).is_in(*expected_users)
+        assert_that(user.get("adminlevel")).is_equal_to("Administrator")
+
+
+@retry(stop_max_attempt_number=36, wait_fixed=10 * 1000)
+def _test_successful_startup_in_log(remote_command_executor):
+    log_file = "/var/log/slurmdbd.log"
+
+    log = remote_command_executor.run_remote_command("sudo cat {0}".format(log_file), hide=True).stdout
+    assert_that(
+        [line for line in log.splitlines() if STARTED_PATTERN.fullmatch(line) is not None], "Successful Startup"
+    ).is_not_empty()
+
+
+@retry(stop_max_attempt_number=36, wait_fixed=10 * 1000)
+def _test_slurmdbd_log_exists_in_log_group(cluster):
+    log_groups = cw_utils.get_cluster_log_groups_from_boto3(f"/aws/parallelcluster/{cluster.name}")
+    assert_that(log_groups).is_length(1)
+    log_group_name = log_groups[0].get("logGroupName")
+    log_streams = cw_utils.get_log_streams(log_group_name)
+    streams = [
+        stream.get("logStreamName")
+        for stream in log_streams
+        if re.fullmatch(r".*\.slurmdbd", stream.get("logStreamName")) is not None
+    ]
+    assert_that(streams).is_length(1)
+    stream_name = streams[0]
+    events = cw_utils.get_log_events(log_group_name, stream_name)
+    messages = (event.get("message") for event in events)
+    assert_that([message for message in messages if STARTED_PATTERN.fullmatch(message) is not None]).is_not_empty()
+
+
+def _test_jobs_get_recorded(scheduler_commands):
+    job_submission_output = scheduler_commands.submit_command(
+        'echo "$(hostname) ${SLURM_JOB_ACCOUNT} ${SLURM_JOB_ID} ${SLURM_JOB_NAME}"',
+    ).stdout
+    job_id = scheduler_commands.assert_job_submitted(job_submission_output)
+    logging.info(" Submitted Job ID: %s", job_id)
+    scheduler_commands.wait_job_completed(job_id)
+    results = scheduler_commands.get_records_for_job(job_id)
+    for row in results:
+        logging.info(" Result: %s", row)
+        assert_that(row.get("state")).is_equal_to("COMPLETED")
+
+
+def _test_that_slurmdbd_is_not_running(remote_command_executor):
+    assert_that(_is_accounting_enabled(remote_command_executor)).is_false()
+
+
+def _test_that_slurmdbd_is_running(remote_command_executor):
+    assert_that(_is_accounting_enabled(remote_command_executor)).is_true()
+
+
+@pytest.mark.usefixtures("os", "instance", "scheduler")
+def test_slurm_accounting(
+    region,
+    pcluster_config_reader,
+    database_factory,
+    request,
+    test_datadir,
+    test_resources_dir,
+    clusters_factory,
+    scheduler_commands_factory,
+):
+    database_stack_name = database_factory(
+        request.config.getoption("slurm_database_stack_name"),
+        str(test_datadir),
+        region,
+    )
+
+    database_stack_outputs = get_infra_stack_outputs(database_stack_name)
+
+    config_params = _get_slurm_database_config_parameters(database_stack_outputs)
+    cluster_config = pcluster_config_reader(**config_params)
+    cluster = clusters_factory(cluster_config)
+
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+
+    _test_that_slurmdbd_is_running(remote_command_executor)
+    _test_successful_startup_in_log(remote_command_executor)
+    _test_slurmdbd_log_exists_in_log_group(cluster)
+    _test_slurmdb_users(remote_command_executor, scheduler_commands, test_resources_dir)
+    _test_jobs_get_recorded(scheduler_commands)
+
+
+@pytest.mark.usefixtures("os", "instance", "scheduler")
+def test_slurm_accounting_disabled_to_enabled_update(
+    region,
+    pcluster_config_reader,
+    database_factory,
+    request,
+    test_datadir,
+    test_resources_dir,
+    clusters_factory,
+    scheduler_commands_factory,
+):
+    database_stack_name = database_factory(
+        request.config.getoption("slurm_database_stack_name"),
+        str(test_datadir),
+        region,
+    )
+
+    database_stack_outputs = get_infra_stack_outputs(database_stack_name)
+
+    # First create a cluster without Slurm Accounting enabled
+    cluster_config = pcluster_config_reader(config_file="pcluster.config.yaml")
+    cluster = clusters_factory(cluster_config)
+
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    _test_that_slurmdbd_is_not_running(remote_command_executor)
+
+    config_params = _get_slurm_database_config_parameters(database_stack_outputs)
+
+    # Then update the cluster to enable Slurm Accounting
+    updated_config_file = pcluster_config_reader(config_file="pcluster.config.update.yaml", **config_params)
+    cluster.update(str(updated_config_file), force_update="true")
+
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+
+    # Test for successful Slurm Accounting start up
+    _test_that_slurmdbd_is_running(remote_command_executor)
+    _test_successful_startup_in_log(remote_command_executor)
+    _test_slurmdbd_log_exists_in_log_group(cluster)
+    _test_slurmdb_users(remote_command_executor, scheduler_commands, test_resources_dir)
+    _test_jobs_get_recorded(scheduler_commands)

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
@@ -43,7 +43,7 @@ def _is_accounting_enabled(remote_command_executor):
 def _test_slurmdb_users(remote_command_executor, scheduler_commands, test_resources_dir):
     logging.info("Testing Slurm Accounting Users")
     expected_users = _get_expected_users(remote_command_executor, test_resources_dir)
-    users = list(scheduler_commands.get_users())
+    users = list(scheduler_commands.get_accounting_users())
     assert_that(users).is_length(len(expected_users))
     for user in users:
         logging.info("  User: %s", user)
@@ -86,7 +86,7 @@ def _test_jobs_get_recorded(scheduler_commands):
     job_id = scheduler_commands.assert_job_submitted(job_submission_output)
     logging.info(" Submitted Job ID: %s", job_id)
     scheduler_commands.wait_job_completed(job_id)
-    results = scheduler_commands.get_records_for_job(job_id)
+    results = scheduler_commands.get_accounting_job_records(job_id)
     for row in results:
         logging.info(" Result: %s", row)
         assert_that(row.get("state")).is_equal_to("COMPLETED")

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/resources/get_accounting_users.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/resources/get_accounting_users.sh
@@ -13,4 +13,4 @@ getent passwd 0 | cut -d : -f 1
 # Get the configured cluster user name from the dna.json (added to the database during node configuration)
 jq -r '.cluster.cluster_user' < "/etc/chef/dna.json"
 # Get the configured Slurm user from the slurm configuration (added to the database during node configuration)
-get_setting_value "/opt/slurm/etc/slurm.conf" "^SlurmUser\w*="
+get_setting_value "/opt/slurm/etc/slurm.conf" "^SlurmUser="

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/resources/get_accounting_users.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/resources/get_accounting_users.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+get_setting_value() {
+  local _file=$1
+  local _search=$2
+  local _pattern
+
+  _pattern=$(grep "${_search}" "${_file}")
+  echo "${_pattern}" | tr -d '\n' | cut -d = -f 2 | xargs
+}
+
+# Get the root user (root is added to Slurm accounting by default during configuration)
+getent passwd 0 | cut -d : -f 1
+# Get the configured cluster user name from the dna.json (added to the database during node configuration)
+jq -r '.cluster.cluster_user' < "/etc/chef/dna.json"
+# Get the configured Slurm user from the slurm configuration (added to the database during node configuration)
+get_setting_value "/opt/slurm/etc/slurm.conf" "^SlurmUser\w*="

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
@@ -1,0 +1,41 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+    AdditionalSecurityGroups:
+      - {{ database_client_security_group }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmSettings:
+    Database:
+      Uri: {{ database_host }}
+      UserName: {{ database_admin_user }}
+      PasswordSecretArn: {{ database_secret_arn }}
+  SlurmQueues:
+    - Name: compute
+      ComputeResources:
+        - Name: cit
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
+          MinCount: 0
+          MaxCount: 10
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+Monitoring:
+  Logs:
+    CloudWatch:
+      Enabled: true
+      RetentionInDays: 14

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.update.yaml
@@ -1,0 +1,41 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+    AdditionalSecurityGroups:
+      - {{ database_client_security_group }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmSettings:
+    Database:
+      Uri: {{ database_host }}
+      UserName: {{ database_admin_user }}
+      PasswordSecretArn: {{ database_secret_arn }}
+  SlurmQueues:
+    - Name: compute
+      ComputeResources:
+        - Name: cit
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
+          MinCount: 0
+          MaxCount: 10
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+Monitoring:
+  Logs:
+    CloudWatch:
+      Enabled: true
+      RetentionInDays: 14

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.yaml
@@ -1,0 +1,34 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: compute
+      ComputeResources:
+        - Name: cit
+          InstanceTypeList:
+            - InstanceType: {{ instance }}
+          MinCount: 0
+          MaxCount: 10
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
+Monitoring:
+  Logs:
+    CloudWatch:
+      Enabled: true
+      RetentionInDays: 14


### PR DESCRIPTION
Signed-off-by: David Pratt <davprat@amazon.com>


### Description of changes
* Added integration test for configured Slurm Accounting
* Added integration test for updating a cluster from no Slurm Accounting to Slurm Accounting configured
* Added --slurm-database-stack-name option to test_runner to reuse database cluster stack between tests.
* Added package scope fixture for database stack
* Modified get_log_streams in cloudwatch utils to get multiple pages
* Work in progress

### Tests
* Ran integration tests [amzn2, ubuntu2004]x[x86, Arm]
* Ran cloudwatch integration tests to make sure they were compatible with change to get_log_streams
* Tested both database cluster stack creation and recycling

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
