### PR TITLE
[3.x] Add unit tests to increase cluster CFN template test coverage

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -695,6 +695,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
             if capacity_reservation_ids:
                 policy.append(
                     iam.PolicyStatement(
+                        sid="AllowRunningReservedCapacity",
                         actions=["ec2:RunInstances"],
                         effect=iam.Effect.ALLOW,
                         resources=[
@@ -711,6 +712,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                 policy.extend(
                     [
                         iam.PolicyStatement(
+                            sid="AllowManagingReservedCapacity",
                             actions=["ec2:RunInstances", "ec2:CreateFleet", "resource-groups:ListGroupResources"],
                             effect=iam.Effect.ALLOW,
                             resources=capacity_reservation_resource_group_arns,
@@ -749,6 +751,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
         if self._config.directory_service:
             policy.append(
                 iam.PolicyStatement(
+                    sid="AllowGettingDirectorySecretValue",
                     actions=["secretsmanager:GetSecretValue"],
                     effect=iam.Effect.ALLOW,
                     resources=[self._config.directory_service.password_secret_arn],
@@ -758,6 +761,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
         if self._config.scheduling.scheduler == "slurm" and self._config.scheduling.settings.database:
             policy.append(
                 iam.PolicyStatement(
+                    sid="AllowGettingSlurmDbSecretValue",
                     actions=["secretsmanager:GetSecretValue"],
                     effect=iam.Effect.ALLOW,
                     resources=[self._config.scheduling.settings.database.password_secret_arn],

--- a/cli/tests/pcluster/templates/test_additional_packages.py
+++ b/cli/tests/pcluster/templates/test_additional_packages.py
@@ -1,0 +1,66 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.schemas.cluster_schema import ClusterSchema
+from pcluster.templates.cdk_builder import CDKTemplateBuilder
+from pcluster.utils import load_yaml_dict
+from tests.pcluster.aws.dummy_aws_api import mock_aws_api
+from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket
+from tests.pcluster.utils import get_resources
+
+
+@pytest.mark.parametrize(
+    "config_file_name,enabled",
+    [
+        ("config-enabled.yaml", True),
+        ("config-disabled.yaml", False),
+    ],
+)
+def test_intel_hpc_platform(mocker, test_datadir, config_file_name, enabled):
+    mock_aws_api(mocker)
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    for _, template in get_resources(
+        generated_template,
+        type="AWS::EC2::LaunchTemplate",
+        properties={"LaunchTemplateName": "clustername-queue1-compute_resource1"},
+    ).items():
+        tag_specs = template["Properties"]["LaunchTemplateData"]["TagSpecifications"]
+        instance_tags = next(filter(lambda ts: ts["ResourceType"] == "instance", tag_specs), None)
+        assert_that(instance_tags).is_not_none()
+        tag = next(filter(lambda t: t["Key"] == "parallelcluster:intel-hpc", instance_tags["Tags"]), None)
+
+        if enabled:
+            assert_that(tag).is_not_none()
+            assert_that(tag["Value"]).is_equal_to("enable_intel_hpc_platform=true")
+        else:
+            assert_that(tag).is_none()
+
+    for _, template in get_resources(generated_template, type="AWS::EC2::Instance", name="HeadNode").items():
+        tags = template["Properties"]["Tags"]
+        assert_that(tags).is_not_none()
+        tag = next(filter(lambda t: t["Key"] == "parallelcluster:intel-hpc", tags), None)
+
+        if enabled:
+            assert_that(tag).is_not_none()
+            assert_that(tag["Value"]).is_equal_to("enable_intel_hpc_platform=true")
+        else:
+            assert_that(tag).is_none()

--- a/cli/tests/pcluster/templates/test_additional_packages/test_intel_hpc_platform/config-disabled.yaml
+++ b/cli/tests/pcluster/templates/test_additional_packages/test_intel_hpc_platform/config-disabled.yaml
@@ -1,0 +1,16 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge

--- a/cli/tests/pcluster/templates/test_additional_packages/test_intel_hpc_platform/config-enabled.yaml
+++ b/cli/tests/pcluster/templates/test_additional_packages/test_intel_hpc_platform/config-enabled.yaml
@@ -1,0 +1,19 @@
+Image:
+  Os: alinux2
+AdditionalPackages:
+  IntelSoftware:
+    IntelHpcPlatform: True
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge

--- a/cli/tests/pcluster/templates/test_capacity_reservation.py
+++ b/cli/tests/pcluster/templates/test_capacity_reservation.py
@@ -1,0 +1,92 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.schemas.cluster_schema import ClusterSchema
+from pcluster.templates.cdk_builder import CDKTemplateBuilder
+from pcluster.utils import load_yaml_dict
+from tests.pcluster.aws.dummy_aws_api import mock_aws_api
+from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket
+from tests.pcluster.utils import get_head_node_policy, get_statement_by_sid
+
+
+@pytest.mark.parametrize(
+    "config_file_name,",
+    [
+        ("config.yaml"),
+    ],
+)
+def test_capacity_reservation_id_permissions(mocker, test_datadir, config_file_name):
+    mock_aws_api(mocker)
+
+    mocker.patch(
+        "pcluster.aws.ec2.Ec2Client.describe_capacity_reservations",
+        return_value=[
+            {
+                "InstanceType": "c5.xlarge",
+                "AvailabilityZone": "us-east-1a",
+            }
+        ],
+    )
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    head_node_policy = get_head_node_policy(generated_template)
+    statement = get_statement_by_sid(policy=head_node_policy, sid="AllowRunningReservedCapacity")
+    assert_that(statement["Effect"]).is_equal_to("Allow")
+    assert_that(statement["Action"]).is_equal_to("ec2:RunInstances")
+    assert_that(json.dumps(statement["Resource"])).contains("capacity-reservation/cr-12345")
+
+
+@pytest.mark.parametrize(
+    "config_file_name,",
+    [
+        ("config.yaml"),
+    ],
+)
+def test_capacity_reservation_group_arns_permissions(mocker, test_datadir, config_file_name):
+    mock_aws_api(mocker)
+
+    mocker.patch(
+        "pcluster.aws.ec2.Ec2Client.describe_capacity_reservations",
+        return_value=[
+            {
+                "InstanceType": "c5.xlarge",
+                "AvailabilityZone": "us-east-1a",
+            }
+        ],
+    )
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    head_node_policy = get_head_node_policy(generated_template)
+    statement = get_statement_by_sid(policy=head_node_policy, sid="AllowManagingReservedCapacity")
+    assert_that(statement["Effect"]).is_equal_to("Allow")
+    assert_that(statement["Action"]).contains_only(
+        "ec2:RunInstances", "ec2:CreateFleet", "resource-groups:ListGroupResources"
+    )
+    assert_that(statement["Resource"]).is_equal_to("cr-12345")

--- a/cli/tests/pcluster/templates/test_capacity_reservation/test_capacity_reservation_group_arns_permissions/config.yaml
+++ b/cli/tests/pcluster/templates/test_capacity_reservation/test_capacity_reservation_group_arns_permissions/config.yaml
@@ -1,0 +1,18 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      CapacityReservationTarget:
+        CapacityReservationResourceGroupArn: "cr-12345"
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge

--- a/cli/tests/pcluster/templates/test_capacity_reservation/test_capacity_reservation_id_permissions/config.yaml
+++ b/cli/tests/pcluster/templates/test_capacity_reservation/test_capacity_reservation_id_permissions/config.yaml
@@ -1,0 +1,18 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      CapacityReservationTarget:
+        CapacityReservationId: "cr-12345"
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge

--- a/cli/tests/pcluster/templates/test_directory_service/test_head_node_permissions/config.yaml
+++ b/cli/tests/pcluster/templates/test_directory_service/test_head_node_permissions/config.yaml
@@ -1,0 +1,22 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+DirectoryService:
+  DomainName: corp.something.com
+  DomainAddr: ldaps://corp.something.com
+  PasswordSecretArn: arn:aws:secretsmanager:eu-west-1:123456789:secret:a-secret-name
+  DomainReadOnlyUser: cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=something,dc=com
+  LdapTlsCaCert: /path/to/domain-certificate.crt

--- a/cli/tests/pcluster/templates/test_scheduling.py
+++ b/cli/tests/pcluster/templates/test_scheduling.py
@@ -1,0 +1,151 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.schemas.cluster_schema import ClusterSchema
+from pcluster.templates.cdk_builder import CDKTemplateBuilder
+from pcluster.utils import load_yaml_dict
+from tests.pcluster.aws.dummy_aws_api import mock_aws_api
+from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket
+from tests.pcluster.utils import get_head_node_policy, get_resources, get_statement_by_sid
+
+
+@pytest.mark.parametrize(
+    "config_file_name",
+    [
+        ("config.yaml"),
+    ],
+)
+def test_additional_security_groups(mocker, test_datadir, config_file_name):
+    mock_aws_api(mocker)
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    for _, template in get_resources(
+        generated_template,
+        type="AWS::EC2::LaunchTemplate",
+        properties={"LaunchTemplateName": "clustername-queue1-compute_resource1"},
+    ).items():
+        network_interfaces = template["Properties"]["LaunchTemplateData"]["NetworkInterfaces"]
+        network_interface = next(filter(lambda ni: ni["DeviceIndex"] == 0, network_interfaces), None)
+        assert_that(network_interface).is_not_none()
+        assert_that(network_interface["Groups"]).contains_only("sg-12345678", {"Ref": "ComputeSecurityGroup"})
+
+
+@pytest.mark.parametrize(
+    "config_file_name",
+    [
+        ("config.yaml"),
+    ],
+)
+def test_permissions_for_slurm_db_secret(mocker, test_datadir, config_file_name):
+    mock_aws_api(mocker)
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    head_node_policy = get_head_node_policy(generated_template)
+    statement = get_statement_by_sid(policy=head_node_policy, sid="AllowGettingSlurmDbSecretValue")
+    assert_that(statement["Effect"]).is_equal_to("Allow")
+    assert_that(statement["Action"]).is_equal_to("secretsmanager:GetSecretValue")
+    assert_that(statement["Resource"]).is_equal_to("arn:aws:secretsmanager:eu-west-1:123456789:secret:a-secret-name")
+
+
+@pytest.mark.parametrize(
+    "config_file_name",
+    [
+        ("config.yaml"),
+    ],
+)
+def test_head_node_custom_pass_role(mocker, test_datadir, config_file_name):
+    mock_aws_api(mocker)
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    head_node_policy = get_head_node_policy(generated_template)
+    statement = get_statement_by_sid(policy=head_node_policy, sid="PassRole")
+    assert_that(statement["Effect"]).is_equal_to("Allow")
+    assert_that(statement["Action"]).is_equal_to("iam:PassRole")
+    assert_that(statement["Resource"]).is_equal_to("arn:aws:iam::123456789:role/role-name")
+
+
+@pytest.mark.parametrize(
+    "config_file_name",
+    [
+        ("config.yaml"),
+    ],
+)
+def test_head_node_base_pass_role(mocker, test_datadir, config_file_name):
+    mock_aws_api(mocker)
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    head_node_policy = get_head_node_policy(generated_template)
+    statement = get_statement_by_sid(policy=head_node_policy, sid="PassRole")
+    assert_that(statement["Effect"]).is_equal_to("Allow")
+    assert_that(statement["Action"]).is_equal_to("iam:PassRole")
+    assert_that(json.dumps(statement["Resource"])).contains("role/parallelcluster/clustername/*")
+
+
+@pytest.mark.parametrize(
+    "config_file_name",
+    [
+        ("config.yaml"),
+    ],
+)
+def test_head_node_mixed_pass_role(mocker, test_datadir, config_file_name):
+    mock_aws_api(mocker)
+
+    input_yaml = load_yaml_dict(test_datadir / config_file_name)
+
+    cluster_config = ClusterSchema(cluster_name="clustername").load(input_yaml)
+
+    generated_template = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    print(json.dumps(generated_template, sort_keys=True, indent=4))
+
+    head_node_policy = get_head_node_policy(generated_template)
+    statement = get_statement_by_sid(policy=head_node_policy, sid="PassRole")
+    assert_that(statement["Effect"]).is_equal_to("Allow")
+    assert_that(statement["Action"]).is_equal_to("iam:PassRole")
+    resources = statement["Resource"]
+    assert_that(resources).contains("arn:aws:iam::123456789:role/role-name")
+    default_resource = next(filter(lambda r: r != "arn:aws:iam::123456789:role/role-name", resources), None)
+    assert_that(default_resource).is_not_none()
+    assert_that(json.dumps(default_resource)).contains("role/a-prefix/clustername/*")

--- a/cli/tests/pcluster/templates/test_scheduling/test_additional_security_groups/config.yaml
+++ b/cli/tests/pcluster/templates/test_scheduling/test_additional_security_groups/config.yaml
@@ -1,0 +1,18 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+        AdditionalSecurityGroups:
+          - sg-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge

--- a/cli/tests/pcluster/templates/test_scheduling/test_head_node_base_pass_role/config.yaml
+++ b/cli/tests/pcluster/templates/test_scheduling/test_head_node_base_pass_role/config.yaml
@@ -1,0 +1,17 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+

--- a/cli/tests/pcluster/templates/test_scheduling/test_head_node_custom_pass_role/config.yaml
+++ b/cli/tests/pcluster/templates/test_scheduling/test_head_node_custom_pass_role/config.yaml
@@ -1,0 +1,18 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+      Iam:
+        InstanceRole: arn:aws:iam::123456789:role/role-name

--- a/cli/tests/pcluster/templates/test_scheduling/test_head_node_mixed_pass_role/config.yaml
+++ b/cli/tests/pcluster/templates/test_scheduling/test_head_node_mixed_pass_role/config.yaml
@@ -1,0 +1,27 @@
+Image:
+  Os: alinux2
+Iam:
+  ResourcePrefix: "/a-prefix/"
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+      Iam:
+        InstanceRole: arn:aws:iam::123456789:role/role-name
+    - Name: queue2
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource2
+          InstanceType: c5.2xlarge

--- a/cli/tests/pcluster/templates/test_scheduling/test_permissions_for_slurm_db_secret/config.yaml
+++ b/cli/tests/pcluster/templates/test_scheduling/test_permissions_for_slurm_db_secret/config.yaml
@@ -1,0 +1,21 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+  SlurmSettings:
+    Database:
+      Uri: test.example.com:3306
+      UserName: user_name
+      PasswordSecretArn: arn:aws:secretsmanager:eu-west-1:123456789:secret:a-secret-name

--- a/cli/tests/pcluster/templates/test_shared_storage.py
+++ b/cli/tests/pcluster/templates/test_shared_storage.py
@@ -17,7 +17,7 @@ from pcluster.templates.cdk_builder import CDKTemplateBuilder
 from pcluster.utils import load_yaml_dict
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket
-from tests.pcluster.utils import get_resources
+from tests.pcluster.utils import get_head_node_policy, get_resources, get_statement_by_sid
 
 
 @pytest.mark.parametrize(
@@ -219,14 +219,8 @@ def test_efs_permissions(mocker, test_datadir, config_file_name):
         cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
     )
 
-    head_node_policy = get_resources(
-        generated_template, type="AWS::IAM::Policy", name="ParallelClusterPoliciesHeadNode"
-    ).get("ParallelClusterPoliciesHeadNode")
-
-    assert_that(head_node_policy).is_not_none()
-
-    statements = head_node_policy["Properties"]["PolicyDocument"]["Statement"]
-    statement = next(filter(lambda s: s.get("Sid") == "Efs", statements))
+    head_node_policy = get_head_node_policy(generated_template)
+    statement = get_statement_by_sid(policy=head_node_policy, sid="Efs")
 
     assert_that(statement["Effect"]).is_equal_to("Allow")
     assert_that(statement["Action"]).contains_only(

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -9,7 +9,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 # This module provides unit tests for the functions in the pcluster.utils module."""
-import itertools
 import os
 import time
 
@@ -351,7 +350,3 @@ def test_split_resource_prefix(resource_prefix, expected_output):
     iam_path_prefix, iam_role_prefix = utils.split_resource_prefix(resource_prefix=resource_prefix)
     assert_that(iam_path_prefix).is_equal_to(expected_output[0])
     assert_that(iam_role_prefix).is_equal_to(expected_output[1])
-
-
-def flatten(array):
-    return list(itertools.chain(array))

--- a/cli/tests/pcluster/utils.py
+++ b/cli/tests/pcluster/utils.py
@@ -8,6 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import itertools
 import os
 from copy import deepcopy
 
@@ -49,6 +50,27 @@ def get_resources(
             )
         )
     )
+
+
+def get_head_node_policy(template, enforce_not_null=True):
+    policy = get_resources(template, type="AWS::IAM::Policy", name="ParallelClusterPoliciesHeadNode").get(
+        "ParallelClusterPoliciesHeadNode"
+    )
+    if enforce_not_null:
+        assert_that(policy).is_not_none()
+    return policy
+
+
+def get_statement_by_sid(policy, sid, enforce_not_null=True):
+    statements = policy["Properties"]["PolicyDocument"]["Statement"]
+    statement = next(filter(lambda s: s.get("Sid") == sid, statements), None)
+    if enforce_not_null:
+        assert_that(statement).is_not_none()
+    return statement
+
+
+def flatten(array):
+    return list(itertools.chain(array))
 
 
 def assert_lambdas_have_expected_vpc_config_and_managed_policy(generated_template, expected_vpc_config):


### PR DESCRIPTION
In order to facilitate unit testing, sids have been added to production code.


### Description of changes
Add unit tests for CloudFormation template generation code parts which were not covered.
Also, in order to enable testing sids have been added to production code.

### Tests
* Existing and added unit tests
* Since I didn't find any official documentation on Sid max length, I manually created a cluster using a sid which was longer than any of the newly introduced ones.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
