### PR TITLE
[Validators] Pass only strictly required data to SingleSubnetValidator. Added unit tests to verify it is called with expected arguments.

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2087,7 +2087,7 @@ class SlurmScheduling(Resource):
         )
         self._register_validator(
             SingleSubnetValidator,
-            queues=self.queues,
+            queues_subnets=[q.networking.subnet_ids for q in self.queues if q.networking and q.networking.subnet_ids],
         )
 
 
@@ -2443,7 +2443,7 @@ class SchedulerPluginScheduling(Resource):
         )
         self._register_validator(
             SingleSubnetValidator,
-            queues=self.queues,
+            queues_subnets=[q.networking.subnet_ids for q in self.queues if q.networking and q.networking.subnet_ids],
         )
         for queue in self.queues:
             self._register_validator(

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -71,10 +71,7 @@ class ElasticIpValidator(Validator):
 class SingleSubnetValidator(Validator):
     """Validate all queues reference the same subnet."""
 
-    def _validate(self, queues):
-        def _queue_has_subnet_ids(queue):
-            return queue.networking and queue.networking.subnet_ids
-
-        subnet_ids = {tuple(set(q.networking.subnet_ids)) for q in queues if _queue_has_subnet_ids(q)}
+    def _validate(self, queues_subnets):
+        subnet_ids = {tuple(set(queue_subnets)) for queue_subnets in queues_subnets}
         if len(subnet_ids) > 1:
             self._add_failure("The SubnetId used for all of the queues should be the same.", FailureLevel.ERROR)

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -171,6 +171,7 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
         networking_validators + ".SecurityGroupsValidator._validate", return_value=[]
     )
     subnets_validator = mocker.patch(networking_validators + ".SubnetsValidator._validate", return_value=[])
+    single_subnet_validator = mocker.patch(networking_validators + ".SingleSubnetValidator._validate", return_value=[])
 
     fsx_validators = validators_path + ".fsx_validators"
     fsx_s3_validator = mocker.patch(fsx_validators + ".FsxS3Validator._validate", return_value=[])
@@ -262,6 +263,16 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
         any_order=True,
     )
     subnets_validator.assert_has_calls([call(subnet_ids=["subnet-23456789", "subnet-12345678"])])
+    single_subnet_validator.assert_has_calls(
+        [
+            call(
+                queues_subnets=[
+                    ["subnet-23456789"],
+                    ["subnet-23456789"],
+                ]
+            )
+        ]
+    )
     security_groups_validator.assert_has_calls(
         [call(security_group_ids=None), call(security_group_ids=None)], any_order=True
     )
@@ -441,6 +452,7 @@ def test_scheduler_plugin_validators_are_called_with_correct_argument(test_datad
         networking_validators + ".SecurityGroupsValidator._validate", return_value=[]
     )
     subnets_validator = mocker.patch(networking_validators + ".SubnetsValidator._validate", return_value=[])
+    single_subnet_validator = mocker.patch(networking_validators + ".SingleSubnetValidator._validate", return_value=[])
 
     fsx_validators = validators_path + ".fsx_validators"
     fsx_s3_validator = mocker.patch(fsx_validators + ".FsxS3Validator._validate", return_value=[])
@@ -551,6 +563,16 @@ def test_scheduler_plugin_validators_are_called_with_correct_argument(test_datad
         any_order=True,
     )
     subnets_validator.assert_has_calls([call(subnet_ids=["subnet-12345678", "subnet-23456789"])])
+    single_subnet_validator.assert_has_calls(
+        [
+            call(
+                queues_subnets=[
+                    ["subnet-12345678"],
+                    ["subnet-12345678"],
+                ]
+            )
+        ]
+    )
     security_groups_validator.assert_has_calls(
         [call(security_group_ids=None), call(security_group_ids=None)], any_order=True
     )

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -12,7 +12,6 @@ import os
 
 import pytest
 
-from pcluster.config.cluster_config import SlurmComputeResource, SlurmQueue, SlurmQueueNetworking
 from pcluster.validators.networking_validators import SecurityGroupsValidator, SingleSubnetValidator, SubnetsValidator
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.validators.utils import assert_failure_messages
@@ -73,51 +72,15 @@ def test_ec2_subnet_id_validator(mocker):
     [
         (
             [
-                SlurmQueue(
-                    name="queue",
-                    networking=SlurmQueueNetworking(subnet_ids=["subnet-11111111"]),
-                    compute_resources=[
-                        SlurmComputeResource(
-                            instance_type="test",
-                            name="test1",
-                        )
-                    ],
-                ),
-                SlurmQueue(
-                    name="queue",
-                    networking=SlurmQueueNetworking(subnet_ids=["subnet-00000000"]),
-                    compute_resources=[
-                        SlurmComputeResource(
-                            instance_type="test",
-                            name="test1",
-                        )
-                    ],
-                ),
+                ["subnet-11111111"],
+                ["subnet-00000000"],
             ],
             "The SubnetId used for all of the queues should be the same",
         ),
         (
             [
-                SlurmQueue(
-                    name="queue",
-                    networking=SlurmQueueNetworking(subnet_ids=["subnet-00000000"]),
-                    compute_resources=[
-                        SlurmComputeResource(
-                            instance_type="test",
-                            name="test1",
-                        )
-                    ],
-                ),
-                SlurmQueue(
-                    name="queue",
-                    networking=SlurmQueueNetworking(subnet_ids=["subnet-00000000"]),
-                    compute_resources=[
-                        SlurmComputeResource(
-                            instance_type="test",
-                            name="test1",
-                        )
-                    ],
-                ),
+                ["subnet-00000000"],
+                ["subnet-00000000"],
             ],
             None,
         ),


### PR DESCRIPTION
### Description of changes
1. Pass only strictly required data to `SingleSubnetValidator`. We used to pass it the whole Queues structure, but it only requires the subnets ids.
2. Added unit tests to verify that the validator is called with expected arguments both for Slurm and Slurm Plugin.

### Tests
1. Unit tests
3. Manual test: cluster creation with queues using same subnet ids => success
4. Manual test: cluster creation with queues using different subnet ids => validation failure
5. Manual test: cluster creation with queues using different subnet ids with `--suppress-validator ALL` => success
6. Manual test: cluster creation with queues using different subnet ids with `--suppress-validator type:SingleSubnetValidator` => success

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
