### PR TITLE
Moving test_efa_and_placement_group to us-west-2 to avoid ICE

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -108,7 +108,7 @@ configure:
           schedulers: ["slurm"]
   test_pcluster_configure.py::test_efa_and_placement_group:
     dimensions:
-      - regions: ["us-east-1"]
+      - regions: ["us-west-2"]
         instances: {{ common.INSTANCES_EFA_SUPPORTED_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm"]


### PR DESCRIPTION
### Description of the change:
* Moved test_efa_and_placement_group to us-west-2 where there are more free c5n.9xlarge instances.