### PR TITLE
[OnNodeUpdate] Add new integration test to verify custom action behaviour

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -60,7 +60,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
         bucket.upload_file(str(test_datadir / script), f"scripts/{script}")
 
     # Create cluster with initial configuration
-    init_config_file = pcluster_config_reader(resource_bucket=bucket_name, bucket=bucket_name)
+    init_config_file = pcluster_config_reader(resource_bucket=bucket_name)
     cluster = clusters_factory(init_config_file)
 
     # Check update hook is NOT executed at cluster creation time
@@ -141,7 +141,6 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     additional_policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAppStreamServiceAccess"
     updated_config_file = pcluster_config_reader(
         config_file="pcluster.config.update.yaml",
-        bucket=bucket_name,
         resource_bucket=bucket_name,
         additional_policy_arn=additional_policy_arn,
     )

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -10,6 +10,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
+import os.path
 import re
 import time
 
@@ -48,12 +49,22 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     # Create S3 bucket for pre/post install scripts
     bucket_name = s3_bucket_factory()
     bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
-    for script in ["preinstall.sh", "postinstall.sh", "updated_preinstall.sh", "updated_postinstall.sh"]:
+    for script in [
+        "preinstall.sh",
+        "postinstall.sh",
+        "updated_preinstall.sh",
+        "updated_postinstall.sh",
+        "postupdate.sh",
+        "updated_postupdate.sh",
+    ]:
         bucket.upload_file(str(test_datadir / script), f"scripts/{script}")
 
     # Create cluster with initial configuration
     init_config_file = pcluster_config_reader(resource_bucket=bucket_name, bucket=bucket_name)
     cluster = clusters_factory(init_config_file)
+
+    # Check update hook is NOT executed at cluster creation time
+    assert_that(os.path.exists("/tmp/postupdate_out.txt")).is_false()
 
     # Update cluster with the same configuration, command should not result any error even if not using force update
     cluster.update(str(init_config_file), force_update="true")
@@ -61,6 +72,9 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     # Command executors
     command_executor = RemoteCommandExecutor(cluster)
     slurm_commands = SlurmCommands(command_executor)
+
+    # Check update hook is executed at cluster update time
+    _check_head_node_script(command_executor, "postupdate", "UPDATE-ARG1")
 
     # Create shared dir for script results
     command_executor.run_remote_command("mkdir -p /shared/script_results")
@@ -252,8 +266,20 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     _check_script(command_executor, slurm_commands, new_compute_node[0], "updated_preinstall", "ABC")
     _check_script(command_executor, slurm_commands, new_compute_node[0], "updated_postinstall", "DEF")
 
+    # Check the new update hook with new args is executed at cluster update time
+    _check_head_node_script(command_executor, "updated_postupdate", "UPDATE-ARG2")
+
     # check new extra json
     _check_extra_json(command_executor, slurm_commands, new_compute_node[0], "test_value")
+
+
+def _check_head_node_script(command_executor, script_name, script_arg):
+    """Verify that update hook script is executed with the right arguments."""
+    logging.info(f"Checking {script_name} script")
+    output_file_path = f"/tmp/{script_name}_out.txt"
+
+    result = command_executor.run_remote_command(f"cat {output_file_path}")
+    assert_that(result.stdout).matches(rf"{script_name}-{script_arg}")
 
 
 def _assert_launch_templates_config(queues_config, cluster_name, region):

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -14,14 +14,13 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     S3Access:
-      - BucketName: {{ bucket }}
       - BucketName: {{ resource_bucket }}
         EnableWriteAccess: true
     AdditionalIamPolicies:
       - Policy: {{ additional_policy_arn }}
   CustomActions:
     OnNodeUpdated:
-      Script: s3://{{ bucket }}/scripts/updated_postupdate.sh
+      Script: s3://{{ resource_bucket }}/scripts/updated_postupdate.sh
       Args:
         - UPDATE-ARG2
 Scheduling:
@@ -36,11 +35,11 @@ Scheduling:
             Size: 40
       CustomActions:
         OnNodeStart:
-          Script: s3://{{ bucket }}/scripts/updated_preinstall.sh
+          Script: s3://{{ resource_bucket }}/scripts/updated_preinstall.sh
           Args:
             - ABC
         OnNodeConfigured:
-          Script: s3://{{ bucket }}/scripts/updated_postinstall.sh
+          Script: s3://{{ resource_bucket }}/scripts/updated_postinstall.sh
           Args:
             - DEF
       CapacityType: SPOT
@@ -79,11 +78,11 @@ Scheduling:
             Size: 40
       CustomActions:
         OnNodeStart:
-          Script: s3://{{ bucket }}/scripts/updated_preinstall.sh
+          Script: s3://{{ resource_bucket }}/scripts/updated_preinstall.sh
           Args:
             - ABC
         OnNodeConfigured:
-          Script: s3://{{ bucket }}/scripts/updated_postinstall.sh
+          Script: s3://{{ resource_bucket }}/scripts/updated_postinstall.sh
           Args:
             - DEF
       ComputeResources:
@@ -112,11 +111,11 @@ Scheduling:
             Size: 40
       CustomActions:
         OnNodeStart:
-          Script: s3://{{ bucket }}/scripts/updated_preinstall.sh
+          Script: s3://{{ resource_bucket }}/scripts/updated_preinstall.sh
           Args:
             - ABC
         OnNodeConfigured:
-          Script: s3://{{ bucket }}/scripts/updated_postinstall.sh
+          Script: s3://{{ resource_bucket }}/scripts/updated_postinstall.sh
           Args:
             - DEF
       ComputeResources:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -14,10 +14,16 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     S3Access:
+      - BucketName: {{ bucket }}
       - BucketName: {{ resource_bucket }}
         EnableWriteAccess: true
     AdditionalIamPolicies:
       - Policy: {{ additional_policy_arn }}
+  CustomActions:
+    OnNodeUpdated:
+      Script: s3://{{ bucket }}/scripts/updated_postupdate.sh
+      Args:
+        - UPDATE-ARG2
 Scheduling:
   Scheduler: slurm
   SlurmSettings:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -12,6 +12,14 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  CustomActions:
+    OnNodeUpdated:
+      Script: s3://{{ bucket }}/scripts/postupdate.sh
+      Args:
+        - UPDATE-ARG1
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket }}
 Scheduling:
   Scheduler: slurm
   SlurmSettings:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -14,12 +14,12 @@ HeadNode:
     KeyName: {{ key_name }}
   CustomActions:
     OnNodeUpdated:
-      Script: s3://{{ bucket }}/scripts/postupdate.sh
+      Script: s3://{{ resource_bucket }}/scripts/postupdate.sh
       Args:
         - UPDATE-ARG1
   Iam:
     S3Access:
-      - BucketName: {{ bucket }}
+      - BucketName: {{ resource_bucket }}
 Scheduling:
   Scheduler: slurm
   SlurmSettings:
@@ -32,11 +32,11 @@ Scheduling:
             Size: 40
       CustomActions:
         OnNodeStart:
-          Script: s3://{{ bucket }}/scripts/preinstall.sh
+          Script: s3://{{ resource_bucket }}/scripts/preinstall.sh
           Args:
             - QWE
         OnNodeConfigured:
-          Script: s3://{{ bucket }}/scripts/postinstall.sh
+          Script: s3://{{ resource_bucket }}/scripts/postinstall.sh
           Args:
             - RTY
       CapacityType: ONDEMAND

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/postupdate.sh
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/postupdate.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+echo "starting postupdate script"
+echo "postupdate-$1" > /tmp/postupdate_out.txt
+echo "postupdate run OK"

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/updated_postupdate.sh
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/updated_postupdate.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+echo "starting updated_postupdate script"
+echo "updated_postupdate-$1" > /tmp/updated_postupdate_out.txt
+echo "updated_postupdate run OK"


### PR DESCRIPTION
### Description of changes
The test verifies:
* the `postupdate.sh` script is NOT executed at cluster creation time
* the `postupdate.sh` script is executed at update time with the right argument (`UPDATE-ARG1`)
* the custom bootstrap script and the arguments are updatable
* the `updated_postupdate.sh` is executed during second update with the right argument (`UPDATE-ARG2`)

### Tests
* Tested creating a custom ami with cookbook changes and running `test_update_slurm`.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1600
* https://github.com/aws/aws-parallelcluster/pull/4501

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
