### PR TITLE
[release-3.4] Moves back some tests to single-az configuration

### DIFF
--- a/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/pcluster.config.yaml
@@ -26,4 +26,3 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
-          - {{ public_az2_subnet_id }}

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_scaling/pcluster.config.yaml
@@ -20,9 +20,6 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
-          {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
-          {% endif %}
       ComputeResources:
         - Name: dummy-1
           {% if scheduler == "plugin" %}
@@ -43,9 +40,6 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
-          {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
-          {% endif %}
       ComputeResources:
         - Name: dummy-2
           {% if scheduler == "plugin" %}


### PR DESCRIPTION
### Description of changes
* multiple_job_submission and
*slurm_scaling
must run on regions with constraints on the number of AZ available so they are not compatible with a multi-az configuration

This change restore their original single-az configuration.

### Tests
* Verified failures in regions with constrained number of AZ.
* New changes restore the previously working single-ax config.

### References
N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
