### PR TITLE
develop: Improve integ tests code to be compatible with hpc6id

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -213,7 +213,7 @@ def _test_osu_benchmarks_multiple_bandwidth(
         # 4 100 Gbps NICS -> declared NetworkPerformance 400 Gbps
         "p4de.24xlarge": 30000,  # Equivalent to a theoretical maximum of a single 240Gbps card
         # 2 up to 170 Gbps NICS -> declared NetworkPerformance 200 Gbps
-        "hpc6id.32xlarge": 23500,  # Equivalent to a theoretical maximum of a single 188Gbps card
+        "hpc6id.32xlarge": 23000,  # Equivalent to a theoretical maximum of a single 184Gbps card
         # 8 100 Gbps NICS -> declared NetworkPerformance 800 Gbps
         "trn1.32xlarge": 80000,  # Equivalent to a theoretical maximum of a single 640Gbps card
     }

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.yaml
@@ -22,10 +22,10 @@ Scheduling:
           # we usually use c4.xlarge and c5.xlarge for test, the min vcpus for one instance is 4.
           MinvCpus: 4
           DesiredvCpus: 8
-          MaxvCpus: 40
-          # EFS is integrated in order to exercise the mount_efs.sh script called from the
-          # entry point of the docker image generated when the scheduler is awsbatch.
+          MaxvCpus: 64
 SharedStorage:
+  # EFS is useful to exercise the mount_efs.sh script called from the
+  # entry point of the docker image generated when the scheduler is awsbatch.
   - MountDir: efs
     Name: efs
     StorageType: Efs


### PR DESCRIPTION
### 1. Reduce threshold for hpc6id EFA test to be compatible with Ubuntu 20
I did multiple tests and Ubuntu 20 I obtained a value of 23057.79

### 2. Increase number of MaxvCpus to fit with instances with more vcpus

The test will be ready if in future instances like hpc6id will be supported by AWS Batch.

### 3. Make pcluster configure test prompts compatible with instances with EFA

If the instance has EFA support (like hpc6id) the prompt will ask to enable EFA and if answering in a positive way, will ask for placement group too.

In this way the code is generic enough to support both the cases.
I tested it using hpc6id and c5.xlarge as instances.

### Tests
* Tested running the tests with hpc6id as instance.
* configure change tested with c5.large as instance too.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
