### PR TITLE
[3.x] Integ-tests: improve test_multiple_efs

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -445,6 +445,13 @@ class SlurmCommands(SchedulerCommands):
             else current_node_states
         )
 
+    @retry(wait_fixed=seconds(15), stop_max_delay=minutes(5))
+    def wait_nodes_status(self, status, filter_by_nodes=None):
+        """Wait nodes to reach the status specified"""
+        nodes_status = self.get_nodes_status(filter_by_nodes)
+        for node_status in nodes_status.values():
+            assert_that(node_status).is_equal_to(status)
+
     def get_node_addr_host(self):
         """Return a list of nodename, nodeaddr, nodehostname entries."""
         # q1-dy-c5xlarge-1 172.31.4.241 q1-dy-c5xlarge-1

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -161,18 +161,27 @@ def _write_user_data(efs_id, random_file_name):
         """  # noqa: E501
 
 
-def test_efs_correctly_mounted(remote_command_executor, mount_dir):
-    logging.info("Testing ebs {0} is correctly mounted".format(mount_dir))
-    result = remote_command_executor.run_remote_command("df | grep '{0}'".format(mount_dir))
+def test_efs_correctly_mounted(remote_command_executor, mount_dir, tls=False):
+    # TODO: Add iam. The value of the two parameters should be set according to cluster configuration parameters.
+    logging.info("Checking efs {0} is correctly mounted".format(mount_dir))
+    # Following EFS instruction to check https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html
+    result = remote_command_executor.run_remote_command("mount | column -t | grep '{0}'".format(mount_dir))
     assert_that(result.stdout).contains(mount_dir)
-
-    result = remote_command_executor.run_remote_command("cat /etc/fstab")
-    assert_that(result.stdout).matches(
-        (
-            r".* {mount_dir} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,"
-            r"timeo=30,retrans=2,noresvport,_netdev 0 0"
-        ).format(mount_dir=mount_dir)
+    if tls:
+        logging.info("Checking efs {0} enables in-transit encryption".format(mount_dir))
+        assert_that(result.stdout).contains("127.0.0.1:/")
+    logging.info("Checking efs {0} is successfully mounted in efs mount log".format(mount_dir))
+    result = remote_command_executor.run_remote_command(
+        f'grep -E "Successfully mounted.*{mount_dir}" /var/log/amazon/efs/mount.log'
     )
+    assert_that(result.stdout).contains(mount_dir)
+    # Check fstab content according to https://docs.aws.amazon.com/efs/latest/ug/automount-with-efs-mount-helper.html
+    logging.info("Checking efs {0} is correctly configured in fstab".format(mount_dir))
+    result = remote_command_executor.run_remote_command("cat /etc/fstab")
+    if tls:  # TODO: Add a another check when tls and iam are enabled together
+        assert_that(result.stdout).matches(rf".* {mount_dir} efs _netdev,noresvport,tls 0 0")
+    else:
+        assert_that(result.stdout).matches(rf".* {mount_dir} efs _netdev,noresvport 0 0")
 
 
 # for FSX


### PR DESCRIPTION
1. Check EFS file systems are mounted with `amazon-efs-utils`
2. Check EFS file systems are auto mounted after instances reboot.
3. Minor refactor of the test code. 

To Do: this change assumes `tls` and `iam` are turned off. After making CLI change to support the new parameters, we should enrich the test to test enabling `tls` and `iam`

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
* test_multiple_efs has been passed

### References
* This test can pass only after https://github.com/aws/aws-parallelcluster-cookbook/pull/1588 is merged

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
