### PR TITLE
develop: Install efibootmgr before updating Ubuntu OS packages

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -103,6 +103,19 @@ phases:
                 update-grub
               fi
 
+      - name: InstallEfiBootManager
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -v
+              PLATFORM='{{ build.PlatformName.outputs.stdout }}'
+              ARCH=$(uname -m)
+              if [[ `echo ${!ARCH}` == 'aarch64' ]] && [[ ${!PLATFORM} == DEBIAN ]]; then
+                # temporary workaround to solve https://bugs.launchpad.net/ubuntu/+source/grub2-signed/+bug/1936857
+                apt-get -y install efibootmgr
+              fi
+
       - name: UpdateOS
         action: ExecuteBash
         inputs:


### PR DESCRIPTION
### Description of changes
This step is needed to unblock the first stage build that is failing during the update of the `grub-efi-arm64` with the error:
```
Setting up grub-efi-arm64 (2.04-1ubuntu47.4) ...
Installing for arm64-efi platform.
grub-install: error: efibootmgr: not found.
```

The discarded alternative is to exclude some packages from the update:
```
sudo apt-mark hold grub-efi-arm64 grub-efi-arm64-bin grub-efi-arm64-signed
```

### Tests
Tested AMI creation for Ubuntu20 and Ubuntu18 ARM with the following config:
```
Image:
  Name: first-stage-test-aws-parallelcluster-3.3.0-ubuntu-1804-lts-hvm-arm64
  RootVolume:
    Size: 35
Build:
  Iam:
    AdditionalIamPolicies:
      - Policy: arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
  InstanceType: g5g.2xlarge
  ParentImage: ami-024b8a7b6c33e84eb  # Ubuntu18
  # ParentImage: ami-06a5b9a010e54ab8d # Ubuntu20
  UpdateOsPackages:
    Enabled: true
DevSettings:
  DisablePclusterComponent: true
```

### References
* Known ubuntu issue: https://bugs.launchpad.net/ubuntu/+source/grub2-signed/+bug/1936857
* EFI Boot manager documentation: https://manpages.ubuntu.com/manpages/bionic/man8/efibootmgr.8.html

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
