### PR TITLE
[integ-tests] Make assertions on DeleteStackFunction after it has been created

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -20,9 +20,12 @@ import time
 import boto3
 import pytest
 from assertpy import assert_that
+from botocore.exceptions import ClientError
 from cfn_stacks_factory import CfnStack
 from dateutil.parser import parse as date_parse
 from remote_command_executor import RemoteCommandExecutor
+from retrying import retry
+from time_utils import minutes, seconds
 from troposphere import Template, iam
 from utils import generate_stack_name, get_arn_partition
 
@@ -128,6 +131,15 @@ def test_build_image(
     image = images_factory(image_id, image_config, region)
     _test_build_tag(image)
     _test_image_stack_events(image)
+
+    cfn_client = boto3.client("cloudformation", region_name=region)
+    _wait_for_creation_of_delete_stack_function(image.image_id, cfn_client)
+
+    lamda_vpc_config = image.config["DeploymentSettings"]["LambdaFunctionsVpcConfig"]
+    assert_lambda_vpc_settings_are_correct(
+        image.image_id, region, lamda_vpc_config["SecurityGroupIds"], lamda_vpc_config["SubnetIds"]
+    )
+
     _test_build_image_success(image)
     _test_build_imds_settings(image, "required", region)
     _test_image_tag_and_volume(image)
@@ -136,9 +148,23 @@ def test_build_image(
     _test_list_images(image)
     _test_export_logs(s3_bucket_factory, image, region)
 
-    lamda_vpc_config = image.config["DeploymentSettings"]["LambdaFunctionsVpcConfig"]
-    assert_lambda_vpc_settings_are_correct(
-        image.image_id, region, lamda_vpc_config["SecurityGroupIds"], lamda_vpc_config["SubnetIds"]
+
+@retry(
+    retry_on_result=lambda result: result == "CREATE_IN_PROGRESS",
+    retry_on_exception=lambda exception: (
+        isinstance(exception, ClientError)
+        and any(
+            message in str(exception) for message in {"Rate exceeded", "Resource DeleteStackFunction does not exist"}
+        )
+    ),
+    wait_fixed=seconds(10),
+    stop_max_delay=minutes(30),
+)
+def _wait_for_creation_of_delete_stack_function(stack_name, cfn_client):
+    return (
+        cfn_client.describe_stack_resource(StackName=stack_name, LogicalResourceId="DeleteStackFunction")
+        .get("StackResourceDetail")
+        .get("ResourceStatus")
     )
 
 


### PR DESCRIPTION
### Description of changes
Previously, in the `build_image_test` integration test, the assertions on the PC delete stack function were made after the image had already been created. However, PC deletes the image stack after the image has been created, so depending on the timing, the assertions could be made on a function that no longer exists, leading to errors. This patch changes this behaviour, doing the assertions only after the CloudFormation `DeleteStackFunction` has been created, but before the execution of the `_test_build_image_success` function, which completes after ImageBuilder has finished building the AMI.

### Tests
Run integration tests with the following configuration:

```
test-suites:
  createami:
    test_createami.py::test_build_image:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
