### PR TITLE
2.x: Print changes in the vpc_security_group_id when the update is allowed

### DIFF
--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -285,8 +285,7 @@ UpdatePolicy.MANAGED_FSX = UpdatePolicy(
         else "Remove the parameter '{0}'".format(change.param_key)
     ),
     condition_checker=_check_unmanaged_fsx,
-    # We don't want to show the change if allowed (e.g local value is empty)
-    print_succeeded=False,
+    print_succeeded=True,
 )
 
 # Update effects are unknown.

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -482,7 +482,7 @@ def test_vpc_security_id_changes(
             Change("vpc", "default", "vpc_security_group_id", src_value, dst_value, UpdatePolicy.MANAGED_FSX),
         )
         if expected_patch_allowed:
-            check = "SUCCEDED"
+            check = "SUCCEEDED"
             reason = "-"
             action_needed = None
         else:
@@ -509,7 +509,7 @@ def test_vpc_security_id_changes(
     is_patch_allowed, rows = ConfigPatch(base_config=src_conf, target_config=dst_conf).check()
     assert_that(expected_patch_allowed).is_equal_to(is_patch_allowed)
 
-    for line in rows:
+    for line in expected_message_rows:
         # Handle unicode string
         line = ["{0}".format(element) if isinstance(element, str) else element for element in line]
-        assert_that(expected_message_rows).contains(line)
+        assert_that(rows).contains(line)


### PR DESCRIPTION
### Description of changes
Without this patch the update command wasn't displaying any change in the config when the update of the vpc_security_group_id parameter was allowed (not managed fsx).

Invert test logic to verify all the expected changes are in the output and not viceversa.
This logic was hiding the fact we were not printing the change in case of allowed update and was hiding a typo in the check result.

### Tests
Before the patch:
```
$ pcluster update -c/config.2.simple.ini unmanaged-fsx
Retrieving configuration from CloudFormation for cluster unmanaged-fsx...
Validating configuration file config.2.simple.ini...
No changes found in your cluster configuration.
Do you want to proceed with the update? - Y/N: N
Update aborted.
```
After the patch:
```
$ pcluster update -c config.2.simple.ini unmanaged-fsx
Retrieving configuration from CloudFormation for cluster unmanaged-fsx...
Validating configuration file config.2.simple.ini...
Found Configuration Changes:

#    parameter              old value             new value
---  ---------------------  --------------------  --------------------
     [vpc default]
01   vpc_security_group_id  sg-0e13e54b41eb0e80d  sg-05c40bf4cce481315

Validating configuration update...
Congratulations! The new configuration can be safely applied to your cluster.
Do you want to proceed with the update? - Y/N: N

```
### References
* Minor fix related to: https://github.com/aws/aws-parallelcluster/pull/4592

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
