### PR TITLE
[3.x] Moving tests to IMDSv2

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -154,7 +154,7 @@ createami:
         oss: ["alinux2", "ubuntu2004", "centos7"]
   test_createami.py::test_kernel4_build_image_run_cluster:
     dimensions:
-      - regions: ["ca-central-1"]
+      - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         schedulers: ["awsbatch", "slurm"]
         oss: ["alinux2"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -764,6 +764,7 @@ def _get_default_template_values(vpc_stack, request):
     ):
         default_values["scheduler"] = "plugin"
     default_values["imds_secured"] = default_values.get("scheduler") in SCHEDULERS_SUPPORTING_IMDS_SECURED
+    default_values["imds_support"] = "v2.0"
     default_values["scheduler_prefix"] = {
         "slurm": "Slurm",
         "awsbatch": "AwsBatch",

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/arm_pl/test_arm_pl/test_arm_pl/pcluster.config.yaml
+++ b/tests/integration-tests/tests/arm_pl/test_arm_pl/test_arm_pl/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_install_args_quotes/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_install_args_quotes/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cfn-init/test_cfn_init/test_replace_compute_on_failure/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.with.warnings.yaml
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.with.warnings.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
   CustomAmi: {{ custom_ami}}  # If an AMI without proper tags is provided, it will generate an warning

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands/test_slurm_cli_commands/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_os/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
   CustomAmi: {{ custom_ami }}

--- a/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_wrong_pcluster_version/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
   CustomAmi: {{ custom_ami }}

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image_custom_components/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image_custom_components/image.config.yaml
@@ -1,4 +1,6 @@
 Build:
+  Imds:
+    ImdsSupport: { { imds_support } }
   InstanceType: {{ instance_type }}
   ParentImage: {{ parent_image }}
   Components:

--- a/tests/integration-tests/tests/createami/test_createami/test_build_image_wrong_pcluster_version/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image_wrong_pcluster_version/image.config.yaml
@@ -1,3 +1,5 @@
 Build:
+  Imds:
+    ImdsSupport: { { imds_support } }
   InstanceType: {{ instance_type }}
   ParentImage: {{ parent_image }}

--- a/tests/integration-tests/tests/createami/test_createami/test_invalid_config/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_invalid_config/image.config.yaml
@@ -4,6 +4,8 @@ Image:
         Encrypted: True
 
 Build:
+    Imds:
+        ImdsSupport: { { imds_support } }
     InstanceType: {{ instance }}
     ParentImage: {{ parent_image }}
 

--- a/tests/integration-tests/tests/createami/test_createami/test_invalid_config/warnings.image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_invalid_config/warnings.image.config.yaml
@@ -1,4 +1,6 @@
 Image:
+    Imds:
+        ImdsSupport: { { imds_support } }
     RootVolume:
         Size: 200
         Encrypted: True

--- a/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/pcluster.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_kernel4_build_image_run_cluster/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
   CustomAmi: {{ custom_ami }}

--- a/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dashboard/test_dashboard/test_dashboard/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_configuration/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dcv/test_dcv/test_dcv_with_remote_access/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_hit_disable_hyperthreading/pcluster.config.yaml
+++ b/tests/integration-tests/tests/disable_hyperthreading/test_disable_hyperthreading/test_hit_disable_hyperthreading/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/dns/test_dns/test_existing_hosted_zone/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dns/test_dns/test_existing_hosted_zone/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/dns/test_dns/test_hit_no_cluster_dns_mpi/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dns/test_dns/test_hit_no_cluster_dns_mpi/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/efa/test_fabric/test_fabric/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_fabric/test_fabric/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_policies/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_resource_prefix/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_resource_prefix/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 Iam:

--- a/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_iam_roles/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 Iam:

--- a/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam/test_s3_read_write_resource/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/iam/test_iam_image/test_iam_roles/image.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam_image/test_iam_roles/image.config.yaml
@@ -6,6 +6,8 @@ Image:
         Size: 35
 
 Build:
+    Imds:
+        ImdsSupport: { { imds_support } }
     Iam:
         InstanceProfile: {{ instance_profile }}
         CleanupLambdaRole: {{ lambda_cleanup_role }}

--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_no_internet_subnet/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_existing_eip/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_existing_eip/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pg.config.yaml
+++ b/tests/integration-tests/tests/networking/test_placement_group/test_placement_group/pg.config.yaml
@@ -1,4 +1,6 @@
 Region: us-west-2
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: alinux2
 HeadNode:

--- a/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_additional_sg_and_ssh_from/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_awsbatch/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_awsbatch/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 Tags:

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_awsbatch/pcluster.config.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_awsbatch/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 Tags:

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_cluster_slurm/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_custom_image/image.config.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_custom_image/image.config.yaml
@@ -1,4 +1,6 @@
 Build:
+  Imds:
+    ImdsSupport: { { imds_support } }
   InstanceType: {{ instance }}
   ParentImage: {{ parent_image }}
   UpdateOsPackages:

--- a/tests/integration-tests/tests/performance_tests/test_simple/test_simple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_simple/test_simple/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.yaml
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_awsbatch.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 CustomS3Bucket: {{ resource_bucket }}

--- a/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
+++ b/tests/integration-tests/tests/resource_bucket/test_resource_bucket/test_resource_bucket/pcluster.config_slurm.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 CustomS3Bucket: {{ resource_bucket }}

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_mpi/test_mpi_ssh/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.before_update.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.before_update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch_defaults/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch_defaults/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_error_handling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_error_handling/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.update.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.update.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update_scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update_scheduling.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_overrides/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_overrides/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_pmix/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_pmix/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 CustomS3Bucket: {{ bucket }}

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 CustomS3Bucket: {{ bucket }}

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 CustomS3Bucket: {{ bucket }}

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_scaling/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_update_slurm_reconfigure_race_condition/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_update_slurm_reconfigure_race_condition/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting_disabled_to_enabled_update/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
+++ b/tests/integration-tests/tests/spot/test_spot/test_spot_default/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_deletion_policy/test_retain_on_deletion/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_deletion_policy/test_retain_on_deletion/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single_empty/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_same_az/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster_restore_fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_backup/pcluster_restore_fsx.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_configuration_options/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-managed-fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-managed-fsx.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-unmanaged-fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-unmanaged-fsx.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multiple_fsx/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multiple_fsx/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_fault_tolerance_mode/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_raid/test_raid_performance_mode/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 Tags:

--- a/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/tags/test_tag_propagation/test_tag_propagation/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 Tags:

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/pcluster.config.yaml
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_drain.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_drain.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_rollback.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_rollback.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_create.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_create.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_1.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_1.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_2.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_2.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
   CustomAmi: {{ global_custom_ami }}

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update_drain.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.update_drain.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
   CustomAmi: {{ global_custom_ami }}

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
   CustomAmi: {{ global_custom_ami }}

--- a/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.update_drain_without_running_job.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_queue_parameters_update/pcluster.update_drain_without_running_job.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
   CustomAmi: {{ global_custom_ami }}

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 Tags:

--- a/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_awsbatch/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 Tags:

--- a/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
   CustomAmi: {{ global_custom_ami }}

--- a/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
   CustomAmi: {{ global_custom_ami }}

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.remove.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.remove.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 HeadNode:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 Tags:

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -1,3 +1,5 @@
+Imds:
+  ImdsSupport: {{ imds_support }}
 Image:
   Os: {{ os }}
 Tags:


### PR DESCRIPTION
### Description of changes
* Move all integration tests to IMDSv2 enforcement
* Move `test_kernel4_build_image_run_cluster` test to MXP to have all IMDSv1 test there

### Tests
* Running one of the tests with test-runner (in progress)

### References
* https://github.com/aws/aws-parallelcluster/pull/4747

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
