### PR TITLE
Improve test for dynamic nodes not powering down after cluster update

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -523,6 +523,12 @@ schedulers:
         instances:  {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7", "ubuntu1804"]
         schedulers: ["slurm"]
+  test_slurm.py::test_slurm_reconfigure_race_condition:
+     dimensions:
+      - regions: ["af-south-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: [ "slurm" ]
 spot:
   test_spot.py::test_spot_default:
     dimensions:

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -10,6 +10,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
+import re
 import time
 from datetime import datetime, timezone
 
@@ -484,80 +485,6 @@ def test_scontrol_reboot(
         slurm_commands,
         "queue1-st-t2micro-2",
     )
-
-
-@pytest.mark.usefixtures("region", "os", "instance", "scheduler")
-def test_update_slurm_reconfigure_race_condition(
-    pcluster_config_reader,
-    clusters_factory,
-    test_datadir,
-    scheduler_commands_factory,
-):
-    """
-    Test race condition between restart of slurmctld and scontrol reconfigure.
-
-    In Slurm 21.08 it looks like cloud nodes may not get powered-down after their
-    SuspendTime has expired if a cluster update is performed, which restarts the
-    slurmctld daemon and immediately performs an scontrol reconfigure.
-
-    See https://bugs.schedmd.com/show_bug.cgi?id=13953
-    """
-
-    max_count_cr1 = 10
-    scale_down_idle_time_mins = 5
-
-    cluster_config = pcluster_config_reader(
-        config_file="pcluster.config.yaml",
-        output_file="pcluster.config.initial.yaml",
-        max_count_cr1=max_count_cr1,
-        scale_down_idle_time_mins=scale_down_idle_time_mins,
-    )
-    cluster = clusters_factory(cluster_config)
-    remote_command_executor = RemoteCommandExecutor(cluster)
-    slurm_commands = scheduler_commands_factory(remote_command_executor)
-
-    assert_compute_node_states(slurm_commands, compute_nodes=None, expected_states=["idle~"])
-
-    max_retries = 5
-    for iter in range(1, max_retries + 1):
-
-        job_id_1 = slurm_commands.submit_command_and_assert_job_accepted(
-            submit_command_args={
-                "nodes": 2,
-                "slots": 2,
-                "command": "srun sleep 300",
-                "raise_on_error": False,
-            }
-        )
-        slurm_commands.wait_job_running(job_id_1)
-        nodelist = slurm_commands.get_job_info(job_id_1, field="NodeList")
-        nodes = remote_command_executor.run_remote_command(
-            f"sinfo -N --nodes {nodelist} -h -O NodeHost:100 | sort | uniq"
-        ).stdout.splitlines()
-        nodes = [node.strip() for node in nodes]
-        slurm_commands.cancel_job(job_id_1)
-
-        max_count_cr1 = max_count_cr1 + 3
-
-        updated_config_file = pcluster_config_reader(
-            config_file="pcluster.config.yaml",
-            output_file=f"pcluster.config.iter_{iter}.yaml",
-            max_count_cr1=max_count_cr1,
-            scale_down_idle_time_mins=scale_down_idle_time_mins,
-        )
-        cluster.update(
-            config_file=updated_config_file,
-            wait=True,
-        )
-
-        # Check that nodes get powered down by Slurm.
-        retry(wait_fixed=seconds(30), stop_max_delay=minutes(2 * scale_down_idle_time_mins))(
-            assert_compute_node_states
-        )(
-            scheduler_commands=slurm_commands,
-            compute_nodes=nodes,
-            expected_states=["idle%"],
-        )
 
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
@@ -2024,6 +1951,74 @@ def _test_scontrol_reboot_nodes(
         remote_command_executor,
         ["/var/log/parallelcluster/clustermgtd"],
         ["Found the following unhealthy static nodes"],
+    )
+
+
+@retry(wait_fixed=seconds(10), stop_max_delay=minutes(5))
+def trigger_slurm_reconfigure_race_condition(remote_command_executor):
+    # trigger slurmctld restart and scontrol reconfigure until they are executed in the same timestamp second
+    remote_command_executor.run_remote_command("sudo -i systemctl restart slurmctld && sudo -i scontrol reconfigure")
+    restart_time = _get_latest_timestamp_for_log_entry(
+        remote_command_executor, "/var/log/slurmctld.log", "slurmctld version .* started on cluster"
+    )
+    reconfigure_time = _get_latest_timestamp_for_log_entry(
+        remote_command_executor, "/var/log/slurmctld.log", "_slurm_rpc_reconfigure_controller: completed"
+    )
+    assert_that(restart_time.second).is_equal_to(reconfigure_time.second)
+    assert_that((reconfigure_time - restart_time).total_seconds()).is_less_than_or_equal_to(1.0)
+
+
+def _get_latest_timestamp_for_log_entry(remote_command_executor, log_path, log_entry):
+    log = remote_command_executor.run_remote_command("sudo cat {0}".format(log_path), hide=True).stdout
+    match = re.findall(rf"\[(.+?)\] {log_entry}", log)[-1]
+    return datetime.strptime(match, "%Y-%m-%dT%H:%M:%S.%f")
+
+
+@pytest.mark.usefixtures("region", "os", "instance", "scheduler")
+def test_slurm_reconfigure_race_condition(
+    pcluster_config_reader,
+    clusters_factory,
+    test_datadir,
+    scheduler_commands_factory,
+):
+    """
+    Test race condition between restart of slurmctld and scontrol reconfigure.
+
+    In Slurm 21.08 cloud nodes are not get powered-down after their
+    SuspendTime has expired if a cluster update is performed, which restarts the
+    slurmctld daemon and immediately performs a scontrol reconfigure.
+
+    See https://bugs.schedmd.com/show_bug.cgi?id=13953
+    """
+
+    scale_down_idle_time_mins = 1
+    cluster_config = pcluster_config_reader(
+        config_file="pcluster.config.yaml",
+        scale_down_idle_time_mins=scale_down_idle_time_mins,
+    )
+
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    slurm_commands = scheduler_commands_factory(remote_command_executor)
+
+    trigger_slurm_reconfigure_race_condition(remote_command_executor)
+
+    job_id = slurm_commands.submit_command_and_assert_job_accepted(
+        submit_command_args={
+            "command": "sleep 1",
+            "nodes": 1,
+            "slots": 1,
+        }
+    )
+    slurm_commands.wait_job_completed(job_id)
+    compute_nodes = slurm_commands.get_compute_nodes()
+    # Check that nodes get powered down by Slurm after scale_down_idle_time_mins.
+    wait_for_compute_nodes_states(
+        scheduler_commands=slurm_commands,
+        compute_nodes=compute_nodes,
+        expected_states=["idle~"],
+        wait_fixed_secs=30,
+        stop_max_delay_secs=5 * scale_down_idle_time_mins * 60,
     )
 
 

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_reconfigure_race_condition/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_reconfigure_race_condition/pcluster.config.yaml
@@ -1,0 +1,21 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    ScaledownIdletime: {{ scale_down_idle_time_mins }}
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: compute-resource1
+          InstanceType: {{ instance }}
+          MaxCount: 1


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Improve test for dynamic nodes not powering down after cluster update: 
the new test manually trigger a slurmctld restart and scontrol reconfigure until they are executed in the same timestamp second, so to trigger the issue that was present up to Slurm < 22.05.6

Executed the test with PCluster 3.2.1, which ships Slurm 21.08.8 and got a failure
```
>           assert_that(expected_states).contains(node_states.get(node))
E           AssertionError: Expected <['idle~']> to contain item <idle>, but did not.
```

Executed the test with Slurm 22.05.7 and got no failure

ref. https://bugs.schedmd.com/show_bug.cgi?id=13953

### Tests
* integration tests modified 

### References
* https://bugs.schedmd.com/show_bug.cgi?id=13953

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
