### PR TITLE
[3.1][Integ tests] Fix test_ebs volume size

### DIFF
--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -65,7 +65,8 @@ def test_ebs_snapshot(
 
     mount_dir = "/" + mount_dir
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
-    _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size="9.8")
+    # In alinux2 the volume is rounded smaller (9.7G)
+    _test_ebs_correctly_mounted(remote_command_executor, mount_dir, volume_size="9.[7,8]")
     _test_ebs_resize(remote_command_executor, mount_dir, volume_size=volume_size)
     _test_ebs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
@@ -148,7 +149,8 @@ def test_ebs_existing(
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = get_scheduler_commands(scheduler, remote_command_executor)
     existing_mount_dir = "/" + existing_mount_dir
-    _test_ebs_correctly_mounted(remote_command_executor, existing_mount_dir, volume_size="9.8")
+    # In alinux2 the volume is rounded smaller (9.7G)
+    _test_ebs_correctly_mounted(remote_command_executor, existing_mount_dir, volume_size="9.[7,8]")
     _test_ebs_correctly_shared(remote_command_executor, existing_mount_dir, scheduler_commands)
     # Checks for test data
     result = remote_command_executor.run_remote_command("cat {}/test.txt".format(existing_mount_dir))


### PR DESCRIPTION
Signed-off-by: Edoardo Antonini <eantonin@amazon.com>

### Description of changes
* Fix integration test with test_ebs_snapshot, for alinux2, the volume size is 9.7G, for other OSs, it is 9.8G

### References
* Similar PRs https://github.com/aws/aws-parallelcluster/pull/4508 and https://github.com/aws/aws-parallelcluster/pull/4495

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
