### PR TITLE
Add subnet_id -> az mapping property at queue level

### DIFF
--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -117,6 +117,10 @@ class Ec2Client(Boto3Client):
             return subnets[0].get("AvailabilityZone")
         raise AWSClientError(function_name="describe_subnets", message=f"Subnet {subnet_id} not found")
 
+    def get_subnets_az_mapping(self, subnet_ids):
+        """Return a dictionary mapping the input subnet_ids to their respective availability zones."""
+        return {subnet_id: self.get_subnet_avail_zone(subnet_id) for subnet_id in subnet_ids}
+
     @AWSExceptionHandler.handle_client_exception
     @Cache.cached
     def get_subnet_vpc(self, subnet_id):

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -625,7 +625,7 @@ class _QueueNetworking(_BaseNetworking):
         self.subnet_ids = Resource.init_param(subnet_ids)
 
     @property
-    def queue_subnet_id_az_mapping(self):
+    def subnet_id_az_mapping(self):
         """Map queue subnet ids to availability zones."""
         return AWSApi.instance().ec2.get_subnets_az_mapping(self.subnet_ids)
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -624,6 +624,11 @@ class _QueueNetworking(_BaseNetworking):
         self.assign_public_ip = Resource.init_param(assign_public_ip)
         self.subnet_ids = Resource.init_param(subnet_ids)
 
+    @property
+    def queue_subnet_id_az_mapping(self):
+        """Map queue subnet ids to availability zones."""
+        return AWSApi.instance().ec2.get_subnets_az_mapping(self.subnet_ids)
+
 
 class SlurmQueueNetworking(_QueueNetworking):
     """Represent the networking configuration for the slurm Queue."""


### PR DESCRIPTION
### Description of changes
* Add subnet_id -> az mapping property at queue level to be used for various validators in Multi-AZ scenarios.

### Tests
* Add unit test to cover the newly implemented `get_subnets_az_mapping` method.
* Modify `get_describe_subnets_mocked_request` to allow it to return information about the subnet's AZ.

### References
* This PR is needed by #4541 #4544 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
