### PR TITLE
Suppress suggestions to use EFA when MultiAZ is enabled.

### DIFF
--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -303,12 +303,12 @@ class MaxCountValidator(Validator):
 class EfaValidator(Validator):
     """Check if EFA and EFA GDR are supported features in the given instance type."""
 
-    def _validate(self, instance_type, efa_enabled, gdr_support):
+    def _validate(self, instance_type, efa_enabled, gdr_support, multiaz_enabled):
 
         instance_type_supports_efa = AWSApi.instance().ec2.get_instance_type_info(instance_type).is_efa_supported()
         if efa_enabled and not instance_type_supports_efa:
             self._add_failure(f"Instance type '{instance_type}' does not support EFA.", FailureLevel.ERROR)
-        if instance_type_supports_efa and not efa_enabled:
+        if instance_type_supports_efa and not efa_enabled and not multiaz_enabled:
             self._add_failure(
                 f"The EC2 instance selected ({instance_type}) supports enhanced networking capabilities using "
                 "Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of "

--- a/cli/src/pcluster/validators/instances_validators.py
+++ b/cli/src/pcluster/validators/instances_validators.py
@@ -124,6 +124,7 @@ class InstancesEFAValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
         compute_resource_name: str,
         instance_types_info: Dict[str, InstanceTypeInfo],
         efa_enabled: bool,
+        multiaz_queue: bool,
         **kwargs,
     ):
         """Check if EFA requirements are met.
@@ -159,7 +160,7 @@ class InstancesEFAValidator(Validator, _FlexibleInstanceTypesValidatorMixin):
                 for instance_type_name, instance_type_info in instance_types_info.items()
                 if instance_type_info.is_efa_supported()
             }
-            if instance_types_with_efa_support:
+            if instance_types_with_efa_support and not multiaz_queue:
                 self._add_failure(
                     (
                         "The EC2 instance type(s) selected ({0}) for the Compute Resource {1} support enhanced "


### PR DESCRIPTION
EFAValidator and InstancesEFAValidator propose customers to enable EFA when a specified instance type supports EFA.
However since EFA is not compatible with MultiAZ we have to suppress these messages when MultiAZ is enabled.

### Description of changes
* Suppress EFAValidator and InstancesEFAValidator suggestions about enabling EFA when MultiAZ is enabled.

EFAValidator has been moved one step up in the hierarchy, where the information about MultiAZ was available.


### Tests
* Unit Tests
* pcluster create ... --dryrun true with configs where instance-types supporting EFA were selected: no suggestion about using EFA is proposed when MultiAZ is enabled.

### References
-

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
