### PR TITLE
[3.x] Integ-tests: Add checks for EFS utils on Amazon Linux 2

### DIFF
--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -208,6 +208,10 @@ def check_fsx(
             assert_fsx_correctly_shared(scheduler_commands, remote_command_executor, mount_dir)
 
 
+def get_efs_ids(cluster, region):
+    return retrieve_cfn_outputs(cluster.cfn_name, region).get("EFSIds").split(",")
+
+
 def get_fsx_ids(cluster, region):
     return retrieve_cfn_outputs(cluster.cfn_name, region).get("FSXIds").split(",")
 

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -214,6 +214,20 @@ def get_cluster_nodes_instance_ids(stack_name, region, instance_types=None, node
         raise
 
 
+def get_compute_nodes_instance_ips(stack_name, region):
+    """Return a list of compute Instances Ip's."""
+    try:
+        instances = describe_cluster_instances(
+            stack_name,
+            region,
+            filter_by_node_type="Compute",
+        )
+        return [instance["PrivateIpAddress"] for instance in instances]
+    except Exception as e:
+        logging.error("Failed retrieving instance ips for stack %s in region %s", stack_name, region)
+        raise e
+
+
 def describe_cluster_instances(
     stack_name,
     region,


### PR DESCRIPTION
We only install EFS utils on Amazon Linux 2. EFS file systems are still mounted by basic NFS. test_multiple_efs is improved to unmount all EFS and mount them again using EFS utils.

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
* The following tests have been passed:
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  storage:
    test_efs.py::test_multiple_efs:
      dimensions:
        - regions: [ "ap-northeast-1" ]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: [ "slurm" ]
          benchmarks:
            - mpi_variants: [ "openmpi", "intelmpi" ]
              num_instances: [ 20 ] # Change the head node instance type if you'd test more than 30 instances
              slots_per_instance: 2
              osu_benchmarks:
                collective: [ "osu_allreduce", "osu_alltoall" ]
        - regions: [ "eu-west-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: [ "slurm" ]
```
### References
This PR has to be merged together with https://github.com/aws/aws-parallelcluster-cookbook/pull/1567

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
