### PR TITLE
Validate cluster name length with Slurm accounting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ CHANGELOG
 3.5.0
 -----
 
+**ENHANCEMENTS**
+
+**CHANGES**
+
+**BUG FIXES**
+- Add check in the validators to verify that the cluster name is not longer than 40 characters when Slurm accounting is enabled.
+
 3.4.0
 -----
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1264,7 +1264,7 @@ class BaseClusterConfig(Resource):
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(RegionValidator, region=self.region)
-        self._register_validator(ClusterNameValidator, name=self.cluster_name)
+        self._register_validator(ClusterNameValidator, name=self.cluster_name, scheduling=self.scheduling)
         self._register_validator(
             ArchitectureOsValidator,
             os=self.image.os,

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -12,6 +12,10 @@
 from pkg_resources import packaging
 
 PCLUSTER_NAME_MAX_LENGTH = 60
+# When Slurm accounting is enabled, Slurm creates database tables with the format 'cluster_name' + 'suffix'.
+# MySQL and MariaDB have a maximum table name length of 64 characters.
+# The longest suffix used by Slurm is 24 chars, therefore the cluster name must be at most 40 chars long.
+PCLUSTER_NAME_MAX_LENGTH_SLURM_ACCOUNTING = 40
 PCLUSTER_NAME_REGEX = r"^([a-zA-Z][a-zA-Z0-9-]{0,%d})$"
 PCLUSTER_ISSUES_LINK = "https://github.com/aws/aws-parallelcluster/issues"
 

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -26,6 +26,7 @@ from pcluster.constants import (
     FSX_PORTS,
     PCLUSTER_IMAGE_BUILD_STATUS_TAG,
     PCLUSTER_NAME_MAX_LENGTH,
+    PCLUSTER_NAME_MAX_LENGTH_SLURM_ACCOUNTING,
     PCLUSTER_NAME_REGEX,
     PCLUSTER_TAG_VALUE_REGEX,
     PCLUSTER_VERSION_TAG,
@@ -84,16 +85,29 @@ CLUSTER_NAME_AND_CUSTOM_DOMAIN_NAME_MAX_LENGTH = 255 - HOST_NAME_MAX_LENGTH - 1
 class ClusterNameValidator(Validator):
     """Cluster name validator."""
 
-    def _validate(self, name):
-        if not re.match(PCLUSTER_NAME_REGEX % (PCLUSTER_NAME_MAX_LENGTH - 1), name):
-            self._add_failure(
-                (
-                    "Error: The cluster name can contain only alphanumeric characters (case-sensitive) and hyphens. "
-                    "It must start with an alphabetic character and can't be longer "
-                    f"than {PCLUSTER_NAME_MAX_LENGTH} characters."
-                ),
-                FailureLevel.ERROR,
-            )
+    def _validate(self, name, scheduling):
+        if scheduling.scheduler == "slurm" and scheduling.settings.database is not None:
+            if not re.match(PCLUSTER_NAME_REGEX % (PCLUSTER_NAME_MAX_LENGTH_SLURM_ACCOUNTING - 1), name):
+                self._add_failure(
+                    (
+                        "Error: The cluster name can contain only alphanumeric characters (case-sensitive) and "
+                        "hyphens. "
+                        "It must start with an alphabetic character and when using Slurm accounting it can't be longer "
+                        f"than {PCLUSTER_NAME_MAX_LENGTH_SLURM_ACCOUNTING} characters."
+                    ),
+                    FailureLevel.ERROR,
+                )
+        else:
+            if not re.match(PCLUSTER_NAME_REGEX % (PCLUSTER_NAME_MAX_LENGTH - 1), name):
+                self._add_failure(
+                    (
+                        "Error: The cluster name can contain only alphanumeric characters (case-sensitive) and "
+                        "hyphens. "
+                        "It must start with an alphabetic character and can't be longer "
+                        f"than {PCLUSTER_NAME_MAX_LENGTH} characters."
+                    ),
+                    FailureLevel.ERROR,
+                )
 
 
 class RegionValidator(Validator):


### PR DESCRIPTION


### Description of changes
* Add condition to the ClusterNameValidator to check that the cluster name is not longer than 40 chars.
  * When enabling Slurm accounting, Slurm creates database tables with a name equal to "cluster_name" + "suffix". MySQL and MariaDB have a maximum table name length of 64 chars. The maximum suffix length used by Slurm is 24 chars. Therefore, when Slurm accounting is enabled the cluster name must not be longer than 40 chars.


### Tests
* Add new unit test for ClusterNameValidator.
* Manually run `pcluster create-cluster --dryrun true` with different combinations of cluster name and Slurm accounting configuration (i.e. configured vs not configured).

### References
* The [public documentation](https://docs.aws.amazon.com/parallelcluster/latest/ug/pcluster.create-cluster-v3.html#pcluster-v3.create-cluster.namedargs) already includes the relevant information for the `--cluster-name` option.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
