### PR TITLE
3.x Add IAM Policy to allow head node to retrieve compute node console output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 **ENHANCEMENTS**
+- Add logging of compute node console output to CloudWatch on compute node bootstrap failure.
 
 **CHANGES**
 
@@ -81,7 +82,7 @@ CHANGELOG
 - Upgrade EFA installer to version 1.18.0.
 - Upgrade NICE DCV to version 2022.1-13300.
 - Allow for suppressing the `SingleSubnetValidator` for `Queues`.
-- Remove usage of prolog/epilog Slurm configuration when `UseEc2Hostnames` is set to `true`.  
+- Remove usage of prolog/epilog Slurm configuration when `UseEc2Hostnames` is set to `true`.
 
 **BUG FIXES**
 - Fix validation of `filters` parameter in `ListClusterLogStreams` command to fail when incorrect filters are passed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ CHANGELOG
 - Add new configuration parameter `DeletionPolicy` for EFS and FSx for Lustre shared storage to support storage retention.
 - Add new configuration section `Scheduling/SlurmSettings/Database` to enable accounting functionality in Slurm.
 - Add support for On-Demand Capacity Reservations and Capacity Reservations Resource Groups.
-- Add new configuration parameter in `Imds/ImdsSettings` to specify the IMDS version to support in a cluster or build image infrastructure. 
+- Add new configuration parameter in `Imds/ImdsSettings` to specify the IMDS version to support in a cluster or build image infrastructure.
 - Add support for `Networking/PlacementGroup` in the `SlurmQueues/ComputeResources` section.
 - Add support for instances with multiple network interfaces that allows only one ENI per device.
 - Add support for hp6id instance type as compute nodes.

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -774,7 +774,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
         return policy
 
     def _add_compute_console_output_policy_statement(self, policy):
-        if self._config.monitoring.compute_console_logging_enabled:
+        if self._config.monitoring.logs.cloud_watch.enabled:
             queue_names = [queue.name for queue in self._config.scheduling.queues]
             policy.append(
                 iam.PolicyStatement(

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -157,6 +157,7 @@ class SlurmConstruct(Construct):
                     "dynamodb:PutItem",
                     "dynamodb:BatchWriteItem",
                     "dynamodb:GetItem",
+                    "dynamodb:BatchGetItem",
                 ],
                 "effect": iam.Effect.ALLOW,
                 "resources": [


### PR DESCRIPTION
### Description of changes
* Changes required for retrieving console output from failed static compute nodes.
   * Add IAM Policy to allow head node to retrieve compute node console output.
   * Add permission to parallelcluster-slurm-head-node policy to allow head node to use batch-get-item DynamoDB call.


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
