### PR TITLE
[integ-tests] Check that update is rolled back if post update script fails

### DIFF
--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/failed_postupdate.sh
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/failed_postupdate.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+echo "starting failed_postupdate script"
+exit 1

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -20,7 +20,7 @@ HeadNode:
       - Policy: {{ additional_policy_arn }}
   CustomActions:
     OnNodeUpdated:
-      Script: s3://{{ resource_bucket }}/scripts/updated_postupdate.sh
+      Script: s3://{{ resource_bucket }}/scripts/{{ postupdate_script }}
       Args:
         - UPDATE-ARG2
 Scheduling:


### PR DESCRIPTION
### Description of changes
In the integration test, check that a cluster update is rolled back with the expected message when the post update script fails.

### Tests
Run integration tests with configuration:

```
{%- import 'common.jinja2' as common with context -%}
---

test-suites:
  update:
    test_update.py::test_update_slurm:
      dimensions:
        - regions: ["eu-central-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
