### PR TITLE
[MultiAZ] Clarify which InstanceType parameter is referenced for the CapacityReservationValidator messaging

### DIFF
--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -262,7 +262,9 @@ class CapacityReservationValidator(Validator):
         if capacity_reservation_id:
             if not instance_type:  # If the instance type doesn't exist, this is an invalid config
                 self._add_failure(
-                    "The CapacityReservationId parameter can only be used with the InstanceType parameter.",
+                    "The CapacityReservationId parameter can only be used with the InstanceType parameter "
+                    "(https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-"
+                    "Scheduling-SlurmQueues-ComputeResources-InstanceType).",
                     FailureLevel.ERROR,
                 )
             else:


### PR DESCRIPTION
### Description of changes
* CapacityReservation ID can be specified only when using Single InstanceType Parameter, not Instances/InstanceType parameter
```
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "CapacityReservationValidator",
      "message": "The CapacityReservationId parameter can only be used with the InstanceType parameter (https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-Scheduling-SlurmQueues-ComputeResources-InstanceType)."
    }
  ],
  "message": "Invalid cluster configuration."
}
```
* This commit adds a link to which `InstanceType` parameter is being referred to in the validation message

### Tests
* Manually tested

### References
* [SlurmQueues-ComputeResources-InstanceType](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-Scheduling-SlurmQueues-ComputeResources-InstanceType) vs [SlurmQueues-ComputeResources-Instances-InstanceType](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-Scheduling-SlurmQueues-ComputeResources-Instances-InstanceType)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
