### PR TITLE
[IntegTests] Fix fetching order of build-image events when logging

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -553,5 +553,5 @@ def _test_build_image_failed(image):
 def _keep_recent_logs(image):
     """Keep several lines of recent log to the console when creating an image fails."""
     log_stream_name = f"{get_installed_parallelcluster_base_version()}/1"
-    failure_logs = image.get_log_events(log_stream_name, start_from_head=True, query="events[*].message", limit=100)
+    failure_logs = image.get_log_events(log_stream_name, start_from_head=False, query="events[*]", limit=100)
     logging.info(f"Image built failed for {image.image_id}, the last 100 lines of the log are: {failure_logs}")


### PR DESCRIPTION
### Description of changes
- Currently build image events are fetched from the earliest event (start-from-head = true). This does not return the most recent logs.
- This commit sets the start-from-head argument to False, ensuring that the events are fetched from the tail/most recent.
- [get-image-log-events-v3](https://docs.aws.amazon.com/parallelcluster/latest/ug/pcluster.get-image-log-events-v3.html)

```
--start-from-head START_FROM_HEAD
If the value is true, the earliest log events are returned first. If the value is false, the most recent log events are returned first. (Defaults to false.)
```

### Tests
With start-from-head set to `false`

```
» pcluster get-image-log-events --image-id "..." --log-stream-name 3.3.1/1 --start-from-head false --limit 2 --query "events[*].timestamp"
[
  "2022-12-22T12:41:05.355Z",
  "2022-12-22T12:41:05.358Z"
]
```

With start-from-head set to `true`

```
» pcluster get-image-log-events --image-id "..." --log-stream-name 3.3.1/1 --start-from-head true --limit 2 --query "events[*].timestamp"
[
  "2022-12-22T11:51:00.644Z",
  "2022-12-22T11:51:01.374Z"
]
```

### References
* [get-image-log-events-v3](https://docs.aws.amazon.com/parallelcluster/latest/ug/pcluster.get-image-log-events-v3.html)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
