### PR TITLE
3.x Use more aggressive timeouts for s3api call when downloading custom cookbooks

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -149,14 +149,21 @@ write_files:
       [ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh
       custom_cookbook=${CustomChefCookbook}
       export _region=${AWS::Region}
+      cookbook_retry_strategy=--retry 3
       s3_url=${AWS::URLSuffix}
       if [ "${!custom_cookbook}" != "NONE" ]; then
         if [[ "${!custom_cookbook}" =~ ^s3://([^/]*)(.*) ]]; then
-          bucket_region=$(aws s3api get-bucket-location --bucket ${!BASH_REMATCH[1]} | jq -r '.LocationConstraint')
+          export AWS_RETRY_MODE=standard
+          export AWS_MAX_ATTEMPTS=2
+          # S3API_RESULT=$(aws s3api get-bucket-location --debug --cli-connect-timeout 60 --bucket ${!BASH_REMATCH[1]} 2>&1 | tee -a /var/log/aws.log) || error_exit "${!S3API_RESULT}"
+          S3API_RESULT=$(aws s3api get-bucket-location --cli-connect-timeout 15 --bucket ${!BASH_REMATCH[1]} 2>&1) || error_exit "${!S3API_RESULT}"
+          bucket_region=$(echo "${!S3API_RESULT}" | jq -r '.LocationConstraint')
           if [[ "${!bucket_region}" == null ]]; then
             bucket_region="us-east-1"
           fi
           cookbook_url=$(aws s3 presign "${!custom_cookbook}" --region "${!bucket_region}")
+          # Use a more aggressive timeout for s3 endpoints
+          cookbook_retry_strategy=${!cookbook_retry_strategy} --connect-timeout 60
         else
           cookbook_url=${!custom_cookbook}
         fi
@@ -175,7 +182,7 @@ write_files:
         error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."
       fi
       if [ "${!custom_cookbook}" != "NONE" ]; then
-        curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+        curl ${!cookbook_retry_strategy} -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url} || error_exit "Failed to download custom cookbook from ${!cookbook_url}"
         vendor_cookbook
       fi
       cd /tmp


### PR DESCRIPTION
### Description of changes
* Set connection timeout for AWS CLI call to s3api to timeout after 2 minutes with 3 attempts to connect.
* This is done to fail compute node launch faster if there is no connectivity from the compute node to AWS services.
* Before this change it would make 5 attempts with each attempt taking ~8minutes for a total time to failure of ~40m.
* With this change the TTF should be ~6m
* Reason for s3 failure is now included in the user_data.sh exit reason.

### Tests
* Deployed a cluster with a custom cookbook where the compute fleet was deployed into an isolated subnet.
* Compute nodes successfully self-terminated after ~6m.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
