### PR TITLE
[release-3.4] Ensure subnets in VPC stack are in different AZ when at least two are available

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -976,15 +976,18 @@ def vpc_stacks(cfn_stacks_factory, request):
             az_id_to_az_name = get_az_id_to_az_name_map(region, credential)
             az_names = [az_id_to_az_name.get(az_id) for az_id in az_ids_for_region]
             # if only one AZ can be used for the given region, use it multiple times
-            if len(az_names) <= 2:
-                az_names *= 3
-            availability_zones = random.sample(az_names, k=3)
+            if len(az_names) == 1:
+                availability_zones = az_names * 3
+            if len(az_names) == 2:
+                # ensures that az[0] and az[1] are always different if two az are available for use
+                availability_zones = az_names + random.sample(az_names, k=1)
         # otherwise, select a subset of all AZs in the region
         else:
             az_list = get_availability_zones(region, credential)
-            # if number of available zones is smaller than 2, available zones should be [None, None]
+            # if number of available zones is smaller than 3, list is expanded to 3 and filled with [None, ...]
             if len(az_list) < 3:
-                availability_zones = [None, None, None]
+                diff = 3 - len(az_list)
+                availability_zones = az_list + [None] * diff
             else:
                 availability_zones = random.sample(az_list, k=3)
 


### PR DESCRIPTION
### Description of changes
Subnets in vpc_stacks are assigned to AZ that are picked from a list. When there are overrides the limit the number of available AZ, the element in the list may be duplicated.
This change ensure that the first two element of the list are always different if at least two AZ are available in the region.

Signed-off-by: Nicola Sirena <nssirena@amazon.it>

### Tests
* Manually launched some test that were previously failing.

### References
N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
