### PR TITLE
[Parsing] Make YAML parser fail on duplicate keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ CHANGELOG
 - Fix `UpdateParallelClusterLambdaRole` in the ParallelCluster API to upload logs to CloudWatch.
 - Fix Cinc not using the local CA certificates bundle when installing packages before any cookbooks are executed.
 - Fix a hang in upgrading ubuntu via `pcluster build-image` when `Build:UpdateOsPackages:Enabled:true` is set.
+- Fix parsing of YAML cluster configuration by failing on duplicate keys.
 
 3.2.1
 -----

--- a/cli/src/pcluster/cli/model.py
+++ b/cli/src/pcluster/cli/model.py
@@ -15,11 +15,10 @@ import importlib
 import json
 
 import jmespath
-import yaml
 
 from pcluster.api import encoder, openapi
 from pcluster.cli.exceptions import APIOperationException
-from pcluster.utils import to_kebab_case, to_snake_case
+from pcluster.utils import to_kebab_case, to_snake_case, yaml_load
 
 # For importing package resources
 try:
@@ -90,7 +89,7 @@ def _resolve_body(spec, operation):
 def package_spec():
     """Load the OpenAPI specification from the package."""
     with pkg_resources.open_text(openapi, "openapi.yaml") as spec_file:
-        return yaml.safe_load(spec_file.read())
+        return yaml_load(spec_file.read())
 
 
 def load_model(spec):

--- a/cli/src/pcluster/imagebuilder_utils.py
+++ b/cli/src/pcluster/imagebuilder_utils.py
@@ -13,7 +13,7 @@ import os
 import yaml
 
 from pcluster.aws.aws_api import AWSApi
-from pcluster.utils import get_url_scheme
+from pcluster.utils import get_url_scheme, yaml_load
 
 ROOT_VOLUME_TYPE = "gp3"
 PCLUSTER_RESERVED_VOLUME_SIZE = 27
@@ -51,7 +51,7 @@ def wrap_script_to_component(url):
     custom_component_script_template_file = os.path.join(current_dir, "resources", "imagebuilder", "custom_script.yaml")
 
     with open(custom_component_script_template_file, "r", encoding="utf-8") as file:
-        custom_component_script_template = yaml.safe_load(file)
+        custom_component_script_template = yaml_load(file)
 
     script_url_action = _generate_action("ScriptUrl", "set -v\necho {0}\n".format(url))
     custom_component_script_template["phases"][0]["steps"].insert(0, script_url_action)

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -25,7 +25,6 @@ from typing import List, Optional, Set, Tuple
 from urllib.request import urlopen
 
 import pkg_resources
-import yaml
 from jinja2 import BaseLoader
 from jinja2.sandbox import SandboxedEnvironment
 from marshmallow import ValidationError
@@ -67,7 +66,14 @@ from pcluster.models.compute_fleet_status_manager import ComputeFleetStatus, Com
 from pcluster.models.s3_bucket import S3Bucket, S3BucketFactory, S3FileFormat, create_s3_presigned_url, parse_bucket_url
 from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
-from pcluster.utils import datetime_to_epoch, generate_random_name_with_prefix, get_attr, get_installed_version, grouper
+from pcluster.utils import (
+    datetime_to_epoch,
+    generate_random_name_with_prefix,
+    get_attr,
+    get_installed_version,
+    grouper,
+    yaml_load,
+)
 from pcluster.validators.common import FailureLevel, ValidationResult
 
 # pylint: disable=C0302
@@ -651,7 +657,7 @@ class Cluster:
     def _get_stack_template(self):
         """Return the template body of the stack."""
         try:
-            return yaml.safe_load(AWSApi.instance().cfn.get_stack_template(self.stack_name))
+            return yaml_load(AWSApi.instance().cfn.get_stack_template(self.stack_name))
         except AWSClientError as e:
             raise _cluster_error_mapper(e, f"Unable to retrieve template for stack {self.stack_name}. {e}")
 

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -19,12 +19,11 @@ import time
 from typing import List
 
 import configparser
-import yaml
 
 from pcluster.api.encoder import JSONEncoder
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError, get_region
-from pcluster.utils import datetime_to_epoch, to_utc_datetime
+from pcluster.utils import datetime_to_epoch, to_utc_datetime, yaml_load
 
 LOGGER = logging.getLogger(__name__)
 
@@ -56,17 +55,17 @@ class NotFound(Exception):
 def parse_config(config: str) -> dict:
     """Parse a YAML configuration into a dictionary."""
     try:
-        config_dict = yaml.safe_load(config)
+        config_dict = yaml_load(config)
         if not isinstance(config_dict, dict):
             LOGGER.error("Failed: parsed config is not a dict")
-            raise Exception("parsed config is not a dict")
+            raise Exception("Parsed config is not a dict")
         return config_dict
     except Exception as e:
         try:
             configparser.ConfigParser().read_string(config)
         except Exception:
             LOGGER.error("Failed when parsing the configuration due to invalid YAML document: %s", e)
-            raise BadRequest("Configuration must be a valid YAML document")
+            raise BadRequest("Configuration must be a valid YAML document. %s" % e)
         LOGGER.error("Please use pcluster3 configuration file format: %s", e)
         raise BadRequest(
             "ParallelCluster 3 requires configuration files to be valid YAML documents. "

--- a/cli/src/pcluster/models/s3_bucket.py
+++ b/cli/src/pcluster/models/s3_bucket.py
@@ -24,7 +24,7 @@ import yaml
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError, get_region
 from pcluster.constants import PCLUSTER_S3_BUCKET_VERSION
-from pcluster.utils import get_partition, zip_dir
+from pcluster.utils import get_partition, yaml_load, zip_dir
 
 LOGGER = logging.getLogger(__name__)
 
@@ -293,7 +293,7 @@ class S3Bucket:
         file_content = result["Body"].read().decode("utf-8")
 
         if format == S3FileFormat.YAML:
-            file = yaml.safe_load(file_content)
+            file = yaml_load(file_content)
         elif format == S3FileFormat.JSON:
             file = json.loads(file_content)
         else:

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -21,7 +21,6 @@ import re
 from typing import List
 from urllib.request import urlopen
 
-import yaml
 from marshmallow import ValidationError, fields, post_load, pre_dump, pre_load, validate, validates, validates_schema
 from yaml import YAMLError
 
@@ -134,6 +133,7 @@ from pcluster.schemas.common_schema import (
     get_field_validator,
     validate_no_reserved_tag,
 )
+from pcluster.utils import yaml_load
 from pcluster.validators.cluster_validators import EFS_MESSAGES, FSX_MESSAGES
 
 # pylint: disable=C0302
@@ -1777,7 +1777,7 @@ class SchedulerPluginSettingsSchema(BaseSchema):
 
         LOGGER.info("Using the following scheduler plugin definition:\n%s", scheduler_definition)
         try:
-            data["SchedulerDefinition"] = yaml.safe_load(scheduler_definition)
+            data["SchedulerDefinition"] = yaml_load(scheduler_definition)
         except YAMLError as e:
             raise ValidationError(
                 f"The retrieved SchedulerDefinition ({original_scheduler_definition}) is not a valid YAML."

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -297,7 +297,7 @@ Scheduling:
                 None,
                 "us-east-1",
                 None,
-                {"message": "Bad Request: Configuration must be a valid YAML document"},
+                {"message": "Bad Request: Configuration must be a valid YAML document. Parsed config is not a dict"},
             ),
             (
                 {"clusterConfiguration": "[cluster]\nkey_name=mykey", "clusterName": "cluster"},
@@ -1541,7 +1541,10 @@ class TestUpdateCluster:
                 None,
                 None,
                 None,
-                {"message": "Bad Request: Cluster update failed.\nConfiguration must be a valid YAML document"},
+                {
+                    "message": "Bad Request: Cluster update failed.\nConfiguration must be a valid YAML document. "
+                    "Parsed config is not a dict"
+                },
                 id="request with single string configuration",
             ),
             pytest.param(

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -916,7 +916,7 @@ def test_scheduler_plugin_settings_schema(
                 "pcluster.schemas.cluster_schema.urlopen", side_effect=https_error
             ).return_value.__enter__.return_value = file_mock
     if yaml_load_error:
-        mocker.patch("pcluster.schemas.cluster_schema.yaml.safe_load", side_effect=yaml_load_error)
+        mocker.patch("pcluster.utils.yaml.safe_load", side_effect=yaml_load_error)
     if scheduler_definition:
         scheduler_plugin_settings_schema["SchedulerDefinition"] = scheduler_definition
     if grant_sudo_privileges:


### PR DESCRIPTION
### Description of changes
1. Make YAML parser fail on duplicate keys.
2. Move YAML parsing logic into a single place to avoid code duplication.
3. Added unit test covering YAML parsing with and without duplicate keys.


With this change, a cluster configuraiton like the following one:

```
...
Scheduling:
  Scheduler: slurm
  SlurmSettings:
    QueueUpdateStrategy: DRAIN
  SlurmSettings:
    QueueUpdateStrategy: TERMINATE
...
```

makes the pcluster create-cluster and update-cluster fail with message:

```
{
  "message": "Bad Request: Configuration must be a valid YAML document. Duplicate key found: SlurmSettings\n  in \"<unicode string>\", line 17, column 3:\n      SlurmSettings:\n      ^"
}

```

In `pcluster.log` there will be the parsing failure detail:

```
2022-10-11 13:31:59,106 - ERROR - common.py:67:parse_config() - Failed when parsing the configuration due to invalid YAML document: Duplicate key found: SlurmSettings
  in "<unicode string>", line 17, column 3:
      SlurmSettings:
      ^
```

Without this change, the above configuration would be accepted with `SlurmSettings.QueueUpdateStrategy=TERMINATE` that is unexpected.

### Tests
1. Unit tests
4. Manually tested that a cluster config with [without] duplicate keys in cluster config file makes the command fail [succeed]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
