### PR TITLE
Temporarily disable test_protected_mode on Slurm scheduler plugin

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -465,12 +465,13 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm"]
-{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
-      - regions: ["eu-west-2"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["slurm_plugin"]
-{%- endif %}
+# Temporarily disable test_protected_mode for the Slurm scheduler plugin
+#{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
+#      - regions: ["eu-west-2"]
+#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+#        oss: ["alinux2"]
+#        schedulers: ["slurm_plugin"]
+#{%- endif %}
   test_slurm.py::test_fast_capacity_failover:
     dimensions:
       - regions: ["ap-east-1"]


### PR DESCRIPTION
### Description of changes
Currently aws-parallelcluster-node is pinned to `release-3.2` on the scheduler plugin due to incompatibilities with features recently implemented in the parallelcluster daemons. This means the workaround for the nodes stuck in a bad state cannot be  implemented in the plugin.

### References
* See the [PR for the workaround implemented in aws-parallelcluster-node](https://github.com/aws/aws-parallelcluster-node/pull/447)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
