### PR TITLE
Move test_efa with c6gn.16xlarge from IAD to DUB to mitigate ICE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        # To run Python 3.6 we can only use up to Ubuntu 20: https://github.com/actions/setup-python/issues/544
+        os: [ubuntu-20.04]
         name:
           - Python 3.6 Tests
           - Python 3.7 Tests

--- a/cli/src/pcluster/config/cfn_param_types.py
+++ b/cli/src/pcluster/config/cfn_param_types.py
@@ -88,6 +88,15 @@ class CfnParam(Param):
         """
         return str(self.value if self.value is not None else self.definition.get("default", "NONE"))
 
+    def refresh(self):
+        """
+        Refresh the parameter's value.
+
+        Does nothing by default. Subclasses can implement this method by updating parameter's value based on
+        PClusterConfig status.
+        """
+        pass
+
 
 class CommaSeparatedCfnParam(CfnParam):
     """Class to manage comma separated parameters. E.g. additional_iam_policies."""

--- a/cli/src/pcluster/config/json_param_types.py
+++ b/cli/src/pcluster/config/json_param_types.py
@@ -56,6 +56,15 @@ class JsonParam(Param):
         # No conversion is applied at base level
         return config_parser.get(section_name, self.key)
 
+    def refresh(self):
+        """
+        Refresh the parameter's value.
+
+        Does nothing by default. Subclasses can implement this method by updating parameter's value based on
+        PClusterConfig status.
+        """
+        pass
+
 
 class IntJsonParam(JsonParam):
     """Base JsonParam to manage int parameters."""
@@ -85,6 +94,15 @@ class BooleanJsonParam(JsonParam):
     def get_string_value(self):
         """Convert internal representation into string."""
         return self.get_default_value().lower() if self.value is None else str(bool(self.value)).lower()
+
+    def refresh(self):
+        """
+        Refresh the parameter's value.
+
+        Does nothing by default. Subclasses can implement this method by updating parameter's value based on
+        PClusterConfig status.
+        """
+        pass
 
 
 class FloatJsonParam(JsonParam):

--- a/cli/src/pcluster/config/param_types.py
+++ b/cli/src/pcluster/config/param_types.py
@@ -222,6 +222,7 @@ class Param(ABC):
         """Reset parameter to default value."""
         self.value = self.get_default_value()
 
+    @abc.abstractmethod
     def refresh(self):
         """
         Refresh the parameter's value.

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -78,7 +78,7 @@ def convert_to_date_mock(request, mocker):
         # executes convert_to_date but overrides arguments so that timezone is enforced to utc
         if "timezone" in kwargs:
             del kwargs["timezone"]
-        return convert_to_date(timezone=tz.tzutc(), *args, **kwargs)
+        return convert_to_date(timezone=tz.tzutc(), *args, **kwargs)  # noqa: B026
 
     return mocker.patch("awsbatch." + module_under_test + ".convert_to_date", wraps=_convert_to_date_utc)
 

--- a/cloudformation/tests/test_cfn_template_rendering.py
+++ b/cloudformation/tests/test_cfn_template_rendering.py
@@ -27,6 +27,12 @@ def substack_rendering(tmp_path, template_name, test_config):
 
     # Run cfn-lint
     cfn_lint_args = ["--info", str(rendered_file)]  # TODO "-i", "W2001" could be added to ignore unused vars
+
+    if "cw-dashboard-substack.cfn" in template_name:
+        # Ignore W8003 "Fn::Equals element will always return false"
+        # because this mechanism is used to enable/disable CW logging through a condition in the rendered template
+        cfn_lint_args.extend(["-i", "W8003"])
+
     with patch.object(sys, "argv", cfn_lint_args):
         assert cfnlint() == 0
 

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -213,7 +213,7 @@ efa:
         instances: ["c5n.9xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
-      - regions: ["us-east-1"]
+      - regions: ["eu-west-1"]
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
         schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
* Move test_efa with c6gn.16xlarge from IAD to DUB to mitigate ICE

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
