### PR TITLE
[Test] Move test_intel_hpc to us-east-2 and make it use c5.18xlarge to reduce the risk of ICEs. Move test_efa using instance_type_1 to us-east-2.

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -265,7 +265,7 @@ efa:
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
         schedulers: ["slurm"]
-      - regions: [ "us-west-2" ]
+      - regions: [ "us-east-2" ]
         instances: [{{ common.instance("instance_type_1") }}]
         oss: [ "alinux2", "centos7", "ubuntu2004" ]
         schedulers: [ "slurm" ]
@@ -296,8 +296,8 @@ iam:
 intel_hpc:
   test_intel_hpc.py::test_intel_hpc:
     dimensions:
-      - regions: ["us-west-2"]
-        instances: ["c5n.18xlarge"]
+      - regions: ["us-east-2"]
+        instances: ["c5.18xlarge"]
         oss: ["centos7"]
         schedulers: ["slurm"]
 networking:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -25,7 +25,7 @@ test-suites:
           instances: ["c6gn.16xlarge"]
           oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
           schedulers: ["slurm"]
-        - regions: [ "us-west-2" ]
+        - regions: [ "us-east-2" ]
           instances: [{{ common.instance("instance_type_1") }}]
           oss: [ "alinux2", "centos7", "ubuntu2004" ]
           schedulers: [ "slurm" ]

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
@@ -30,6 +30,7 @@ Scheduling:
             - {{ instance }}
           {% else %}
           Instances:
+            - InstanceType: c5.18xlarge
             - InstanceType: c5n.18xlarge
             - InstanceType: c5n.metal
           {% endif %}


### PR DESCRIPTION
### Description of changes
Made changes to regions and instance types for some tests to reduce the risk of ICEs.
1. test_efa using instance_type_1 moved to us-east-2.
2. test_intel_hpc moved to us-east-2 with c5.18xlarge

### Tests
Will be tested on authoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
