### PR TITLE
[integ-tests-3.4.0] Moving IMDSv1 test in MXP

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -154,7 +154,7 @@ createami:
         oss: ["alinux2", "ubuntu2004", "centos7"]
   test_createami.py::test_kernel4_build_image_run_cluster:
     dimensions:
-      - regions: ["ca-central-1"]
+      - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         schedulers: ["awsbatch", "slurm"]
         oss: ["alinux2"]


### PR DESCRIPTION
### Description of changes
* Move `test_kernel4_build_image_run_cluster` test to MXP to have all IMDSv1 test there

### Tests
* Running one of the tests with test-runner

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
