### PR TITLE
[3.x] Add IMDSv2 enforcement in some utilities

### DIFF
--- a/tests/integration-tests/tests/storage/snapshots_factory.py
+++ b/tests/integration-tests/tests/storage/snapshots_factory.py
@@ -208,6 +208,7 @@ class EBSSnapshotsFactory:
             MinCount=1,
             MaxCount=1,
             InstanceType="t2.micro",
+            MetadataOptions={"HttpTokens": "required", "HttpEndpoint": "enabled"},
             NetworkInterfaces=[
                 {
                     "SubnetId": subnet.id,


### PR DESCRIPTION
Signed-off-by: Edoardo Antonini <eantonin@amazon.com>


### Description of changes
* Add IMDSv2 enforcement in some utilities
* PR in 3.4.1 branch https://github.com/aws/aws-parallelcluster/pull/4807

### Tests
* Run integration tests that were exercising those code and checked instances were launched with imdsv2 enforced (saw a test failure, that seems unrelated to those changes)

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
