### PR TITLE
[Multi-AZ] Modify networking validators impacted by Multi-AZ

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -165,6 +165,7 @@ from pcluster.validators.monitoring_validators import ComputeConsoleLoggingValid
 from pcluster.validators.networking_validators import (
     ElasticIpValidator,
     MultiAzPlacementGroupValidator,
+    QueueSubnetsValidator,
     SecurityGroupsValidator,
     SingleSubnetValidator,
     SubnetsValidator,
@@ -2087,6 +2088,11 @@ class SlurmQueue(_CommonQueue):
             max_length=MAX_NUMBER_OF_COMPUTE_RESOURCES,
             resource_name="ComputeResources",
         )
+        self._register_validator(
+            QueueSubnetsValidator,
+            queue_name=self.name,
+            subnet_ids=self.networking.subnet_ids,
+        )
         for compute_resource in self.compute_resources:
             self._register_validator(
                 EfaSecurityGroupValidator,
@@ -2218,6 +2224,11 @@ class SchedulerPluginQueue(_CommonQueue):
             DuplicateNameValidator,
             name_list=[compute_resource.name for compute_resource in self.compute_resources],
             resource_name="Compute resource",
+        )
+        self._register_validator(
+            QueueSubnetsValidator,
+            queue_name=self.name,
+            subnet_ids=self.networking.subnet_ids,
         )
         for compute_resource in self.compute_resources:
             self._register_validator(

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2093,6 +2093,12 @@ class SlurmQueue(_CommonQueue):
             queue_name=self.name,
             subnet_ids=self.networking.subnet_ids,
         )
+        if any(isinstance(compute_resource, SlurmComputeResource) for compute_resource in self.compute_resources):
+            self._register_validator(
+                SingleSubnetValidator,
+                queue_name=self.name,
+                subnet_ids=self.networking.subnet_ids,
+            )
         for compute_resource in self.compute_resources:
             self._register_validator(
                 EfaSecurityGroupValidator,
@@ -2201,10 +2207,6 @@ class SlurmScheduling(Resource):
             max_length=MAX_NUMBER_OF_QUEUES,
             resource_name="SlurmQueues",
         )
-        self._register_validator(
-            SingleSubnetValidator,
-            queues_subnets=[q.networking.subnet_ids for q in self.queues if q.networking and q.networking.subnet_ids],
-        )
 
 
 class SchedulerPluginQueue(_CommonQueue):
@@ -2230,6 +2232,12 @@ class SchedulerPluginQueue(_CommonQueue):
             queue_name=self.name,
             subnet_ids=self.networking.subnet_ids,
         )
+        if any(isinstance(compute_resource, SlurmComputeResource) for compute_resource in self.compute_resources):
+            self._register_validator(
+                SingleSubnetValidator,
+                queue_name=self.name,
+                subnet_ids=self.networking.subnet_ids,
+            )
         for compute_resource in self.compute_resources:
             self._register_validator(
                 CapacityTypeValidator, capacity_type=self.capacity_type, instance_type=compute_resource.instance_type
@@ -2562,10 +2570,6 @@ class SchedulerPluginScheduling(Resource):
                 default=MAX_NUMBER_OF_QUEUES,
             ),
             resource_name="SchedulerQueues",
-        )
-        self._register_validator(
-            SingleSubnetValidator,
-            queues_subnets=[q.networking.subnet_ids for q in self.queues if q.networking and q.networking.subnet_ids],
         )
         for queue in self.queues:
             self._register_validator(

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2089,6 +2089,7 @@ class SlurmQueue(_CommonQueue):
             QueueSubnetsValidator,
             queue_name=self.name,
             subnet_ids=self.networking.subnet_ids,
+            subnet_id_az_mapping=self.networking.subnet_id_az_mapping,
         )
         if any(isinstance(compute_resource, SlurmComputeResource) for compute_resource in self.compute_resources):
             self._register_validator(
@@ -2228,6 +2229,7 @@ class SchedulerPluginQueue(_CommonQueue):
             QueueSubnetsValidator,
             queue_name=self.name,
             subnet_ids=self.networking.subnet_ids,
+            subnet_id_az_mapping=self.networking.subnet_id_az_mapping,
         )
         if any(isinstance(compute_resource, SlurmComputeResource) for compute_resource in self.compute_resources):
             self._register_validator(

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1241,6 +1241,7 @@ class BaseClusterConfig(Resource):
             self._register_validator(
                 AmiOsCompatibleValidator, os=self.image.os, image_id=self.head_node.image.custom_ami
             )
+        # Check that all subnets in the cluster (head node subnet included) are in the same VPC and support DNS.
         self._register_validator(
             SubnetsValidator, subnet_ids=self.compute_subnet_ids + [self.head_node.networking.subnet_id]
         )

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -643,9 +643,9 @@ class _QueueNetworking(_BaseNetworking):
     def az_subnet_ids_mapping(self):
         """Map queue subnet ids to availability zones."""
         if not self._az_subnet_ids_mapping:
-            self._az_subnet_ids_mapping = defaultdict(list)
+            self._az_subnet_ids_mapping = defaultdict(set)
             for subnet_id, _az in self.subnet_id_az_mapping.items():
-                self._az_subnet_ids_mapping[_az].append(subnet_id)
+                self._az_subnet_ids_mapping[_az].add(subnet_id)
         return self._az_subnet_ids_mapping
 
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1478,15 +1478,12 @@ class BaseClusterConfig(Resource):
     @property
     def compute_subnet_ids(self):
         """Return the list of all compute subnet ids in the cluster."""
-        return list(
-            {
-                subnet_id
-                for queue in self.scheduling.queues
-                if queue.networking.subnet_ids
-                for subnet_id in queue.networking.subnet_ids
-                if queue.networking.subnet_ids
-            }
-        )
+        subnet_ids_list = []
+        for queue in self.scheduling.queues:
+            for subnet_id in queue.networking.subnet_ids:
+                if subnet_id not in subnet_ids_list:
+                    subnet_ids_list.append(subnet_id)
+        return subnet_ids_list
 
     @property
     def availability_zones_subnets_mapping(self):

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -77,7 +77,7 @@ class QueueSubnetsValidator(Validator):
         # Test if there are duplicate IDs in subnet_ids
         if len(set(subnet_ids)) < len(subnet_ids):
             self._add_failure(
-                "The list of subnet IDs specified in queue {0} contains duplicate IDs.".format(queue_name),
+                "SubnetIds specified in queue {0} contains duplicate subnet IDs.".format(queue_name),
                 FailureLevel.ERROR,
             )
 
@@ -91,8 +91,8 @@ class QueueSubnetsValidator(Validator):
 
             if len(az_set) < len(subnet_ids):
                 self._add_failure(
-                    "Some of the subnet IDs specified in queue {0} are in the same AZ. Please make sure all subnets "
-                    "are in different AZs.".format(queue_name),
+                    "SubnetIds specified in queue {0} contains multiple subnets in the same AZ. "
+                    "Please make sure all subnets are in different AZs.".format(queue_name),
                     FailureLevel.ERROR,
                 )
 
@@ -117,9 +117,10 @@ class SingleSubnetValidator(Validator):
     def _validate(self, queue_name, subnet_ids):
         if len(subnet_ids) > 1:
             self._add_failure(
-                "At least one compute resource in queue {0} use a single instance type. "
-                "Multi AZ configuration does not support single instance type. "
-                "Please make sure to use the multiple instance type allocation.".format(queue_name),
+                "At least one compute resource in queue {0} uses a single instance type. "
+                "Multiple subnets configuration is not supported for single instance type, "
+                "please use the Instances configuration parameter for multiple instance type "
+                "allocation.".format(queue_name),
                 FailureLevel.ERROR,
             )
 

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -112,12 +112,16 @@ class ElasticIpValidator(Validator):
 
 
 class SingleSubnetValidator(Validator):
-    """Validate all queues reference the same subnet."""
+    """Validate only one subnet is used for compute resources with single instance type."""
 
-    def _validate(self, queues_subnets):
-        subnet_ids = {tuple(set(queue_subnets)) for queue_subnets in queues_subnets}
+    def _validate(self, queue_name, subnet_ids):
         if len(subnet_ids) > 1:
-            self._add_failure("The SubnetId used for all of the queues should be the same.", FailureLevel.ERROR)
+            self._add_failure(
+                "At least one compute resource in queue {0} use a single instance type. "
+                "Multi AZ configuration does not support single instance type. "
+                "Please make sure to use the multiple instance type allocation.".format(queue_name),
+                FailureLevel.ERROR,
+            )
 
 
 class MultiAzPlacementGroupValidator(Validator):

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -67,11 +67,21 @@ class QueueSubnetsValidator(Validator):
     """
     Queue Subnets validator.
 
+    Check that there is no duplicate subnet id in the subnet_ids list.
     Check that subnets in a queue belong to different AZs (EC2 Fleet requests do not support multiple subnets
     in the same AZ).
     """
 
     def _validate(self, queue_name, subnet_ids: List[str]):
+
+        # Test if there are duplicate IDs in subnet_ids
+        if len(set(subnet_ids)) < len(subnet_ids):
+            self._add_failure(
+                "The list of subnet IDs specified in queue {0} contains duplicate IDs.".format(queue_name),
+                FailureLevel.ERROR,
+            )
+
+        # Test if the subnets are all in different AZs
         try:
             subnets = AWSApi.instance().ec2.describe_subnets(subnet_ids=subnet_ids)
 
@@ -81,7 +91,7 @@ class QueueSubnetsValidator(Validator):
 
             if len(az_set) < len(subnet_ids):
                 self._add_failure(
-                    "Some of the subnet ids specified in queue {0} are in the same AZ. Please make sure all subnets "
+                    "Some of the subnet IDs specified in queue {0} are in the same AZ. Please make sure all subnets "
                     "are in different AZs.".format(queue_name),
                     FailureLevel.ERROR,
                 )

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -92,25 +92,23 @@ class QueueSubnetsValidator(Validator):
             )
 
         # Test if the subnets are all in different AZs
-        else:
-            try:
-                azs_with_multiple_subnets = self._find_azs_with_multiple_subnets(az_subnet_ids_mapping)
-                if len(azs_with_multiple_subnets) > 0:
+        try:
+            azs_with_multiple_subnets = self._find_azs_with_multiple_subnets(az_subnet_ids_mapping)
+            if len(azs_with_multiple_subnets) > 0:
 
-                    self._add_failure(
-                        "SubnetIds specified in queue {0} contains multiple subnets in the same AZs: {1}. "
-                        "Please make sure all subnets in the queue are in different AZs.".format(
-                            queue_name,
-                            "; ".join(
-                                f"{az}: {', '.join(subnets)}"
-                                for az, subnets in sorted(azs_with_multiple_subnets.items())
-                            ),
+                self._add_failure(
+                    "SubnetIds specified in queue {0} contains multiple subnets in the same AZs: {1}. "
+                    "Please make sure all subnets in the queue are in different AZs.".format(
+                        queue_name,
+                        "; ".join(
+                            f"{az}: {', '.join(subnets)}" for az, subnets in sorted(azs_with_multiple_subnets.items())
                         ),
-                        FailureLevel.ERROR,
-                    )
+                    ),
+                    FailureLevel.ERROR,
+                )
 
-            except AWSClientError as e:
-                self._add_failure(str(e), FailureLevel.ERROR)
+        except AWSClientError as e:
+            self._add_failure(str(e), FailureLevel.ERROR)
 
 
 class ElasticIpValidator(Validator):

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -28,7 +28,13 @@ class SecurityGroupsValidator(Validator):
 
 
 class SubnetsValidator(Validator):
-    """Subnets validator."""
+    """
+    Subnets validator.
+
+    Check that all subnets in the input list belong to the same VPC.
+    Also, check that said VPC supports DNS resolution via the Amazon DNS server and assigning DNS hostnames to
+    instances.
+    """
 
     def _validate(self, subnet_ids: List[str]):
         try:

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -72,7 +72,7 @@ class QueueSubnetsValidator(Validator):
     in the same AZ).
     """
 
-    def _validate(self, queue_name, subnet_ids: List[str]):
+    def _validate(self, queue_name, subnet_ids: List[str], subnet_id_az_mapping: dict):
 
         # Test if there are duplicate IDs in subnet_ids
         if len(set(subnet_ids)) < len(subnet_ids):
@@ -83,16 +83,12 @@ class QueueSubnetsValidator(Validator):
 
         # Test if the subnets are all in different AZs
         try:
-            subnets = AWSApi.instance().ec2.describe_subnets(subnet_ids=subnet_ids)
-
-            az_set = set()
-            for subnet in subnets:
-                az_set.add(subnet["AvailabilityZone"])
+            az_set = {subnet_id_az_mapping[subnet_id] for subnet_id in subnet_ids}
 
             if len(az_set) < len(subnet_ids):
                 self._add_failure(
                     "SubnetIds specified in queue {0} contains multiple subnets in the same AZ. "
-                    "Please make sure all subnets are in different AZs.".format(queue_name),
+                    "Please make sure all subnets in the queue are in different AZs.".format(queue_name),
                     FailureLevel.ERROR,
                 )
 

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -270,11 +270,13 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     single_subnet_validator.assert_has_calls(
         [
             call(
-                queues_subnets=[
-                    ["subnet-23456789"],
-                    ["subnet-23456789"],
-                ]
-            )
+                queue_name="queue1",
+                subnet_ids=["subnet-23456789"],
+            ),
+            call(
+                queue_name="queue2",
+                subnet_ids=["subnet-23456789"],
+            ),
         ]
     )
     security_groups_validator.assert_has_calls(
@@ -571,11 +573,13 @@ def test_scheduler_plugin_validators_are_called_with_correct_argument(test_datad
     single_subnet_validator.assert_has_calls(
         [
             call(
-                queues_subnets=[
-                    ["subnet-12345678"],
-                    ["subnet-12345678"],
-                ]
-            )
+                queue_name="queue1",
+                subnet_ids=["subnet-12345678"],
+            ),
+            call(
+                queue_name="queue2",
+                subnet_ids=["subnet-12345678"],
+            ),
         ]
     )
     security_groups_validator.assert_has_calls(

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -95,8 +95,8 @@ def test_ec2_subnet_id_validator(mocker):
                     "AvailabilityZone": "us-east-1a",
                 },
             ],
-            "Some of the subnet IDs specified in queue subnets-in-common-az-queue are in the same AZ."
-            " Please make sure all subnets are in different AZs.",
+            "SubnetIds specified in queue subnets-in-common-az-queue contains multiple subnets in the same AZ. "
+            "Please make sure all subnets are in different AZs.",
         ),
         (
             "duplicate-subnets-queue",
@@ -112,11 +112,11 @@ def test_ec2_subnet_id_validator(mocker):
                     "AvailabilityZone": "us-east-1a",
                 },
             ],
-            "The list of subnet IDs specified in queue duplicate-subnets-queue contains duplicate IDs.",
+            "SubnetIds specified in queue duplicate-subnets-queue contains duplicate subnet IDs.",
         ),
     ],
 )
-def test_queue_subnet_id_validator(mocker, queue_name, queue_subnets, queue_subnets_dicts, failure_message):
+def test_queue_subnets_validator(mocker, queue_name, queue_subnets, queue_subnets_dicts, failure_message):
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
     mocker.patch(
         "pcluster.aws.ec2.Ec2Client.describe_subnets",
@@ -157,12 +157,13 @@ def test_multi_az_placement_group_validator(multi_az_enabled, placement_group_en
                 ["subnet-00000000"],
                 ["subnet-11111111"],
             ],
-            "At least one compute resource in queue multi-subnet-queue use a single instance type. "
-            "Multi AZ configuration does not support single instance type. "
-            "Please make sure to use the multiple instance type allocation.",
+            "At least one compute resource in queue multi-subnet-queue uses a single instance type. "
+            "Multiple subnets configuration is not supported for single instance type, "
+            "please use the Instances configuration parameter for multiple instance type "
+            "allocation.",
         ),
         (
-            "multi-subnet-queue",
+            "single-subnet-queue",
             [
                 ["subnet-00000000"],
             ],

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -82,7 +82,7 @@ def test_ec2_subnet_id_validator(mocker):
             None,
         ),
         (
-            "bad-queue",
+            "subnets-in-common-az-queue",
             [
                 "subnet-00000000",
                 "subnet-11111111",
@@ -95,14 +95,30 @@ def test_ec2_subnet_id_validator(mocker):
                     "AvailabilityZone": "us-east-1a",
                 },
             ],
-            "Some of the subnet ids specified in queue bad-queue are in the same AZ."
-                " Please make sure all subnets are in different AZs.",
+            "Some of the subnet IDs specified in queue subnets-in-common-az-queue are in the same AZ."
+            " Please make sure all subnets are in different AZs.",
+        ),
+        (
+            "duplicate-subnets-queue",
+            [
+                "subnet-00000000",
+                "subnet-00000000",
+            ],
+            [
+                {
+                    "AvailabilityZone": "us-east-1a",
+                },
+                {
+                    "AvailabilityZone": "us-east-1a",
+                },
+            ],
+            "The list of subnet IDs specified in queue duplicate-subnets-queue contains duplicate IDs.",
         ),
     ],
 )
 def test_queue_subnet_id_validator(mocker, queue_name, queue_subnets, queue_subnets_dicts, failure_message):
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-    describe_subnets_mock = mocker.patch(
+    mocker.patch(
         "pcluster.aws.ec2.Ec2Client.describe_subnets",
         return_value=queue_subnets_dicts,
     )

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -101,6 +101,23 @@ def test_ec2_subnet_id_validator(mocker):
             "The following subnet ids are specified multiple times in queue duplicate-subnets-queue: "
             "subnet-00000000, subnet-11111111.",
         ),
+        # This test should trigger both validation errors for duplicate subnet ids and multiple subnets
+        # in the same AZ, that's why it's repeated twice below.
+        (
+            "duplicate-subnets-queue-1",
+            ["subnet-00000000", "subnet-00000000", "subnet-11111111"],
+            {"subnet-00000000": "us-east-1a", "subnet-11111111": "us-east-1a"},
+            "The following subnet ids are specified multiple times in queue duplicate-subnets-queue-1: "
+            "subnet-00000000.",
+        ),
+        (
+            "duplicate-subnets-queue-2",
+            ["subnet-00000000", "subnet-00000000", "subnet-11111111"],
+            {"subnet-00000000": "us-east-1a", "subnet-11111111": "us-east-1a"},
+            "SubnetIds specified in queue duplicate-subnets-queue-2 contains multiple subnets in the same AZs: "
+            "us-east-1a: subnet-00000000, subnet-11111111. "
+            "Please make sure all subnets in the queue are in different AZs.",
+        ),
     ],
 )
 def test_queue_subnets_validator(mocker, queue_name, queue_subnets, subnet_id_az_mapping, failure_message):

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -149,26 +149,29 @@ def test_multi_az_placement_group_validator(multi_az_enabled, placement_group_en
 
 
 @pytest.mark.parametrize(
-    "queues, failure_message",
+    "queue_name, subnet_ids, failure_message",
     [
         (
+            "multi-subnet-queue",
             [
-                ["subnet-11111111"],
                 ["subnet-00000000"],
+                ["subnet-11111111"],
             ],
-            "The SubnetId used for all of the queues should be the same",
+            "At least one compute resource in queue multi-subnet-queue use a single instance type. "
+            "Multi AZ configuration does not support single instance type. "
+            "Please make sure to use the multiple instance type allocation.",
         ),
         (
+            "multi-subnet-queue",
             [
-                ["subnet-00000000"],
                 ["subnet-00000000"],
             ],
             None,
         ),
     ],
 )
-def test_single_subnet_validator(queues, failure_message):
-    actual_failure = SingleSubnetValidator().execute(queues)
+def test_single_subnet_validator(queue_name, subnet_ids, failure_message):
+    actual_failure = SingleSubnetValidator().execute(queue_name, subnet_ids)
 
     assert_failure_messages(actual_failure, failure_message)
 

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -72,17 +72,33 @@ def test_ec2_subnet_id_validator(mocker):
             None,
         ),
         (
-            "subnets-in-common-az-queue",
+            "subnets-in-common-az-queue-1",
             ["subnet-00000000", "subnet-11111111"],
             {"subnet-00000000": "us-east-1a", "subnet-11111111": "us-east-1a"},
-            "SubnetIds specified in queue subnets-in-common-az-queue contains multiple subnets in the same AZ. "
+            "SubnetIds specified in queue subnets-in-common-az-queue-1 contains multiple subnets in the same AZs: "
+            "us-east-1a: subnet-00000000, subnet-11111111. "
+            "Please make sure all subnets in the queue are in different AZs.",
+        ),
+        (
+            "subnets-in-common-az-queue-2",
+            ["subnet-1", "subnet-2", "subnet-3", "subnet-4", "subnet-5"],
+            {
+                "subnet-1": "us-east-1a",
+                "subnet-2": "us-east-1a",
+                "subnet-3": "us-east-1b",
+                "subnet-4": "us-east-1b",
+                "subnet-5": "us-east-1b",
+            },
+            "SubnetIds specified in queue subnets-in-common-az-queue-2 contains multiple subnets in the same AZs: "
+            "us-east-1a: subnet-1, subnet-2; us-east-1b: subnet-3, subnet-4, subnet-5. "
             "Please make sure all subnets in the queue are in different AZs.",
         ),
         (
             "duplicate-subnets-queue",
-            ["subnet-00000000", "subnet-00000000"],
-            {"subnet-00000000": "us-east-1a"},
-            "SubnetIds specified in queue duplicate-subnets-queue contains duplicate subnet IDs.",
+            ["subnet-00000000", "subnet-00000000", "subnet-11111111", "subnet-11111111", "subnet-11111111"],
+            {"subnet-00000000": "us-east-1a", "subnet-11111111": "us-east-1b"},
+            "The following subnet ids are specified multiple times in queue duplicate-subnets-queue: "
+            "subnet-00000000, subnet-11111111.",
         ),
     ],
 )

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -9,6 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from collections import defaultdict
 
 import pytest
 
@@ -103,10 +104,13 @@ def test_ec2_subnet_id_validator(mocker):
     ],
 )
 def test_queue_subnets_validator(mocker, queue_name, queue_subnets, subnet_id_az_mapping, failure_message):
+    az_subnet_ids_mapping = defaultdict(list)
+    for subnet_id, _az in subnet_id_az_mapping.items():
+        az_subnet_ids_mapping[_az].append(subnet_id)
     actual_failure = QueueSubnetsValidator().execute(
         queue_name,
         queue_subnets,
-        subnet_id_az_mapping,
+        az_subnet_ids_mapping,
     )
     assert_failure_messages(actual_failure, failure_message)
 


### PR DESCRIPTION
### Description of changes
* Modify Networking validators impacted by the Multi-AZ functionality in the Slurm and Scheduler Plugin scenarios:
  * Add better description for `SubnetsValidator`.
  * Add new `QueueSubnetsValidator` to check
    * if there are duplicate IDs in `subnet_ids`;
    * if all subnets in a queue are from different AZs;
  * Modify `SingleSubnetValidator` to:
    * remove check on unique subnet across all compute queues;   
    * check if compute resources with single instance type have one single subnet;
  * Make the implementation of `compute_subnet_ids` more readable

### Tests
* Added or modified unit tests for the validator impacted by this PR
* No change was introduced in the core functioning of the product, so except for the validation phase the behavior of the product is the same.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
