### PR TITLE
[Test] Add fixture to serialize the execution of marked tests according to the adopted instance type

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -12,6 +12,7 @@
 import logging
 import re
 
+import pytest
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 from utils import get_compute_nodes_instance_ids
@@ -22,6 +23,7 @@ from tests.common.osu_common import run_individual_osu_benchmark
 from tests.common.utils import fetch_instance_slots, run_system_analyzer
 
 
+@pytest.mark.usefixtures("serial_execution_by_instance")
 def test_efa(
     os,
     region,

--- a/tests/integration-tests/tests/efa/test_fabric.py
+++ b/tests/integration-tests/tests/efa/test_fabric.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 
+import pytest
 import xmltodict
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
@@ -24,6 +25,7 @@ FABTESTS_BASIC_TESTS = ["rdm_tagged_bw", "rdm_tagged_pingpong"]
 FABTESTS_GDRCOPY_TESTS = ["runt"]
 
 
+@pytest.mark.usefixtures("serial_execution_by_instance")
 def test_fabric(
     os,
     region,

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc.py
@@ -21,6 +21,7 @@ from tests.common.assertions import assert_no_errors_in_logs
 
 
 @pytest.mark.usefixtures("os", "instance")
+@pytest.mark.usefixtures("serial_execution_by_instance")
 def test_intel_hpc(
     region, scheduler, pcluster_config_reader, clusters_factory, test_datadir, scheduler_commands_factory
 ):


### PR DESCRIPTION
### Description of changes
1. Add fixture `serial_execution_by_instance` to serialize the execution of marked tests when they are executed with instances c5n.18xlarge or p4d.24xlarge.
2. Applied the above fixture to tests: test_efa, test_fabric and test_intel_hpc.


### How to use this fixture
```
@pytest.mark.usefixtures("serial_execution_by_instance")
def test_1(...):
   ...

@pytest.mark.usefixtures("serial_execution_by_instance")
def test_2(...):
   ...
```

When the above tests are executed with instance equal to c5n.18xlarge or p4d.24xlarge, then theior execution is serialized via file locking, otherwise, the desired parallelism is applied.

### Tests
1. Tested locally with fake tests to validate enforcement of serial execution on the desired tests.
4. Tested serial execution of tests test_efa, test_fabric and test_intel_hpc with parallelism 16, even with for some of them I still got ICEd

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
