### PR TITLE
[integ-3.4] Add launch template to disable imdsv1 in AD CloudFormation templates

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -12,6 +12,14 @@ Parameters:
     Description: Subnet ID of the public subnet.
     Type: String
 Resources:
+  DisableImdsv1LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpPutResponseHopLimit: 4
+          HttpTokens: required
   AdDomainAdminNodeSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -103,6 +111,9 @@ Resources:
       ImageId: {{ admin_node_ami_id }}
       InstanceType: {{ admin_node_instance_type }}
       KeyName: {{ admin_node_key_name }}
+      LaunchTemplate:
+        LaunchTemplateId: !Ref 'DisableImdsv1LaunchTemplate'
+        Version: !GetAtt 'DisableImdsv1LaunchTemplate.LatestVersionNumber'
       SecurityGroupIds:
         - Ref: AdDomainAdminNodeSecurityGroup
       SubnetId:


### PR DESCRIPTION
Signed-off-by: Edoardo Antonini <eantonin@amazon.com>


### Description of changes
* Partial backport of https://github.com/aws/aws-parallelcluster/pull/4794 the other, public, ad-template has not been changed as it does not make sense doing it for 3.4 version 

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
