### PR TITLE
[MultiAZ] Validate compatibility of a Capacity Reservation Resource Group with multiple instance types and subnets

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2662,7 +2662,9 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                         CapacityReservationResourceGroupValidator,
                         capacity_reservation_resource_group_arn=cr_target.capacity_reservation_resource_group_arn,
                         instance_types=compute_resource.instance_types,
-                        subnet=queue.networking.subnet_ids[0],
+                        subnet_ids=queue.networking.subnet_ids,
+                        queue_name=queue.name,
+                        subnet_id_az_mapping=queue.networking.subnet_id_az_mapping,
                     )
                     self._register_validator(
                         PlacementGroupCapacityReservationValidator,

--- a/cli/tests/pcluster/validators/utils.py
+++ b/cli/tests/pcluster/validators/utils.py
@@ -26,6 +26,10 @@ def assert_failure_messages(actual_failures, expected_messages):
             res = any(re.search(expected_message, actual_failure.message) for actual_failure in actual_failures) or any(
                 expected_message == actual_failure.message for actual_failure in actual_failures
             )
+            # PyTest truncates the full expected & failure messages if there is an error
+            # These print statements ensure the full message is shown in the console if there is an assertion error
+            print(f"Expected Message: {expected_message}")
+            print(f"Actual Failures: {actual_failures}")
             assert_that(res).is_true()
     else:
         print(actual_failures)


### PR DESCRIPTION
### Description of changes
- These changes modify the Capacity Reservation Resource Group Validator to validate multi subnet/AZ scenarios
- When using multiple instance types:
    - At least one capacity reservation in the resource group can be used with one of the instances
- When using multiple subnets
    - At least one capacity reservation in the resource group can be used with one of the subnets

### Tests
* Automated unit tests
* Manual tests

    - At least one capacity reservation in the resource group can be used with one of the subnets but there are multiple subnets
    ```
    {
      "level": "WARNING",
      "type": "CapacityReservationResourceGroupValidator",
      "message": "Queue queue1 may launch nodes in these availability zones: eu-west-1a but the Capacity Reservation Group (arn:aws:resource-groups:eu-west-1:162389774010:group/CRGroupViaCLI) reserves capacity in these availability zones: eu-west-1b. Consider adding capacity reservations in all the availability zones covered by the queue."
    }
 
    ```

    - All capacity reservations in the resource group are in Availability zone that are not covered by any of the subnets
    ```
    {
      "level": "ERROR",
      "type": "CapacityReservationResourceGroupValidator",
      "message": "Queue queue1 uses subnets in these availability zones: (subnet-0230367ab0e5123a4: eu-west-1a) but the Capacity Reservation Resource Group (arn:aws:resource-groups:eu-west-1:162389774010:group/CRGroupViaCLI) has reservations in these availability zones: eu-west-1b. You can either add a capacity reservation in the availability zones that the subnets are in or remove the Capacity Reservation from the Cluster Configuration."
    }
    ```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
