### PR TITLE
Adds resources to ODCR fixture for multi-az integration tests

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -980,7 +980,7 @@ def vpc_stacks(cfn_stacks_factory, request):
         # http://www.davidc.net/sites/default/subnets/subnets.html?network=192.168.0.0&mask=16&division=7.70
         public_subnet = SubnetConfig(
             name="Public",
-            cidr="192.168.32.0/19",  # 8190 IPs
+            cidr="192.168.32.0/20",  # 4096 IPs
             map_public_ip_on_launch=True,
             has_nat_gateway=True,
             availability_zone=availability_zones[0],
@@ -988,7 +988,7 @@ def vpc_stacks(cfn_stacks_factory, request):
         )
         private_subnet = SubnetConfig(
             name="Private",
-            cidr="192.168.64.0/19",  # 8190 IPs
+            cidr="192.168.64.0/20",  # 4096 IPs
             map_public_ip_on_launch=False,
             has_nat_gateway=False,
             availability_zone=availability_zones[0],
@@ -996,7 +996,7 @@ def vpc_stacks(cfn_stacks_factory, request):
         )
         private_subnet_different_cidr = SubnetConfig(
             name="PrivateAdditionalCidr",
-            cidr="192.168.96.0/19",  # 8190 IPs
+            cidr="192.168.96.0/20",  # 4096 IPs
             map_public_ip_on_launch=False,
             has_nat_gateway=False,
             availability_zone=availability_zones[1],
@@ -1004,7 +1004,7 @@ def vpc_stacks(cfn_stacks_factory, request):
         )
         no_internet_subnet = SubnetConfig(
             name="NoInternet",
-            cidr="192.168.16.0/20",  # 4094 IPs
+            cidr="192.168.16.0/20",  # 4096 IPs
             map_public_ip_on_launch=False,
             has_nat_gateway=False,
             availability_zone=availability_zones[0],
@@ -1012,7 +1012,7 @@ def vpc_stacks(cfn_stacks_factory, request):
         )
         public_subnet_az2 = SubnetConfig(
             name="PublicAz2",
-            cidr="192.168.128.0/19",  # 8190 IPs
+            cidr="192.168.128.0/20",  # 4096 IPs
             map_public_ip_on_launch=True,
             has_nat_gateway=True,
             availability_zone=availability_zones[1],
@@ -1020,7 +1020,7 @@ def vpc_stacks(cfn_stacks_factory, request):
         )
         private_subnet_az2 = SubnetConfig(
             name="PrivateAz2",
-            cidr="192.168.160.0/19",  # 8190 IPs
+            cidr="192.168.160.0/20",  # 4096 IPs
             map_public_ip_on_launch=False,
             has_nat_gateway=False,
             availability_zone=availability_zones[1],
@@ -1028,7 +1028,7 @@ def vpc_stacks(cfn_stacks_factory, request):
         )
         public_subnet_az3 = SubnetConfig(
             name="PublicAz3",
-            cidr="192.168.192.0/19",  # 8190 IPs
+            cidr="192.168.192.0/20",  # 4096 IPs
             map_public_ip_on_launch=True,
             has_nat_gateway=True,
             availability_zone=availability_zones[2],
@@ -1036,7 +1036,7 @@ def vpc_stacks(cfn_stacks_factory, request):
         )
         private_subnet_az3 = SubnetConfig(
             name="PrivateAz3",
-            cidr="192.168.224.0/19",  # 8190 IPs
+            cidr="192.168.224.0/20",  # 4096 IPs
             map_public_ip_on_launch=False,
             has_nat_gateway=False,
             availability_zone=availability_zones[2],

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1356,7 +1356,10 @@ def placement_group_stack(cfn_stacks_factory, request, region):
 
     yield stack
 
-    cfn_stacks_factory.delete_stack(stack.name, region)
+    if not request.config.getoption("no_delete"):
+        cfn_stacks_factory.delete_stack(stack.name, region)
+    else:
+        logging.warning("Skipping deletion of CFN stacks because --no-delete option is set")
 
 
 @pytest.fixture(scope="class")
@@ -1445,7 +1448,10 @@ def odcr_stack(request, region, placement_group_stack, cfn_stacks_factory, vpc_s
 
     yield stack
 
-    cfn_stacks_factory.delete_stack(stack.name, region)
+    if not request.config.getoption("no_delete"):
+        cfn_stacks_factory.delete_all_stacks()
+    else:
+        logging.warning("Skipping deletion of CFN stacks because --no-delete option is set")
 
 
 @pytest.fixture()


### PR DESCRIPTION
### Description of changes
* [Fix] Resize subnets from 8192 to 4096 IP address to avoid hitting limits on total IP addresses
* [Fix] Add `--no-delete` behavior to `odcr` and `placement_groups` stacks 
* Adds 2 Reservations (in different AZ) and a ReservationGroup in ODCR stack that will be used by Multi-AZ integration tests

**Note** : the actual changes of this PR are the ones in `conftest.py` . Likely the others were brought in by rebasing the local branch on top of `upstream/develop` to fix a strange behavior in the CLI while testing (so they should already be merged in the develop branch).

### Tests
* Changes were tested while manually launching integration tests for MultiAz 

### References
* [Creates multi-az subnets in pcluster vpc_stacks)](https://github.com/aws/aws-parallelcluster/pull/4650)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
