### PR TITLE
Update tabulate dependency to support python 3.10

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -211,7 +211,7 @@ efa:
         instances: ["c5n.9xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
-      - regions: ["us-east-1"]
+      - regions: ["eu-west-1"]
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/resources/batch_instance_policy.json
+++ b/tests/integration-tests/resources/batch_instance_policy.json
@@ -105,6 +105,8 @@
     {
       "Action": [
         "logs:CreateLogGroup",
+        "logs:TagResource",
+        "logs:UntagResource",
         "logs:CreateLogStream"
       ],
       "Resource": [


### PR DESCRIPTION
Change to fix the [error](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=592951&view=logs&j=aaada960-d85f-5b88-82e5-99df4d27a2ce&t=1169dac8-f5b1-5012-e49a-d6d84b7b929b&l=702) in the [PR](https://github.com/conda-forge/aws-parallelcluster-feedstock/pull/64) regarding python 3.10

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
