### PR TITLE
[DFSM] Make validation of EBS volume id succeed when the volume is attached to the head node.

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -103,6 +103,7 @@ from pcluster.validators.cluster_validators import (
     SharedStorageMountDirValidator,
     SharedStorageNameValidator,
 )
+from pcluster.validators.common import ValidatorContext
 from pcluster.validators.database_validators import DatabaseUriValidator
 from pcluster.validators.directory_service_validators import (
     AdditionalSssdConfigsValidator,
@@ -192,7 +193,7 @@ class Ebs(Resource):
         self.iops = Resource.init_param(iops, default=EBS_VOLUME_TYPE_IOPS_DEFAULT.get(self.volume_type))
         self.throughput = Resource.init_param(throughput, default=125 if self.volume_type == "gp3" else None)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             EbsVolumeThroughputValidator, volume_type=self.volume_type, volume_throughput=self.throughput
         )
@@ -276,8 +277,8 @@ class SharedEbs(Ebs):
         self.raid = raid
         self.deletion_policy = Resource.init_param(deletion_policy, default=DELETE_POLICY if not volume_id else None)
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         self._register_validator(EbsVolumeTypeSizeValidator, volume_type=self.volume_type, volume_size=self.size)
         self._register_validator(
             EbsVolumeIopsValidator, volume_type=self.volume_type, volume_size=self.size, volume_iops=self.iops
@@ -286,7 +287,11 @@ class SharedEbs(Ebs):
         if self.kms_key_id:
             self._register_validator(KmsKeyValidator, kms_key_id=self.kms_key_id)
             self._register_validator(KmsKeyIdEncryptedValidator, kms_key_id=self.kms_key_id, encrypted=self.encrypted)
-        self._register_validator(SharedEbsVolumeIdValidator, volume_id=self.volume_id)
+        self._register_validator(
+            SharedEbsVolumeIdValidator,
+            volume_id=self.volume_id,
+            head_node_instance_id=context.head_node_instance_id,
+        )
         self._register_validator(EbsVolumeSizeSnapshotValidator, snapshot_id=self.snapshot_id, volume_size=self.size)
         self._register_validator(DeletionPolicyValidator, deletion_policy=self.deletion_policy, name=self.name)
 
@@ -320,7 +325,7 @@ class SharedEfs(Resource):
             deletion_policy, default=DELETE_POLICY if not file_system_id else None
         )
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(SharedStorageNameValidator, name=self.name)
         if self.kms_key_id:
             self._register_validator(KmsKeyValidator, kms_key_id=self.kms_key_id)
@@ -338,7 +343,7 @@ class BaseSharedFsx(Resource):
         self.shared_storage_type = SharedStorageType.FSX
         self.__file_system_data = None
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(SharedStorageNameValidator, name=self.name)
 
     @property
@@ -405,8 +410,8 @@ class SharedFsxLustre(BaseSharedFsx):
             deletion_policy, default=DELETE_POLICY if not file_system_id else None
         )
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         self._register_validator(
             FsxS3Validator,
             import_path=self.import_path,
@@ -538,7 +543,7 @@ class _BaseNetworking(Resource):
         self.security_groups = Resource.init_param(security_groups)
         self.additional_security_groups = Resource.init_param(additional_security_groups)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(SecurityGroupsValidator, security_group_ids=self.security_groups)
         self._register_validator(SecurityGroupsValidator, security_group_ids=self.additional_security_groups)
 
@@ -552,8 +557,8 @@ class HeadNodeNetworking(_BaseNetworking):
         self.elastic_ip = Resource.init_param(elastic_ip)
         self.proxy = proxy
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         self._register_validator(ElasticIpValidator, elastic_ip=self.elastic_ip)
 
     @property
@@ -571,7 +576,7 @@ class PlacementGroup(Resource):
         self.name = Resource.init_param(name)
         self.id = Resource.init_param(id)  # Duplicate of name
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(PlacementGroupNamingValidator, placement_group=self)
 
     @property
@@ -632,7 +637,7 @@ class Ssh(Resource):
         self.key_name = Resource.init_param(key_name)
         self.allowed_ips = Resource.init_param(allowed_ips, default=CIDR_ALL_IPS)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(KeyPairValidator, key_name=self.key_name)
 
 
@@ -719,7 +724,7 @@ class Roles(Resource):
         super().__init__()
         self.lambda_functions_role = Resource.init_param(lambda_functions_role)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.lambda_functions_role:
             self._register_validator(RoleValidator, role_arn=self.lambda_functions_role)
 
@@ -794,7 +799,7 @@ class Iam(Resource):
             instance_role_arns = {}
         return list(instance_role_arns)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.instance_role:
             self._register_validator(RoleValidator, role_arn=self.instance_role)
         elif self.instance_profile:
@@ -836,7 +841,7 @@ class DirectoryService(Resource):
         self.generate_ssh_keys_for_users = Resource.init_param(generate_ssh_keys_for_users, default=True)
         self.additional_sssd_configs = Resource.init_param(additional_sssd_configs, default={})
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.domain_name:
             self._register_validator(DomainNameValidator, domain_name=self.domain_name)
         if self.domain_addr:
@@ -863,7 +868,7 @@ class ClusterIam(Resource):
         self.roles = roles
         self.permissions_boundary = Resource.init_param(permissions_boundary)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.permissions_boundary:
             self._register_validator(IamPolicyValidator, policy=self.permissions_boundary)
 
@@ -932,8 +937,8 @@ class ClusterDevSettings(BaseDevSettings):
         self.instance_types_data = Resource.init_param(instance_types_data)
         self.timeouts = Resource.init_param(timeouts)
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         if self.cluster_template:
             self._register_validator(UrlValidator, url=self.cluster_template)
 
@@ -949,7 +954,7 @@ class Image(Resource):
         self.os = Resource.init_param(os)
         self.custom_ami = Resource.init_param(custom_ami)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.custom_ami:
             self._register_validator(CustomAmiTagValidator, custom_ami=self.custom_ami)
             self._register_validator(AmiOsCompatibleValidator, os=self.os, image_id=self.custom_ami)
@@ -962,7 +967,7 @@ class HeadNodeImage(Resource):
         super().__init__()
         self.custom_ami = Resource.init_param(custom_ami)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.custom_ami:
             self._register_validator(CustomAmiTagValidator, custom_ami=self.custom_ami)
 
@@ -974,7 +979,7 @@ class QueueImage(Resource):
         super().__init__()
         self.custom_ami = Resource.init_param(custom_ami)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.custom_ami:
             self._register_validator(CustomAmiTagValidator, custom_ami=self.custom_ami)
 
@@ -987,7 +992,7 @@ class CustomAction(Resource):
         self.script = Resource.init_param(script)
         self.args = Resource.init_param(args)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(UrlValidator, url=self.script)
 
 
@@ -1031,7 +1036,7 @@ class HeadNode(Resource):
         self.image = image
         self.__instance_type_info = None
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(InstanceTypeValidator, instance_type=self.instance_type)
 
     @property
@@ -1079,7 +1084,7 @@ class BaseComputeResource(Resource):
         super().__init__()
         self.name = Resource.init_param(name)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(NameValidator, name=self.name)
 
 
@@ -1107,7 +1112,7 @@ class BaseQueue(Resource):
         _capacity_type = CapacityType[capacity_type.upper()] if capacity_type else None
         self.capacity_type = Resource.init_param(_capacity_type, default=CapacityType.ONDEMAND)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(NameValidator, name=self.name)
 
 
@@ -1161,7 +1166,7 @@ class BaseClusterConfig(Resource):
         self._official_ami = None
         self.imds = imds or TopLevelImds(implied=False)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(RegionValidator, region=self.region)
         self._register_validator(ClusterNameValidator, name=self.cluster_name)
         self._register_validator(
@@ -1565,8 +1570,8 @@ class AwsBatchComputeResource(BaseComputeResource):
         self.desired_vcpus = Resource.init_param(desired_vcpus, default=self.min_vcpus)
         self.spot_bid_percentage = Resource.init_param(spot_bid_percentage)
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         self._register_validator(
             AwsBatchComputeInstanceTypeValidator, instance_types=self.instance_types, max_vcpus=self.max_vcpus
         )
@@ -1586,8 +1591,8 @@ class AwsBatchQueue(BaseQueue):
         self.compute_resources = compute_resources
         self.networking = networking
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         self._register_validator(
             DuplicateNameValidator,
             name_list=[compute_resource.name for compute_resource in self.compute_resources],
@@ -1610,7 +1615,7 @@ class AwsBatchScheduling(Resource):
         self.queues = queues
         self.settings = settings
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             DuplicateNameValidator, name_list=[queue.name for queue in self.queues], resource_name="Queue"
         )
@@ -1623,8 +1628,8 @@ class AwsBatchClusterConfig(BaseClusterConfig):
         super().__init__(cluster_name, **kwargs)
         self.scheduling = scheduling
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         self._register_validator(AwsBatchRegionValidator, region=self.region)
         # TODO add InstanceTypesBaseAMICompatibleValidator
 
@@ -1786,8 +1791,8 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
         """Return instance type information."""
         return AWSApi.instance().ec2.get_instance_type_info(self.instance_type)
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         self._register_validator(ComputeResourceSizeValidator, min_count=self.min_count, max_count=self.max_count)
         self._register_validator(
             EfaValidator,
@@ -1962,8 +1967,8 @@ class SlurmQueue(_CommonQueue):
             result.update(compute_resource.instance_types_with_instance_storage)
         return result
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         self._register_validator(
             DuplicateNameValidator,
             name_list=[compute_resource.name for compute_resource in self.compute_resources],
@@ -2025,7 +2030,7 @@ class Database(Resource):
         self.user_name = Resource.init_param(user_name)
         self.password_secret_arn = Resource.init_param(password_secret_arn)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.uri:
             self._register_validator(DatabaseUriValidator, uri=self.uri)
         if self.password_secret_arn:
@@ -2071,7 +2076,7 @@ class SlurmScheduling(Resource):
         self.queues = queues
         self.settings = settings or SlurmSettings(implied=True)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             DuplicateNameValidator, name_list=[queue.name for queue in self.queues], resource_name="Queue"
         )
@@ -2094,8 +2099,8 @@ class SchedulerPluginQueue(_CommonQueue):
         super().__init__(**kwargs)
         self.custom_settings = custom_settings
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         self._register_validator(
             DuplicateNameValidator,
             name_list=[compute_resource.name for compute_resource in self.compute_resources],
@@ -2183,7 +2188,7 @@ class SchedulerPluginRequirements(Resource):
         self.supports_cluster_update = Resource.init_param(supports_cluster_update, default=True)
         self.supported_parallel_cluster_versions = supported_parallel_cluster_versions
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.supported_parallel_cluster_versions:
             self._register_validator(
                 SupportedVersionsValidator,
@@ -2201,7 +2206,7 @@ class SchedulerPluginCloudFormationInfrastructure(Resource):
         self.s3_bucket_owner = s3_bucket_owner
         self.checksum = checksum
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             UrlValidator,
             url=self.template,
@@ -2228,7 +2233,7 @@ class SchedulerPluginClusterSharedArtifact(Resource):
         self.s3_bucket_owner = s3_bucket_owner
         self.checksum = checksum
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(UrlValidator, url=self.source, expected_bucket_owner=self.s3_bucket_owner)
 
 
@@ -2331,7 +2336,7 @@ class SchedulerPluginUser(Resource):
         self.enable_imds = Resource.init_param(enable_imds, default=False)
         self.sudoer_configuration = sudoer_configuration
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             UserNameValidator,
             user_name=self.name,
@@ -2365,7 +2370,7 @@ class SchedulerPluginDefinition(Resource):
         self.system_users = system_users
         self.tags = tags
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             PluginInterfaceVersionValidator,
             plugin_version=self.plugin_interface_version,
@@ -2393,7 +2398,7 @@ class SchedulerPluginSettings(Resource):
         self.scheduler_definition_s3_bucket_owner = scheduler_definition_s3_bucket_owner
         self.scheduler_definition_checksum = scheduler_definition_checksum
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             SudoPrivilegesValidator,
             grant_sudo_privileges=self.grant_sudo_privileges,
@@ -2418,7 +2423,7 @@ class SchedulerPluginScheduling(Resource):
         self.queues = queues
         self.settings = settings
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             DuplicateNameValidator, name_list=[queue.name for queue in self.queues], resource_name="Queue"
         )
@@ -2448,8 +2453,8 @@ class SchedulerPluginScheduling(Resource):
 class CommonSchedulerClusterConfig(BaseClusterConfig):
     """Represent the common Cluster configuration between Slurm Config and Scheduler Plugin Config."""
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         checked_images = []
         for queue in self.scheduling.queues:
             queue_image = self.image_dict[queue.name]
@@ -2593,8 +2598,8 @@ class SchedulerPluginClusterConfig(CommonSchedulerClusterConfig):
             self.scheduling, "settings.scheduler_definition.tags", default=[]
         )
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         scheduler_definition = self.scheduling.settings.scheduler_definition
         self._register_validator(
             SchedulerPluginOsArchitectureValidator,
@@ -2646,8 +2651,8 @@ class SlurmClusterConfig(CommonSchedulerClusterConfig):
                     result[instance_type] = instance_type_info.instance_type_data
         return result
 
-    def _register_validators(self):
-        super()._register_validators()
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
         self._register_validator(
             MixedSecurityGroupOverwriteValidator,
             head_node_security_groups=self.head_node.networking.security_groups,

--- a/cli/src/pcluster/config/imagebuilder_config.py
+++ b/cli/src/pcluster/config/imagebuilder_config.py
@@ -18,6 +18,7 @@ from typing import List
 from pcluster.aws.common import get_region
 from pcluster.config.common import AdditionalIamPolicy, BaseDevSettings, BaseTag, ExtraChefAttributes, Imds, Resource
 from pcluster.imagebuilder_utils import ROOT_VOLUME_TYPE
+from pcluster.validators.common import ValidatorContext
 from pcluster.validators.ebs_validators import EbsVolumeTypeSizeValidator
 from pcluster.validators.ec2_validators import InstanceTypeBaseAMICompatibleValidator
 from pcluster.validators.iam_validators import IamPolicyValidator, InstanceProfileValidator, RoleValidator
@@ -43,7 +44,7 @@ class Volume(Resource):
         self.encrypted = Resource.init_param(encrypted, default=False)
         self.kms_key_id = Resource.init_param(kms_key_id)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.kms_key_id:
             self._register_validator(KmsKeyIdEncryptedValidator, kms_key_id=self.kms_key_id, encrypted=self.encrypted)
             self._register_validator(KmsKeyValidator, kms_key_id=self.kms_key_id)
@@ -111,7 +112,7 @@ class Iam(Resource):
             arns.append(policy.policy)
         return arns
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         if self.instance_role:
             self._register_validator(RoleValidator, role_arn=self.instance_role)
         elif self.instance_profile:
@@ -161,7 +162,7 @@ class Build(Resource):
         self.update_os_packages = update_os_packages
         self.imds = imds or Imds(implied=False)
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             InstanceTypeBaseAMICompatibleValidator,
             instance_type=self.instance_type,
@@ -227,7 +228,7 @@ class ImageBuilderConfig(Resource):
         self.custom_s3_bucket = Resource.init_param(custom_s3_bucket)
         self.source_config = source_config
 
-    def _register_validators(self):
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         # Volume size validator only validates specified volume size
         if self.image and self.image.root_volume and self.image.root_volume.size:
             self._register_validator(

--- a/cli/src/pcluster/validators/common.py
+++ b/cli/src/pcluster/validators/common.py
@@ -64,3 +64,10 @@ class Validator(ABC):
     def _validate(self, *args, **kwargs):
         """Must be implemented with specific validation logic."""
         pass
+
+
+class ValidatorContext:
+    """Context containing information about cluster environment meant to be passed to validators."""
+
+    def __init__(self, head_node_instance_id: str = None):
+        self.head_node_instance_id = head_node_instance_id

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -1614,6 +1614,10 @@ class TestUpdateCluster:
     ):
         stack_data = cfn_describe_stack_mock_response()
         mocker.patch("pcluster.aws.cfn.CfnClient.describe_stack", return_value=stack_data)
+        mocker.patch(
+            "pcluster.aws.ec2.Ec2Client.describe_instances",
+            return_value=([{"InstanceId": "i-123456789"}], None),
+        )
 
         response = self._send_test_request(
             client=client,

--- a/cli/tests/pcluster/config/test_common.py
+++ b/cli/tests/pcluster/config/test_common.py
@@ -14,7 +14,7 @@ import pytest
 from assertpy import assert_that
 
 from pcluster.config.common import Resource
-from pcluster.validators.common import FailureLevel, Validator
+from pcluster.validators.common import FailureLevel, Validator, ValidatorContext
 
 
 class FakeInfoValidator(Validator):
@@ -62,7 +62,7 @@ def test_resource_validate():
             self.fake_attribute = "fake-value"
             self.other_attribute = "other-value"
 
-        def _register_validators(self):
+        def _register_validators(self, context: ValidatorContext = None):
             self._register_validator(FakeErrorValidator, param=self.fake_attribute)
             self._register_validator(
                 FakeComplexValidator,
@@ -90,7 +90,7 @@ def test_dynamic_property_validate():
             super().__init__()
             self.deps_value = ""
 
-        def _register_validators(self):
+        def _register_validators(self, context: ValidatorContext = None):
             self._register_validator(FakePropertyValidator, property_value=self.dynamic_attribute)
 
         @property
@@ -126,7 +126,7 @@ def test_nested_resource_validate():
             super().__init__()
             self.fake_attribute = fake_value
 
-        def _register_validators(self):
+        def _register_validators(self, context: ValidatorContext = None):
             self._register_validator(FakeErrorValidator, param=self.fake_attribute)
 
     class FakeParentResource(Resource):
@@ -138,7 +138,7 @@ def test_nested_resource_validate():
             self.other_attribute = "other-value"
             self.list_of_resources = list_of_resources
 
-        def _register_validators(self):
+        def _register_validators(self, context: ValidatorContext = None):
             self._register_validator(FakeInfoValidator, param=self.other_attribute)
 
     fake_resource = FakeParentResource(FakeNestedResource("value1"), [FakeNestedResource("value2")])

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -26,7 +26,12 @@ from pcluster.aws.common import AWSClientError
 from pcluster.config.cluster_config import Tag
 from pcluster.config.common import AllValidatorsSuppressor
 from pcluster.config.update_policy import UpdatePolicy
-from pcluster.constants import PCLUSTER_CLUSTER_NAME_TAG, PCLUSTER_S3_ARTIFACTS_DICT, PCLUSTER_VERSION_TAG
+from pcluster.constants import (
+    PCLUSTER_CLUSTER_NAME_TAG,
+    PCLUSTER_NODE_TYPE_TAG,
+    PCLUSTER_S3_ARTIFACTS_DICT,
+    PCLUSTER_VERSION_TAG,
+)
 from pcluster.models.cluster import BadRequestClusterActionError, Cluster, ClusterActionError, NodeType
 from pcluster.models.cluster_resources import ClusterStack
 from pcluster.models.compute_fleet_status_manager import ComputeFleetStatus
@@ -619,6 +624,14 @@ class TestCluster:
             "pcluster.aws.ec2.Ec2Client.describe_image",
             return_value=ImageInfo({"BlockDeviceMappings": [{"Ebs": {"VolumeSize": 35}}]}),
         )
+        mocker.patch(
+            "pcluster.aws.ec2.Ec2Client.describe_instances",
+            return_value=([{"InstanceId": "i-123456789"}], None),
+            expected_params=[
+                {"Name": f"tag:{PCLUSTER_CLUSTER_NAME_TAG}", "Values": ["WHATEVER-CLUSTER-NAME"]},
+                {"Name": f"tag:{PCLUSTER_NODE_TYPE_TAG}", "Values": ["HeadNode"]},
+            ],
+        )
         cluster = Cluster(
             FAKE_NAME,
             stack=ClusterStack(
@@ -825,6 +838,14 @@ Scheduling:
         mocker.patch(
             "pcluster.aws.ec2.Ec2Client.describe_image",
             return_value=ImageInfo({"BlockDeviceMappings": [{"Ebs": {"VolumeSize": 35}}]}),
+        )
+        mocker.patch(
+            "pcluster.aws.ec2.Ec2Client.describe_instances",
+            return_value=([{"InstanceId": "i-123456789"}], None),
+            expected_params=[
+                {"Name": f"tag:{PCLUSTER_CLUSTER_NAME_TAG}", "Values": ["WHATEVER-CLUSTER-NAME"]},
+                {"Name": f"tag:{PCLUSTER_NODE_TYPE_TAG}", "Values": ["HeadNode"]},
+            ],
         )
 
         try:

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -29,7 +29,7 @@ from pcluster.validators import (
     s3_validators,
     scheduler_plugin_validators,
 )
-from pcluster.validators.common import Validator
+from pcluster.validators.common import Validator, ValidatorContext
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 
 
@@ -65,7 +65,7 @@ def _mock_all_validators(mocker, mockers, additional_modules=None):
 def _load_and_validate(config_path):
     input_yaml = load_yaml_dict(config_path)
     cluster = ClusterSchema(cluster_name="clustername").load(input_yaml)
-    failures = cluster.validate()
+    failures = cluster.validate(context=ValidatorContext())
     assert_that(failures).is_empty()
 
 


### PR DESCRIPTION
### Description of changes
1. Make validation of EBS volume id succeed when the volume is attached to the head node.
2. Prepared code to support multi-attach (commented out because we do not officially support it).
3. Added unit tests

**Note:** I think this validator should fail with an error when attempting to mount a not available volume without multi-attach, but I'd keep it as it was in previous releases at least in this PR because such a change required product approval. 

**Without this change**, whenever a user update a cluster with an EBS volume already mounted to it, the following error is emitted:

```
    {
      "level": "WARNING",
      "type": "SharedEbsVolumeIdValidator",
      "message": "Volume vol-0725fd369d04f4937 is in state 'in-use' not 'available'."
    },
```

The above is undesired because the volume is in-use because it is actually already mounted to the cluster.

### Tests
1. Create with available EBS volume => success
2. Create with in-use EBS volume => warning
4. Update with available EBS volume => success
5. Update with in-use EBS volume attached to the head node => success
6. Create/Update with in-use EBS volume having multi-attach => warning

Double-checked that there is no `_register_validators()` call without a context:
```
cat cli/src/**/*.py | grep _register_validators | wc -l          
      63
cat cli/src/**/*.py | grep _register_validators | grep context | wc -l
      63
cat cli/src/**/*.py | grep "def _register_validators" | wc -l                                    
      49
cat cli/src/**/*.py | grep "def _register_validators" | grep "context: ValidatorContext = None" | wc -l
      49

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
