### PR TITLE
Add MultiAzPlacementGroupValidator that fails if both MultiAZ and PlacementGroup are enabled

### DIFF
--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -77,6 +77,18 @@ class SingleSubnetValidator(Validator):
             self._add_failure("The SubnetId used for all of the queues should be the same.", FailureLevel.ERROR)
 
 
+class MultiAzPlacementGroupValidator(Validator):
+    """Validate a PlacementGroup is not specified when MultiAZ is enabled."""
+
+    def _validate(self, multi_az_enabled: bool, placement_group_enabled: bool):
+        if multi_az_enabled and placement_group_enabled:
+            self._add_failure(
+                "Multiple subnets configuration does not support specifying Placement Group. "
+                "Either specify a single subnet or remove the Placement Group configuration.",
+                FailureLevel.ERROR,
+            )
+
+
 class LambdaFunctionsVpcConfigValidator(Validator):
     """Validator of Pcluster Lambda functions' VPC configuration."""
 

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -14,6 +14,7 @@ import pytest
 
 from pcluster.validators.networking_validators import (
     LambdaFunctionsVpcConfigValidator,
+    MultiAzPlacementGroupValidator,
     SecurityGroupsValidator,
     SingleSubnetValidator,
     SubnetsValidator,
@@ -58,6 +59,25 @@ def test_ec2_subnet_id_validator(mocker):
     # TODO test with invalid key
     actual_failures = SubnetsValidator().execute(["subnet-12345678", "subnet-23456789"])
     assert_failure_messages(actual_failures, None)
+
+
+@pytest.mark.parametrize(
+    "multi_az_enabled, placement_group_enabled, expected_message",
+    [
+        (True, False, None),
+        (False, True, None),
+        (False, False, None),
+        (
+            True,
+            True,
+            "Multiple subnets configuration does not support specifying Placement Group. "
+            "Either specify a single subnet or remove the Placement Group configuration.",
+        ),
+    ],
+)
+def test_multi_az_placement_group_validator(multi_az_enabled, placement_group_enabled, expected_message):
+    actual_failures = MultiAzPlacementGroupValidator().execute(multi_az_enabled, placement_group_enabled)
+    assert_failure_messages(actual_failures, expected_message)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fails if both MultiAZ and PlacementGroup are enabled.

Signed-off-by: Nicola Sirena <nssirena@amazon.com>


### Description of changes
* Added a new MultiAzPlacementGroupValidator that fails if both MultiAZ and PlacementGroup are enabled.
  * A PlacementGroup is enabled if Enabled is true or a Name or Id are specified.

### Tests
* Unit tests
* pcluster create ... --dryrun enabled where
  * both where disabled -> success
  * either MultiAz or PG where enabled (by flag, name or Id) -> success
  * both where enabled -> failure 

### References
-

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
