### PR TITLE
Replace inheritance from Stack with composition in ClusterCdkStack

### DIFF
--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -594,6 +594,7 @@ class AwsBatchConstruct(Construct):
 
             manage_docker_images_lambda_execution_role = add_lambda_cfn_role(
                 scope=self.stack_scope,
+                config=self.config,
                 function_id="ManageDockerImages",
                 statements=[
                     iam.PolicyStatement(
@@ -670,6 +671,7 @@ class AwsBatchConstruct(Construct):
         if self.create_lambda_roles:
             build_notification_lambda_execution_role = add_lambda_cfn_role(
                 scope=self.stack_scope,
+                config=self.config,
                 function_id="BuildNotification",
                 statements=[
                     get_cloud_watch_logs_policy_statement(

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -273,13 +273,13 @@ def add_cluster_iam_resource_prefix(stack_name, config, name: str, iam_type: str
     return full_resource_path, full_resource_name
 
 
-def add_lambda_cfn_role(scope, function_id: str, statements: List[iam.PolicyStatement], has_vpc_config: bool):
+def add_lambda_cfn_role(scope, config, function_id: str, statements: List[iam.PolicyStatement], has_vpc_config: bool):
     """Return a CfnRole to be used for a Lambda function."""
     role_path, role_name = add_cluster_iam_resource_prefix(
-        scope.config.cluster_name, scope.config, name=f"{function_id}Role", iam_type="AWS::IAM::Role"
+        config.cluster_name, config, name=f"{function_id}Role", iam_type="AWS::IAM::Role"
     )
     _, policy_name = add_cluster_iam_resource_prefix(
-        scope.config.cluster_name, scope.config, "LambdaPolicy", iam_type="AWS::IAM::Policy"
+        config.cluster_name, config, "LambdaPolicy", iam_type="AWS::IAM::Policy"
     )
 
     role_id = f"{function_id}Role" if role_name else f"{function_id}FunctionExecutionRole"

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -104,7 +104,7 @@ from pcluster.utils import get_attr, get_http_tokens_setting, join_shell_args
 StorageInfo = namedtuple("StorageInfo", ["id", "config"])
 
 
-class ClusterCdkStack(Stack):
+class ClusterCdkStack:
     """Create the CloudFormation stack template for the Cluster."""
 
     def __init__(
@@ -117,7 +117,7 @@ class ClusterCdkStack(Stack):
         log_group_name=None,
         **kwargs,
     ) -> None:
-        super().__init__(scope, construct_id, **kwargs)
+        self.stack = Stack(scope=scope, id=construct_id, **kwargs)
         self._stack_name = stack_name
         self._launch_template_builder = CdkLaunchTemplateBuilder()
         self.config = cluster_config
@@ -131,7 +131,7 @@ class ClusterCdkStack(Stack):
             else:
                 # pcluster create create a log group with timestamp suffix
                 timestamp = f"{datetime.utcnow().strftime('%Y%m%d%H%M')}"
-                self.log_group_name = f"{CW_LOG_GROUP_NAME_PREFIX}{self.stack_name}-{timestamp}"
+                self.log_group_name = f"{CW_LOG_GROUP_NAME_PREFIX}{self.stack.stack_name}-{timestamp}"
 
         self.shared_storage_infos = {storage_type: [] for storage_type in SharedStorageType}
         self.shared_storage_mount_dirs = {storage_type: [] for storage_type in SharedStorageType}
@@ -149,10 +149,10 @@ class ClusterCdkStack(Stack):
     # -- Utility methods --------------------------------------------------------------------------------------------- #
 
     def _stack_unique_id(self):
-        return Fn.select(2, Fn.split("/", self.stack_id))
+        return Fn.select(2, Fn.split("/", self.stack.stack_id))
 
     def _build_resource_path(self):
-        return self.stack_id
+        return self.stack.stack_id
 
     def _get_head_node_security_groups(self):
         """Return the security groups to be used for the head node, created by us OR provided by the user."""
@@ -193,41 +193,41 @@ class ClusterCdkStack(Stack):
 
     def _add_parameters(self):
         CfnParameter(
-            self,
+            self.stack,
             "ClusterUser",
             description="Username to login to head node",
             default=OS_MAPPING[self.config.image.os]["user"],
         )
         CfnParameter(
-            self,
+            self.stack,
             "ResourcesS3Bucket",
             description="S3 user bucket where AWS ParallelCluster resources are stored",
             default=self.bucket.name,
         )
         CfnParameter(
-            self,
+            self.stack,
             "ArtifactS3RootDirectory",
             description="Root directory in S3 bucket where cluster artifacts are stored",
             default=self.bucket.artifact_directory,
         )
-        CfnParameter(self, "Scheduler", default=self.config.scheduling.scheduler)
+        CfnParameter(self.stack, "Scheduler", default=self.config.scheduling.scheduler)
 
         try:
-            CfnParameter(self, "OfficialAmi", default=self.config.official_ami)
+            CfnParameter(self.stack, "OfficialAmi", default=self.config.official_ami)
         except AWSClientError:
             # This might happen if there is no official AMI
             # and custom AMIs are defined for the head node and compute nodes
             pass
 
         CfnParameter(
-            self,
+            self.stack,
             "ConfigVersion",
             description="Version of the original config used to generate the stack",
             default=self.config.original_config_version,
         )
         if self.config.is_cw_logging_enabled:
             CfnParameter(
-                self,
+                self.stack,
                 CW_LOGS_CFN_PARAM_NAME,
                 description="CloudWatch Log Group associated to the cluster",
                 default=self.log_group_name,
@@ -255,7 +255,7 @@ class ClusterCdkStack(Stack):
 
         # Additional Cfn Stack
         if self.config.additional_resources:
-            CfnStack(self, "AdditionalCfnStack", template_url=self.config.additional_resources)
+            CfnStack(self.stack, "AdditionalCfnStack", template_url=self.config.additional_resources)
 
         # Cleanup Resources Lambda Function
         cleanup_lambda_role, cleanup_lambda = self._add_cleanup_resources_lambda()
@@ -274,7 +274,7 @@ class ClusterCdkStack(Stack):
         # AWS Batch related resources
         if self._condition_is_batch():
             self.scheduler_resources = AwsBatchConstruct(
-                scope=self,
+                scope=self.stack,
                 id="AwsBatch",
                 stack_name=self._stack_name,
                 cluster_config=self.config,
@@ -290,9 +290,9 @@ class ClusterCdkStack(Stack):
         # CloudWatch Dashboard
         if self.config.is_cw_dashboard_enabled:
             self.cloudwatch_dashboard = CWDashboardConstruct(
-                scope=self,
+                scope=self.stack,
                 id="PclusterDashboard",
-                stack_name=self.stack_name,
+                stack_name=self.stack.stack_name,
                 cluster_config=self.config,
                 head_node_instance=self.head_node_instance,
                 shared_storage_infos=self.shared_storage_infos,
@@ -301,7 +301,7 @@ class ClusterCdkStack(Stack):
 
     def _add_iam_resources(self):
         head_node_iam_resources = HeadNodeIamResources(
-            self,
+            self.stack,
             "HeadNodeIamResources",
             self.config,
             self.config.head_node,
@@ -316,7 +316,7 @@ class ClusterCdkStack(Stack):
             iam_resources = {}
             for queue in self.config.scheduling.queues:
                 iam_resources[queue.name] = ComputeNodeIamResources(
-                    self,
+                    self.stack,
                     f"ComputeNodeIamResources{queue.name}",
                     self.config,
                     queue,
@@ -329,7 +329,7 @@ class ClusterCdkStack(Stack):
 
     def _add_cluster_log_group(self):
         log_group = logs.CfnLogGroup(
-            self,
+            self.stack,
             "CloudWatchLogGroup",
             log_group_name=self.log_group_name,
             retention_in_days=get_cloud_watch_logs_retention_days(self.config),
@@ -342,7 +342,7 @@ class ClusterCdkStack(Stack):
         self.scheduler_resources = None
         if self._condition_is_slurm():
             self.scheduler_resources = SlurmConstruct(
-                scope=self,
+                scope=self.stack,
                 id="Slurm",
                 stack_name=self._stack_name,
                 cluster_config=self.config,
@@ -354,9 +354,9 @@ class ClusterCdkStack(Stack):
             )
         if not self._condition_is_batch():
             _dynamodb_table_status = dynamomdb.CfnTable(
-                self,
+                self.stack,
                 "DynamoDBTable",
-                table_name=PCLUSTER_DYNAMODB_PREFIX + self.stack_name,
+                table_name=PCLUSTER_DYNAMODB_PREFIX + self.stack.stack_name,
                 attribute_definitions=[
                     dynamomdb.CfnTable.AttributeDefinitionProperty(attribute_name="Id", attribute_type="S"),
                 ],
@@ -369,7 +369,7 @@ class ClusterCdkStack(Stack):
         self.compute_fleet_resources = None
         if not self._condition_is_batch():
             self.compute_fleet_resources = ComputeFleetConstruct(
-                scope=self,
+                scope=self.stack,
                 id="ComputeFleet",
                 cluster_config=self.config,
                 log_group=self.log_group,
@@ -393,15 +393,16 @@ class ClusterCdkStack(Stack):
             s3_policy_actions = ["s3:DeleteObject", "s3:DeleteObjectVersion", "s3:ListBucket", "s3:ListBucketVersions"]
 
             cleanup_resources_lambda_role = add_lambda_cfn_role(
-                scope=self,
+                scope=self.stack,
+                config=self.config,
                 function_id="CleanupResources",
                 statements=[
                     iam.PolicyStatement(
                         actions=s3_policy_actions,
                         effect=iam.Effect.ALLOW,
                         resources=[
-                            self.format_arn(service="s3", resource=self.bucket.name, region="", account=""),
-                            self.format_arn(
+                            self.stack.format_arn(service="s3", resource=self.bucket.name, region="", account=""),
+                            self.stack.format_arn(
                                 service="s3",
                                 resource=f"{self.bucket.name}/{self.bucket.artifact_directory}/*",
                                 region="",
@@ -411,10 +412,10 @@ class ClusterCdkStack(Stack):
                         sid="S3BucketPolicy",
                     ),
                     get_cloud_watch_logs_policy_statement(
-                        resource=self.format_arn(
+                        resource=self.stack.format_arn(
                             service="logs",
-                            account=self.account,
-                            region=self.region,
+                            account=self.stack.account,
+                            region=self.stack.region,
                             resource=get_lambda_log_group_prefix("CleanupResources-*"),
                         )
                     ),
@@ -423,7 +424,7 @@ class ClusterCdkStack(Stack):
             )
 
         cleanup_resources_lambda = PclusterLambdaConstruct(
-            scope=self,
+            scope=self.stack,
             id="CleanupResourcesFunctionConstruct",
             function_id="CleanupResources",
             bucket=self.bucket,
@@ -435,7 +436,7 @@ class ClusterCdkStack(Stack):
         ).lambda_func
 
         CustomResource(
-            self,
+            self.stack,
             "CleanupResourcesS3BucketCustomResource",
             service_token=cleanup_resources_lambda.attr_arn,
             properties={
@@ -452,7 +453,7 @@ class ClusterCdkStack(Stack):
         head_eni_group_set = self._get_head_node_security_groups_full()
 
         head_eni = ec2.CfnNetworkInterface(
-            self,
+            self.stack,
             "HeadNodeENI",
             description="AWS ParallelCluster head node interface",
             subnet_id=self.config.head_node.networking.subnet_id,
@@ -464,11 +465,13 @@ class ClusterCdkStack(Stack):
         if elastic_ip:
             # Create and associate EIP to Head Node
             if elastic_ip is True:
-                allocation_id = ec2.CfnEIP(self, "HeadNodeEIP", domain="vpc").attr_allocation_id
+                allocation_id = ec2.CfnEIP(self.stack, "HeadNodeEIP", domain="vpc").attr_allocation_id
             # Attach existing EIP
             else:
                 allocation_id = AWSApi.instance().ec2.get_eip_allocation_id(elastic_ip)
-            ec2.CfnEIPAssociation(self, "AssociateEIP", allocation_id=allocation_id, network_interface_id=head_eni.ref)
+            ec2.CfnEIPAssociation(
+                self.stack, "AssociateEIP", allocation_id=allocation_id, network_interface_id=head_eni.ref
+            )
 
         return head_eni
 
@@ -538,7 +541,7 @@ class ClusterCdkStack(Stack):
 
     def _allow_all_ingress(self, description, source_security_group_id, group_id):
         return ec2.CfnSecurityGroupIngress(
-            self,
+            self.stack,
             description,
             ip_protocol="-1",
             from_port=0,
@@ -549,7 +552,7 @@ class ClusterCdkStack(Stack):
 
     def _allow_all_egress(self, description, destination_security_group_id, group_id):
         return ec2.CfnSecurityGroupEgress(
-            self,
+            self.stack,
             description,
             ip_protocol="-1",
             from_port=0,
@@ -561,7 +564,7 @@ class ClusterCdkStack(Stack):
     def _add_storage_security_group(self, storage_cfn_id, storage):
         storage_type = storage.shared_storage_type
         storage_security_group = ec2.CfnSecurityGroup(
-            self,
+            self.stack,
             "{0}SecurityGroup".format(storage_cfn_id),
             group_description=f"Allow access to {storage_type} file system {storage_cfn_id}",
             vpc_id=self.config.vpc_id,
@@ -603,13 +606,16 @@ class ClusterCdkStack(Stack):
 
     def _add_compute_security_group(self):
         compute_security_group = ec2.CfnSecurityGroup(
-            self, "ComputeSecurityGroup", group_description="Allow access to compute nodes", vpc_id=self.config.vpc_id
+            self.stack,
+            "ComputeSecurityGroup",
+            group_description="Allow access to compute nodes",
+            vpc_id=self.config.vpc_id,
         )
 
         # ComputeSecurityGroupEgress
         # Access to other compute nodes from compute nodes
         compute_security_group_egress = ec2.CfnSecurityGroupEgress(
-            self,
+            self.stack,
             "ComputeSecurityGroupEgress",
             ip_protocol="-1",
             from_port=0,
@@ -621,7 +627,7 @@ class ClusterCdkStack(Stack):
         # ComputeSecurityGroupNormalEgress
         # Internet access from compute nodes
         ec2.CfnSecurityGroupEgress(
-            self,
+            self.stack,
             "ComputeSecurityGroupNormalEgress",
             ip_protocol="-1",
             from_port=0,
@@ -633,7 +639,7 @@ class ClusterCdkStack(Stack):
         # ComputeSecurityGroupIngress
         # Access to compute nodes from other compute nodes
         ec2.CfnSecurityGroupIngress(
-            self,
+            self.stack,
             "ComputeSecurityGroupIngress",
             ip_protocol="-1",
             from_port=0,
@@ -663,7 +669,7 @@ class ClusterCdkStack(Stack):
                 )
             )
         return ec2.CfnSecurityGroup(
-            self,
+            self.stack,
             "HeadNodeSecurityGroup",
             group_description="Enable access to the head node",
             vpc_id=self.config.vpc_id,
@@ -708,7 +714,7 @@ class ClusterCdkStack(Stack):
                     drive_cache_type = "NONE"
             file_system_security_groups = [self._add_storage_security_group(id, shared_fsx)]
             fsx_resource = fsx.CfnFileSystem(
-                self,
+                self.stack,
                 id,
                 storage_capacity=shared_fsx.storage_capacity,
                 lustre_configuration=fsx.CfnFileSystem.LustreConfigurationProperty(
@@ -761,7 +767,7 @@ class ClusterCdkStack(Stack):
         deletion_policy = convert_deletion_policy(shared_efs.deletion_policy)
         if not efs_id and shared_efs.mount_dir:
             efs_resource = efs.CfnFileSystem(
-                self,
+                self.stack,
                 id,
                 encrypted=shared_efs.encrypted,
                 kms_key_id=shared_efs.kms_key_id,
@@ -823,7 +829,7 @@ class ClusterCdkStack(Stack):
         if availability_zone not in checked_availability_zones:
             if new_file_system:
                 efs_resource = efs.CfnMountTarget(
-                    self,
+                    self.stack,
                     "{0}MT{1}".format(efs_cfn_resource_id, availability_zone),
                     file_system_id=file_system_id,
                     security_groups=[sg.ref for sg in security_groups],
@@ -853,7 +859,7 @@ class ClusterCdkStack(Stack):
 
     def _add_cfn_volume(self, id: str, shared_ebs: SharedEbs):
         volume = ec2.CfnVolume(
-            self,
+            self.stack,
             id,
             availability_zone=self.config.head_node.networking.availability_zone,
             encrypted=shared_ebs.encrypted,
@@ -871,9 +877,11 @@ class ClusterCdkStack(Stack):
         return volume.ref
 
     def _add_wait_condition(self):
-        wait_condition_handle = cfn.CfnWaitConditionHandle(self, id="HeadNodeWaitConditionHandle" + self.timestamp)
+        wait_condition_handle = cfn.CfnWaitConditionHandle(
+            self.stack, id="HeadNodeWaitConditionHandle" + self.timestamp
+        )
         wait_condition = cfn.CfnWaitCondition(
-            self,
+            self.stack,
             id="HeadNodeWaitCondition" + self.timestamp,
             count=1,
             handle=wait_condition_handle.ref,
@@ -908,7 +916,7 @@ class ClusterCdkStack(Stack):
 
         # Head node Launch Template
         head_node_launch_template = ec2.CfnLaunchTemplate(
-            self,
+            self.stack,
             "HeadNodeLaunchTemplate",
             launch_template_data=ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
                 instance_type=head_node.instance_type,
@@ -960,7 +968,7 @@ class ClusterCdkStack(Stack):
             {
                 "cluster": {
                     "stack_name": self._stack_name,
-                    "stack_arn": self.stack_id,
+                    "stack_arn": self.stack.stack_id,
                     "scheduler_plugin_substack_arn": self.scheduler_plugin_stack.ref
                     if self.scheduler_plugin_stack
                     else "",
@@ -984,7 +992,7 @@ class ClusterCdkStack(Stack):
                     "postupdate_args": join_shell_args(post_update_action.args)
                     if post_update_action and post_update_action.args
                     else "NONE",
-                    "region": self.region,
+                    "region": self.stack.region,
                     "efs_fs_ids": get_shared_storage_ids_by_type(self.shared_storage_infos, SharedStorageType.EFS),
                     "efs_shared_dirs": to_comma_separated_string(self.shared_storage_mount_dirs[SharedStorageType.EFS]),
                     "efs_encryption_in_transits": to_comma_separated_string(
@@ -1118,7 +1126,7 @@ class ClusterCdkStack(Stack):
                                 "--resource HeadNodeLaunchTemplate --configsets update --region ${Region}\n"
                                 "runas=root\n"
                             ),
-                            {"StackName": self._stack_name, "Region": self.region},
+                            {"StackName": self._stack_name, "Region": self.stack.region},
                         ),
                         "mode": "000400",
                         "owner": "root",
@@ -1127,7 +1135,7 @@ class ClusterCdkStack(Stack):
                     "/etc/cfn/cfn-hup.conf": {
                         "content": Fn.sub(
                             "[main]\nstack=${StackId}\nregion=${Region}\ninterval=2",
-                            {"StackId": self.stack_id, "Region": self.region},
+                            {"StackId": self.stack.stack_id, "Region": self.stack.region},
                         ),
                         "mode": "000400",
                         "owner": "root",
@@ -1217,7 +1225,7 @@ class ClusterCdkStack(Stack):
 
         head_node_launch_template.add_metadata("AWS::CloudFormation::Init", cfn_init)
         head_node_instance = ec2.CfnInstance(
-            self,
+            self.stack,
             "HeadNode",
             launch_template=ec2.CfnInstance.LaunchTemplateSpecificationProperty(
                 launch_template_id=head_node_launch_template.ref,
@@ -1263,7 +1271,7 @@ class ClusterCdkStack(Stack):
 
         parameters = {
             "ClusterName": self._stack_name,
-            "ParallelClusterStackId": self.stack_id,
+            "ParallelClusterStackId": self.stack.stack_id,
             "VpcId": self.config.vpc_id,
             # Empty if passed in config and not created by pclsuter
             "HeadNodeRoleName": self._managed_head_node_instance_role.ref
@@ -1281,7 +1289,7 @@ class ClusterCdkStack(Stack):
                 ] = compute_resource["LaunchTemplate"]["Version"]
 
         self.scheduler_plugin_stack = CfnStack(
-            self, "SchedulerPluginStack", template_url=template_url, parameters=parameters
+            self.stack, "SchedulerPluginStack", template_url=template_url, parameters=parameters
         )
 
     # -- Conditions -------------------------------------------------------------------------------------------------- #
@@ -1309,28 +1317,28 @@ class ClusterCdkStack(Stack):
         # Storage filesystem Ids
         for storage_type, storage_list in self.shared_storage_infos.items():
             CfnOutput(
-                self,
+                self.stack,
                 "{0}Ids".format(storage_type.name),
                 description="{0} Filesystem IDs".format(storage_type.name),
                 value=",".join(storage.id for storage in storage_list),
             )
 
         CfnOutput(
-            self,
+            self.stack,
             "HeadNodeInstanceID",
             description="ID of the head node instance",
             value=self.head_node_instance.ref,
         )
 
         CfnOutput(
-            self,
+            self.stack,
             "HeadNodePrivateIP",
             description="Private IP Address of the head node",
             value=self.head_node_instance.attr_private_ip,
         )
 
         CfnOutput(
-            self,
+            self.stack,
             "HeadNodePrivateDnsName",
             description="Private DNS name of the head node",
             value=self.head_node_instance.attr_private_dns_name,

--- a/cli/src/pcluster/templates/slurm_builder.py
+++ b/cli/src/pcluster/templates/slurm_builder.py
@@ -244,6 +244,7 @@ class SlurmConstruct(Construct):
         if self.cleanup_lambda_role:
             cleanup_route53_lambda_execution_role = add_lambda_cfn_role(
                 scope=self.stack_scope,
+                config=self.config,
                 function_id="CleanupRoute53",
                 statements=[
                     iam.PolicyStatement(


### PR DESCRIPTION
### Description of changes
In order to empower unit testing of `ClusterCdkStack`, we need to use composition instead of inheritance.
This will allow us to move code parts out of `ClusterCdkStack` constructor and gradually unit test them.

### Tests
Changing code has an excellent test code coverage:
- [awsbatch_builder](https://app.codecov.io/gh/aws/aws-parallelcluster/blob/develop/cli/src/pcluster/templates/awsbatch_builder.py)
- [cluster_stack.py](https://app.codecov.io/gh/aws/aws-parallelcluster/blob/develop/cli/src/pcluster/templates/cluster_stack.py)
- [cdk_builder_utils.py](https://app.codecov.io/gh/aws/aws-parallelcluster/blob/develop/cli/src/pcluster/templates/cdk_builder_utils.py)
- [slurm_builder.py](https://app.codecov.io/gh/aws/aws-parallelcluster/blob/develop/cli/src/pcluster/templates/slurm_builder.py)

This is why I believe running automated tests and manually checking the few lines missing from the test coverage is sufficient to verify this change.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
