### PR TITLE
[3.x] Rebelance integration tests

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -18,6 +18,7 @@ ad_integration:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004", "centos7"]
         schedulers: ["slurm"]
+# m6g.xlarge is available in the following region: ap-south-1, eu-north-1, eu-west-3, eu-south-1, eu-west-2, eu-west-1, ap-northeast-2, me-south-1, ap-northeast-1, ca-central-1, sa-east-1, ap-east-1, ap-southeast-1, ap-southeast-2, eu-central-1, ap-southeast-3, us-east-1, us-east-2, us-west-1, us-west-2
 arm_pl:
   test_arm_pl.py::test_arm_pl:
     dimensions:
@@ -74,14 +75,14 @@ cloudwatch_logging:
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
       # 3) run the test for all ARM OSes on an ARM instance
-      - regions: ["eu-west-1"]
+      - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: {{ common.OSS_COMMERCIAL_ARM }}
         schedulers: ["slurm"]
 configure:
   test_pcluster_configure.py::test_pcluster_configure:
     dimensions:
-      - regions: ["ap-southeast-1"]
+      - regions: ["af-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_ONE_PER_DISTRO }}
         schedulers: ["slurm"]
@@ -151,13 +152,13 @@ createami:
         oss: ["alinux2", "ubuntu2004", "centos7"]
   test_createami.py::test_kernel4_build_image_run_cluster:
     dimensions:
-      - regions: ["eu-west-1"]
+      - regions: ["ca-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         schedulers: ["awsbatch", "slurm"]
         oss: ["alinux2"]
   test_createami.py::test_build_image_custom_components:
     dimensions:
-      - regions: ["ap-southeast-2"]
+      - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7", "ubuntu1804"]
       - regions: ["eu-west-1"]
@@ -423,7 +424,7 @@ schedulers:
 {%- endif %}
   test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
     dimensions:
-      - regions: ["ap-southeast-2"]
+      - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
@@ -692,7 +693,7 @@ update:
         oss: ["alinux2"]
   test_update.py::test_update_slurm:
     dimensions:
-      - regions: ["eu-west-1"]
+      - regions: ["us-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
   test_update.py::test_update_compute_ami:
@@ -718,7 +719,7 @@ update:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
-      - regions: ["ap-southeast-1"]
+      - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: {{ common.OSS_COMMERCIAL_ARM }}
         schedulers: ["slurm"]


### PR DESCRIPTION
Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
The following tests have been passed
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  cloudwatch_logging:
    test_cloudwatch_logging.py::test_cloudwatch_logging:
      dimensions:
        - regions: [ "ap-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  configure:
    test_pcluster_configure.py::test_pcluster_configure:
      dimensions:
        - regions: [ "af-south-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: [ "slurm" ]
  createami:
    test_createami.py::test_kernel4_build_image_run_cluster:
      dimensions:
        - regions: ["ca-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          schedulers: [ "awsbatch", "slurm" ]
          oss: [ "alinux2" ]
    test_createami.py::test_build_image_custom_components:
      dimensions:
        - regions: [ "eu-north-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
  schedulers:
    test_slurm.py::test_slurm_pmix: # TODO: include in main test_slurm to reduce number of created clusters
      dimensions:
        - regions: [ "ap-south-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: [ "slurm" ]
```
Note I didn't run update test in us-west-2 because I assume us-west-2 has all resources required.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
