### PR TITLE
Upgrade Python runtime used by Lambda functions to python3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+2.11.8
+**CHANGES**
+Upgrade Python runtime used by Lambda functions to python3.9.
+
 2.11.7
 -----
 

--- a/cloudformation/aws-parallelcluster.cfn.json
+++ b/cloudformation/aws-parallelcluster.cfn.json
@@ -2314,7 +2314,7 @@
             }
           ]
         },
-        "Runtime": "python3.8",
+        "Runtime": "python3.9",
         "Timeout": 900
       }
     },

--- a/cloudformation/batch-substack.cfn.json
+++ b/cloudformation/batch-substack.cfn.json
@@ -866,7 +866,7 @@
             }
           ]
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Timeout": 60
       }
     },
@@ -1026,7 +1026,7 @@
             }
           ]
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Timeout": 60
       },
       "DependsOn": "DockerBuildWaitHandle"


### PR DESCRIPTION
### Description of changes
* Upgrade Python runtime used by Lambda functions to python3.9
* Upgrade Python runtime used by Lambda functions used for lambda integration to python3.9 because. python 3.6 is deprecated by Lambda: https://github.com/aws/aws-parallelcluster/wiki/(2.11.7-and-earlier)-Cluster-creation-fails-with-awsbatch-scheduler

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
