### PR TITLE
Make unit tests more robust when region is already set

### DIFF
--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -25,9 +25,10 @@ from pcluster.constants import CW_LOGS_CFN_PARAM_NAME
 
 
 @pytest.fixture(autouse=True)
-def clear_env():
+def clear_env(mocker):
     if "AWS_DEFAULT_REGION" in os.environ:
         del os.environ["AWS_DEFAULT_REGION"]
+    mocker.patch("botocore.session.Session.get_scoped_config", return_value={})
 
 
 @pytest.fixture(autouse=True)

--- a/cli/tests/pcluster/api/controllers/test_common.py
+++ b/cli/tests/pcluster/api/controllers/test_common.py
@@ -19,11 +19,6 @@ from pcluster.api.errors import BadRequestException
     [("eu-west-1", None), ("eu-west-", "invalid or unsupported region"), (None, "region needs to be set")],
 )
 class TestConfigureAwsRegion:
-    @pytest.fixture(autouse=True)
-    def unset_aws_default_region(self, unset_env, mocker):
-        unset_env("AWS_DEFAULT_REGION")
-        mocker.patch("botocore.session.Session.get_scoped_config", return_value={})
-
     def test_validate_region_query(self, region, error):
         @configure_aws_region()
         def _decorated_func(region):
@@ -65,11 +60,6 @@ class TestConfigureAwsRegion:
     ],
 )
 class TestConfigureAwsRegionFromConfig:
-    @pytest.fixture(autouse=True)
-    def unset_aws_default_region(self, unset_env, mocker):
-        unset_env("AWS_DEFAULT_REGION")
-        mocker.patch("botocore.session.Session.get_scoped_config", return_value={})
-
     def test_validate_region(self, region, yaml, error, set_env, unset_env):
         expected = "eu-west-1"
 


### PR DESCRIPTION
### Notes
Currently, if the region is already set in the environment where the tests are run, some unit tests break because they expect a failure when running without explicitly setting their region. This patch improves the `clear_env` fixture that is applied to every unit tests with the code in the tests in `test_common`'s `TestConfigureAwsRegionFromConfig` and `TestConfigureAwsRegion` classes that handled the case where the default region is set, for example in the `~/.aws/config` file, and removes the ad-hoc fixtures in those tests.

### Tests
Set the following in the `~/.aws/config` file:

```
[default]
region = eu-west-1
```

Running the unit tests, without the patch you see errors due to tests expecting a bad request to be thrown due to the region being unset, while with the patch, all the unit tests run correctly.

---

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
