### PR TITLE
Add INFO messages in the log to better identify bottlenecks in the cluster creation

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -365,9 +365,11 @@ class Cluster:
 
             # Create template if not provided by the user
             if not (self.config.dev_settings and self.config.dev_settings.cluster_template):
+                LOGGER.info("Generating CDK template...")
                 self.template_body = CDKTemplateBuilder().build_cluster_template(
                     cluster_config=self.config, bucket=self.bucket, stack_name=self.stack_name
                 )
+                LOGGER.info("CDK template generated correctly.")
 
             # upload cluster artifacts and generated template
             self._upload_artifacts()
@@ -504,6 +506,7 @@ class Cluster:
         All files contained in root dir will be uploaded to
         {bucket_name}/parallelcluster/{version}/clusters/{cluster_name}/{resource_dir}/artifact.
         """
+        LOGGER.info("Uploading cluster artifacts to S3...")
         self._check_bucket_existence()
         try:
             resources = pkg_resources.resource_filename(__name__, "../resources/custom_resources")
@@ -530,6 +533,7 @@ class Cluster:
 
             if isinstance(self.config.scheduling, SchedulerPluginScheduling):
                 self._render_and_upload_scheduler_plugin_template()
+            LOGGER.info("Cluster artifacts uploaded correctly.")
         except BadRequestClusterActionError:
             raise
         except Exception as e:


### PR DESCRIPTION
Thanks to these new info messages it's easier to analyze the time spent by the different phases (in both CLI and API with X-ray):
* config parameter validation
* CDK import and generation
* artifacts upload
* cluster creation

### Tests
* Tested manual creation and checked the logs.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
