### PR TITLE
Fix unit test for schema validation logic

### DIFF
--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -87,7 +87,7 @@ class BaseSchema(Schema):
         """
         if kwargs.get("partial"):
             # If the schema is to be loaded partially, do not check existence constrain.
-            return True
+            return False
         num_of_fields = len([data.get(field_name) for field_name in field_list if data.get(field_name)])
         return num_of_fields != 1 if one_required else num_of_fields > 1
 


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
If partial = true, the schema is partial, hence the check on coexistent field must be skipped.

### Tests
* unit tested

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
