### PR TITLE
[3.x] Move the postupdate logic inside the chef update to easily handle signal, this is temporary

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1029,7 +1029,7 @@ class ClusterCdkStack(Stack):
                     "shellRunPostInstall",
                     "chefFinalize",
                 ],
-                "update": ["deployConfigFiles", "chefUpdate", "shellRunOnPostUpdate"],
+                "update": ["deployConfigFiles", "chefUpdate"],
             },
             "deployConfigFiles": {
                 "files": {
@@ -1153,9 +1153,6 @@ class ClusterCdkStack(Stack):
                     },
                 }
             },
-            "shellRunOnPostUpdate": {
-                "commands": {"runpostupdate": {"command": "/opt/parallelcluster/scripts/fetch_and_run -postupdate"}}
-            },
             "chefUpdate": {
                 "commands": {
                     "chef": {
@@ -1165,6 +1162,7 @@ class ClusterCdkStack(Stack):
                             " --logfile /var/log/chef-client.log --force-formatter --no-color"
                             " --chef-zero-port 8889 --json-attributes /etc/chef/dna.json"
                             " --override-runlist aws-parallelcluster::update &&"
+                            " /opt/parallelcluster/scripts/fetch_and_run -postupdate &&"
                             " cfn-signal --exit-code=0 --reason='Update complete'"
                             f" '{self.wait_condition_handle.ref}' ||"
                             " cfn-signal --exit-code=1 --reason='Update failed'"


### PR DESCRIPTION
Move the postupdate logic inside the chef update to easily handle signal, this is temporary, without this change when the script provided by the user fails, nothing happens

### Tests
Manual tests performed:
* Script in bucket unreachable -> update rollbacks to previous state
* Script with `exit 1` -> update rollbacks to previous state
* Template causing an error in the cookbook -> update rollbacks to previous state
* Script with a simple echo (positive exit code) -> update completes successfully 

### References
PRs for the same feature
* https://github.com/aws/aws-parallelcluster/pull/4501
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1600
* https://github.com/aws/aws-parallelcluster/pull/4563

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change. -> documentation will be handled in the future

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
