### PR TITLE
[Integ-tests] Fix test_on_demand_capacity_reservation

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1329,14 +1329,14 @@ def odcr_stack(request, region, placement_group_stack, cfn_stacks_factory, vpc_s
         AvailabilityZone=availability_zone,
         InstanceCount=4,
         InstancePlatform="Linux/UNIX",
-        InstanceType="c6gn.xlarge",
+        InstanceType="c5.xlarge",
     )
     target_odcr = ec2.CapacityReservation(
         "integTestsTargetOdcr",
         AvailabilityZone=availability_zone,
         InstanceCount=4,
         InstancePlatform="Linux/UNIX",
-        InstanceType="c7g.xlarge",
+        InstanceType="r5.xlarge",
         InstanceMatchCriteria="targeted",
     )
     pg_name = placement_group_stack.cfn_resources["PlacementGroup"]
@@ -1345,7 +1345,7 @@ def odcr_stack(request, region, placement_group_stack, cfn_stacks_factory, vpc_s
         AvailabilityZone=availability_zone,
         InstanceCount=2,
         InstancePlatform="Linux/UNIX",
-        InstanceType="m6g.xlarge",
+        InstanceType="m5.xlarge",
         InstanceMatchCriteria="targeted",
         PlacementGroupArn=boto3.resource("ec2").PlacementGroup(pg_name).group_arn,
     )

--- a/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
@@ -1,7 +1,7 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: c7g.xlarge
+  InstanceType: r5.xlarge
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:
@@ -12,19 +12,19 @@ Scheduling:
     - Name: open-odcr-q
       ComputeResources:
         - Name: open-odcr-id-cr
-          InstanceType: c6gn.xlarge
+          InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
             CapacityReservationId: {{ open_capacity_reservation_id }}
         - Name: open-odcr-arn-cr
-          InstanceType: c6gn.xlarge
+          InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: {{ open_capacity_reservation_arn }}
         - Name: open-odcr-id-pg-cr
-          InstanceType: c6gn.xlarge
+          InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 10
           Networking:
@@ -33,7 +33,7 @@ Scheduling:
           CapacityReservationTarget:
             CapacityReservationId: {{ open_capacity_reservation_id }}
         - Name: open-odcr-arn-pg-cr
-          InstanceType: c6gn.xlarge
+          InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 10
           Networking:
@@ -47,19 +47,19 @@ Scheduling:
     - Name: target-odcr-q
       ComputeResources:
         - Name: target-odcr-id-cr
-          InstanceType: c7g.xlarge
+          InstanceType: r5.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
             CapacityReservationId: {{ target_capacity_reservation_id }}
         - Name: target-odcr-arn-cr
-          InstanceType: c7g.xlarge
+          InstanceType: r5.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: {{ target_capacity_reservation_arn }}
         - Name: target-odcr-id-pg-cr
-          InstanceType: c7g.xlarge
+          InstanceType: r5.xlarge
           MinCount: 1
           MaxCount: 10
           Networking:
@@ -68,7 +68,7 @@ Scheduling:
           CapacityReservationTarget:
             CapacityReservationId: {{ target_capacity_reservation_id }}
         - Name: target-odcr-arn-pg-cr
-          InstanceType: c7g.xlarge
+          InstanceType: r5.xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
@@ -79,7 +79,7 @@ Scheduling:
     - Name: pg-odcr-q
       ComputeResources:
         - Name: pg-odcr-id-cr
-          InstanceType: m6g.xlarge
+          InstanceType: m5.xlarge
           MinCount: 1
           MaxCount: 10
           Networking:
@@ -88,7 +88,7 @@ Scheduling:
           CapacityReservationTarget:
             CapacityReservationId: {{ pg_capacity_reservation_id }}
         - Name: pg-odcr-arn-cr
-          InstanceType: m6g.xlarge
+          InstanceType: m5.xlarge
           MinCount: 1
           MaxCount: 10
           Networking:


### PR DESCRIPTION
The fixtures to create capacity reservations failed because of insufficient capacity. Solution: Change the instance types to more common ones. Note that burstable instance types do not support placement groups. Therefore, I have to use c5, r5, m5 instances.

Signed-off-by: Hanwen <hanwenli@amazon.com>

### References
This PR cherry-picks integration tests changes in https://github.com/aws/aws-parallelcluster/pull/4621

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
