### PR TITLE
Remove empty capacity reservation id/resource group ARN from dict in launch template validator

### DIFF
--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -1262,8 +1262,10 @@ class DictLaunchTemplateBuilder(_LaunchTemplateBuilder):
 
     def _capacity_reservation(self, cr_target):
         return {
-            "CapacityReservationTarget": {
-                "CapacityReservationId": cr_target.capacity_reservation_id,
-                "CapacityReservationResourceGroupArn": cr_target.capacity_reservation_resource_group_arn,
-            }
+            "CapacityReservationTarget": remove_none_values(
+                {
+                    "CapacityReservationId": cr_target.capacity_reservation_id,
+                    "CapacityReservationResourceGroupArn": cr_target.capacity_reservation_resource_group_arn,
+                }
+            )
         }

--- a/cli/tests/pcluster/templates/test_cdk_builder_utils.py
+++ b/cli/tests/pcluster/templates/test_cdk_builder_utils.py
@@ -336,7 +336,6 @@ class TestCdkLaunchTemplateBuilder:
                 SlurmQueue(
                     name="queue1",
                     capacity_reservation_target=CapacityReservationTarget(
-                        capacity_reservation_id="queue_cr_id",
                         capacity_reservation_resource_group_arn="queue_cr_rg_arn",
                     ),
                     compute_resources=[],
@@ -346,13 +345,12 @@ class TestCdkLaunchTemplateBuilder:
                     name="compute1",
                     instance_type="t2.medium",
                     capacity_reservation_target=CapacityReservationTarget(
-                        capacity_reservation_id="comp_res_cr_id",
                         capacity_reservation_resource_group_arn="comp_res_cr_rg_arn",
                     ),
                 ),
                 ec2.CfnLaunchTemplate.CapacityReservationSpecificationProperty(
                     capacity_reservation_target=ec2.CfnLaunchTemplate.CapacityReservationTargetProperty(
-                        capacity_reservation_id="comp_res_cr_id",
+                        capacity_reservation_id=None,
                         capacity_reservation_resource_group_arn="comp_res_cr_rg_arn",
                     )
                 ),
@@ -363,7 +361,6 @@ class TestCdkLaunchTemplateBuilder:
                     name="queue1",
                     capacity_reservation_target=CapacityReservationTarget(
                         capacity_reservation_id="queue_cr_id",
-                        capacity_reservation_resource_group_arn="queue_cr_rg_arn",
                     ),
                     compute_resources=[],
                     networking=None,
@@ -375,7 +372,7 @@ class TestCdkLaunchTemplateBuilder:
                 ec2.CfnLaunchTemplate.CapacityReservationSpecificationProperty(
                     capacity_reservation_target=ec2.CfnLaunchTemplate.CapacityReservationTargetProperty(
                         capacity_reservation_id="queue_cr_id",
-                        capacity_reservation_resource_group_arn="queue_cr_rg_arn",
+                        capacity_reservation_resource_group_arn=None,
                     )
                 ),
                 id="test with only queue capacity reservation",

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -1623,7 +1623,6 @@ class TestDictLaunchTemplateBuilder:
                 SlurmQueue(
                     name="queue1",
                     capacity_reservation_target=CapacityReservationTarget(
-                        capacity_reservation_id="queue_cr_id",
                         capacity_reservation_resource_group_arn="queue_cr_rg_arn",
                     ),
                     compute_resources=[],
@@ -1633,13 +1632,11 @@ class TestDictLaunchTemplateBuilder:
                     name="compute1",
                     instance_type="t2.medium",
                     capacity_reservation_target=CapacityReservationTarget(
-                        capacity_reservation_id="comp_res_cr_id",
                         capacity_reservation_resource_group_arn="comp_res_cr_rg_arn",
                     ),
                 ),
                 {
                     "CapacityReservationTarget": {
-                        "CapacityReservationId": "comp_res_cr_id",
                         "CapacityReservationResourceGroupArn": "comp_res_cr_rg_arn",
                     }
                 },
@@ -1650,7 +1647,6 @@ class TestDictLaunchTemplateBuilder:
                     name="queue1",
                     capacity_reservation_target=CapacityReservationTarget(
                         capacity_reservation_id="queue_cr_id",
-                        capacity_reservation_resource_group_arn="queue_cr_rg_arn",
                     ),
                     compute_resources=[],
                     networking=None,
@@ -1662,7 +1658,6 @@ class TestDictLaunchTemplateBuilder:
                 {
                     "CapacityReservationTarget": {
                         "CapacityReservationId": "queue_cr_id",
-                        "CapacityReservationResourceGroupArn": "queue_cr_rg_arn",
                     }
                 },
                 id="test with only queue capacity reservation",


### PR DESCRIPTION
### Description of changes
Capacity reservations specifications can have either a capacity reservation ID or a capacity reservation resource group ARN, but not both at the same time. This patch removes the one of the two which has None value from the dictionary of the capacity reservation that is passed to the launch template validator's RunInstances DryRun, as the RunInstances DryRun breaks when it is passed a None as an argument (since it expects a String). Note that by contrast the actual CDK capacity reservation specification construct that we use to create the actual launch template accepts None as an argument.

### Tests
Unit tests.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
