### PR TITLE
Cherry pick headnode bootstrap error to feature branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 - Add new configuration parameter in `Iam/ResourcePrefix` to specify a prefix for path and name of IAM resources created by ParallelCluster
 - Add new configuration section `DeploySettings/LambdaFunctionsVpcConfig` for specifying the Vpc config used by ParallelCluster Lambda Functions.
 - Add possibility to specify a custom script to be executed in the head node during the update of the cluster. The script can be specified with `OnNodeUpdated` parameter when using Slurm as scheduler.
+- Add `failureReason` to `describe-cluster` output when cluster creation fails with headnode wait condition.
 
 **CHANGES**
 - Remove creation of EFS mount targets for existing FS.

--- a/cli/src/pcluster/models/cluster_resources.py
+++ b/cli/src/pcluster/models/cluster_resources.py
@@ -9,13 +9,14 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import datetime
+import itertools
 import re
 from typing import List
 
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.aws_resources import InstanceInfo, StackInfo
 from pcluster.constants import CW_LOGS_CFN_PARAM_NAME, OS_MAPPING, PCLUSTER_NODE_TYPE_TAG, PCLUSTER_VERSION_TAG
-from pcluster.models.common import FiltersParserError, LogGroupTimeFiltersParser
+from pcluster.models.common import FiltersParserError, LogGroupTimeFiltersParser, get_all_stack_events
 
 
 class ClusterStack(StackInfo):
@@ -73,6 +74,21 @@ class ClusterStack(StackInfo):
     def batch_compute_environment(self):
         """Return Batch compute environment."""
         return self._get_output("BatchComputeEnvironmentArn")
+
+    def get_failure_reason(self):
+        """Reason of the failure when the cluster_status is in CREATE_FAILED."""
+
+        def _is_failed_wait(event):
+            if (
+                event.get("ResourceType") == "AWS::CloudFormation::WaitCondition"
+                and event.get("ResourceStatus") == "CREATE_FAILED"
+            ):
+                return True
+            return False
+
+        stack_events = list(itertools.chain.from_iterable(get_all_stack_events(self.name)))
+        failure_event = next(filter(_is_failed_wait, stack_events), None)
+        return failure_event.get("ResourceStatusReason") if failure_event else None
 
 
 class ClusterInstance(InstanceInfo):

--- a/cli/src/pcluster/models/common.py
+++ b/cli/src/pcluster/models/common.py
@@ -245,14 +245,20 @@ class CloudWatchLogsExporter:
             os.remove(compressed_path)
 
 
-def export_stack_events(stack_name: str, output_file: str):
-    """Save CFN stack events into a file."""
+def get_all_stack_events(stack_name: str):
+    """Retrieve all stack events."""
     stack_events = []
     chunk = AWSApi.instance().cfn.get_stack_events(stack_name)
     stack_events.append(chunk["StackEvents"])
     while chunk.get("nextToken"):
         chunk = AWSApi.instance().cfn.get_stack_events(stack_name, next_token=chunk["nextToken"])
         stack_events.append(chunk["StackEvents"])
+    return stack_events
+
+
+def export_stack_events(stack_name: str, output_file: str):
+    """Save CFN stack events into a file."""
+    stack_events = get_all_stack_events(stack_name)
 
     with open(output_file, "w", encoding="utf-8") as cfn_events_file:
         cfn_events_file.write(json.dumps(stack_events, cls=JSONEncoder, indent=2))

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -66,7 +66,7 @@ function error_exit
 {
   # wait logs flush before signaling the failure
   sleep 10
-  reason=$(cat /var/log/parallelcluster/chef_error_msg 2>/dev/null) || reason="$1"
+  reason=$(cat /var/log/parallelcluster/headnode_bootstrap_error_msg 2>/dev/null) || reason="$1"
   cfn-signal --exit-code=1 --reason="${!reason}" "${!wait_condition_handle_presigned_url}"
   exit 1
 }

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -66,7 +66,7 @@ function error_exit
 {
   # wait logs flush before signaling the failure
   sleep 10
-  reason=$(cat /var/log/parallelcluster/headnode_bootstrap_error_msg 2>/dev/null) || reason="$1"
+  reason=$(cat /var/log/parallelcluster/bootstrap_error_msg 2>/dev/null) || reason="$1"
   cfn-signal --exit-code=1 --reason="${!reason}" "${!wait_condition_handle_presigned_url}"
   exit 1
 }

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -66,7 +66,10 @@ function error_exit
 {
   # wait logs flush before signaling the failure
   sleep 10
-  reason=$(cat /var/log/parallelcluster/bootstrap_error_msg 2>/dev/null) || reason="$1"
+  # trim the error message because there is a size limit of 4096 bytes for cfn-signal
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
+  cutoff=$(expr 4096 - $(stat --printf="%s" /tmp/wait_condition_handle.txt))
+  reason=$(head --bytes=${!cutoff} /var/log/parallelcluster/bootstrap_error_msg 2>/dev/null) || reason="$1"
   cfn-signal --exit-code=1 --reason="${!reason}" "${!wait_condition_handle_presigned_url}"
   exit 1
 }


### PR DESCRIPTION
### Description of changes
* Cherry pick  a0da04fba - surface head node bootstrap errors - trim error message before passing to cfn-signal (6 days ago) <delongmeng>
* c4bd7c457 - rename the bootstrap error file (7 days ago) <delongmeng>
* 7be702034 - rename error message file for both chef and custom scripts (#4540) (2 weeks ago) <delongmeng>
* b5809572f - Add failure reason to describe-cluster output when cluster creation fail (#4554) (7 days ago) <chenwany> 

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
