### PR TITLE
[Isolated Regions] Add controllers assertion to check operations support by region

### DIFF
--- a/cli/src/pcluster/api/controllers/image_logs_controller.py
+++ b/cli/src/pcluster/api/controllers/image_logs_controller.py
@@ -8,7 +8,12 @@
 
 # pylint: disable=W0613
 
-from pcluster.api.controllers.common import configure_aws_region, convert_errors, validate_timestamp
+from pcluster.api.controllers.common import (
+    assert_supported_operation,
+    configure_aws_region,
+    convert_errors,
+    validate_timestamp,
+)
 from pcluster.api.errors import BadRequestException
 from pcluster.api.models import (
     GetImageLogEventsResponseContent,
@@ -18,6 +23,7 @@ from pcluster.api.models import (
     LogStream,
     StackEvent,
 )
+from pcluster.constants import Operation
 from pcluster.models.imagebuilder import ImageBuilder
 from pcluster.utils import to_iso_timestr, to_utc_datetime
 
@@ -61,6 +67,7 @@ def get_image_log_events(
 
     :rtype: GetImageLogEventsResponseContent
     """
+    assert_supported_operation(operation=Operation.GET_IMAGE_LOG_EVENTS, region=region)
     start_dt = start_time and validate_timestamp(start_time, "start_time")
     end_dt = end_time and validate_timestamp(end_time, "end_time")
 
@@ -106,6 +113,7 @@ def get_image_stack_events(image_id, region=None, next_token=None):
 
     :rtype: GetImageStackEventsResponseContent
     """
+    assert_supported_operation(operation=Operation.GET_IMAGE_STACK_EVENTS, region=region)
     imagebuilder = ImageBuilder(image_id=image_id)
     stack_events = imagebuilder.get_stack_events(next_token=next_token)
 
@@ -142,6 +150,7 @@ def list_image_log_streams(image_id, region=None, next_token=None):
             log[ts_name] = to_iso_timestr(to_utc_datetime(log[ts_name]))
         return LogStream.from_dict(log)
 
+    assert_supported_operation(operation=Operation.LIST_IMAGE_LOG_STREAMS, region=region)
     imagebuilder = ImageBuilder(image_id=image_id)
     logs = imagebuilder.list_log_streams(next_token=next_token)
     log_streams = [convert_log(log) for log in logs.log_streams]

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -11,6 +11,7 @@ import logging
 import os as os_lib
 
 from pcluster.api.controllers.common import (
+    assert_supported_operation,
     configure_aws_region,
     configure_aws_region_from_config,
     convert_errors,
@@ -50,7 +51,7 @@ from pcluster.api.util import assert_valid_node_js
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError
 from pcluster.aws.ec2 import Ec2Client
-from pcluster.constants import SUPPORTED_ARCHITECTURES, SUPPORTED_OSES
+from pcluster.constants import SUPPORTED_ARCHITECTURES, SUPPORTED_OSES, Operation
 from pcluster.models.imagebuilder import (
     BadRequestImageBuilderActionError,
     ConfigValidationError,
@@ -97,6 +98,7 @@ def build_image(
     :rtype: BuildImageResponseContent
     """
     assert_valid_node_js()
+    assert_supported_operation(operation=Operation.BUILD_IMAGE, region=region)
     configure_aws_region_from_config(region, build_image_request_content["imageConfiguration"])
     rollback_on_failure = rollback_on_failure if rollback_on_failure is not None else False
     disable_rollback = not rollback_on_failure
@@ -158,6 +160,7 @@ def delete_image(image_id, region=None, force=None):
 
     :rtype: DeleteImageResponseContent
     """
+    assert_supported_operation(operation=Operation.DELETE_IMAGE, region=region)
     force = force or False
     imagebuilder = ImageBuilder(image_id=image_id)
     image, stack = _get_underlying_image_or_stack(imagebuilder)
@@ -204,6 +207,7 @@ def describe_image(image_id, region=None):
 
     :rtype: DescribeImageResponseContent
     """
+    assert_supported_operation(operation=Operation.DESCRIBE_IMAGE, region=region)
     imagebuilder = ImageBuilder(image_id=image_id)
 
     try:
@@ -326,6 +330,7 @@ def list_images(image_status, region=None, next_token=None):
 
     :rtype: ListImagesResponseContent
     """
+    assert_supported_operation(operation=Operation.LIST_IMAGES, region=region)
     if image_status == ImageStatusFilteringOption.AVAILABLE:
         return ListImagesResponseContent(images=_get_available_images())
     else:

--- a/cli/src/pcluster/cli/commands/image_logs.py
+++ b/cli/src/pcluster/cli/commands/image_logs.py
@@ -13,7 +13,10 @@ from typing import List
 from argparse import ArgumentParser, Namespace
 
 from pcluster import utils
+from pcluster.api.controllers.common import assert_supported_operation
+from pcluster.aws.common import get_region
 from pcluster.cli.commands.common import CliCommand, ExportLogsCommand
+from pcluster.constants import Operation
 from pcluster.models.imagebuilder import ImageBuilder
 
 LOGGER = logging.getLogger(__name__)
@@ -51,6 +54,7 @@ class ExportImageLogsCommand(ExportLogsCommand, CliCommand):
         )
 
     def execute(self, args: Namespace, extra_args: List[str]) -> None:  # noqa: D102 #pylint: disable=unused-argument
+        assert_supported_operation(operation=Operation.EXPORT_IMAGE_LOGS, region=args.region or get_region())
         try:
             if args.output_file:
                 self._validate_output_file_path(args.output_file)

--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -215,7 +215,15 @@ def _run_operation(model, args, extra_args):
             error_encoded = encoder.JSONEncoder().encode(message)
             raise APIOperationException(json.loads(error_encoded))
     else:
-        return args.func(args, extra_args)
+        try:
+            return args.func(args, extra_args)
+        except pcluster.api.errors.ParallelClusterApiException as e:
+            # Format exception messages in the same manner as the api
+            message = pcluster.api.errors.exception_message(e)
+            error_encoded = encoder.JSONEncoder().encode(message)
+            raise APIOperationException(json.loads(error_encoded))
+        except Exception as e:
+            raise e
 
 
 def run(sys_args, model=None):

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -238,3 +238,55 @@ UNSUPPORTED_FEATURES_MAP = {
     Feature.FSX_ONTAP: ["us-iso"],
     Feature.FSX_OPENZFS: ["us-iso"],
 }
+
+
+# Operations support
+# By default, all operations are considered supported.
+# To mark an operation as unsupported for certain regions,
+# add the entry to the map below by region prefixes.
+class Operation(Enum):
+    """
+    Enumeration of operations.
+
+    We do not expect this enumeration to list all the operations,
+    but at least those that are considered for operations flagging.
+    """
+
+    BUILD_IMAGE = "build-image"
+    CONFIGURE = "configure"
+    CREATE_CLUSTER = "create-cluster"
+    DCV_CONNECT = "dcv-connect"
+    DELETE_CLUSTER = "delete-cluster"
+    DELETE_CLUSTER_INSTANCES = "delete-cluster-instances"
+    DELETE_IMAGE = "delete-image"
+    DESCRIBE_CLUSTER = "describe-cluster"
+    DESCRIBE_CLUSTER_INSTANCES = "describe-cluster-instances"
+    DESCRIBE_COMPUTE_FLEET = "describe-compute-fleet"
+    DESCRIBE_IMAGE = "describe-image"
+    EXPORT_CLUSTER_LOGS = "export-cluster-logs"
+    EXPORT_IMAGE_LOGS = "export-image-logs"
+    GET_CLUSTER_LOG_EVENTS = "get-cluster-log-events"
+    GET_CLUSTER_STACK_EVENTS = "get-cluster-stack-events"
+    GET_IMAGE_LOG_EVENTS = "get-image-log-events"
+    GET_IMAGE_STACK_EVENTS = "get-image-stack-events"
+    LIST_CLUSTER_LOG_STREAMS = "list-cluster-log-streams"
+    LIST_CLUSTERS = "list-clusters"
+    LIST_IMAGES = "list-images"
+    LIST_IMAGE_LOG_STREAMS = "list-image-log-streams"
+    LIST_OFFICIAL_IMAGES = "list-official-images"
+    SSH = "ssh"
+    UPDATE_CLUSTER = "update-cluster"
+    UPDATE_COMOPUTE_FLEET = "update-compute-fleet"
+    VERSION = "version"
+
+
+UNSUPPORTED_OPERATIONS_MAP = {
+    Operation.BUILD_IMAGE: ["us-iso"],
+    Operation.DELETE_IMAGE: ["us-iso"],
+    Operation.DESCRIBE_IMAGE: ["us-iso"],
+    Operation.LIST_IMAGES: ["us-iso"],
+    Operation.EXPORT_IMAGE_LOGS: ["us-iso"],
+    Operation.GET_IMAGE_LOG_EVENTS: ["us-iso"],
+    Operation.GET_IMAGE_STACK_EVENTS: ["us-iso"],
+    Operation.LIST_IMAGE_LOG_STREAMS: ["us-iso"],
+}

--- a/cli/tests/pcluster/api/controllers/test_image_logs_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_logs_controller.py
@@ -10,8 +10,10 @@ import pytest
 from assertpy import assert_that
 
 from pcluster.aws.common import AWSClientError
+from pcluster.constants import Operation
 from pcluster.models.common import LogStream
 from pcluster.utils import to_utc_datetime
+from tests.pcluster.api.controllers.utils import mock_assert_supported_operation, verify_unsupported_operation
 
 
 class TestGetImageLogEvents:
@@ -176,6 +178,18 @@ class TestGetImageLogEvents:
         response = self._send_test_request(client, "image", "logstream", "us-east-2", None, None, None, None, None)
         self._assert_invalid_response(response, expected_response, 404)
 
+    def test_unsupported_operation_error(self, client, mocker):
+        mocked_assert_supported_operation = mock_assert_supported_operation(
+            mocker, "pcluster.api.controllers.image_logs_controller.assert_supported_operation"
+        )
+        response = self._send_test_request(client, "image", "logstream", "us-east-2", None, None, None, None, None)
+        verify_unsupported_operation(
+            mocked_assertion=mocked_assert_supported_operation,
+            operation=Operation.GET_IMAGE_LOG_EVENTS,
+            region="us-east-2",
+            response=response,
+        )
+
     @staticmethod
     def _assert_invalid_response(response, expected_response, response_code=400):
         assert_that(response.status_code).is_equal_to(response_code)
@@ -278,6 +292,18 @@ class TestGetImageStackEvents:
         mock_image_stack(image_id="image", stack_exists=image_stack_found)
         response = self._send_test_request(client, "image", "us-east-2", None)
         self._assert_invalid_response(response, expected_response, 404)
+
+    def test_unsupported_operation_error(self, client, mocker):
+        mocked_assert_supported_operation = mock_assert_supported_operation(
+            mocker, "pcluster.api.controllers.image_logs_controller.assert_supported_operation"
+        )
+        response = self._send_test_request(client, "image", "us-east-2", None)
+        verify_unsupported_operation(
+            mocked_assertion=mocked_assert_supported_operation,
+            operation=Operation.GET_IMAGE_STACK_EVENTS,
+            region="us-east-2",
+            response=response,
+        )
 
     @staticmethod
     def _assert_invalid_response(response, expected_response, response_code=400):
@@ -405,6 +431,18 @@ class TestListImageLogStreams:
         )
         response = self._send_test_request(client, "image", "us-east-1", None)
         self._assert_invalid_response(response, expected_response, 404)
+
+    def test_unsupported_operation_error(self, client, mocker):
+        mocked_assert_supported_operation = mock_assert_supported_operation(
+            mocker, "pcluster.api.controllers.image_logs_controller.assert_supported_operation"
+        )
+        response = self._send_test_request(client, "image", "us-east-1", None)
+        verify_unsupported_operation(
+            mocked_assertion=mocked_assert_supported_operation,
+            operation=Operation.LIST_IMAGE_LOG_STREAMS,
+            region="us-east-1",
+            response=response,
+        )
 
     @staticmethod
     def _assert_invalid_response(response, expected_response, response_code=400):

--- a/cli/tests/pcluster/api/controllers/utils.py
+++ b/cli/tests/pcluster/api/controllers/utils.py
@@ -1,0 +1,15 @@
+from assertpy import assert_that
+
+from pcluster.api.errors import BadRequestException
+from pcluster.constants import Operation
+
+
+def mock_assert_supported_operation(mocker, path: str):
+    return mocker.patch(path, side_effect=BadRequestException("ERROR MESSAGE"))
+
+
+def verify_unsupported_operation(mocked_assertion, operation: Operation, region: str, response):
+    mocked_assertion.assert_called_once()
+    mocked_assertion.assert_called_with(operation=operation, region=region)
+    assert_that(response.status_code).is_equal_to(400)
+    assert_that(response.get_json()["message"]).matches("ERROR MESSAGE")


### PR DESCRIPTION
### Description of changes
Add assertion on operations controllers to fail fast with a BadRequest when the requested operation is not supported in the given region. In particular, the following operations are set as unsupported both on CLI and API
 * `build-image` us-iso* regions
 * `delete-image` us-iso* regions
 * `describe-image` us-iso* regions
 * `list-images` us-iso* regions
 * `export-image-logs` us-iso* regions
 * `get-image-log-events` us-iso* regions
 * `get-image-stack-events` us-iso* regions
 * `list-image-log-streams` us-iso* regions

#### Customer Experience
When a customer attempts to execute an operation that is unsupported in the target region, the following error message is returned:

```
{
  "message": "Bad Request: The operation 'build-image' is not supported in region 'us-iso-east-1'."
}
```

#### Developer Experience
When a developer wants to modify the support for a given operation in some regions, he/she needs to modify `UNSUPPORTED_FEATURES_MAP` in `cli/src/pcluster/constants.py` accordingly, where we have region prefixes mapped to unsupported features.

```
UNSUPPORTED_OPERATIONS_MAP = {
    Operation.BUILD_IMAGE: ["us-iso"],
    Operation.DELETE_IMAGE: ["us-iso"],
    Operation.DESCRIBE_IMAGE: ["us-iso"],
    Operation.LIST_IMAGES: ["us-iso"],
    Operation.EXPORT_IMAGE_LOGS: ["us-iso"],
    Operation.GET_IMAGE_LOG_EVENTS: ["us-iso"],
    Operation.GET_IMAGE_STACK_EVENTS: ["us-iso"],
    Operation.LIST_IMAGE_LOG_STREAMS: ["us-iso"],
}
```

and add the corresponding assertion within the operation controller, if it's not there yet:

```
assert_supported_operation(operation=Operation.BUILD_IMAGE, region=region)
```


### Tests
* Unit test
* Manual test pretending that an operation is not supported in eu-west-1 to verify error messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>





Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
