### PR TITLE
Add missing fields to launch template validators

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1193,6 +1193,7 @@ class BaseClusterConfig(Resource):
         self._register_validator(
             HeadNodeLaunchTemplateValidator,
             head_node=self.head_node,
+            os=self.image.os,
             ami_id=self.head_node_ami,
             tags=self.get_cluster_tags(),
         )
@@ -2469,6 +2470,7 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
             self._register_validator(
                 ComputeResourceLaunchTemplateValidator,
                 queue=queue,
+                os=self.image.os,
                 ami_id=queue_image,
                 tags=self.get_cluster_tags(),
             )


### PR DESCRIPTION
### Notes
This patch adds the missing fields to the launch template validators. For the head node, these are the `BlockDeviceMappings` and `KeyName`, while for the compute resources these are the `BlockDeviceMappings`, `InstanceMetadataOptions` and `CapacityReservationSpecification`.

This patch extracts the common code into functions that generate dictionaries (or lists of dictionaries), which are consumed directly by the validators (they do a run instance dry run, as they cannot validate the launch templates produced via CDK), and converted into CDK objects in the case of the code that actually generate the launch templates via CDK/CloudFormation.

#### Tests
Unit tests

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
