### PR TITLE
[release-3.3] Add UpdateReplacePolicy to EFS, EBS and FSX CFN resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 
 3.3.1
 -----
+
+**ENHANCEMENTS**
+- When setting `DeletionPolicy` to `Retain`, the file system configured in the SharedStorage section is now preserved 
+  also during a cluster update operation.
+
 **CHANGES**
 - Allow usage of deprecated official AMIs.
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -546,7 +546,9 @@ class ClusterCdkStack(Stack):
             vpc_id=self.config.vpc_id,
         )
         storage_deletion_policy = convert_deletion_policy(storage.deletion_policy)
-        storage_security_group.cfn_options.deletion_policy = storage_deletion_policy
+        storage_security_group.cfn_options.deletion_policy = (
+            storage_security_group.cfn_options.update_replace_policy
+        ) = storage_deletion_policy
 
         target_security_groups = {
             "Head": self._get_head_node_security_groups(),
@@ -569,8 +571,12 @@ class ClusterCdkStack(Stack):
                 )
 
                 if sg_type == "Storage":
-                    ingress_rule.cfn_options.deletion_policy = storage_deletion_policy
-                    egress_rule.cfn_options.deletion_policy = storage_deletion_policy
+                    ingress_rule.cfn_options.deletion_policy = (
+                        ingress_rule.cfn_options.update_replace_policy
+                    ) = storage_deletion_policy
+                    egress_rule.cfn_options.deletion_policy = (
+                        egress_rule.cfn_options.update_replace_policy
+                    ) = storage_deletion_policy
 
         return storage_security_group
 
@@ -707,7 +713,9 @@ class ClusterCdkStack(Stack):
                 file_system_type_version=shared_fsx.file_system_type_version,
                 tags=[CfnTag(key="Name", value=shared_fsx.name)],
             )
-            fsx_resource.cfn_options.deletion_policy = convert_deletion_policy(shared_fsx.deletion_policy)
+            fsx_resource.cfn_options.deletion_policy = (
+                fsx_resource.cfn_options.update_replace_policy
+            ) = convert_deletion_policy(shared_fsx.deletion_policy)
 
             fsx_id = fsx_resource.ref
             # Get MountName for new filesystem. DNSName cannot be retrieved from CFN and will be generated in cookbook
@@ -741,7 +749,7 @@ class ClusterCdkStack(Stack):
                 throughput_mode=shared_efs.throughput_mode,
             )
             efs_resource.tags.set_tag(key="Name", value=shared_efs.name)
-            efs_resource.cfn_options.deletion_policy = deletion_policy
+            efs_resource.cfn_options.deletion_policy = efs_resource.cfn_options.update_replace_policy = deletion_policy
             efs_id = efs_resource.ref
 
         checked_availability_zones = []
@@ -795,7 +803,9 @@ class ClusterCdkStack(Stack):
                     security_groups=[sg.ref for sg in security_groups],
                     subnet_id=subnet_id,
                 )
-                efs_resource.cfn_options.deletion_policy = deletion_policy
+                efs_resource.cfn_options.deletion_policy = (
+                    efs_resource.cfn_options.update_replace_policy
+                ) = deletion_policy
             checked_availability_zones.append(availability_zone)
 
     def _add_raid_volume(self, id_prefix: str, shared_ebs: SharedEbs):
@@ -829,7 +839,9 @@ class ClusterCdkStack(Stack):
             volume_type=shared_ebs.volume_type,
             tags=[CfnTag(key="Name", value=shared_ebs.name)],
         )
-        volume.cfn_options.deletion_policy = convert_deletion_policy(shared_ebs.deletion_policy)
+        volume.cfn_options.deletion_policy = volume.cfn_options.update_replace_policy = convert_deletion_policy(
+            shared_ebs.deletion_policy
+        )
         return volume.ref
 
     def _add_wait_condition(self):

--- a/cli/tests/pcluster/templates/test_shared_storage.py
+++ b/cli/tests/pcluster/templates/test_shared_storage.py
@@ -46,6 +46,7 @@ def test_shared_storage_ebs(mocker, test_datadir, config_file_name, storage_name
 
     volume = next(iter(volumes.values()))
     assert_that(volume["DeletionPolicy"]).is_equal_to(deletion_policy)
+    assert_that(volume["UpdateReplacePolicy"]).is_equal_to(deletion_policy)
 
 
 @pytest.mark.parametrize(
@@ -77,6 +78,7 @@ def test_shared_storage_efs(mocker, test_datadir, config_file_name, storage_name
     file_system_name = next(iter(file_systems.keys()))
     file_system = file_systems[file_system_name]
     assert_that(file_system["DeletionPolicy"]).is_equal_to(deletion_policy)
+    assert_that(file_system["UpdateReplacePolicy"]).is_equal_to(deletion_policy)
 
     mount_targets = get_resources(
         generated_template, type="AWS::EFS::MountTarget", properties={"FileSystemId": {"Ref": file_system_name}}
@@ -86,10 +88,12 @@ def test_shared_storage_efs(mocker, test_datadir, config_file_name, storage_name
 
     mount_target = next(iter(mount_targets.values()))
     assert_that(mount_target["DeletionPolicy"]).is_equal_to(deletion_policy)
+    assert_that(mount_target["UpdateReplacePolicy"]).is_equal_to(deletion_policy)
 
     mount_target_sg_name = mount_target["Properties"]["SecurityGroups"][0]["Ref"]
     mount_target_sg = generated_template["Resources"][mount_target_sg_name]
     assert_that(mount_target_sg["DeletionPolicy"]).is_equal_to(deletion_policy)
+    assert_that(mount_target_sg["UpdateReplacePolicy"]).is_equal_to(deletion_policy)
 
     for sg in ["HeadNodeSecurityGroup", "ComputeSecurityGroup", mount_target_sg_name]:
         rule_deletion_policy = deletion_policy if sg == mount_target_sg_name else None
@@ -140,10 +144,12 @@ def test_shared_storage_fsx(mocker, test_datadir, config_file_name, storage_name
     file_system = next(iter(file_systems.values()))
     assert_that(file_system["Properties"]["FileSystemType"]).is_equal_to(fs_type)
     assert_that(file_system["DeletionPolicy"]).is_equal_to(deletion_policy)
+    assert_that(file_system["UpdateReplacePolicy"]).is_equal_to(deletion_policy)
 
     file_system_sg_name = file_system["Properties"]["SecurityGroupIds"][0]["Ref"]
     file_system_sg = generated_template["Resources"][file_system_sg_name]
     assert_that(file_system_sg["DeletionPolicy"]).is_equal_to(deletion_policy)
+    assert_that(file_system_sg["UpdateReplacePolicy"]).is_equal_to(deletion_policy)
 
     for sg in ["HeadNodeSecurityGroup", "ComputeSecurityGroup", file_system_sg_name]:
         rule_deletion_policy = deletion_policy if sg == file_system_sg_name else None


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
UpdateReplacePolicy allows to set a policy in case the CFN resource is replaced, default is `delete`.
UpdateReplacePolicy value is set to be equal to the value for DeletionPolicy, which can be set through the dedicated cluster configuration option.

Allowed values for UpdateReplacePolicy are equal to the value possible for DeletionPolicy, see docs
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html

### Tests
* unit tests added
* manually verified that FS is retained in case of replacement

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
