### PR TITLE
Remove unused configuration setting in build image configuration in integration tests

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -18,10 +18,3 @@ Build:
           Value: dummyBuildTag
 
 CustomS3Bucket: {{ bucket_name }}
-
-DeploymentSettings:
-    LambdaFunctionsVpcConfig:
-        SubnetIds:
-        - {{ subnet_id }}
-        SecurityGroupIds:
-        - {{ security_group_id }}


### PR DESCRIPTION
### Notes
This patch removes an unused build image configuration setting in the `test_build_image` integration test. I will put it back once I complete the integration test that uses it.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
