### PR TITLE
[develop] Use multiaz config for slurm only in test_cloudwatch_logging

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
@@ -25,7 +25,9 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+          {% if scheduler == "slurm" %}
           - {{ private_az2_subnet_id }}
+          {% endif %}
 Monitoring:
   Logs:
     CloudWatch:


### PR DESCRIPTION
### Description of changes
* Change config for `test_cloudwatch_logging` in order to create a second subnet in a different AZ only for slurm scheduler

### Tests
* Will be tested by launching the full test suite in our automation test pipeline

### References
N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
