### PR TITLE
[3.1.x] Remove Ubuntu 18 test in gov cloud aligning with develop

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -131,9 +131,6 @@ createami:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2", "ubuntu2004", "centos7"]
-      - regions: ["us-gov-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1804"]
   test_createami.py::test_build_image_custom_components:
     dimensions:
       - regions: ["ap-southeast-2"]


### PR DESCRIPTION
Signed-off-by: Edoardo Antonini <eantonin@amazon.com>


### Description of changes
Remove Ubuntu 18 test in gov cloud aligning with develop

### Tests
No test needed

### References
[Current develop code](https://github.com/aws/aws-parallelcluster/blob/develop/tests/integration-tests/configs/common/common.yaml#L147) is not testing with ubuntu 18

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
