### PR TITLE
Adds MultiAzRootNodeValidator and aggregates multiple notifications for MultiAzEbsVolumeValidator

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -121,6 +121,7 @@ from pcluster.validators.ebs_validators import (
     EbsVolumeThroughputValidator,
     EbsVolumeTypeSizeValidator,
     MultiAzEbsVolumeValidator,
+    MultiAzRootVolumeValidator,
     SharedEbsVolumeIdValidator,
 )
 from pcluster.validators.ec2_validators import (
@@ -1421,6 +1422,8 @@ class BaseClusterConfig(Resource):
             compute_subnet_ids=compute_subnet_ids,
             new_storage_count=new_storage_count,
         )
+        ebs_volumes = []
+        head_node_az = self.head_node.networking.availability_zone
         for storage in self.shared_storage:
             if isinstance(storage, (SharedFsxLustre, ExistingFsxOpenZfs, ExistingFsxOntap)) and storage.is_unmanaged:
                 self._register_validator(
@@ -1428,19 +1431,25 @@ class BaseClusterConfig(Resource):
                     queues=queues,
                     fsx_az_list=storage.file_system_availability_zones,
                 )
-            if isinstance(storage, (RootVolume, SharedEbs)):
-                head_node_az = self.head_node.networking.availability_zone
+            if isinstance(storage, SharedEbs):
                 ebs_az = head_node_az
                 # if the EBS volume is managed we set the AZ == to the HeadNode AZ otherwise we ask EC2 about
                 # the AZ where the existing volume is created
-                if isinstance(storage, SharedEbs) and not storage.is_managed:
+                if not storage.is_managed:
                     ebs_az = storage.availability_zone
-                self._register_validator(
-                    MultiAzEbsVolumeValidator,
-                    ebs_az=ebs_az,
-                    head_node_az=head_node_az,
-                    queues=queues,
-                )
+                ebs_volumes.append({"name": storage.name, "az": ebs_az})
+
+        self._register_validator(
+            MultiAzEbsVolumeValidator,
+            head_node_az=head_node_az,
+            ebs_volumes=ebs_volumes,
+            queues=queues,
+        )
+        self._register_validator(
+            MultiAzRootVolumeValidator,
+            head_node_az=head_node_az,
+            queues=queues,
+        )
 
     def _validate_max_storage_count(self, ebs_count, existing_storage_count, new_storage_count):
         for storage_type in ["EFS", "FSx", "RAID"]:

--- a/cli/src/pcluster/validators/ebs_validators.py
+++ b/cli/src/pcluster/validators/ebs_validators.py
@@ -193,24 +193,57 @@ class MultiAzEbsVolumeValidator(Validator):
 
     Validate that the EBS volume, HeanNode and ComputeFleet are in the same AZ.
     If they aren't inform the customers about possible increases of latency or costs.
+    If the volume is in a different az w.r.t the HeadNode raises an error.
     """
 
-    def _validate(self, ebs_az: str, head_node_az: str, queues):
-        if ebs_az != head_node_az:
+    def _validate(self, head_node_az: str, ebs_volumes, queues):
+        cross_az_queues = set()
+        for volume in ebs_volumes:
+            if volume["az"] != head_node_az:
+                self._add_failure(
+                    "Your configuration includes an EBS volume '{0}' created in a different availability zone than "
+                    "the Head Node. The volume and instance must be in the same availability "
+                    "zone.".format(volume["name"]),
+                    FailureLevel.ERROR,
+                )
+
+            for queue in queues:
+                queue_az_set = set(queue.networking.az_list)
+                if len(queue_az_set) > 1 or (set([volume["az"]]) != queue_az_set):
+                    cross_az_queues.add(queue.name)
+
+        if cross_az_queues:
             self._add_failure(
-                "Your configuration includes an EBS volume created in a different availability zone than the "
-                "Head Node. The volume and instance must be in the same Availability Zone.",
-                FailureLevel.ERROR,
+                "Your configuration for Queues '{0}' includes compute resources in an availability zone different from "
+                "where one external shared storage resides. Accessing a shared storage from different AZs can lead to "
+                "increased latency and costs.".format(", ".join(sorted(cross_az_queues))),
+                FailureLevel.INFO,
             )
+
+
+class MultiAzRootVolumeValidator(Validator):
+    """
+    Root Volume Validator.
+
+    Validates that the root volume associated to the HeanNode and ComputeFleet are in the same AZ.
+    If they aren't inform the customers about possible increases of latency or costs.
+    """
+
+    def _validate(self, head_node_az: str, queues):
+        cross_az_queues = set()
+
         for queue in queues:
             queue_az_set = set(queue.networking.az_list)
-            if len(queue_az_set) > 1 or (set(ebs_az) != queue_az_set):
-                self._add_failure(
-                    "Your configuration for Queue '{0}' includes multiple subnets and external shared storage "
-                    "configuration. Accessing a shared storage from different AZs can lead to increased "
-                    "latency and costs.".format(queue.name),
-                    FailureLevel.INFO,
-                )
+            if len(queue_az_set) > 1 or (set([head_node_az]) != queue_az_set):
+                cross_az_queues.add(queue.name)
+
+        if cross_az_queues:
+            self._add_failure(
+                "Your configuration for Queues '{0}' includes compute resources in an availability zone different "
+                "from the HeadNode. Accessing a shared storage from different AZs can lead to increased latency "
+                "and costs.".format(", ".join(sorted(cross_az_queues))),
+                FailureLevel.INFO,
+            )
 
 
 class SharedEbsVolumeIdValidator(Validator):


### PR DESCRIPTION
### Description of changes
* MultiAzEbsVolumeValidator now avoids emitting multiple Info messages about increased latency and costs for each queue/volume combination 
* Added a MultiAzRootVolumeValidator that informs of possible increased increase in latency and costs if a queue has resources in a AZ different from the HeadNode (where the RootVolume is created)
 
### Tests
* Unit tests

### References
None

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
