### PR TITLE
[3.3] Update the error message for the PlacementGroupCapacityReservationValidator

### DIFF
--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -337,8 +337,8 @@ class PlacementGroupCapacityReservationValidator(Validator):
                         open_or_targeted = True
             if not (pg_match or open_or_targeted):
                 self._add_failure(
-                    f"The placement group provided '{chosen_pg}' does not match any placement group in the set of "
-                    f"target PG/ODCRs and there are no open or targeted '{instance_type}' ODCRs included.",
+                    f"The placement group provided '{chosen_pg}' targets the '{instance_type}' instance type but there "
+                    f"are no ODCRs included in the resource group that target that instance type.",
                     FailureLevel.ERROR,
                 )
             elif open_or_targeted:

--- a/cli/tests/pcluster/validators/test_ec2_validators.py
+++ b/cli/tests/pcluster/validators/test_ec2_validators.py
@@ -755,8 +755,8 @@ mock_odcrs = [
             "mock-subnet-3",
             ["mock-type"],
             mock_odcrs[1:2],
-            "The placement group provided 'test' does not match any placement group in the set of target PG/ODCRs and "
-            "there are no open or targeted 'mock-type' ODCRs included.",
+            "The placement group provided 'test' targets the 'mock-type' instance type but there "
+            "are no ODCRs included in the resource group that target that instance type.",
         ),
         (
             "test-2",
@@ -764,8 +764,8 @@ mock_odcrs = [
             "mock-subnet-3",
             ["mock-type"],
             mock_odcrs[1:2],
-            "The placement group provided 'test-2' does not match any placement group in the set of target PG/ODCRs "
-            "and there are no open or targeted 'mock-type' ODCRs included.",
+            "The placement group provided 'test-2' targets the 'mock-type' instance type but there "
+            "are no ODCRs included in the resource group that target that instance type.",
         ),
     ],
 )


### PR DESCRIPTION
Update the error message for the PlacementGroupCapacityReservationValidator
when there isn't a capacity reservation with the instance type

Signed-off-by: Ryan Anderson <ndry@amazon.com>

### Description of changes
* Update the error message to be clearer

### Tests
* Updated unit tests for the validator

### References
* https://sim.amazon.com/issues/PCLUSTER-5372

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
