### PR TITLE
3.x: Allow cluster creation with no suitable official AMI

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -42,6 +42,7 @@ from aws_cdk.core import (
 )
 
 from pcluster.aws.aws_api import AWSApi
+from pcluster.aws.common import AWSClientError
 from pcluster.config.cluster_config import (
     AwsBatchClusterConfig,
     BaseSharedFsx,
@@ -210,7 +211,14 @@ class ClusterCdkStack(Stack):
             default=self.bucket.artifact_directory,
         )
         CfnParameter(self, "Scheduler", default=self.config.scheduling.scheduler)
-        CfnParameter(self, "OfficialAmi", default=self.config.official_ami)
+
+        try:
+            CfnParameter(self, "OfficialAmi", default=self.config.official_ami)
+        except AWSClientError:
+            # This might happen if there is no official AMI
+            # and custom AMIs are defined for the head node and compute nodes
+            pass
+
         CfnParameter(
             self,
             "ConfigVersion",


### PR DESCRIPTION
### Description of changes
If there is no suitable official AMI, it must still be possible to create a cluster if a custom AMI is configured.
This behavior was broken by a previous PR: https://github.com/aws/aws-parallelcluster/pull/4606 .
Current PR restores the correct behavior for this corner case.

### Tests
* A cluster created and updated when there was no official AMI, configuring a custom AMI
* A cluster based on an official AMI created and updated

### References
* https://github.com/aws/aws-parallelcluster/pull/4606


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
