### PR TITLE
Fix DeviceIndex value to 1 on secondary interfaces for the headnode

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -861,7 +861,7 @@ class ClusterCdkStack(Stack):
         for network_interface_index in range(1, head_node.max_network_interface_count):
             head_lt_nw_interfaces.append(
                 ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
-                    device_index=0,
+                    device_index=1,
                     network_card_index=network_interface_index,
                     groups=head_lt_security_groups,
                     subnet_id=head_node.networking.subnet_id,


### PR DESCRIPTION
* Fix DeviceIndex value to 1 on secondary interfaces for the headnode

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
