### PR TITLE
Adds MultiAzEBSVolumeValidator

### DIFF
--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -474,6 +474,7 @@ class Ec2Client(Boto3Client):
         )
 
     @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
     def describe_volume(self, volume_id):
         """Describe a volume."""
         return self._client.describe_volumes(VolumeIds=[volume_id]).get("Volumes")[0]

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -124,6 +124,12 @@ class _DummyEc2Client(Ec2Client):
         }
         self.security_groups_cache = {}
 
+    @property
+    def _client(self):
+        # Required to mock calls like
+        # AWSApi.instance().ec2._client.describe_volumes()
+        return self
+
     def get_official_image_id(self, os, architecture, filters=None):
         return "dummy-ami-id"
 
@@ -136,6 +142,38 @@ class _DummyEc2Client(Ec2Client):
                 "VpcId": "vpc-123",
             },
         ]
+
+    def describe_volumes(self, volume_ids):
+        return {
+            "Volumes": [
+                {
+                    "Attachments": [
+                        {
+                            "Device": "dev-01",
+                            "InstanceId": "instance-01",
+                            "State": "attached",
+                            "VolumeId": "vol-01",
+                            "DeleteOnTermination": True,
+                        },
+                    ],
+                    "AvailabilityZone": "az-1",
+                    "Encrypted": False,
+                    "KmsKeyId": "kms-key",
+                    "Size": 123,
+                    "SnapshotId": "snapshot-123",
+                    "State": "available",
+                    "VolumeId": "vol-123",
+                    "Iops": 123,
+                    "Tags": [
+                        {"Key": "string", "Value": "string"},
+                    ],
+                    "VolumeType": "gp3",
+                    "MultiAttachEnabled": False,
+                    "Throughput": 123,
+                },
+            ],
+            "NextToken": "next",
+        }
 
     def get_subnet_vpc(self, subnet_id):
         return "vpc-123"

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -124,12 +124,6 @@ class _DummyEc2Client(Ec2Client):
         }
         self.security_groups_cache = {}
 
-    @property
-    def _client(self):
-        # Required to mock calls like
-        # AWSApi.instance().ec2._client.describe_volumes()
-        return self
-
     def get_official_image_id(self, os, architecture, filters=None):
         return "dummy-ami-id"
 
@@ -143,36 +137,31 @@ class _DummyEc2Client(Ec2Client):
             },
         ]
 
-    def describe_volumes(self, volume_ids):
+    def describe_volume(self, volume_id):
         return {
-            "Volumes": [
+            "Attachments": [
                 {
-                    "Attachments": [
-                        {
-                            "Device": "dev-01",
-                            "InstanceId": "instance-01",
-                            "State": "attached",
-                            "VolumeId": "vol-01",
-                            "DeleteOnTermination": True,
-                        },
-                    ],
-                    "AvailabilityZone": "az-1",
-                    "Encrypted": False,
-                    "KmsKeyId": "kms-key",
-                    "Size": 123,
-                    "SnapshotId": "snapshot-123",
-                    "State": "available",
-                    "VolumeId": "vol-123",
-                    "Iops": 123,
-                    "Tags": [
-                        {"Key": "string", "Value": "string"},
-                    ],
-                    "VolumeType": "gp3",
-                    "MultiAttachEnabled": False,
-                    "Throughput": 123,
+                    "Device": "dev-01",
+                    "InstanceId": "instance-01",
+                    "State": "attached",
+                    "VolumeId": "vol-01",
+                    "DeleteOnTermination": True,
                 },
             ],
-            "NextToken": "next",
+            "AvailabilityZone": "az-1",
+            "Encrypted": False,
+            "KmsKeyId": "kms-key",
+            "Size": 123,
+            "SnapshotId": "snapshot-123",
+            "State": "available",
+            "VolumeId": "vol-123",
+            "Iops": 123,
+            "Tags": [
+                {"Key": "string", "Value": "string"},
+            ],
+            "VolumeType": "gp3",
+            "MultiAttachEnabled": False,
+            "Throughput": 123,
         }
 
     def get_subnet_vpc(self, subnet_id):

--- a/cli/tests/pcluster/aws/test_ec2.py
+++ b/cli/tests/pcluster/aws/test_ec2.py
@@ -601,23 +601,21 @@ def test_describe_security_groups_cache(boto3_stubber):
     assert_that(AWSApi.instance().ec2.describe_security_groups([security_group])[0]["IpPermissions"]).is_not_empty()
 
 
-def get_describe_volumes_mocked_request(volume_ids, az):
+def get_describe_volumes_mocked_request(volume_id, az):
     return MockedBoto3Request(
         method="describe_volumes",
-        response={"Volumes": [{"VolumeId": volume_id, "AvailabilityZone": az} for volume_id in volume_ids]},
-        expected_params={"VolumeIds": volume_ids},
+        response={"Volumes": [{"VolumeId": volume_id, "AvailabilityZone": az}]},
+        expected_params={"VolumeIds": [volume_id]},
     )
 
 
-def test_describe_volumes(boto3_stubber):
-    volume_ids = ["vol-1", "vol-2"]
+def test_describe_volume(boto3_stubber):
+    volume_id = "vol-1"
     az = "az-1"
     mocked_requests = [
-        get_describe_volumes_mocked_request(volume_ids, az),
+        get_describe_volumes_mocked_request(volume_id, az),
     ]
     boto3_stubber("ec2", mocked_requests)
-    response = AWSApi.instance().ec2.describe_volumes(volume_ids)
+    response = AWSApi.instance().ec2.describe_volume(volume_id)
 
-    assert_that(response).is_length(2)
-    assert_that(response[0]["AvailabilityZone"] == az).is_true()
-    assert_that(response[1]["AvailabilityZone"] == az).is_true()
+    assert_that(response["AvailabilityZone"] == az).is_true()


### PR DESCRIPTION
### Description of changes
* Adds MultiAzEBSVolumeValidator that 
  * fails the cluster creation if the EBS Volume is created in an AZ different from the HeadNode
  * informs customers of risks of increased latency and costs if a queue has resources in an AZ different from the EBS volume

* Adds some property to SharedEBS

### Tests
* Unit test

### References
None

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
