### PR TITLE
[develop] Check read-after-write consistency

### DIFF
--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -67,7 +67,9 @@ def verify_directory_correctly_shared(remote_command_executor, mount_dir, schedu
     head_node_file = random_alphanumeric()
     logging.info(f"Writing HeadNode File: {head_node_file}")
     remote_command_executor.run_remote_command(
-        "touch {mount_dir}/{head_node_file}".format(mount_dir=mount_dir, head_node_file=head_node_file)
+        "touch {mount_dir}/{head_node_file} && cat {mount_dir}/{head_node_file}".format(
+            mount_dir=mount_dir, head_node_file=head_node_file
+        )
     )
 
     # Submit a "Write" job to each partition
@@ -78,7 +80,9 @@ def verify_directory_correctly_shared(remote_command_executor, mount_dir, schedu
     for partition in partitions:
         compute_file = "{}-{}".format(partition, random_alphanumeric())
         logging.info(f"Writing Compute File: {compute_file} from {partition}")
-        job_command = "touch {mount_dir}/{compute_file}".format(mount_dir=mount_dir, compute_file=compute_file)
+        job_command = "touch {mount_dir}/{compute_file} && cat {mount_dir}/{compute_file}".format(
+            mount_dir=mount_dir, compute_file=compute_file
+        )
         result = scheduler_commands.submit_command(job_command, partition=partition)
         job_id = scheduler_commands.assert_job_submitted(result.stdout)
         scheduler_commands.wait_job_completed(job_id)


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Perform a read right after a write to check if the consistency is respected when read-after-write is performed from the same host

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
