### PR TITLE
Set DeviceIndex to 0 for all the interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 - Add support for specifying the supported IMDS version in cluster and build image configurations via the `Imds > ImdsSettings` property. A value of `v1.0` (the default) means that both IMDSv1 and IMDSv2 are supported, while a value of `v2.0` means that only IMDSv2 is supported.
 - Add support for Slurm Accounting.
 - Improve validation of networking for external EFS file systems by checking the CIDR block in the attached security group.
+- Improve support for EC2 instances with several NICs.
 
 **CHANGES**
 - Remove support for Python 3.6 in aws-parallelcluster-batch-cli.

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1433,7 +1433,7 @@ class ComputeFleetConstruct(Construct):
         for network_interface_index in range(1, compute_resource.max_network_interface_count):
             compute_lt_nw_interfaces.append(
                 ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
-                    device_index=1,
+                    device_index=0,
                     network_card_index=network_interface_index,
                     interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
                     groups=queue_lt_security_groups,


### PR DESCRIPTION
### Description of changes
* Set DeviceIndex to 0 to support the instances with multiple interfaces that allows only 1  ENI for Device.

### Tests
* Test_efa with p4d and ubuntu1804

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
