### PR TITLE
[Test] Add unit tests covering the generation of cluster stack template. 

### DIFF
--- a/cli/tests/pcluster/templates/test_dev_settings.py
+++ b/cli/tests/pcluster/templates/test_dev_settings.py
@@ -1,0 +1,52 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.schemas.cluster_schema import ClusterSchema
+from pcluster.templates.cdk_builder import CDKTemplateBuilder
+from pcluster.utils import load_yaml_dict
+from tests.pcluster.aws.dummy_aws_api import mock_aws_api
+from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket
+from tests.pcluster.test_utils import flatten
+from tests.pcluster.utils import get_resources
+
+
+@pytest.mark.parametrize(
+    "config_file_name",
+    [
+        ("config.yaml"),
+    ],
+)
+def test_custom_cookbook(mocker, test_datadir, config_file_name):
+    mock_aws_api(mocker)
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    custom_cookbook_policy_head_node = get_resources(
+        generated_template, type="AWS::IAM::Policy", name="CustomCookbookPoliciesHeadNode"
+    ).get("CustomCookbookPoliciesHeadNode")
+
+    assert_that(custom_cookbook_policy_head_node).is_not_none()
+
+    statements = custom_cookbook_policy_head_node["Properties"]["PolicyDocument"]["Statement"]
+    effects = [statement["Effect"] for statement in statements]
+    actions = flatten([statement["Action"] for statement in statements])
+
+    assert_that(effects).contains_only("Allow")
+    assert_that(actions).contains_only("s3:GetObject", "s3:GetBucketLocation")

--- a/cli/tests/pcluster/templates/test_dev_settings/test_custom_cookbook/config.yaml
+++ b/cli/tests/pcluster/templates/test_dev_settings/test_custom_cookbook/config.yaml
@@ -1,0 +1,19 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+DevSettings:
+  Cookbook:
+    ChefCookbook: s3://folder/object

--- a/cli/tests/pcluster/templates/test_shared_storage/test_efs_permissions/config.yaml
+++ b/cli/tests/pcluster/templates/test_shared_storage/test_efs_permissions/config.yaml
@@ -1,0 +1,22 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+SharedStorage:
+  - MountDir: /shared/efs/1
+    Name: shared-efs-1
+    StorageType: Efs
+    EfsSettings:
+      IamAuthorization: True

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -9,6 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 # This module provides unit tests for the functions in the pcluster.utils module."""
+import itertools
 import os
 import time
 
@@ -350,3 +351,7 @@ def test_split_resource_prefix(resource_prefix, expected_output):
     iam_path_prefix, iam_role_prefix = utils.split_resource_prefix(resource_prefix=resource_prefix)
     assert_that(iam_path_prefix).is_equal_to(expected_output[0])
     assert_that(iam_role_prefix).is_equal_to(expected_output[1])
+
+
+def flatten(array):
+    return list(itertools.chain(array))


### PR DESCRIPTION
### Description of changes
Add unit tests covering the generation of cluster stack template. In particular, to cover: 
1. IAM permissions required by IamAuthentication for EFS shared storage;
2. IAM permissions required by the usage of custom cookbook.

### Tests
* Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
