### PR TITLE
develop: Permit SSH access from the bastion in tests using it

### DIFF
--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -44,7 +44,8 @@ def test_cluster_in_private_subnet(
 ):
     # This test just creates a cluster in the private subnet and just checks that no failures occur
     fsx_mount_dir = "/fsx_mount"
-    cluster_config = pcluster_config_reader(fsx_mount_dir=fsx_mount_dir)
+    bastion_ip = bastion_instance.split("@")[1]  # bastion_instance has a value like: ec2-user@52.81.238.68
+    cluster_config = pcluster_config_reader(fsx_mount_dir=fsx_mount_dir, bastion_ip=bastion_ip)
     cluster = clusters_factory(cluster_config)
     assert_that(cluster).is_not_none()
 
@@ -130,9 +131,13 @@ def test_cluster_in_no_internet_subnet(
     bucket_name = s3_bucket_factory()
     _upload_pre_install_script(bucket_name, test_datadir)
 
+    bastion_ip = bastion_instance.split("@")[1]  # bastion_instance has a value like: ec2-user@52.81.238.68
     vpc_default_security_group_id = get_default_vpc_security_group(vpc_stack.cfn_outputs["VpcId"], region)
     cluster_config = pcluster_config_reader(
-        vpc_default_security_group_id=vpc_default_security_group_id, bucket_name=bucket_name, architecture=architecture
+        vpc_default_security_group_id=vpc_default_security_group_id,
+        bucket_name=bucket_name,
+        architecture=architecture,
+        bastion_ip=bastion_ip,
     )
     cluster = clusters_factory(cluster_config)
 

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
@@ -8,6 +8,7 @@ HeadNode:
       - {{ vpc_default_security_group_id }}
   Ssh:
     KeyName: {{ key_name }}
+    AllowedIps: {{ bastion_ip }}/32
   Imds:
     Secured: {{ imds_secured }}
   CustomActions:

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
@@ -6,6 +6,7 @@ HeadNode:
     SubnetId: {{ private_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+    AllowedIps: {{ bastion_ip }}/32
   Imds:
     Secured: {{ imds_secured }}
 Scheduling:


### PR DESCRIPTION
### Description of changes
The access is by default limited to the instance launching the tests only. With this patch we're permitting the bastion IP to access by SSH to the head node.

### Tests
Executing the `test_cluster_in_private_subnet` and `test_cluster_in_no_internet_subnet` tests locally I can see in the pytest output:
```
Bastion_ip: 54.194.132.217
```

Then in the cluster config of the integ tests cluster:
```
    AllowedIps: 54.194.132.217/32
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
