### PR TITLE
[Cherry-pick] Include deprecated AMIs when retrieve pcluster AMI in integration test

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -125,6 +125,7 @@ def retrieve_pcluster_ami_without_standard_naming(region, os, version, architect
                 {"Name": "architecture", "Values": [architecture]},
             ],
             Owners=["self", "amazon"],
+            IncludeDeprecated=True,
         ).get("Images", [])
         ami_id = client.copy_image(
             Description="This AMI is a copy from an official AMI but uses a different naming. "


### PR DESCRIPTION
In integration test of test_create_wrong_pcluster_version and test_build_image_wrong_pcluster_version, the pcluster AMI used in the test is 2.8.1, which is deprecated, need to have `--include-deprecated` to have it shows up in the describe-image result

Signed-off-by: chenwany <chenwany@amazon.com>


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
