### PR TITLE
[fix] failure with AWS Batch when mounting with efs-utils

### DIFF
--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -90,6 +90,8 @@ def test_multiple_efs(
 
     To verify the efs is the existing efs, the test expects a file with random ran inside the efs mounted
     """
+    if scheduler == "awsbatch":
+        return
     # Names of files that will be written from separate instance. The test checks the cluster nodes can access them.
     existing_efs_filenames = []
     existing_efs_mount_dirs = []

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -102,9 +102,9 @@ def test_multiple_efs(
         num_existing_efs = 20
     else:
         num_existing_efs = 3
+    # create an additional EFS with file system policy to prevent anonymous access
+    existing_efs_ids = efs_stack_factory(num_existing_efs)
     if scheduler != "awsbatch":
-        # create an additional EFS with file system policy to prevent anonymous access
-        existing_efs_ids = efs_stack_factory(num_existing_efs)
         account_id = (
             boto3.client("sts", region_name=region, endpoint_url=get_sts_endpoint(region))
             .get_caller_identity()

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -90,8 +90,6 @@ def test_multiple_efs(
 
     To verify the efs is the existing efs, the test expects a file with random ran inside the efs mounted
     """
-    if scheduler == "awsbatch":
-        return
     # Names of files that will be written from separate instance. The test checks the cluster nodes can access them.
     existing_efs_filenames = []
     existing_efs_mount_dirs = []

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -95,8 +95,8 @@ def test_multiple_efs(
     # Names of files that will be written from separate instance. The test checks the cluster nodes can access them.
     existing_efs_filenames = []
     existing_efs_mount_dirs = []
-    iam_authorizations = [False, False, True] if scheduler != "awsbatch" else 3*[False]
-    encryption_in_transits = [False, True, True] if scheduler != "awsbatch" else 3*[False]
+    iam_authorizations = [False, False, True] if scheduler != "awsbatch" else 3 * [False]
+    encryption_in_transits = [False, True, True] if scheduler != "awsbatch" else 3 * [False]
     if request.config.getoption("benchmarks") and os == "alinux2":
         # Only create more EFS when benchmarks are specified. Limiting OS to reduce cost of too many file systems
         num_existing_efs = 20

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -129,7 +129,7 @@ def test_multiple_efs(
                 }
             ],
         }
-    boto3.client("efs").put_file_system_policy(FileSystemId=existing_efs_ids[-1], Policy=json.dumps(policy))
+        boto3.client("efs").put_file_system_policy(FileSystemId=existing_efs_ids[-1], Policy=json.dumps(policy))
     efs_mount_target_stack_factory(existing_efs_ids)
     existing_efs_filenames.extend(
         write_file_into_efs(


### PR DESCRIPTION
### Description of changes
* fix failure with AWS Batch when mounting with efs-utils

### Tests
* passed test_efs.py::test_multiple_efs with awsbatch

### References
* https://github.com/aws/aws-parallelcluster/pull/4668

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
