### PR TITLE
Disable B028 flake8-bugbear lint check

### DIFF
--- a/awsbatch-cli/.flake8
+++ b/awsbatch-cli/.flake8
@@ -15,7 +15,10 @@ ignore =
     # D413: Missing blank line after last section
     D413,
     # F821: undefined name
-    F821
+    F821,
+    # B028: Consider replacing f"'{foo}'" with f"{foo!r}".
+    # Currently being disabled by flake8-bugbear. See https://github.com/PyCQA/flake8-bugbear/pull/333
+    B028
 # D101 Missing docstring in public class
 # D102 Missing docstring in public method
 per-file-ignores =
@@ -36,4 +39,4 @@ max-complexity = 10
 max-line-length = 120
 import-order-style = google
 application-import-names = flake8
-format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
+format = %(cyan)s%(path)s%(reset)s:%(bold)s%(yellow)s%(row)d%(reset)s:%(bold)s%(green)s%(col)d%(reset)s: %(bold)s%(red)s%(code)s%(reset)s %(text)s

--- a/cli/.flake8
+++ b/cli/.flake8
@@ -17,7 +17,10 @@ ignore =
     # F821: undefined name
     F821,
     # N818: exception name should be named with an Error suffix
-    N818
+    N818,
+    # B028: Consider replacing f"'{foo}'" with f"{foo!r}".
+    # Currently being disabled by flake8-bugbear. See https://github.com/PyCQA/flake8-bugbear/pull/333
+    B028
 # D101 Missing docstring in public class
 # D102 Missing docstring in public method
 # D202 No blank lines allowed after function docstring
@@ -47,4 +50,4 @@ max-complexity = 10
 max-line-length = 120
 import-order-style = google
 application-import-names = flake8
-format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
+format = %(cyan)s%(path)s%(reset)s:%(bold)s%(yellow)s%(row)d%(reset)s:%(bold)s%(green)s%(col)d%(reset)s: %(bold)s%(red)s%(code)s%(reset)s %(text)s


### PR DESCRIPTION
### Description of changes
* Disable B028 flake8-bugbear lint check recently implemented.
  * The check is going to be disabled by the flake8-bugbear developers. See https://github.com/PyCQA/flake8-bugbear/pull/333
* Fix color formatting on flake8 style offenses.

### Tests
* manually run `tox -e code-linters`

### References:
- https://github.com/aws/aws-parallelcluster/pull/4798
- https://github.com/aws/aws-parallelcluster-cookbook/pull/1644
- https://github.com/aws/aws-parallelcluster-node/pull/485

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
