### PR TITLE
[develop] [MultiAz] Creates only one NatGateway in vpc_stacks

### DIFF
--- a/tests/integration-tests/network_template_builder.py
+++ b/tests/integration-tests/network_template_builder.py
@@ -123,7 +123,7 @@ class NetworkTemplateBuilder:
         for subnet in self.__vpc_subnets:
             subnet_ref = self.__build_subnet(subnet, self.__vpc, self.__additional_vpc_cidr_blocks)
             subnet_refs.append(subnet_ref)
-            if subnet.has_nat_gateway:
+            if subnet.has_nat_gateway and nat_gateway is None:
                 nat_gateway = self.__build_nat_gateway(subnet, subnet_ref)
 
         for subnet, subnet_ref in zip(self.__vpc_subnets, subnet_refs):


### PR DESCRIPTION
### Description of changes
* Fix a bug in VPC_stacks
  * previously a NatGateway was created for each Public Subnet, but only one was really used 

This change creates only one NatGateway and (as before) shares it with all private subnets, avoiding the creation of unnecessary resources.


### Tests
* Manually verified that previously
  *  a NatGateway was created of reach public subnet
  *  each RoutTable in the private subnets was using the same Nat Gateway 

### References
N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
