### PR TITLE
Allow for suppressing the single subnet validator for Slurm Scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ CHANGELOG
 - Upgrade Slurm to version 22.05.5.
 - Upgrade EFA installer to version 1.18.0.
 - Upgrade NICE DCV to version 2022.1-13300.
+- Allow for suppressing the `SingleSubnetValidator` for `Queues`.
 
 **BUG FIXES**
 - Fix validation of `filters` parameter in `ListClusterLogStreams` command to fail when incorrect filters are passed.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -152,7 +152,12 @@ from pcluster.validators.instances_validators import (
     InstancesNetworkingValidator,
 )
 from pcluster.validators.kms_validators import KmsKeyIdEncryptedValidator, KmsKeyValidator
-from pcluster.validators.networking_validators import ElasticIpValidator, SecurityGroupsValidator, SubnetsValidator
+from pcluster.validators.networking_validators import (
+    ElasticIpValidator,
+    SecurityGroupsValidator,
+    SingleSubnetValidator,
+    SubnetsValidator,
+)
 from pcluster.validators.s3_validators import (
     S3BucketRegionValidator,
     S3BucketUriValidator,
@@ -2080,6 +2085,10 @@ class SlurmScheduling(Resource):
             max_length=MAX_NUMBER_OF_QUEUES,
             resource_name="SlurmQueues",
         )
+        self._register_validator(
+            SingleSubnetValidator,
+            queues=self.queues,
+        )
 
 
 class SchedulerPluginQueue(_CommonQueue):
@@ -2431,6 +2440,10 @@ class SchedulerPluginScheduling(Resource):
                 default=MAX_NUMBER_OF_QUEUES,
             ),
             resource_name="SchedulerQueues",
+        )
+        self._register_validator(
+            SingleSubnetValidator,
+            queues=self.queues,
         )
         for queue in self.queues:
             self._register_validator(

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1873,19 +1873,6 @@ class SchedulingSchema(BaseSchema):
                     f"Scheduling > *Queues section is not appropriate to the Scheduler: {configured_scheduler}."
                 )
 
-    @validates_schema
-    def same_subnet_in_different_queues(self, data, **kwargs):
-        """Validate subnet_ids configured in different queues are the same."""
-        if "slurm_queues" in data or "scheduler_queues" in data:
-            queues = "slurm_queues" if "slurm_queues" in data else "scheduler_queues"
-
-            def _queue_has_subnet_ids(queue):
-                return queue.networking and queue.networking.subnet_ids
-
-            subnet_ids = {tuple(set(q.networking.subnet_ids)) for q in data[queues] if _queue_has_subnet_ids(q)}
-            if len(subnet_ids) > 1:
-                raise ValidationError("The SubnetIds used for all of the queues should be the same.")
-
     @post_load
     def make_resource(self, data, **kwargs):
         """Generate the right type of scheduling according to the child type (Slurm vs AwsBatch vs Custom)."""

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -66,3 +66,15 @@ class ElasticIpValidator(Validator):
                 AWSApi.instance().ec2.get_eip_allocation_id(elastic_ip)
             except AWSClientError as e:
                 self._add_failure(str(e), FailureLevel.ERROR)
+
+
+class SingleSubnetValidator(Validator):
+    """Validate all queues reference the same subnet."""
+
+    def _validate(self, queues):
+        def _queue_has_subnet_ids(queue):
+            return queue.networking and queue.networking.subnet_ids
+
+        subnet_ids = {tuple(set(q.networking.subnet_ids)) for q in queues if _queue_has_subnet_ids(q)}
+        if len(subnet_ids) > 1:
+            self._add_failure("The SubnetId used for all of the queues should be the same.", FailureLevel.ERROR)

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -274,23 +274,6 @@ def dummy_slurm_compute_resource(name, instance_type):
             },
             None,
         ),
-        (
-            {
-                "Scheduler": "slurm",
-                "SlurmQueues": [
-                    dummy_slurm_queue(),
-                    {
-                        "Name": "queue2",
-                        "Networking": {"SubnetIds": ["subnet-00000000"]},
-                        "ComputeResources": [
-                            {"Name": "compute_resource3", "InstanceType": "c5.2xlarge", "MaxCount": 5},
-                            {"Name": "compute_resource4", "InstanceType": "c4.2xlarge"},
-                        ],
-                    },
-                ],
-            },
-            "The SubnetIds used for all of the queues should be the same",
-        ),
         (  # maximum slurm queue length
             {
                 "Scheduler": "slurm",


### PR DESCRIPTION
Allow for suppressing the single subnet validator for Slurm Scheduling and
Scheduler Plugin Scheduling by making the validation on the config rather than the schema

Signed-off-by: Ryan Anderson <ndry@amazon.com>

### Description of changes
* See above

### Tests
* Added unit tests for the new validator

### References
* https://sim.amazon.com/issues/PCLUSTER-5386

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
