### PR TITLE
[develop] Add validator to avoid managed FSx storage with multiple subnets

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -89,6 +89,7 @@ from pcluster.validators.cluster_validators import (
     InstanceArchitectureCompatibilityValidator,
     IntelHpcArchitectureValidator,
     IntelHpcOsValidator,
+    ManagedFsxMultiAzValidator,
     MaxCountValidator,
     MixedSecurityGroupOverwriteValidator,
     NameValidator,
@@ -1315,6 +1316,7 @@ class BaseClusterConfig(Resource):
             )
 
             self._validate_max_storage_count(ebs_count, existing_storage_count, new_storage_count)
+            self._validate_new_storage_multiple_subnets(self.scheduling.queues, new_storage_count)
 
         self._validate_mount_dirs()
 
@@ -1328,6 +1330,13 @@ class BaseClusterConfig(Resource):
             OverlappingMountDirValidator,
             shared_mount_dir_list=[mount_dir for mount_dir, _ in self.shared_storage_name_mount_dir_tuple_list],
             local_mount_dir_list=list(self.local_mount_dir_instance_types_dict.keys()),
+        )
+
+    def _validate_new_storage_multiple_subnets(self, queues, new_storage_count):
+        self._register_validator(
+            ManagedFsxMultiAzValidator,
+            queues=queues,
+            new_storage_count=new_storage_count,
         )
 
     def _validate_max_storage_count(self, ebs_count, existing_storage_count, new_storage_count):

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -664,6 +664,23 @@ class NumberOfStorageValidator(Validator):
             )
 
 
+class ManagedFsxMultiAzValidator(Validator):
+    """
+    Managed FSx Storage Vs Multiple Subnets validator.
+
+    Validate if managed storage of type FSx is set when using multiple subnets in queues configuration.
+    """
+
+    def _validate(self, queues, new_storage_count):
+        if any(len(queue.networking.subnet_ids) > 1 for queue in queues) and new_storage_count.get("fsx") > 0:
+            self._add_failure(
+                "Multiple subnets configuration does not support FSx 'managed' storage. Found {0} 'managed' "
+                "FSx storage. Please make sure to provide an existing shared storage, properly configured to work "
+                "across the target subnets.".format(new_storage_count.get("fsx")),
+                FailureLevel.ERROR,
+            )
+
+
 class EfsIdValidator(Validator):  # TODO add tests
     """
     EFS id validator.


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
Validator check if managed FSx are set in cluster configuration and fail if there is at least one set.

### Tests
* unit tests added

### References
* n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
