### PR TITLE
[release-3.3][SubnetUpdate] Block subnet updates when using a managed Fsx for Lustre FileSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 **CHANGES**
 - Allow usage of deprecated official AMIs.
 
+**BUG FIXES**
+- Block updating ComputeFleet `SubnetIds` when a Cluster has managed Fsx for Lustre FileSystem. This prevents the Fsx FileSystem from being deleted due to the Replacement update behaviour by CloudFormation.
+
 3.3.0
 -----
 

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -200,9 +200,9 @@ def get_managed_fsx_from_config(config):
 
 def unchanged_managed_fsx_lustre_names(_, patch):
     """Get list of managed Fsx for Lustre Shared Storage that hasn't changed between cluster configuration updates."""
-    fsx_names_before_update = {fsx.get("Name") for fsx in get_managed_fsx_from_config(patch.base_config)}
-    fsx_names_after_update = {fsx.get("Name") for fsx in get_managed_fsx_from_config(patch.target_config)}
-    return fsx_names_before_update.intersection(fsx_names_after_update)
+    managed_fsx_names_before_update = {fsx.get("Name") for fsx in get_managed_fsx_from_config(patch.base_config)}
+    managed_fsx_names_after_update = {fsx.get("Name") for fsx in get_managed_fsx_from_config(patch.target_config)}
+    return managed_fsx_names_before_update.intersection(managed_fsx_names_after_update)
 
 
 def is_slurm_scheduler(patch):
@@ -256,11 +256,11 @@ def fail_reason_managed_placement_group(change, patch):
 
 
 def fail_reason_managed_fsx(change, patch):
-    fsx_lustre_names = unchanged_managed_fsx_lustre_names(change, patch)
-    if fsx_lustre_names:
+    managed_fsx_lustre_names = unchanged_managed_fsx_lustre_names(change, patch)
+    if managed_fsx_lustre_names:
         reason = (
             f"Updating the {change.key} parameter will cause these FSx for Lustre file system(s) to be replaced: "
-            f"{fsx_lustre_names}"
+            f"{managed_fsx_lustre_names}"
         )
     else:
         reason = fail_reason_queue_update_strategy(change, patch)
@@ -508,7 +508,7 @@ UpdatePolicy.UNSUPPORTED = UpdatePolicy(
 # Block update if cluster has a managed Fsx for Lustre FileSystem, otherwise fallback to QueueUpdateStrategy
 UpdatePolicy.MANAGED_FSX = UpdatePolicy(
     name="MANAGED_FSX",
-    level=5,
+    level=6,
     fail_reason=fail_reason_managed_fsx,
     action_needed=UpdatePolicy.ACTIONS_NEEDED["managed_fsx"],
     condition_checker=condition_checker_managed_fsx,

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -193,7 +193,7 @@ def get_managed_fsx_from_config(config):
     managed_fsx_storage = [
         storage
         for storage in config.get("SharedStorage", [])
-        if storage.get("StorageType") == "FsxLustre" and "FileSystemId" not in storage
+        if storage.get("StorageType") == "FsxLustre" and "FileSystemId" not in storage.get("FsxLustreSettings", {})
     ]
     return managed_fsx_storage
 

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -505,8 +505,9 @@ UpdatePolicy.UNSUPPORTED = UpdatePolicy(
     + ". If you need this change, please consider creating a new cluster instead of updating the existing one.",
 )
 
-UpdatePolicy.MANAGED_FSX_WITH_QUEUE_UPDATE_STRATEGY = UpdatePolicy(
-    name="MANAGED_FSX_WITH_QUEUE_UPDATE_STRATEGY",
+# Block update if cluster has a managed Fsx for Lustre FileSystem, otherwise fallback to QueueUpdateStrategy
+UpdatePolicy.MANAGED_FSX = UpdatePolicy(
+    name="MANAGED_FSX",
     level=5,
     fail_reason=fail_reason_managed_fsx,
     action_needed=UpdatePolicy.ACTIONS_NEEDED["managed_fsx"],

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -188,6 +188,33 @@ def is_managed_placement_group_deletion(change, patch):
     ) and not is_placement_group_managed_for_compute_resource(target_q_networking, target_cr_networking)
 
 
+def is_subnet_update(change):
+    """Check if the update involves SubnetIds."""
+    return any(path.startswith("Networking") and change.key == "SubnetIds" for path in change.path)
+
+
+def get_managed_fsx_from_config(config):
+    """Extract managed Fsx for Lustre shared storage entries in a cluster configuration."""
+    managed_fsx_storage = [
+        storage
+        for storage in config.get("SharedStorage", [])
+        if storage.get("StorageType") == "FsxLustre" and "FileSystemId" not in storage
+    ]
+    return managed_fsx_storage
+
+
+def unchanged_managed_fsx_lustre_names(patch):
+    """Get list of managed Fsx for Lustre Shared Storage that hasn't changed between cluster configuration updates."""
+    fsx_names_before_update = {fsx.get("Name") for fsx in get_managed_fsx_from_config(patch.base_config)}
+    fsx_names_after_update = {fsx.get("Name") for fsx in get_managed_fsx_from_config(patch.target_config)}
+    return fsx_names_before_update.intersection(fsx_names_after_update)
+
+
+def subnet_updated_in_cluster_with_managed_fsx_lustre(change, patch):
+    """Check if the update targets SubnetIds and the cluster has managed Fsx for Lustre Shared Storage."""
+    return is_subnet_update(change) and unchanged_managed_fsx_lustre_names(patch)
+
+
 def is_slurm_scheduler(patch):
     return patch.cluster.stack.scheduler == SLURM
 
@@ -238,6 +265,18 @@ def fail_reason_managed_placement_group(change, patch):
     return reason
 
 
+def fail_reason_subnet_update_policy(change, patch):
+    if subnet_updated_in_cluster_with_managed_fsx_lustre(change, patch):
+        fsx_lustre_names = unchanged_managed_fsx_lustre_names(patch)
+        reason = (
+            "Updating the compute fleet subnet will cause these FSx for Lustre file system(s) to be replaced: "
+            f"{fsx_lustre_names}."
+        )
+    else:
+        reason = fail_reason_queue_update_strategy(change, patch)
+    return reason
+
+
 def condition_checker_queue_update_strategy(change, patch):
     result = not patch.cluster.has_running_capacity()
     # QueueUpdateStrategy can override UpdatePolicy of parameters under SlurmQueues
@@ -261,6 +300,14 @@ def condition_checker_managed_placement_group(change, patch):
     return result
 
 
+def condition_checker_subnet_update(change, patch):
+    if subnet_updated_in_cluster_with_managed_fsx_lustre(change, patch):
+        result = False
+    else:
+        result = condition_checker_queue_update_strategy(change, patch)
+    return result
+
+
 def actions_needed_shared_storage_update(change, patch):
     if is_awsbatch_scheduler(change, patch):
         return (
@@ -274,6 +321,17 @@ def actions_needed_shared_storage_update(change, patch):
         actions += ", or set QueueUpdateStrategy in the configuration used for the 'update-cluster' operation"
 
     return actions
+
+
+def actions_needed_subnet_update(change, patch):
+    if subnet_updated_in_cluster_with_managed_fsx_lustre(change, patch):
+        fsx_lustre_names = unchanged_managed_fsx_lustre_names(patch)
+        return (
+            "If you intend to proceed with the update, please make sure to back-up your data and explicitly replace the"
+            f" file system(s) ({fsx_lustre_names}) with a new one(s) in the cluster configuration."
+        )
+    else:
+        return actions_needed_queue_update_strategy(change, patch)
 
 
 def condition_checker_shared_storage_update_policy(change, patch):
@@ -320,6 +378,7 @@ UpdatePolicy.ACTIONS_NEEDED = {
     "pcluster_stop_conditional": actions_needed_queue_update_strategy,
     "managed_placement_group": actions_needed_managed_placement_group,
     "shared_storage_update_conditional": actions_needed_shared_storage_update,
+    "subnet_update": actions_needed_subnet_update,
 }
 
 # Base policies
@@ -454,4 +513,12 @@ UpdatePolicy.UNSUPPORTED = UpdatePolicy(
         else "{0} the parameter '{1}'".format("Restore" if change.is_list else "Remove", change.key)
     )
     + ". If you need this change, please consider creating a new cluster instead of updating the existing one.",
+)
+
+UpdatePolicy.SUBNET_UPDATE_POLICY = UpdatePolicy(
+    name="SUBNET_UPDATE_POLICY",
+    level=5,
+    fail_reason=fail_reason_subnet_update_policy,
+    action_needed=UpdatePolicy.ACTIONS_NEEDED["subnet_update"],
+    condition_checker=condition_checker_subnet_update,
 )

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -649,7 +649,7 @@ class QueueNetworkingSchema(BaseNetworkingSchema):
         fields.Str(validate=get_field_validator("subnet_id")),
         required=True,
         validate=validate.Length(equal=1),
-        metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY},
+        metadata={"update_policy": UpdatePolicy.MANAGED_FSX_WITH_QUEUE_UPDATE_STRATEGY},
     )
     assign_public_ip = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 
@@ -657,12 +657,6 @@ class QueueNetworkingSchema(BaseNetworkingSchema):
 class SlurmQueueNetworkingSchema(QueueNetworkingSchema):
     """Represent the schema of the Networking, child of slurm Queue."""
 
-    subnet_ids = fields.List(
-        fields.Str(validate=get_field_validator("subnet_id")),
-        required=True,
-        validate=validate.Length(min=1),
-        metadata={"update_policy": UpdatePolicy.SUBNET_UPDATE_POLICY},
-    )
     placement_group = fields.Nested(
         PlacementGroupSchema, metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP}
     )
@@ -676,13 +670,6 @@ class SlurmQueueNetworkingSchema(QueueNetworkingSchema):
 
 class AwsBatchQueueNetworkingSchema(QueueNetworkingSchema):
     """Represent the schema of the Networking, child of aws batch Queue."""
-
-    subnet_ids = fields.List(
-        fields.Str(validate=get_field_validator("subnet_id")),
-        required=True,
-        validate=validate.Length(equal=1),
-        metadata={"update_policy": UpdatePolicy.SUBNET_UPDATE_POLICY},
-    )
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -649,7 +649,7 @@ class QueueNetworkingSchema(BaseNetworkingSchema):
         fields.Str(validate=get_field_validator("subnet_id")),
         required=True,
         validate=validate.Length(equal=1),
-        metadata={"update_policy": UpdatePolicy.MANAGED_FSX_WITH_QUEUE_UPDATE_STRATEGY},
+        metadata={"update_policy": UpdatePolicy.MANAGED_FSX},
     )
     assign_public_ip = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -657,6 +657,12 @@ class QueueNetworkingSchema(BaseNetworkingSchema):
 class SlurmQueueNetworkingSchema(QueueNetworkingSchema):
     """Represent the schema of the Networking, child of slurm Queue."""
 
+    subnet_ids = fields.List(
+        fields.Str(validate=get_field_validator("subnet_id")),
+        required=True,
+        validate=validate.Length(min=1),
+        metadata={"update_policy": UpdatePolicy.SUBNET_UPDATE_POLICY},
+    )
     placement_group = fields.Nested(
         PlacementGroupSchema, metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP}
     )
@@ -670,6 +676,13 @@ class SlurmQueueNetworkingSchema(QueueNetworkingSchema):
 
 class AwsBatchQueueNetworkingSchema(QueueNetworkingSchema):
     """Represent the schema of the Networking, child of aws batch Queue."""
+
+    subnet_ids = fields.List(
+        fields.Str(validate=get_field_validator("subnet_id")),
+        required=True,
+        validate=validate.Length(equal=1),
+        metadata={"update_policy": UpdatePolicy.SUBNET_UPDATE_POLICY},
+    )
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -280,7 +280,7 @@ def test_multiple_param_changes(mocker, pcluster_config_reader, test_datadir):
             "SubnetIds",
             ["subnet-12345678"],
             ["subnet-1234567a"],
-            UpdatePolicy.SUBNET_UPDATE_POLICY,
+            UpdatePolicy.MANAGED_FSX_WITH_QUEUE_UPDATE_STRATEGY,
             is_list=False,
         ),
         Change(

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -280,7 +280,7 @@ def test_multiple_param_changes(mocker, pcluster_config_reader, test_datadir):
             "SubnetIds",
             ["subnet-12345678"],
             ["subnet-1234567a"],
-            UpdatePolicy.MANAGED_FSX_WITH_QUEUE_UPDATE_STRATEGY,
+            UpdatePolicy.MANAGED_FSX,
             is_list=False,
         ),
         Change(

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -280,7 +280,7 @@ def test_multiple_param_changes(mocker, pcluster_config_reader, test_datadir):
             "SubnetIds",
             ["subnet-12345678"],
             ["subnet-1234567a"],
-            UpdatePolicy.QUEUE_UPDATE_STRATEGY,
+            UpdatePolicy.SUBNET_UPDATE_POLICY,
             is_list=False,
         ),
         Change(

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -1319,7 +1319,7 @@ def test_condition_checker_managed_placement_group(
                 ],
             },
             Change(
-                path=["Queues[mock-q]", "Networking"],
+                path=["SlurmQueues[mock-q]", "Networking"],
                 key="SubnetIds",
                 old_value=["subnet-12345678"],
                 new_value=["subnet-87654321"],
@@ -1348,7 +1348,7 @@ def test_condition_checker_managed_placement_group(
                 ],
             },
             Change(
-                path=["Queues[mock-q]", "Networking"],
+                path=["SlurmQueues[mock-q]", "Networking"],
                 key="SubnetIds",
                 old_value=["subnet-12345678"],
                 new_value=["subnet-87654321"],
@@ -1356,8 +1356,9 @@ def test_condition_checker_managed_placement_group(
                 is_list=False,
             ),
             False,
-            "All compute nodes must be stopped",
-            "Stop the compute fleet with the pcluster update-compute-fleet command",
+            "All compute nodes must be stopped or QueueUpdateStrategy must be set",
+            "Stop the compute fleet with the pcluster update-compute-fleet command, or set QueueUpdateStrategy in the "
+            "configuration used for the 'update-cluster' operation",
         ),
         # If change includes SubnetIds and existing + new cluster configuration does not have an Fsx FileSystem
         #   - Fall back to QueueUpdateStrategy Update Policy failure message
@@ -1377,7 +1378,7 @@ def test_condition_checker_managed_placement_group(
                 ],
             },
             Change(
-                path=["Queues[mock-q]", "Networking"],
+                path=["SlurmQueues[mock-q]", "Networking"],
                 key="SubnetIds",
                 old_value=["subnet-12345678"],
                 new_value=["subnet-87654321"],
@@ -1385,8 +1386,9 @@ def test_condition_checker_managed_placement_group(
                 is_list=False,
             ),
             False,
-            "All compute nodes must be stopped",
-            "Stop the compute fleet with the pcluster update-compute-fleet command",
+            "All compute nodes must be stopped or QueueUpdateStrategy must be set",
+            "Stop the compute fleet with the pcluster update-compute-fleet command, or set QueueUpdateStrategy in the "
+            "configuration used for the 'update-cluster' operation",
         ),
     ],
 )

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -15,11 +15,11 @@ from pcluster.config.cluster_config import QueueUpdateStrategy
 from pcluster.config.config_patch import Change, ConfigPatch
 from pcluster.config.update_policy import (
     UpdatePolicy,
-    actions_needed_subnet_update,
+    actions_needed_managed_fsx,
+    condition_checker_managed_fsx,
     condition_checker_managed_placement_group,
-    condition_checker_subnet_update,
+    fail_reason_managed_fsx,
     fail_reason_managed_placement_group,
-    fail_reason_subnet_update_policy,
     is_managed_placement_group_deletion,
 )
 from pcluster.models.cluster import Cluster
@@ -1327,8 +1327,8 @@ def test_condition_checker_managed_placement_group(
                 is_list=False,
             ),
             False,
-            "Updating the compute fleet subnet will cause these FSx for Lustre file system(s) to be replaced: "
-            "{'test-fsx-lustre'}.",
+            "Updating the SubnetIds parameter will cause these FSx for Lustre file system(s) to be replaced: "
+            "{'test-fsx-lustre'}",
             "If you intend to proceed with the update, please make sure to back-up your data and explicitly replace "
             "the file system(s) ({'test-fsx-lustre'}) with a new one(s) in the cluster configuration.",
         ),
@@ -1390,7 +1390,7 @@ def test_condition_checker_managed_placement_group(
         ),
     ],
 )
-def test_condition_checker_subnet_ids_updated(
+def test_condition_checker_managed_fsx(
     mocker,
     base_config,
     target_config,
@@ -1402,6 +1402,6 @@ def test_condition_checker_subnet_ids_updated(
     cluster = Cluster(name="mock-name", stack="mock-stack")
     mocker.patch.object(cluster, "has_running_capacity", return_value=True)
     patch = ConfigPatch(cluster=cluster, base_config=base_config, target_config=target_config)
-    assert_that(condition_checker_subnet_update(change, patch)).is_equal_to(expected_subnet_updated)
-    assert_that(fail_reason_subnet_update_policy(change, patch)).is_equal_to(expected_fail_reason)
-    assert_that(actions_needed_subnet_update(change, patch)).is_equal_to(expected_action_needed)
+    assert_that(condition_checker_managed_fsx(change, patch)).is_equal_to(expected_subnet_updated)
+    assert_that(fail_reason_managed_fsx(change, patch)).is_equal_to(expected_fail_reason)
+    assert_that(actions_needed_managed_fsx(change, patch)).is_equal_to(expected_action_needed)

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -1338,7 +1338,11 @@ def test_condition_checker_managed_placement_group(
             {
                 "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-12345678"]}}]},
                 "SharedStorage": [
-                    {"MountDir": "/test-fsx-lustre", "FileSystemId": "test-fsx-lustre-id", "StorageType": "FsxLustre"}
+                    {
+                        "MountDir": "/test-fsx-lustre",
+                        "FsxLustreSettings": {"FileSystemId": "test-fsx-lustre-id"},
+                        "StorageType": "FsxLustre",
+                    }
                 ],
             },
             {


### PR DESCRIPTION
### Description of changes
- Cluster updates involving ComputeFleet SubnetIds when a managed Fsx for Lustre FileSystem is in use results in deleteion of the Fsx FileSystem.
- These changes introduce a new update policy for the SubnetIds which:
    - Checks if the cluster uses a managed Fsx for Lustre FileSystem
        - Shows an update validation error communicating the related risks and mitigation
    - Otherwise fall back to the QueueUpdateStrategy update policy

### Tests
- Unit tests:
    - If update includes SubnetIds and cluster configuration uses a managed Fsx for Lustre
    - Show validation failure message
    - If update includes SubnetIds and existing cluster configuration uses an External Fsx for Lustre FS
        - DO NOT show validation failure message
    - If update includes SubnetIds and new cluster configuration does NOT have a managed Fsx for Lustre FS
        - DO NOT show validation failure message
- Manual tests
    - Attempted running pcluster update after updating the ComputeFleet SubnetIds
    - Confirmed validation message is shown
    ```
    {
      "parameter": "Scheduling.SlurmQueues[queue1].Networking.SubnetIds",
      "requestedValue": [
        "subnet-0230367ab0e5123a4"
      ],
      "message": "Updating the SubnetIds parameter will cause these FSx for Lustre file system(s) to be replaced: {'custom-fsx-lustre'}. If you intend to proceed with the update, please make sure to back-up your data and explicitly replace the file system(s) ({'custom-fsx-lustre'}) with a new one(s) in the cluster configuration.",
      "currentValue": [
        "subnet-01b3415bfd0bbbee6"
      ]
    }
    ```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
