### PR TITLE
Realign Imds settings feature to our desired user experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ CHANGELOG
   to support storage retention on deletion.
 - Enable server-side encryption for the EcrImageBuilder SNS topic created when deploying ParallelCluster API and used to notify on docker image build events.
 - Add support for on-demand capacity reservations.
-- Add support for requiring IMDSv2 in cluster and build image configurations via the `Imds > RequireImdsV2` property.
+- Add support for specifying the supported IMDS version in cluster and build image configurations via the `Imds > ImdsSettings` property. A value of `v1.0` (the default) means that both IMDSv1 and IMDSv2 are supported, while a value of `v2.0` means that only IMDSv2 is supported.
 - Add support for Slurm Accounting.
 - Improve validation of networking for external EFS file systems by checking the CIDR block in the attached security group.
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1163,7 +1163,7 @@ class BaseClusterConfig(Resource):
         self.config_version = ""
         self.original_config_version = ""
         self._official_ami = None
-        self.imds = imds or TopLevelImds(implied=False)
+        self.imds = imds or TopLevelImds(implied="v1.0")
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(RegionValidator, region=self.region)

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -95,7 +95,6 @@ from pcluster.validators.cluster_validators import (
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
     RegionValidator,
-    RequireImdsV2Validator,
     RootVolumeSizeValidator,
     SchedulableMemoryValidator,
     SchedulerOsValidator,
@@ -1240,7 +1239,6 @@ class BaseClusterConfig(Resource):
             volume_size=root_volume_size,
             volume_iops=root_volume.iops,
         )
-        self._register_validator(RequireImdsV2Validator, require_imds_v2=self.imds.require_imds_v2)
 
     def _register_storage_validators(self):
         if self.shared_storage:

--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -286,9 +286,9 @@ class Imds(Resource):
     or in the Build section of the build image config file.
     """
 
-    def __init__(self, require_imds_v2: bool = None, **kwargs):
+    def __init__(self, imds_support: str = None, **kwargs):
         super().__init__(**kwargs)
-        self.require_imds_v2 = Resource.init_param(require_imds_v2, default=False)
+        self.imds_support = Resource.init_param(imds_support, default="v1.0")
 
 
 # ------------ Common attributes class between ImageBuilder an Cluster models ----------- #

--- a/cli/src/pcluster/config/imagebuilder_config.py
+++ b/cli/src/pcluster/config/imagebuilder_config.py
@@ -159,7 +159,7 @@ class Build(Resource):
         self.security_group_ids = security_group_ids
         self.components = components
         self.update_os_packages = update_os_packages
-        self.imds = imds or Imds(implied=False)
+        self.imds = imds or Imds(implied="v1.0")
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(

--- a/cli/src/pcluster/config/imagebuilder_config.py
+++ b/cli/src/pcluster/config/imagebuilder_config.py
@@ -25,7 +25,6 @@ from pcluster.validators.iam_validators import IamPolicyValidator, InstanceProfi
 from pcluster.validators.imagebuilder_validators import (
     AMIVolumeSizeValidator,
     ComponentsValidator,
-    RequireImdsV2Validator,
     SecurityGroupsAndSubnetValidator,
 )
 from pcluster.validators.kms_validators import KmsKeyIdEncryptedValidator, KmsKeyValidator
@@ -176,7 +175,6 @@ class Build(Resource):
         self._register_validator(
             SecurityGroupsAndSubnetValidator, security_group_ids=self.security_group_ids, subnet_id=self.subnet_id
         )
-        self._register_validator(RequireImdsV2Validator, require_imds_v2=self.imds.require_imds_v2)
 
 
 # ---------------------- Dev Settings ---------------------- #

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -36,6 +36,8 @@ ALLOWED_VALUES = {
     "volume_type": ["standard", "io1", "io2", "gp2", "st1", "sc1", "gp3"],
 }
 
+SUPPORTED_IMDS_VERSIONS = ["v1.0", "v2.0"]
+
 
 def validate_json_format(data):
     """Validate the input data in json format."""
@@ -215,7 +217,11 @@ class ImdsSchema(BaseSchema):
     or in the Build section of the build image config file.
     """
 
-    require_imds_v2 = fields.Bool(data_key="RequireImdsV2", metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+    imds_support = fields.Str(
+        data_key="ImdsSupport",
+        validate=validate.OneOf(SUPPORTED_IMDS_VERSIONS),
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
+    )
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -182,7 +182,7 @@ class AwsBatchConstruct(Construct):
                 instance_role=self._iam_instance_profile.ref,
                 bid_percentage=self.compute_resource.spot_bid_percentage,
                 spot_iam_fleet_role=self._spot_iam_fleet_role.attr_arn if self._spot_iam_fleet_role else None,
-                launch_template=self._launch_template() if self.config.imds.require_imds_v2 else None,
+                launch_template=self._launch_template() if self.config.imds.imds_support == "v2.0" else None,
                 tags={
                     **get_default_instance_tags(
                         self.stack_name,

--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -39,6 +39,7 @@ from pcluster.templates.cdk_builder_utils import (
     get_shared_storage_ids_by_type,
     to_comma_separated_string,
 )
+from pcluster.utils import get_http_tokens_setting
 
 
 class AwsBatchConstruct(Construct):
@@ -151,12 +152,12 @@ class AwsBatchConstruct(Construct):
         self._code_build_notification_rule = self._add_code_build_notification_rule()
         self._manage_docker_images_custom_resource.add_depends_on(self._code_build_notification_rule)
 
-    def _launch_template(self):
+    def _launch_template(self, http_tokens):
         launch_template = ec2.CfnLaunchTemplate(
             self.stack_scope,
             "PclusterComputeEnvironmentLaunchTemplate",
             launch_template_data=ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
-                metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(http_tokens="required")
+                metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(http_tokens=http_tokens)
             ),
         )
         return batch.CfnComputeEnvironment.LaunchTemplateSpecificationProperty(
@@ -182,7 +183,9 @@ class AwsBatchConstruct(Construct):
                 instance_role=self._iam_instance_profile.ref,
                 bid_percentage=self.compute_resource.spot_bid_percentage,
                 spot_iam_fleet_role=self._spot_iam_fleet_role.attr_arn if self._spot_iam_fleet_role else None,
-                launch_template=self._launch_template() if self.config.imds.imds_support == "v2.0" else None,
+                launch_template=self._launch_template(
+                    http_tokens=get_http_tokens_setting(self.config.imds.imds_support)
+                ),
                 tags={
                     **get_default_instance_tags(
                         self.stack_name,

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -99,7 +99,7 @@ from pcluster.templates.cdk_builder_utils import (
 )
 from pcluster.templates.cw_dashboard_builder import CWDashboardConstruct
 from pcluster.templates.slurm_builder import SlurmConstruct
-from pcluster.utils import get_attr, join_shell_args
+from pcluster.utils import get_attr, get_http_tokens_setting, join_shell_args
 
 StorageInfo = namedtuple("StorageInfo", ["id", "config"])
 
@@ -882,9 +882,9 @@ class ClusterCdkStack(Stack):
                 iam_instance_profile=ec2.CfnLaunchTemplate.IamInstanceProfileProperty(
                     name=self._head_node_instance_profile
                 ),
-                metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(http_tokens="required")
-                if self.config.imds.imds_support == "v2.0"
-                else None,
+                metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(
+                    http_tokens=get_http_tokens_setting(self.config.imds.imds_support)
+                ),
                 user_data=Fn.base64(
                     Fn.sub(
                         get_user_data_content("../resources/head_node/user_data.sh"),
@@ -1487,9 +1487,9 @@ class ComputeFleetConstruct(Construct):
                 instance_market_options=instance_market_options,
                 instance_initiated_shutdown_behavior="terminate",
                 capacity_reservation_specification=capacity_reservation_specification,
-                metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(http_tokens="required")
-                if self._config.imds.imds_support == "v2.0"
-                else None,
+                metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(
+                    http_tokens=get_http_tokens_setting(self._config.imds.imds_support)
+                ),
                 user_data=Fn.base64(
                     Fn.sub(
                         get_user_data_content("../resources/compute_node/user_data.sh"),

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -883,7 +883,7 @@ class ClusterCdkStack(Stack):
                     name=self._head_node_instance_profile
                 ),
                 metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(http_tokens="required")
-                if self.config.imds.require_imds_v2
+                if self.config.imds.imds_support == "v2.0"
                 else None,
                 user_data=Fn.base64(
                     Fn.sub(
@@ -1488,7 +1488,7 @@ class ComputeFleetConstruct(Construct):
                 instance_initiated_shutdown_behavior="terminate",
                 capacity_reservation_specification=capacity_reservation_specification,
                 metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(http_tokens="required")
-                if self._config.imds.require_imds_v2
+                if self._config.imds.imds_support == "v2.0"
                 else None,
                 user_data=Fn.base64(
                     Fn.sub(

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -586,7 +586,7 @@ class ImageBuilderCdkStack(Stack):
             instance_metadata_options=imagebuilder.CfnInfrastructureConfiguration.InstanceMetadataOptionsProperty(
                 http_tokens="required"
             )
-            if self.config.build.imds.require_imds_v2
+            if self.config.build.imds.imds_support == "v2.0"
             else None,
         )
         if not self.custom_cleanup_lambda_role:

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -52,6 +52,7 @@ from pcluster.imagebuilder_utils import (
 )
 from pcluster.models.s3_bucket import S3Bucket, S3FileType, create_s3_presigned_url, parse_bucket_url
 from pcluster.templates.cdk_builder_utils import apply_permissions_boundary, get_assume_role_policy_document
+from pcluster.utils import get_http_tokens_setting
 
 
 class ImageBuilderCdkStack(Stack):
@@ -584,10 +585,8 @@ class ImageBuilderCdkStack(Stack):
             subnet_id=self.config.build.subnet_id,
             sns_topic_arn=Fn.ref("BuildNotificationTopic"),
             instance_metadata_options=imagebuilder.CfnInfrastructureConfiguration.InstanceMetadataOptionsProperty(
-                http_tokens="required"
-            )
-            if self.config.build.imds.imds_support == "v2.0"
-            else None,
+                http_tokens=get_http_tokens_setting(self.config.build.imds.imds_support)
+            ),
         )
         if not self.custom_cleanup_lambda_role:
             self._add_resource_delete_policy(

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -356,3 +356,8 @@ def yaml_no_duplicates_constructor(loader, node, deep=False):
         mapping[key] = value
 
     return loader.construct_mapping(node, deep)
+
+
+def get_http_tokens_setting(imds_support):
+    """Get http tokens settings for supported IMDS version."""
+    return "required" if imds_support == "v2.0" else "optional"

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -100,23 +100,6 @@ class RegionValidator(Validator):
             )
 
 
-class RequireImdsV2Validator(Validator):
-    """IMDSv2 enforcement validator."""
-
-    def _validate(self, require_imds_v2):
-        if not require_imds_v2:
-            self._add_failure(
-                "The current cluster configuration does not disable IMDSv1, "
-                "which we plan to disable by default in future versions. "
-                "If you do not explicitly need to use IMDSv1 enforce IMDSv2 "
-                "usage by setting the RequireImdsV2 configuration parameter "
-                "to true (see documentation at: https://docs.aws.amazon.com/"
-                "parallelcluster/latest/ug/cluster-configuration-file-v3.html"
-                "#cluster-configuration-file-v3.properties)",
-                level=FailureLevel.INFO,
-            )
-
-
 class SchedulerOsValidator(Validator):
     """
     scheduler - os validator.

--- a/cli/src/pcluster/validators/imagebuilder_validators.py
+++ b/cli/src/pcluster/validators/imagebuilder_validators.py
@@ -54,18 +54,3 @@ class SecurityGroupsAndSubnetValidator(Validator):
                     "Subnet id {0} is specified, security groups is required.".format(subnet_id),
                     FailureLevel.ERROR,
                 )
-
-
-class RequireImdsV2Validator(Validator):
-    """IMDSv2 enforcement validator."""
-
-    def _validate(self, require_imds_v2):
-        if not require_imds_v2:
-            self._add_failure(
-                "The current build image configuration does not disable IMDSv1, "
-                "which we plan to disable by default in future versions. If you do "
-                "not explicitly need to use IMDSv1 enforce IMDSv2 usage by setting the "
-                "RequireImdsV2 configuration parameter to true (see documentation at: "
-                "https://docs.aws.amazon.com/parallelcluster/latest/ug/Build-v3.html)",
-                level=FailureLevel.INFO,
-            )

--- a/cli/tests/pcluster/example_configs/awsbatch.full.yaml
+++ b/cli/tests/pcluster/example_configs/awsbatch.full.yaml
@@ -1,5 +1,5 @@
 Imds:
-  RequireImdsV2: true
+  ImdsSupport: v2.0
 Region: us-east-1
 Image:
   Os: alinux2  # alinux2 | centos7 | ubuntu1804 | ubuntu2004

--- a/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
+++ b/cli/tests/pcluster/example_configs/scheduler_plugin.full.yaml
@@ -1,5 +1,5 @@
 Imds:
-  RequireImdsV2: true
+  ImdsSupport: v2.0
 Region: us-east-1
 Image:
   Os: centos7

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -1,5 +1,5 @@
 Imds:
-  RequireImdsV2: true
+  ImdsSupport: v2.0
 Region: us-east-1
 Image:
   Os: centos7

--- a/cli/tests/pcluster/models/test_imagebuilder.py
+++ b/cli/tests/pcluster/models/test_imagebuilder.py
@@ -49,7 +49,6 @@ from tests.pcluster.test_utils import FAKE_NAME
                         ],
                     },
                     "build": {
-                        "imds": {"require_imds_v2": True},
                         "parent_image": "ami-0185634c5a8a37250",
                         "instance_type": "c5.xlarge",
                     },

--- a/cli/tests/pcluster/schemas/test_common_schema.py
+++ b/cli/tests/pcluster/schemas/test_common_schema.py
@@ -10,8 +10,9 @@
 # limitations under the License.
 import pytest
 from assertpy import assert_that
+from marshmallow import ValidationError
 
-from pcluster.schemas.common_schema import validate_json_format
+from pcluster.schemas.common_schema import ImdsSchema, validate_json_format
 
 
 @pytest.mark.parametrize(
@@ -23,3 +24,25 @@ from pcluster.schemas.common_schema import validate_json_format
 )
 def test_validate_json_format(data, expected_value):
     assert_that(validate_json_format(data)).is_equal_to(expected_value)
+
+
+@pytest.mark.parametrize(
+    "imds_support, failure_message",
+    [
+        ("unsupportedValue", "Must be one of"),
+        ("v1.0", None),
+        ("v2.0", None),
+    ],
+)
+def test_imds_schema(imds_support, failure_message):
+    imds_schema = {}
+
+    if imds_support:
+        imds_schema["ImdsSupport"] = imds_support
+
+    if failure_message:
+        with pytest.raises(ValidationError, match=failure_message):
+            ImdsSchema().load(imds_schema)
+    else:
+        imds = ImdsSchema().load(imds_schema)
+        assert_that(imds.imds_support).is_equal_to(imds_support)

--- a/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
+++ b/cli/tests/pcluster/schemas/test_imagebuilder_schema/test_imagebuilder_schema/imagebuilder_schema_dev.yaml
@@ -13,7 +13,7 @@ Image:
 
 Build:
   Imds:
-    RequireImdsV2: true
+    ImdsSupport: v2.0
   Iam:
     InstanceRole: arn:aws:iam::111122223333:role/executionServiceEC2Role/parallelcluster-imagebuilder-test-InstanceRole-J7MKRFYF6634
     CleanupLambdaRole: arn:aws:iam::111122223333:role/executionServiceEC2Role/parallelcluster-imagebuilder-test-LambdaRole-J7MKRFYF6634

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -545,7 +545,7 @@ def test_head_node_tags_from_instance_definition(mocker, config_file_name, expec
     "config_file_name",
     ["slurm.full.yaml", "awsbatch.full.yaml", "scheduler_plugin.full.yaml"],
 )
-def test_required_imds_v2(mocker, config_file_name):
+def test_with_imds_support_setting(mocker, config_file_name):
     mock_aws_api(mocker)
     mock_bucket(mocker)
     input_yaml, cluster = load_cluster_model_from_yaml(config_file_name)
@@ -567,7 +567,7 @@ def test_required_imds_v2(mocker, config_file_name):
     "config_file_name",
     ["slurm.required.yaml", "awsbatch.simple.yaml", "scheduler_plugin.required.yaml"],
 )
-def test_without_required_imds_v2(mocker, config_file_name):
+def test_without_imds_support_setting(mocker, config_file_name):
     mock_aws_api(mocker)
     mock_bucket(mocker)
     input_yaml, cluster = load_cluster_model_from_yaml(config_file_name)

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -3437,7 +3437,7 @@ def test_imagebuilder_root_volume(mocker, resource, response, expected_root_volu
             {
                 "imagebuilder": {
                     "build": {
-                        "imds": {"require_imds_v2": True},
+                        "imds": {"imds_support": "v2.0"},
                         "parent_image": "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x",
                         "instance_type": "c5.xlarge",
                     },
@@ -3460,7 +3460,7 @@ def test_imagebuilder_root_volume(mocker, resource, response, expected_root_volu
             {
                 "imagebuilder": {
                     "build": {
-                        "imds": {"require_imds_v2": False},
+                        "imds": {"imds_support": "v1.0"},
                         "parent_image": "arn:aws:imagebuilder:us-east-1:aws:image/amazon-linux-2-x86/x.x.x",
                         "instance_type": "c5.xlarge",
                     },

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -3431,7 +3431,7 @@ def test_imagebuilder_root_volume(mocker, resource, response, expected_root_volu
 
 
 @pytest.mark.parametrize(
-    "resource, response, expected_instance_metadata_options",
+    "resource, response, http_tokens",
     [
         (
             {
@@ -3454,7 +3454,7 @@ def test_imagebuilder_root_volume(mocker, resource, response, expected_root_volu
                     }
                 ],
             },
-            {"HttpTokens": "required"},
+            "required",
         ),
         (
             {
@@ -3477,7 +3477,7 @@ def test_imagebuilder_root_volume(mocker, resource, response, expected_root_volu
                     }
                 ],
             },
-            None,
+            "optional",
         ),
         (
             {
@@ -3499,11 +3499,11 @@ def test_imagebuilder_root_volume(mocker, resource, response, expected_root_volu
                     }
                 ],
             },
-            None,
+            "optional",
         ),
     ],
 )
-def test_imagebuilder_imds_settings(mocker, resource, response, expected_instance_metadata_options):
+def test_imagebuilder_imds_settings(mocker, resource, response, http_tokens):
     mock_aws_api(mocker)
     mocker.patch("pcluster.imagebuilder_utils.get_ami_id", return_value="ami-0185634c5a8a37250")
     mocker.patch(
@@ -3522,8 +3522,9 @@ def test_imagebuilder_imds_settings(mocker, resource, response, expected_instanc
         generated_template.get("Resources")
         .get("InfrastructureConfiguration")
         .get("Properties")
-        .get("InstanceMetadataOptions", None)
-    ).is_equal_to(expected_instance_metadata_options)
+        .get("InstanceMetadataOptions")
+        .get("HttpTokens")
+    ).is_equal_to(http_tokens)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -321,3 +321,8 @@ def test_yaml_load(yaml_string, expected_yaml_dict, expected_error):
     else:
         yaml_dict = yaml_load(yaml_string)
         assert_that(yaml_dict).is_equal_to(expected_yaml_dict)
+
+
+@pytest.mark.parametrize("imds_support, http_tokens", [("v1.0", "optional"), ("v2.0", "required")])
+def test_get_http_token_settings(imds_support, http_tokens):
+    assert_that(utils.get_http_tokens_setting(imds_support)).is_equal_to(http_tokens)

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -9,7 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
-from assertpy import assert_that, soft_assertions
+from assertpy import assert_that
 from munch import DefaultMunch
 
 from pcluster.aws.aws_resources import InstanceTypeInfo
@@ -42,7 +42,6 @@ from pcluster.validators.cluster_validators import (
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
     RegionValidator,
-    RequireImdsV2Validator,
     RootVolumeSizeValidator,
     SchedulableMemoryValidator,
     SchedulerOsValidator,
@@ -95,30 +94,6 @@ def test_cluster_name_validator(cluster_name, should_trigger_error):
 def test_region_validator(region, expected_message):
     actual_failures = RegionValidator().execute(region)
     assert_failure_messages(actual_failures, expected_message)
-
-
-@pytest.mark.parametrize(
-    "require_imds_v2, expected_message, expected_failure_level",
-    [
-        (
-            False,
-            "The current cluster configuration does not disable IMDSv1, "
-            "which we plan to disable by default in future versions. "
-            "If you do not explicitly need to use IMDSv1 enforce IMDSv2 "
-            "usage by setting the RequireImdsV2 configuration parameter "
-            "to true (see documentation at: https://docs.aws.amazon.com/"
-            "parallelcluster/latest/ug/cluster-configuration-file-v3.html"
-            "#cluster-configuration-file-v3.properties)",
-            FailureLevel.INFO,
-        ),
-        (True, None, None),
-    ],
-)
-def test_require_imds_v2_validator(require_imds_v2, expected_message, expected_failure_level):
-    actual_failures = RequireImdsV2Validator().execute(require_imds_v2)
-    with soft_assertions():
-        assert_failure_messages(actual_failures, expected_message)
-        assert_failure_level(actual_failures, expected_failure_level)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/validators/test_imagebuilder_validators.py
+++ b/cli/tests/pcluster/validators/test_imagebuilder_validators.py
@@ -10,18 +10,15 @@
 # limitations under the License.
 
 import pytest
-from assertpy import soft_assertions
 
 from pcluster.aws.aws_resources import ImageInfo
-from pcluster.validators.common import FailureLevel
 from pcluster.validators.imagebuilder_validators import (
     AMIVolumeSizeValidator,
     ComponentsValidator,
-    RequireImdsV2Validator,
     SecurityGroupsAndSubnetValidator,
 )
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
-from tests.pcluster.validators.utils import assert_failure_level, assert_failure_messages
+from tests.pcluster.validators.utils import assert_failure_messages
 
 
 @pytest.mark.parametrize(
@@ -137,25 +134,3 @@ def test_components_validator(components, expected_message):
 def test_security_groups_and_subnet_validator(security_group_ids, subnet_ids, expected_message):
     actual_failures = SecurityGroupsAndSubnetValidator().execute(security_group_ids, subnet_ids)
     assert_failure_messages(actual_failures, expected_message)
-
-
-@pytest.mark.parametrize(
-    "require_imds_v2, expected_message, expected_failure_level",
-    [
-        (
-            False,
-            "The current build image configuration does not disable IMDSv1, "
-            "which we plan to disable by default in future versions. If you do "
-            "not explicitly need to use IMDSv1 enforce IMDSv2 usage by setting the "
-            "RequireImdsV2 configuration parameter to true (see documentation at: "
-            "https://docs.aws.amazon.com/parallelcluster/latest/ug/Build-v3.html)",
-            FailureLevel.INFO,
-        ),
-        (True, None, None),
-    ],
-)
-def test_require_imds_v2_validator(require_imds_v2, expected_message, expected_failure_level):
-    actual_failures = RequireImdsV2Validator().execute(require_imds_v2)
-    with soft_assertions():
-        assert_failure_messages(actual_failures, expected_message)
-        assert_failure_level(actual_failures, expected_failure_level)

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -578,8 +578,8 @@ def inject_additional_image_configs_settings(image_config, request):
     with open(image_config, encoding="utf-8") as conf_file:
         config_content = yaml.load(conf_file, Loader=yaml.SafeLoader)
 
-    if not dict_has_nested_key(config_content, ("Build", "Imds", "RequireImdsV2")):
-        dict_add_nested_key(config_content, True, ("Build", "Imds", "RequireImdsV2"))
+    if not dict_has_nested_key(config_content, ("Build", "Imds", "ImdsSupport")):
+        dict_add_nested_key(config_content, "v2.0", ("Build", "Imds", "ImdsSupport"))
 
     if request.config.getoption("createami_custom_chef_cookbook") and not dict_has_nested_key(
         config_content, ("DevSettings", "Cookbook", "ChefCookbook")
@@ -607,8 +607,8 @@ def inject_additional_config_settings(  # noqa: C901
     with open(cluster_config, encoding="utf-8") as conf_file:
         config_content = yaml.safe_load(conf_file)
 
-    if not dict_has_nested_key(config_content, ("Imds", "RequireImdsV2")):
-        dict_add_nested_key(config_content, True, ("Imds", "RequireImdsV2"))
+    if not dict_has_nested_key(config_content, ("Imds", "ImdsSupport")):
+        dict_add_nested_key(config_content, "v2.0", ("Imds", "ImdsSupport"))
 
     if request.config.getoption("custom_chef_cookbook") and not dict_has_nested_key(
         config_content, ("DevSettings", "Cookbook", "ChefCookbook")

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -76,23 +76,23 @@ def test_create_wrong_pcluster_version(
 
 @pytest.mark.usefixtures("instance", "scheduler")
 @pytest.mark.parametrize(
-    "imds_secured, users_allow_list, require_imds_v2",
+    "imds_secured, users_allow_list, imds_support",
     [
-        (True, {"root": True, "pcluster-admin": True, "slurm": False}, True),
-        (False, {"root": True, "pcluster-admin": True, "slurm": True}, False),
+        (True, {"root": True, "pcluster-admin": True, "slurm": False}, "v2.0"),
+        (False, {"root": True, "pcluster-admin": True, "slurm": True}, "v1.0"),
     ],
 )
 def test_create_imds_secured(
-    imds_secured, users_allow_list, require_imds_v2, region, os, pcluster_config_reader, clusters_factory, architecture
+    imds_secured, users_allow_list, imds_support, region, os, pcluster_config_reader, clusters_factory, architecture
 ):
     """
     Test IMDS access with different configurations.
     In particular, it also verifies that IMDS access is preserved on instance reboot.
-    Also checks that the cluster instances respect the desired RequireImdsV2 setting.
+    Also checks that the cluster instances respect the desired ImdsSupport setting.
     """
-    cluster_config = pcluster_config_reader(imds_secured=imds_secured, require_imds_v2=require_imds_v2)
+    cluster_config = pcluster_config_reader(imds_secured=imds_secured, imds_support=imds_support)
     cluster = clusters_factory(cluster_config, raise_on_error=True)
-    status = "required" if require_imds_v2 else "optional"
+    status = "required" if imds_support == "v2.0" else "optional"
 
     assert_head_node_is_running(region, cluster)
     assert_aws_identity_access_is_correct(cluster, users_allow_list)

--- a/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
@@ -1,5 +1,5 @@
 Imds:
-  RequireImdsV2: {{ require_imds_v2 }}
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -103,7 +103,7 @@ def test_build_image(
     """
     Test build image for given region and os.
 
-    Also check that the build instance has the desired IMDSv2 settings (RequireImdsV2: true).
+    Also check that the build instance has the desired ImdsSupport setting (v2.0, so IMDSv2 is required).
     """
     image_id = generate_stack_name("integ-tests-build-image", request.config.getoption("stackname_suffix"))
 
@@ -151,7 +151,7 @@ def test_kernel4_build_image_run_cluster(
     """
     Test build image for given region and os and run a job in a new cluster created from the new images.
 
-    Also check that the build instance has the desired IMDSv2 settings (RequireImdsV2: false).
+    Also check that the build instance has the desired ImdsSupport setting (v1.0, so IMDSv2 is optional).
     """
 
     # Get base AMI from kernel4

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -8,7 +8,7 @@ Image:
 
 Build:
     Imds:
-        RequireImdsV2: true
+        ImdsSupport: v2.0
     Iam:
         InstanceRole: {{ instance_role }}
     InstanceType: {{ instance }}

--- a/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/image.config.yaml
@@ -1,5 +1,5 @@
 Build:
     Imds:
-        RequireImdsV2: false
+        ImdsSupport: v1.0
     InstanceType: {{ instance }}
     ParentImage: {{ parent_image }}


### PR DESCRIPTION
#### Notes
This patch realigns the `Imds` settings in cluster and build image configs to our desired user experience, through the following changes:
- The `Imds>RequireImdsV2` boolean property in the cluster config and the `Build` section of the build image config becomes `Imds>ImdsSupport`, a string with a value of `v2.0` or `v1.0` (default `v1.0`) which indicates the level of IMDS support, with the meaning that version greater or equal to the setting are supported (i.e. by selecting `v2.0` only IMDSv2 is enabled, while with `v1.0` both IMDSv1 and IMDSv2 are enabled.
- The validators that returned a message at `INFO` level if the property was not set to require IMDSv2 have been removed, because we felt that they made for an untidy user experience and did not significantly increased the customer exposure to our future changes compared to just documenting the change and plan to change the default setting in the future.
- In light of the property change, I thought to explicitly set both the `required` and `optional` values depending on the chosen IMDS setting, to future proof our code in the off chance that EC2 changed their default to something other than `optional`; this also makes the code closer to the semantics of the property, rather than relying on the EC2 default.

#### Tests
- Unit tests.
- Integration tests with config:
```yaml
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
    test_createami.py::test_kernel4_build_image_run_cluster:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          schedulers: ["slurm"]
          oss: ["alinux2"]
  create:
    test_create.py::test_create_imds_secured:
      dimensions:
        - regions: [ "eu-central-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: [ "slurm" ]
```

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
