### PR TITLE
[Fix] Passing the expected cluster stack scope to apply permissions boundary to the cluster.

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -142,7 +142,7 @@ class ClusterCdkStack:
         self._add_outputs()
 
         try:
-            apply_permissions_boundary(cluster_config.iam.permissions_boundary, self)
+            apply_permissions_boundary(cluster_config.iam.permissions_boundary, self.stack)
         except AttributeError:
             pass
 

--- a/cli/tests/pcluster/templates/test_iam.py
+++ b/cli/tests/pcluster/templates/test_iam.py
@@ -1,0 +1,43 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.schemas.cluster_schema import ClusterSchema
+from pcluster.templates.cdk_builder import CDKTemplateBuilder
+from pcluster.utils import load_yaml_dict
+from tests.pcluster.aws.dummy_aws_api import mock_aws_api
+from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket
+from tests.pcluster.utils import get_resources
+
+
+@pytest.mark.parametrize(
+    "config_file_name,permissions_boundary",
+    [
+        ("config.yaml", "arn:aws:iam:123456789:policy/APolicy"),
+    ],
+)
+def test_iam_permissions_boundary(mocker, test_datadir, config_file_name, permissions_boundary):
+    mock_aws_api(mocker)
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    role_head_node = get_resources(generated_template, type="AWS::IAM::Role", name="RoleHeadNode").get("RoleHeadNode")
+
+    assert_that(role_head_node).is_not_none()
+    assert_that(role_head_node["Properties"]["PermissionsBoundary"]).is_equal_to(permissions_boundary)

--- a/cli/tests/pcluster/templates/test_iam/test_iam_permissions_boundary/config.yaml
+++ b/cli/tests/pcluster/templates/test_iam/test_iam_permissions_boundary/config.yaml
@@ -1,0 +1,18 @@
+Image:
+  Os: alinux2
+Iam:
+  PermissionsBoundary: "arn:aws:iam:123456789:policy/APolicy"
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge


### PR DESCRIPTION
### Description of changes
1. Fix the cluster stack scope passed to apply the permissions boundary to the cluster;
2. Add a new unit test to cover the fixed flow;

#### User Experience
The change fixes a failing path that is triggered whenever a user attempts to create/update a cluster applying a permissions boundary. For example, without this change, the following configuration:

```
...
Iam:
  PermissionsBoundary: "arn:aws:iam::REDACTED:policy/AdminPermissionsBoundary"
...
```

would trigger the following customer facing error:

```
{
  "message": "Cluster update failed.\ntype of argument scope must be constructs.Construct; got pcluster.templates.cluster_stack.ClusterCdkStack instead"
}
```



### Tests
1. Unit tests (existing and the newly added to reproduce the failure we are fixing with this change)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
