### PR TITLE
[Develop][SubnetUpdate] Block subnet updates when using a managed Fsx for Lustre FileSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ CHANGELOG
 - Allow usage of deprecated official AMIs.
 - Increase memory size of ParallelCluster API Lambda to 2048 in order to reduce cold start penalty and avoid timeouts.
 
+**BUG FIXES**
+- Block updating ComputeFleet `SubnetIds` when a Cluster has managed Fsx for Lustre FileSystem. This prevents the Fsx FileSystem from being deleted due to the Replacement update behaviour by CloudFormation.
+
 3.3.0
 -----
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -662,7 +662,7 @@ class SlurmQueueNetworkingSchema(QueueNetworkingSchema):
         fields.Str(validate=get_field_validator("subnet_id")),
         required=True,
         validate=validate.Length(min=1),
-        metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY},
+        metadata={"update_policy": UpdatePolicy.MANAGED_FSX},
     )
     placement_group = fields.Nested(
         PlacementGroupSchema, metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP}
@@ -682,7 +682,7 @@ class AwsBatchQueueNetworkingSchema(QueueNetworkingSchema):
         fields.Str(validate=get_field_validator("subnet_id")),
         required=True,
         validate=validate.Length(equal=1),
-        metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY},
+        metadata={"update_policy": UpdatePolicy.MANAGED_FSX},
     )
 
     @post_load

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -280,7 +280,7 @@ def test_multiple_param_changes(mocker, pcluster_config_reader, test_datadir):
             "SubnetIds",
             ["subnet-12345678"],
             ["subnet-1234567a"],
-            UpdatePolicy.QUEUE_UPDATE_STRATEGY,
+            UpdatePolicy.MANAGED_FSX,
             is_list=False,
         ),
         Change(

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -15,7 +15,10 @@ from pcluster.config.cluster_config import QueueUpdateStrategy
 from pcluster.config.config_patch import Change, ConfigPatch
 from pcluster.config.update_policy import (
     UpdatePolicy,
+    actions_needed_managed_fsx,
+    condition_checker_managed_fsx,
     condition_checker_managed_placement_group,
+    fail_reason_managed_fsx,
     fail_reason_managed_placement_group,
     is_managed_placement_group_deletion,
 )
@@ -1295,3 +1298,187 @@ def test_condition_checker_managed_placement_group(
     assert_that(actual_top).is_equal_to(expected_result_top)
     actual_message = fail_reason_managed_placement_group(change, patch)
     assert_that(actual_message).is_equal_to(expected_message)
+
+
+@pytest.mark.parametrize(
+    "base_config, target_config, change, expected_subnet_updated, expected_fail_reason, expected_action_needed",
+    [
+        # If change includes SubnetIds and existing + new cluster configuration uses the same managed Fsx for Lustre
+        #   - Show Managed Fsx validation failure message
+        (
+            {
+                "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-12345678"]}}]},
+                "SharedStorage": [
+                    {"MountDir": "/test-fsx-lustre", "Name": "test-fsx-lustre", "StorageType": "FsxLustre"}
+                ],
+            },
+            {
+                "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-87654321"]}}]},
+                "SharedStorage": [
+                    {"MountDir": "/test-fsx-lustre", "Name": "test-fsx-lustre", "StorageType": "FsxLustre"}
+                ],
+            },
+            Change(
+                path=["SlurmQueues[mock-q]", "Networking"],
+                key="SubnetIds",
+                old_value=["subnet-12345678"],
+                new_value=["subnet-87654321"],
+                update_policy={},
+                is_list=False,
+            ),
+            False,
+            "Updating the SubnetIds parameter will cause these FSx for Lustre file system(s) to be replaced: "
+            "{'test-fsx-lustre'}",
+            "If you intend to proceed with the update, please make sure to back-up your data and explicitly replace "
+            "the file system(s) ({'test-fsx-lustre'}) with a new one(s) in the cluster configuration.",
+        ),
+        # If update includes SubnetIds and existing cluster configuration uses an External Fsx for Lustre FS
+        #   - Fall back to QueueUpdateStrategy Update Policy failure message
+        (
+            {
+                "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-12345678"]}}]},
+                "SharedStorage": [
+                    {
+                        "MountDir": "/test-fsx-lustre",
+                        "FsxLustreSettings": {"FileSystemId": "test-fsx-lustre-id"},
+                        "StorageType": "FsxLustre",
+                    }
+                ],
+            },
+            {
+                "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-87654321"]}}]},
+                "SharedStorage": [
+                    {
+                        "MountDir": "/test-fsx-lustre",
+                        "FsxLustreSettings": {"FileSystemId": "test-fsx-lustre-id"},
+                        "StorageType": "FsxLustre",
+                    }
+                ],
+            },
+            Change(
+                path=["SlurmQueues[mock-q]", "Networking"],
+                key="SubnetIds",
+                old_value=["subnet-12345678"],
+                new_value=["subnet-87654321"],
+                update_policy={},
+                is_list=False,
+            ),
+            False,
+            "All compute nodes must be stopped or QueueUpdateStrategy must be set",
+            "Stop the compute fleet with the pcluster update-compute-fleet command, or set QueueUpdateStrategy in the "
+            "configuration used for the 'update-cluster' operation",
+        ),
+        # If change includes SubnetIds and existing + new cluster configuration does not have an Fsx FileSystem
+        #   - Fall back to QueueUpdateStrategy Update Policy failure message
+        (
+            {
+                "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-12345678"]}}]},
+                "SharedStorage": [
+                    {"MountDir": "/test-efs", "Name": "test-efs", "StorageType": "Efs"},
+                    {"MountDir": "/test-ebs", "Name": "test-ebs", "StorageType": "Ebs"},
+                ],
+            },
+            {
+                "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-87654321"]}}]},
+                "SharedStorage": [
+                    {"MountDir": "/test-efs", "Name": "test-efs", "StorageType": "Efs"},
+                    {"MountDir": "/test-ebs", "Name": "test-ebs", "StorageType": "Ebs"},
+                ],
+            },
+            Change(
+                path=["SlurmQueues[mock-q]", "Networking"],
+                key="SubnetIds",
+                old_value=["subnet-12345678"],
+                new_value=["subnet-87654321"],
+                update_policy={},
+                is_list=False,
+            ),
+            False,
+            "All compute nodes must be stopped or QueueUpdateStrategy must be set",
+            "Stop the compute fleet with the pcluster update-compute-fleet command, or set QueueUpdateStrategy in the "
+            "configuration used for the 'update-cluster' operation",
+        ),
+        # If change includes SubnetIds and existing managed Fsx FileSystem is updated to unmanaged Fsx FileSystem
+        #   - Fall back to QueueUpdateStrategy Update Policy failure message
+        (
+            {
+                "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-12345678"]}}]},
+                "SharedStorage": [
+                    {
+                        "MountDir": "/test-fsx-lustre",
+                        "FsxLustreSettings": {"FileSystemId": "test-fsx-lustre-id"},
+                        "StorageType": "FsxLustre",
+                    }
+                ],
+            },
+            {
+                "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-87654321"]}}]},
+                "SharedStorage": [
+                    {"MountDir": "/test-fsx-lustre", "Name": "test-fsx-lustre", "StorageType": "FsxLustre"},
+                ],
+            },
+            Change(
+                path=["SlurmQueues[mock-q]", "Networking"],
+                key="SubnetIds",
+                old_value=["subnet-12345678"],
+                new_value=["subnet-87654321"],
+                update_policy={},
+                is_list=False,
+            ),
+            False,
+            "All compute nodes must be stopped or QueueUpdateStrategy must be set",
+            "Stop the compute fleet with the pcluster update-compute-fleet command, or set QueueUpdateStrategy in the "
+            "configuration used for the 'update-cluster' operation",
+        ),
+        # If SubnetIds is updated and the existing cluster has a managed Fsx FileSystem
+        # and an unmanaged Fsx FileSystem is added:
+        #   - Show Managed Fsx validation failure message
+        (
+            {
+                "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-12345678"]}}]},
+                "SharedStorage": [
+                    {"MountDir": "/test-fsx-lustre", "Name": "test-fsx-lustre", "StorageType": "FsxLustre"},
+                ],
+            },
+            {
+                "Scheduling": {"Queues": [{"Name": "mock-q", "Networking": {"SubnetIds": ["subnet-87654321"]}}]},
+                "SharedStorage": [
+                    {
+                        "MountDir": "/test-fsx-lustre-unmanaged",
+                        "FsxLustreSettings": {"FileSystemId": "test-fsx-lustre-id"},
+                        "StorageType": "FsxLustre",
+                    },
+                    {"MountDir": "/test-fsx-lustre", "Name": "test-fsx-lustre", "StorageType": "FsxLustre"},
+                ],
+            },
+            Change(
+                path=["SlurmQueues[mock-q]", "Networking"],
+                key="SubnetIds",
+                old_value=["subnet-12345678"],
+                new_value=["subnet-87654321"],
+                update_policy={},
+                is_list=False,
+            ),
+            False,
+            "Updating the SubnetIds parameter will cause these FSx for Lustre file system(s) to be replaced: "
+            "{'test-fsx-lustre'}",
+            "If you intend to proceed with the update, please make sure to back-up your data and explicitly replace "
+            "the file system(s) ({'test-fsx-lustre'}) with a new one(s) in the cluster configuration.",
+        ),
+    ],
+)
+def test_condition_checker_managed_fsx(
+    mocker,
+    base_config,
+    target_config,
+    change,
+    expected_subnet_updated,
+    expected_fail_reason,
+    expected_action_needed,
+):
+    cluster = Cluster(name="mock-name", stack="mock-stack")
+    mocker.patch.object(cluster, "has_running_capacity", return_value=True)
+    patch = ConfigPatch(cluster=cluster, base_config=base_config, target_config=target_config)
+    assert_that(condition_checker_managed_fsx(change, patch)).is_equal_to(expected_subnet_updated)
+    assert_that(fail_reason_managed_fsx(change, patch)).is_equal_to(expected_fail_reason)
+    assert_that(actions_needed_managed_fsx(change, patch)).is_equal_to(expected_action_needed)


### PR DESCRIPTION
### Description of changes
- Cluster updates involving ComputeFleet SubnetIds when a managed Fsx for Lustre FileSystem is in use results in deleteion of the Fsx FileSystem.
- These changes introduce a new update policy for the SubnetIds which:
    - Checks if the cluster uses a managed Fsx for Lustre FileSystem
        - Shows an update validation error communicating the related risks and mitigation
    - Otherwise fall back to the QueueUpdateStrategy update policy

### Tests
- Unit tests:
    - If update includes SubnetIds and cluster configuration uses a managed Fsx for Lustre
    - Show validation failure message
    - If update includes SubnetIds and existing cluster configuration uses an External Fsx for Lustre FS
        - DO NOT show validation failure message
    - If update includes SubnetIds and new cluster configuration does NOT have a managed Fsx for Lustre FS
        - DO NOT show validation failure message
- Manual tests
    - Attempted running pcluster update after updating the ComputeFleet SubnetIds
    - Confirmed validation message is shown
    ```
    {
      "parameter": "Scheduling.SlurmQueues[queue1].Networking.SubnetIds",
      "requestedValue": [
        "subnet-0230367ab0e5123a4"
      ],
      "message": "Updating the SubnetIds parameter will cause these FSx for Lustre file system(s) to be replaced: {'custom-fsx-lustre'}. If you intend to proceed with the update, please make sure to back-up your data and explicitly replace the file system(s) ({'custom-fsx-lustre'}) with a new one(s) in the cluster configuration.",
      "currentValue": [
        "subnet-01b3415bfd0bbbee6"
      ]
    }
    ```

### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
