### PR TITLE
[3.x] Add logs to better identify the timing of the different phases of create-cluster calls

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -359,21 +359,23 @@ class Cluster:
                 validator_suppressors, validation_failure_level
             )
 
+            LOGGER.info("Generating artifact dir and uploading config...")
             self._add_tags()
             self._generate_artifact_dir()
             artifact_dir_generated = True
             self._upload_config()
+            LOGGER.info("Generation and upload completed successfully")
 
             # Create template if not provided by the user
             if not (self.config.dev_settings and self.config.dev_settings.cluster_template):
-                LOGGER.info("Generating CDK template...")
                 self.template_body = CDKTemplateBuilder().build_cluster_template(
                     cluster_config=self.config, bucket=self.bucket, stack_name=self.stack_name
                 )
-                LOGGER.info("CDK template generated correctly.")
 
+            LOGGER.info("Uploading cluster artifacts...")
             # upload cluster artifacts and generated template
             self._upload_artifacts()
+            LOGGER.info("Upload of cluster artifacts completed successfully")
 
             LOGGER.info("Creating stack named: %s", self.stack_name)
             creation_result = AWSApi.instance().cfn.create_stack_from_url(

--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -8,10 +8,11 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-
 #
 # This module contains all the classes required to convert a Cluster into a CFN template by using CDK.
 #
+
+import logging
 import os
 import tempfile
 
@@ -19,6 +20,8 @@ from pcluster.config.cluster_config import BaseClusterConfig
 from pcluster.config.imagebuilder_config import ImageBuilderConfig
 from pcluster.models.s3_bucket import S3Bucket
 from pcluster.utils import load_yaml_dict
+
+LOGGER = logging.getLogger(__name__)
 
 
 class CDKTemplateBuilder:
@@ -29,16 +32,20 @@ class CDKTemplateBuilder:
         cluster_config: BaseClusterConfig, bucket: S3Bucket, stack_name: str, log_group_name: str = None
     ):
         """Build template for the given cluster and return as output in Yaml format."""
+        LOGGER.info("Importing CDK...")
         from aws_cdk.core import App  # pylint: disable=C0415
 
         from pcluster.templates.cluster_stack import ClusterCdkStack  # pylint: disable=C0415
 
+        LOGGER.info("CDK import completed successfully")
+        LOGGER.info("Starting CDK template generation...")
         with tempfile.TemporaryDirectory() as tempdir:
             output_file = str(stack_name)
             app = App(outdir=str(tempdir))
             ClusterCdkStack(app, output_file, stack_name, cluster_config, bucket, log_group_name)
             app.synth()
             generated_template = load_yaml_dict(os.path.join(tempdir, f"{output_file}.template.json"))
+        LOGGER.info("CDK template generation completed successfully")
 
         return generated_template
 


### PR DESCRIPTION
Signed-off-by: Edoardo Antonini <eantonin@amazon.com>

### Description of changes
* Just adding logs to better track times, we could use it to better troubleshoot issues

### Tests
* Saw logs on both API and CLI

### References
* Relevant PR adding logs for the same reason (but in different points) https://github.com/aws/aws-parallelcluster/pull/4528

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
