### PR TITLE
[release-3.3] Allow to identify a deprecated AMI as the official one (#4571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 3.3.1
 -----
 **CHANGES**
-- Allow to identify a deprecated AMI as the official one.
+- Allow usage of deprecated official AMIs.
 
 3.3.0
 -----

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -8,6 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import itertools
 import re
 from datetime import datetime
 from typing import Any, List, Tuple
@@ -284,6 +285,9 @@ class Ec2Client(Boto3Client):
     def _is_image_deprecated(image):
         return "DeprecationTime" in image and utils.to_iso_timestr(datetime.now()) >= image["DeprecationTime"]
 
+    def _find_valid_official_image(self, images):
+        return max(images, key=lambda image: ("0" if self._is_image_deprecated(image) else "1") + image["CreationDate"])
+
     @AWSExceptionHandler.handle_client_exception
     @Cache.cached
     def get_official_image_id(self, os, architecture, filters=None):
@@ -296,21 +300,22 @@ class Ec2Client(Boto3Client):
         images = self._client.describe_images(Owners=[owner], Filters=filters, IncludeDeprecated=True).get("Images")
         if not images:
             raise AWSClientError(function_name="describe_images", message="Cannot find official ParallelCluster AMI")
+        return self._find_valid_official_image(images).get("ImageId")
 
-        def sort_by(image):
-            return ("0" if self._is_image_deprecated(image) else "1") + image["CreationDate"]
-
-        return max(images, key=sort_by).get("ImageId")
-
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
     def get_official_images(self, os=None, architecture=None):
         """Get the list of official images, optionally filtered by os and architecture."""
-        try:
-            owners = ["amazon"]
-            name = f"{self._get_official_image_name_prefix(os, architecture)}*"
-            filters = [{"Name": "name", "Values": [name]}]
-            return self.describe_images(ami_ids=[], owners=owners, filters=filters)
-        except ImageNotFoundError:
-            return []
+        owners = ["amazon"]
+        name = f"{self._get_official_image_name_prefix(os, architecture)}*"
+        filters = [{"Name": "name", "Values": [name]}]
+        return [
+            ImageInfo(self._find_valid_official_image(images_os_arch))
+            for _, images_os_arch in itertools.groupby(
+                self._client.describe_images(Owners=owners, Filters=filters, IncludeDeprecated=True).get("Images"),
+                key=lambda image: f'{self.extract_os_from_official_image_name(image["Name"])}-{image["Architecture"]}',
+            )
+        ]
 
     @AWSExceptionHandler.handle_client_exception
     @Cache.cached

--- a/cli/tests/pcluster/aws/test_ec2.py
+++ b/cli/tests/pcluster/aws/test_ec2.py
@@ -133,12 +133,31 @@ def test_extract_os_from_official_image_name(os_part, expected_os):
             None,
             {
                 "Images": [
-                    {"Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-other"},
-                    {"Name": "ami-parallelcluster-3.0.0-centos7-hvm-x86_64-other"},
+                    {
+                        "Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-created-earlier",
+                        "Architecture": "x86_64",
+                        "CreationDate": "2018-11-09T01:21:00.000Z",
+                    },
+                    {
+                        "Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-created-later",
+                        "Architecture": "x86_64",
+                        "CreationDate": "2019-11-09T01:21:00.000Z",
+                    },
+                    {
+                        "Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-deprecated",
+                        "Architecture": "x86_64",
+                        "CreationDate": "2020-11-09T01:21:00.000Z",
+                        "DeprecationTime": "2022-11-09T01:21:00.000Z",
+                    },
+                    {
+                        "Name": "ami-parallelcluster-3.0.0-centos7-hvm-x86_64-other",
+                        "Architecture": "x86_64",
+                        "CreationDate": "2018-11-09T01:21:00.000Z",
+                    },
                 ]
             },
             [
-                ImageInfo({"Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-other"}),
+                ImageInfo({"Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-created-later"}),
                 ImageInfo({"Name": "ami-parallelcluster-3.0.0-centos7-hvm-x86_64-other"}),
             ],
             None,
@@ -147,15 +166,38 @@ def test_extract_os_from_official_image_name(os_part, expected_os):
         pytest.param(
             "alinux2",
             None,
-            {"Images": [{"Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-other"}]},
-            [ImageInfo({"Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-other"})],
+            {
+                "Images": [
+                    {
+                        "Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-created-earlier",
+                        "Architecture": "x86_64",
+                        "CreationDate": "2020-10-09T01:21:00.000Z",
+                        "DeprecationTime": "2022-11-09T01:21:00.000Z",
+                    },
+                    {
+                        "Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-created-later",
+                        "Architecture": "x86_64",
+                        "CreationDate": "2020-11-09T01:21:00.000Z",
+                        "DeprecationTime": "2022-11-09T01:21:00.000Z",
+                    },
+                ]
+            },
+            [ImageInfo({"Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-created-later"})],
             None,
             id="test with os",
         ),
         pytest.param(
             None,
             "x86_64",
-            {"Images": [{"Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-other"}]},
+            {
+                "Images": [
+                    {
+                        "Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-other",
+                        "Architecture": "x86_64",
+                        "CreationDate": "2018-11-09T01:21:00.000Z",
+                    },
+                ]
+            },
             [ImageInfo({"Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-other"})],
             None,
             id="test with architecture",
@@ -163,7 +205,15 @@ def test_extract_os_from_official_image_name(os_part, expected_os):
         pytest.param(
             "alinux2",
             "x86_64",
-            {"Images": [{"Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-other"}]},
+            {
+                "Images": [
+                    {
+                        "Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-other",
+                        "Architecture": "x86_64",
+                        "CreationDate": "2018-11-09T01:21:00.000Z",
+                    },
+                ]
+            },
             [ImageInfo({"Name": "aws-parallelcluster-3.0.0-amzn2-hvm-x86_64-other"})],
             None,
             id="test with os and architecture",
@@ -179,8 +229,8 @@ def test_get_official_images(boto3_stubber, os, architecture, boto3_response, ex
         "Filters": [
             {"Name": "name", "Values": [f"aws-parallelcluster-{filter_version}-{filter_os}-{filter_arch}*"]},
         ],
-        "ImageIds": [],
         "Owners": ["amazon"],
+        "IncludeDeprecated": True,
     }
     mocked_requests = [
         MockedBoto3Request(


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
- If there are not deprecated suitable AMIs, the not deprecated one with the latest creation date will be picked as the official AMI.
- If all the suitable AMIs are deprecated, the one with the latest creation date will be picked as the official AMI.

Backport of https://github.com/aws/aws-parallelcluster/pull/4571

### Tests
* unit tests

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
