### PR TITLE
EFA MultiAZ Validator (3.x)

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2085,6 +2085,7 @@ class SlurmQueue(_CommonQueue):
                     compute_resource
                 ).enabled
                 is False,
+                multi_az_enabled=self.multi_az_enabled,
             )
             for instance_type in compute_resource.instance_types:
                 self._register_validator(
@@ -2219,6 +2220,7 @@ class SchedulerPluginQueue(_CommonQueue):
                     compute_resource
                 ).enabled
                 is False,
+                multi_az_enabled=self.multi_az_enabled,
             )
 
     @property

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -380,6 +380,23 @@ class EfaSecurityGroupValidator(Validator):
         return False
 
 
+class EfaMultiAzValidator(Validator):
+    """Validate MultiAZ if EFA is enabled."""
+
+    def _validate(
+        self, queue_name: str, multi_az_enabled: bool, compute_resource_name: str, compute_resource_efa_enabled: bool
+    ):
+        if multi_az_enabled and compute_resource_efa_enabled:
+            message = (
+                f"Elastic Fabric Adapter (EFA) was enabled on ComputeResource '{compute_resource_name}' in Queue "
+                f"'{queue_name}' but enhanced networking cannot be leveraged across multiple AZs. "
+            )
+            self._add_failure(
+                message,
+                FailureLevel.ERROR,
+            )
+
+
 # --------------- Storage validators --------------- #
 
 

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -323,12 +323,15 @@ class EfaValidator(Validator):
 class EfaPlacementGroupValidator(Validator):
     """Validate placement group if EFA is enabled."""
 
-    def _validate(self, efa_enabled: bool, placement_group_key: str, placement_group_disabled: bool):
-        if efa_enabled and placement_group_disabled:
+    def _validate(
+        self, efa_enabled: bool, placement_group_key: str, placement_group_disabled: bool, multi_az_enabled: bool
+    ):
+        # if multi_az is enabled suggestions about PlacementGroups will be suppressed
+        if efa_enabled and placement_group_disabled and not multi_az_enabled:
             self._add_failure(
                 "You may see better performance using a placement group for the queue.", FailureLevel.WARNING
             )
-        elif efa_enabled and placement_group_key is None:
+        elif efa_enabled and placement_group_key is None and not multi_az_enabled:
             self._add_failure(
                 "The placement group for EFA-enabled compute resources must be explicit. "
                 "You may see better performance using a placement group, but if you don't wish to use one please add "

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -243,30 +243,38 @@ def test_efa_validator(mocker, boto3_stubber, instance_type, efa_enabled, gdr_su
 
 
 @pytest.mark.parametrize(
-    "efa_enabled, placement_group_key, placement_group_disabled, expected_message",
+    "efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled, expected_message",
     [
         # Efa disabled
-        (False, "test", False, None),
-        (False, "test", True, None),
-        (False, None, False, None),
-        (False, None, True, None),
+        (False, "test", False, False, None),
+        (False, "test", True, False, None),
+        (False, None, False, False, None),
+        (False, None, True, False, None),
         # Efa enabled
         (
             True,
             None,
+            False,
             False,
             "The placement group for EFA-enabled compute resources must be explicit. "
             "You may see better performance using a placement group, "
             "but if you don't wish to use one please add "
             "'Enabled: false' to the compute resource's configuration section.",
         ),
-        (True, None, True, "You may see better performance using a placement group for the queue."),
-        (True, "test", False, None),
-        (True, "test", True, "You may see better performance using a placement group for the queue."),
+        (True, None, True, False, "You may see better performance using a placement group for the queue."),
+        (True, "test", False, False, None),
+        (True, "test", True, False, "You may see better performance using a placement group for the queue."),
+        # EFA and MultiAZ enabled
+        (True, "test", False, True, None),
+        (True, "test", True, True, None),
     ],
 )
-def test_efa_placement_group_validator(efa_enabled, placement_group_key, placement_group_disabled, expected_message):
-    actual_failures = EfaPlacementGroupValidator().execute(efa_enabled, placement_group_key, placement_group_disabled)
+def test_efa_placement_group_validator(
+    efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled, expected_message
+):
+    actual_failures = EfaPlacementGroupValidator().execute(
+        efa_enabled, placement_group_key, placement_group_disabled, multi_az_enabled
+    )
 
     assert_failure_messages(actual_failures, expected_message)
 

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -33,6 +33,7 @@ from pcluster.validators.cluster_validators import (
     DeletionPolicyValidator,
     DictLaunchTemplateBuilder,
     DuplicateMountDirValidator,
+    EfaMultiAzValidator,
     EfaOsArchitectureValidator,
     EfaPlacementGroupValidator,
     EfaSecurityGroupValidator,
@@ -426,6 +427,25 @@ def test_efa_security_group_validator(
 )
 def test_efa_os_architecture_validator(efa_enabled, os, architecture, expected_message):
     actual_failures = EfaOsArchitectureValidator().execute(efa_enabled, os, architecture)
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "multi_az_enabled, efa_enabled, expected_message",
+    [
+        (True, False, None),
+        (False, True, None),
+        (False, False, None),
+        (
+            True,
+            True,
+            "Elastic Fabric Adapter (EFA) was enabled on ComputeResource 'compute' in Queue 'queue' "
+            "but enhanced networking cannot be leveraged across multiple AZs. ",
+        ),
+    ],
+)
+def test_efa_multi_az_validator(multi_az_enabled, efa_enabled, expected_message):
+    actual_failures = EfaMultiAzValidator().execute("queue", multi_az_enabled, "compute", efa_enabled)
     assert_failure_messages(actual_failures, expected_message)
 
 


### PR DESCRIPTION
### Description of changes
* Added two properties to _CommonQueue
  * az_list that returns the list of AZ (without duplicates) associated to the subnets defined in the networking section 
  * multi_az_enabled that is True if the Queue extends over more than one AZ
* Added a new Validator that will fail if both MultiAZ and EFA are enabled at the same time
* Changed the EfaPlacementGroupValidator to suppress suggestions about PlacementGroups when MultiAZ is enabled 

### Tests
* Unit tests
* Dryrun pcluster create with configurations where
    * Both EFA and MultiAZ were enabled (Failed) - No suggestions for PlacementGroups with EFA
    * EFA was enabled but in a Single AZ queue (Success)
    * EFA was disabled and MultiAZ was enabled (Success)

### References
-

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
