### PR TITLE
Make integration test create_ami install vim instead of mysql within the custom script.

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami/test_build_image_custom_components/custom_script.sh
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image_custom_components/custom_script.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-yum -y install mysql
+yum -y install vim


### PR DESCRIPTION
### Description of changes
Make integration test `create_ami` install `vim` instead of `mysql` within the custom script.

Note: the change is safe because the test make no assertion on the installed package, it only aims at checking that the build succeeds.

### Tests
1. Will be tested on authoritative pipeline.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
