### PR TITLE
[3.x] Fix test_on_demand_capacity_reservation

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2611,13 +2611,6 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
         checked_images = []
         for queue in self.scheduling.queues:
             queue_image = self.image_dict[queue.name]
-            self._register_validator(
-                ComputeResourceLaunchTemplateValidator,
-                queue=queue,
-                ami_id=queue_image,
-                os=self.image.os,
-                tags=self.get_cluster_tags(),
-            )
             ami_volume_size = AWSApi.instance().ec2.describe_image(queue_image).volume_size
             root_volume = queue.compute_settings.local_storage.root_volume
             root_volume_size = root_volume.size
@@ -2641,6 +2634,14 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                 checked_images.append(queue_image)
                 self._register_validator(AmiOsCompatibleValidator, os=self.image.os, image_id=queue_image)
             for compute_resource in queue.compute_resources:
+                self._register_validator(
+                    ComputeResourceLaunchTemplateValidator,
+                    queue=queue,
+                    compute_resource=compute_resource,
+                    ami_id=queue_image,
+                    os=self.image.os,
+                    tags=self.get_cluster_tags(),
+                )
                 for instance_type in compute_resource.instance_types:
                     self._register_validator(
                         InstanceTypeBaseAMICompatibleValidator,

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1330,14 +1330,14 @@ def odcr_stack(request, region, placement_group_stack, cfn_stacks_factory, vpc_s
         AvailabilityZone=availability_zone,
         InstanceCount=4,
         InstancePlatform="Linux/UNIX",
-        InstanceType="c6gn.xlarge",
+        InstanceType="c5.xlarge",
     )
     target_odcr = ec2.CapacityReservation(
         "integTestsTargetOdcr",
         AvailabilityZone=availability_zone,
         InstanceCount=4,
         InstancePlatform="Linux/UNIX",
-        InstanceType="c7g.xlarge",
+        InstanceType="r5.xlarge",
         InstanceMatchCriteria="targeted",
     )
     pg_name = placement_group_stack.cfn_resources["PlacementGroup"]
@@ -1346,7 +1346,7 @@ def odcr_stack(request, region, placement_group_stack, cfn_stacks_factory, vpc_s
         AvailabilityZone=availability_zone,
         InstanceCount=2,
         InstancePlatform="Linux/UNIX",
-        InstanceType="m6g.xlarge",
+        InstanceType="m5.xlarge",
         InstanceMatchCriteria="targeted",
         PlacementGroupArn=boto3.resource("ec2").PlacementGroup(pg_name).group_arn,
     )

--- a/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: c7g.xlarge
+  InstanceType: r5.xlarge
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:
@@ -12,19 +12,19 @@ Scheduling:
     - Name: open-odcr-q
       ComputeResources:
         - Name: open-odcr-id-cr
-          InstanceType: c6gn.xlarge
+          InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
             CapacityReservationId: {{ open_capacity_reservation_id }}
         - Name: open-odcr-arn-cr
-          InstanceType: c6gn.xlarge
+          InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: {{ open_capacity_reservation_arn }}
         - Name: open-odcr-id-pg-cr
-          InstanceType: c6gn.xlarge
+          InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 10
           Networking:
@@ -33,7 +33,7 @@ Scheduling:
           CapacityReservationTarget:
             CapacityReservationId: {{ open_capacity_reservation_id }}
         - Name: open-odcr-arn-pg-cr
-          InstanceType: c6gn.xlarge
+          InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 10
           Networking:
@@ -47,19 +47,19 @@ Scheduling:
     - Name: target-odcr-q
       ComputeResources:
         - Name: target-odcr-id-cr
-          InstanceType: c7g.xlarge
+          InstanceType: r5.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
             CapacityReservationId: {{ target_capacity_reservation_id }}
         - Name: target-odcr-arn-cr
-          InstanceType: c7g.xlarge
+          InstanceType: r5.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: {{ target_capacity_reservation_arn }}
         - Name: target-odcr-id-pg-cr
-          InstanceType: c7g.xlarge
+          InstanceType: r5.xlarge
           MinCount: 1
           MaxCount: 10
           Networking:
@@ -68,7 +68,7 @@ Scheduling:
           CapacityReservationTarget:
             CapacityReservationId: {{ target_capacity_reservation_id }}
         - Name: target-odcr-arn-pg-cr
-          InstanceType: c7g.xlarge
+          InstanceType: r5.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
@@ -79,7 +79,7 @@ Scheduling:
     - Name: pg-odcr-q
       ComputeResources:
         - Name: pg-odcr-id-cr
-          InstanceType: m6g.xlarge
+          InstanceType: m5.xlarge
           MinCount: 1
           MaxCount: 10
           Networking:
@@ -88,7 +88,7 @@ Scheduling:
           CapacityReservationTarget:
             CapacityReservationId: {{ pg_capacity_reservation_id }}
         - Name: pg-odcr-arn-cr
-          InstanceType: m6g.xlarge
+          InstanceType: m5.xlarge
           MinCount: 1
           MaxCount: 10
           Networking:


### PR DESCRIPTION
There are two kinds of failure of this test:
1. The fixtures to create capacity reservations fail because of insufficient capacity. Solution: Change the instance types to more common ones. Note that burstable instance types do not support placement groups. Therefore, I have to use c5, r5, m5 instances.
2. The test started to fail constantly after https://github.com/aws/aws-parallelcluster/pull/4484. Because the PR added CapacityReservationSpecification in the CLI ec2 run_instances dryrun validator. The PR itself is correct, but uncovered an issue about placement group. With ODCR support, we started supporting placement groups on both queue and compute resource level. But the dryrun still used placement group only on queue level. As a result, the dryrun validation would fail if the capacity reservation in CapacityReservationSpecification required a placement group and the placement group was specified on compute resource level. Solution: Use the right placement group in the dry run. To achieve this, the dry run validation needs to be in an inner loop

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
The following tests have been passed:
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  cfn-init:
    test_cfn_init.py::test_replace_compute_on_failure:
      dimensions:
        - regions: ["af-south-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  cli_commands:
    test_cli_commands.py::test_slurm_cli_commands:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  create:
    test_create.py::test_create_imds_secured:
      dimensions:
        - regions: [ "us-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2" ]
          schedulers: [ "slurm" ]
  dns:
    test_dns.py::test_hit_no_cluster_dns_mpi:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  dashboard:
    test_dashboard.py::test_dashboard:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
  cloudwatch_logging:
    test_cloudwatch_logging.py::test_cloudwatch_logging:
      dimensions:
        - regions: ["ap-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
  iam:
    test_iam.py::test_iam_policies:
      dimensions:
        - regions: ["eu-north-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  schedulers:
    test_awsbatch.py::test_awsbatch:
      dimensions:
        - regions: ["ap-southeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
    test_slurm.py::test_slurm:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_pmix:
      dimensions:
        - regions: ["ap-northeast-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
  storage:
    test_efs.py::test_multiple_efs:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["awsbatch"]
          benchmarks:
            - mpi_variants: ["openmpi", "intelmpi"]
              num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
              slots_per_instance: 2
              osu_benchmarks:
                collective: ["osu_allreduce", "osu_alltoall"]
    test_ebs.py::test_ebs_single:
      dimensions:
        - regions: ["eu-west-3"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu1804"]
          schedulers: ["slurm"]
  dcv:
    test_dcv.py::test_dcv_configuration:
      dimensions:
        - regions: ["sa-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  update:
    test_update.py::test_update_awsbatch:
      dimensions:
        - regions: ["eu-south-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
    test_update.py::test_update_slurm:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
  networking:
    test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
      dimensions:
        - regions: [ "us-west-2" ]
          oss: [ "alinux2" ]
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
