### PR TITLE
[Iam] Change update policy for cluster Iam section from SUPPORTED to IGNORED so that the update policy depends on the nested fields.

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1981,7 +1981,7 @@ class ClusterSchema(BaseSchema):
     tags = fields.Nested(
         TagSchema, many=True, metadata={"update_policy": UpdatePolicy.UNSUPPORTED, "update_key": "Key"}
     )
-    iam = fields.Nested(ClusterIamSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    iam = fields.Nested(ClusterIamSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
     directory_service = fields.Nested(
         DirectoryServiceSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP}
     )


### PR DESCRIPTION
### Description of changes
Change update policy for cluster Iam section from SUPPORTED to IGNORED so that the update policy depends on the nested fields. In fact, some of them are updatable and some others are not.
This change is part of the ResourcePrefix feature as ResourcePrefix is the first not updatable field in Iam section.

##### Important Notes
Additional unit tests should be added to cover this change and protect it from future regressions.
Such unit tests have been intentionally considered out of scope of this PR as per internal team agreement and will be implemented in an immediate follow up activity.

### Tests
Manual tests:
1. [OK] ResourcePrefix specified => Iam section cannot be removed
1. [OK] Iam section omitted => Iam.ResourcePrefix cannot be added
1. [OK] Iam section omitted => Iam.PermissionsBoundary and Iam.Roles.LambdaFunctionsRole can be added
1. [OK] Iam.PermissionsBoundary and Iam.Roles.LambdaFunctionsRole specified => Iam section can be removed
Existing unit tests to verify no regression has been introduced.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
