### PR TITLE
2.x: Temporary commit to use p4d ODCR in the head node launch template

### DIFF
--- a/cloudformation/master-server-substack.cfn.yaml
+++ b/cloudformation/master-server-substack.cfn.yaml
@@ -283,6 +283,9 @@ Resources:
             - DisableMasterHyperthreadingViaCpuOptions
             - 1
             - !Ref 'AWS::NoValue'
+        CapacityReservationSpecification:
+          CapacityReservationTarget:
+            CapacityReservationId: cr-0fa65fcdbd597f551
         BlockDeviceMappings:
           - DeviceName: /dev/xvdba
             VirtualName: ephemeral0


### PR DESCRIPTION
I'm pushing this commit into wip/release-2.11-p4d-tests to save this change and use as part of the release process.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.