### PR TITLE
2.x: Split p4d EFA and multi-NICs tests in separate files 

### DIFF
--- a/tests/integration-tests/configs/p4d-efa.yaml
+++ b/tests/integration-tests/configs/p4d-efa.yaml
@@ -1,0 +1,13 @@
+{%- import 'common.jinja2' as common -%}
+{%- set regions = ["us-east-1"] -%}
+{%- set instances = ["p4d.24xlarge"] -%}
+
+---
+test-suites:
+  efa:
+    test_efa.py::test_hit_efa:
+      dimensions:
+        - regions: {{ regions }}
+          instances: {{ instances }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]

--- a/tests/integration-tests/configs/p4d-multinics.yaml
+++ b/tests/integration-tests/configs/p4d-multinics.yaml
@@ -4,13 +4,6 @@
 
 ---
 test-suites:
-  efa:
-    test_efa.py::test_hit_efa:
-      dimensions:
-        - regions: {{ regions }}
-          instances: {{ instances }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
-          schedulers: ["slurm"]
   multiple_nics:
     test_multiple_nics.py::test_multiple_nics:
       dimensions:


### PR DESCRIPTION
### Description of changes
EFA tests don't need p4d in the head node and they can be executed with the current code.

Instead, to run multi-NICs test it is required to force usage of ODCR for the head node
by adding `CapacityReservationSpecification` in the launch template.

By splitting the tests is easier to execute them separately.

### References
* Related to https://github.com/enrico-usai/aws-parallelcluster/commit/3dd6da3bcd3603c02b56e6fb74bedf5e8e0ea05a

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
