### PR TITLE
[2.x][Integ-tests] use Capacity Reservation in multiple NICS test

### DIFF
--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.ini
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.ini
@@ -13,6 +13,12 @@ compute_instance_type = {{ instance }}
 initial_queue_size = 1
 maintain_initial_size = true
 vpc_settings = parallelcluster-vpc
+{% if instance == "p4d.24xlarge" %}
+# Needed to use the p4d capacity reservation
+additional_iam_policies = arn:aws:iam::aws:policy/AmazonEC2FullAccess
+post_install = s3://{{ bucket_name }}/run_instance_override.sh
+s3_read_resource = arn:aws:s3:::{{ bucket_name }}/*
+{% endif %}
 
 [vpc parallelcluster-vpc]
 vpc_id = {{ vpc_id }}

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/run_instance_override.sh
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/run_instance_override.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+. "/etc/parallelcluster/cfnconfig"
+
+
+if [[ $cfn_node_type == "MasterServer" ]]; then
+    # Override run_instance attributes
+    cat > /opt/slurm/etc/pcluster/run_instances_overrides.json << 'EOF'
+{
+    "compute": {
+        "p4d.24xlarge": {
+            "CapacityReservationSpecification": {
+                "CapacityReservationTarget": {
+                    "CapacityReservationId": "cr-0fa65fcdbd597f551"
+                }
+            }
+        }
+    }
+}
+EOF
+fi


### PR DESCRIPTION
### Description of changes
* Use targeted ODCR for multi NICS test
* Reference:
  * targeted ODCR with test_efa: https://github.com/aws/aws-parallelcluster/commit/68e243fe45fee94ed9490ed0ca9001be9804ce7f#
  * multi nics test with targeted ODCR in pcluster3: https://github.com/aws/aws-parallelcluster/commit/18af39c75cfa7b7e7d6191c317d81ff82cfc8d19

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
