### PR TITLE
3.x: Allow to identify a deprecated AMI as the official one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 - Remove creation of EFS mount targets for existing FS.
 - Mount EFS file systems using amazon-efs-utils. EFS files systems can be mounted using in-transit encryption and IAM identity.
 - Install stunnel 5.67 on CentOS7 and Ubuntu to support EFS in-transit encryption.
+- Allow to identify a deprecated AMI as the official one.
 
 3.3.0
 -----

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -9,6 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+from datetime import datetime
 from typing import Any, List, Tuple
 
 from botocore.exceptions import ClientError
@@ -283,6 +284,10 @@ class Ec2Client(Boto3Client):
         instance_info = self.get_instance_type_info(instance_type)
         return instance_info.supported_architecture()
 
+    @staticmethod
+    def _is_image_deprecated(image):
+        return "DeprecationTime" in image and utils.to_iso_timestr(datetime.now()) >= image["DeprecationTime"]
+
     @AWSExceptionHandler.handle_client_exception
     @Cache.cached
     def get_official_image_id(self, os, architecture, filters=None):
@@ -292,10 +297,14 @@ class Ec2Client(Boto3Client):
 
         filters = [{"Name": "name", "Values": ["{0}*".format(self._get_official_image_name_prefix(os, architecture))]}]
         filters.extend([{"Name": f"tag:{tag.key}", "Values": [tag.value]} for tag in tags])
-        images = self._client.describe_images(Owners=[owner], Filters=filters).get("Images")
+        images = self._client.describe_images(Owners=[owner], Filters=filters, IncludeDeprecated=True).get("Images")
         if not images:
             raise AWSClientError(function_name="describe_images", message="Cannot find official ParallelCluster AMI")
-        return max(images, key=lambda image: image["CreationDate"]).get("ImageId")
+
+        def sort_by(image):
+            return ("0" if self._is_image_deprecated(image) else "1") + image["CreationDate"]
+
+        return max(images, key=sort_by).get("ImageId")
 
     def get_official_images(self, os=None, architecture=None):
         """Get the list of official images, optionally filtered by os and architecture."""


### PR DESCRIPTION
### Description of changes
As per [EC2 documentation](https://aws.amazon.com/about-aws/whats-new/2022/03/amazon-machine-images-public-visibility-two-years/), all public AMIs are now deprecated after 2 years at most after their creation. In ParallelCluster context, it means that after 2 years from a ParallelCluster release its official AMIs are going to be deprecated.

This change aims at making them still discoverable after the deprecation, even if not supported, in order to restore the behavior prior to the change by EC2.

Specifically:
* If there are active (not deprecated) suitable AMIs, the active AMI with the latest creation date will be picked as the official AMI
* If all the suitable AMIs are deprecated, the one with the latest creation date will be picked as the official AMI even if deprecated

### Tests

#### Unit tests
A specific Unit Test has been added to verify the correct AMI is picked as the official one, according to the rules above.

#### Manual tests
In order to simulate AMI deprecation, private images with names matching ParallelCluster official image names were created in `ACCOUNT_A` and shared with `ACCOUNT_B`.

`DevSettings > AmiSearchFilters > Owner` in ParallelCluster config file was set to ACCOUNT_A and test performed on ACCOUNT_B.

The behavior prior to the patch verified:
* AMI1 created and shared
* create-cluster: AMI1 was picked as the official image
* AMI1 deprecated 
* create-cluster: received the response message "Cannot find official ParallelCluster AMI"

After applying the patch:
* create-cluster: deprecated AMI1 was picked as the official image
* AMI2 created and shared
* create-cluster: active AMI2 was picked as the official image because it was the only active image
* AMI2 deprecated 
* create-cluster: deprecated AMI2 was picked as the official AMI because of a later CreationDate
* Deprecation removed from AMI1
* create-cluster: AMI1 was picked as the official AMI despite the earlier CreationDate, as the only active image
* Deprecation removed from AMI2
* create-cluster: AMI2 was picked as the official AMI because of a later CreationDate

### References
* [Amazon EC2 now reduces visibility of public Amazon Machine Images (AMIs) older than two years](https://aws.amazon.com/about-aws/whats-new/2022/03/amazon-machine-images-public-visibility-two-years/)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
