### PR TITLE
[MultiAZ] Validate Capacity Reservation Instance Type compatibility per Availability Zone

### DIFF
--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 import json
 import logging
+from collections import defaultdict
 from typing import Dict, List
 
 from pcluster import imagebuilder_utils
@@ -314,6 +315,14 @@ def capacity_reservation_resource_group_is_service_linked_group(capacity_reserva
         return False
 
 
+def get_capacity_reservations_per_az(capacity_reservations: List) -> Dict:
+    """Create a mapping of an AZ and its related Capacity Reservations."""
+    capacity_reservations_per_az = defaultdict(list)
+    for capacity_reservation in capacity_reservations:
+        capacity_reservations_per_az[capacity_reservation["AvailabilityZone"]].append(capacity_reservation)
+    return capacity_reservations_per_az
+
+
 class CapacityReservationResourceGroupValidator(Validator):
     """Validate capacity reservation group is can be used with existing instance types and subnets.
 
@@ -341,8 +350,11 @@ class CapacityReservationResourceGroupValidator(Validator):
                 )
             else:
                 capacity_reservations = get_capacity_reservations(capacity_reservation_resource_group_arn)
-                self._validate_with_instance_types(
-                    instance_types, capacity_reservations, capacity_reservation_resource_group_arn
+                self._validate_unreserved_instance_types_for_azs(
+                    capacity_reservations,
+                    capacity_reservation_resource_group_arn,
+                    {subnet_id_az_mapping[subnet_id] for subnet_id in subnet_ids},
+                    instance_types,
                 )
                 self._validate_with_subnets(
                     queue_name,
@@ -352,21 +364,45 @@ class CapacityReservationResourceGroupValidator(Validator):
                     subnet_id_az_mapping,
                 )
 
-    def _validate_with_instance_types(
-        self, instance_types, capacity_reservations, capacity_reservation_resource_group_arn
+    def _validate_unreserved_instance_types_for_azs(
+        self, capacity_reservations, capacity_reservation_resource_group_arn, availability_zones, instance_types
     ):
+        capacity_reservations_per_az = get_capacity_reservations_per_az(capacity_reservations)
+        unreserved_instance_types_per_az = defaultdict(list)
         for instance_type in instance_types:
-            found_qualified_capacity_reservation = False
-            for capacity_reservation in capacity_reservations:
-                if capacity_reservation_matches_instance(capacity_reservation, instance_type):
-                    found_qualified_capacity_reservation = True
-                    break
-            if not found_qualified_capacity_reservation:
+            found_reservation_for_instance_type_in_group = False
+            for availability_zone in availability_zones:
+                found_reservation_for_instance_type_in_az = False
+                for capacity_reservation in capacity_reservations_per_az.get(availability_zone, []):
+                    if capacity_reservation_matches_instance(capacity_reservation, instance_type):
+                        found_reservation_for_instance_type_in_az = found_reservation_for_instance_type_in_group = True
+                        break
+                if not found_reservation_for_instance_type_in_az:
+                    unreserved_instance_types_per_az[availability_zone].append(instance_type)
+            if not found_reservation_for_instance_type_in_group:
                 self._add_failure(
                     f"Capacity reservation resource group {capacity_reservation_resource_group_arn} must have "
                     f"at least one capacity reservation for {instance_type}.",
                     FailureLevel.ERROR,
                 )
+
+        if unreserved_instance_types_per_az:
+            self._add_failure(
+                "The Capacity Reservation Resource Group ({crrg_arn}) has reservations for these "
+                "InstanceTypes and Availability Zones: {cr_instance_az}. Please consider that the cluster can "
+                "launch instances in these Availability Zones that have no reserved capacity for the given "
+                "instance types: {unreserved_instance_types}.".format(
+                    crrg_arn=capacity_reservation_resource_group_arn,
+                    cr_instance_az=", ".join(
+                        ["(%s: %s)" % (cr["InstanceType"], cr["AvailabilityZone"]) for cr in capacity_reservations]
+                    ),
+                    unreserved_instance_types=", ".join(
+                        "{%s: %s}" % (az, instance_types)
+                        for az, instance_types in sorted(unreserved_instance_types_per_az.items())
+                    ),
+                ),
+                FailureLevel.WARNING,
+            )
 
     def _validate_with_subnets(
         self, queue_name, cr_group_arn, capacity_reservations, subnet_ids, subnet_id_az_mapping: Dict[str, str]


### PR DESCRIPTION
### Description of changes
- Capacity Reservations are made based on the Instance Type and Availability Zone
- With Multi-AZ, there may be scenarios where an Instance Type is reserved in one AZ but not the other
- These changes ensure that a WARNING message is logged on cluster creation/update to inform the user about the potential availability zones for which no capacity reservation exists for certain instance types.

### Tests
* Automated unit test scenario included
* Manually tested by
    * Using a configuration with a Capacity Reservation Resource Group (with reservation in `eu-west-1b` )
    * Subnets in `eu-west-1a` and `eu-west-1b`
    * Instances/InstanceType: [t2.micro]

```
  SlurmQueues:
  - Name: queue1
    ComputeResources:
    - Name: compute-resource-1
      Instances:
        - InstanceType: t2.micro
      MinCount: 2
      MaxCount: 10
    Networking:
      SubnetIds:
      - subnet-0230367ab0e5123a4  # eu-west-1a
      - subnet-0b903123096649662  # eu-west-1b
    CapacityReservationTarget:
      CapacityReservationResourceGroupArn: arn:aws:resource-groups:eu-west-1:162389774010:group/CRGroupViaCLI # eu-west-1b
```

Cluster creation works with a warning log:

```
{
  "cluster": {
    "clusterName": "CRGroupCluster",
    "cloudformationStackStatus": "CREATE_IN_PROGRESS",
    "cloudformationStackArn": "...",
    "region": "eu-west-1",
    "version": "...",
    "clusterStatus": "CREATE_IN_PROGRESS",
    "scheduler": {
      "type": "slurm"
    }
  },
  "validationMessages": [
    {
      "level": "WARNING",
      "type": "CapacityReservationResourceGroupValidator",
      "message": "The Capacity Reservation Resource Group (arn:aws:resource-groups:...) has reservations for these InstanceTypes and Availability Zones: (t2.micro: eu-west-1b). Please consider that the cluster can launch instances in these Availability Zones that have no reserved capacity for the given instance types: {'eu-west-1a': ['t2.micro']}."
    },
```

### References
* #4551 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
