### PR TITLE
[develop] Rename InstanceTypeLIst to Instances

### DIFF
--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -212,7 +212,7 @@ def configure(args):  # noqa: C901
                     if compute_instance_type not in [
                         instances["InstanceType"]
                         for compute_resource in compute_resources
-                        for instances in compute_resource["InstanceTypeList"]
+                        for instances in compute_resource["Instances"]
                     ]:
                         break
                     print(
@@ -247,7 +247,7 @@ def configure(args):  # noqa: C901
             else:
                 compute_resource = {
                     "Name": compute_resource_name,
-                    "InstanceTypeList": [{"InstanceType": compute_instance_type}],
+                    "Instances": [{"InstanceType": compute_instance_type}],
                     "MinCount": min_cluster_size,
                     "MaxCount": max_cluster_size,
                 }

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -142,13 +142,13 @@ from pcluster.validators.fsx_validators import (
     FsxStorageTypeOptionsValidator,
 )
 from pcluster.validators.iam_validators import IamPolicyValidator, InstanceProfileValidator, RoleValidator
-from pcluster.validators.instance_type_list_validators import (
-    InstanceTypeListAcceleratorsValidator,
-    InstanceTypeListAllocationStrategyValidator,
-    InstanceTypeListCPUValidator,
-    InstanceTypeListEFAValidator,
-    InstanceTypeListMemorySchedulingValidator,
-    InstanceTypeListNetworkingValidator,
+from pcluster.validators.instances_validators import (
+    InstancesAcceleratorsValidator,
+    InstancesAllocationStrategyValidator,
+    InstancesCPUValidator,
+    InstancesEFAValidator,
+    InstancesMemorySchedulingValidator,
+    InstancesNetworkingValidator,
 )
 from pcluster.validators.kms_validators import KmsKeyIdEncryptedValidator, KmsKeyValidator
 from pcluster.validators.networking_validators import ElasticIpValidator, SecurityGroupsValidator, SubnetsValidator
@@ -1730,7 +1730,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
 
 
 class FlexibleInstanceType(Resource):
-    """Represent an instance type listed in the InstanceTypeList of a ComputeResources."""
+    """Represent an instance type listed in the Instances of a ComputeResources."""
 
     def __init__(self, instance_type: str, **kwargs):
         super().__init__(**kwargs)
@@ -1740,14 +1740,14 @@ class FlexibleInstanceType(Resource):
 class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
     """Represents a Slurm Compute Resource with Multiple Instance Types."""
 
-    def __init__(self, instance_type_list: List[FlexibleInstanceType], **kwargs):
+    def __init__(self, instances: List[FlexibleInstanceType], **kwargs):
         super().__init__(**kwargs)
-        self.instance_type_list = Resource.init_param(instance_type_list)
+        self.instances = Resource.init_param(instances)
 
     @property
     def instance_types(self) -> List[str]:
         """Return list of instance type names in this compute resource."""
-        return [flexible_instance_type.instance_type for flexible_instance_type in self.instance_type_list]
+        return [flexible_instance_type.instance_type for flexible_instance_type in self.instances]
 
     @property
     def disable_simultaneous_multithreading_manually(self) -> bool:
@@ -2695,12 +2695,12 @@ class SlurmClusterConfig(CommonSchedulerClusterConfig):
                         memory_scheduling_enabled=self.scheduling.settings.enable_memory_based_scheduling,
                     )
                     flexible_instance_types_validators = [
-                        InstanceTypeListCPUValidator,
-                        InstanceTypeListAcceleratorsValidator,
-                        InstanceTypeListEFAValidator,
-                        InstanceTypeListNetworkingValidator,
-                        InstanceTypeListAllocationStrategyValidator,
-                        InstanceTypeListMemorySchedulingValidator,
+                        InstancesCPUValidator,
+                        InstancesAcceleratorsValidator,
+                        InstancesEFAValidator,
+                        InstancesNetworkingValidator,
+                        InstancesAllocationStrategyValidator,
+                        InstancesMemorySchedulingValidator,
                     ]
                     for validator in flexible_instance_types_validators:
                         self._register_validator(validator, **validator_args)

--- a/cli/src/pcluster/validators/instances_validators.py
+++ b/cli/src/pcluster/validators/instances_validators.py
@@ -42,7 +42,7 @@ class _FlexibleInstanceTypesValidatorMixin:
             instance_type = current_instance_type
 
 
-class InstanceTypeListCPUValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
+class InstancesCPUValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
     """Confirm CPU requirements for Flexible Instance Types."""
 
     def _validate(
@@ -74,7 +74,7 @@ class InstanceTypeListCPUValidator(Validator, _FlexibleInstanceTypesValidatorMix
             )
 
 
-class InstanceTypeListAcceleratorsValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
+class InstancesAcceleratorsValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
     """Confirm Accelerator requirements for Flexible Instance Types."""
 
     def _validate(
@@ -116,7 +116,7 @@ class InstanceTypeListAcceleratorsValidator(Validator, _FlexibleInstanceTypesVal
         )
 
 
-class InstanceTypeListEFAValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
+class InstancesEFAValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
     """Validate EFA requirements for Flexible Instance Types."""
 
     def _validate(
@@ -175,7 +175,7 @@ class InstanceTypeListEFAValidator(Validator, _FlexibleInstanceTypesValidatorMix
                 )
 
 
-class InstanceTypeListNetworkingValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
+class InstancesNetworkingValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
     """Confirm Networking requirements for Flexible Instance Types."""
 
     def _validate(
@@ -215,7 +215,7 @@ class InstanceTypeListNetworkingValidator(Validator, _FlexibleInstanceTypesValid
             )
 
 
-class InstanceTypeListAllocationStrategyValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
+class InstancesAllocationStrategyValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
     """Confirm Allocation Strategy matches with the Capacity Type."""
 
     def _validate(self, compute_resource_name: str, capacity_type: Enum, allocation_strategy: Enum, **kwargs):
@@ -232,7 +232,7 @@ class InstanceTypeListAllocationStrategyValidator(Validator, _FlexibleInstanceTy
             )
 
 
-class InstanceTypeListMemorySchedulingValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
+class InstancesMemorySchedulingValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
     """Validate support for Memory-based Scheduling when using Flexible Instance Types."""
 
     def _validate(
@@ -246,7 +246,7 @@ class InstanceTypeListMemorySchedulingValidator(Validator, _FlexibleInstanceType
         if memory_scheduling_enabled and len(instance_types_info.items()) > 1:
             self._add_failure(
                 "Memory-based scheduling is only supported for Compute Resources using either 'InstanceType' or "
-                f"'InstanceTypeList' with one instance type. Compute Resource {compute_resource_name} has more than "
+                f"'Instances' with one instance type. Compute Resource {compute_resource_name} has more than "
                 "one instance type specified.",
                 FailureLevel.ERROR,
             )

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: c5n18xlarge
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5n.18xlarge
           MinCount: 0
           MaxCount: 10

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_efa_not_supported/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_efa_not_supported/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: c5n18xlarge
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5n.18xlarge
           MinCount: 0
           MaxCount: 10

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: c5n18xlarge
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5n.18xlarge
           MinCount: 0
           MaxCount: 10

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: c5n18xlarge
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5n.18xlarge
           MinCount: 0
           MaxCount: 10

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: c5n18xlarge
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5n.18xlarge
           MinCount: 0
           MaxCount: 10

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 10

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 10

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/pcluster.config.yaml
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: myqueue
       ComputeResources:
         - Name: t2micro
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 0
           MaxCount: 14

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -127,7 +127,7 @@ class TestBaseClusterConfig:
         cluster_config._register_validators()
         assert_that(cluster_config._validators).is_not_empty()
 
-    def test_instance_type_list_in_slurm_queue(self):
+    def test_instances_in_slurm_queue(self):
         queue = SlurmQueue(
             name="queue0",
             networking=SlurmQueueNetworking(subnet_ids=["subnet"]),
@@ -136,7 +136,7 @@ class TestBaseClusterConfig:
                 SlurmComputeResource(name="compute_resource_2", instance_type="t2.micro"),
                 SlurmFlexibleComputeResource(
                     name="compute_resource_3",
-                    instance_type_list=[
+                    instances=[
                         FlexibleInstanceType(instance_type="c5n.4xlarge"),
                         FlexibleInstanceType(instance_type="c5n.9xlarge"),
                         FlexibleInstanceType(instance_type="c5n.18xlarge"),
@@ -144,7 +144,7 @@ class TestBaseClusterConfig:
                 ),
                 SlurmFlexibleComputeResource(
                     name="compute_resource_4",
-                    instance_type_list=[
+                    instances=[
                         FlexibleInstanceType(instance_type="c5n.4xlarge"),
                     ],
                 ),

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -341,7 +341,7 @@ def test_scheduling_schema(mocker, config_dict, failure_message):
                 "ComputeResources": [
                     {
                         "Name": "compute_resource1",
-                        "InstanceTypeList": [{"InstanceType": "c5.2xlarge"}],
+                        "Instances": [{"InstanceType": "c5.2xlarge"}],
                     }
                 ],
             },
@@ -356,14 +356,14 @@ def test_scheduling_schema(mocker, config_dict, failure_message):
                 "ComputeResources": [
                     {
                         "Name": "compute_resource1",
-                        "InstanceTypeList": [{"InstanceType": "c5.2xlarge"}, {"InstanceType": "c4.2xlarge"}],
+                        "Instances": [{"InstanceType": "c5.2xlarge"}, {"InstanceType": "c4.2xlarge"}],
                     },
                     {"Name": "compute_resource2", "InstanceType": "c4.2xlarge"},
                 ],
             },
             "",
         ),
-        # Failing to specify either InstanceType or InstanceTypeList should return a validation error
+        # Failing to specify either InstanceType or Instances should return a validation error
         (
             {
                 "Name": "Flex-Queue",
@@ -375,9 +375,9 @@ def test_scheduling_schema(mocker, config_dict, failure_message):
                     }
                 ],
             },
-            "A Compute Resource needs to specify either InstanceType or InstanceTypeList.",
+            "A Compute Resource needs to specify either InstanceType or Instances.",
         ),
-        # Mixing InstanceType and InstanceTypeList in a Compute Resource should return a validation error
+        # Mixing InstanceType and Instances in a Compute Resource should return a validation error
         (
             {
                 "Name": "Mixed-Instance-Types",
@@ -387,20 +387,20 @@ def test_scheduling_schema(mocker, config_dict, failure_message):
                     {
                         "Name": "compute_resource1",
                         "InstanceType": "c5.2xlarge",
-                        "InstanceTypeList": [{"InstanceType": "c4.2xlarge"}],
+                        "Instances": [{"InstanceType": "c4.2xlarge"}],
                     },
                 ],
             },
-            "A Compute Resource needs to specify either InstanceType or InstanceTypeList.",
+            "A Compute Resource needs to specify either InstanceType or Instances.",
         ),
-        # InstanceTypeList in a Compute Resource should not have duplicate instance types
+        # Instances in a Compute Resource should not have duplicate instance types
         (
             {
                 "Name": "DuplicateInstanceTypes",
                 "ComputeResources": [
                     {
                         "Name": "compute_resource1",
-                        "InstanceTypeList": [
+                        "Instances": [
                             {"InstanceType": "c4.2xlarge"},
                             {"InstanceType": "c5.xlarge"},
                             {"InstanceType": "c5a.xlarge"},

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_compute_launch_template_properties/cluster-using-flexible-instance-types.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_compute_launch_template_properties/cluster-using-flexible-instance-types.yaml
@@ -14,7 +14,7 @@ Scheduling:
     AllocationStrategy: lowest-price
     ComputeResources:
     - Name: testcomputeresource
-      InstanceTypeList:
+      Instances:
         - InstanceType: t2.micro
         - InstanceType: c4.xlarge
       MinCount: 0

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -23,7 +23,7 @@ from pcluster.validators import (
     ec2_validators,
     fsx_validators,
     iam_validators,
-    instance_type_list_validators,
+    instances_validators,
     kms_validators,
     networking_validators,
     s3_validators,
@@ -42,7 +42,7 @@ def _mock_all_validators(mocker, mockers, additional_modules=None):
         fsx_validators,
         kms_validators,
         iam_validators,
-        instance_type_list_validators,
+        instances_validators,
         networking_validators,
         s3_validators,
     ]
@@ -72,15 +72,13 @@ def _load_and_validate(config_path):
 def _assert_instance_architecture(expected_instance_architecture_validator_input, validator):
     for call_index, validator_call in enumerate(validator.call_args_list):
         args, kwargs = validator_call
-        instance_type_list = [
-            instance_type_info.instance_type() for instance_type_info in kwargs.get("instance_type_info_list")
-        ]
+        instances = [instance_type_info.instance_type() for instance_type_info in kwargs.get("instance_type_info_list")]
         architecture = kwargs.get("architecture")
-        expected_instance_type_list = expected_instance_architecture_validator_input[call_index].get("instance_types")
+        expected_instances = expected_instance_architecture_validator_input[call_index].get("instance_types")
         expected_architecture = expected_instance_architecture_validator_input[call_index].get("architecture")
 
-        assert_that(instance_type_list).is_length(len(expected_instance_type_list))
-        assert_that(set(instance_type_list) - set(expected_instance_type_list)).is_length(0)
+        assert_that(instances).is_length(len(expected_instances))
+        assert_that(set(instances) - set(expected_instances)).is_length(0)
         assert_that(architecture).is_equal_to(expected_architecture)
 
 
@@ -364,12 +362,12 @@ def test_scheduler_plugin_all_validators_are_called(test_datadir, mocker):
 
     # FlexibleInstanceTypes Only supported in Slurm
     flexible_instance_types_validators = [
-        "InstanceTypeListCPUValidator",
-        "InstanceTypeListAcceleratorsValidator",
-        "InstanceTypeListEFAValidator",
-        "InstanceTypeListNetworkingValidator",
-        "InstanceTypeListAllocationStrategyValidator",
-        "InstanceTypeListMemorySchedulingValidator",
+        "InstancesCPUValidator",
+        "InstancesAcceleratorsValidator",
+        "InstancesEFAValidator",
+        "InstancesNetworkingValidator",
+        "InstancesAllocationStrategyValidator",
+        "InstancesMemorySchedulingValidator",
     ]
 
     # Assert validators are called

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -115,7 +115,7 @@ Scheduling:
         - Name: compute_resource_1
           InstanceType: c4.2xlarge
         - Name: compute_resource_2
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.2xlarge
           MinCount: 1
           MaxCount: 15

--- a/cli/tests/pcluster/validators/test_instances_validators.py
+++ b/cli/tests/pcluster/validators/test_instances_validators.py
@@ -15,13 +15,13 @@ import pytest
 
 from pcluster.aws.aws_resources import InstanceTypeInfo
 from pcluster.config.cluster_config import AllocationStrategy, CapacityType
-from pcluster.validators.instance_type_list_validators import (
-    InstanceTypeListAcceleratorsValidator,
-    InstanceTypeListAllocationStrategyValidator,
-    InstanceTypeListCPUValidator,
-    InstanceTypeListEFAValidator,
-    InstanceTypeListMemorySchedulingValidator,
-    InstanceTypeListNetworkingValidator,
+from pcluster.validators.instances_validators import (
+    InstancesAcceleratorsValidator,
+    InstancesAllocationStrategyValidator,
+    InstancesCPUValidator,
+    InstancesEFAValidator,
+    InstancesMemorySchedulingValidator,
+    InstancesNetworkingValidator,
 )
 from tests.pcluster.validators.utils import assert_failure_messages
 
@@ -83,13 +83,13 @@ from tests.pcluster.validators.utils import assert_failure_messages
         ),
     ],
 )
-def test_instance_type_list_cpu_validator(
+def test_instances_cpu_validator(
     compute_resource_name,
     instance_types_info,
     disable_simultaneous_multithreading,
     expected_message,
 ):
-    actual_failures = InstanceTypeListCPUValidator().execute(
+    actual_failures = InstancesCPUValidator().execute(
         compute_resource_name,
         instance_types_info,
         disable_simultaneous_multithreading,
@@ -322,8 +322,8 @@ def test_instance_type_list_cpu_validator(
         ),
     ],
 )
-def test_instance_type_list_accelerators_validator(compute_resource_name, instance_types_info, expected_message):
-    actual_failures = InstanceTypeListAcceleratorsValidator().execute(
+def test_instances_accelerators_validator(compute_resource_name, instance_types_info, expected_message):
+    actual_failures = InstancesAcceleratorsValidator().execute(
         compute_resource_name,
         instance_types_info,
     )
@@ -382,13 +382,13 @@ def test_instance_type_list_accelerators_validator(compute_resource_name, instan
         ),
     ],
 )
-def test_instance_type_list_efa_validator(
+def test_instances_efa_validator(
     compute_resource_name,
     instance_types_info,
     efa_enabled,
     expected_message,
 ):
-    actual_failures = InstanceTypeListEFAValidator().execute(compute_resource_name, instance_types_info, efa_enabled)
+    actual_failures = InstancesEFAValidator().execute(compute_resource_name, instance_types_info, efa_enabled)
     assert_failure_messages(actual_failures, expected_message)
 
 
@@ -430,14 +430,14 @@ def test_instance_type_list_efa_validator(
         ),
     ],
 )
-def test_instance_type_list_networking_validator(
+def test_instances_networking_validator(
     queue_name: str,
     compute_resource_name: str,
     instance_types_info: Dict[str, InstanceTypeInfo],
     placement_group_enabled: bool,
     expected_message: str,
 ):
-    actual_failures = InstanceTypeListNetworkingValidator().execute(
+    actual_failures = InstancesNetworkingValidator().execute(
         queue_name, compute_resource_name, instance_types_info, placement_group_enabled
     )
     assert_failure_messages(actual_failures, expected_message)
@@ -458,10 +458,10 @@ def test_instance_type_list_networking_validator(
         ("TestComputeResource", CapacityType.ONDEMAND, AllocationStrategy.LOWEST_PRICE, ""),
     ],
 )
-def test_instance_type_list_allocation_strategy_validator(
+def test_instances_allocation_strategy_validator(
     compute_resource_name: str, capacity_type: Enum, allocation_strategy: Enum, expected_message: str
 ):
-    actual_failures = InstanceTypeListAllocationStrategyValidator().execute(
+    actual_failures = InstancesAllocationStrategyValidator().execute(
         compute_resource_name, capacity_type, allocation_strategy
     )
     assert_failure_messages(actual_failures, expected_message)
@@ -471,7 +471,7 @@ def test_instance_type_list_allocation_strategy_validator(
     "compute_resource_name, instance_types_info, memory_scheduling_enabled, expected_message",
     [
         # Memory-based scheduling is supported for Compute Resource that use either 'InstanceType' or have a single
-        # instance type under 'InstanceTypeList'
+        # instance type under 'Instances'
         (
             "TestComputeResource",
             {
@@ -480,7 +480,7 @@ def test_instance_type_list_allocation_strategy_validator(
             },
             True,
             "Memory-based scheduling is only supported for Compute Resources using either 'InstanceType' or "
-            "'InstanceTypeList' with one instance type. Compute Resource TestComputeResource has more than one "
+            "'Instances' with one instance type. Compute Resource TestComputeResource has more than one "
             "instance type specified.",
         ),
         (
@@ -493,13 +493,13 @@ def test_instance_type_list_allocation_strategy_validator(
         ),
     ],
 )
-def test_instance_type_list_memory_scheduling_validator(
+def test_instances_memory_scheduling_validator(
     compute_resource_name: str,
     instance_types_info: List[InstanceTypeInfo],
     memory_scheduling_enabled: bool,
     expected_message: str,
 ):
-    actual_failures = InstanceTypeListMemorySchedulingValidator().execute(
+    actual_failures = InstancesMemorySchedulingValidator().execute(
         compute_resource_name, instance_types_info, memory_scheduling_enabled
     )
     assert_failure_messages(actual_failures, expected_message)

--- a/tests/integration-tests/benchmarks/test_scaling_performance/test_scaling_performance/pcluster.config.yaml
+++ b/tests/integration-tests/benchmarks/test_scaling_performance/test_scaling_performance/pcluster.config.yaml
@@ -14,7 +14,7 @@ Scheduling:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MaxCount: {{ scaling_target }}
       Networking:

--- a/tests/integration-tests/benchmarks/test_scheduler_performance/test_scheduler_performance/pcluster.config.yaml
+++ b/tests/integration-tests/benchmarks/test_scheduler_performance/test_scheduler_performance/pcluster.config.yaml
@@ -14,7 +14,7 @@ Scheduling:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MaxCount: {{ scaling_target + 10 }}
       Networking:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -14,7 +14,7 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: cit
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ compute_instance_type }}
           MinCount: 2
           MaxCount: 150

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
@@ -14,7 +14,7 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: cit
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ compute_instance_type }}
           MinCount: 2
           MaxCount: 150

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -14,7 +14,7 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: cit
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ compute_instance_type }}
           MinCount: 2
           MaxCount: 150

--- a/tests/integration-tests/tests/arm_pl/test_arm_pl/test_arm_pl/pcluster.config.yaml
+++ b/tests/integration-tests/tests/arm_pl/test_arm_pl/test_arm_pl/pcluster.config.yaml
@@ -18,7 +18,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_install_args_quotes/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_install_args_quotes/pcluster.config.yaml
@@ -49,7 +49,7 @@ Scheduling:
             - {{ instance }}
           MinvCpus: 1
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
@@ -22,7 +22,7 @@ Scheduling:
           Script: s3://{{ bucket_name }}/failing_post_install.sh
       ComputeResources:
         - Name: compute-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.yaml
@@ -24,10 +24,10 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-11
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
         - Name: compute-resource-12
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
     - Name: ondemand2
@@ -36,9 +36,9 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-21
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
         - Name: compute-resource-22
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
@@ -18,7 +18,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           {% endif %}
           {% if scheduler == "awsbatch" %}DesiredvCpus:{% else %}MinCount:{% endif %} {{ queue_size }}

--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -362,7 +362,7 @@ def assert_config_contains_expected_values(
                     0,
                     "ComputeResources",
                     0,
-                    "InstanceTypeList",
+                    "Instances",
                     0,
                     "InstanceType",
                 ],

--- a/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_imds_secured/pcluster.config.yaml
@@ -16,7 +16,7 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: compute-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
@@ -15,7 +15,7 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: compute-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
@@ -15,7 +15,7 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: compute-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
       Networking:
         SubnetIds:

--- a/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/pcluster.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/pcluster.config.yaml
@@ -22,6 +22,6 @@ Scheduling:
         InstanceTypes:
           - {{ instance }}
         {% else %}
-        InstanceTypeList:
+        Instances:
           - InstanceType: {{ instance }}
         {% endif %}

--- a/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
@@ -21,7 +21,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           {% endif %}
 Monitoring:

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
@@ -26,7 +26,7 @@ Scheduling:
           DesiredvCpus: 8
           MaxvCpus: 8
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
@@ -26,7 +26,7 @@ Scheduling:
           DesiredvCpus: 8
           MaxvCpus: 8
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_hit_disable_hyperthreading/pcluster.config.yaml
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_hit_disable_hyperthreading/pcluster.config.yaml
@@ -18,7 +18,7 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-11
           DisableSimultaneousMultithreading: true
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
     - Name: ht-enabled
@@ -28,7 +28,7 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-21
           DisableSimultaneousMultithreading: false
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
 SharedStorage:

--- a/tests/integration-tests/tests/dns/test_dns/test_existing_hosted_zone/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dns/test_dns/test_existing_hosted_zone/pcluster.config.yaml
@@ -19,7 +19,7 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand-1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: {{ queue_size }}
 SharedStorage:

--- a/tests/integration-tests/tests/dns/test_dns/test_hit_no_cluster_dns_mpi/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dns/test_dns/test_hit_no_cluster_dns_mpi/pcluster.config.yaml
@@ -21,7 +21,7 @@ Scheduling:
           - {{ public_subnet_id }}
       ComputeResources:
         - Name: default-queue-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MaxCount: {{ max_queue_size }}
           MinCount: {{ min_queue_size }}

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: efa-enabled-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MaxCount: {{ max_queue_size }}
           MinCount: {{ max_queue_size }}

--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: efa-enabled
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 2
           MaxCount: 2

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.yaml
@@ -30,7 +30,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
@@ -27,7 +27,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: {{ min_count }}
           Efa:
@@ -43,7 +43,7 @@ Scheduling:
         InstanceRole: {{ compute_instance_role }}
       ComputeResources:
         - Name: compute-resource-0
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: {{ min_count }}
           Efa:

--- a/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
@@ -26,7 +26,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           Efa:
             Enabled: false

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
@@ -29,7 +29,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5n.18xlarge
             - InstanceType: c5n.metal
           {% endif %}

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -32,7 +32,7 @@ Scheduling:
             - {{ instance }}
           MinvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           Efa:

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
@@ -32,7 +32,7 @@ Scheduling:
   - Name: queue-0
     ComputeResources:
       - Name: compute-resource-0
-        InstanceTypeList:
+        Instances:
           - InstanceType: {{ instance }}
         MinCount: 1
         MaxCount: 2

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
@@ -18,7 +18,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 1

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_existing_eip/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_existing_eip/pcluster.config.yaml
@@ -19,7 +19,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 4
           MaxvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 1

--- a/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
@@ -14,7 +14,7 @@ Scheduling:
     - Name: dynamic
       ComputeResources:
         - Name: compute-resource-0
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MaxCount: 5
       Networking:
@@ -25,7 +25,7 @@ Scheduling:
     - Name: existing
       ComputeResources:
         - Name: compute-resource-1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
       Networking:
         PlacementGroup:

--- a/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.yaml
@@ -23,7 +23,7 @@ Scheduling:
           MinvCpus: 4
           MaxvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 1

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
@@ -19,7 +19,7 @@ Scheduling:
             - {{ instance }}
           MinvCpus: 1
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 2
           {% endif %}

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
@@ -21,7 +21,7 @@ Scheduling:
             - {{ instance }}
           MinvCpus: 1
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 2
           {% endif %}

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.update.yaml
@@ -17,7 +17,7 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 2
@@ -27,6 +27,6 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-2
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.yaml
@@ -17,7 +17,7 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 1
@@ -27,6 +27,6 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource-2
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1

--- a/tests/integration-tests/tests/performance_tests/test_simple/test_simple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_simple/test_simple/pcluster.config.yaml
@@ -25,7 +25,7 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: res-1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ compute_instance_type }}
           MinCount: 0
           MaxCount: {{ num_compute_nodes }}

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
@@ -16,7 +16,7 @@ Scheduling:
       CapacityType: ONDEMAND
       ComputeResources:
         - Name: compute-resource-0
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
       Networking:

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi/pcluster.config.yaml
@@ -16,7 +16,7 @@ Scheduling:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MaxCount: {{ max_queue_size }}
       Networking:

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/pcluster.config.yaml
@@ -14,7 +14,7 @@ Scheduling:
     - Name: queue-0
       ComputeResources:
         - Name: compute-resource-0
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
       Networking:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_error_handling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_error_handling/pcluster.config.yaml
@@ -25,14 +25,14 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.large
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
           {% endif %}
         - Name: ondemand1-i1
           {% if scheduler == "plugin" %}
           InstanceType: {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           {% endif %}
           MinCount: 1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot/pcluster.config.yaml
@@ -15,7 +15,7 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: t2micro
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 2
           MaxCount: 4

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.yaml
@@ -25,14 +25,14 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c4.xlarge
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c4.xlarge
           {% endif %}
         - Name: same-name-diff-queue
           {% if scheduler == "plugin" %}
           InstanceType: c5.xlarge
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           {% endif %}
           MaxCount: 5
@@ -46,7 +46,7 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: {{ gpu_instance_type }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ gpu_instance_type }}
           {% endif %}
           MaxCount: 5

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.update.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.update.config.yaml
@@ -17,10 +17,10 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
         - Name: same-name-diff-queue
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MaxCount: 5
     - Name: gpu
@@ -30,7 +30,7 @@ Scheduling:
       CapacityType: ONDEMAND
       ComputeResources:
         - Name: same-name-diff-queue
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ gpu_instance_type }}
           MaxCount: 5
 SharedStorage:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update.yaml
@@ -18,11 +18,11 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
           MinCount: 1
         - Name: ondemand1-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
 SharedStorage:
   - MountDir: /shared

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update_scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update_scheduling.yaml
@@ -18,11 +18,11 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
           MinCount: 0
         - Name: ondemand1-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
 SharedStorage:
   - MountDir: /shared

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.yaml
@@ -15,11 +15,11 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
           MinCount: 1
         - Name: ondemand1-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
 SharedStorage:
   - MountDir: /shared

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
@@ -21,14 +21,14 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
           MinCount: 1
         - Name: ondemand1-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
         - Name: ondemand1-i3
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.4xlarge
           MinCount: 0
           SchedulableMemory: 31400

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
@@ -21,15 +21,15 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
           MinCount: 1
           SchedulableMemory: 3000
         - Name: ondemand1-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
         - Name: ondemand1-i3
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.4xlarge
           MinCount: 0
           SchedulableMemory: 31400

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
@@ -18,14 +18,14 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
           MinCount: 1
         - Name: ondemand1-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
         - Name: ondemand1-i3
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.4xlarge
           MinCount: 0
 SharedStorage:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_overrides/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_overrides/pcluster.config.yaml
@@ -21,7 +21,7 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: fleet-1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
     - Name: single
       Networking:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_pmix/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_pmix/pcluster.config.yaml
@@ -16,7 +16,7 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: ondemand-1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: {{ queue_size }}
 SharedStorage:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
@@ -27,7 +27,7 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.large # instance type has bootstrap failure
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large # instance type has bootstrap failure
           {% endif %}
           MinCount: 2
@@ -49,7 +49,7 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.large # instance type has bootstrap failure
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large # instance type has bootstrap failure
           {% endif %}
           MaxCount: 250
@@ -57,7 +57,7 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.xlarge # instance type works as expected
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge # instance type works as expected
           {% endif %}
           MinCount: 1
@@ -79,7 +79,7 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.xlarge # instance type works as expected
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge # instance type works as expected
           {% endif %}
           MinCount: 1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
@@ -23,7 +23,7 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.large # instance type has bootstrap failure
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large # instance type has bootstrap failure
           {% endif %}
           MinCount: 3 # Set min_count larger than bootstrap failure threshold (which is 2) to test pcluster stop and start don't treat static nodes as bootstrap failure nodes and not set into protected node
@@ -40,14 +40,14 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.large # instance type has bootstrap failure
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large # instance type has bootstrap failure
           {% endif %}
         - Name: working-static
           {% if scheduler == "plugin" %}
           InstanceType: c5.xlarge # instance type has bootstrap failure
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge # instance type works as expected
           {% endif %}
       Iam:
@@ -63,7 +63,7 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.xlarge # instance type works as expected
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge # instance type works as expected
           {% endif %}
       Iam:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
@@ -23,7 +23,7 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.large # instance type has bootstrap failure
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large # instance type has bootstrap failure
           {% endif %}
       Iam:
@@ -39,14 +39,14 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.large # instance type has bootstrap failure
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large # instance type has bootstrap failure
           {% endif %}
         - Name: working-static
           {% if scheduler == "plugin" %}
           InstanceType: c5.large # instance type works as expected
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge # instance type works as expected
           {% endif %}
       Iam:
@@ -62,7 +62,7 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.xlarge # instance type works as expected
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge # instance type works as expected
           {% endif %}
       Iam:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_scaling/pcluster.config.yaml
@@ -25,14 +25,14 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.large
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
           {% endif %}
         - Name: ondemand1-i1
           {% if scheduler == "plugin" %}
           InstanceType: {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           {% endif %}
           MinCount: 2   # FIXME expecting 3 initial nodes and a min count of 2
@@ -45,14 +45,14 @@ Scheduling:
           {% if scheduler == "plugin" %}
           InstanceType: c5.large
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.large
           {% endif %}
         - Name: ondemand2-i1
           {% if scheduler == "plugin" %}
           InstanceType: {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           {% endif %}
           MinCount: 2

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_update_slurm_reconfigure_race_condition/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_update_slurm_reconfigure_race_condition/pcluster.config.yaml
@@ -17,6 +17,6 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: compute-resource1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MaxCount: {{ max_count_cr1 }}

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
@@ -24,7 +24,7 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: cit
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 0
           MaxCount: 10

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.update.yaml
@@ -24,7 +24,7 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: cit
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 0
           MaxCount: 10

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.yaml
@@ -17,7 +17,7 @@ Scheduling:
     - Name: compute
       ComputeResources:
         - Name: cit
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 0
           MaxCount: 10

--- a/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
+++ b/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
@@ -15,7 +15,7 @@ Scheduling:
       CapacityType: SPOT
       ComputeResources:
         - Name: compute-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: {{ min_count }}
       Networking:

--- a/tests/integration-tests/tests/storage/test_deletion_policy/test_retain_on_deletion/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_deletion_policy/test_retain_on_deletion/pcluster.config.yaml
@@ -23,7 +23,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 1
           DesiredvCpus: 1
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -35,7 +35,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -22,7 +22,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 1
           DesiredvCpus: 1
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 30

--- a/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
@@ -24,7 +24,7 @@ Scheduling:
           InstanceTypes:
             - {{ instance }}
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           {% endif %}
       Networking:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
@@ -28,7 +28,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster_restore_fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster_restore_fsx.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
@@ -26,7 +26,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multiple_fsx/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multiple_fsx/pcluster.config.yaml
@@ -26,7 +26,7 @@ Scheduling:
           MinvCpus: 1
           DesiredvCpus: 1
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 30

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.update.yaml
@@ -23,7 +23,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
@@ -23,7 +23,7 @@ Scheduling:
           MinvCpus: 4
           DesiredvCpus: 4
           {% else %}
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           {% endif %}

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/pcluster.config.yaml
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/pcluster.config.yaml
@@ -20,7 +20,7 @@ Scheduling:
     - Name: queue-trn32
       ComputeResources:
         - Name: compute-resource-trn32
-          InstanceTypeList:
+          Instances:
             - InstanceType: trn1.32xlarge
           MinCount: 2
           Efa:
@@ -45,7 +45,7 @@ Scheduling:
     - Name: queue-trn2
       ComputeResources:
         - Name: compute-resource-trn2
-          InstanceTypeList:
+          Instances:
             - InstanceType: trn1.2xlarge
           MinCount: 0  # TODO change to 1 once allreduce test is passing
       Networking:

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -66,7 +66,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
         "queue1": {
             "compute_resources": {
                 "queue1-i1": {
-                    "instance_type_list": [
+                    "instances": [
                         {
                             "instance_type": "c5.xlarge",
                         }
@@ -77,7 +77,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
                     "disable_hyperthreading": False,
                 },
                 "queue1-i2": {
-                    "instance_type_list": [
+                    "instances": [
                         {
                             "instance_type": "t2.micro",
                         }
@@ -93,7 +93,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
         "queue2": {
             "compute_resources": {
                 "queue2-i1": {
-                    "instance_type_list": [
+                    "instances": [
                         {
                             "instance_type": "c5n.18xlarge",
                         }
@@ -140,7 +140,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
         "queue1": {
             "compute_resources": {
                 "queue1-i1": {
-                    "instance_type_list": [
+                    "instances": [
                         {
                             "instance_type": "c5.xlarge",
                         }
@@ -151,7 +151,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
                     "enable_efa": False,
                 },
                 "queue1-i2": {
-                    "instance_type_list": [
+                    "instances": [
                         {
                             "instance_type": "c5.2xlarge",
                         }
@@ -162,7 +162,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
                     "enable_efa": False,
                 },
                 "queue1-i3": {
-                    "instance_type_list": [
+                    "instances": [
                         {
                             "instance_type": "t2.micro",
                         }
@@ -178,7 +178,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
         "queue2": {
             "compute_resources": {
                 "queue2-i1": {
-                    "instance_type_list": [
+                    "instances": [
                         {
                             "instance_type": "c5n.18xlarge",
                         }
@@ -195,7 +195,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
         "queue3": {
             "compute_resources": {
                 "queue3-i1": {
-                    "instance_type_list": [
+                    "instances": [
                         {
                             "instance_type": "c5n.18xlarge",
                         }
@@ -206,7 +206,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
                     "enable_efa": True,
                 },
                 "queue3-i2": {
-                    "instance_type_list": [
+                    "instances": [
                         {
                             "instance_type": "t2.xlarge",
                         }

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_drain.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_drain.yaml
@@ -20,7 +20,7 @@ Scheduling:
           - BucketName: {{ bucket_name }}
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 2
@@ -33,7 +33,7 @@ Scheduling:
           - BucketName: {{ bucket_name }}
       ComputeResources:
         - Name: queue2-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 2

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 2
@@ -22,7 +22,7 @@ Scheduling:
     - Name: queue2
       ComputeResources:
         - Name: queue2-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
           MaxCount: 2

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
@@ -27,7 +27,7 @@ Scheduling:
     - Name: queue2
       ComputeResources:
         - Name: queue2-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update_drain.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update_drain.yaml
@@ -15,7 +15,7 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
@@ -29,7 +29,7 @@ Scheduling:
     - Name: queue2
       ComputeResources:
         - Name: queue2-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
@@ -27,7 +27,7 @@ Scheduling:
     - Name: queue2
       ComputeResources:
         - Name: queue2-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.update_drain_without_running_job.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.update_drain_without_running_job.yaml
@@ -15,7 +15,7 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
@@ -29,7 +29,7 @@ Scheduling:
     - Name: queue2
       ComputeResources:
         - Name: queue2-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2

--- a/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.update.yaml
@@ -17,12 +17,12 @@ Scheduling:
             Size: 200
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
         - Name: queue1-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 1
           MaxCount: 2

--- a/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.yaml
@@ -13,12 +13,12 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
         - Name: queue1-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 1
           MaxCount: 2

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.remove.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.remove.yaml
@@ -12,7 +12,7 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5a.xlarge
           MinCount: 1
           MaxCount: 2

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
@@ -12,7 +12,7 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
             - InstanceType: c5a.xlarge
           MinCount: 1

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
@@ -12,7 +12,7 @@ Scheduling:
     - Name: queue1
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -40,16 +40,16 @@ Scheduling:
       CapacityType: SPOT
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 2
           MaxCount: 4
         - Name: queue1-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.2xlarge
           SpotPrice: 2.1
         - Name: queue1-i3
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
       Iam:
         S3Access:
@@ -82,7 +82,7 @@ Scheduling:
             - DEF
       ComputeResources:
         - Name: queue2-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5n.18xlarge
           MaxCount: 1
           DisableSimultaneousMultithreading: true
@@ -115,13 +115,13 @@ Scheduling:
             - DEF
       ComputeResources:
         - Name: queue3-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5n.18xlarge
           DisableSimultaneousMultithreading: true
           Efa:
             Enabled: true
         - Name: queue3-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.xlarge
           DisableSimultaneousMultithreading: true
           Efa:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -34,12 +34,12 @@ Scheduling:
       CapacityType: ONDEMAND
       ComputeResources:
         - Name: queue1-i1
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
         - Name: queue1-i2
-          InstanceTypeList:
+          Instances:
             - InstanceType: t2.micro
           MinCount: 1
       Networking:
@@ -58,7 +58,7 @@ Scheduling:
         - Name: queue2-i1
           Efa:
             Enabled: true
-          InstanceTypeList:
+          Instances:
             - InstanceType: c5n.18xlarge
       Iam:
         S3Access:


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* renamed `InstanceTypeLIst` to `Instances`
* renamed `instance_type_list` to `instances`, except for the SlurmQueue/SchedulerPluginQueue class method 
```
  def instance_type_list(self):
        """Return the list of instance types associated to the Queue."""
```

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
