### PR TITLE
Separate p4d multinics test from other p4d tests

### DIFF
--- a/tests/integration-tests/configs/p4d-efa.yaml
+++ b/tests/integration-tests/configs/p4d-efa.yaml
@@ -1,0 +1,13 @@
+{%- import 'common.jinja2' as common -%}
+{%- set regions = ["us-east-1"] -%}
+{%- set instances = ["p4d.24xlarge"] -%}
+
+---
+test-suites:
+  efa:
+    test_efa.py::test_efa:
+      dimensions:
+        - regions: {{ regions }}
+          instances: {{ instances }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]

--- a/tests/integration-tests/configs/p4d-multinics.yaml
+++ b/tests/integration-tests/configs/p4d-multinics.yaml
@@ -1,16 +1,9 @@
 {%- import 'common.jinja2' as common -%}
-{%- set regions = ["us-east-1"] -%}
-{%- set instances = ["p4d.24xlarge"] -%}
+  {%- set regions = ["us-east-1"] -%}
+  {%- set instances = ["p4d.24xlarge"] -%}
 
 ---
 test-suites:
-  efa:
-    test_efa.py::test_efa:
-      dimensions:
-        - regions: {{ regions }}
-          instances: {{ instances }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
-          schedulers: ["slurm"]
   multiple_nics:
     test_multiple_nics.py::test_multiple_nics:
       dimensions:


### PR DESCRIPTION
### Description of changes
* Separated p4d multinics test into its own test so that it can be run by itself.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
