### PR TITLE
2.x: Add aws-parallelcluster-maintainers to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @aws/aws-parallelcluster-admins
+*       @aws/aws-parallelcluster-admins @aws/aws-parallelcluster-maintainers


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
