### PR TITLE
Add check to prevent security exclusions

### DIFF
--- a/.github/workflows/security_exclusions_checker.yml
+++ b/.github/workflows/security_exclusions_checker.yml
@@ -1,0 +1,15 @@
+name: Security Exclusions Checker
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Prevent security exclusions
+  security-exclusions-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check PR
+      uses: francesco-giordano/gh-pr-content-checker@v1.0.0
+      with:
+        diffDoesNotContainRegex: "\\bnosec\\b|\\bnosemgrep\\b"
+        skipLabels: skip-security-exclusions-check


### PR DESCRIPTION
### Description of changes
* This pr add a github action to check the presence of `nosec` and `nosemgrep `
* The GitHub action can be skipped with the label `skip-security-exclusions-check`

### Tests
* Check the action from this PR
* test [PR](https://github.com/aws/aws-parallelcluster/pull/4684)
* [Failed action](https://github.com/aws/aws-parallelcluster/actions/runs/3686760199/jobs/6239493058)
* [Skip action](https://github.com/aws/aws-parallelcluster/actions/runs/3686768735/jobs/6239491487)

### References
* https://github.com/francesco-giordano/gh-pr-content-checker

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
