### PR TITLE
Set DeviceIndex to 0 in cluster validator

### DIFF
--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -941,16 +941,17 @@ class MixedSecurityGroupOverwriteValidator(Validator):
 class _LaunchTemplateValidator(Validator):
     """Abstract class to contain utility functions used by head node and queue LaunchTemplate validators."""
 
+    @staticmethod
     def _build_launch_network_interfaces(
-        self, network_interfaces_count, use_efa, security_group_ids, subnet, use_public_ips=False
+        network_interfaces_count, use_efa, security_group_ids, subnet, use_public_ips=False
     ):
         """Build the needed NetworkInterfaces to launch an instance."""
         network_interfaces = []
-        for device_index in range(network_interfaces_count):
+        for network_interface_index in range(network_interfaces_count):
             network_interfaces.append(
                 {
-                    "DeviceIndex": device_index,
-                    "NetworkCardIndex": device_index,
+                    "DeviceIndex": 0,
+                    "NetworkCardIndex": network_interface_index,
                     "InterfaceType": "efa" if use_efa else "interface",
                     "Groups": security_group_ids,
                     "SubnetId": subnet,

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -1117,6 +1117,75 @@ def test_generate_tag_specifications(input_tags):
 
 
 @pytest.mark.parametrize(
+    "network_interfaces_count, use_efa, security_group_ids, subnet, use_public_ips, expected_result",
+    [
+        [
+            1,
+            False,
+            "sg-1",
+            "subnet-1",
+            False,
+            [
+                {
+                    "DeviceIndex": 0,
+                    "NetworkCardIndex": 0,
+                    "InterfaceType": "interface",
+                    "Groups": "sg-1",
+                    "SubnetId": "subnet-1",
+                }
+            ],
+        ],
+        [
+            4,
+            True,
+            "sg-2",
+            "subnet-2",
+            True,
+            [
+                {
+                    "DeviceIndex": 0,
+                    "NetworkCardIndex": 0,
+                    "InterfaceType": "efa",
+                    "Groups": "sg-2",
+                    "SubnetId": "subnet-2",
+                    "AssociatePublicIpAddress": True,
+                },
+                {
+                    "DeviceIndex": 0,
+                    "NetworkCardIndex": 1,
+                    "InterfaceType": "efa",
+                    "Groups": "sg-2",
+                    "SubnetId": "subnet-2",
+                },
+                {
+                    "DeviceIndex": 0,
+                    "NetworkCardIndex": 2,
+                    "InterfaceType": "efa",
+                    "Groups": "sg-2",
+                    "SubnetId": "subnet-2",
+                },
+                {
+                    "DeviceIndex": 0,
+                    "NetworkCardIndex": 3,
+                    "InterfaceType": "efa",
+                    "Groups": "sg-2",
+                    "SubnetId": "subnet-2",
+                },
+            ],
+        ],
+    ],
+)
+def test_build_launch_network_interfaces(
+    network_interfaces_count, use_efa, security_group_ids, subnet, use_public_ips, expected_result
+):
+    """Verify function to build network interfaces for dry runs of RunInstances works as expected."""
+    lt_network_interfaces = _LaunchTemplateValidator._build_launch_network_interfaces(
+        network_interfaces_count, use_efa, security_group_ids, subnet, use_public_ips
+    )
+    assert_that(lt_network_interfaces).is_equal_to(expected_result)
+
+
+@pytest.mark.parametrize(
     "head_node_security_groups, queues, expect_warning",
     [
         [None, [{"networking": {"security_groups": None}}, {"networking": {"security_groups": None}}], False],


### PR DESCRIPTION
### Description of changes
* Set DeviceIndex to 0 in cluster validato
  * To make DryRun run-instances api call uses the configuration that will be later set in the actual launch-template.
 
### Tests
* test_multiple_nics with trn1. From `.parallelcluster/pcluster-cli.log`
```bash
2022-10-21 17:50:54,529 - INFO - common.py:134:_log_boto3_calls() - Executing boto3 call: region=us-west-2, service=ec2, operation=RunInstances, params={'InstanceType': 'trn1.32xlarge', 'MinCount': 1, 'MaxCount': 1, 'ImageId': 'ami-044517b3a994b80f1', 'Placement': {}, 'NetworkInterfaces': [{'DeviceIndex': 0, 'NetworkCardIndex': 0, 'InterfaceType': 'efa', 'Groups': [], 'SubnetId': 'subnet-0de1ce2724194d659'}, {'DeviceIndex': 0, 'NetworkCardIndex': 1, 'InterfaceType': 'efa', 'Groups': [], 'SubnetId': 'subnet-0de1ce2724194d659'}, {'DeviceIndex': 0, 'NetworkCardIndex': 2, 'InterfaceType': 'efa', 'Groups': [], 'SubnetId': 'subnet-0de1ce2724194d659'}, {'DeviceIndex': 0, 'NetworkCardIndex': 3, 'InterfaceType': 'efa', 'Groups': [], 'SubnetId': 'subnet-0de1ce2724194d659'}, {'DeviceIndex': 0, 'NetworkCardIndex': 4, 'InterfaceType': 'efa', 'Groups': [], 'SubnetId': 'subnet-0de1ce2724194d659'}, {'DeviceIndex': 0, 'NetworkCardIndex': 5, 'InterfaceType': 'efa', 'Groups': [], 'SubnetId': 'subnet-0de1ce2724194d659'}, {'DeviceIndex': 0, 'NetworkCardIndex': 6, 'InterfaceType': 'efa', 'Groups': [], 'SubnetId': 'subnet-0de1ce2724194d659'}, {'DeviceIndex': 0, 'NetworkCardIndex': 7, 'InterfaceType': 'efa', 'Groups': [], 'SubnetId': 'subnet-0de1ce2724194d659'}], 'DryRun': True, 'TagSpecifications': []}
```
### References
* PR where the DeviceIndex is set to 0 in the actual launch template - https://github.com/aws/aws-parallelcluster/pull/4447

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
