### PR TITLE
Increase memory size of API Lambda from 1024 to 2048

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 - Add new configuration section `DeploySettings/LambdaFunctionsVpcConfig` for specifying the Vpc config used by ParallelCluster Lambda Functions.
 - Add `failureReason` to `describe-cluster` output when cluster creation fails with headnode wait condition.
 - Add possibility to specify a custom script to be executed in the head node during the update of the cluster. The script can be specified with `OnNodeUpdated` parameter when using Slurm as scheduler.
+- Increase memory size of ParallelCluster API Lambda to 2048 in order to reduce cold start penalty and avoid timeouts.
 
 **CHANGES**
 - Remove creation of EFS mount targets for existing FS.

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -263,7 +263,7 @@ Resources:
     Properties:
       Tracing: Active
       PackageType: Image
-      MemorySize: 1024
+      MemorySize: 2048
       Role: !If [UseCustomParallelClusterFunctionRole, !Ref ParallelClusterFunctionRole, !GetAtt ParallelClusterUserRole.Arn]
       Tags:
         'parallelcluster:resource': api

--- a/tests/integration-tests/tests/pcluster_api/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api_infrastructure.py
@@ -103,7 +103,7 @@ def _assert_parallelcluster_lambda(lambda_name, lambda_arn, lambda_image_uri):
     if "TracingConfig" in lambda_configuration:
         # When executed in GovCloud get_function does not return TracingConfig
         assert_that(lambda_configuration["TracingConfig"]["Mode"]).is_equal_to("Active")
-    assert_that(lambda_configuration["MemorySize"]).is_equal_to(1024)
+    assert_that(lambda_configuration["MemorySize"]).is_equal_to(2048)
     assert_that(lambda_resource["Tags"]).contains("parallelcluster:version")
     assert_that(lambda_resource["Tags"]).contains("parallelcluster:resource")
     assert_that(lambda_resource["Code"]["ImageUri"]).is_equal_to(lambda_image_uri)


### PR DESCRIPTION


### Description of changes
This reduces by ~40% the cold start penalty when loading CDK modules

### Tests
* CreateCluster with cold start penalty
![image (3)](https://user-images.githubusercontent.com/12721611/203618539-06e19e8d-9bcd-4056-8b01-3d37633692a0.png)
* CreateCluster without
![image](https://user-images.githubusercontent.com/12721611/203618682-c0cedb98-9528-44e2-9749-ea6e44663533.png)


### References
* https://github.com/alexcasalboni/aws-lambda-power-tuning

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
