### PR TITLE
Support requiring IMDSv2 in cluster and build image config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
   to support storage retention on deletion.
 - Enable server-side encryption for the EcrImageBuilder SNS topic created when deploying ParallelCluster API and used to notify on docker image build events.
 - Add support for on-demand capacity reservations.
+- Add support for requiring IMDSv2 in cluster configurations.
 - Add support for Slurm Accounting.
 
 **CHANGES**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ CHANGELOG
   to support storage retention on deletion.
 - Enable server-side encryption for the EcrImageBuilder SNS topic created when deploying ParallelCluster API and used to notify on docker image build events.
 - Add support for on-demand capacity reservations.
-- Add support for requiring IMDSv2 in cluster configurations.
+- Add support for requiring IMDSv2 in cluster and build image configurations via the `Imds > RequireImdsV2` property.
 - Add support for Slurm Accounting.
 
 **CHANGES**

--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -276,6 +276,19 @@ class BaseDevSettings(Resource):
             self._register_validator(UrlValidator, url=self.aws_batch_cli_package)
 
 
+class Imds(Resource):
+    """
+    Represent the IMDS configuration shared between the ImageBuilder and Cluster.
+
+    It represents the Imds element that can be either at top level in the cluster config file,
+    or in the Build section of the build image config file.
+    """
+
+    def __init__(self, require_imds_v2: bool = None, **kwargs):
+        super().__init__(**kwargs)
+        self.require_imds_v2 = Resource.init_param(require_imds_v2, default=False)
+
+
 # ------------ Common attributes class between ImageBuilder an Cluster models ----------- #
 
 

--- a/cli/src/pcluster/config/imagebuilder_config.py
+++ b/cli/src/pcluster/config/imagebuilder_config.py
@@ -16,7 +16,7 @@
 from typing import List
 
 from pcluster.aws.common import get_region
-from pcluster.config.common import AdditionalIamPolicy, BaseDevSettings, BaseTag, ExtraChefAttributes, Resource
+from pcluster.config.common import AdditionalIamPolicy, BaseDevSettings, BaseTag, ExtraChefAttributes, Imds, Resource
 from pcluster.imagebuilder_utils import ROOT_VOLUME_TYPE
 from pcluster.validators.ebs_validators import EbsVolumeTypeSizeValidator
 from pcluster.validators.ec2_validators import InstanceTypeBaseAMICompatibleValidator
@@ -24,6 +24,7 @@ from pcluster.validators.iam_validators import IamPolicyValidator, InstanceProfi
 from pcluster.validators.imagebuilder_validators import (
     AMIVolumeSizeValidator,
     ComponentsValidator,
+    RequireImdsV2Validator,
     SecurityGroupsAndSubnetValidator,
 )
 from pcluster.validators.kms_validators import KmsKeyIdEncryptedValidator, KmsKeyValidator
@@ -147,6 +148,7 @@ class Build(Resource):
         security_group_ids: List[str] = None,
         components: List[Component] = None,
         update_os_packages: UpdateOsPackages = None,
+        imds: Imds = None,
     ):
         super().__init__()
         self.instance_type = Resource.init_param(instance_type)
@@ -157,6 +159,7 @@ class Build(Resource):
         self.security_group_ids = security_group_ids
         self.components = components
         self.update_os_packages = update_os_packages
+        self.imds = imds or Imds(implied=False)
 
     def _register_validators(self):
         self._register_validator(
@@ -172,6 +175,7 @@ class Build(Resource):
         self._register_validator(
             SecurityGroupsAndSubnetValidator, security_group_ids=self.security_group_ids, subnet_id=self.subnet_id
         )
+        self._register_validator(RequireImdsV2Validator, require_imds_v2=self.imds.require_imds_v2)
 
 
 # ---------------------- Dev Settings ---------------------- #

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -125,14 +125,9 @@ from pcluster.constants import (
     SUPPORTED_OSES,
 )
 from pcluster.models.s3_bucket import parse_bucket_url
-from pcluster.schemas.common_schema import (
-    AdditionalIamPolicySchema,
-    BaseDevSettingsSchema,
-    BaseSchema,
-    TagSchema,
-    get_field_validator,
-    validate_no_reserved_tag,
-)
+from pcluster.schemas.common_schema import AdditionalIamPolicySchema, BaseDevSettingsSchema, BaseSchema
+from pcluster.schemas.common_schema import ImdsSchema as TopLevelImdsSchema
+from pcluster.schemas.common_schema import TagSchema, get_field_validator, validate_no_reserved_tag
 from pcluster.utils import yaml_load
 from pcluster.validators.cluster_validators import EFS_MESSAGES, FSX_MESSAGES
 
@@ -1973,6 +1968,7 @@ class ClusterSchema(BaseSchema):
         DirectoryServiceSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP}
     )
     config_region = fields.Str(data_key="Region", metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+    imds = fields.Nested(TopLevelImdsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     custom_s3_bucket = fields.Str(metadata={"update_policy": UpdatePolicy.READ_ONLY_RESOURCE_BUCKET})
     additional_resources = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     dev_settings = fields.Nested(ClusterDevSettingsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -20,7 +20,7 @@ import json
 from marshmallow import Schema, ValidationError, fields, post_dump, post_load, pre_dump, validate, validates
 
 from pcluster.config.cluster_config import BaseTag
-from pcluster.config.common import AdditionalIamPolicy, Cookbook
+from pcluster.config.common import AdditionalIamPolicy, Cookbook, Imds
 from pcluster.config.update_policy import UpdatePolicy
 from pcluster.constants import PCLUSTER_PREFIX, SUPPORTED_ARCHITECTURES
 from pcluster.utils import to_pascal_case
@@ -205,3 +205,19 @@ class BaseDevSettingsSchema(BaseSchema):
     cookbook = fields.Nested(CookbookSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     node_package = fields.Str(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     aws_batch_cli_package = fields.Str(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+
+
+class ImdsSchema(BaseSchema):
+    """
+    Represent the Imds schema shared between cluster and build image files.
+
+    It represents the Imds element that can be either at top level in the cluster config file,
+    or in the Build section of the build image config file.
+    """
+
+    require_imds_v2 = fields.Bool(data_key="RequireImdsV2", metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return Imds(**data)

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -35,6 +35,7 @@ from pcluster.schemas.common_schema import (
     AdditionalIamPolicySchema,
     BaseDevSettingsSchema,
     BaseSchema,
+    ImdsSchema,
     TagSchema,
     get_field_validator,
     validate_json_format,
@@ -175,6 +176,7 @@ class BuildSchema(BaseSchema):
     security_group_ids = fields.List(fields.Str)
     subnet_id = fields.Str(validate=get_field_validator("subnet_id"))
     update_os_packages = fields.Nested(UpdateOsPackagesSchema)
+    imds = fields.Nested(ImdsSchema)
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -882,6 +882,9 @@ class ClusterCdkStack(Stack):
                 iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(
                     name=self._head_node_instance_profile
                 ),
+                metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(http_tokens="required")
+                if self.config.imds.require_imds_v2
+                else None,
                 user_data=Fn.base64(
                     Fn.sub(
                         get_user_data_content("../resources/head_node/user_data.sh"),
@@ -1484,6 +1487,9 @@ class ComputeFleetConstruct(Construct):
                 instance_market_options=instance_market_options,
                 instance_initiated_shutdown_behavior="terminate",
                 capacity_reservation_specification=capacity_reservation_specification,
+                metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(http_tokens="required")
+                if self._config.imds.require_imds_v2
+                else None,
                 user_data=Fn.base64(
                     Fn.sub(
                         get_user_data_content("../resources/compute_node/user_data.sh"),

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -583,6 +583,11 @@ class ImageBuilderCdkStack(Stack):
             security_group_ids=self.config.build.security_group_ids,
             subnet_id=self.config.build.subnet_id,
             sns_topic_arn=Fn.ref("BuildNotificationTopic"),
+            instance_metadata_options=imagebuilder.CfnInfrastructureConfiguration.InstanceMetadataOptionsProperty(
+                http_tokens="required"
+            )
+            if self.config.build.imds.require_imds_v2
+            else None,
         )
         if not self.custom_cleanup_lambda_role:
             self._add_resource_delete_policy(

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -99,6 +99,23 @@ class RegionValidator(Validator):
             )
 
 
+class RequireImdsV2Validator(Validator):
+    """IMDSv2 enforcement validator."""
+
+    def _validate(self, require_imds_v2):
+        if not require_imds_v2:
+            self._add_failure(
+                "The current cluster configuration does not disable IMDSv1, "
+                "which we plan to disable by default in future versions. "
+                "If you do not explicitly need to use IMDSv1 enforce IMDSv2 "
+                "usage by setting the RequireImdsV2 configuration parameter "
+                "to true (see documentation at: https://docs.aws.amazon.com/"
+                "parallelcluster/latest/ug/cluster-configuration-file-v3.html"
+                "#cluster-configuration-file-v3.properties)",
+                level=FailureLevel.INFO,
+            )
+
+
 class SchedulerOsValidator(Validator):
     """
     scheduler - os validator.

--- a/cli/src/pcluster/validators/imagebuilder_validators.py
+++ b/cli/src/pcluster/validators/imagebuilder_validators.py
@@ -54,3 +54,18 @@ class SecurityGroupsAndSubnetValidator(Validator):
                     "Subnet id {0} is specified, security groups is required.".format(subnet_id),
                     FailureLevel.ERROR,
                 )
+
+
+class RequireImdsV2Validator(Validator):
+    """IMDSv2 enforcement validator."""
+
+    def _validate(self, require_imds_v2):
+        if not require_imds_v2:
+            self._add_failure(
+                "The current build image configuration does not disable IMDSv1, "
+                "which we plan to disable by default in future versions. If you do "
+                "not explicitly need to use IMDSv1 enforce IMDSv2 usage by setting the "
+                "RequireImdsV2 configuration parameter to true (see documentation at: "
+                "https://docs.aws.amazon.com/parallelcluster/latest/ug/Build-v3.html)",
+                level=FailureLevel.INFO,
+            )

--- a/cli/tests/pcluster/config/dummy_imagebuilder_config.py
+++ b/cli/tests/pcluster/config/dummy_imagebuilder_config.py
@@ -8,7 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from pcluster.config.common import BaseTag, Cookbook
+from pcluster.config.common import BaseTag, Cookbook, Imds
 from pcluster.config.imagebuilder_config import (
     AdditionalIamPolicy,
     Build,
@@ -35,6 +35,7 @@ CLASS_DICT = {
     "iam": Iam,
     "additional_iam_policies": AdditionalIamPolicy,
     "update_os_packages": UpdateOsPackages,
+    "imds": Imds,
 }
 
 

--- a/cli/tests/pcluster/example_configs/awsbatch.full.yaml
+++ b/cli/tests/pcluster/example_configs/awsbatch.full.yaml
@@ -1,3 +1,5 @@
+Imds:
+  RequireImdsV2: true
 Region: us-east-1
 Image:
   Os: alinux2  # alinux2 | centos7 | ubuntu1804 | ubuntu2004

--- a/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
+++ b/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
@@ -1,3 +1,5 @@
+Imds:
+  RequireImdsV2: true
 Region: us-east-1
 Image:
   Os: centos7

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -1,3 +1,5 @@
+Imds:
+  RequireImdsV2: true
 Region: us-east-1
 Image:
   Os: centos7

--- a/cli/tests/pcluster/models/test_imagebuilder.py
+++ b/cli/tests/pcluster/models/test_imagebuilder.py
@@ -48,7 +48,11 @@ from tests.pcluster.test_utils import FAKE_NAME
                             {"key": "date", "value": "2022.1.1"},
                         ],
                     },
-                    "build": {"parent_image": "ami-0185634c5a8a37250", "instance_type": "c5.xlarge"},
+                    "build": {
+                        "imds": {"require_imds_v2": True},
+                        "parent_image": "ami-0185634c5a8a37250",
+                        "instance_type": "c5.xlarge",
+                    },
                 }
             },
             {

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
@@ -12,6 +12,8 @@ Image:
     KmsKeyId: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
 
 Build:
+  Imds:
+    RequireImdsV2: true
   Iam:
     InstanceRole: arn:aws:iam::111122223333:role/executionServiceEC2Role/parallelcluster-imagebuilder-test-InstanceRole-J7MKRFYF6634
     CleanupLambdaRole: arn:aws:iam::111122223333:role/executionServiceEC2Role/parallelcluster-imagebuilder-test-LambdaRole-J7MKRFYF6634

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -600,6 +600,9 @@ def inject_additional_config_settings(  # noqa: C901
     with open(cluster_config, encoding="utf-8") as conf_file:
         config_content = yaml.safe_load(conf_file)
 
+    if not dict_has_nested_key(config_content, ("Imds", "RequireImdsV2")):
+        dict_add_nested_key(config_content, True, ("Imds", "RequireImdsV2"))
+
     if request.config.getoption("custom_chef_cookbook") and not dict_has_nested_key(
         config_content, ("DevSettings", "Cookbook", "ChefCookbook")
     ):

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -574,6 +574,9 @@ def inject_additional_image_configs_settings(image_config, request):
     with open(image_config, encoding="utf-8") as conf_file:
         config_content = yaml.load(conf_file, Loader=yaml.SafeLoader)
 
+    if not dict_has_nested_key(config_content, ("Build", "Imds", "RequireImdsV2")):
+        dict_add_nested_key(config_content, True, ("Build", "Imds", "RequireImdsV2"))
+
     if request.config.getoption("createami_custom_chef_cookbook") and not dict_has_nested_key(
         config_content, ("DevSettings", "Cookbook", "ChefCookbook")
     ):

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -172,12 +172,17 @@ def assert_cluster_imds_v2_requirement_status(region, cluster, status):
 
     for reservations in describe_response.get("Reservations"):
         for instance in reservations.get("Instances"):
-            instance_id = instance.get("InstanceId")
-            imds_v2_status = instance.get("MetadataOptions").get("HttpTokens")
+            assert_instance_has_desired_imds_v2_setting(instance, status)
 
-            logging.info(f"Instance {instance_id} has IMDSv2 {imds_v2_status}")
 
-            assert_that(imds_v2_status).is_equal_to(status)
+def assert_instance_has_desired_imds_v2_setting(instance, status):
+    instance_id = instance.get("InstanceId")
+    instance_name = instance.get("Tags").get("Name")
+    imds_v2_status = instance.get("MetadataOptions").get("HttpTokens")
+
+    logging.info(f"Instance {instance_id} ({instance_name}) has IMDSv2 {imds_v2_status}")
+
+    assert_that(imds_v2_status).is_equal_to(status)
 
 
 def assert_aws_identity_access_is_correct(cluster, users_allow_list, remote_command_executor=None):

--- a/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  RequireImdsV2: {{ require_imds_v2 }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -7,6 +7,8 @@ Image:
         Encrypted: True
 
 Build:
+    Imds:
+        RequireImdsV2: true
     Iam:
         InstanceRole: {{ instance_role }}
     InstanceType: {{ instance }}

--- a/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/image.config.yaml
@@ -1,3 +1,5 @@
 Build:
+    Imds:
+        RequireImdsV2: false
     InstanceType: {{ instance }}
     ParentImage: {{ parent_image }}


### PR DESCRIPTION
#### Notes
This patch implements support for specifying a section like the following:

```
Imds:
  RequireImdsV2: true
```

at the top level of the cluster config file, or in the `Build` section of the build image file.  If omitted, it defaults to `false` but we show the customer a warning clarifying that we will change the default in the future.

#### Tests
* Unite tests.
* Manual tests: created clusters with Slurm, AWS Batch and BYOS schedulers, verified both the default case and the case when specifying the parameter to `true`, checking the metadata of the EC2 cluster instances (head and compute nodes) and validating that the `http_token` was `optional` and `required`, respectively. Did the same with the Build instance launched in the course of the `build-image` command.
* Changes to integration tests:
  * If not specified in the cluster or build image config for the integration test, we set the `RequireImdsV2` to `true`
  * We change the `test_create.py::test_create_imds_secured` to take an additional `require_imds_v2` parameter, and launch it with `true` and `false` to test the positive and negative case, asserting that all the nodes of the cluster have the desired status (`"required"` or `"optional"`, respectively).
  * We change the `test_build_image` and `test_kernel4_build_image_run_cluster` in `test_createami.py` to assert that the build instance has the required IMDSv2 setting.
* Run integration tests with the following configuration:
```
{%- import 'common.jinja2' as common with context -%}
---
scheduler-plugins:
  slurm_plugin:
    scheduler-definition: "../../scheduler_plugins/slurm/utils/upload_artifacts.sh"
    scheduler-commands: "tests.common.schedulers_common.SlurmCommands"
    requires-sudo: true
test-suites:
  schedulers:
    test_slurm.py::test_slurm:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm_plugin"]
  createami:
    test_createami.py::test_build_image:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
    test_createami.py::test_kernel4_build_image_run_cluster:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          schedulers: ["slurm"]
          oss: ["alinux2"]
  create:
    test_create.py::test_create_imds_secured:
      dimensions:
        - regions: [ "eu-central-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: [ "slurm" ]
```

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
