### PR TITLE
Move security exclusion from .bandit.ini to the corresponding code line

### DIFF
--- a/awsbatch-cli/.bandit.ini
+++ b/awsbatch-cli/.bandit.ini
@@ -1,5 +1,1 @@
-# B105 checks for potentially hard-coded passwords/API tokens.
-# It's disabled because it seems to have a high rate of false failures.
-# B404 checks for imports of the subprocess module.
-# It's disabled because we make use of that module.
-skips: ['B105', 'B404']
+skips: []

--- a/awsbatch-cli/.isort.cfg
+++ b/awsbatch-cli/.isort.cfg
@@ -10,3 +10,4 @@ known_third_party=boto3,botocore,awscli,tabulate,argparse,configparser,pytest,py
 # )
 multi_line_output=3
 include_trailing_comma=true
+profile=black

--- a/cli/.bandit.ini
+++ b/cli/.bandit.ini
@@ -1,5 +1,1 @@
-# B105 checks for potentially hard-coded passwords/API tokens.
-# It's disabled because it seems to have a high rate of false failures.
-# B404 checks for imports of the subprocess module.
-# It's disabled because we make use of that module.
-skips: ['B105', 'B404']
+skips: []

--- a/cli/.isort.cfg
+++ b/cli/.isort.cfg
@@ -11,3 +11,4 @@ known_third_party=boto3,botocore,awscli,tabulate,argparse,configparser,pytest,py
 multi_line_output=3
 include_trailing_comma=true
 skip=pcluster/resources/custom_resources/custom_resources_code/crhelper
+profile=black

--- a/cli/src/pcluster/api/util.py
+++ b/cli/src/pcluster/api/util.py
@@ -11,7 +11,10 @@
 import datetime
 import logging
 import shutil
-import subprocess
+
+# A nosec comment is appended to the following line in order to disable the B404 check.
+# In this file the input of the module subprocess is trusted.
+import subprocess  # nosec B404
 
 import six
 from pkg_resources import packaging

--- a/cli/src/pcluster/cli/commands/dcv_connect.py
+++ b/cli/src/pcluster/cli/commands/dcv_connect.py
@@ -10,7 +10,10 @@
 # limitations under the License.
 import logging
 import re
-import subprocess as sub
+
+# A nosec comment is appended to the following line in order to disable the B404 check.
+# In this file the input of the module subprocess is trusted.
+import subprocess as sub  # nosec B404
 import time
 import webbrowser
 from typing import List


### PR DESCRIPTION
### Description of changes
* Move security exclusion from .bandit.ini to the corresponding code line. This change aims to avoid global security exclusions.
* The security exclusions added by this PR will be assessed as part of another PR.
* Added the label skip-security-exclusions-check since now the checks are more precise.
* Also added `profile=black` in isort.cfg to avoid clashing between isort and black8


Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
