### PR TITLE
[DFSM] Make security group validator for EFS and FSx succeed when rules contain target security groups

### DIFF
--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -558,39 +558,63 @@ def test_queue_name_validator(name, expected_message):
             ["eni-09b9460295ddd4e5f"],
             None,
         ),
-        (  # not working case, wrong security group. Lustre
-            # Security group without CIDR cannot work with clusters containing pcluster created security group.
+        (   # Working case, security group specified. Lustre
             "LUSTRE",
             "vpc-06e4ab6c6cEXAMPLE",
             [{"IpProtocol": "-1", "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}]}],
+            False,
+            ["eni-09b9460295ddd4e5f"],
+            None,
+        ),
+        (   # Not working case, wrong port. Lustre
+            # Security group not allowing traffic on the expected ports.
+            "LUSTRE",
+            "vpc-06e4ab6c6cEXAMPLE",
+            [{"IpProtocol": "tpc", "FromPort": 22, "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}]}],
             False,
             ["eni-09b9460295ddd4e5f"],
             "The current security group settings on file system .* does not satisfy mounting requirement. "
             "The file system must be associated to a security group that "
             r"allows inbound and outbound TCP traffic through ports \[988\].",
         ),
-        (  # not working case, wrong security group. OpenZFS
-            # Security group without CIDR cannot work with clusters containing pcluster created security group.
+        (   # Working case, security group specified. OpenZFS
             "OPENZFS",
             "vpc-06e4ab6c6cEXAMPLE",
             [{"IpProtocol": "-1", "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}]}],
+            False,
+            ["eni-09b9460295ddd4e5f"],
+            None,
+        ),
+        (   # Not working case, wrong port. OpenZFS
+            # Security group not allowing traffic on the expected ports.
+            "OPENZFS",
+            "vpc-06e4ab6c6cEXAMPLE",
+            [{"IpProtocol": "tpc", "FromPort": 22, "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}]}],
             False,
             ["eni-09b9460295ddd4e5f"],
             "The current security group settings on file system .* does not satisfy mounting requirement. "
             "The file system must be associated to a security group that "
             r"allows inbound and outbound TCP traffic through ports \[111, 2049, 20001, 20002, 20003\].",
         ),
-        (  # not working case, wrong security group. Ontap
-            # Security group without CIDR cannot work with clusters containing pcluster created security group.
+        (   # Working case, security group specified. Ontap
             "ONTAP",
             "vpc-06e4ab6c6cEXAMPLE",
             [{"IpProtocol": "-1", "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}]}],
             False,
             ["eni-09b9460295ddd4e5f"],
+            None,
+        ),
+        (   # Not working case, wrong port. Ontap
+            # Security group not allowing traffic on the expected ports.
+            "ONTAP",
+            "vpc-06e4ab6c6cEXAMPLE",
+            [{"IpProtocol": "tpc", "FromPort": 22, "UserIdGroupPairs": [{"UserId": "123456789012", "GroupId": "sg-12345678"}]}],
+            False,
+            ["eni-09b9460295ddd4e5f"],
             "The current security group settings on file system .* does not satisfy mounting requirement. "
             "The file system must be associated to a security group that "
-            r"allows inbound and outbound TCP traffic through ports \[111, 635, 2049, 4046\].",
-        ),
+            r"allows inbound and outbound TCP traffic through ports \[111, 635, 2049, 4046\]."
+    ),
         (  # not working case --> no network interfaces
             "LUSTRE",
             "vpc-06e4ab6c6cEXAMPLE",


### PR DESCRIPTION
### Description of changes
Make security group validator for EFS and FSx succeed when rules contain target security groups.
Currently, the validator succeeds if the SG has rules on the expected ports, but targets for those rules are expected to be defined only as _IpRanges_ or _PrefixListIds_.

With this change we will consider as valid targets also those defined as _Ipv6Ranges_ or _UserIdGroupPairs_.

This change is not meant to be the long term solution for this validator, but to simply address a current limitation.
The long term solution would be to inspect the content of each target and validate it against the current networking posture.

#### User experience without this change
When the end user request to attach an external file system (EFS,FSx*), the request fails even if the security group for that file systems allows all traffic to the head and compute nodes security groups.


### Tests
1. Unit tests
2. Cluster creation/update with external file systems (triggering the changed validator)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
