### PR TITLE
develop: Do not check for EFA support when there is no selected instance type

### DIFF
--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -240,7 +240,9 @@ def standard_queue_prompts(scheduler, instance, region, size=""):
         PROMPTS["compute_instance_type"](resource=1, queue_name="myqueue", instance=instance),
     ]
 
-    is_efa_supported = get_instance_info(instance, region).get("NetworkInfo", {}).get("EfaSupported", False)
+    is_efa_supported = False
+    if instance:
+        is_efa_supported = get_instance_info(instance, region).get("NetworkInfo", {}).get("EfaSupported", False)
     if is_efa_supported:
         queue_prompts.append(PROMPTS["enable_efa"]("y"))
 


### PR DESCRIPTION
### Description of changes
The previous code was working when using an instance with and without EFA support but wasn't considering the case on which the instance is empty, when we want to test with default values.

### References
* Issue introduced with: https://github.com/aws/aws-parallelcluster/pull/4687

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
