### PR TITLE
develop: Remove SSH password authentication from the AD Domain Admin node

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -156,12 +156,6 @@ Resources:
                 grep fallback_homedir "$SSSD_CONFIG_PATH"
                 systemctl restart sssd
 
-                # Configure SSHD
-                # SSHD: enable password auth
-                sed -ri 's/\s*PasswordAuthentication\s+no$/PasswordAuthentication yes/g' /etc/ssh/sshd_config
-                grep -E '\s*PasswordAuthentication\s+yes' "$SSHD_CONFIG_PATH"
-                systemctl restart sshd
-
                 # Script to add a number of users
                 cat << EOF > /usr/local/bin/add_a_number_of_users.sh
                 #!/bin/bash


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
