### PR TITLE
[3.x] Integ-tests: create mount targets when creating EFS

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1814,7 +1814,7 @@ def efs_stack_factory(cfn_stacks_factory, request, region, vpc_stack):
 
 
 @pytest.fixture(scope="class")
-def mount_target_stack_factory(cfn_stacks_factory, request, region, vpc_stack):
+def efs_mount_target_stack_factory(cfn_stacks_factory, request, region, vpc_stack):
     """
     EFS mount target stack.
 

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -54,6 +54,7 @@ from retrying import retry
 from troposphere import Ref, Sub, Template, ec2, resourcegroups
 from troposphere.ec2 import PlacementGroup
 from troposphere.efs import FileSystem as EFSFileSystem
+from troposphere.efs import MountTarget
 from troposphere.fsx import (
     ClientConfigurations,
     FileSystem,
@@ -1810,3 +1811,87 @@ def efs_stack_factory(cfn_stacks_factory, request, region, vpc_stack):
     if not request.config.getoption("no_delete"):
         for stack in created_stacks:
             cfn_stacks_factory.delete_stack(stack.name, region)
+
+
+@pytest.fixture(scope="class")
+def mount_target_stack_factory(cfn_stacks_factory, request, region, vpc_stack):
+    """
+    EFS mount target stack.
+
+    Create mount targets in all availability zones of vpc_stack
+    """
+    created_stacks = []
+
+    def create_mount_targets(efs_ids):
+        template = Template()
+        template.set_version("2010-09-09")
+        template.set_description("Mount targets stack")
+
+        # Create a security group that allows all communication between the mount targets and instances in the VPC
+        vpc_id = vpc_stack.cfn_outputs["VpcId"]
+        security_group = template.add_resource(
+            ec2.SecurityGroup(
+                "SecurityGroupResource",
+                GroupDescription="custom security group for EFS mount targets",
+                VpcId=vpc_id,
+            )
+        )
+        # Allow inbound connection though NFS port within the VPC
+        cidr_block_association_set = boto3.client("ec2").describe_vpcs(VpcIds=[vpc_id])["Vpcs"][0][
+            "CidrBlockAssociationSet"
+        ]
+        for index, cidr_block_association in enumerate(cidr_block_association_set):
+            vpc_cidr = cidr_block_association["CidrBlock"]
+            template.add_resource(
+                ec2.SecurityGroupIngress(
+                    f"SecurityGroupIngressResource{index}",
+                    IpProtocol="-1",
+                    FromPort=2049,
+                    ToPort=2049,
+                    CidrIp=vpc_cidr,
+                    GroupId=Ref(security_group),
+                )
+            )
+
+        # Create mount targets
+        subnet_ids = [value for key, value in vpc_stack.cfn_outputs.items() if key.endswith("SubnetId")]
+        _add_mount_targets(subnet_ids, efs_ids, security_group, template)
+
+        stack_name = generate_stack_name("integ-tests-mount-targets", request.config.getoption("stackname_suffix"))
+        stack = CfnStack(name=stack_name, region=region, template=template.to_json())
+        cfn_stacks_factory.create_stack(stack)
+        created_stacks.append(stack)
+        return stack.name
+
+    yield create_mount_targets
+
+    if not request.config.getoption("no_delete"):
+        for stack in created_stacks:
+            cfn_stacks_factory.delete_stack(stack.name, region)
+
+
+def _add_mount_targets(subnet_ids, efs_ids, security_group, template):
+    subnet_response = boto3.client("ec2").describe_subnets(SubnetIds=subnet_ids)["Subnets"]
+    for efs_index, efs_id in enumerate(efs_ids):
+        availability_zones_with_mount_target = set()
+        for mount_target in boto3.client("efs").describe_mount_targets(FileSystemId=efs_id)["MountTargets"]:
+            availability_zones_with_mount_target.add(mount_target["AvailabilityZoneName"])
+        for subnet_index, subnet in enumerate(subnet_response):
+            if subnet["AvailabilityZone"] not in availability_zones_with_mount_target:
+                # One and only one mount target should be created in each availability zone.
+                depends_on_arg = {}
+                resources = list(template.resources.keys())
+                max_concurrency = 10
+                if len(resources) >= max_concurrency:
+                    # Create at most 10 resources in parallel.
+                    depends_on_arg = {"DependsOn": [resources[-max_concurrency]]}
+                template.add_resource(
+                    MountTarget(
+                        f"MountTargetResourceEfs{efs_index}Subnet{subnet_index}",
+                        FileSystemId=efs_id,
+                        SubnetId=subnet["SubnetId"],
+                        SecurityGroups=[Ref(security_group)],
+                        **depends_on_arg,
+                    )
+                )
+                availability_zones_with_mount_target.add(subnet["AvailabilityZone"])

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -105,14 +105,16 @@ def test_raid_correctly_mounted(remote_command_executor, mount_dir, volume_size)
 # for EFS
 
 
-def write_file_into_efs(region, vpc_stack, efs_ids, request, key_name, cfn_stacks_factory, mount_target_stack_factory):
+def write_file_into_efs(
+    region, vpc_stack, efs_ids, request, key_name, cfn_stacks_factory, efs_mount_target_stack_factory
+):
     """Write file stack contains an instance to write an empty file with random name into each of the efs in efs_ids."""
     write_file_template = Template()
     write_file_template.set_version("2010-09-09")
     write_file_template.set_description("Stack to write a file to the existing EFS")
 
     # Create mount targets so the instance can communicate with the file system
-    mount_target_stack_name = mount_target_stack_factory(efs_ids)
+    mount_target_stack_name = efs_mount_target_stack_factory(efs_ids)
 
     random_file_names = []
     write_file_user_data = ""

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -69,7 +69,7 @@ def test_multiple_efs(
     region,
     scheduler,
     efs_stack_factory,
-    mount_target_stack_factory,
+    efs_mount_target_stack_factory,
     pcluster_config_reader,
     clusters_factory,
     vpc_stack,
@@ -94,10 +94,10 @@ def test_multiple_efs(
         num_existing_efs = 2
     # TODO: create an additional EFS with file system policy to prevent anonymous access
     existing_efs_ids = efs_stack_factory(num_existing_efs)
-    mount_target_stack_factory(existing_efs_ids)
+    efs_mount_target_stack_factory(existing_efs_ids)
     existing_efs_filenames.extend(
         write_file_into_efs(
-            region, vpc_stack, existing_efs_ids, request, key_name, cfn_stacks_factory, mount_target_stack_factory
+            region, vpc_stack, existing_efs_ids, request, key_name, cfn_stacks_factory, efs_mount_target_stack_factory
         )
     )
     for i in range(num_existing_efs):

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -14,11 +14,8 @@ import logging
 import boto3
 import pytest
 from assertpy import assert_that
-from cfn_stacks_factory import CfnStack
 from remote_command_executor import RemoteCommandExecutor
-from troposphere import Ref, Template, ec2
-from troposphere.efs import MountTarget
-from utils import generate_stack_name, get_compute_nodes_instance_ips, get_vpc_snakecase_value
+from utils import get_compute_nodes_instance_ips, get_vpc_snakecase_value
 
 from tests.common.utils import reboot_head_node
 from tests.storage.storage_common import (
@@ -97,8 +94,7 @@ def test_multiple_efs(
         num_existing_efs = 2
     # TODO: create an additional EFS with file system policy to prevent anonymous access
     existing_efs_ids = efs_stack_factory(num_existing_efs)
-    if request.config.getoption("benchmarks"):
-        mount_target_stack_factory(existing_efs_ids)
+    mount_target_stack_factory(existing_efs_ids)
     existing_efs_filenames.extend(
         write_file_into_efs(
             region, vpc_stack, existing_efs_ids, request, key_name, cfn_stacks_factory, mount_target_stack_factory
@@ -151,90 +147,6 @@ def _check_efs_correctly_mounted_and_shared(all_mount_dirs, remote_command_execu
     for mount_dir in all_mount_dirs:
         test_efs_correctly_mounted(remote_command_executor, mount_dir)
         _test_efs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
-
-
-def _add_mount_targets(subnet_ids, efs_ids, security_group, template):
-    subnet_response = boto3.client("ec2").describe_subnets(SubnetIds=subnet_ids)["Subnets"]
-    for efs_index, efs_id in enumerate(efs_ids):
-        availability_zones_with_mount_target = set()
-        for mount_target in boto3.client("efs").describe_mount_targets(FileSystemId=efs_id)["MountTargets"]:
-            availability_zones_with_mount_target.add(mount_target["AvailabilityZoneName"])
-        for subnet_index, subnet in enumerate(subnet_response):
-            if subnet["AvailabilityZone"] not in availability_zones_with_mount_target:
-                # One and only one mount target should be created in each availability zone.
-                depends_on_arg = {}
-                resources = list(template.resources.keys())
-                max_concurrency = 10
-                if len(resources) >= max_concurrency:
-                    # Create at most 10 resources in parallel.
-                    depends_on_arg = {"DependsOn": [resources[-max_concurrency]]}
-                template.add_resource(
-                    MountTarget(
-                        f"MountTargetResourceEfs{efs_index}Subnet{subnet_index}",
-                        FileSystemId=efs_id,
-                        SubnetId=subnet["SubnetId"],
-                        SecurityGroups=[Ref(security_group)],
-                        **depends_on_arg,
-                    )
-                )
-                availability_zones_with_mount_target.add(subnet["AvailabilityZone"])
-
-
-@pytest.fixture(scope="class")
-def mount_target_stack_factory(cfn_stacks_factory, request, region, vpc_stack):
-    """
-    EFS mount target stack.
-
-    Create mount targets in all availability zones of vpc_stack
-    """
-    created_stacks = []
-
-    def create_mount_targets(efs_ids):
-        template = Template()
-        template.set_version("2010-09-09")
-        template.set_description("Mount targets stack")
-
-        # Create a security group that allows all communication between the mount targets and instances in the VPC
-        vpc_id = vpc_stack.cfn_outputs["VpcId"]
-        security_group = template.add_resource(
-            ec2.SecurityGroup(
-                "SecurityGroupResource",
-                GroupDescription="custom security group for EFS mount targets",
-                VpcId=vpc_id,
-            )
-        )
-        # Allow inbound connection though NFS port within the VPC
-        cidr_block_association_set = boto3.client("ec2").describe_vpcs(VpcIds=[vpc_id])["Vpcs"][0][
-            "CidrBlockAssociationSet"
-        ]
-        for index, cidr_block_association in enumerate(cidr_block_association_set):
-            vpc_cidr = cidr_block_association["CidrBlock"]
-            template.add_resource(
-                ec2.SecurityGroupIngress(
-                    f"SecurityGroupIngressResource{index}",
-                    IpProtocol="-1",
-                    FromPort=2049,
-                    ToPort=2049,
-                    CidrIp=vpc_cidr,
-                    GroupId=Ref(security_group),
-                )
-            )
-
-        # Create mount targets
-        subnet_ids = [value for key, value in vpc_stack.cfn_outputs.items() if key.endswith("SubnetId")]
-        _add_mount_targets(subnet_ids, efs_ids, security_group, template)
-
-        stack_name = generate_stack_name("integ-tests-mount-targets", request.config.getoption("stackname_suffix"))
-        stack = CfnStack(name=stack_name, region=region, template=template.to_json())
-        cfn_stacks_factory.create_stack(stack)
-        created_stacks.append(stack)
-        return stack.name
-
-    yield create_mount_targets
-
-    if not request.config.getoption("no_delete"):
-        for stack in created_stacks:
-            cfn_stacks_factory.delete_stack(stack.name, region)
 
 
 def _test_efs_correctly_shared(remote_command_executor, mount_dir, scheduler_commands):

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -777,6 +777,7 @@ def test_dynamic_file_systems_update(
     request,
     snapshots_factory,
     efs_stack_factory,
+    mount_target_stack_factory,
     vpc_stack,
     key_name,
     s3_bucket_factory,
@@ -815,6 +816,7 @@ def test_dynamic_file_systems_update(
         vpc_stack,
         region,
         efs_stack_factory,
+        mount_target_stack_factory,
         fsx_factory,
         svm_factory,
         open_zfs_volume_factory,
@@ -947,6 +949,7 @@ def _create_shared_storages_resources(
     vpc_stack,
     region,
     efs_stack_factory,
+    mount_target_stack_factory,
     fsx_factory,
     svm_factory,
     open_zfs_volume_factory,
@@ -957,7 +960,9 @@ def _create_shared_storages_resources(
     ebs_volume_id = snapshots_factory.create_existing_volume(request, vpc_stack.cfn_outputs["PublicSubnetId"], region)
 
     # create 1 efs
-    existing_efs_id = efs_stack_factory(1)[0]
+    existing_efs_ids = efs_stack_factory(1)
+    mount_target_stack_factory(existing_efs_ids)
+    existing_efs_id = existing_efs_ids[0]
 
     # create 1 fsx lustre
     import_path = "s3://{0}".format(bucket_name)

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -777,7 +777,7 @@ def test_dynamic_file_systems_update(
     request,
     snapshots_factory,
     efs_stack_factory,
-    mount_target_stack_factory,
+    efs_mount_target_stack_factory,
     vpc_stack,
     key_name,
     s3_bucket_factory,
@@ -816,7 +816,7 @@ def test_dynamic_file_systems_update(
         vpc_stack,
         region,
         efs_stack_factory,
-        mount_target_stack_factory,
+        efs_mount_target_stack_factory,
         fsx_factory,
         svm_factory,
         open_zfs_volume_factory,
@@ -949,7 +949,7 @@ def _create_shared_storages_resources(
     vpc_stack,
     region,
     efs_stack_factory,
-    mount_target_stack_factory,
+    efs_mount_target_stack_factory,
     fsx_factory,
     svm_factory,
     open_zfs_volume_factory,
@@ -961,7 +961,7 @@ def _create_shared_storages_resources(
 
     # create 1 efs
     existing_efs_ids = efs_stack_factory(1)
-    mount_target_stack_factory(existing_efs_ids)
+    efs_mount_target_stack_factory(existing_efs_ids)
     existing_efs_id = existing_efs_ids[0]
 
     # create 1 fsx lustre


### PR DESCRIPTION
After https://github.com/aws/aws-parallelcluster/pull/4532, ParallelCluster no long creates mount targets for external EFS file systems. ParallelCluster CLI validates the external EFS file systems have necessary mount targets. Therefore, we need to change our integration tests to create mount targets for any external EFS file systems.

Note that because EFS file systems are used in multiple tests, I had move the mount targets fixture from `test_efs.py` to `conftest.py` so that it can be used by all tests. This move does not change any content of the fixture

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
The following integration tests have been passed
```
test-suites:
  update:
    test_update.py::test_dynamic_file_systems_update:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - alinux2
        regions:
        - eu-west-2
        schedulers:
        - slurm
  storage:
    test_efs.py::test_multiple_efs:
      dimensions:
      - instances:
        - c5.xlarge
        oss:
        - alinux2
        regions:
        - us-west-1
        schedulers:
        - slurm
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
