### PR TITLE
Upgrade Slurm to version 22.05.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ CHANGELOG
   - Libfabric-aws: `libfabric-aws-1.16.1`
   - Rdma-core: `rdma-core-43.0-2`
   - Open MPI: `openmpi40-aws-4.1.4-3`
-- Upgrade Slurm to version 22.05.6.
+- Upgrade Slurm to version 22.05.7.
 
 3.3.1
 -----

--- a/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/attributes/default.rb
+++ b/scheduler_plugins/slurm/artifacts/slurm_plugin_cookbook/attributes/default.rb
@@ -23,9 +23,9 @@ default['pcluster']['instance_types_data_path'] = ENV['PCLUSTER_INSTANCE_TYPES_D
 default['pcluster']['node_type'] = ENV['PCLUSTER_NODE_TYPE']
 default['pcluster']['python_root'] = ENV['PCLUSTER_PYTHON_ROOT']
 
-default['slurm']['version'] = '22-05-6-1'
+default['slurm']['version'] = '22-05-7-1'
 default['slurm']['url'] = "https://github.com/SchedMD/slurm/archive/slurm-#{node['slurm']['version']}.tar.gz"
-default['slurm']['sha1'] = 'bd2fbc4f6fcf41bfce899eaac0d92d9f09996cd3'
+default['slurm']['sha1'] = 'a9208e0d6af8465e417d5a60a6ea82b151b6fc34'
 default['slurm']['user'] = 'slurm-user'
 default['slurm']['group'] = node['slurm']['user']
 default['slurm']['install_dir'] = "#{node['pcluster']['shared_dir']}/slurm"

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1259,7 +1259,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
 def _test_slurm_version(remote_command_executor):
     logging.info("Testing Slurm Version")
     version = remote_command_executor.run_remote_command("sinfo -V").stdout
-    assert_that(version).is_equal_to("slurm 22.05.6")
+    assert_that(version).is_equal_to("slurm 22.05.7")
 
 
 def _test_job_dependencies(slurm_commands, region, stack_name, scaledown_idletime):


### PR DESCRIPTION
### Description of changes
* Upgrade Slurm to version 22.05.7

### Tests
* Tests will be performed in the daily pipelines.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1630
* Slurm Changelog: https://github.com/SchedMD/slurm/blob/slurm-22-05-7-1/NEWS

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
