### PR TITLE
[3.x] Make an assertion in test_unsupported_content_type more stable

### DIFF
--- a/cli/tests/pcluster/api/test_flask_app.py
+++ b/cli/tests/pcluster/api/test_flask_app.py
@@ -187,7 +187,6 @@ class TestParallelClusterFlaskApp:
         )
         assert_that(caplog.records[2].levelno).is_equal_to(logging.INFO)
         assert_that(caplog.records[2].message).contains(
-            "Handling exception (status code 415): {'message': 'Unsupported Media Type: "
-            "Invalid Content-type (text/plain), expected JSON data'}"
+            "'Unsupported Media Type: Invalid Content-type (text/plain), expected JSON data'}"
         )
         assert_that(caplog.records[2].exc_info).is_false()


### PR DESCRIPTION
Signed-off-by: Edoardo Antonini <eantonin@amazon.com>

### Description of changes
* Make an assertion in test_unsupported_content_type more stable, in this way we test only what we are interested in (The unsupported content type message) without being too rigid, as different packet version could generate slightly different messagges
* Example of failure generated by the assertion being too rigid

```
Expected <Responding to request POST /v3/clusters?region=eu-west-1: 415 - Body: {'message': 'Unsupported Media Type: Invalid Content-type (text/plain), expected JSON data'}> to contain item <Handling exception (status code 415): {'message': 'Unsupported Media Type: Invalid Content-type (text/plain), expected JSON data'}>, but did not.
```
### Tests
* Unit test

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
