### PR TITLE
[integ-tests] Fix usage of --use-default-iam-credentials flag

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -430,7 +430,7 @@ class ClustersFactory:
                 timeout=7200,
                 raise_on_error=raise_on_error,
                 log_error=log_error,
-                custom_cli_credentials=kwargs.get("custom_cli_credentials"),
+                custom_cli_credentials=cluster.custom_cli_credentials,
             )
             logging.info("create-cluster response: %s", result.stdout)
             response = json.loads(result.stdout)
@@ -481,11 +481,10 @@ class ClustersFactory:
             kwargs["suppress_validators"] = validators_list
 
         for k, val in kwargs.items():
-            if k != "custom_cli_credentials":
-                if isinstance(val, (list, tuple)):
-                    command.extend([f"--{kebab_case(k)}"] + list(map(str, val)))
-                else:
-                    command.extend([f"--{kebab_case(k)}", str(val)])
+            if isinstance(val, (list, tuple)):
+                command.extend([f"--{kebab_case(k)}"] + list(map(str, val)))
+            else:
+                command.extend([f"--{kebab_case(k)}", str(val)])
 
         return command, wait
 

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -373,7 +373,7 @@ def clusters_factory(request, region):
     """
     factory = ClustersFactory(delete_logs_on_success=request.config.getoption("delete_logs_on_success"))
 
-    def _cluster_factory(cluster_config, upper_case_cluster_name=False, **kwargs):
+    def _cluster_factory(cluster_config, upper_case_cluster_name=False, custom_cli_credentials=None, **kwargs):
         cluster_config = _write_config_to_outdir(request, cluster_config, "clusters_configs")
         cluster = Cluster(
             name=request.config.getoption("cluster")
@@ -386,7 +386,7 @@ def clusters_factory(request, region):
             config_file=cluster_config,
             ssh_key=request.config.getoption("key_path"),
             region=region,
-            custom_cli_credentials=kwargs.get("custom_cli_credentials"),
+            custom_cli_credentials=custom_cli_credentials,
         )
         if not request.config.getoption("cluster"):
             cluster.creation_response = factory.create_cluster(cluster, **kwargs)

--- a/tests/integration-tests/framework/credential_providers.py
+++ b/tests/integration-tests/framework/credential_providers.py
@@ -23,7 +23,7 @@ def register_cli_credentials_for_region(region, iam_role):
     cli_credentials[region] = iam_role
 
 
-def run_pcluster_command(*args, **kwargs):
+def run_pcluster_command(*args, custom_cli_credentials=None, **kwargs):
     """Run a command after assuming the role configured through register_cli_credentials_for_region."""
 
     region = kwargs.get("region")
@@ -31,10 +31,7 @@ def run_pcluster_command(*args, **kwargs):
         region = os.environ["AWS_DEFAULT_REGION"]
 
     if region in cli_credentials:
-        with sts_credential_provider(
-            region, credential_arn=kwargs.get("custom_cli_credentials") or cli_credentials.get(region)
-        ):
-            kwargs.pop("custom_cli_credentials", None)
+        with sts_credential_provider(region, credential_arn=custom_cli_credentials or cli_credentials.get(region)):
             return run_command(*args, **kwargs)
     else:
         return run_command(*args, **kwargs)


### PR DESCRIPTION
### Description of changes
PR https://github.com/aws/aws-parallelcluster/pull/4652 was breaking the usage of `--use-default-iam-credentials` because the `custom_cli_credentials` param was being passed as a kwarg to the pcluster command. 

As part of the fix I made the custom_cli_credentials an explicit argument assuming that generics kwargs are being used to propagate custom args to the pcluster commands. In this case this is a known argument we want to handle as part of the framework, therefore making it explicit with a default.

### Tests
* Locally executed tests with and without the --use-default-iam-credentials flag

### References
* https://github.com/aws/aws-parallelcluster/pull/4652

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
