### PR TITLE
[MultiAZ] Shared Storage Integration Tests: External FSx in a MultiAZ cluster

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -560,6 +560,12 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm"]
+  test_fsx_lustre.py::test_multi_az_fsx:
+    dimensions:
+      - regions: ["eu-west-2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        schedulers: ["slurm"]
   test_fsx_lustre.py::test_fsx_lustre_configuration_options:
     dimensions:
       - regions: ["us-east-2"]

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -306,14 +306,10 @@ def assert_subnet_az_relations_from_config(
 
 
 def assert_fsx_correctly_shared(scheduler_commands, remote_command_executor, mount_dir):
-    logging.info("Testing fsx correctly mounted on compute nodes")
-    remote_command_executor.run_remote_command("touch {mount_dir}/test_file".format(mount_dir=mount_dir))
-    job_command = "cat {mount_dir}/test_file && touch {mount_dir}/compute_output".format(mount_dir=mount_dir)
-    result = scheduler_commands.submit_command(job_command)
-    job_id = scheduler_commands.assert_job_submitted(result.stdout)
-    scheduler_commands.wait_job_completed(job_id)
-    scheduler_commands.assert_job_succeeded(job_id)
-    remote_command_executor.run_remote_command("cat {mount_dir}/compute_output".format(mount_dir=mount_dir))
+    logging.info("Testing fsx correctly shared on HeadNode and Compute Nodes")
+    verify_directory_correctly_shared(
+        remote_command_executor, mount_dir, scheduler_commands, partitions=scheduler_commands.get_partitions()
+    )
 
 
 def assert_fsx_ontap_correctly_mounted(remote_command_executor, mount_dir, volume_id):

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-managed-fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-managed-fsx.config.yaml
@@ -1,0 +1,52 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue-0
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+    - Name: queue-1
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_az2_subnet_id }}
+SharedStorage:
+  - MountDir: test-managed-fsx
+    Name: fsx1
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 1200
+      ImportPath: s3://{{ bucket_name }}
+      ExportPath: s3://{{ bucket_name }}/export_dir
+      DeploymentType: PERSISTENT_1
+      PerUnitStorageThroughput: 200

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-unmanaged-fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-unmanaged-fsx.config.yaml
@@ -1,0 +1,48 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue-0
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+    - Name: queue-1
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_az2_subnet_id }}
+SharedStorage:
+  - MountDir: {{ fsx_lustre_mount_dir }}
+    Name: existingfsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      FileSystemId: {{ existing_fsx_lustre_fs_id }}

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/s3_test_file
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/s3_test_file
@@ -1,0 +1,1 @@
+Downloaded by FSx Lustre


### PR DESCRIPTION
### Description of changes
- Multi AZ is supported in clusters with Unmanaged FSx FileSystems
- This test creates a Multi-AZ cluster with Unmanaged Ontap, OpenZFS and Lustre FSx FileSystems
- Each partition writes to the FileSystem and reads files written by all partitions
- The test also tries to use a configuration with a Managed FSx FileSystem
    - In this case there is an assertion to check if there is a `ManagedFsxMultiAzValidator` validation error

### Tests
* Creates a MultiAZ Cluster with FSx
* Write from each partition/queue and read all files from each queue (and HeadNode)

### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
