### PR TITLE
[3.x] Test concurrent cdk import

### DIFF
--- a/cli/tests/pcluster/templates/test_concurrent_cdk_import.py
+++ b/cli/tests/pcluster/templates/test_concurrent_cdk_import.py
@@ -1,0 +1,42 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from multiprocessing import Process
+
+from assertpy import assert_that
+
+from pcluster.templates.import_cdk import start
+
+
+def concurrent_imports(iterations=20, delay=0.1):
+    threads = []
+    for _ in range(0, iterations):
+        threads.append(start())
+        time.sleep(delay)
+
+    for t in threads:
+        t.join()
+
+
+def test_import():
+    """
+    This test ensures concurrent cdk library imports work.
+
+    Concurrent cdk library import might occur during cluster creation and update.
+    Here we test it doesn't break for some unknown race condition.
+    """
+    # We need to use a separate process to test concurrent imports
+    # because cdk library might be already imported in the test process by previous tests
+    p = Process(target=concurrent_imports, args=(50, 0.1))
+    p.start()
+    p.join()
+    assert_that(p.exitcode).is_equal_to(0)


### PR DESCRIPTION
### Description of changes
Concurrent cdk library import might occur during cluster creation and update due to [this PR](https://github.com/aws/aws-parallelcluster/pull/4778). 
This test verifies it doesn't break for some unknown race condition, mainly in case of changes to cdk library.

### Tests
* Committed unit test.

### References
* https://github.com/aws/aws-parallelcluster/pull/4778

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
