### PR TITLE
[release-3.1] Bump to version 3.1.5, fix linters errors and pin Smithy version

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -22,7 +22,7 @@ Parameters:
   ApiDefinitionS3Uri:
     Description: S3 URI of the ParallelCluster API spec
     Type: String
-    Default: s3://<REGION>-aws-parallelcluster/parallelcluster/3.1.4/api/ParallelCluster.openapi.yaml
+    Default: s3://<REGION>-aws-parallelcluster/parallelcluster/3.1.5/api/ParallelCluster.openapi.yaml
 
   CustomDomainName:
     Description: When specified, the custom domain name of the ParallelCluster API. Requires specifying a custom domain certificate
@@ -42,7 +42,7 @@ Parameters:
   PublicEcrImageUri:
     Description: When specified, the URI of the Docker image for the Lambda of the ParallelCluster API
     Type: String
-    Default: public.ecr.aws/parallelcluster/pcluster-api:3.1.4
+    Default: public.ecr.aws/parallelcluster/pcluster-api:3.1.5
 
   VpcEndpointId:
     Description: When specified, configure a private API with the specified endpoint
@@ -87,8 +87,8 @@ Parameters:
 Mappings:
   ParallelCluster:
     Constants:
-      Version: 3.1.4  # major.minor.patch+alpha/beta_identifier
-      ShortVersion: 3.1.4  # major.minor.patch
+      Version: 3.1.5  # major.minor.patch+alpha/beta_identifier
+      ShortVersion: 3.1.5  # major.minor.patch
       Stage: prod
 
 

--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -66,13 +66,13 @@ paths:
       tags:
         - Cluster Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     post:
       description: Create a managed cluster in a given region.
       operationId: CreateCluster
@@ -166,13 +166,13 @@ paths:
       tags:
         - Cluster Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}:
     delete:
       description: Initiate the deletion of a cluster.
@@ -232,13 +232,13 @@ paths:
       tags:
         - Cluster Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     get:
       description: Get detailed information about an existing cluster.
       operationId: DescribeCluster
@@ -297,13 +297,13 @@ paths:
       tags:
         - Cluster Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     put:
       description: Update a cluster managed in a given region.
       operationId: UpdateCluster
@@ -411,13 +411,13 @@ paths:
       tags:
         - Cluster Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}/computefleet:
     get:
       description: Describe the status of the compute fleet.
@@ -477,13 +477,13 @@ paths:
       tags:
         - Cluster ComputeFleet
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     patch:
       description: Update the status of the cluster compute fleet.
       operationId: UpdateComputeFleet
@@ -548,13 +548,13 @@ paths:
       tags:
         - Cluster ComputeFleet
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}/instances:
     delete:
       description: Initiate the forced termination of all cluster compute nodes. Does not work with AWS Batch clusters.
@@ -617,13 +617,13 @@ paths:
       tags:
         - Cluster Instances
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     get:
       description: Describe the instances belonging to a given cluster.
       operationId: DescribeClusterInstances
@@ -693,13 +693,13 @@ paths:
       tags:
         - Cluster Instances
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}/logstreams:
     get:
       description: Retrieve the list of log streams associated with a cluster.
@@ -784,13 +784,13 @@ paths:
       tags:
         - Cluster Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}/logstreams/{logStreamName}:
     get:
       description: Retrieve the events associated with a log stream.
@@ -892,13 +892,13 @@ paths:
       tags:
         - Cluster Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/clusters/{clusterName}/stackevents:
     get:
       description: Retrieve the events associated with the stack for a given cluster.
@@ -964,13 +964,13 @@ paths:
       tags:
         - Cluster Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/custom:
     get:
       description: Retrieve the list of existing custom images.
@@ -1028,13 +1028,13 @@ paths:
       tags:
         - Image Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     post:
       description: Create a custom ParallelCluster image in a given region.
       operationId: BuildImage
@@ -1128,13 +1128,13 @@ paths:
       tags:
         - Image Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/custom/{imageId}:
     delete:
       description: Initiate the deletion of the custom ParallelCluster image.
@@ -1201,13 +1201,13 @@ paths:
       tags:
         - Image Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
     get:
       description: Get detailed information about an existing image.
       operationId: DescribeImage
@@ -1266,13 +1266,13 @@ paths:
       tags:
         - Image Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/custom/{imageId}/logstreams:
     get:
       description: Retrieve the list of log streams associated with an image.
@@ -1338,13 +1338,13 @@ paths:
       tags:
         - Image Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/custom/{imageId}/logstreams/{logStreamName}:
     get:
       description: Retrieve the events associated with an image build.
@@ -1446,13 +1446,13 @@ paths:
       tags:
         - Image Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/custom/{imageId}/stackevents:
     get:
       description: Retrieve the events associated with the stack for a given image build.
@@ -1518,13 +1518,13 @@ paths:
       tags:
         - Image Logs
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
   /v3/images/official:
     get:
       description: List Official ParallelCluster AMIs.
@@ -1582,13 +1582,13 @@ paths:
       tags:
         - Image Operations
       x-amazon-apigateway-integration:
-        credentials:
-          Fn::Sub: ${APIGatewayExecutionRole.Arn}
-        httpMethod: POST
-        payloadFormatVersion: "2.0"
         type: aws_proxy
+        httpMethod: POST
         uri:
           Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ParallelClusterFunction.Arn}/invocations
+        credentials:
+          Fn::Sub: ${APIGatewayExecutionRole.Arn}
+        payloadFormatVersion: "2.0"
 components:
   schemas:
     AmiInfo:

--- a/api/spec/smithy/build.gradle.kts
+++ b/api/spec/smithy/build.gradle.kts
@@ -10,17 +10,18 @@ repositories {
 
 buildscript {
     dependencies {
-        classpath("software.amazon.smithy:smithy-openapi:1.16.2")
-        classpath("software.amazon.smithy:smithy-aws-traits:1.16.2")
-        classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:1.16.2")
+        classpath("software.amazon.smithy:smithy-cli:1.22.0")
+        classpath("software.amazon.smithy:smithy-openapi:1.22.0")
+        classpath("software.amazon.smithy:smithy-aws-traits:1.22.0")
+        classpath("software.amazon.smithy:smithy-aws-apigateway-openapi:1.22.0")
     }
 }
 
 dependencies {
-    implementation("software.amazon.smithy:smithy-aws-apigateway-traits:1.16.2")
-    implementation("software.amazon.smithy:smithy-aws-traits:1.16.2")
-    implementation("software.amazon.smithy:smithy-model:1.16.2")
-    implementation("software.amazon.smithy:smithy-linters:1.16.2")
+    implementation("software.amazon.smithy:smithy-aws-apigateway-traits:1.22.0")
+    implementation("software.amazon.smithy:smithy-aws-traits:1.22.0")
+    implementation("software.amazon.smithy:smithy-model:1.22.0")
+    implementation("software.amazon.smithy:smithy-linters:1.22.0")
 }
 
 tasks["jar"].enabled = false

--- a/awsbatch-cli/tests/conftest.py
+++ b/awsbatch-cli/tests/conftest.py
@@ -61,9 +61,8 @@ def convert_to_date_mock(request, mocker):
         from awsbatch.utils import convert_to_date
 
         # executes convert_to_date but overrides arguments so that timezone is enforced to utc
-        if "timezone" in kwargs:
-            del kwargs["timezone"]
-        return convert_to_date(timezone=tz.tzutc(), *args, **kwargs)
+        kwargs["timezone"] = tz.tzutc()
+        return convert_to_date(*args, **kwargs)
 
     return mocker.patch("awsbatch." + module_under_test + ".convert_to_date", wraps=_convert_to_date_utc)
 

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -20,7 +20,7 @@ def readme():
         return f.read()
 
 
-VERSION = "3.1.4"
+VERSION = "3.1.5"
 CDK_VERSION = "1.137,!=1.153.0"
 REQUIRES = [
     "setuptools",

--- a/cli/src/pcluster/api/errors.py
+++ b/cli/src/pcluster/api/errors.py
@@ -5,7 +5,6 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from abc import ABC
 
 from connexion import ProblemException
 from werkzeug.exceptions import HTTPException
@@ -59,7 +58,7 @@ def exception_message(exception):
         }
 
 
-class ParallelClusterApiException(ABC, Exception):
+class ParallelClusterApiException(Exception):
     """Base class for ParallelCluster Api exceptions."""
 
     code: int = None

--- a/cli/src/pcluster/aws/common.py
+++ b/cli/src/pcluster/aws/common.py
@@ -14,7 +14,6 @@ import logging
 import os
 import threading
 import time
-from abc import ABC
 from enum import Enum
 from typing import Dict
 
@@ -137,7 +136,7 @@ def _log_boto3_calls(params, **kwargs):
     )
 
 
-class Boto3Client(ABC):
+class Boto3Client:
     """Abstract Boto3 client."""
 
     def __init__(self, client_name: str, botocore_config_kwargs: Dict = None):
@@ -160,7 +159,7 @@ class Boto3Client(ABC):
                 yield result
 
 
-class Boto3Resource(ABC):
+class Boto3Resource:
     """Abstract Boto3 resource."""
 
     def __init__(self, resource_name: str):

--- a/cli/src/pcluster/cli/commands/common.py
+++ b/cli/src/pcluster/cli/commands/common.py
@@ -93,7 +93,7 @@ class Iso8601Arg:
             )
 
 
-class ExportLogsCommand(ABC):
+class ExportLogsCommand:
     """Class to put in common code between image and cluster export logs commands."""
 
     @staticmethod

--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -217,7 +217,7 @@ def configure(args):  # noqa: C901
             max_cluster_size = int(
                 prompt(
                     "Maximum {0}".format(size_name),
-                    validator=lambda x: str(x).isdigit() and int(x) >= min_cluster_size,  # pylint: disable=W0640
+                    validator=lambda x, ms=min_cluster_size: str(x).isdigit() and int(x) >= ms,  # pylint: disable=W0640
                     default_value=DEFAULT_MAX_COUNT,
                 )
             )

--- a/cli/src/pcluster/cli/exceptions.py
+++ b/cli/src/pcluster/cli/exceptions.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import json
-from abc import ABC
 
 
-class CLIException(Exception, ABC):
+class CLIException(Exception):
     """Base CLI Exception class."""
 
     def __init__(self, data):

--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -65,7 +65,7 @@ class TypeMatchValidatorsSuppressor(ValidatorSuppressor):
         return validator.type in self._validators_to_suppress
 
 
-class Resource(ABC):
+class Resource:
     """Represent an abstract Resource entity."""
 
     class Param:

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -65,8 +65,8 @@ MAX_NUMBER_OF_COMPUTE_RESOURCES = 5
 MAX_STORAGE_COUNT = {"ebs": 5, "efs": 1, "fsx": 1, "raid": 1}
 
 COOKBOOK_PACKAGES_VERSIONS = {
-    "parallelcluster": "3.1.4",
-    "cookbook": "aws-parallelcluster-cookbook-3.1.4",
+    "parallelcluster": "3.1.5",
+    "cookbook": "aws-parallelcluster-cookbook-3.1.5",
     "chef": "17.2.29",
     "berkshelf": "7.2.0",
     "ami": "dev",

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -9,7 +9,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import re
-from abc import ABC
 from enum import Enum
 
 from pcluster.aws.aws_api import AWSApi
@@ -745,7 +744,7 @@ class MixedSecurityGroupOverwriteValidator(Validator):
 # --------------- Instance settings validators --------------- #
 
 
-class _LaunchTemplateValidator(Validator, ABC):
+class _LaunchTemplateValidator(Validator):
     """Abstract class to contain utility functions used by head node and queue LaunchTemplate validators."""
 
     def _build_launch_network_interfaces(

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -200,7 +200,7 @@ def get_latest_images(images):
         for _key, value in DISTROS.items():
             ami_filtered_and_sorted = sorted(
                 filter(
-                    lambda ami: "-{0}-".format(value) in ami["Name"] and ami["Architecture"] == architecture,
+                    lambda ami, v=value, a=architecture: "-{0}-".format(v) in ami["Name"] and ami["Architecture"] == a,
                     images["Images"],
                 ),
                 key=lambda ami: ami["CreationDate"],


### PR DESCRIPTION
### Description of changes
* Bump to version 3.1.5
* Cherry-pick of https://github.com/aws/aws-parallelcluster/commit/5701d621e0069f9ee63383fa631f7b773be09ef4 to pin Smithy version for API
* Cherry-pick of https://github.com/aws/aws-parallelcluster/commit/c2c08cf09eb590b07264713e66daff28b6174d1d to fix code-linter errors
* Fixed code linter errors

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
