### PR TITLE
[integ-tests] Add integration test for LambdaFunctionsVpcConfig in test_build_image

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -540,7 +540,7 @@ def pcluster_config_reader(test_datadir, vpc_stack, request, region, scheduler_p
     The config can be written by using Jinja2 template engine.
     The current renderer already replaces placeholders for current keys:
         {{ region }}, {{ os }}, {{ instance }}, {{ scheduler}}, {{ key_name }},
-        {{ vpc_id }}, {{ public_subnet_id }}, {{ private_subnet_id }}
+        {{ vpc_id }}, {{ public_subnet_id }}, {{ private_subnet_id }}, {{ default_vpc_security_group_id }}
     The current renderer injects options for custom templates and packages in case these
     are passed to the cli and not present already in the cluster config.
     Also sanity_check is set to true by default unless explicitly set in config.

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -29,6 +29,7 @@ from utils import generate_stack_name, get_arn_partition
 from tests.common.assertions import (
     assert_head_node_is_running,
     assert_instance_has_desired_imds_v2_setting,
+    assert_lambda_vpc_settings_are_correct,
     assert_no_msg_in_logs,
 )
 from tests.common.utils import (
@@ -134,6 +135,11 @@ def test_build_image(
     _test_get_image_log_events(image)
     _test_list_images(image)
     _test_export_logs(s3_bucket_factory, image, region)
+
+    lamda_vpc_config = image.config["DeploymentSettings"]["LambdaFunctionsVpcConfig"]
+    assert_lambda_vpc_settings_are_correct(
+        image.image_id, region, lamda_vpc_config["SecurityGroupIds"], lamda_vpc_config["SubnetIds"]
+    )
 
 
 @pytest.mark.usefixtures("instance")

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -18,3 +18,10 @@ Build:
           Value: dummyBuildTag
 
 CustomS3Bucket: {{ bucket_name }}
+
+DeploymentSettings:
+    LambdaFunctionsVpcConfig:
+        SubnetIds:
+        - {{ private_subnet_id }}
+        SecurityGroupIds:
+        - {{ default_vpc_security_group_id }}


### PR DESCRIPTION
### Description of changes
This patch tests a build image specifying a Vpc configuration for the PCluster Lambda Functions, asserting that each function in the stack has the correct Vpc configuration and the execution role contains the expected managed policy.

### Tests
Successfully run integration test with configuration:

```
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
