### PR TITLE
[MultiAZ] Include SubnetID only when using RunInstances API

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1431,7 +1431,9 @@ class ComputeFleetConstruct(Construct):
                 else None,  # parameter not supported for instance types with multiple network interfaces
                 interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
                 groups=queue_lt_security_groups,
-                subnet_id=queue.networking.subnet_ids[0],
+                subnet_id=queue.networking.subnet_ids[0]
+                if isinstance(compute_resource, SlurmComputeResource)
+                else None,
             )
         ]
 
@@ -1442,7 +1444,9 @@ class ComputeFleetConstruct(Construct):
                     network_card_index=network_interface_index,
                     interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
                     groups=queue_lt_security_groups,
-                    subnet_id=queue.networking.subnet_ids[0],
+                    subnet_id=queue.networking.subnet_ids[0]
+                    if isinstance(compute_resource, SlurmComputeResource)
+                    else None,
                 )
             )
 


### PR DESCRIPTION
### Description of changes
- When using CreateFleet (with Overrides) the Compute Fleet subnet is selected implicitly based on the list of subnets in the cluster-config or fleet-config.json file
- RunInstances is used for SlurmComputeResource, CreateFleet is used for SlurmFlexibleComputeResource.
- The Cookbook and Node daemons have already been configured to use the list of subnets in the Overrides parameter of CreateFleet Requests

### Tests
- Manually tested
    - Created a cluster and verified that the Compute Node Launch Template did not include a Subnet assigned
- Automated test
    - If using InstanceType include the subnet id [cluster-using-single-instance-type](https://github.com/aws/aws-parallelcluster/pull/4521/files#diff-ae0563fd69eebbd889ce88edc944dc7bae4acb4f698e07a600ac589362e51794R342)
    - If using Instances set Subnet Id to None [cluster-using-flexible-instance-types](https://github.com/aws/aws-parallelcluster/pull/4521/files#diff-ae0563fd69eebbd889ce88edc944dc7bae4acb4f698e07a600ac589362e51794R334)

### References
* [Support compute node launches on multiple subnets across availability zones #456](https://github.com/aws/aws-parallelcluster-node/pull/456)
* [Include Networking/SubnetIds in the fleet-config file for CreateFleet API #1581](https://github.com/aws/aws-parallelcluster-cookbook/pull/1581)
* [FleetLaunchTemplateOverridesRequest](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_FleetLaunchTemplateOverridesRequest.html)


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
