### PR TITLE
Move test_efa with c6gn.16xlarge from IAD to DUB to mitigate ICE

### DIFF
--- a/awsbatch-cli/.flake8
+++ b/awsbatch-cli/.flake8
@@ -1,13 +1,21 @@
 [flake8]
 ignore =
-    D105, # Missing docstring in magic method
-    D100, # Missing docstring in public module
-    D104, # Missing docstring in public package
-    D107, # Missing docstring in __init__
-    D103, # Missing docstring in public function
-    W503, # line break before binary operator => Conflicts with black style.
-    D413, # Missing blank line after last section
-    F821, # undefined name
+    # D105: Missing docstring in magic method
+    D105,
+    # D100: Missing docstring in public module
+    D100,
+    # D104: Missing docstring in public package
+    D104,
+    # D107: Missing docstring in __init__
+    D107,
+    # D103: Missing docstring in public function
+    D103,
+    # W503: line break before binary operator => Conflicts with black style.
+    W503,
+    # D413: Missing blank line after last section
+    D413,
+    # F821: undefined name
+    F821
 # D101 Missing docstring in public class
 # D102 Missing docstring in public method
 per-file-ignores =

--- a/cli/.flake8
+++ b/cli/.flake8
@@ -1,14 +1,23 @@
 [flake8]
 ignore =
-    D105, # Missing docstring in magic method
-    D100, # Missing docstring in public module
-    D104, # Missing docstring in public package
-    D107, # Missing docstring in __init__
-    D103, # Missing docstring in public function
-    W503, # line break before binary operator => Conflicts with black style.
-    D413, # Missing blank line after last section
-    F821, # undefined name
-    N818, # exception name should be named with an Error suffix
+    # D105:  Missing docstring in magic method
+    D105,
+    # D100: Missing docstring in public module
+    D100,
+    # D104: Missing docstring in public package
+    D104,
+    # D107: Missing docstring in __init__
+    D107,
+    # D103: Missing docstring in public function
+    D103,
+    # W503: line break before binary operator => Conflicts with black style.
+    W503,
+    # D413: Missing blank line after last section
+    D413,
+    # F821: undefined name
+    F821,
+    # N818: exception name should be named with an Error suffix
+    N818
 # D101 Missing docstring in public class
 # D102 Missing docstring in public method
 # D202 No blank lines allowed after function docstring

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -261,7 +261,7 @@ efa:
         instances: ["p4d.24xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
-      - regions: ["us-east-1"]
+      - regions: ["eu-west-1"]
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -21,7 +21,7 @@ test-suites:
           instances: ["p4d.24xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]
-        - regions: ["us-east-1"]
+        - regions: ["eu-west-1"]
           instances: ["c6gn.16xlarge"]
           oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
           schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
* Move test_efa with c6gn.16xlarge from IAD to DUB to mitigate ICE

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
