### PR TITLE
[Test] Move test_efa running with c5n.18xlarge to us-east-1.

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -13,7 +13,7 @@ test-suites:
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: ["us-west-2"]
+        - regions: ["us-east-1"]
           instances: ["c5n.18xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
1. Move `test_efa` running with c5n.18xlarge to us-east-1.

### Tests
1. [ONGOING] Tested on autoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
