### PR TITLE
[3.x] Avoid calling validators for each compute resource

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2648,6 +2648,13 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
         checked_images = []
         for queue in self.scheduling.queues:
             queue_image = self.image_dict[queue.name]
+            self._register_validator(
+                ComputeResourceLaunchTemplateValidator,
+                queue=queue,
+                ami_id=queue_image,
+                os=self.image.os,
+                tags=self.get_cluster_tags(),
+            )
             ami_volume_size = AWSApi.instance().ec2.describe_image(queue_image).volume_size
             root_volume = queue.compute_settings.local_storage.root_volume
             root_volume_size = root_volume.size
@@ -2671,14 +2678,6 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                 checked_images.append(queue_image)
                 self._register_validator(AmiOsCompatibleValidator, os=self.image.os, image_id=queue_image)
             for compute_resource in queue.compute_resources:
-                self._register_validator(
-                    ComputeResourceLaunchTemplateValidator,
-                    queue=queue,
-                    compute_resource=compute_resource,
-                    ami_id=queue_image,
-                    os=self.image.os,
-                    tags=self.get_cluster_tags(),
-                )
                 for instance_type in compute_resource.instance_types:
                     self._register_validator(
                         InstanceTypeBaseAMICompatibleValidator,


### PR DESCRIPTION
Signed-off-by: Edoardo Antonini <eantonin@amazon.com>


### Description of changes
* Avoid calling validators for each compute resource as this do not scale
* We'll call validate only the first compute resource Placement group as we are doing with with the compute resource itself

### Tests
* Verified the correct number of run-instances validators is called (10 and not 40 with 10 queues and 40 compute resources)

### References
* The error was coming from https://github.com/aws/aws-parallelcluster/pull/4621
* PR for 3.4 branch https://github.com/aws/aws-parallelcluster/pull/4722

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
