### PR TITLE
2.x: Modify update policy of tags property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 CHANGELOG
 =========
 
-2.x.x
+2.11.8
 -----
+
 **CHANGES**
-Upgrade Python runtime used by Lambda functions in AWS Batch integration to python3.9.
+- Upgrade Python runtime used by Lambda functions in AWS Batch integration to python3.9.
+
+**BUG FIXES**
+- Prevent cluster tags to be changed during an update because not supported.
 
 2.11.7
 -----

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -949,7 +949,7 @@ CLUSTER_COMMON_PARAMS = [
         # There is no cfn_param_mapping because it's not converted to a CFN Input parameter
         "type": TagsParam,
         "validators": [tags_validator],
-        "update_policy": UpdatePolicy.COMPUTE_FLEET_STOP,
+        "update_policy": UpdatePolicy.UNSUPPORTED,
     }),
     ("custom_chef_cookbook", {
         "cfn_param_mapping": "CustomChefCookbook",

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -78,7 +78,7 @@ def convert_to_date_mock(request, mocker):
         # executes convert_to_date but overrides arguments so that timezone is enforced to utc
         if "timezone" in kwargs:
             del kwargs["timezone"]
-        return convert_to_date(timezone=tz.tzutc(), *args, **kwargs)
+        return convert_to_date(timezone=tz.tzutc(), *args, **kwargs)  # noqa: B026
 
     return mocker.patch("awsbatch." + module_under_test + ".convert_to_date", wraps=_convert_to_date_utc)
 


### PR DESCRIPTION
### Description of changes
* The update policy has been modified to COMPUTE_FLEET_STOP in ParallelCluster 2.10.0 but it never worked, because a change in the tags requires a change in the LaunchTemplate of the head node and this triggers a head node replacement.

With this change the update of the tags is no longer supported during a cluster update.

### Tests
* Created a cluster with no tags and tried to update it --> Update is aborted.
```
Retrieving configuration from CloudFormation for cluster test2x...
Validating configuration file ...
Found Configuration Changes:

#    parameter          old value    new value
---  -----------------  -----------  ------------------------------
     [cluster alinux2]
01*  tags               {}           {'key': 'value', 'key2': 'v...

Validating configuration update...
The requested update cannot be performed. Line numbers with an asterisk indicate updates requiring additional actions. Please review the details below:

#01
Update actions are not currently supported for the 'tags' parameter
How to fix:
Restore 'tags' value to '{}'. If you need this change, please consider creating a new cluster instead of updating the existing one.

In case you want to override these checks and proceed with the update please use the --force flag. Note that the cluster could end up in an unrecoverable state.
Update aborted.
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
