### PR TITLE
[develop] Validate PlacementGroup for InstanceType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
 - Add support for Slurm Accounting.
 - Improve validation of networking for external EFS file systems by checking the CIDR block in the attached security group.
 - Improve support for EC2 instances with several NICs.
+- Add validator for instances being launched in a cluster placement group when the instance type does not support it. 
 
 **CHANGES**
 - Remove support for Python 3.6 in aws-parallelcluster-batch-cli.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -127,6 +127,7 @@ from pcluster.validators.ec2_validators import (
     InstanceTypeAcceleratorManufacturerValidator,
     InstanceTypeBaseAMICompatibleValidator,
     InstanceTypeMemoryInfoValidator,
+    InstanceTypePlacementGroupValidator,
     InstanceTypeValidator,
     KeyPairValidator,
     PlacementGroupCapacityReservationValidator,
@@ -2679,6 +2680,14 @@ class SlurmClusterConfig(CommonSchedulerClusterConfig):
                         InstanceTypeAcceleratorManufacturerValidator,
                         instance_type=instance_type,
                         instance_type_data=instance_types_data[instance_type],
+                    )
+                    self._register_validator(
+                        InstanceTypePlacementGroupValidator,
+                        instance_type=instance_type,
+                        instance_type_data=instance_types_data[instance_type],
+                        placement_group_enabled=(
+                            queue.get_placement_group_key_for_compute_resource(compute_resource)[0] is not None
+                        ),
                     )
                 if isinstance(compute_resource, SlurmFlexibleComputeResource):
                     validator_args = dict(

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1382,7 +1382,9 @@ class ComputeFleetConstruct(Construct):
 
     @staticmethod
     def _get_placement_group_for_compute_resource(queue, managed_placement_groups, compute_resource) -> str:
-        placement_group_key, managed = queue.get_placement_group_key_for_compute_resource(compute_resource)
+        placement_group_settings = queue.get_placement_group_settings_for_compute_resource(compute_resource)
+        placement_group_key = placement_group_settings.get("key")
+        managed = placement_group_settings.get("is_managed")
         return managed_placement_groups[placement_group_key].ref if managed else placement_group_key
 
     def _add_launch_templates(self, managed_placement_groups, instance_profiles):

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -21,6 +21,26 @@ from pcluster.validators.common import FailureLevel, Validator
 LOGGER = logging.getLogger(__name__)
 
 
+class InstanceTypePlacementGroupValidator(Validator):
+    """
+    EC2 Instance Type Placement Group validator.
+
+    Not all EC2 Instance Type can be launched in a Placement Group.
+    """
+
+    def _validate(self, instance_type: str, instance_type_data: dict, placement_group_enabled: bool):
+        if placement_group_enabled:
+            placement_group_supported_strategies = instance_type_data.get("PlacementGroupInfo", {}).get(
+                "SupportedStrategies", []
+            )
+            if "cluster" not in placement_group_supported_strategies:
+                self._add_failure(
+                    f"The instance type '{instance_type}' doesn't support being launched in a cluster placement group. "
+                    f"Please either disable the placement group or remove the instance type from the compute resource.",
+                    FailureLevel.ERROR,
+                )
+
+
 class InstanceTypeAcceleratorManufacturerValidator(Validator):
     """
     EC2 Instance Type Accelerator Manufacturer validator.

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -279,7 +279,13 @@ class TestBaseClusterConfig:
                     networking=SlurmQueueNetworking(subnet_ids=[], placement_group=PlacementGroup(enabled=False)),
                     compute_resources=mock_compute_resources,
                 ),
-                [(None, None), ("queue-test2", True), (None, False), ("test", False), ("test", False)],
+                [
+                    {"key": None, "is_managed": None},
+                    {"key": "queue-test2", "is_managed": True},
+                    {"key": None, "is_managed": False},
+                    {"key": "test", "is_managed": False},
+                    {"key": "test", "is_managed": False},
+                ],
             ),
             (
                 SlurmQueue(
@@ -287,7 +293,13 @@ class TestBaseClusterConfig:
                     networking=SlurmQueueNetworking(subnet_ids=[], placement_group=PlacementGroup(enabled=True)),
                     compute_resources=mock_compute_resources,
                 ),
-                [("queue-test1", True), ("queue-test2", True), (None, False), ("test", False), ("test", False)],
+                [
+                    {"key": "queue-test1", "is_managed": True},
+                    {"key": "queue-test2", "is_managed": True},
+                    {"key": None, "is_managed": False},
+                    {"key": "test", "is_managed": False},
+                    {"key": "test", "is_managed": False},
+                ],
             ),
             (
                 SlurmQueue(
@@ -295,7 +307,13 @@ class TestBaseClusterConfig:
                     networking=SlurmQueueNetworking(subnet_ids=[], placement_group=PlacementGroup(name="test-q")),
                     compute_resources=mock_compute_resources,
                 ),
-                [("test-q", False), ("queue-test2", True), (None, False), ("test", False), ("test", False)],
+                [
+                    {"key": "test-q", "is_managed": False},
+                    {"key": "queue-test2", "is_managed": True},
+                    {"key": None, "is_managed": False},
+                    {"key": "test", "is_managed": False},
+                    {"key": "test", "is_managed": False},
+                ],
             ),
             (
                 SlurmQueue(
@@ -303,14 +321,20 @@ class TestBaseClusterConfig:
                     networking=SlurmQueueNetworking(subnet_ids=[], placement_group=PlacementGroup()),
                     compute_resources=mock_compute_resources,
                 ),
-                [(None, None), ("queue-test2", True), (None, False), ("test", False), ("test", False)],
+                [
+                    {"key": None, "is_managed": None},
+                    {"key": "queue-test2", "is_managed": True},
+                    {"key": None, "is_managed": False},
+                    {"key": "test", "is_managed": False},
+                    {"key": "test", "is_managed": False},
+                ],
             ),
         ],
     )
-    def test_get_placement_group_key_for_compute_resource(self, queue, expected_result):
+    def test_get_placement_group_settings_for_compute_resource(self, queue, expected_result):
         actual = []
         for resource in queue.compute_resources:
-            actual.append(queue.get_placement_group_key_for_compute_resource(resource))
+            actual.append(queue.get_placement_group_settings_for_compute_resource(resource))
         assert_that(actual).is_equal_to(expected_result)
 
     @pytest.mark.parametrize(

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -162,6 +162,9 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     instance_type_accelerator_manufacturer_validator = mocker.patch(
         ec2_validators + ".InstanceTypeAcceleratorManufacturerValidator._validate", return_value=[]
     )
+    instance_type_placement_group_validator = mocker.patch(
+        ec2_validators + ".InstanceTypePlacementGroupValidator._validate", return_value=[]
+    )
 
     networking_validators = validators_path + ".networking_validators"
     security_groups_validator = mocker.patch(
@@ -323,6 +326,7 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     fsx_persistent_options_validator.assert_called()
     deletion_policy_validator.assert_called()
     instance_type_accelerator_manufacturer_validator.assert_called()
+    instance_type_placement_group_validator.assert_called()
 
 
 def test_scheduler_plugin_all_validators_are_called(test_datadir, mocker):
@@ -386,6 +390,7 @@ def test_scheduler_plugin_all_validators_are_called(test_datadir, mocker):
                 "CapacityReservationValidator",
                 "CapacityReservationResourceGroupValidator",
                 "DatabaseUriValidator",
+                "InstanceTypePlacementGroupValidator",
             ]
             + flexible_instance_types_validators
         ):


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Not all InstanceType support cluster placement group (ref. https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#concepts-placement-groups)

  Validator check if the InstanceType set supports PlacementGroup when this is enabled
  
  Example of describe-instace-types for instance that doesn't support cluster placement group
  ```
  $ aws ec2 describe-instance-types --region us-east-1 --instance-types t3.large | jq -r ".InstanceTypes[0].PlacementGroupInfo"  
  
  {
    "SupportedStrategies": [
      "partition",
      "spread"
    ]
  }
  ```

* Change method returning placement group settings

  Before the method was called `get_placement_group_key_for_compute_resource` and it was returning a tuple, not just the key, so it was not clear from the caller the returned output (without knowing in advance was the method was returing.
  
  Method is now called get_placement_group_settings_for_compute_resource and it's returning a dict.

### Tests
added unit test

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
