### PR TITLE
Add DescribeStacks permission to Slurm HeadNode instance profile

### DIFF
--- a/tests/iam_policies/cluster-roles.cfn.yaml
+++ b/tests/iam_policies/cluster-roles.cfn.yaml
@@ -120,6 +120,7 @@ Resources:
               - Action:
                   - cloudformation:DescribeStackResource
                   - cloudformation:SignalResource
+                  - cloudformation:DescribeStacks
                 Effect: Allow
                 Resource: '*'
               - Action:


### PR DESCRIPTION
### Description of changes
Add DescribeStacks permission to Slurm HeadNode instance profile.


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
