### PR TITLE
3.x Require existing VPC for database cluster

### DIFF
--- a/cloudformation/database/serverless-database.yaml
+++ b/cloudformation/database/serverless-database.yaml
@@ -17,7 +17,6 @@ Metadata:
           - Vpc
           - DatabaseClusterSubnetOne
           - DatabaseClusterSubnetTwo
-          - VpcCidrBlock
           - Subnet1CidrBlock
           - Subnet2CidrBlock
     ParameterLabels:
@@ -35,8 +34,6 @@ Metadata:
         default: "The first subnet to use for the database cluster."
       DatabaseClusterSubnetTwo:
         default: "The second subnet to use for the database cluster."
-      VpcCidrBlock:
-        default: "The CIDR block to be used for the VPC if its creation is requested."
       Subnet1CidrBlock:
         default: "The CIDR block to be used for the first Subnet if its creation is requested."
       Subnet2CidrBlock:
@@ -62,10 +59,8 @@ Parameters:
     MinLength: 3
     MaxLength: 64
   Vpc:
-    Description: VPC ID (leave BLANK to create a new VPC).
-    Type: String
-    # Type: AWS::EC2::VPC::Id
-    Default: ''
+    Description: VPC ID.
+    Type: AWS::EC2::VPC::Id
   DatabaseClusterSubnetOne:
     Description: First Subnet ID (leave BLANK to create a new subnet).
     Type: String
@@ -76,14 +71,6 @@ Parameters:
     Type: String
     # Type: AWS::EC2::Subnet::Id
     Default: ''
-  VpcCidrBlock:
-    Description: CIDR block for the VPC (used only if creation is requested - IN THIS CASE THE DEFAULT VALUE MUST BE CHANGED).
-    Type: String
-    Default: '0.0.0.0/16'
-    AllowedPattern: >-
-      ^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8])))$
-    ConstraintDescription: >-
-      The CIDR block must be formatted as W.X.Y.Z/prefix , where prefix must be between 16 and 28.
   Subnet1CidrBlock:
     Description: CIDR block for first Subnet (used only if creation is requested - IN THIS CASE THE DEFAULT VALUE MUST BE CHANGED).
     Type: String
@@ -130,37 +117,10 @@ Parameters:
       - 256
 Transform: AWS::Serverless-2016-10-31
 Conditions:
-  CreateVPC: !Equals [!Ref Vpc, '']
-  CreateSubnets: !Or [!Condition CreateVPC, !Equals [!Ref DatabaseClusterSubnetOne, ''], !Equals [!Ref DatabaseClusterSubnetTwo, '']]
+  CreateSubnets: !Or [!Equals [!Ref DatabaseClusterSubnetOne, ''], !Equals [!Ref DatabaseClusterSubnetTwo, '']]
 Rules:
-  EmptyVpcAssertions:
-    RuleCondition: !Equals
-      - !Ref Vpc
-      - ''
-    Assertions:
-      - Assert: !Equals
-          - !Ref DatabaseClusterSubnetOne
-          - ''
-        AssertDescription: DatabaseClusterSubnetOne must be empty if VPC is not provided.
-      - Assert: !Equals
-          - !Ref DatabaseClusterSubnetTwo
-          - ''
-        AssertDescription: DatabaseClusterSubnetTwo must be empty if VPC is not provided.
-  BadVpcCidrAssertion:
-    RuleCondition: !Equals
-      - !Ref Vpc
-      - ''
-    Assertions:
-      - Assert: !Not
-          - !Equals
-            - !Ref VpcCidrBlock
-            - '0.0.0.0/16'
-        AssertDescription: The default CIDR block for the VPC must be changed if the VPC creation is requested.
   BadSubnetsCidrsAssertion:
     RuleCondition: !Or
-      - !Equals
-        - !Ref Vpc
-        - ''
       - !Equals
         - !Ref DatabaseClusterSubnetOne
         - ''
@@ -182,24 +142,11 @@ Resources:
   #
   # Optional Networking
   #
-  ServerlessDatabaseClusterVpc:
-    Type: 'AWS::EC2::VPC'
-    Condition: CreateVPC
-    Properties:
-      CidrBlock: !Ref VpcCidrBlock
-      EnableDnsHostnames: true
-      EnableDnsSupport: true
-      InstanceTenancy: default
-      Tags:
-        - Key: Name
-          Value: ServerlessDatabaseClusterVPC
-        - Key: 'parallelcluster:usecase'
-          Value: 'infrastructure'
   ServerlessDatabaseClusterSubnet1:
     Type: 'AWS::EC2::Subnet'
     Condition: CreateSubnets
     Properties:
-      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+      VpcId: !Ref Vpc
       AvailabilityZone: !Sub '${AWS::Region}a'
       CidrBlock: !Ref Subnet1CidrBlock
       MapPublicIpOnLaunch: false
@@ -212,7 +159,7 @@ Resources:
     Type: 'AWS::EC2::RouteTable'
     Condition: CreateSubnets
     Properties:
-      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+      VpcId: !Ref Vpc
       Tags:
         - Key: Name
           Value: ServerlessDatabaseClusterSubnet1
@@ -228,7 +175,7 @@ Resources:
     Type: 'AWS::EC2::Subnet'
     Condition: CreateSubnets
     Properties:
-      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+      VpcId: !Ref Vpc
       AvailabilityZone: !Sub '${AWS::Region}b'
       CidrBlock:  !Ref Subnet2CidrBlock
       MapPublicIpOnLaunch: false
@@ -241,7 +188,7 @@ Resources:
     Type: 'AWS::EC2::RouteTable'
     Condition: CreateSubnets
     Properties:
-      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+      VpcId: !Ref Vpc
       Tags:
         - Key: Name
           Value: ServerlessDatabaseClusterSubnet2
@@ -289,7 +236,7 @@ Resources:
       Tags:
         - Key: 'parallelcluster:usecase'
           Value: 'slurm accounting'
-      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+      VpcId: !Ref Vpc
   ServerlessDatabaseClusterSecurityGroupInboundRule:
     Type: 'AWS::EC2::SecurityGroupIngress'
     Properties:
@@ -348,7 +295,7 @@ Resources:
       Tags:
         - Key: 'parallel-cluster:usecase'
           Value: 'slurm accounting'
-      VpcId: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+      VpcId: !Ref Vpc
   ServerlessClusterDatabaseClientSecurityGroupOutboundRule:
     Type: 'AWS::EC2::SecurityGroupEgress'
     Properties:
@@ -380,7 +327,7 @@ Outputs:
   DatabaseSecretArn:
     Value: !Ref ServerlessDatabaseClusterAdminSecret
   DatabaseVpcId:
-    Value: !If [CreateVPC, !Ref ServerlessDatabaseClusterVpc, !Ref Vpc]
+    Value: !Ref Vpc
   DatabaseClusterSecurityGroup:
     Value: !GetAtt
       - ServerlessDatabaseClusterSecurityGroup


### PR DESCRIPTION
### Description of changes
* Require user to use an existing VPC rather than optionally creating one as part of the template

### Tests
* Manually deployed from Cloud Formation console.
* Created ParallelCluster with accounting enabled.
* Verified connection to database cluster from head node.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
