### PR TITLE
[develop] Fix validator to avoid managed FSx storage

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1357,7 +1357,7 @@ class BaseClusterConfig(Resource):
             )
 
             self._validate_max_storage_count(ebs_count, existing_storage_count, new_storage_count)
-            self._validate_new_storage_multiple_subnets(self.scheduling.queues, new_storage_count)
+            self._validate_new_storage_multiple_subnets(self.compute_subnet_ids, new_storage_count)
 
         self._validate_mount_dirs()
 
@@ -1373,10 +1373,10 @@ class BaseClusterConfig(Resource):
             local_mount_dir_list=list(self.local_mount_dir_instance_types_dict.keys()),
         )
 
-    def _validate_new_storage_multiple_subnets(self, queues, new_storage_count):
+    def _validate_new_storage_multiple_subnets(self, compute_subnet_ids, new_storage_count):
         self._register_validator(
             ManagedFsxMultiAzValidator,
-            queues=queues,
+            compute_subnet_ids=compute_subnet_ids,
             new_storage_count=new_storage_count,
         )
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -703,7 +703,7 @@ class ClusterCdkStack(Stack):
                 kms_key_id=shared_fsx.kms_key_id,
                 file_system_type=LUSTRE,
                 storage_type=shared_fsx.fsx_storage_type,
-                subnet_ids=self.config.compute_subnet_ids,
+                subnet_ids=self.config.compute_subnet_ids[0:1],
                 security_group_ids=[sg.ref for sg in file_system_security_groups],
                 file_system_type_version=shared_fsx.file_system_type_version,
                 tags=[CfnTag(key="Name", value=shared_fsx.name)],

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -691,8 +691,8 @@ class ManagedFsxMultiAzValidator(Validator):
     Validate if managed storage of type FSx is set when using multiple subnets in queues configuration.
     """
 
-    def _validate(self, queues, new_storage_count):
-        if any(len(queue.networking.subnet_ids) > 1 for queue in queues) and new_storage_count.get("fsx") > 0:
+    def _validate(self, compute_subnet_ids, new_storage_count):
+        if len(compute_subnet_ids) > 1 and new_storage_count.get("fsx") > 0:
             self._add_failure(
                 "Multiple subnets configuration does not support FSx 'managed' storage. Found {0} 'managed' "
                 "FSx storage. Please make sure to provide an existing shared storage, properly configured to work "

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -1663,6 +1663,29 @@ def test_efs_id_validator(
                     name="queue2",
                     compute_resources=[],
                     networking=SlurmQueueNetworking(
+                        subnet_ids=["subnet-2"],
+                    ),
+                ),
+            ],
+            {"efs": 1, "fsx": 1, "raid": 1},
+            FailureLevel.ERROR,
+            "Multiple subnets configuration does not support FSx 'managed' storage. "
+            "Found 1 'managed' FSx storage. Please make sure to provide "
+            "an existing shared storage, properly configured to work across the target subnets.",
+        ),
+        (
+            [
+                SlurmQueue(
+                    name="queue1",
+                    compute_resources=[],
+                    networking=SlurmQueueNetworking(
+                        subnet_ids=["subnet-1"],
+                    ),
+                ),
+                SlurmQueue(
+                    name="queue2",
+                    compute_resources=[],
+                    networking=SlurmQueueNetworking(
                         subnet_ids=["subnet-1", "subnet-2"],
                     ),
                 ),
@@ -1688,7 +1711,7 @@ def test_efs_id_validator(
                     ),
                 ),
             ],
-            {"efs": 1, "fsx": 1, "raid": 1},
+            {"efs": 1, "fsx": 0, "raid": 1},
             None,
             "",
         ),


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Fix validator to avoid managed FSx storage with different single subnets in different queues.
  Validator check if managed FSx are set in cluster configuration and fail if there is at least one set. The case is when a single subnet is set for a queue, but each queue use a different subnet.
  
  FSx for Lustre cannot be created passing a list of subnets, even if all the subnet are in the same AZ.

* Pass only one subnet to FSx storage creation
  
  In case MultiAZ FSx validator is disabled, the storage is created into the first element of the compute subnet list.

### Tests
* unit tests added

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
