### PR TITLE
2.x: Improve wording when blocking the update in case of managed FSx usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        # To run Python 3.6 we can only use up to Ubuntu 20: https://github.com/actions/setup-python/issues/544
+        os: [ubuntu-20.04]
         name:
           - Python 3.6 Tests
           - Python 3.7 Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ CHANGELOG
 2.11.9
 -----
 
-**CHANGES**
-- Block cluster update when using a managed FSx for Lustre file system and updating VPC Security Group Id, to avoid data loss.
+**BUG FIXES**
+- Prevent updating `vpc_security_group_id` when a managed FSx for Lustre file system is configured in the cluster.
+  Doing so would result in file system deletion and potential data loss.
 
 2.11.8
 -----

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -273,11 +273,8 @@ def _check_unmanaged_fsx(_, patch):
 UpdatePolicy.MANAGED_FSX = UpdatePolicy(
     level=40,
     fail_reason=lambda change, patch: (
-        "'{0}' parameter cannot be updated because the cluster was created with a managed FSx. "
-        "The change in the '{0}' will trigger a creation of a new file system to replace the old one, "
-        "without preserving the existing data. If you force the update you'll lose your data. "
-        "Make sure to back up the data from the existing FSx for Lustre file system if you want to preserve them. "
-        "For more information, see https://docs.aws.amazon.com/fsx/latest/LustreGuide/using-backups-fsx.html"
+        "'{0}' parameter cannot be updated when a managed FSx for Lustre file system is configured. "
+        "Do not force the update or the file system will be deleted and the cluster enter an unrecoverable state."
     ).format(change.param_key),
     action_needed=lambda change, patch: (
         "Restore the value of parameter '{0}' to '{1}'".format(change.param_key, change.old_value)

--- a/cli/tests/pcluster/config/test_config_patch.py
+++ b/cli/tests/pcluster/config/test_config_patch.py
@@ -488,12 +488,9 @@ def test_vpc_security_id_changes(
         else:
             check = "ACTION NEEDED"
             reason = (
-                "'vpc_security_group_id' parameter cannot be updated because the cluster was created with a "
-                "managed FSx. The change in the 'vpc_security_group_id' will trigger a creation of a new file system "
-                "to replace the old one, without preserving the existing data. If you force the update you'll lose "
-                "your data. Make sure to back up the data from the existing FSx for Lustre file system "
-                "if you want to preserve them. For more information, see "
-                "https://docs.aws.amazon.com/fsx/latest/LustreGuide/using-backups-fsx.html"
+                "'vpc_security_group_id' parameter cannot be updated when a managed FSx for Lustre file "
+                "system is configured. Do not force the update or the file system will be deleted "
+                "and the cluster enter an unrecoverable state."
             )
             action_needed = (
                 f"Restore the value of parameter 'vpc_security_group_id' to '{src_value}'"

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -27,6 +27,12 @@ def substack_rendering(tmp_path, template_name, test_config):
 
     # Run cfn-lint
     cfn_lint_args = ["--info", str(rendered_file)]  # TODO "-i", "W2001" could be added to ignore unused vars
+
+    if "cw-dashboard-substack.cfn" in template_name:
+        # Ignore W8003 "Fn::Equals element will always return false"
+        # because this mechanism is used to enable/disable CW logging through a condition in the rendered template
+        cfn_lint_args.extend(["-i", "W8003"])
+
     with patch.object(sys, "argv", cfn_lint_args):
         assert cfnlint() == 0
 


### PR DESCRIPTION
Related to: https://github.com/aws/aws-parallelcluster/pull/4592
