### PR TITLE
Scheduler plugin test fixes

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -26,6 +26,7 @@ arm_pl:
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: {{ common.OSS_COMMERCIAL_ARM }}
         schedulers: ["slurm"]
+{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
 scheduler_plugin:
   test_scheduler_plugin.py::test_scheduler_plugin_integration:
     dimensions:
@@ -37,6 +38,7 @@ scheduler_plugin:
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: {{ common.OSS_COMMERCIAL_ARM }}
         schedulers: ["plugin"]
+{%- endif %}
 cfn-init:
   test_cfn_init.py::test_replace_compute_on_failure:
     dimensions:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
@@ -257,7 +257,7 @@ def _wait_instance_running(ec2_client, instance_ids):
     )
 
 
-@retry(wait_fixed=seconds(10), stop_max_delay=minutes(3))
+@retry(wait_fixed=seconds(10), stop_max_delay=minutes(5))
 def _wait_compute_cloudinit_done(command_executor, compute_node):
     """Wait till cloud-init complete on a given compute node"""
     compute_node_private_ip = compute_node.get("privateIpAddress")


### PR DESCRIPTION
### Description of changes
* Disabled scheduler plugin tests in released config since the feature is not publicly available
* Increased the timeout in the scheduler plugin test so that it does not fail if a node is slow at bootstrap time. We will have a dedicated test case for this.

### Tests
* `python -m test_runner --reports html junitxml json --tests-config configs/develop.yaml --sequential -n 1 --dry-run`
* `python -m test_runner --reports html junitxml json --tests-config configs/released.yaml --sequential -n 1 --dry-run`

### References
* https://github.com/aws/aws-parallelcluster/pull/4290

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
