### PR TITLE
Fix JobState assertion for memory-based scheduling integ test

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1975,7 +1975,7 @@ def _test_memory_based_scheduling_enabled_true(
         }
     )
     slurm_commands.wait_job_completed(job_id_1)
-    assert_that(slurm_commands.get_job_info(job_id_1, field="JobState")).is_equal_to("OUT_OF_MEMORY")
+    assert_that(slurm_commands.get_job_info(job_id_1, field="JobState")).is_equal_to("FAILED")
     slurm_commands.wait_job_completed(job_id_2)
     assert_that(slurm_commands.get_job_info(job_id_2, field="JobState")).is_equal_to("COMPLETED")
 


### PR DESCRIPTION
### Description of changes
* As of Slurm 22.05.4 the JobState of a job where a step fails due to OOM is FAILED and not OUT_OF_MEMORY (only the job step is assigned the OUT_OF_MEMORY state).
* This relates only to the logic of the integration test, not to the logic of the product itself.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
