### PR TITLE
Add integ tests configuration file to be used for new OS support

### DIFF
--- a/tests/integration-tests/configs/new_os.yaml
+++ b/tests/integration-tests/configs/new_os.yaml
@@ -1,0 +1,131 @@
+{%- import 'common.jinja2' as common -%}
+{%- set REGION = ["##PLACEHOLDER##"] -%}
+{%- set NEW_OS = ["##PLACEHOLDER##"] -%}
+---
+test-suites:
+  scaling:
+    test_mpi.py::test_mpi:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+  schedulers:
+    test_slurm.py::test_slurm:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+    test_awsbatch.py::test_awsbatch:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+  storage:
+    test_fsx_lustre.py::test_fsx_lustre:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+    test_efs.py::test_efs_compute_az:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+    test_ebs.py::test_ebs_single:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+    test_ephemeral.py::test_head_node_stop:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+  dcv:
+    test_dcv.py::test_dcv_configuration:
+      dimensions:
+        # DCV on GPU enabled instance
+        - regions: {{ REGION }}
+          instances: ["g3.8xlarge"]
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        # DCV on non GPU enabled instance
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+  efa:
+    test_efa.py::test_efa:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+  configure:
+    test_pcluster_configure.py::test_pcluster_configure:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+  networking:
+    test_cluster_networking.py::test_cluster_in_private_subnet:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]
+    # Useful for instances with multiple network interfaces
+    test_multi_cidr.py::test_multi_cidr:
+      dimensions:
+        - regions: {{ REGION }}
+          instances: [ "p4d.24xlarge" ]
+          oss: {{ NEW_OS }}
+          schedulers: [ "slurm" ]


### PR DESCRIPTION
This new configuration file can be used to verify that all the main features are working as expected in the new os.

The enabled tests are:
* MPI, EFA and schedulers
* storages: FSx for Lustre, EFS and EBS, to verify client/tools compatibility
* dcv: to verify GPU capabilities and drivers compatibility
* configure: to verify the new os is accepted by the configure command
* networking: be sure the cluster works in a private subnet and a specific multi-cidr test
* test for both the architectures


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
