### PR TITLE
[IntegTests] Shared Storage: Set correct number of external OpenZFS Volumes to be created

### DIFF
--- a/tests/integration-tests/tests/storage/test_fsx_lustre.py
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre.py
@@ -294,7 +294,7 @@ def test_multiple_fsx(
     )
     fsx_on_tap_volume_ids = _create_fsx_on_tap_volume_ids(num_existing_fsx_ontap_volumes, fsx_factory, svm_factory)
     fsx_open_zfs_volume_ids = _create_fsx_open_zfs_volume_ids(
-        num_existing_fsx_ontap_volumes, fsx_factory, open_zfs_volume_factory
+        num_existing_fsx_open_zfs_volumes, fsx_factory, open_zfs_volume_factory
     )
 
     cluster_config = pcluster_config_reader(


### PR DESCRIPTION
### Description of changes
* This PR introduced changes which set an incorrect number of external OpenZFS volumes to be created: #4694 
* This commit restores the correct number of external OpenZFS volumes to be created

### Tests
* N/A

### References
* #4694 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
