### PR TITLE
[3.1.x] Move the following integration tests regions to reduce the risk of insufficient capacity: test_efa and test_intel_hpc

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -271,7 +271,7 @@ iam:
 intel_hpc:
   test_intel_hpc.py::test_intel_hpc:
     dimensions:
-      - regions: ["sa-east-1"]
+      - regions: ["us-west-2"]
         instances: ["c5n.18xlarge"]
         oss: ["centos7"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -31,7 +31,7 @@ test-suites:
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: [ "sa-east-1" ]
+        - regions: [ "us-gov-west-1" ]
           instances: [ "c5n.18xlarge" ]
           oss: [ "alinux2" ]
           schedulers: [ "slurm" ]


### PR DESCRIPTION
### Description of changes
Move the following integration tests regions to reduce the risk of insufficient capacity: test_efa and test_intel_hpc

### Tests
No test needed

### References
Partial backport of https://github.com/aws/aws-parallelcluster/pull/4461/files

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
