### PR TITLE
[develop] Show errors in validators when volume id does not exist

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1432,12 +1432,7 @@ class BaseClusterConfig(Resource):
                     fsx_az_list=storage.file_system_availability_zones,
                 )
             if isinstance(storage, SharedEbs):
-                ebs_az = head_node_az
-                # if the EBS volume is managed we set the AZ == to the HeadNode AZ otherwise we ask EC2 about
-                # the AZ where the existing volume is created
-                if not storage.is_managed:
-                    ebs_az = storage.availability_zone
-                ebs_volumes.append({"name": storage.name, "az": ebs_az})
+                ebs_volumes.append(storage)
 
         self._register_validator(
             MultiAzEbsVolumeValidator,

--- a/cli/src/pcluster/validators/ebs_validators.py
+++ b/cli/src/pcluster/validators/ebs_validators.py
@@ -199,18 +199,27 @@ class MultiAzEbsVolumeValidator(Validator):
     def _validate(self, head_node_az: str, ebs_volumes, queues):
         cross_az_queues = set()
         for volume in ebs_volumes:
-            if volume["az"] != head_node_az:
-                self._add_failure(
-                    "Your configuration includes an EBS volume '{0}' created in a different availability zone than "
-                    "the Head Node. The volume and instance must be in the same availability "
-                    "zone.".format(volume["name"]),
-                    FailureLevel.ERROR,
-                )
+            try:
+                # if the EBS volume is managed we set the AZ == to the HeadNode AZ otherwise we ask EC2 about
+                # the AZ where the existing volume is created
+                ebs_az = head_node_az if volume.is_managed else volume.availability_zone
+                if ebs_az != head_node_az:
+                    self._add_failure(
+                        "Your configuration includes an EBS volume '{0}' created in a different availability zone than "
+                        "the Head Node. The volume and instance must be in the same availability "
+                        "zone.".format(volume.name),
+                        FailureLevel.ERROR,
+                    )
 
-            for queue in queues:
-                queue_az_set = set(queue.networking.az_list)
-                if len(queue_az_set) > 1 or (set([volume["az"]]) != queue_az_set):
-                    cross_az_queues.add(queue.name)
+                for queue in queues:
+                    queue_az_set = set(queue.networking.az_list)
+                    if len(queue_az_set) > 1 or ({ebs_az} != queue_az_set):
+                        cross_az_queues.add(queue.name)
+            except AWSClientError as e:
+                if str(e).endswith("parameter volumes is invalid. Expected: 'vol-...'."):
+                    self._add_failure(f"Volume '{volume.volume_id}' does not exist.", FailureLevel.ERROR)
+                else:
+                    self._add_failure(str(e), FailureLevel.ERROR)
 
         if cross_az_queues:
             self._add_failure(
@@ -273,6 +282,6 @@ class SharedEbsVolumeIdValidator(Validator):
                     )
             except AWSClientError as e:
                 if str(e).endswith("parameter volumes is invalid. Expected: 'vol-...'."):
-                    self._add_failure(f"Volume {volume_id} does not exist.", FailureLevel.ERROR)
+                    self._add_failure(f"Volume '{volume_id}' does not exist.", FailureLevel.ERROR)
                 else:
                     self._add_failure(str(e), FailureLevel.ERROR)

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1178,7 +1178,7 @@ def _test_shared_storage_rollback(
         str(problematic_cluster_config),
         force_update="true",
         raise_on_error=False,
-        suppress_validators="type:SharedEbsVolumeIdValidator",
+        suppress_validators="ALL",
     )
     assert_that(response["clusterStatus"]).is_equal_to("UPDATE_FAILED")
     # Test rollback update recipe run finished


### PR DESCRIPTION
To show errors of volume id in validators, we move the describe_volumes boto3 call from cluster_config to validator MultiAzEbsVolumeValidator.

If a non-existing volume id is specified:
Prior to this change, pcluster will show the following error:
```
{
  "message": "Invalid cluster configuration: Value (vol-1237688f4dd67d123) for parameter volumes is invalid. Expected: 'vol-...'."
}
```
After this change, pcluster will show the following error:
```
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "SharedEbsVolumeIdValidator",
      "message": "Volume vol-1237688f4dd67d123 does not exist."
    },
    {
      "level": "ERROR",
      "type": "MultiAzEbsVolumeValidator",
      "message": "Volume vol-1237688f4dd67d123 does not exist."
    }
  ],
  "message": "Invalid cluster configuration."
}
```
I also tested that after suppressing SharedEbsVolumeIdValidator and MultiAzEbsVolumeValidator, `pcluster update-cluster` can go ahead.

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
