### PR TITLE
[3.x] Fix IMDSv2 enforcement in launch templates

### DIFF
--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -336,10 +336,10 @@ def bastion_instance(vpc_stack, cfn_stacks_factory, request, region, key_name):
     launch_template = ec2.LaunchTemplate.from_dict(
         "LaunchTemplateIMDSv2",
         {
-            "LaunchTemplateName": "imdsv2-network-enforcer",
             "LaunchTemplateData": {"MetadataOptions": {"HttpTokens": "required", "HttpEndpoint": "enabled"}},
         },
     )
+    bastion_template.add_resource(launch_template)
     instance = ec2.Instance(
         "NetworkingBastionInstance",
         InstanceType="c5.xlarge",
@@ -347,12 +347,10 @@ def bastion_instance(vpc_stack, cfn_stacks_factory, request, region, key_name):
         KeyName=key_name,
         SecurityGroupIds=[Ref(bastion_sg)],
         LaunchTemplate=ec2.LaunchTemplateSpecification(
-            LaunchTemplateName="imdsv2-network-enforcer",
-            Version="1",
+            LaunchTemplateId=Ref(launch_template), Version=GetAtt(launch_template, "LatestVersionNumber")
         ),
         SubnetId=vpc_stack.cfn_outputs["PublicSubnetId"],
     )
-    bastion_template.add_resource(launch_template)
     bastion_template.add_resource(bastion_sg)
     bastion_template.add_resource(instance)
     bastion_template.add_output(


### PR DESCRIPTION
Signed-off-by: Edoardo Antonini <eantonin@amazon.com>

### Description of changes
* [3.x] Fix IMDSv2 enforcement in launch templates

### Tests
* Test launched locally not showing the "Launch template already exists" error

### References
* 3.4 PR https://github.com/aws/aws-parallelcluster/pull/4814

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
