### PR TITLE
[Develop][Fsx] Improve MANAGED_FSX Policy messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ CHANGELOG
 - Increase memory size of ParallelCluster API Lambda to 2048 in order to reduce cold start penalty and avoid timeouts.
 
 **BUG FIXES**
-- Block updating ComputeFleet `SubnetIds` when a Cluster has managed Fsx for Lustre FileSystem. This prevents the Fsx FileSystem from being deleted due to the Replacement update behaviour by CloudFormation.
+- Block updating ComputeFleet SubnetIds when a Cluster has a managed FSx for Lustre FileSystem. This prevents the FSx FileSystem from being recreated in case of a cluster update.
 
 3.3.0
 -----

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -259,8 +259,8 @@ def fail_reason_managed_fsx(change, patch):
     managed_fsx_lustre_names = unchanged_managed_fsx_lustre_names(change, patch)
     if managed_fsx_lustre_names:
         reason = (
-            f"Updating the {change.key} parameter will cause these FSx for Lustre file system(s) to be replaced: "
-            f"{managed_fsx_lustre_names}"
+            f"{change.key} configuration cannot be updated when a managed FSx for Lustre file system is configured. "
+            "Forcing an update would trigger a deletion of the existing file system and result in potential data loss"
         )
     else:
         reason = fail_reason_queue_update_strategy(change, patch)
@@ -317,8 +317,8 @@ def actions_needed_managed_fsx(change, patch):
     fsx_lustre_names = unchanged_managed_fsx_lustre_names(change, patch)
     if fsx_lustre_names:
         return (
-            "If you intend to proceed with the update, please make sure to back-up your data and explicitly replace the"
-            f" file system(s) ({fsx_lustre_names}) with a new one(s) in the cluster configuration."
+            "If you intend to preserve the same file system or you want to create a new one please refer to the "
+            "shared storage section in ParallelCluster user guide."
         )
     else:
         return actions_needed_queue_update_strategy(change, patch)

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -1327,10 +1327,10 @@ def test_condition_checker_managed_placement_group(
                 is_list=False,
             ),
             False,
-            "Updating the SubnetIds parameter will cause these FSx for Lustre file system(s) to be replaced: "
-            "{'test-fsx-lustre'}",
-            "If you intend to proceed with the update, please make sure to back-up your data and explicitly replace "
-            "the file system(s) ({'test-fsx-lustre'}) with a new one(s) in the cluster configuration.",
+            "SubnetIds configuration cannot be updated when a managed FSx for Lustre file system is configured. "
+            "Forcing an update would trigger a deletion of the existing file system and result in potential data loss",
+            "If you intend to preserve the same file system or you want to create a new one please refer to the "
+            "shared storage section in ParallelCluster user guide.",
         ),
         # If update includes SubnetIds and existing cluster configuration uses an External Fsx for Lustre FS
         #   - Fall back to QueueUpdateStrategy Update Policy failure message
@@ -1460,10 +1460,10 @@ def test_condition_checker_managed_placement_group(
                 is_list=False,
             ),
             False,
-            "Updating the SubnetIds parameter will cause these FSx for Lustre file system(s) to be replaced: "
-            "{'test-fsx-lustre'}",
-            "If you intend to proceed with the update, please make sure to back-up your data and explicitly replace "
-            "the file system(s) ({'test-fsx-lustre'}) with a new one(s) in the cluster configuration.",
+            "SubnetIds configuration cannot be updated when a managed FSx for Lustre file system is configured. "
+            "Forcing an update would trigger a deletion of the existing file system and result in potential data loss",
+            "If you intend to preserve the same file system or you want to create a new one please refer to the "
+            "shared storage section in ParallelCluster user guide.",
         ),
     ],
 )


### PR DESCRIPTION
### Description of changes
* Improved messaging when updating a Subnet in a Cluster with managed Fsx for Lustre filesystem

> SubnetIds configuration cannot be updated when a managed FSx for Lustre file system is configured. Forcing an update would trigger a deletion of the existing file system and result in potential data loss. If you intend to preserve the same file system or you want to create a new one please refer to the shared storage section in ParallelCluster user guide.

### Tests
* Updated existing automated unit tests
* Manually tested with `pcluster update-cluster`

```
{
  "message": "Update failure",
  "updateValidationErrors": [
    {
      "parameter": "Scheduling.SlurmQueues[queue1].Networking.SubnetIds",
      "requestedValue": [
        "subnet-01b3415bfd0bbbee6"
      ],
      "message": "SubnetIds configuration cannot be updated when a managed FSx for Lustre file system is configured. Forcing an update would trigger a deletion of the existing file system and result in potential data loss. If you intend to preserve the same file system or you want to create a new one please refer to the shared storage section in ParallelCluster user guide.",
      "currentValue": [
        "subnet-0230367ab0e5123a4"
      ]
    }
  ],
  "changeSet": [
    {
      "parameter": "Scheduling.SlurmQueues[queue1].Networking.SubnetIds",
      "requestedValue": [
        "subnet-01b3415bfd0bbbee6"
      ],
      "currentValue": [
        "subnet-0230367ab0e5123a4"
      ]
    }
  ]
}
```

### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
