### PR TITLE
[develop][integ-tests] Allow fetching of deprecated Centos 7 images

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -30,7 +30,8 @@ SYSTEM_ANALYZER_SCRIPT = pathlib.Path(__file__).parent / "data/system-analyzer.s
 
 OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
     "alinux2": {"name": "amzn2-ami-kernel-5.10-hvm-*.*.*.*-*-gp2", "owners": ["amazon"]},
-    "centos7": {"name": "CentOS 7.*", "owners": ["125523088429"]},
+    # TODO: use marketplace AMI if possible
+    "centos7": {"name": "CentOS 7.*", "owners": ["125523088429"], "includeDeprecated": True},
     "ubuntu1804": {
         "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-*-server-*",
         "owners": ["099720109477", "513442679011", "837727238323"],
@@ -95,6 +96,7 @@ def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64", 
             Filters=[{"Name": "name", "Values": [ami_name]}, {"Name": "architecture", "Values": [architecture]}]
             + additional_filters,
             Owners=AMI_TYPE_DICT.get(ami_type).get(os).get("owners"),
+            IncludeDeprecated=AMI_TYPE_DICT.get(ami_type).get(os).get("includeDeprecated", False),
         )
         # Sort on Creation date Desc
         amis = sorted(response.get("Images", []), key=lambda x: x["CreationDate"], reverse=True)


### PR DESCRIPTION
Official Centos 7 AMIs listed here https://wiki.centos.org/Cloud/AWS have reached the 2 year EC2 default deprecation period. Allowing usage of deprecated AMIs for the build-image test while evaluating usage of marketplace AMIs

Signed-off-by: Francesco De Martino <fdm@amazon.com>

### References
Backport https://github.com/aws/aws-parallelcluster/pull/4536

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
