### PR TITLE
Add policies to cluster nodes to allow mounting EFS with EFS utils

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -118,8 +118,12 @@ def get_directory_service_dna_json_for_head_node(config: BaseClusterConfig) -> d
     )
 
 
-def to_comma_separated_string(list):
-    return ",".join(str(item) for item in list)
+def to_comma_separated_string(list, use_lower_case=False):
+    result = ",".join(str(item) for item in list)
+    if use_lower_case:
+        return result.lower()
+    else:
+        return result
 
 
 def get_shared_storage_ids_by_type(shared_storage_infos: dict, storage_type: SharedStorageType):
@@ -318,15 +322,21 @@ class NodeIamResourcesBase(Construct):
     """Abstract construct defining IAM resources for a cluster node."""
 
     def __init__(
-        self, scope: Construct, id: str, config: BaseClusterConfig, node: Union[HeadNode, BaseQueue], name: str
+        self,
+        scope: Construct,
+        id: str,
+        config: BaseClusterConfig,
+        node: Union[HeadNode, BaseQueue],
+        shared_storage_infos: dict,
+        name: str,
     ):
         super().__init__(scope, id)
         self._config = config
         self.instance_role = None
 
-        self._add_role_and_policies(node, name)
+        self._add_role_and_policies(node, shared_storage_infos, name)
 
-    def _add_role_and_policies(self, node: Union[HeadNode, BaseQueue], name: str):
+    def _add_role_and_policies(self, node: Union[HeadNode, BaseQueue], shared_storage_infos: dict, name: str):
         """Create role and policies for the given node/queue."""
         suffix = create_hash_suffix(name)
         if node.instance_profile:
@@ -339,7 +349,9 @@ class NodeIamResourcesBase(Construct):
             self.instance_role = self._add_node_role(node, f"Role{suffix}")
 
             # ParallelCluster Policies
-            self._add_pcluster_policies_to_role(self.instance_role.ref, f"ParallelClusterPolicies{suffix}")
+            self._add_pcluster_policies_to_role(
+                self.instance_role.ref, shared_storage_infos, f"ParallelClusterPolicies{suffix}"
+            )
 
             # Custom Cookbook S3 url policy
             if self._condition_custom_cookbook_with_s3_url():
@@ -380,17 +392,45 @@ class NodeIamResourcesBase(Construct):
             role_name=role_name,
         )
 
-    def _add_pcluster_policies_to_role(self, role_ref: str, name: str):
+    def _add_pcluster_policies_to_role(self, role_ref: str, shared_storage_infos: dict, name: str):
         _, policy_name = add_cluster_iam_resource_prefix(
             self._config.cluster_name, self._config, "parallelcluster", iam_type="AWS::IAM::Policy"
         )
+        common_policies = []
+        if self._config.scheduling.scheduler != "awsbatch":
+            efs_with_iam_authorization_arns = self._get_efs_with_iam_authorization_arns(shared_storage_infos)
+            if efs_with_iam_authorization_arns:
+                common_policies.append(
+                    iam.PolicyStatement(
+                        sid="Efs",
+                        actions=[
+                            "elasticfilesystem:ClientMount",
+                            "elasticfilesystem:ClientRootAccess",
+                            "elasticfilesystem:ClientWrite",
+                        ],
+                        effect=iam.Effect.ALLOW,
+                        resources=efs_with_iam_authorization_arns,
+                    ),
+                )
         iam.CfnPolicy(
             Stack.of(self),
             name,
             policy_name=policy_name or "parallelcluster",
-            policy_document=iam.PolicyDocument(statements=self._build_policy()),
+            policy_document=iam.PolicyDocument(statements=self._build_policy() + common_policies),
             roles=[role_ref],
         )
+
+    def _get_efs_with_iam_authorization_arns(self, shared_storage_infos):
+        return [
+            self._format_arn(
+                service="elasticfilesystem",
+                resource=f"file-system/{efs_id}",
+                region=Stack.of(self).region,
+                account=Stack.of(self).account,
+            )
+            for efs_id, efs_storage in shared_storage_infos[SharedStorageType.EFS]
+            if efs_storage.iam_authorization
+        ]
 
     def _condition_custom_cookbook_with_s3_url(self):
         try:
@@ -494,11 +534,12 @@ class HeadNodeIamResources(NodeIamResourcesBase):
         id: str,
         config: BaseClusterConfig,
         node: Union[HeadNode, BaseQueue],
+        shared_storage_infos: dict,
         name: str,
         cluster_bucket: S3Bucket,
     ):
         self._cluster_bucket = cluster_bucket
-        super().__init__(scope, id, config, node, name)
+        super().__init__(scope, id, config, node, shared_storage_infos, name)
 
     def _build_policy(self) -> List[iam.PolicyStatement]:
         policy = [
@@ -757,9 +798,15 @@ class ComputeNodeIamResources(NodeIamResourcesBase):
     """Construct defining IAM resources for a compute node."""
 
     def __init__(
-        self, scope: Construct, id: str, config: BaseClusterConfig, node: Union[HeadNode, BaseQueue], name: str
+        self,
+        scope: Construct,
+        id: str,
+        config: BaseClusterConfig,
+        node: Union[HeadNode, BaseQueue],
+        shared_storage_infos: dict,
+        name: str,
     ):
-        super().__init__(scope, id, config, node, name)
+        super().__init__(scope, id, config, node, shared_storage_infos, name)
 
     def _build_policy(self) -> List[iam.PolicyStatement]:
         return [

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -233,13 +233,17 @@ class ClusterCdkStack(Stack):
         if self.config.is_cw_logging_enabled:
             self.log_group = self._add_cluster_log_group()
 
-        self._add_iam_resources()
-
         # Managed security groups
         self._head_security_group, self._compute_security_group = self._add_security_groups()
 
         # Head Node ENI
         self._head_eni = self._add_head_eni()
+
+        if self.config.shared_storage:
+            for storage in self.config.shared_storage:
+                self._add_shared_storage(storage)
+
+        self._add_iam_resources()
 
         # Additional Cfn Stack
         if self.config.additional_resources:
@@ -247,10 +251,6 @@ class ClusterCdkStack(Stack):
 
         # Cleanup Resources Lambda Function
         cleanup_lambda_role, cleanup_lambda = self._add_cleanup_resources_lambda()
-
-        if self.config.shared_storage:
-            for storage in self.config.shared_storage:
-                self._add_shared_storage(storage)
 
         self._add_fleet_and_scheduler_resources(cleanup_lambda, cleanup_lambda_role)
 
@@ -293,7 +293,13 @@ class ClusterCdkStack(Stack):
 
     def _add_iam_resources(self):
         head_node_iam_resources = HeadNodeIamResources(
-            self, "HeadNodeIamResources", self.config, self.config.head_node, "HeadNode", self.bucket
+            self,
+            "HeadNodeIamResources",
+            self.config,
+            self.config.head_node,
+            self.shared_storage_infos,
+            "HeadNode",
+            self.bucket,
         )
         self._head_node_instance_profile = head_node_iam_resources.instance_profile
         self._managed_head_node_instance_role = head_node_iam_resources.instance_role
@@ -302,7 +308,12 @@ class ClusterCdkStack(Stack):
             iam_resources = {}
             for queue in self.config.scheduling.queues:
                 iam_resources[queue.name] = ComputeNodeIamResources(
-                    self, f"ComputeNodeIamResources{queue.name}", self.config, queue, queue.name
+                    self,
+                    f"ComputeNodeIamResources{queue.name}",
+                    self.config,
+                    queue,
+                    self.shared_storage_infos,
+                    queue.name,
                 )
 
             self._compute_instance_profiles = {k: v.instance_profile for k, v in iam_resources.items()}
@@ -969,10 +980,11 @@ class ClusterCdkStack(Stack):
                     "efs_fs_ids": get_shared_storage_ids_by_type(self.shared_storage_infos, SharedStorageType.EFS),
                     "efs_shared_dirs": to_comma_separated_string(self.shared_storage_mount_dirs[SharedStorageType.EFS]),
                     "efs_encryption_in_transits": to_comma_separated_string(
-                        self.shared_storage_attributes[SharedStorageType.EFS]["EncryptionInTransits"]
+                        self.shared_storage_attributes[SharedStorageType.EFS]["EncryptionInTransits"],
+                        use_lower_case=True,
                     ),
                     "efs_iam_authorizations": to_comma_separated_string(
-                        self.shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"]
+                        self.shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"], use_lower_case=True
                     ),
                     "fsx_fs_ids": get_shared_storage_ids_by_type(self.shared_storage_infos, SharedStorageType.FSX),
                     "fsx_mount_names": to_comma_separated_string(
@@ -1548,10 +1560,12 @@ class ComputeFleetConstruct(Construct):
                                     self._shared_storage_mount_dirs[SharedStorageType.EFS]
                                 ),
                                 "EFSEncryptionInTransits": to_comma_separated_string(
-                                    self._shared_storage_attributes[SharedStorageType.EFS]["EncryptionInTransits"]
+                                    self._shared_storage_attributes[SharedStorageType.EFS]["EncryptionInTransits"],
+                                    use_lower_case=True,
                                 ),
                                 "EFSIamAuthorizations": to_comma_separated_string(
-                                    self._shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"]
+                                    self._shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"],
+                                    use_lower_case=True,
                                 ),
                                 "FSXIds": get_shared_storage_ids_by_type(
                                     self._shared_storage_infos, SharedStorageType.FSX


### PR DESCRIPTION
1. If IamAuthorization is used when mounting EFS, the clients of the mount (EC2 instances) need to have additional policies:
```
{
            "Action": [
                "elasticfilesystem:ClientWrite",
                "elasticfilesystem:ClientMount",
                "elasticfilesystem:DescribeMountTargets",
            ],
            "Resource": <EFS file system ARN>,
            "Effect": "Allow",
            "Sid": "Efs"
        },
```
Therefore, we add the policies whenever an EFS file system uses IamAuthorization. This EFS file system can be either managed or unmanaged. I manually tested both cases. We don't add the policies by default to keep cluster policies minimal
2. Because these policies apply to both head and compute nodes, they are added in the parent class NodeIamResourcesBase, instead of the subclass HeadNodeIamResources or ComputeNodeIamResources
3. Because now the policy resource depends on shared EFS resource, the logic of creating shared storage is moved ahead of Iam resource
4. This commit also fixes a bug. Before the fix, the information of EFS were passed to cookbook dna.json as "True,False...". After the change, we pass the value to cookbook using lower case "true, false..."

## Test
Manually created a cluster with the following cluster configuration file:
```
Region: us-east-1
Image:
  Os: alinux2
  CustomAmi: ami-xxx
HeadNode:
  InstanceType: m6g.xlarge
  Networking:
    SubnetId: subnet-xxx
  Ssh:
    KeyName: jan2022
Scheduling:
  Scheduler: slurm
  SlurmQueues:
  - Name: queue1
    ComputeResources:
    - Name: m6gxlarge
      InstanceType: m6g.xlarge
      MinCount: 1
      MaxCount: 13
    Networking:
      SubnetIds:
      - subnet-xxx
SharedStorage:
  - MountDir: efs1
    Name: efs1
    StorageType: Efs
    EfsSettings:
      FileSystemId: fs-xxx # With file system policy
      EncryptionInTransit: true
      IamAuthorization: true
  - MountDir: efs2
    Name: efs2
    StorageType: Efs
    EfsSettings:
      FileSystemId: fs-xxx # Without file system policy
      EncryptionInTransit: true
      IamAuthorization: true
  - MountDir: efs3
    Name: efs3
    StorageType: Efs
    EfsSettings:
      EncryptionInTransit: true
      IamAuthorization: true

```

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
