### PR TITLE
[tox] Replace whitelist_externals with allowlist_externals in tox.ini

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -12,7 +12,7 @@ passenv =
 usedevelop =
     cov: true
     nocov: false
-whitelist_externals =
+allowlist_externals =
     bash
 deps =
     -rtests/requirements.txt


### PR DESCRIPTION
A breaking change from tox broke unit tests from tox. See tox changelog https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4

Signed-off-by: Hanwen hanwenli@amazon.com

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
