### PR TITLE
Make updates fail in case of failures during cfn-hup actions

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1082,7 +1082,10 @@ class ClusterCdkStack(Stack):
                                 "action=PATH=/usr/local/bin:/bin:/usr/bin:/opt/aws/bin; "
                                 ". /etc/profile.d/pcluster.sh; "
                                 "cfn-init -v --stack ${StackName} "
-                                "--resource HeadNodeLaunchTemplate --configsets update --region ${Region}\n"
+                                "--resource HeadNodeLaunchTemplate --configsets update --region ${Region} || "
+                                "cfn-signal --exit-code=1 "
+                                "--reason='Failed to run cfn-init. Check the CloudWatch logs.' "
+                                "$(cat /tmp/wait_condition_handle.txt)\n"
                                 "runas=root\n"
                             ),
                             {"StackName": self._stack_name, "Region": self.region},


### PR DESCRIPTION
### Description of changes
Previously, if during a cluster update errors occurred during `cfn-hup` actions, such as a failure while running the cookbooks, in CloudFormation the update completed successfully. This patch alters the hook that is called during the `cfn-hup` so that in case errors occur during `cfn-hup` actions the CloudFormation update fails with an error message. 

### Tests
Triggered a failure during an update when running the cookbooks, by creating a cluster with the following post update script:

```
#!/bin/bash

exit 1
```

---


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
