### PR TITLE
[release-3.3] Add logs:TagResource and logs:UntagResource actions to Parallelcluster Policy

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -725,6 +725,8 @@ Resources:
               - logs:PutRetentionPolicy
               - logs:DescribeLogGroups
               - logs:CreateLogGroup
+              - logs:TagResource
+              - logs:UntagResource
             Resource: '*'
             Effect: Allow
             Condition: !If
@@ -788,6 +790,8 @@ Resources:
             Effect: Allow
             Action:
               - logs:CreateLogGroup
+              - logs:TagResource
+              - logs:UntagResource
             Resource:
               - !Sub 'arn:${AWS::Partition}:logs:${Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*'
           - Sid: CloudFormation

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -465,6 +465,8 @@ Resources:
               - logs:PutRetentionPolicy
               - logs:DescribeLogGroups
               - logs:CreateLogGroup
+              - logs:TagResource
+              - logs:UntagResource
             Resource: '*'
             Effect: Allow
             Condition: !If
@@ -527,6 +529,8 @@ Resources:
             Effect: Allow
             Action:
               - logs:CreateLogGroup
+              - logs:TagResource
+              - logs:UntagResource
             Resource:
               - !Sub 'arn:${AWS::Partition}:logs:${Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*'
           - Sid: CloudFormation
@@ -1004,6 +1008,8 @@ Resources:
               - logs:CreateLogStream
               - logs:CreateLogGroup
               - logs:PutLogEvents
+              - logs:TagResource
+              - logs:UntagResource
             Resource: !Sub arn:${AWS::Partition}:logs:*:*:log-group:/aws/imagebuilder/*
 
 Outputs:


### PR DESCRIPTION
### Description of changes
* Add logs:TagResource and logs:UntagResource actions to Parallelcluster Policy
* Change needed to fix error when API are used to create cluster: `User with accountId: XXX is not authorized to perform CreateLogGroup with Tags (Service: CloudWatchLogs, Status Code: 400, Request ID: 4c848ae1-5ff5-43dc-b67b-fd1a0f8cc33e)`

### Test
* Tested a cluster creation in a new region and the issue is resolved by the configuration of the change

### References
* https://github.com/aws/aws-parallelcluster/issues/4529


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
