### PR TITLE
[release-3.3] Allow to identify a deprecated AMI as the official one (#4571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+3.3.1
+-----
+**CHANGES**
+- Allow to identify a deprecated AMI as the official one.
+
 3.3.0
 -----
 

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -9,6 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+from datetime import datetime
 from typing import Any, List, Tuple
 
 from botocore.exceptions import ClientError
@@ -279,6 +280,10 @@ class Ec2Client(Boto3Client):
         instance_info = self.get_instance_type_info(instance_type)
         return instance_info.supported_architecture()
 
+    @staticmethod
+    def _is_image_deprecated(image):
+        return "DeprecationTime" in image and utils.to_iso_timestr(datetime.now()) >= image["DeprecationTime"]
+
     @AWSExceptionHandler.handle_client_exception
     @Cache.cached
     def get_official_image_id(self, os, architecture, filters=None):
@@ -288,10 +293,14 @@ class Ec2Client(Boto3Client):
 
         filters = [{"Name": "name", "Values": ["{0}*".format(self._get_official_image_name_prefix(os, architecture))]}]
         filters.extend([{"Name": f"tag:{tag.key}", "Values": [tag.value]} for tag in tags])
-        images = self._client.describe_images(Owners=[owner], Filters=filters).get("Images")
+        images = self._client.describe_images(Owners=[owner], Filters=filters, IncludeDeprecated=True).get("Images")
         if not images:
             raise AWSClientError(function_name="describe_images", message="Cannot find official ParallelCluster AMI")
-        return max(images, key=lambda image: image["CreationDate"]).get("ImageId")
+
+        def sort_by(image):
+            return ("0" if self._is_image_deprecated(image) else "1") + image["CreationDate"]
+
+        return max(images, key=sort_by).get("ImageId")
 
     def get_official_images(self, os=None, architecture=None):
         """Get the list of official images, optionally filtered by os and architecture."""


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
- If there are not deprecated suitable AMIs, the not deprecated one with the latest creation date will be picked as the official AMI.
- If all the suitable AMIs are deprecated, the one with the latest creation date will be picked as the official AMI.

Backport of https://github.com/aws/aws-parallelcluster/pull/4571

### Tests
n/a

### References
https://github.com/aws/aws-parallelcluster/pull/4571

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
