### PR TITLE
[3.x] Change parallelcluster inline policy of Headnode

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -768,10 +768,13 @@ class HeadNodeIamResources(NodeIamResourcesBase):
 
     def _generate_head_node_pass_role_resources(self):
         """Return a unique list of ARNs that the head node should be able to use when calling PassRole."""
+        resource_iam_path, _ = add_cluster_iam_resource_prefix(
+            self._config.cluster_name, self._config, "", iam_type="AWS::IAM::Role"
+        )
         default_pass_role_resource = self._format_arn(
             service="iam",
             region="",
-            resource=f"role{self._cluster_scoped_iam_path()}*",
+            resource=f"role{self._cluster_scoped_iam_path(iam_path=resource_iam_path)}*",
         )
 
         # If there are any queues where a custom instance role was specified,

--- a/cli/tests/pcluster/templates/test_cdk_builder_utils/test_iam_resource_prefix_build_in_cdk/resourcePrefix.both_path_n_role_prefix.yaml
+++ b/cli/tests/pcluster/templates/test_cdk_builder_utils/test_iam_resource_prefix_build_in_cdk/resourcePrefix.both_path_n_role_prefix.yaml
@@ -15,6 +15,8 @@ Scheduling:
       ComputeResources:
         - Name: compute_resource1
           InstanceType: t2.micro
+          MinCount: 1
+          MaxCount: 5
       Networking:
         SubnetIds:
           - subnet-12345678

--- a/cli/tests/pcluster/templates/test_cdk_builder_utils/test_iam_resource_prefix_build_in_cdk/resourcePrefix.both_path_n_role_prefix_with_s3.yaml
+++ b/cli/tests/pcluster/templates/test_cdk_builder_utils/test_iam_resource_prefix_build_in_cdk/resourcePrefix.both_path_n_role_prefix_with_s3.yaml
@@ -19,6 +19,8 @@ Scheduling:
       ComputeResources:
         - Name: compute_resource1
           InstanceType: t2.micro
+          MinCount: 1
+          MaxCount: 5
       Networking:
         SubnetIds:
           - subnet-12345678

--- a/cli/tests/pcluster/templates/test_cdk_builder_utils/test_iam_resource_prefix_build_in_cdk/resourcePrefix.no_prefix.yaml
+++ b/cli/tests/pcluster/templates/test_cdk_builder_utils/test_iam_resource_prefix_build_in_cdk/resourcePrefix.no_prefix.yaml
@@ -17,6 +17,8 @@ Scheduling:
       ComputeResources:
         - Name: compute_resource1
           InstanceType: t2.micro
+          MinCount: 1
+          MaxCount: 5
       Networking:
         SubnetIds:
           - subnet-12345678

--- a/cli/tests/pcluster/templates/test_cdk_builder_utils/test_iam_resource_prefix_build_in_cdk/resourcePrefix.only_path_prefix.yaml
+++ b/cli/tests/pcluster/templates/test_cdk_builder_utils/test_iam_resource_prefix_build_in_cdk/resourcePrefix.only_path_prefix.yaml
@@ -15,6 +15,8 @@ Scheduling:
       ComputeResources:
         - Name: compute_resource1
           InstanceType: t2.micro
+          MinCount: 1
+          MaxCount: 5
       Networking:
         SubnetIds:
           - subnet-12345678

--- a/cli/tests/pcluster/templates/test_cdk_builder_utils/test_iam_resource_prefix_build_in_cdk/resourcePrefix.only_role_prefix.yaml
+++ b/cli/tests/pcluster/templates/test_cdk_builder_utils/test_iam_resource_prefix_build_in_cdk/resourcePrefix.only_role_prefix.yaml
@@ -15,6 +15,8 @@ Scheduling:
       ComputeResources:
         - Name: compute_resource1
           InstanceType: t2.micro
+          MinCount: 1
+          MaxCount: 5
       Networking:
         SubnetIds:
           - subnet-12345678


### PR DESCRIPTION
### Description of changes
Added Resource prefix to the PassRole SID of parallelcluster Inline policy attached to HeadNode role. 
Unit Test case change for checking the Resource path for PassRole SID.

### Tests
* Ran Manual Tests with respect to Resource Prefix
* Amended unit test cases to check the default and new behaviour



### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
