### PR TITLE
Add ComputeConsoleLogging parameters to cluster configuration schema

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -31,6 +31,7 @@ from pcluster.constants import (
     CW_DASHBOARD_ENABLED_DEFAULT,
     CW_LOGS_ENABLED_DEFAULT,
     CW_LOGS_RETENTION_DAYS_DEFAULT,
+    DEFAULT_COMPUTE_CONSOLE_LOGGING_MAX_SAMPLE_SIZE,
     DEFAULT_EPHEMERAL_DIR,
     DEFAULT_MAX_COUNT,
     DEFAULT_MIN_COUNT,
@@ -159,6 +160,7 @@ from pcluster.validators.instances_validators import (
     InstancesNetworkingValidator,
 )
 from pcluster.validators.kms_validators import KmsKeyIdEncryptedValidator, KmsKeyValidator
+from pcluster.validators.monitoring_validators import ComputeConsoleLoggingValidator
 from pcluster.validators.networking_validators import (
     ElasticIpValidator,
     SecurityGroupsValidator,
@@ -716,11 +718,26 @@ class Dashboards(Resource):
 class Monitoring(Resource):
     """Represent the Monitoring configuration."""
 
-    def __init__(self, detailed_monitoring: bool = None, logs: Logs = None, dashboards: Dashboards = None, **kwargs):
+    def __init__(
+        self,
+        detailed_monitoring: bool = None,
+        logs: Logs = None,
+        dashboards: Dashboards = None,
+        compute_console_logging_enabled: bool = None,
+        compute_console_logging_max_sample_size: int = None,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.detailed_monitoring = Resource.init_param(detailed_monitoring, default=False)
         self.logs = logs or Logs(implied=True)
         self.dashboards = dashboards or Dashboards(implied=True)
+        self.compute_console_logging_enabled = Resource.init_param(compute_console_logging_enabled, default=True)
+        self.compute_console_logging_max_sample_size = Resource.init_param(
+            compute_console_logging_max_sample_size, default=DEFAULT_COMPUTE_CONSOLE_LOGGING_MAX_SAMPLE_SIZE
+        )
+
+    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
+        self._register_validator(ComputeConsoleLoggingValidator, monitoring=self)
 
 
 # ---------------------- Others ---------------------- #

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -197,5 +197,6 @@ SCHEDULER_PLUGIN_INTERFACE_VERSION_LOW_RANGE = packaging.version.Version("1.0")
 DIRECTORY_SERVICE_RESERVED_SETTINGS = {"id_provider": "ldap"}
 
 DEFAULT_EPHEMERAL_DIR = "/scratch"
+DEFAULT_COMPUTE_CONSOLE_LOGGING_MAX_SAMPLE_SIZE = 100
 
 LAMBDA_VPC_ACCESS_MANAGED_POLICY = "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -790,6 +790,10 @@ class MonitoringSchema(BaseSchema):
     detailed_monitoring = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     logs = fields.Nested(LogsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     dashboards = fields.Nested(DashboardsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    compute_console_logging_enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    compute_console_logging_max_sample_size = fields.Int(
+        validate=validate.NoneOf([0]), metadata={"update_policy": UpdatePolicy.SUPPORTED}
+    )
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/validators/monitoring_validators.py
+++ b/cli/src/pcluster/validators/monitoring_validators.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from pcluster.validators.common import FailureLevel, Validator
+
+
+class ComputeConsoleLoggingValidator(Validator):
+    """Security groups validator."""
+
+    def _validate(self, monitoring):
+        if not monitoring.compute_console_logging_enabled and not monitoring.is_implied(
+            "compute_console_logging_max_sample_size"
+        ):
+            self._add_failure(
+                "ComputeConsoleLoggingMaxSampleSize can not be set when setting ComputeConsoleLoggingEnabled is False. "
+                "Please either remove ComputeConsoleLoggingMaxSampleSize or set ComputeConsoleLoggingEnabled to True.",
+                FailureLevel.ERROR,
+            )

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -200,6 +200,8 @@ Monitoring:
   Dashboards:
     CloudWatch:
       Enabled: true  # true
+  ComputeConsoleLoggingEnabled: True
+  ComputeConsoleLoggingMaxSampleSize: 150 # 100
 AdditionalPackages:
   IntelSoftware:
     IntelHpcPlatform: false

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -28,6 +28,7 @@ from pcluster.schemas.cluster_schema import (
     HeadNodeRootVolumeSchema,
     IamSchema,
     ImageSchema,
+    MonitoringSchema,
     QueueEphemeralVolumeSchema,
     QueueNetworkingSchema,
     QueueRootVolumeSchema,
@@ -615,3 +616,20 @@ def test_instance_role_validator(instance_role, expected_message):
 )
 def test_password_secret_arn_validator(password_secret_arn, expected_message):
     _validate_and_assert_error(DirectoryServiceSchema(), {"PasswordSecretArn": password_secret_arn}, expected_message)
+
+
+@pytest.mark.parametrize(
+    "compute_console_logging_max_sample_size, expected_message",
+    [
+        (-5, None),
+        (0, "Invalid input"),
+        (150, None),
+        ("wrong_value", "Not a valid integer"),
+    ],
+)
+def test_compute_console_logging_max_sample_size_validator(compute_console_logging_max_sample_size, expected_message):
+    _validate_and_assert_error(
+        MonitoringSchema(),
+        {"ComputeConsoleLoggingMaxSampleSize": compute_console_logging_max_sample_size},
+        expected_message,
+    )

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
@@ -238,6 +238,8 @@ Monitoring:
   Dashboards:
     CloudWatch:
       Enabled: true
+  ComputeConsoleLoggingEnabled: True
+  ComputeConsoleLoggingMaxSampleSize: 123 # 100
 AdditionalPackages:
   IntelSoftware:
     IntelHpcPlatform: false

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -212,6 +212,10 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     kms_key_id_encrypted_validator = mocker.patch(
         kms_validators + ".KmsKeyIdEncryptedValidator._validate", return_value=[]
     )
+    monitoring_validators = validators_path + ".monitoring_validators"
+    compute_console_logging_validator = mocker.patch(
+        monitoring_validators + ".ComputeConsoleLoggingValidator._validate", return_value=[]
+    )
 
     mocker.patch(
         "pcluster.config.cluster_config.HeadNode.architecture", new_callable=PropertyMock(return_value="x86_64")
@@ -338,6 +342,7 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
     deletion_policy_validator.assert_called()
     instance_type_accelerator_manufacturer_validator.assert_called()
     instance_type_placement_group_validator.assert_called()
+    compute_console_logging_validator.assert_called()
 
 
 def test_scheduler_plugin_all_validators_are_called(test_datadir, mocker):

--- a/cli/tests/pcluster/validators/test_monitoring_validators.py
+++ b/cli/tests/pcluster/validators/test_monitoring_validators.py
@@ -1,0 +1,39 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from pcluster.config.cluster_config import Monitoring
+from pcluster.validators.monitoring_validators import ComputeConsoleLoggingValidator
+from tests.pcluster.validators.utils import assert_failure_messages
+
+
+@pytest.mark.parametrize(
+    "monitoring, expected_message",
+    [
+        (Monitoring(compute_console_logging_enabled=True, compute_console_logging_max_sample_size=50), None),
+        (
+            Monitoring(
+                compute_console_logging_enabled=False,
+            ),
+            None,
+        ),
+        (Monitoring(compute_console_logging_max_sample_size=-5), None),
+        (Monitoring(compute_console_logging_max_sample_size=100), None),
+        (
+            Monitoring(compute_console_logging_enabled=False, compute_console_logging_max_sample_size=50),
+            "ComputeConsoleLoggingMaxSampleSize can not be set when setting ComputeConsoleLoggingEnabled is False. "
+            "Please either remove ComputeConsoleLoggingMaxSampleSize or set ComputeConsoleLoggingEnabled to True.",
+        ),
+    ],
+)
+def test_compute_console_logging_validator(monitoring, expected_message):
+    actual_failures = ComputeConsoleLoggingValidator().execute(monitoring)
+    assert_failure_messages(actual_failures, expected_message)


### PR DESCRIPTION
### Description of changes
* Add the parameter under monitoring sections
```
Monitoring:
  ComputeConsoleLoggingEnabled: True
  ComputeConsoleLoggingMaxSampleSize: 150 # 100
```
* Default value of `ComputeConsoleLoggingEnabled` is True
* Default value of `ComputeConsoleLoggingMaxSampleSize` is 100
* `ComputeConsoleLoggingEnabled` can not be set to False when ComputeConsoleLoggingMaxSampleSize is set in the config.
* When `ComputeConsoleLoggingMaxSampleSize` <0, do not sample, use all of the logs, doesn't allow value =0, it can be set by ComputeConsoleLoggingEnabled: False

### Tests
* Unit tests
* Manual tests

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
