### PR TITLE
3.x [bugfix] Fix behaviour of list-cluster-log-streams filters parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ CHANGELOG
 - SlurmQueues.Networking.PlacementGroup.Enabled alone will now create a unique managed placement for each compute resource instead of a single managed placement group for all compute resources
 
 **BUG FIXES**
+- Fix validation of `filters` parameter in `ListClusterLogStreams` command to fail when incorrect filters are passed.
 - Fix validation of parameter `SharedStorage/EfsSettings`: now validation fails when `FileSystemId` is specified
   along with other `SharedStorage/EfsSettings` parameters, whereas it was previously ignoring them.
 - Fix cluster update when changing the order of SharedStorage together with other changes in the configuration.

--- a/api/README.md
+++ b/api/README.md
@@ -73,6 +73,7 @@ The usual development workflow to follow when extending the ParallelCluster API 
    to the aws-parallelcluster source code:
    1. Changes to the API request/response model require changes to files under `cli/src/pcluster/api/models`. The
       newly generated models in the server stub can be imported as is, just mind fixing unused imports and formatting.
+      To avoid huge diffs import only models related to you modifications.
    2. Changes to the API operations and request/response model require an update to the controllers (namely the handlers
       of the various API endpoints). The updated controller signature can be retrieved from the generated stub files and
       relevant changes need to be applied to controllers under the `cli/src/pcluster/api/controllers` directory.

--- a/api/README.md
+++ b/api/README.md
@@ -73,7 +73,7 @@ The usual development workflow to follow when extending the ParallelCluster API 
    to the aws-parallelcluster source code:
    1. Changes to the API request/response model require changes to files under `cli/src/pcluster/api/models`. The
       newly generated models in the server stub can be imported as is, just mind fixing unused imports and formatting.
-      To avoid huge diffs import only models related to you modifications.
+      To avoid huge diffs import only models related to your modifications.
    2. Changes to the API operations and request/response model require an update to the controllers (namely the handlers
       of the various API endpoints). The updated controller signature can be retrieved from the generated stub files and
       relevant changes need to be applied to controllers under the `cli/src/pcluster/api/controllers` directory.

--- a/api/client/src/pcluster_client/api/cluster_logs_api.py
+++ b/api/client/src/pcluster_client/api/cluster_logs_api.py
@@ -271,7 +271,7 @@ class ClusterLogsApi(object):
                     'next_token': 'query',
                 },
                 'collection_format_map': {
-                    'filters': 'multi',
+                    'filters': 'ssv',
                 }
             },
             headers_map={

--- a/api/spec/build-model.sh
+++ b/api/spec/build-model.sh
@@ -8,4 +8,6 @@ then
     exit 1
 fi
 pushd smithy && ../../gradlew build && popd
-yq eval -P smithy/build/smithyprojections/smithy/source/openapi/ParallelCluster.openapi.json > openapi/ParallelCluster.openapi.yaml
+GENERATED_YAML_PATH="smithy/build/smithyprojections/smithy/source/openapi/ParallelCluster.openapi.json"
+./spec_overrides.sh "$GENERATED_YAML_PATH"
+yq eval -P $GENERATED_YAML_PATH > openapi/ParallelCluster.openapi.yaml

--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -721,7 +721,7 @@ paths:
             Accepted filters are:
             private-dns-name - The short form of the private DNS name of the instance (e.g. ip-10-0-0-101).
             node-type - The node type, the only accepted value for this filter is HeadNode.
-          style: form
+          style: spaceDelimited
           schema:
             type: array
             items:

--- a/api/spec/spec_overrides.sh
+++ b/api/spec/spec_overrides.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ex
+
+YAML_PATH=$1
+export INDEX="$(yq '.paths["/v3/clusters/{clusterName}/logstreams"].get.parameters.[] | select(.name == "filters") | path | .[-1]' "$YAML_PATH")"
+yq e -i '.paths["/v3/clusters/{clusterName}/logstreams"].get.parameters[env(INDEX)].style = "spaceDelimited"' "$YAML_PATH"

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -851,7 +851,7 @@ paths:
             type: string
           type: array
           uniqueItems: true
-        style: form
+        style: spaceDelimited
       - description: Token to use for paginated requests.
         explode: true
         in: query

--- a/cli/tests/pcluster/api/controllers/test_cluster_logs_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_logs_controller.py
@@ -425,7 +425,7 @@ class TestListClusterLogStreams:
             ),
             (
                 ["Name=private-dns-name,Values=ip-10-0-0-101,ip-10-0-0-102", "Name=node-type,Value=HeadNode"],
-                "filters parameter must be in the form",
+                "provided filters parameter 'Name=node-type,Value=HeadNode' must be in the form",
             ),
         ],
     )


### PR DESCRIPTION
### Description of changes

- [bugfix] Fix behaviour of list-cluster-log-streams filters parameter
- [api-spec] Add openapi spec overrides method
- [api-README] Fix models import paragraph

This change fixes both the API specification, the controller and the client files related to the list-cluster-log-streams to allow both the API and CLI to have the correct behaviour when handling invalid filters.
    
In addition I created a file in which we can specify all the overrides to the specification we need, in particular this is useful when Smithy is missing needed features. The first override specified here is about the 'style' of a query parameter.
    
I also better specified which models to import after generating the Python server stub to help the developer in his/hers activities.

Documentation is not impacted by those changes as the CLI documentation is correct and the API documentation is not yet available (although I'm monitoring it)
    
    Signed-off-by: Edoardo Antonini <eantonin@amazon.com>


### Tests
* Added unit tests
* Manually tested the command with both API and CLI

### References
* [list-cluster-log-stream CLI command](https://docs.aws.amazon.com/parallelcluster/latest/ug/pcluster.list-cluster-log-streams-v3.html)
* [spaceDelimited style vs form style](https://swagger.io/docs/specification/serialization/#:~:text=values%20get%20prefixed.-,Query%20Parameters,-Query%20parameters%20support)

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
