### PR TITLE
Require IMDSv2 in PC API Cfn infrastructure

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -1073,6 +1073,8 @@ Resources:
           - NonDefaultVpc
           - [!Ref InfrastructureConfigurationSecurityGroup]
           - !Ref AWS::NoValue
+      InstanceMetadataOptions:
+        HttpTokens: required
 
   PrivateEcrRepository:
     Condition: DoNotUseCustomEcrImageUri


### PR DESCRIPTION
#### Notes
This patch requires IMDSv2 for the ImageBuilder build instance used when setting up the PC API infrastructure with CloudFormation, which we use to copy the Docker image used by the Lambda into the customer's private ECR repository. This change is safe because there are no custom components that do `curl` calls with IMDSv2, (see the `EcrImageRecipe` resource).

#### Tests
Stack deployed in personal account.


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
