### PR TITLE
[3.x] Catch AWSClientError when caching capacity reservation information

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -22,7 +22,7 @@ import pkg_resources
 
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.aws_resources import InstanceTypeInfo
-from pcluster.aws.common import get_region
+from pcluster.aws.common import AWSClientError, get_region
 from pcluster.config.common import AdditionalIamPolicy, BaseDevSettings, BaseTag
 from pcluster.config.common import Imds as TopLevelImds
 from pcluster.config.common import Resource
@@ -2588,8 +2588,14 @@ class SchedulerPluginClusterConfig(CommonSchedulerClusterConfig):
         super().__init__(cluster_name, **kwargs)
         self.scheduling = scheduling
         self.__image_dict = None
-        # Cache capacity reservations information together to reduce number of boto3 calls
-        AWSApi.instance().ec2.describe_capacity_reservations(self.all_relevant_capacity_reservation_ids)
+        # Cache capacity reservations information together to reduce number of boto3 calls.
+        # Since this cache is only used for validation, if AWSClientError happens
+        # (e.g insufficient IAM permissions to describe the capacity reservations), we catch the exception to avoid
+        # blocking CLI execution if the user want to suppress the validation.
+        try:
+            AWSApi.instance().ec2.describe_capacity_reservations(self.all_relevant_capacity_reservation_ids)
+        except AWSClientError:
+            logging.warning("Unable to cache describe_capacity_reservations results for all capacity reservation ids.")
 
     def get_instance_types_data(self):
         """Get instance type infos for all instance types used in the configuration file."""
@@ -2646,8 +2652,14 @@ class SlurmClusterConfig(CommonSchedulerClusterConfig):
         super().__init__(cluster_name, **kwargs)
         self.scheduling = scheduling
         self.__image_dict = None
-        # Cache capacity reservations information together to reduce number of boto3 calls
-        AWSApi.instance().ec2.describe_capacity_reservations(self.all_relevant_capacity_reservation_ids)
+        # Cache capacity reservations information together to reduce number of boto3 calls.
+        # Since this cache is only used for validation, if AWSClientError happens
+        # (e.g insufficient IAM permissions to describe the capacity reservations), we catch the exception to avoid
+        # blocking CLI execution if the user want to suppress the validation.
+        try:
+            AWSApi.instance().ec2.describe_capacity_reservations(self.all_relevant_capacity_reservation_ids)
+        except AWSClientError:
+            logging.warning("Unable to cache describe_capacity_reservations results for all capacity reservation ids.")
 
     def get_instance_types_data(self):
         """Get instance type infos for all instance types used in the configuration file."""


### PR DESCRIPTION
Since this cache is only used for validation, if AWSClientError happens (e.g insufficient IAM permissions to describe the capacity reservations), we catch the exception to avoid blocking CLI execution if the user want to suppress the validation. In other words, we delay any boto3 exceptions from caching phase to validator execution phase.

Signed-off-by: Hanwen <hanwenli@amazon.com>


### Tests
* Manually testing with an IAM role denying access to any resource groups:
Before this PR:
```
pcluster create-cluster --cluster-name mycluster --cluster-config ~/.parallelcluster/config
{
  "message": "Invalid cluster configuration: User: xxx is not authorized to perform: resource-groups:ListGroupResources on resource: arn:aws:resource-groups:us-east-1:123:group/MyCRGroup with an explicit deny"
}
```
After this PR:
```
pcluster create-cluster --cluster-name mycluster --cluster-config ~/.parallelcluster/config
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "CapacityReservationResourceGroupValidator",
      "message": "Capacity reservation resource group arn:aws:resource-groups:us-east-1:123:group/MyCRGroup must be a Service Linked Group created from the AWS CLI.  See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-cr-group.html for more details."
    },
    {
      "level": "ERROR",
      "type": "PlacementGroupCapacityReservationValidator",
      "message": "User: xxx is not authorized to perform: resource-groups:ListGroupResources on resource: arn:aws:resource-groups:us-east-1:123:group/MyCRGroup with an explicit deny"
    }
  ],
  "message": "Invalid cluster configuration."
}

```
* I ran tests in `configs/pcluster3.yaml`, the result looks good

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
