### PR TITLE
[Test] Delete the security group created by EBS snapshot factory as soon as possible to mitigate the risk of failing deletion of dependent VPC stack.

### DIFF
--- a/tests/integration-tests/tests/storage/snapshots_factory.py
+++ b/tests/integration-tests/tests/storage/snapshots_factory.py
@@ -257,6 +257,7 @@ class EBSSnapshotsFactory:
         if self.snapshot:
             logging.info("Deleting snapshot %s" % self.snapshot.id)
             self.snapshot.delete()
+            logging.info("Snapshot %s deleted" % self.snapshot.id)
 
     @retry(stop_max_attempt_number=5, wait_fixed=5000)
     def _release_instance(self):
@@ -274,10 +275,12 @@ class EBSSnapshotsFactory:
         if self.volume:
             logging.info("Deleting volume %s" % self.volume.id)
             self.volume.delete()
+            logging.info("Volume %s deleted" % self.volume.id)
         self.volume = None
 
     def _release_security_group(self):
         if self.security_group_id:
             logging.info("Deleting security group %s" % self.security_group_id)
             self.boto_client.delete_security_group(GroupId=self.security_group_id)
+            logging.info("Security group %s deleted" % self.security_group_id)
         self.security_group_id = None

--- a/tests/integration-tests/tests/storage/snapshots_factory.py
+++ b/tests/integration-tests/tests/storage/snapshots_factory.py
@@ -248,9 +248,9 @@ class EBSSnapshotsFactory:
     def release_all(self):
         """Release all resources"""
         self._release_instance()
+        self._release_security_group()
         self._release_volume()
         self._release_snapshot()
-        self._release_security_group()
 
     @retry(stop_max_attempt_number=5, wait_fixed=5000)
     def _release_snapshot(self):


### PR DESCRIPTION
### Description of changes
The EBS snapshot factory creates a Security Group within the VPC used by integ tests. 
If such Security Group is not deleted, the deletion of VPC stack fails because such SG is created within the VPC. 
For this reason we want to delete the SG as soon as possible, i.e. after instance termination and before EBS volume deletion.

Furthermore, added log lines to EBS snapshot factory teardown to ease the troubleshooting.

**Note** This is not the long term fix to the VPC deletion failure, but just a short term mitigation. The long term solution would be to move such resources into a dedicated CloudFormation stack.

### Tests
Will be tested directly on authoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
