### PR TITLE
[3.x] fix Integration testing of efs mounting via efs utils

### DIFF
--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -160,7 +160,7 @@ def write_file_into_efs(
             ],
         )
     )
-    iam_instance_profile = write_file_template.add_resource(InstanceProfile("IAMTLS_Profile", Roles=[Ref(role)]))
+    iam_instance_profile = write_file_template.add_resource(InstanceProfile("IamTlsProfile", Roles=[Ref(role)]))
     write_file_template.add_resource(
         Instance(
             "InstanceToWriteEFS",


### PR DESCRIPTION
### Description of changes
* fix Integration testing of efs mounting via efs utils by removing underscore in InstanceProfile name

### References
* https://github.com/aws/aws-parallelcluster/pull/4668

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
