### PR TITLE
Add lambda vpc testing in private and no internet access integration tests

### DIFF
--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
@@ -77,3 +77,9 @@ Tags:
     Value: String
   - Key: two
     Value: two22
+DeploymentSettings:
+  LambdaFunctionsVpcConfig:
+    SecurityGroupIds:
+    - {{ default_vpc_security_group_id }}
+    SubnetIds:
+    - {{ no_internet_subnet_id }}

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
@@ -33,3 +33,9 @@ SharedStorage:
     FsxLustreSettings:
       StorageCapacity: 1200
       DeploymentType: SCRATCH_2
+DeploymentSettings:
+  LambdaFunctionsVpcConfig:
+    SecurityGroupIds:
+    - {{ default_vpc_security_group_id }}
+    SubnetIds:
+    - {{ private_subnet_id }}


### PR DESCRIPTION
### Description of changes
* Add to integration test with networking in private and no_internet subnet 
* The `LambdaFunctionsVpcConfig` has been added in those test since it should not mask or change the current test result.

### Tests
* Tested with
```
{%- import 'common.jinja2' as common -%}

---
test-suites:
  networking:
    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
      dimensions:
          # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an
          # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          schedulers: ["slurm"]
          oss: [ "alinux2" ]
    test_cluster_networking.py::test_cluster_in_private_subnet:
      dimensions:
        - regions: [ "me-south-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2" ]
          schedulers: [ "slurm" ]
```

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
