### PR TITLE
[3.x] Pre-import cdk libraries at the beginning of cluster create and update

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -66,6 +66,7 @@ from pcluster.models.compute_fleet_status_manager import ComputeFleetStatus, Com
 from pcluster.models.s3_bucket import S3Bucket, S3BucketFactory, S3FileFormat, create_s3_presigned_url, parse_bucket_url
 from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
+from pcluster.templates.import_cdk import start as start_cdk_import
 from pcluster.utils import (
     datetime_to_epoch,
     generate_random_name_with_prefix,
@@ -352,6 +353,7 @@ class Cluster:
         raises ClusterActionError: in case of generic error
         raises ConfigValidationError: if configuration is invalid
         """
+        start_cdk_import()
         creation_result = None
         artifact_dir_generated = False
         try:
@@ -887,6 +889,7 @@ class Cluster:
         raises ConfigValidationError: if configuration is invalid
         raises ClusterUpdateError: if update is not allowed
         """
+        start_cdk_import()
         try:
             target_config, changes, ignored_validation_failures = self.validate_update_request(
                 target_source_config, validator_suppressors, validation_failure_level, force

--- a/cli/src/pcluster/templates/import_cdk.py
+++ b/cli/src/pcluster/templates/import_cdk.py
@@ -1,0 +1,27 @@
+import logging
+import time
+from threading import Thread
+
+LOGGER = logging.getLogger(__name__)
+
+
+def import_cdk():
+    """Import cdk libraries."""
+    LOGGER.info("Start importing")
+    begin = time.time()
+    from aws_cdk.core import App  # noqa: F401 pylint: disable=import-outside-toplevel
+
+    from pcluster.templates.cluster_stack import ClusterCdkStack  # noqa: F401 pylint: disable=import-outside-toplevel
+
+    LOGGER.info("Import complete in %i seconds", time.time() - begin)
+
+
+def start():
+    """
+    Import cdk libraries in a separate thread.
+
+    :return: thread importing cdk libraries
+    """
+    thread = Thread(target=import_cdk)
+    thread.start()
+    return thread


### PR DESCRIPTION
### Description of changes
Import of cdk libraries at lambda cold start takes 12 to 16 seconds, sometimes causing lambda timeout. 
Importing them in a separate thread, started at the beginning of create and update operations and executed concurrently with stack validation allows to reduce the time to complete the operation.
The amount of the execution time gain depends on how long the validation takes.
Longer is the validation more impactful this optimization gets.

### Tests
Manual test via API
* create-cluster dryrun
  * no import performed
* create-cluster no dryrun
  * import starts 1 msec after the lambda execution starts
  * validation takes ~ 5.5 sec.
  * total time to import cdk: ~ 12 sec., waiting time post validation before starting cdk generation: ~ 6.5 sec.
* update-cluster dryrun
  * no import performed
* update-cluster no dryrun
  * import starts 1 msec after the lambda execution starts
  * validation takes ~ 6 sec.
  * total time to import cdk: ~ 12 sec., waiting time post validation before starting cdk generation: ~ 6 sec.
Manual test via CLI
* create-cluster in dryrun mode and real cluster creation worked as expected
* update-cluster considered redundant


### References
* [Open issue on cdk import slowness](https://github.com/aws/jsii/issues/3389)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
