### PR TITLE
Add integration test for db server authentication

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
@@ -56,14 +56,11 @@ def _require_server_identity(remote_command_executor, test_resources_dir, region
     )
 
 
-@retry(stop_max_attempt_number=3, wait_fixed=seconds(10))
-def _assert_accounting_is_enabled(remote_command_executor):
-    assert_that(_is_accounting_enabled(remote_command_executor)).is_true()
-
-
 def _test_require_server_identity(remote_command_executor, test_resources_dir, region):
     _require_server_identity(remote_command_executor, test_resources_dir, region)
-    _assert_accounting_is_enabled(remote_command_executor)
+    retry(stop_max_attempt_number=3, wait_fixed=seconds(10))(_is_accounting_enabled)(
+        remote_command_executor,
+    )
 
 
 def _test_slurmdb_users(remote_command_executor, scheduler_commands, test_resources_dir):

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/resources/require_server_identity.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/resources/require_server_identity.sh
@@ -8,7 +8,7 @@ CA_PATH="/tmp/slurm"
 CA_FILE_PATH="${CA_PATH}/${CA_NAME}"
 SLURMDBD_CONFIG_FILE="/opt/slurm/etc/slurmdbd.conf"
 
-wget ${CA_URL} -nH -x --cut-dirs=1 -P ${CA_PATH}
+wget ${CA_URL} -P ${CA_PATH}
 
 echo "Clearing previous CA Setting"
 sed -i "/^StorageParameters\s*=/d" "${SLURMDBD_CONFIG_FILE}"

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/resources/require_server_identity.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/resources/require_server_identity.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+CA_URL=$1
+CA_NAME=$2
+CA_PATH="/tmp/slurm"
+CA_FILE_PATH="${CA_PATH}/${CA_NAME}"
+SLURMDBD_CONFIG_FILE="/opt/slurm/etc/slurmdbd.conf"
+
+wget ${CA_URL} -nH -x --cut-dirs=1 -P ${CA_PATH}
+
+echo "Clearing previous CA Setting"
+sed -i "s/^StorageParameters=.*$//g" "${SLURMDBD_CONFIG_FILE}"
+echo "StorageParameters=" >> "${SLURMDBD_CONFIG_FILE}"
+
+echo "Setting 'StorageParameters' SSL_CA=${CA_FILE_PATH}"
+sed -i "s:^StorageParameters=.*$:StorageParameters=SSL_CA=${CA_FILE_PATH}:g" "${SLURMDBD_CONFIG_FILE}"
+
+echo "Restarting slurmdbd service"
+systemctl restart slurmdbd

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/resources/require_server_identity.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/resources/require_server_identity.sh
@@ -11,11 +11,10 @@ SLURMDBD_CONFIG_FILE="/opt/slurm/etc/slurmdbd.conf"
 wget ${CA_URL} -nH -x --cut-dirs=1 -P ${CA_PATH}
 
 echo "Clearing previous CA Setting"
-sed -i "s/^StorageParameters=.*$//g" "${SLURMDBD_CONFIG_FILE}"
-echo "StorageParameters=" >> "${SLURMDBD_CONFIG_FILE}"
+sed -i "/^StorageParameters\s*=/d" "${SLURMDBD_CONFIG_FILE}"
 
 echo "Setting 'StorageParameters' SSL_CA=${CA_FILE_PATH}"
-sed -i "s:^StorageParameters=.*$:StorageParameters=SSL_CA=${CA_FILE_PATH}:g" "${SLURMDBD_CONFIG_FILE}"
+echo "StorageParameters=SSL_CA=${CA_FILE_PATH}" >> "${SLURMDBD_CONFIG_FILE}"
 
 echo "Restarting slurmdbd service"
 systemctl restart slurmdbd


### PR DESCRIPTION


Signed-off-by: David Pratt <davprat@amazon.com>


### Description of changes
* This change adds an integration test to make sure enabling MySQL database server authentication on slurmdbd works.
* Serverless template will be removed from this change as it is in another PR.

### Tests
* Manually ran integration test for slurm accounting.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
