### PR TITLE
2.x: Block cluster update when using a managed FSx and vpc_security_group_id is modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
 **CHANGES**
-- TODO
+- Block cluster update when using a managed FSx for Lustre file system and updating VPC Security Group Id, to avoid data loss.
 
 2.11.8
 -----

--- a/cli/src/pcluster/config/mappings.py
+++ b/cli/src/pcluster/config/mappings.py
@@ -303,7 +303,7 @@ VPC = {
             "cfn_param_mapping": "VPCSecurityGroupId",
             "allowed_values": ALLOWED_VALUES["security_group_id"],
             "validators": [ec2_security_group_validator],
-            "update_policy": UpdatePolicy.SUPPORTED
+            "update_policy": UpdatePolicy.MANAGED_FSX
         }),
         ("master_availability_zone", {
             # NOTE: this is not exposed as a configuration parameter

--- a/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.ini
@@ -17,6 +17,7 @@ maintain_initial_size = {{maintain_initial_size}}
 master_subnet_id = {{master_subnet_id}}
 compute_subnet_id = {{compute_subnet_id}}
 additional_sg = {{additional_sg}}
+vpc_security_group_id = {{vpc_security_group_id}}
 
 [ebs ebs-1]
 shared_dir={{shared_dir}}

--- a/cli/tests/pcluster/config/test_config_patch/test_vpc_security_id_changes/pcluster.config.ini
+++ b/cli/tests/pcluster/config/test_config_patch/test_vpc_security_id_changes/pcluster.config.ini
@@ -1,0 +1,17 @@
+[global]
+cluster_template = default
+update_check = true
+sanity_check = false
+
+[aws]
+aws_region_name = us-east-2
+
+[cluster default]
+vpc_settings = default
+
+[vpc default]
+master_subnet_id = subnet-12345678
+compute_subnet_id = subnet-23456789
+{% if vpc_security_group_id %}
+vpc_security_group_id = {{ vpc_security_group_id }}
+{% endif %}


### PR DESCRIPTION
### Description of changes
The change in the `vpc_security_group_id` will trigger a creation of a new file system to replace the old one, without preserving the existing data.

With this patch we're blocking the update communicating the potential data loss. Users can anyway update the cluster with the force flag.

### Tests
Manual creation of a cluster with a managed FSx and updated after adding the `vpc_security_group_id`. Output is the following:
```
$ pcluster update -c config.ini managed-fsx
Retrieving configuration from CloudFormation for cluster managed-fsx...
Validating configuration file config.ini...
Found Configuration Changes:

#    parameter              old value    new value
---  ---------------------  -----------  --------------------
     [vpc default]
01*  vpc_security_group_id  -            sg-0e13ef5e81eb0e80d

Validating configuration update...
The requested update cannot be performed. Line numbers with an asterisk indicate updates requiring additional actions. Please review the details below:

#01
'vpc_security_group_id' parameter cannot be updated because the cluster was created with a managed FSx. The change in the 'vpc_security_group_id' will trigger a creation of a new file system to replace the old one, without preserving the existing data. If you force the update you'll lose your data. Make sure to back up the data from the existing FSx for Lustre file system if you want to preserve them. For more information, see https://docs.aws.amazon.com/fsx/latest/LustreGuide/using-backups-fsx.html
How to fix:
Remove the parameter 'vpc_security_group_id'

In case you want to override these checks and proceed with the update please use the --force flag. Note that the cluster could end up in an unrecoverable state.
Update aborted.
```
For a cluster with a managed FSx and without changes in the config during the update the message is:
``` 
No changes found in your cluster configuration.
```

Note that adding or removal of FSx is not supported, but this is not related to this patch.
``` 
Update actions are not currently supported for the 'fsx_fs_id' parameter
```


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
