### PR TITLE
[MultiAZ] Validate PlacementGroup compatibility with Capacity Reservation only for Single Subnet Queues

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2663,6 +2663,8 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                         odcr=cr_target,
                         subnet=queue.networking.subnet_ids[0],
                         instance_types=compute_resource.instance_types,
+                        multi_az_enabled=queue.multi_az_enabled,
+                        subnet_id_az_mapping=queue.networking.subnet_id_az_mapping,
                     )
 
     @property


### PR DESCRIPTION
### Description of changes
- The [PlacementGroupCapacityReservationValidator](https://github.com/aws/aws-parallelcluster/blob/9c53ea05a0916b925a297ba31727e0354075850f/cli/src/pcluster/validators/ec2_validators.py#L421-L421) validator checks if a PlacementGroup is compatible with available Capacity Reservations
- With the introduction of multiple AZs/Subnets, this compatibility breaks since PlacementGroups are not used in a Multi-AZ Cluster
- This results in the validation error when using multiple subnets:

```
    {
      "level": "ERROR",
      "type": "PlacementGroupCapacityReservationValidator",
      "message": "There are no open or targeted ODCRs that match the instance_type 't2.micro' and no placement group provided. Please either provide a placement group or add an ODCR that does not target a placement group and targets the instance type."
    }
```

### Tests
- Manual and automated unit tests to confirm no validation error from the `PlacementGroupCapacityReservationValidator` occurs when using a queue with multiple subnets, a CRRG and no placement group
- Added test:
    - Configuration with multiple subnets does not result in validation failures.

### References
* #4555 
* #4551 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
