### PR TITLE
Add Unmanaged FSx multiple AZ validator.

### DIFF
--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -312,6 +312,11 @@ class FsxFileSystemInfo:
         """Return network interface ids of the file system."""
         return self.file_system_data.get("NetworkInterfaceIds")
 
+    @property
+    def subnet_ids(self):
+        """Return subnet ids of the file system."""
+        return self.file_system_data.get("SubnetIds")
+
 
 class ImageInfo:
     """Object to store Ec2 Image information, initialized with the describe_image or describe_images in ec2 client."""

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -701,6 +701,28 @@ class ManagedFsxMultiAzValidator(Validator):
             )
 
 
+class UnmanagedFsxMultiAzValidator(Validator):
+    """
+    Unmanaged FSx Storage Vs Multiple Subnets validator.
+
+    Unmanaged FSx volumes can exist in AZ that are different from the ones defined in queues configuration.
+    In these cases we notify customers that they may incur in increased latency and costs.
+    """
+
+    def _validate(self, queues, fsx_az_list):
+        for queue in queues:
+            queue_az_set = set(queue.networking.az_list)
+            fs_az_set = set(fsx_az_list)
+            # we want to ensure that all the az defined in the queue are supported by the FS
+            if not queue_az_set.issubset(fs_az_set):
+                self._add_failure(
+                    "Your configuration for Queue '{0}' includes multiple subnets and external shared storage "
+                    "configuration. Accessing a shared storage from different AZs can lead to increased "
+                    "latency and costs.".format(queue.name),
+                    FailureLevel.INFO,
+                )
+
+
 class EfsIdValidator(Validator):  # TODO add tests
     """
     EFS id validator.

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -204,6 +204,7 @@ class _DummyFSxClient(FSxClient):
                         "FileSystemType": "LUSTRE",
                         "LustreConfiguration": {"MountName": "abcdef"},
                         "FileSystemId": file_system_id,
+                        "SubnetIds": ["subnet-1"],
                     }
                 )
             )


### PR DESCRIPTION
Unmanaged FSx can be associated to AZs that differ from the ones configured in the queues. In such cases we inform the customers that they may incur in increased latency and costs.

Signed-off-by: Nicola Sirena <nssirena@amazon.com>


### Description of changes
* Add few properties in BaseSharedFsx to 
    * retrieve the list of subnets
    * know if the FS is unmanaged
* Add Unmanaged FSx multiple AZ validator that
    * compares the set of subnets of the queue and the subnets of the FS
    * informs of possible increased latency and costs in case of mismatch

### Tests
* Unit tests.

### References
None

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.