### PR TITLE
develop: Limit SSH connection to the cluster from EC2 instance running the test

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -74,6 +74,7 @@ from utils import (
     get_architecture_supported_by_instance_type,
     get_arn_partition,
     get_instance_info,
+    get_metadata,
     get_network_interfaces_count,
     get_vpc_snakecase_value,
     random_alphanumeric,
@@ -607,6 +608,17 @@ def inject_additional_config_settings(  # noqa: C901
 ):  # noqa C901
     with open(cluster_config, encoding="utf-8") as conf_file:
         config_content = yaml.safe_load(conf_file)
+
+    if not dict_has_nested_key(config_content, ("HeadNode", "Ssh", "AllowedIps")):
+        # If the test is running in an EC2 instance limit SSH connection access from instance running the test
+        instance_ip = get_metadata("public-ipv4", raise_error=False)
+        if not instance_ip:
+            instance_ip = get_metadata("local-ipv4", raise_error=False)
+        if instance_ip:
+            logging.info(f"Limiting AllowedIps rule to IP: {instance_ip}")
+            dict_add_nested_key(config_content, f"{instance_ip}/32", ("HeadNode", "Ssh", "AllowedIps"))
+        else:
+            logging.info("Skipping AllowedIps rule because unable to find local and public IP for the instance.")
 
     if not dict_has_nested_key(config_content, ("Imds", "ImdsSupport")):
         dict_add_nested_key(config_content, "v2.0", ("Imds", "ImdsSupport"))

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -21,6 +21,7 @@ import subprocess
 from hashlib import sha1
 
 import boto3
+import requests
 from assertpy import assert_that
 from constants import OS_TO_ROOT_VOLUME_DEVICE
 from jinja2 import FileSystemLoader
@@ -436,6 +437,33 @@ def get_root_volume_id(instance_id, region, os):
     ]
     assert_that(matching_devices).is_length(1)
     return matching_devices[0].get("Ebs").get("VolumeId")
+
+
+def get_metadata(metadata_path, raise_error=True):
+    """
+    Get EC2 instance metadata.
+
+    :param raise_error: set to False if you want to return None in case of Exception (e.g. no EC2 instance)
+    :param metadata_path: the metadata relative path
+    :return: the metadata value.
+    """
+    metadata_value = None
+    try:
+        metadata_base_url = "http://169.254.169.254/latest"
+        token = requests.put(f"{metadata_base_url}/api/token", headers={"X-aws-ec2-metadata-token-ttl-seconds": "300"})
+
+        headers = {}
+        if token.status_code == requests.codes.ok:
+            headers["X-aws-ec2-metadata-token"] = token.content
+        metadata_value = requests.get(f"{metadata_base_url}/meta-data/{metadata_path}", headers=headers).text
+    except Exception as e:
+        error_msg = f"Unable to get {metadata_path} metadata. Failed with exception: {e}"
+        logging.critical(error_msg)
+        if raise_error:
+            raise Exception(error_msg)
+
+    logging.debug("%s=%s", metadata_path, metadata_value)
+    return metadata_value
 
 
 def dict_has_nested_key(d, keys):


### PR DESCRIPTION
### Description of changes
By default the `AllowedIps` value is set to `0.0.0.0/0` with this patch we're limiting the access to the head node by default from instance running the test, if it is an EC2 instance.

This SSH access is used by using the SSH key to execute actions in the head node (e.g. job submission)
and by using the SSH user/password for example by AD tests to verify AD setup is working as expected.

### Tests
* Manual execution of test_ad_integration from local PC and from EC2 instance.
* I see `2022-12-15 17:07:59,685 - INFO - 8978 - test_ad_integration[eu-west-1-c5.xlarge-alinux2-slurm-benchmarks0-SimpleAD-ldaps-True] - conftest - Limiting AllowedIps rule to IP: 52.48.85.144` message when running it in an EC2 instance.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
