### PR TITLE
[3.x] Change validation failure level from WARNING to ERROR if EBS is not available

### DIFF
--- a/cli/src/pcluster/validators/ebs_validators.py
+++ b/cli/src/pcluster/validators/ebs_validators.py
@@ -210,7 +210,7 @@ class SharedEbsVolumeIdValidator(Validator):
                 if not is_available and not is_attached_to_head_node:
                     self._add_failure(
                         "Volume {0} is in state '{1}' not 'available'.".format(volume_id, respond.get("State")),
-                        FailureLevel.WARNING,
+                        FailureLevel.ERROR,
                     )
             except AWSClientError as e:
                 if str(e).endswith("parameter volumes is invalid. Expected: 'vol-...'."):


### PR DESCRIPTION
The warning level came from https://github.com/aws/aws-parallelcluster/blob/integ-tests-2.11.7/cli/src/pcluster/config/validators.py#L931. It was warning because we didn't want to block pcluster update (because the EBS is attached to head node before pcluster update). Now with improvement of https://github.com/aws/aws-parallelcluster/pull/4428, we can change it from warning to error.

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
#### Manual testing:
* Creating a cluster with the following configuration file succeeded:
```
Region: us-east-1
Image:
  Os: alinux2
HeadNode:
  InstanceType: c5.xlarge
  Networking:
    SubnetId: subnet-04xxx
  Ssh:
    KeyName: jan2022
Scheduling:
  Scheduler: slurm
  SlurmQueues:
  - Name: queue1
    ComputeResources:
    - Name: c5xlarge
      InstanceType: c5.xlarge
      MinCount: 1
      MaxCount: 10
    Networking:
      SubnetIds:
      - subnet-04xxx
SharedStorage:
  - MountDir: shared
    Name: ebs
    StorageType: Ebs
    EbsSettings:
      VolumeId: vol-0dxxx
```
* Creating another cluster with the configuration above failed because the EBS is already in-use by the previous cluster
```
{
      "level": "ERROR",
      "type": "SharedEbsVolumeIdValidator",
      "message": "Volume vol-0dbb49e8e6d4fa058 is in state 'in-use' not 'available'."
}
```
* Updating the first cluster succeeded

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
