### PR TITLE
Pass IMDS support info to validator

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1293,6 +1293,7 @@ class BaseClusterConfig(Resource):
             os=self.image.os,
             ami_id=self.head_node_ami,
             tags=self.get_cluster_tags(),
+            imds_support=self.imds.imds_support,
         )
         if self.head_node.dcv:
             self._register_validator(
@@ -2654,6 +2655,7 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                 ami_id=queue_image,
                 os=self.image.os,
                 tags=self.get_cluster_tags(),
+                imds_support=self.imds.imds_support,
             )
             ami_volume_size = AWSApi.instance().ec2.describe_image(queue_image).volume_size
             root_volume = queue.compute_settings.local_storage.root_volume


### PR DESCRIPTION
### Description of changes
This patch passes the IMDS support information to the launch template validators. The actual `create-cluster` operation uses launch templates, but our validators "reproduce" the behaviour with a run instance. This is the reason that the validation step failed with policies disallowing launches of instances with IMDSv1 enabled: while the launch template was created correctly, the run instance of the validator did not use the correct setting.

### Tests
Testing a create cluster dry-run with a policy disallowing the launch of instances with IMDSv1 enabled, with the old CLI code I have the expected exception:

```
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "HeadNodeLaunchTemplateValidator",
      "message": "Unable to validate configuration parameters for instance type c5.metal. Please double check your cluster configuration. You are not authorized to perform this operation. Encoded authorization failure message: <encoded message>
    },
    {
      "level": "ERROR",
      "type": "ComputeResourceLaunchTemplateValidator",
      "message": "Unable to validate configuration parameters for instance type c5.xlarge. Please double check your cluster configuration. You are not authorized to perform this operation. Encoded authorization failure message: <encoded message>
    }
  ],
  "message": "Invalid cluster configuration."
}
```

with this patch instead I have:

```
{
  "message": "Request would have succeeded, but DryRun flag is set."
}
```

Relevant part of configuration used, disabling IMDSv1:

```
Imds:
  ImdsSupport: v2.0
Region: eu-west-1
Image:
  Os: centos7
HeadNode:
...
```

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
