### PR TITLE
[surface head node bootstrap errors] rename error message file for both chef and custom scripts

### DIFF
--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -66,7 +66,7 @@ function error_exit
 {
   # wait logs flush before signaling the failure
   sleep 10
-  reason=$(cat /var/log/parallelcluster/chef_error_msg 2>/dev/null) || reason="$1"
+  reason=$(cat /var/log/parallelcluster/headnode_bootstrap_error_msg 2>/dev/null) || reason="$1"
   cfn-signal --exit-code=1 --reason="${!reason}" "${!wait_condition_handle_presigned_url}"
   exit 1
 }


### PR DESCRIPTION
### Description of changes
* The current name of the error message file, 'chef_error_msg', is limited to chef errors. We would like to use it for both chef errors and errors from custom scripts (pre-/post-install scripts). Thus, we would rename this file to be more generic.

### Tests
* No tests needed as this doesn't have any impact on any functionality.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
