### PR TITLE
3.x: Use the original official AMI when updating the cluster

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1669,6 +1669,10 @@ class BaseClusterConfig(Resource):
             )
         return self._official_ami
 
+    @official_ami.setter
+    def official_ami(self, value):
+        self._official_ami = value
+
     @property
     def lambda_functions_vpc_config(self):
         """Return the vpc config of the PCluster Lambda Functions or None."""

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -172,7 +172,7 @@ class Cluster:
         self.template_body = None
         self.__config = None
         self.__s3_artifact_dir = None
-
+        self.__official_ami = None
         self.__has_running_capacity = None
         self.__running_capacity = None
 
@@ -181,6 +181,7 @@ class Cluster:
         """Return the ClusterStack object."""
         if not self.__stack:
             self.__stack = ClusterStack(AWSApi.instance().cfn.describe_stack(self.stack_name))
+            self.__official_ami = self.__stack.official_ami
         return self.__stack
 
     @property
@@ -434,6 +435,8 @@ class Cluster:
             LOGGER.info("Validating cluster configuration...")
             Cluster._load_additional_instance_type_data(cluster_config_dict)
             config = self._load_config(cluster_config_dict)
+            config.official_ami = self.__official_ami
+
             validation_failures = config.validate(validator_suppressors, context)
             if any(f.level.value >= FailureLevel(validation_failure_level).value for f in validation_failures):
                 raise ConfigValidationError("Invalid cluster configuration.", validation_failures=validation_failures)

--- a/cli/src/pcluster/models/cluster_resources.py
+++ b/cli/src/pcluster/models/cluster_resources.py
@@ -65,6 +65,11 @@ class ClusterStack(StackInfo):
         """Return the version of the original config used to generate the stack in the cluster."""
         return self._get_param("ConfigVersion")
 
+    @property
+    def official_ami(self):
+        """Return the original official AMI."""
+        return self._get_param("OfficialAmi")
+
     def delete(self):
         """Delete stack."""
         AWSApi.instance().cfn.delete_stack(self.name)

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -210,6 +210,7 @@ class ClusterCdkStack(Stack):
             default=self.bucket.artifact_directory,
         )
         CfnParameter(self, "Scheduler", default=self.config.scheduling.scheduler)
+        CfnParameter(self, "OfficialAmi", default=self.config.official_ami)
         CfnParameter(
             self,
             "ConfigVersion",


### PR DESCRIPTION
### Description of changes
As of today, ParallelCluster does not support head node replacement. 
For this reason, if the official AMI is upgraded after the cluster creation, a later cluster update would break.
This change avoids the issue, reusing the original AMI instead of picking the latest one.

### Tests
Manual tests:
  * New cluster created with the official AMI, CFN parameter `OfficialAmi` is set correctly
  * During cluster update, the official AMI is not looked up but is taken from the CFN parameter

### References
* https://github.com/aws/aws-parallelcluster/pull/4571
* https://github.com/aws/aws-parallelcluster/pull/4584

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
