### PR TITLE
[2.x][integ-tests] Fix test_ebs_snapshot volume size

### DIFF
--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -68,7 +68,8 @@ def test_ebs_snapshot(
 
     mount_dir = "/" + mount_dir
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
-    _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size="9.8")
+    # In alinux2 the volume is rounded smaller (9.7G)
+    _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size="9.[7,8]")
     _test_ebs_resize(remote_command_executor, mount_dir, volume_size=volume_size)
     _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 


### PR DESCRIPTION
### Description of changes
* Fix integration test with test_ebs_snapshot, for alinux2, the volume size is 9.7G, for other OSs, it is 9.8G

Signed-off-by: chenwany <chenwany@amazon.com>

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
