### PR TITLE
[MultiAz][IntegTests] MultiAz cluster creation and update

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -723,6 +723,11 @@ update:
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: {{ common.OSS_COMMERCIAL_ARM }}
         schedulers: ["slurm"]
+  test_update.py::test_multi_az_create_and_update:
+    dimensions:
+      - regions: [ "eu-west-2" ]
+        schedulers: [ "slurm" ]
+        oss: ["alinux2"]
 # Temporarily disabling p4d tests
 # multiple_nics:
 #   test_multiple_nics.py::test_multiple_nics:

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -25,7 +25,7 @@ from retrying import retry
 from s3_common_utils import check_s3_read_resource, check_s3_read_write_resource, get_policy_resources
 from time_utils import minutes, seconds
 from troposphere.fsx import LustreConfiguration
-from utils import wait_for_computefleet_changed
+from utils import describe_cluster_instances, retrieve_cfn_resources, wait_for_computefleet_changed
 
 from tests.common.assertions import assert_lines_in_logs, assert_no_msg_in_logs
 from tests.common.hit_common import assert_compute_node_states, assert_initial_conditions, wait_for_compute_nodes_states
@@ -1230,3 +1230,94 @@ def _test_shared_storage_rollback(
     logging.info("Checking managed FSX is deleted after stack rollback")
     with pytest.raises(ClientError, match="FileSystemNotFound"):
         boto3.client("fsx", region).describe_file_systems(FileSystemIds=managed_fsx)
+
+
+@pytest.mark.usefixtures("os")
+def test_multi_az_create_and_update(
+    region, pcluster_config_reader, clusters_factory, odcr_stack, scheduler_commands_factory, test_datadir
+):
+    """Test creation and then update of a multi-az cluster."""
+
+    # Step 1
+    # Create a cluster with two queues
+    #  q1 with 2 subnets in different AZ
+    #    plus a ReservationGroup with two reservations that ensure hosts are provisioned in both AZs
+    #  q2 with 1 subnet in one AZ
+
+    resource_groups_client = boto3.client(service_name="resource-groups", region_name=region)
+    odcr_resources = retrieve_cfn_resources(odcr_stack.name, region)
+    resource_group_arn = resource_groups_client.get_group(Group=odcr_stack.cfn_resources["multiAzOdcrGroup"])["Group"][
+        "GroupArn"
+    ]
+
+    init_config_file = pcluster_config_reader(
+        config_file="pcluster_create.config.yaml",
+        multi_az_capacity_reservation_arn=resource_group_arn,
+    )
+
+    cluster = clusters_factory(init_config_file)
+
+    # Retrieves list of cluster instances and checks that
+    # at least one instance was launched in each AZ/Reservation
+    instances = describe_cluster_instances(cluster.name, region, filter_by_compute_resource_name="compute-resource-1")
+    _assert_instance_in_capacity_reservation(instances, odcr_resources["az1Odcr"])
+    _assert_instance_in_capacity_reservation(instances, odcr_resources["az2Odcr"])
+
+    # ## First update
+    # - add a subnet in Queue2
+    # update should succeed without failures or warning messages
+    first_update_config = pcluster_config_reader(
+        config_file="pcluster_update_1.config.yaml",
+        multi_az_capacity_reservation_arn=resource_group_arn,
+    )
+
+    response = cluster.update(str(first_update_config))
+    assert_that(response["clusterStatus"]).is_equal_to("UPDATE_COMPLETE")
+
+    # Second update
+    # - remove a subnet in Queue2
+    # update should fail asking to stop the fleet
+    second_update_config = pcluster_config_reader(
+        config_file="pcluster_update_2.config.yaml",
+        multi_az_capacity_reservation_arn=resource_group_arn,
+    )
+
+    response = cluster.update(str(second_update_config), raise_on_error=False)
+    assert_that(response["message"]).is_equal_to("Update failure")
+    assert_that(response["updateValidationErrors"][0]["message"]).contains("All compute nodes must be stopped")
+
+    # Third update
+    #  - stops the fleet
+    #  - wait until all compute instances are terminated
+    # after fully stopping the fleet, the update should succeed
+
+    cluster.stop()
+    _wait_until_instances_are_stopped(cluster)
+
+    response = cluster.update(str(second_update_config))
+    assert_that(response["computeFleetStatus"]).is_equal_to("STOPPED")
+    assert_that(response["clusterStatus"]).is_equal_to("UPDATE_COMPLETE")
+
+
+def _assert_instance_in_capacity_reservation(instances, expected_reservation):
+    if any(
+        instance["CapacityReservationId"] == expected_reservation
+        for instance in instances
+        if "CapacityReservationId" in instance
+    ):
+        logging.info("Instances found in reservation: %s", expected_reservation)
+    else:
+        logging.error("No instances found in reservation: %s", expected_reservation)
+        pytest.fail("No instances found in the reservation")
+
+
+@retry(retry_on_result=lambda result: result is False, wait_fixed=seconds(20), stop_max_delay=seconds(360))
+def _wait_until_instances_are_stopped(cluster):
+    instances = cluster.describe_cluster_instances()
+    n_compute_instances = len(instances) - 1  # Do not count the HeadNode
+    if n_compute_instances <= 1:
+        logging.info("All compute instances were stopped.")
+    else:
+        logging.info("Still found %2d compute instances in the cluster. Waiting... ", n_compute_instances)
+
+    return n_compute_instances <= 1

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_create.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_create.config.yaml
@@ -1,0 +1,34 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      ComputeResources:
+        - Name: compute-resource-1
+          Instances:
+            - InstanceType: t3.micro
+          MinCount: 6
+          MaxCount: 10
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: {{ multi_az_capacity_reservation_arn }}
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+          - {{ public_az2_subnet_id }}
+    - Name: queue2
+      ComputeResources:
+        - Name: compute-resource-2
+          Instances:
+            - InstanceType: t2.micro
+          MinCount: 0
+          MaxCount: 4
+      Networking:
+        SubnetIds:
+          - {{ public_az3_subnet_id }}

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_1.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_1.config.yaml
@@ -1,0 +1,35 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      ComputeResources:
+        - Name: compute-resource-1
+          Instances:
+            - InstanceType: t3.micro
+          MinCount: 6
+          MaxCount: 10
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: {{ multi_az_capacity_reservation_arn }}
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+          - {{ public_az2_subnet_id }}
+    - Name: queue2
+      ComputeResources:
+        - Name: compute-resource-2
+          Instances:
+            - InstanceType: t2.micro
+          MinCount: 0
+          MaxCount: 4
+      Networking:
+        SubnetIds:
+          - {{ public_az3_subnet_id }}
+          - {{ public_az2_subnet_id }}

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_2.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_2.config.yaml
@@ -1,0 +1,34 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      ComputeResources:
+        - Name: compute-resource-1
+          Instances:
+            - InstanceType: t3.micro
+          MinCount: 6
+          MaxCount: 10
+          CapacityReservationTarget:
+            CapacityReservationResourceGroupArn: {{ multi_az_capacity_reservation_arn }}
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+          - {{ public_az2_subnet_id }}
+    - Name: queue2
+      ComputeResources:
+        - Name: compute-resource-2
+          Instances:
+            - InstanceType: t2.micro
+          MinCount: 0
+          MaxCount: 4
+      Networking:
+        SubnetIds:
+          - {{ public_az3_subnet_id }}


### PR DESCRIPTION
### Description of changes
* Add integration test for verify pcluster behavior when creating/updating a Multi-AZ cluster

### Tests
#### Step 1 
*  Create a cluster with two queues
    * q1 with 2 subnets in different AZ plus a ReservationGroup with two reservations that ensure hosts are provisioned in both AZs
    * q2 with 1 subnet in one AZ
      * Assert cluster is successfully created
      * Asserts that at least one compute node per Reservation/AZ is launched

#### Step 2 
*  Update the cluster adding a subnet in a new AZ on Q2
      * Assert cluster is successfully updated

#### Step 3 
*  Update the cluster removing a subnet in a new AZ from Q2
      * Assert cluster creation fails 
      * Assert user is asked to stop the fleet

#### Step 4 
*  Stops the fleet
  * wait until all compute nodes are terminated
* Makes a second attempt to update the cluster 
      * Assert that cluster is successfully updated
      * Assert compute fleet is stopped

### Test outputs
```
[
  "update/test_update.py::test_multi_az_create_and_update[eu-west-1-alinux2-slurm]"
]

conftest - Setting up the ODCR stack
...
clusters_factory - Creating cluster integ-tests-jfzn9jg6omgkgels-nssirena-test-slurm

 create-cluster response: {
...
  "computeFleetStatus": "RUNNING",
...
  "clusterStatus": "CREATE_COMPLETE",
...
}


clusters_factory - Updating cluster integ-tests-jfzn9jg6omgkgels-nssirena-test-slurm 

update-cluster response: {
...
  "computeFleetStatus": "RUNNING",
... 
  "clusterStatus": "UPDATE_COMPLETE",
...
 }


clusters_factory - Updating cluster integ-tests-jfzn9jg6omgkgels-nssirena-test-slurm 

Command pcluster update-cluster ...  failed with error:

  "updateValidationErrors": [
    {
      "parameter": "Scheduling.SlurmQueues[queue2].Networking.SubnetIds",
      "requestedValue": [
        "subnet-054c87771b339174d"
      ],
      "message": "All compute nodes must be stopped or QueueUpdateStrategy must be set. Stop the compute fleet with the pcluster update-compute-fleet command, or set QueueUpdateStrategy in the configuration used for the 'update-cluster' operation",
      "currentValue": [
        "subnet-054c87771b339174d",
        "subnet-0e2cb7e91bde698b4"
      ]
    }


Executing command: pcluster update-compute-fleet --cluster-name i nteg-tests-jfzn9jg6omgkgels-nssirena-test-slurm --status STOP_REQUESTED

clusters_factory - Cluster integ-tests-jfzn9jg6omgkgels-nssirena-test-slurm stopped successfully

test_update - Still found  6 compute instances in the cluster. Waiting...
test_update - Still found  6 compute instances in the cluster. Waiting... 
test_update - All compute instances were stopped.

clusters_factory - Updating cluster integ-tests-jfzn9jg6omgkgels-nssirena-test-slurm  

clusters_factory - update-cluster response: {
...
"computeFleetStatus": "STOPPED",
...
"clusterStatus": "UPDATE_COMPLETE",
}
```

### References
* [Adds resources to ODCR fixture for multi-az integration tests](https://github.com/aws/aws-parallelcluster/pull/4676)
* [Creates multi-az subnets in pcluster vpc_stacks](https://github.com/aws/aws-parallelcluster/pull/4650)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
