### PR TITLE
[integ-tests] Add default security group ID to outputs of VPC stack

### DIFF
--- a/tests/integration-tests/network_template_builder.py
+++ b/tests/integration-tests/network_template_builder.py
@@ -140,6 +140,13 @@ class NetworkTemplateBuilder:
             )
         )
         self.__template.add_output(Output("VpcId", Value=Ref(vpc), Description="The Vpc Id"))
+        self.__template.add_output(
+            Output(
+                "DefaultVpcSecurityGroupId",
+                Value=GetAtt(vpc, "DefaultSecurityGroup"),
+                Description="The Vpc default security group ID",
+            )
+        )
 
         additional_vpc_cidr_blocks = []
         for idx, cidr_block in enumerate(self.__vpc_config.additional_cidr_blocks):


### PR DESCRIPTION
### Description of changes
This patch adds the default security group ID of the VPC to the outputs of the VPC stack, so it can be used in tests the same way as other parameters related to subnets/VPC that are created by the networking stack (such as `private_subnet_id`).

Signed-off-by: Ermanno Moser <ermann@amazon.com>

### Tests
Launched integration test and verified that the security group is present in the outputs of the VPC stack.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
