### PR TITLE
Add missing fields to launch template validators

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1112,6 +1112,10 @@ class BaseQueue(Resource):
         _capacity_type = CapacityType[capacity_type.upper()] if capacity_type else None
         self.capacity_type = Resource.init_param(_capacity_type, default=CapacityType.ONDEMAND)
 
+    def is_spot(self):
+        """Return True if the queue has SPOT capacity."""
+        return self.capacity_type == CapacityType.SPOT
+
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(NameValidator, name=self.name)
 
@@ -1193,6 +1197,7 @@ class BaseClusterConfig(Resource):
         self._register_validator(
             HeadNodeLaunchTemplateValidator,
             head_node=self.head_node,
+            os=self.image.os,
             ami_id=self.head_node_ami,
             tags=self.get_cluster_tags(),
         )
@@ -2470,6 +2475,7 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                 ComputeResourceLaunchTemplateValidator,
                 queue=queue,
                 ami_id=queue_image,
+                os=self.image.os,
                 tags=self.get_cluster_tags(),
             )
             ami_volume_size = AWSApi.instance().ec2.describe_image(queue_image).volume_size

--- a/cli/src/pcluster/launch_template_utils.py
+++ b/cli/src/pcluster/launch_template_utils.py
@@ -1,0 +1,56 @@
+from abc import ABC, abstractmethod
+
+from pcluster.constants import OS_MAPPING
+
+
+class _LaunchTemplateBuilder(ABC):
+    """Abstract class with methods with the common logic for launch template builders."""
+
+    def get_block_device_mappings(self, root_volume, image_os):
+        """Return a list of block device mappings."""
+        block_device_mappings = []
+        for _, (device_name_index, virtual_name_index) in enumerate(zip(list(map(chr, range(97, 121))), range(0, 24))):
+            device_name = "/dev/xvdb{0}".format(device_name_index)
+            virtual_name = "ephemeral{0}".format(virtual_name_index)
+            block_device_mappings.append(self._block_device_mapping_for_virt(device_name, virtual_name))
+
+        block_device_mappings.append(
+            self._block_device_mapping_for_ebs(OS_MAPPING[image_os]["root-device"], root_volume)
+        )
+        return block_device_mappings
+
+    def get_instance_market_options(self, queue, compute_resource):
+        """Return the instance market options for spot instances."""
+        instance_market_options = None
+        if queue.is_spot():
+            instance_market_options = self._instance_market_option(
+                market_type="spot",
+                spot_instance_type="one-time",
+                instance_interruption_behavior="terminate",
+                max_price=None if compute_resource.spot_price is None else str(compute_resource.spot_price),
+            )
+        return instance_market_options
+
+    def get_capacity_reservation(self, queue, compute_resource):
+        """Return the capacity reservation if a target is defined at the queue or compute resource level."""
+        capacity_reservation = None
+        cr_target = compute_resource.capacity_reservation_target or queue.capacity_reservation_target
+        if cr_target:
+            capacity_reservation = self._capacity_reservation(cr_target)
+        return capacity_reservation
+
+    @abstractmethod
+    def _block_device_mapping_for_virt(self, device_name, virtual_name):
+        pass
+
+    @abstractmethod
+    def _block_device_mapping_for_ebs(self, device_name, volume):
+        pass
+
+    @abstractmethod
+    def _instance_market_option(self, market_type, spot_instance_type, instance_interruption_behavior, max_price):
+        pass
+
+    @abstractmethod
+    def _capacity_reservation(self, cr_target):
+        pass

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -361,3 +361,8 @@ def yaml_no_duplicates_constructor(loader, node, deep=False):
 def get_http_tokens_setting(imds_support):
     """Get http tokens settings for supported IMDS version."""
     return "required" if imds_support == "v2.0" else "optional"
+
+
+def remove_none_values(original_dictionary):
+    """Return a dictionary without entries with None value."""
+    return {key: value for key, value in original_dictionary.items() if value is not None}

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -35,7 +35,13 @@ from pcluster.constants import (
     SUPPORTED_REGIONS,
     SUPPORTED_SCHEDULERS,
 )
-from pcluster.utils import get_installed_version, get_supported_os_for_architecture, get_supported_os_for_scheduler
+from pcluster.launch_template_utils import _LaunchTemplateBuilder
+from pcluster.utils import (
+    get_installed_version,
+    get_supported_os_for_architecture,
+    get_supported_os_for_scheduler,
+    remove_none_values,
+)
 from pcluster.validators.common import FailureLevel, Validator
 
 # pylint: disable=C0302
@@ -941,6 +947,10 @@ class MixedSecurityGroupOverwriteValidator(Validator):
 class _LaunchTemplateValidator(Validator):
     """Abstract class to contain utility functions used by head node and queue LaunchTemplate validators."""
 
+    def __init__(self):
+        super().__init__()
+        self._launch_template_builder = DictLaunchTemplateBuilder()
+
     @staticmethod
     def _build_launch_network_interfaces(
         network_interfaces_count, use_efa, security_group_ids, subnet, use_public_ips=False
@@ -966,7 +976,7 @@ class _LaunchTemplateValidator(Validator):
     def _ec2_run_instance(self, availability_zone: str, **kwargs):  # noqa: C901 FIXME!!!
         """Wrap ec2 run_instance call. Useful since a successful run_instance call signals 'DryRunOperation'."""
         try:
-            AWSApi.instance().ec2.run_instances(**kwargs)
+            AWSApi.instance().ec2.run_instances(**remove_none_values(kwargs))
         except AWSClientError as e:
             code = e.error_code
             message = str(e)
@@ -1032,7 +1042,7 @@ class _LaunchTemplateValidator(Validator):
 class HeadNodeLaunchTemplateValidator(_LaunchTemplateValidator):
     """Try to launch the requested instance (in dry-run mode) to verify configuration parameters."""
 
-    def _validate(self, head_node, ami_id, tags):
+    def _validate(self, head_node, os, ami_id, tags):
         try:
             head_node_security_groups = []
             if head_node.networking.security_groups:
@@ -1057,6 +1067,10 @@ class HeadNodeLaunchTemplateValidator(_LaunchTemplateValidator):
                 NetworkInterfaces=head_node_network_interfaces,
                 DryRun=True,
                 TagSpecifications=self._generate_tag_specifications(tags),
+                KeyName=head_node.ssh.key_name,
+                BlockDeviceMappings=(
+                    self._launch_template_builder.get_block_device_mappings(head_node.local_storage.root_volume, os)
+                ),
             )
         except Exception as e:
             self._add_failure(
@@ -1087,7 +1101,7 @@ class HeadNodeImdsValidator(Validator):
 class ComputeResourceLaunchTemplateValidator(_LaunchTemplateValidator):
     """Try to launch the requested instances (in dry-run mode) to verify configuration parameters."""
 
-    def _validate(self, queue, ami_id, tags):
+    def _validate(self, queue, os, ami_id, tags):
         try:
             # Retrieve network parameters
             queue_subnet_id = queue.networking.subnet_ids[0]
@@ -1109,6 +1123,8 @@ class ComputeResourceLaunchTemplateValidator(_LaunchTemplateValidator):
             )
             # For SlurmFlexibleComputeResource test only the first InstanceType through a RunInstances
             self._test_compute_resource(
+                queue=queue,
+                os=os,
                 compute_resource=dry_run_compute_resource,
                 use_public_ips=bool(queue.networking.assign_public_ip),
                 ami_id=ami_id,
@@ -1123,7 +1139,7 @@ class ComputeResourceLaunchTemplateValidator(_LaunchTemplateValidator):
             )
 
     def _test_compute_resource(
-        self, compute_resource, use_public_ips, ami_id, subnet_id, security_groups_ids, placement_group, tags
+        self, queue, os, compute_resource, use_public_ips, ami_id, subnet_id, security_groups_ids, placement_group, tags
     ):
         """Test Compute Resource Instance Configuration."""
         network_interfaces = self._build_launch_network_interfaces(
@@ -1143,6 +1159,13 @@ class ComputeResourceLaunchTemplateValidator(_LaunchTemplateValidator):
             NetworkInterfaces=network_interfaces,
             DryRun=True,
             TagSpecifications=self._generate_tag_specifications(tags),
+            InstanceMarketOptions=self._launch_template_builder.get_instance_market_options(queue, compute_resource),
+            CapacityReservationSpecification=self._launch_template_builder.get_capacity_reservation(
+                queue, compute_resource
+            ),
+            BlockDeviceMappings=self._launch_template_builder.get_block_device_mappings(
+                queue.compute_settings.local_storage.root_volume, os
+            ),
         )
 
 
@@ -1202,3 +1225,45 @@ class SchedulerValidator(Validator):
                 f"{scheduler} scheduler is not supported. Supported schedulers are: {', '.join(SUPPORTED_SCHEDULERS)}.",
                 FailureLevel.ERROR,
             )
+
+
+class DictLaunchTemplateBuilder(_LaunchTemplateBuilder):
+    """Concrete class to build a dict with EC2 run instance properties to simulate our launch templates."""
+
+    def _block_device_mapping_for_ebs(self, device_name, volume):
+        return {
+            "DeviceName": device_name,
+            "Ebs": remove_none_values(
+                {
+                    "Encrypted": volume.encrypted,
+                    "VolumeType": volume.volume_type,
+                    "Iops": volume.iops,
+                    "Throughput": volume.throughput,
+                    "DeleteOnTermination": volume.delete_on_termination,
+                    "VolumeSize": volume.size,
+                }
+            ),
+        }
+
+    def _block_device_mapping_for_virt(self, device_name, virtual_name):
+        return {"DeviceName": device_name, "VirtualName": virtual_name}
+
+    def _instance_market_option(self, market_type, spot_instance_type, instance_interruption_behavior, max_price):
+        return {
+            "MarketType": market_type,
+            "SpotOptions": remove_none_values(
+                {
+                    "SpotInstanceType": spot_instance_type,
+                    "InstanceInterruptionBehavior": instance_interruption_behavior,
+                    "MaxPrice": max_price,
+                }
+            ),
+        }
+
+    def _capacity_reservation(self, cr_target):
+        return {
+            "CapacityReservationTarget": {
+                "CapacityReservationId": cr_target.capacity_reservation_id,
+                "CapacityReservationResourceGroupArn": cr_target.capacity_reservation_resource_group_arn,
+            }
+        }

--- a/cli/tests/pcluster/templates/test_cdk_builder_utils.py
+++ b/cli/tests/pcluster/templates/test_cdk_builder_utils.py
@@ -10,10 +10,23 @@
 # limitations under the License.
 import pytest
 from assertpy import assert_that
+from aws_cdk import aws_ec2 as ec2
 from aws_cdk.core import CfnTag
 
+from pcluster.config.cluster_config import (
+    BaseQueue,
+    CapacityReservationTarget,
+    RootVolume,
+    SlurmComputeResource,
+    SlurmQueue,
+)
 from pcluster.constants import PCLUSTER_CLUSTER_NAME_TAG, PCLUSTER_NODE_TYPE_TAG
-from pcluster.templates.cdk_builder_utils import dict_to_cfn_tags, get_cluster_tags, get_default_volume_tags
+from pcluster.templates.cdk_builder_utils import (
+    CdkLaunchTemplateBuilder,
+    dict_to_cfn_tags,
+    get_cluster_tags,
+    get_default_volume_tags,
+)
 
 
 @pytest.mark.parametrize(
@@ -72,3 +85,317 @@ def test_get_cluster_tags(stack_name, raw_dict, expected_result):
 def test_get_default_volume_tags(stack_name, node_type, raw_dict, expected_result):
     """Verify default volume tags."""
     assert_that(get_default_volume_tags(stack_name, node_type, raw_dict)).is_equal_to(expected_result)
+
+
+class TestCdkLaunchTemplateBuilder:
+    @pytest.mark.parametrize(
+        "root_volume, image_os, expected_response",
+        [
+            pytest.param(
+                RootVolume(
+                    size=10,
+                    encrypted=False,
+                    volume_type="mockVolumeType",
+                    iops=13,
+                    throughput=30,
+                    delete_on_termination=False,
+                ),
+                "centos7",
+                [
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdba", virtual_name="ephemeral0"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbb", virtual_name="ephemeral1"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbc", virtual_name="ephemeral2"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbd", virtual_name="ephemeral3"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbe", virtual_name="ephemeral4"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbf", virtual_name="ephemeral5"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbg", virtual_name="ephemeral6"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbh", virtual_name="ephemeral7"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbi", virtual_name="ephemeral8"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbj", virtual_name="ephemeral9"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbk", virtual_name="ephemeral10"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbl", virtual_name="ephemeral11"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbm", virtual_name="ephemeral12"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbn", virtual_name="ephemeral13"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbo", virtual_name="ephemeral14"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbp", virtual_name="ephemeral15"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbq", virtual_name="ephemeral16"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbr", virtual_name="ephemeral17"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbs", virtual_name="ephemeral18"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbt", virtual_name="ephemeral19"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbu", virtual_name="ephemeral20"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbv", virtual_name="ephemeral21"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbw", virtual_name="ephemeral22"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbx", virtual_name="ephemeral23"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/sda1",
+                        ebs=ec2.CfnLaunchTemplate.EbsProperty(
+                            volume_size=10,
+                            encrypted=False,
+                            volume_type="mockVolumeType",
+                            iops=13,
+                            throughput=30,
+                            delete_on_termination=False,
+                        ),
+                    ),
+                ],
+                id="test with all root volume fields populated",
+            ),
+            pytest.param(
+                RootVolume(
+                    encrypted=True,
+                    volume_type="mockVolumeType",
+                    iops=15,
+                    throughput=20,
+                    delete_on_termination=True,
+                ),
+                "alinux2",
+                [
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdba", virtual_name="ephemeral0"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbb", virtual_name="ephemeral1"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbc", virtual_name="ephemeral2"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbd", virtual_name="ephemeral3"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbe", virtual_name="ephemeral4"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbf", virtual_name="ephemeral5"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbg", virtual_name="ephemeral6"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbh", virtual_name="ephemeral7"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbi", virtual_name="ephemeral8"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbj", virtual_name="ephemeral9"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbk", virtual_name="ephemeral10"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbl", virtual_name="ephemeral11"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbm", virtual_name="ephemeral12"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbn", virtual_name="ephemeral13"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbo", virtual_name="ephemeral14"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbp", virtual_name="ephemeral15"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbq", virtual_name="ephemeral16"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbr", virtual_name="ephemeral17"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbs", virtual_name="ephemeral18"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbt", virtual_name="ephemeral19"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbu", virtual_name="ephemeral20"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbv", virtual_name="ephemeral21"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbw", virtual_name="ephemeral22"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvdbx", virtual_name="ephemeral23"
+                    ),
+                    ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
+                        device_name="/dev/xvda",
+                        ebs=ec2.CfnLaunchTemplate.EbsProperty(
+                            volume_size=None,
+                            encrypted=True,
+                            volume_type="mockVolumeType",
+                            iops=15,
+                            throughput=20,
+                            delete_on_termination=True,
+                        ),
+                    ),
+                ],
+                id="test with missing volume size",
+            ),
+        ],
+    )
+    def test_get_block_device_mappings(self, root_volume, image_os, expected_response):
+        assert_that(CdkLaunchTemplateBuilder().get_block_device_mappings(root_volume, image_os)).is_equal_to(
+            expected_response
+        )
+
+    @pytest.mark.parametrize(
+        "queue, compute_resource, expected_response",
+        [
+            pytest.param(
+                BaseQueue(name="queue1", capacity_type="spot"),
+                SlurmComputeResource(name="compute1", instance_type="t2.medium", spot_price=10.0),
+                ec2.CfnLaunchTemplate.InstanceMarketOptionsProperty(
+                    market_type="spot",
+                    spot_options=ec2.CfnLaunchTemplate.SpotOptionsProperty(
+                        spot_instance_type="one-time", instance_interruption_behavior="terminate", max_price="10.0"
+                    ),
+                ),
+                id="test with spot capacity",
+            ),
+            pytest.param(
+                BaseQueue(name="queue2", capacity_type="spot"),
+                SlurmComputeResource(name="compute2", instance_type="t2.medium"),
+                ec2.CfnLaunchTemplate.InstanceMarketOptionsProperty(
+                    market_type="spot",
+                    spot_options=ec2.CfnLaunchTemplate.SpotOptionsProperty(
+                        spot_instance_type="one-time", instance_interruption_behavior="terminate", max_price=None
+                    ),
+                ),
+                id="test with spot capacity but no spot price",
+            ),
+            pytest.param(
+                BaseQueue(name="queue2", capacity_type="ondemand"),
+                SlurmComputeResource(name="compute2", instance_type="t2.medium", spot_price="10.0"),
+                None,
+                id="test without spot capacity",
+            ),
+        ],
+    )
+    def test_get_instance_market_options(self, queue, compute_resource, expected_response):
+        assert_that(CdkLaunchTemplateBuilder().get_instance_market_options(queue, compute_resource)).is_equal_to(
+            expected_response
+        )
+
+    @pytest.mark.parametrize(
+        "queue, compute_resource, expected_response",
+        [
+            pytest.param(
+                SlurmQueue(
+                    name="queue1",
+                    capacity_reservation_target=CapacityReservationTarget(
+                        capacity_reservation_id="queue_cr_id",
+                        capacity_reservation_resource_group_arn="queue_cr_rg_arn",
+                    ),
+                    compute_resources=[],
+                    networking=None,
+                ),
+                SlurmComputeResource(
+                    name="compute1",
+                    instance_type="t2.medium",
+                    capacity_reservation_target=CapacityReservationTarget(
+                        capacity_reservation_id="comp_res_cr_id",
+                        capacity_reservation_resource_group_arn="comp_res_cr_rg_arn",
+                    ),
+                ),
+                ec2.CfnLaunchTemplate.CapacityReservationSpecificationProperty(
+                    capacity_reservation_target=ec2.CfnLaunchTemplate.CapacityReservationTargetProperty(
+                        capacity_reservation_id="comp_res_cr_id",
+                        capacity_reservation_resource_group_arn="comp_res_cr_rg_arn",
+                    )
+                ),
+                id="test with queue and compute resource capacity reservation",
+            ),
+            pytest.param(
+                SlurmQueue(
+                    name="queue1",
+                    capacity_reservation_target=CapacityReservationTarget(
+                        capacity_reservation_id="queue_cr_id",
+                        capacity_reservation_resource_group_arn="queue_cr_rg_arn",
+                    ),
+                    compute_resources=[],
+                    networking=None,
+                ),
+                SlurmComputeResource(
+                    name="compute1",
+                    instance_type="t2.medium",
+                ),
+                ec2.CfnLaunchTemplate.CapacityReservationSpecificationProperty(
+                    capacity_reservation_target=ec2.CfnLaunchTemplate.CapacityReservationTargetProperty(
+                        capacity_reservation_id="queue_cr_id",
+                        capacity_reservation_resource_group_arn="queue_cr_rg_arn",
+                    )
+                ),
+                id="test with only queue capacity reservation",
+            ),
+            pytest.param(
+                SlurmQueue(
+                    name="queue1",
+                    compute_resources=[],
+                    networking=None,
+                ),
+                SlurmComputeResource(
+                    name="compute1",
+                    instance_type="t2.medium",
+                ),
+                None,
+                id="test with no capacity reservation",
+            ),
+        ],
+    )
+    def test_get_capacity_reservation(self, queue, compute_resource, expected_response):
+        assert_that(CdkLaunchTemplateBuilder().get_capacity_reservation(queue, compute_resource)).is_equal_to(
+            expected_response
+        )

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -326,3 +326,11 @@ def test_yaml_load(yaml_string, expected_yaml_dict, expected_error):
 @pytest.mark.parametrize("imds_support, http_tokens", [("v1.0", "optional"), ("v2.0", "required")])
 def test_get_http_token_settings(imds_support, http_tokens):
     assert_that(utils.get_http_tokens_setting(imds_support)).is_equal_to(http_tokens)
+
+
+@pytest.mark.parametrize(
+    "original, response",
+    [({"test1": None, "test2": 2}, {"test2": 2}), ({"test1": 1, "test2": 2}, {"test1": 1, "test2": 2})],
+)
+def test_remove_none_values(original, response):
+    assert_that(utils.remove_none_values(original)).is_equal_to(response)


### PR DESCRIPTION
### Notes
This patch adds the missing fields to the launch template validators. For the head node, these are the `BlockDeviceMappings` and `KeyName`, while for the compute resources these are the `BlockDeviceMappings`, `InstanceMetadataOptions` and `CapacityReservationSpecification`. Created an abstract class holding the common logic, subclassed by two concrete classes generating CDK object and dictionaries for the desired launch template resources, by implementing abstract methods that are called in the template methods defined in the superclass.

### Tests
- Unit tests
- Manual test with the following configuration (note that root volumes are encrypted by default), verifying that it failed with the old code, and passes with my patch (because of the additional fields passed in the run instance dry-run that is executed by the validators):
```
Region: eu-west-1
Image:
  Os: alinux2
HeadNode:
  InstanceType: t2.micro
  Networking:
    SubnetId: <subnet id>
  Ssh:
    KeyName: <ssh key>
  Iam:
    S3Access:
      - BucketName: <bucket name>
Scheduling:
  Scheduler: slurm
  SlurmQueues:
  - Name: queue1
    CapacityType: SPOT
    ComputeResources:
    - Name: t2micro
      InstanceType: c5.xlarge
      MinCount: 1
      MaxCount: 10
    Networking:
      SubnetIds:
      - <subnet id>
```

on an account with the following policy settings disabling the creation of and run instance with unencrypted volumes:

```
{
  "Effect": "Deny",
  "Action": "ec2:CreateVolume",
  "Resource": "*",
  "Condition": {
    "Bool": {
      "ec2:Encrypted": "false"
    }
  }
},
{
  "Effect": "Deny",
  "Action": "ec2:RunInstances",
  "Resource": "arn:aws:ec2:*:*:volume/*",
  "Condition": {
    "Bool": {
      "ec2:Encrypted": "false"
    }
  }
}
```

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
