### PR TITLE
Rename validator checking single InstanceType with MultiAZ

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -165,7 +165,7 @@ from pcluster.validators.networking_validators import (
     MultiAzPlacementGroupValidator,
     QueueSubnetsValidator,
     SecurityGroupsValidator,
-    SingleSubnetValidator,
+    SingleInstanceTypeSubnetValidator,
     SubnetsValidator,
 )
 from pcluster.validators.s3_validators import (
@@ -2092,7 +2092,7 @@ class SlurmQueue(_CommonQueue):
         )
         if any(isinstance(compute_resource, SlurmComputeResource) for compute_resource in self.compute_resources):
             self._register_validator(
-                SingleSubnetValidator,
+                SingleInstanceTypeSubnetValidator,
                 queue_name=self.name,
                 subnet_ids=self.networking.subnet_ids,
             )
@@ -2232,7 +2232,7 @@ class SchedulerPluginQueue(_CommonQueue):
         )
         if any(isinstance(compute_resource, SlurmComputeResource) for compute_resource in self.compute_resources):
             self._register_validator(
-                SingleSubnetValidator,
+                SingleInstanceTypeSubnetValidator,
                 queue_name=self.name,
                 subnet_ids=self.networking.subnet_ids,
             )

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -122,7 +122,7 @@ class ElasticIpValidator(Validator):
                 self._add_failure(str(e), FailureLevel.ERROR)
 
 
-class SingleSubnetValidator(Validator):
+class SingleInstanceTypeSubnetValidator(Validator):
     """Validate only one subnet is used for compute resources with single instance type."""
 
     def _validate(self, queue_name, subnet_ids):

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -171,7 +171,9 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
         networking_validators + ".SecurityGroupsValidator._validate", return_value=[]
     )
     subnets_validator = mocker.patch(networking_validators + ".SubnetsValidator._validate", return_value=[])
-    single_subnet_validator = mocker.patch(networking_validators + ".SingleSubnetValidator._validate", return_value=[])
+    single_instance_type_subnet_validator = mocker.patch(
+        networking_validators + ".SingleInstanceTypeSubnetValidator._validate", return_value=[]
+    )
 
     fsx_validators = validators_path + ".fsx_validators"
     fsx_s3_validator = mocker.patch(fsx_validators + ".FsxS3Validator._validate", return_value=[])
@@ -263,7 +265,7 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
         any_order=True,
     )
     subnets_validator.assert_has_calls([call(subnet_ids=["subnet-23456789", "subnet-12345678"])])
-    single_subnet_validator.assert_has_calls(
+    single_instance_type_subnet_validator.assert_has_calls(
         [
             call(
                 queue_name="queue1",
@@ -454,7 +456,9 @@ def test_scheduler_plugin_validators_are_called_with_correct_argument(test_datad
         networking_validators + ".SecurityGroupsValidator._validate", return_value=[]
     )
     subnets_validator = mocker.patch(networking_validators + ".SubnetsValidator._validate", return_value=[])
-    single_subnet_validator = mocker.patch(networking_validators + ".SingleSubnetValidator._validate", return_value=[])
+    single_instance_type_subnet_validator = mocker.patch(
+        networking_validators + ".SingleInstanceTypeSubnetValidator._validate", return_value=[]
+    )
 
     fsx_validators = validators_path + ".fsx_validators"
     fsx_s3_validator = mocker.patch(fsx_validators + ".FsxS3Validator._validate", return_value=[])
@@ -565,7 +569,7 @@ def test_scheduler_plugin_validators_are_called_with_correct_argument(test_datad
         any_order=True,
     )
     subnets_validator.assert_has_calls([call(subnet_ids=["subnet-12345678", "subnet-23456789"])])
-    single_subnet_validator.assert_has_calls(
+    single_instance_type_subnet_validator.assert_has_calls(
         [
             call(
                 queue_name="queue1",

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -18,7 +18,7 @@ from pcluster.validators.networking_validators import (
     MultiAzPlacementGroupValidator,
     QueueSubnetsValidator,
     SecurityGroupsValidator,
-    SingleSubnetValidator,
+    SingleInstanceTypeSubnetValidator,
     SubnetsValidator,
 )
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
@@ -174,8 +174,8 @@ def test_multi_az_placement_group_validator(multi_az_enabled, placement_group_en
         ),
     ],
 )
-def test_single_subnet_validator(queue_name, subnet_ids, failure_message):
-    actual_failure = SingleSubnetValidator().execute(queue_name, subnet_ids)
+def test_single_instance_type_subnet_validator(queue_name, subnet_ids, failure_message):
+    actual_failure = SingleInstanceTypeSubnetValidator().execute(queue_name, subnet_ids)
 
     assert_failure_messages(actual_failure, failure_message)
 


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Rename validator checking single InstanceType with MultiAZ. 
This is needed so to not change the logic of a previous validator with the same name.

### Tests
* unit tested

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
