### PR TITLE
Shared Storage (EFS, EBS) Integration Tests in clusters with queues in different AZs

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -579,13 +579,13 @@ storage:
   # EFS tests can be done in any region.
   test_efs.py::test_efs_compute_az:
     dimensions:
-      - regions: ["us-west-1"]
+      - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm", "awsbatch"]
   test_efs.py::test_efs_same_az:
     dimensions:
-      - regions: ["ap-northeast-1"]
+      - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
@@ -593,11 +593,11 @@ storage:
   # We should consider this when assigning dimensions to each test.
   test_efs.py::test_multiple_efs:
     dimensions:
-      - regions: ["ap-northeast-2", "cn-north-1"]
+      - regions: ["eu-west-2", "cn-northwest-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_BATCH }}
         schedulers: ["awsbatch"]
-      - regions: [ "ap-northeast-2" ]
+      - regions: [ "eu-west-2" ]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: {{ common.OSS_COMMERCIAL_ARM }}
         schedulers: [ "slurm" ]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -633,17 +633,17 @@ storage:
         schedulers: ["awsbatch"]
   test_ebs.py::test_ebs_multiple:
     dimensions:
-      - regions: ["eu-west-1"]
+      - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
-      - regions: ["eu-west-1"]
+      - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"]
         schedulers: ["slurm"]
   test_ebs.py::test_ebs_single:
     dimensions:
-      {%- for region, oss in [("eu-west-3", common.OSS_COMMERCIAL_X86), ("cn-north-1", common.OSS_CHINA_X86), ("us-gov-west-1", common.OSS_GOVCLOUD_X86)] %}
+      {%- for region, oss in [("eu-west-2", common.OSS_COMMERCIAL_X86), ("cn-northwest-1", common.OSS_CHINA_X86), ("us-gov-west-1", common.OSS_GOVCLOUD_X86)] %}
       - regions: ["{{ region }}"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ oss }}
@@ -651,7 +651,7 @@ storage:
       {%- endfor %}
   test_ebs.py::test_ebs_snapshot:
     dimensions:
-      - regions: ["ap-northeast-2"]
+      - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm"]
@@ -661,7 +661,7 @@ storage:
         schedulers: ["slurm"]
   test_ebs.py::test_ebs_existing:
     dimensions:
-      - regions: ["ap-northeast-2"]
+      - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -406,6 +406,12 @@ class SlurmCommands(SchedulerCommands):
         result = self._remote_command_executor.run_remote_command(check_core_cmd)
         return re.search(r"(\d+)", result.stdout).group(1)
 
+    def get_partitions(self):
+        """Return partitions in the cluster."""
+        check_partitions_cmd = "sinfo --format=%R -h"
+        result = self._remote_command_executor.run_remote_command(check_partitions_cmd)
+        return result.stdout.splitlines()
+
     def get_job_info(self, job_id, field=None):
         """Return job details from slurm. If field is provided, only the field is returned"""
         result = self._remote_command_executor.run_remote_command("scontrol show jobs -o {0}".format(job_id)).stdout

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -15,6 +15,7 @@ import re
 import boto3
 from assertpy import assert_that
 from cfn_stacks_factory import CfnStack
+from clusters_factory import Cluster
 from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
 from time_utils import minutes, seconds
@@ -29,26 +30,74 @@ from troposphere.fsx import (
 )
 from utils import generate_stack_name, random_alphanumeric, retrieve_cfn_outputs
 
+from tests.common.schedulers_common import SlurmCommands
 from tests.common.utils import retrieve_latest_ami
 
 
-def verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands, partition=None):
+def get_cluster_subnet_ids_groups(cluster: Cluster, scheduler: str, include_head_node: bool = True):
+    """
+    Returns a nested list of SubnetIds from the cluster configuration for each queue and headnode by default.
+    Example: [[HeadNode SubnetId], [<queue-0-SubnetIds>], [<queue-1-SubnetIds>], ...]
+    """
+    head_node_subnet_id = cluster.config.get("HeadNode", {}).get("Networking", {}).get("SubnetId")
+    if scheduler == "slurm":
+        queues = cluster.config.get("Scheduling", {}).get("SlurmQueues", [])
+    else:
+        queues = cluster.config.get("Scheduling", {}).get("AwsBatchQueues", [])
+
+    compute_subnet_ids = [queue.get("Networking", {}).get("SubnetIds", []) for queue in queues]
+    if include_head_node:
+        return [[head_node_subnet_id], *compute_subnet_ids]
+    return compute_subnet_ids
+
+
+def verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands, partitions=None):
+    """
+    Confirm nodes can read and write to the FileSystem
+    Example:
+    - Partitions: ["A", "B"]
+    While writing:
+        "A" writes a file "A-<random_alphanumeric_characters>"
+        "B" writes a file "B-<random_alphanumeric_characters>"
+    While Reading:
+        "A" reads files: ["A-<random_alphanumeric_characters>", "B-<random_alphanumeric_characters>"]
+        "B" reads files: ["A-<random_alphanumeric_characters>", "B-<random_alphanumeric_characters>"]
+    """
     head_node_file = random_alphanumeric()
-    compute_file = random_alphanumeric()
+    logging.info(f"Writing HeadNode File: {head_node_file}")
     remote_command_executor.run_remote_command(
         "touch {mount_dir}/{head_node_file}".format(mount_dir=mount_dir, head_node_file=head_node_file)
     )
-    job_command = "cat {mount_dir}/{head_node_file} && touch {mount_dir}/{compute_file}".format(
-        mount_dir=mount_dir, head_node_file=head_node_file, compute_file=compute_file
-    )
 
-    result = scheduler_commands.submit_command(job_command, partition=partition)
-    job_id = scheduler_commands.assert_job_submitted(result.stdout)
-    scheduler_commands.wait_job_completed(job_id)
-    scheduler_commands.assert_job_succeeded(job_id)
-    remote_command_executor.run_remote_command(
-        "cat {mount_dir}/{compute_file}".format(mount_dir=mount_dir, compute_file=compute_file)
+    # Submit a "Write" job to each partition
+    files_to_read = [head_node_file]
+    partitions = (
+        partitions or scheduler_commands.get_partitions() if isinstance(scheduler_commands, SlurmCommands) else [None]
     )
+    for partition in partitions:
+        compute_file = "{}-{}".format(partition, random_alphanumeric())
+        logging.info(f"Writing Compute File: {compute_file} from {partition}")
+        job_command = "touch {mount_dir}/{compute_file}".format(mount_dir=mount_dir, compute_file=compute_file)
+        result = scheduler_commands.submit_command(job_command, partition=partition)
+        job_id = scheduler_commands.assert_job_submitted(result.stdout)
+        scheduler_commands.wait_job_completed(job_id)
+        scheduler_commands.assert_job_succeeded(job_id)
+        files_to_read.append(compute_file)
+
+    read_all_files_command = "cat {files_to_read}".format(
+        files_to_read=" ".join([f"{mount_dir}/{target_file}" for target_file in files_to_read]),
+    )
+    # Attempt reading files from HeadNode
+    logging.info(f"Reading Files: {files_to_read} from HeadNode")
+    remote_command_executor.run_remote_command(read_all_files_command)
+
+    # Submit a "Read" job to each partition
+    for partition in partitions:
+        logging.info(f"Reading Files: {files_to_read} from {partition}")
+        result = scheduler_commands.submit_command(read_all_files_command, partition=partition)
+        job_id = scheduler_commands.assert_job_submitted(result.stdout)
+        scheduler_commands.wait_job_completed(job_id)
+        scheduler_commands.assert_job_succeeded(job_id)
 
 
 # for EBS

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -18,7 +18,11 @@ from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 
 from tests.storage.kms_key_factory import KMSKeyFactory
-from tests.storage.storage_common import test_ebs_correctly_mounted, verify_directory_correctly_shared
+from tests.storage.storage_common import (
+    assert_subnet_az_relations_from_config,
+    test_ebs_correctly_mounted,
+    verify_directory_correctly_shared,
+)
 
 
 @pytest.mark.usefixtures("instance")
@@ -31,6 +35,9 @@ def test_ebs_single(
         mount_dir=mount_dir, ec2_iam_role=kms_key_factory.iam_role_arn, ebs_kms_key_id=kms_key_id
     )
     cluster = clusters_factory(cluster_config)
+    assert_subnet_az_relations_from_config(
+        region, scheduler, cluster, expected_in_same_az=False, include_head_node=False
+    )
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     mount_dir = "/" + mount_dir
@@ -53,6 +60,7 @@ def test_ebs_snapshot(
     snapshots_factory,
     clusters_factory,
     scheduler_commands_factory,
+    scheduler,
 ):
     logging.info("Testing ebs snapshot")
     mount_dir = "ebs_mount_dir"
@@ -67,6 +75,9 @@ def test_ebs_snapshot(
     cluster_config = pcluster_config_reader(mount_dir=mount_dir, volume_size=volume_size, snapshot_id=snapshot_id)
 
     cluster = clusters_factory(cluster_config)
+    assert_subnet_az_relations_from_config(
+        region, scheduler, cluster, expected_in_same_az=False, include_head_node=False
+    )
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     mount_dir = "/" + mount_dir
@@ -96,6 +107,9 @@ def test_ebs_multiple(
     volume_sizes[4] = 500
     cluster_config = pcluster_config_reader(mount_dirs=mount_dirs, volume_sizes=volume_sizes)
     cluster = clusters_factory(cluster_config)
+    assert_subnet_az_relations_from_config(
+        region, scheduler, cluster, expected_in_same_az=False, include_head_node=False
+    )
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
@@ -162,6 +176,9 @@ def test_ebs_existing(
     cluster_config = pcluster_config_reader(volume_id=volume_id, existing_mount_dir=existing_mount_dir)
 
     cluster = clusters_factory(cluster_config)
+    assert_subnet_az_relations_from_config(
+        region, scheduler, cluster, expected_in_same_az=False, include_head_node=False
+    )
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
     existing_mount_dir = "/" + existing_mount_dir

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
@@ -26,6 +26,18 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+    {% if scheduler == "slurm" %}
+    - Name: queue-1
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_az3_subnet_id }}
+    {% endif %}
 SharedStorage:
   - MountDir: {{ existing_mount_dir }}
     Name: name1

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -42,6 +42,25 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+    {% if scheduler == "slurm" %}
+    - Name: queue-1
+      ComputeSettings:
+        LocalStorage:
+          RootVolume:
+            Encrypted: false
+            VolumeType: gp3
+            Iops: 3200
+            Throughput: 130
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_az3_subnet_id }}
+    {% endif %}
 SharedStorage:
   - MountDir: {{ mount_dirs[0] }}
     Name: ebs1

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -33,6 +33,18 @@ Scheduling:
       Iam:
         InstanceRole: {{ ec2_iam_role }}
       {% endif %}
+    {% if scheduler == "slurm" %}
+    - Name: queue-1
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_az3_subnet_id }}
+    {% endif %}
 SharedStorage:
   - MountDir: {{ mount_dir }}
     StorageType: Ebs

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
@@ -27,6 +27,18 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+    {% if scheduler == "slurm" %}
+    - Name: queue-1
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_az3_subnet_id }}
+    {% endif %}
 SharedStorage:
   - MountDir: {{ mount_dir }}
     StorageType: Ebs

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -14,13 +14,12 @@ import logging
 import boto3
 import pytest
 from assertpy import assert_that
-from clusters_factory import Cluster
 from remote_command_executor import RemoteCommandExecutor
 from utils import get_compute_nodes_instance_ips, get_vpc_snakecase_value
 
 from tests.common.utils import reboot_head_node
 from tests.storage.storage_common import (
-    get_cluster_subnet_ids_groups,
+    assert_subnet_az_relations_from_config,
     test_efs_correctly_mounted,
     verify_directory_correctly_shared,
     write_file_into_efs,
@@ -39,7 +38,7 @@ def test_efs_compute_az(
     mount_dir = "efs_mount_dir"
     cluster_config = pcluster_config_reader(mount_dir=mount_dir)
     cluster = clusters_factory(cluster_config)
-    _assert_subnet_az_relations_from_config(region, scheduler, cluster, expected_in_same_az=False)
+    assert_subnet_az_relations_from_config(region, scheduler, cluster, expected_in_same_az=False)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     mount_dir = "/" + mount_dir
@@ -60,7 +59,7 @@ def test_efs_same_az(
     mount_dir = "efs_mount_dir"
     cluster_config = pcluster_config_reader(mount_dir=mount_dir)
     cluster = clusters_factory(cluster_config)
-    _assert_subnet_az_relations_from_config(region, scheduler, cluster, expected_in_same_az=True)
+    assert_subnet_az_relations_from_config(region, scheduler, cluster, expected_in_same_az=True)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
     mount_dir = "/" + mount_dir
@@ -118,7 +117,7 @@ def test_multiple_efs(
         new_efs_mount_dirs=new_efs_mount_dirs,
     )
     cluster = clusters_factory(cluster_config)
-    _assert_subnet_az_relations_from_config(region, scheduler, cluster, expected_in_same_az=False)
+    assert_subnet_az_relations_from_config(region, scheduler, cluster, expected_in_same_az=False)
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
 
@@ -170,23 +169,6 @@ def _assert_subnet_az_relations(region, vpc_stack, expected_in_same_az):
         assert_that(head_node_subnet_az).is_equal_to(compute_subnet_az)
     else:
         assert_that(head_node_subnet_az).is_not_equal_to(compute_subnet_az)
-
-
-def _assert_subnet_az_relations_from_config(region: str, scheduler: str, cluster: Cluster, expected_in_same_az: bool):
-    # [["Subnet1"], ["Subnet2", "Subnet3"], ["Subnet1", "Subnet2"], ...]
-    cluster_subnet_ids_groups = get_cluster_subnet_ids_groups(cluster, scheduler)
-
-    # ["AZ1", "AZ2", "AZ3", "AZ1", "AZ2", ...]
-    cluster_avail_zones = [
-        boto3.resource("ec2", region_name=region).Subnet(subnet_id).availability_zone
-        for subnet_ids_group in cluster_subnet_ids_groups
-        for subnet_id in subnet_ids_group
-    ]
-
-    if expected_in_same_az:
-        assert_that(set(cluster_avail_zones)).is_length(1)
-    else:
-        assert_that(len(set(cluster_avail_zones))).is_equal_to(len(cluster_avail_zones))
 
 
 def _test_efs_utils(remote_command_executor, scheduler_commands, cluster, region, mount_dirs, efs_ids):

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
@@ -23,10 +23,23 @@ Scheduling:
           Instances:
             - InstanceType: {{ instance }}
           MinCount: 1
+          MaxCount: 1
           {% endif %}
       Networking:
         SubnetIds:
           - {{ private_additional_cidr_subnet_id }}
+    {% if scheduler == "slurm" %}
+    - Name: queue-1
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_az3_subnet_id }}
+    {% endif %}
 # This compute subnet would be in a different AZ than head node for regions defined in AVAILABILITY_ZONE_OVERRIDES
 # See conftest for details
 SharedStorage:

--- a/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
@@ -28,6 +28,18 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_additional_cidr_subnet_id }}
+    {% if scheduler == "slurm" %}
+    - Name: queue-1
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_az3_subnet_id }}
+    {% endif %}
 # This compute subnet would be in a different AZ than head node for regions defined in AVAILABILITY_ZONE_OVERRIDES
 # See conftest for details
 SharedStorage:

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -966,10 +966,10 @@ def test_dynamic_file_systems_update(
     for node_name in queue1_nodes:
         _test_directory_not_mounted(remote_command_executor, all_mount_dirs, node_type="compute", node_name=node_name)
     for mount_dir in all_mount_dirs:
-        verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands, partition="queue2")
+        verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands, partitions=["queue2"])
     scheduler_commands.cancel_job(queue1_job_id)
     for mount_dir in all_mount_dirs:
-        verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands, partition="queue1")
+        verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands, partitions=["queue1"])
 
     # update cluster to remove ebs, raid, efs and fsx with compute fleet stop
     cluster.stop()


### PR DESCRIPTION
### Description of changes
* Current EFS tests
    * Scenario 1 (test_efs_compute_az):
        * Creates a cluster with a HeadNode and 1 Queue in **different** AZs with a managed EFS FileSystem
        * Asserts if EFS mount targets exist in both AZs
        * Asserts that files can be written and read from both the HeadNode and Queue
    * Scenario 2 (test_multiple_efs):
        * Creates a cluster with a HeadNode and 1 Queue in **different** AZs with external EFS FileSystems
        * Asserts if EFS mount targets exist in both AZs
        * Asserts that files can be written and read from both the HeadNode and Queue
* Updated EFS tests
    * Scenario 1 (test_efs_compute_az):
        * Creates a cluster with a HeadNode and **2** Queues in **different** AZs with a managed EFS FileSystem
        * Asserts if EFS mount targets exist in all AZs
        * Asserts that files can be written and read from all nodes (including HeadNode)
    * Scenario 2 (test_multiple_efs):
        * Creates a cluster with a HeadNode and **2** Queues in **different** AZs with external EFS FileSystems
        * Asserts if EFS mount targets exist in all AZs
        * Asserts that files can be written and read from both the HeadNode and Queue

---

* Current EBS tests
    * Scenario 1 (test_ebs_single):
        * Creates a cluster with a HeadNode and 1 Queue in the **same** AZ with a **managed** EBS Volume
        * Asserts if EBS Volume is mounted
        * Asserts that files can be written and read from both the HeadNode and Queue
    * Scenario 2 (test_ebs_existing):
        * Creates a cluster with a HeadNode and 1 Queue in the **same** AZ with an **external** EBS Volume
        * Asserts if EBS Volume is mounted
        * Asserts that files can be written and read from both the HeadNode and Queue
* Updated EBS tests
    * Scenario 1 (test_ebs_single):
        * Creates a cluster with a HeadNode and 1 Queue in the **same** AZ with a managed EBS Volume and an extra queue in a different AZ
        * Asserts if EBS Volume is mounted
        * Asserts that files can be written and read from both the HeadNode and **All** Queues (across AZs)
    * Scenario 2 (test_ebs_existing):
        * Creates a cluster with a HeadNode and 1 Queue in the **same** AZ with an **external** EBS Volume  and an extra queue in a **different** AZ
        * Asserts if EBS Volume is mounted
        * Asserts that files can be written and read from both the HeadNode and **All** Queues (across AZs)

* These changes
    * Update the`verify_directory_correctly_shared` function to write to the FileSystem in all partitions (queues) and read *all* files from each partition (including HeadNode)
    * Adds an extra single-subnet queue in a different availability zone to each cluster

### Tests
* Modified existing EFS integration tests to include an extra queue in a different availability zone
* Sample logs from test run:

```
storage_common - Writing Compute File: queue-0-vblnil449au8w21q from queue-0
storage_common - Writing Compute File: queue-1-zc5bgdly2367bhpm from queue-1
...
storage_common - Reading Compute Files: ['queue-0-vblnil449au8w21q', 'queue-1-zc5bgdly2367bhpm'] from queue-0
storage_common - Reading Compute Files: ['queue-0-vblnil449au8w21q', 'queue-1-zc5bgdly2367bhpm'] from queue-1
```


### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
