### PR TITLE
Allow to specify a VcpConfig for PCluster Lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ CHANGELOG
 
 **ENHANCEMENTS**
 - Add new configuration parameter in `Iam/ResourcePrefix` to specify a prefix for path and name of IAM resources created by ParallelCluster
-
-3.4.0
------
+- Add new configuration section `DeploySettings/LambdaFunctionsVpcConfig` for specifying the Vpc config used by ParallelCluster Lambda Functions.
 
 **CHANGES**
 - Remove creation of EFS mount targets for existing FS.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -23,7 +23,7 @@ import pkg_resources
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.aws_resources import InstanceTypeInfo
 from pcluster.aws.common import AWSClientError, get_region
-from pcluster.config.common import AdditionalIamPolicy, BaseDevSettings, BaseTag
+from pcluster.config.common import AdditionalIamPolicy, BaseDevSettings, BaseTag, DeploymentSettings
 from pcluster.config.common import Imds as TopLevelImds
 from pcluster.config.common import Resource
 from pcluster.constants import (
@@ -1148,6 +1148,7 @@ class BaseClusterConfig(Resource):
         imds: TopLevelImds = None,
         additional_resources: str = None,
         dev_settings: ClusterDevSettings = None,
+        deployment_settings: DeploymentSettings = None,
     ):
         super().__init__()
         self.__region = None
@@ -1177,6 +1178,7 @@ class BaseClusterConfig(Resource):
         self.original_config_version = ""
         self._official_ami = None
         self.imds = imds or TopLevelImds(implied="v1.0")
+        self.deployment_settings = deployment_settings
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(RegionValidator, region=self.region)
@@ -1557,6 +1559,11 @@ class BaseClusterConfig(Resource):
                 self.image.os, self.head_node.architecture, ami_filters
             )
         return self._official_ami
+
+    @property
+    def lambda_functions_vpc_config(self):
+        """Return the vpc config of the PCluster Lambda Functions or None."""
+        return self.deployment_settings.lambda_functions_vpc_config if self.deployment_settings else None
 
     def get_cluster_tags(self):
         """Return tags configured in the cluster configuration."""

--- a/cli/src/pcluster/config/imagebuilder_config.py
+++ b/cli/src/pcluster/config/imagebuilder_config.py
@@ -16,7 +16,15 @@
 from typing import List
 
 from pcluster.aws.common import get_region
-from pcluster.config.common import AdditionalIamPolicy, BaseDevSettings, BaseTag, ExtraChefAttributes, Imds, Resource
+from pcluster.config.common import (
+    AdditionalIamPolicy,
+    BaseDevSettings,
+    BaseTag,
+    DeploymentSettings,
+    ExtraChefAttributes,
+    Imds,
+    Resource,
+)
 from pcluster.imagebuilder_utils import ROOT_VOLUME_TYPE
 from pcluster.validators.common import ValidatorContext
 from pcluster.validators.ebs_validators import EbsVolumeTypeSizeValidator
@@ -212,6 +220,7 @@ class ImageBuilderConfig(Resource):
         config_region: str = None,
         custom_s3_bucket: str = None,
         source_config: str = None,
+        deployment_settings: DeploymentSettings = None,
     ):
         super().__init__()
         self.image = image
@@ -225,6 +234,7 @@ class ImageBuilderConfig(Resource):
         self.config_region = config_region
         self.custom_s3_bucket = Resource.init_param(custom_s3_bucket)
         self.source_config = source_config
+        self.deployment_settings = deployment_settings
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         # Volume size validator only validates specified volume size
@@ -243,6 +253,11 @@ class ImageBuilderConfig(Resource):
         if self.custom_s3_bucket:
             self._register_validator(S3BucketValidator, bucket=self.custom_s3_bucket)
             self._register_validator(S3BucketRegionValidator, bucket=self.custom_s3_bucket, region=get_region())
+
+    @property
+    def lambda_functions_vpc_config(self):
+        """Return the vpc config of the PCluster Lambda Functions or None."""
+        return self.deployment_settings.lambda_functions_vpc_config if self.deployment_settings else None
 
 
 # ------------ Attributes class used in imagebuilder resources ----------- #

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -197,3 +197,5 @@ SCHEDULER_PLUGIN_INTERFACE_VERSION_LOW_RANGE = packaging.version.Version("1.0")
 DIRECTORY_SERVICE_RESERVED_SETTINGS = {"id_provider": "ldap"}
 
 DEFAULT_EPHEMERAL_DIR = "/scratch"
+
+LAMBDA_VPC_ACCESS_MANAGED_POLICY = "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -125,7 +125,12 @@ from pcluster.constants import (
     SUPPORTED_OSES,
 )
 from pcluster.models.s3_bucket import parse_bucket_url
-from pcluster.schemas.common_schema import AdditionalIamPolicySchema, BaseDevSettingsSchema, BaseSchema
+from pcluster.schemas.common_schema import (
+    AdditionalIamPolicySchema,
+    BaseDevSettingsSchema,
+    BaseSchema,
+    DeploymentSettingsSchema,
+)
 from pcluster.schemas.common_schema import ImdsSchema as TopLevelImdsSchema
 from pcluster.schemas.common_schema import TagSchema, get_field_validator, validate_no_reserved_tag
 from pcluster.utils import yaml_load
@@ -1961,6 +1966,7 @@ class ClusterSchema(BaseSchema):
     custom_s3_bucket = fields.Str(metadata={"update_policy": UpdatePolicy.READ_ONLY_RESOURCE_BUCKET})
     additional_resources = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     dev_settings = fields.Nested(ClusterDevSettingsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    deployment_settings = fields.Nested(DeploymentSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 
     def __init__(self, cluster_name: str):
         super().__init__()

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -35,6 +35,7 @@ from pcluster.schemas.common_schema import (
     AdditionalIamPolicySchema,
     BaseDevSettingsSchema,
     BaseSchema,
+    DeploymentSettingsSchema,
     ImdsSchema,
     TagSchema,
     get_field_validator,
@@ -220,6 +221,7 @@ class ImageBuilderSchema(BaseSchema):
     dev_settings = fields.Nested(ImagebuilderDevSettingsSchema)
     config_region = fields.Str(data_key="Region")
     custom_s3_bucket = fields.Str()
+    deployment_settings = fields.Nested(DeploymentSettingsSchema)
 
     @post_load(pass_original=True)
     def make_resource(self, data, original_data, **kwargs):

--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -617,6 +617,7 @@ class AwsBatchConstruct(Construct):
                         )
                     ),
                 ],
+                has_vpc_config=self.config.lambda_functions_vpc_config,
             )
 
         return PclusterLambdaConstruct(
@@ -680,6 +681,7 @@ class AwsBatchConstruct(Construct):
                         )
                     )
                 ],
+                has_vpc_config=self.config.lambda_functions_vpc_config,
             )
 
         return PclusterLambdaConstruct(

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -399,6 +399,7 @@ class ClusterCdkStack(Stack):
                         )
                     ),
                 ],
+                has_vpc_config=self.config.lambda_functions_vpc_config,
             )
 
         cleanup_resources_lambda = PclusterLambdaConstruct(

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -261,6 +261,7 @@ class SlurmConstruct(Construct):
                         )
                     ),
                 ],
+                has_vpc_config=self.config.lambda_functions_vpc_config,
             )
 
         cleanup_route53_lambda = PclusterLambdaConstruct(

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -77,8 +77,8 @@ class SingleSubnetValidator(Validator):
             self._add_failure("The SubnetId used for all of the queues should be the same.", FailureLevel.ERROR)
 
 
-class LambdaVpcConfigValidator(Validator):
-    """Validator of a Lambda function's VPC configuration."""
+class LambdaFunctionsVpcConfigValidator(Validator):
+    """Validator of Pcluster Lambda functions' VPC configuration."""
 
     def _validate(self, security_group_ids: List[str], subnet_ids: List[str]):
         existing_security_groups = AWSApi.instance().ec2.describe_security_groups(security_group_ids)

--- a/cli/tests/pcluster/config/dummy_imagebuilder_config.py
+++ b/cli/tests/pcluster/config/dummy_imagebuilder_config.py
@@ -8,7 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from pcluster.config.common import BaseTag, Cookbook, Imds
+from pcluster.config.common import BaseTag, Cookbook, DeploymentSettings, Imds, LambdaFunctionsVpcConfig
 from pcluster.config.imagebuilder_config import (
     AdditionalIamPolicy,
     Build,
@@ -27,6 +27,8 @@ CLASS_DICT = {
     "image": Image,
     "build": Build,
     "dev_settings": ImagebuilderDevSettings,
+    "lambda_functions_vpc_config": LambdaFunctionsVpcConfig,
+    "deployment_settings": DeploymentSettings,
     "root_volume": Volume,
     "tags": BaseTag,
     "components": Component,

--- a/cli/tests/pcluster/validators/test_all_validators/test_scheduler_plugin_all_validators_are_called/scheduler_plugin_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_scheduler_plugin_all_validators_are_called/scheduler_plugin_1.yaml
@@ -268,3 +268,7 @@ DevSettings:
   Timeouts:
     HeadNodeBootstrapTimeout: 1201  # Default 1800 (seconds)
     ComputeNodeBootstrapTimeout: 1001  # Default 1800 (seconds)
+DeploymentSettings:
+  LambdaFunctionsVpcConfig:
+    SecurityGroupIds: ["sg-028d73ae220157d96"]
+    SubnetIds: ["subnet-8e482ce8"]

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -192,3 +192,7 @@ DevSettings:
       {"cluster": {"scheduler_slots": "cores"}}
   AwsBatchCliPackage: s3://test/aws-parallelcluster-batch-3.0.tgz
   NodePackage: s3://test/aws-parallelcluster-node-3.0.tgz
+DeploymentSettings:
+  LambdaFunctionsVpcConfig:
+    SecurityGroupIds: ["sg-028d73ae220157d96"]
+    SubnetIds: ["subnet-8e482ce8"]

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -13,7 +13,7 @@ import os
 import pytest
 
 from pcluster.validators.networking_validators import (
-    LambdaVpcConfigValidator,
+    LambdaFunctionsVpcConfigValidator,
     SecurityGroupsValidator,
     SingleSubnetValidator,
     SubnetsValidator,
@@ -148,11 +148,11 @@ def test_single_subnet_validator(queues, failure_message):
         ),
     ],
 )
-def test_vpc_config_validator(
+def test_lambda_functions_vpc_config_validator(
     aws_api_mock, security_group_ids, subnet_ids, existing_security_groups, existing_subnets, expected_response
 ):
     aws_api_mock.ec2.describe_security_groups.return_value = existing_security_groups
     aws_api_mock.ec2.describe_subnets.return_value = existing_subnets
 
-    actual_response = LambdaVpcConfigValidator().execute(security_group_ids, subnet_ids)
+    actual_response = LambdaFunctionsVpcConfigValidator().execute(security_group_ids, subnet_ids)
     assert_failure_messages(actual_response, expected_response)

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -12,7 +12,12 @@ import os
 
 import pytest
 
-from pcluster.validators.networking_validators import SecurityGroupsValidator, SingleSubnetValidator, SubnetsValidator
+from pcluster.validators.networking_validators import (
+    LambdaVpcConfigValidator,
+    SecurityGroupsValidator,
+    SingleSubnetValidator,
+    SubnetsValidator,
+)
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.validators.utils import assert_failure_messages
 
@@ -78,3 +83,76 @@ def test_single_subnet_validator(queues, failure_message):
     actual_failure = SingleSubnetValidator().execute(queues)
 
     assert_failure_messages(actual_failure, failure_message)
+
+
+@pytest.mark.parametrize(
+    "security_group_ids, subnet_ids, existing_security_groups, existing_subnets, expected_response",
+    [
+        pytest.param(
+            ["sg-test"],
+            ["subnet-test"],
+            [{"GroupId": "sg-test", "VpcId": "vpc-test"}],
+            [{"SubnetId": "subnet-test", "VpcId": "vpc-test"}],
+            "",
+            id="successful case",
+        ),
+        pytest.param(
+            ["sg-test1", "sg-test2"],
+            ["subnet-test"],
+            [{"GroupId": "sg-test1", "VpcId": "vpc-test1"}, {"GroupId": "sg-test2", "VpcId": "vpc-test2"}],
+            [{"SubnetId": "subnet-test", "VpcId": "vpc-test"}],
+            "The security groups associated to the Lambda are required to be in the same VPC.",
+            id="security groups with different VPCs",
+        ),
+        pytest.param(
+            ["sg-test"],
+            ["subnet-test1", "subnet-test2"],
+            [{"GroupId": "sg-test", "VpcId": "vpc-test"}],
+            [{"SubnetId": "subnet-test1", "VpcId": "vpc-test1"}, {"SubnetId": "subnet-test2", "VpcId": "vpc-test2"}],
+            "The subnets associated to the Lambda are required to be in the same VPC.",
+            id="subnets with different VPCs",
+        ),
+        pytest.param(
+            ["sg-test"],
+            ["subnet-test"],
+            [{"GroupId": "sg-test", "VpcId": "vpc-test1"}],
+            [{"SubnetId": "subnet-test", "VpcId": "vpc-test2"}],
+            "The security groups and subnets associated to the Lambda are required to be in the same VPC.",
+            id="security groups and subnets with different VPCs",
+        ),
+        pytest.param(
+            ["sg-test2", "sg-test3", "sg-test1"],
+            ["subnet-test"],
+            [
+                {"GroupId": "sg-test2", "VpcId": "vpc-test"},
+                {"GroupId": "sg-test4", "VpcId": "vpc-test"},
+                {"GroupId": "sg-test5", "VpcId": "vpc-test"},
+                {"GroupId": "sg-test6", "VpcId": "vpc-test"},
+            ],
+            [{"SubnetId": "subnet-test", "VpcId": "vpc-test"}],
+            "Some security groups associated to the Lambda are not present in the account: ['sg-test1', 'sg-test3'].",
+            id="missing security groups",
+        ),
+        pytest.param(
+            ["sg-test"],
+            ["subnet-test2", "subnet-test3", "subnet-test1"],
+            [{"GroupId": "sg-test", "VpcId": "vpc-test"}],
+            [
+                {"SubnetId": "subnet-test2", "VpcId": "vpc-test"},
+                {"SubnetId": "subnet-test4", "VpcId": "vpc-test"},
+                {"SubnetId": "subnet-test5", "VpcId": "vpc-test"},
+                {"SubnetId": "subnet-test6", "VpcId": "vpc-test"},
+            ],
+            "Some subnets associated to the Lambda are not present in the account: ['subnet-test1', 'subnet-test3'].",
+            id="missing subnets",
+        ),
+    ],
+)
+def test_vpc_config_validator(
+    aws_api_mock, security_group_ids, subnet_ids, existing_security_groups, existing_subnets, expected_response
+):
+    aws_api_mock.ec2.describe_security_groups.return_value = existing_security_groups
+    aws_api_mock.ec2.describe_subnets.return_value = existing_subnets
+
+    actual_response = LambdaVpcConfigValidator().execute(security_group_ids, subnet_ids)
+    assert_failure_messages(actual_response, expected_response)

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -18,3 +18,10 @@ Build:
           Value: dummyBuildTag
 
 CustomS3Bucket: {{ bucket_name }}
+
+DeploymentSettings:
+    LambdaFunctionsVpcConfig:
+        SubnetIds:
+        - {{ subnet_id }}
+        SecurityGroupIds:
+        - {{ security_group_id }}


### PR DESCRIPTION
### Description of changes
This patch adds the possibility to specify a VPC configuration to use for ParallelCluster Lambda Functions (which ParallelCluster uses to implement CloudFormation Custom Resources). This patch also adds a validator that will be used to validate the ParallelCluster Lambda functions' VPC configuration. It checks that the configuration's subnets and security groups are present in the account and all have the same VPC.

### Tests
- Unit tests.
- Manual tests with:
  - Private subnet with NATGW.
  - Private subnet isolated from the internet configured with VPC endpoints ([ParallelCluster documentation](https://docs.aws.amazon.com/parallelcluster/latest/ug/network-configuration-v3.html#aws-parallelcluster-in-a-single-public-subnet-no-internet-v3)).

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
