### PR TITLE
Change get of node attributes to use /etc/chef/node_attributes.json

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 constants:
   - CookbookDefaultFile:
       type: string
-      value: /etc/chef/cookbooks/aws-parallelcluster/attributes/default.rb
+      value: /etc/chef/node_attributes.json
 
 phases:
   - name: test
@@ -136,12 +136,6 @@ phases:
                 echo "${VERSION}"
               }
 
-              get_cookbook_attribute () {
-                ATTRIBUTE_NAME="$1"
-                ATTRIBUTE_VALUE=$(grep -F "${ATTRIBUTE_NAME}" {{ CookbookDefaultFile }})
-                echo ${ATTRIBUTE_VALUE}
-              }
-
               # ParallelCluster bootstrap file
               if [[ -f /opt/parallelcluster/.bootstrapped ]]; then
                 add_tag "parallelcluster:bootstrap_file" "$(cat /opt/parallelcluster/.bootstrapped)"
@@ -195,7 +189,8 @@ phases:
               fi
               # ARM - No version file
               if [ -z "${CUDA_VERSION}" ] && [ -d /usr/local/cuda ]; then
-                CUDA_VERSION=$(get_cookbook_attribute "default['cluster']['nvidia']['cuda_version']" | tr -d '\n' | cut -d = -f 2 | xargs)
+                # Get cuda version from chef attributes
+                CUDA_VERSION=$(jq '.default.cluster.nvidia.cuda_version' {{ CookbookDefaultFile }} | tr -d '\n' | cut -d = -f 2 | xargs)
               fi
               add_tag "parallelcluster:cuda_version" "${CUDA_VERSION}"
               append_description "cuda" "${CUDA_VERSION}"

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 constants:
   - CookbookDefaultFile:
       type: string
-      value: /etc/chef/cookbooks/aws-parallelcluster/attributes/default.rb
+      value: /etc/chef/node_attributes.json
 
 phases:
   - name: test
@@ -55,7 +55,7 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(grep -F "default['cluster']['python-version']" {{ CookbookDefaultFile }})
+              PATTERN=$(jq '.default.cluster."python-version"' {{ CookbookDefaultFile }})
               VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo ${VERSION}
 
@@ -65,7 +65,7 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(grep -F "default['cluster']['scheduler_plugin']['python_version']" {{ CookbookDefaultFile }})
+              PATTERN=$(jq '.default.cluster.scheduler_plugin.python_version' {{ CookbookDefaultFile }})
               VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo ${VERSION}
 
@@ -76,9 +76,8 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(grep -F "default['cluster']['base_dir']" {{ CookbookDefaultFile }})
-              BASE_DIR=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
-              PYENV_ROOT+="${BASE_DIR}/pyenv"
+              PATTERN=$(jq '.default.cluster.system_pyenv_root' {{ CookbookDefaultFile }})
+              PYENV_ROOT=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo ${PYENV_ROOT}
 
       - name: SchedulerPluginPyenvRoot
@@ -87,9 +86,8 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(grep -F "default['cluster']['base_dir']" {{ CookbookDefaultFile }})
-              BASE_DIR=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
-              PYENV_ROOT+="${BASE_DIR}/shared/scheduler-plugin/pyenv"
+              PATTERN=$(jq '.default.cluster.scheduler_plugin.pyenv_root' {{ CookbookDefaultFile }})
+              PYENV_ROOT=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo ${PYENV_ROOT}
 
       - name: CookbookVirtualenvPath
@@ -132,7 +130,7 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(grep -F "default['cluster']['reserved_base_uid']" {{ CookbookDefaultFile }})
+              PATTERN=$(jq '.default.cluster.reserved_base_uid' {{ CookbookDefaultFile }})
               RESERVED_BASE_UID=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo "${RESERVED_BASE_UID}"
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -5,7 +5,7 @@ schemaVersion: 1.0
 constants:
   - CookbookDefaultFile:
       type: string
-      value: /etc/chef/cookbooks/aws-parallelcluster/attributes/default.rb
+      value: /etc/chef/node_attributes.json
 
 phases:
   - name: validate
@@ -143,7 +143,7 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(grep -F "default['cluster']['munge']['munge_version']" {{ CookbookDefaultFile }})
+              PATTERN=$(jq '.default.cluster.munge.munge_version' {{ CookbookDefaultFile }})
               VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo ${VERSION}
 
@@ -153,7 +153,7 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(grep -F "default['cluster']['nvidia']['driver_version']" {{ CookbookDefaultFile }})
+              PATTERN=$(jq '.default.cluster.nvidia.driver_version' {{ CookbookDefaultFile }})
               VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo ${VERSION}
 
@@ -163,7 +163,7 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(grep -F "default['cluster']['nvidia']['cuda_version']" {{ CookbookDefaultFile }})
+              PATTERN=$(jq '.default.cluster.nvidia.cuda_version' {{ CookbookDefaultFile }})
               VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo ${VERSION}
 
@@ -175,7 +175,7 @@ phases:
               set -v
               cuda_ver="{{ validate.CudaVersion.outputs.stdout }}"
               if [ ${cuda_ver} \> '11.4' ]; then
-                PATTERN=$(grep -F "default['cluster']['nvidia']['cuda_samples_version']" {{ CookbookDefaultFile }})
+                PATTERN=$(jq '.default.cluster.nvidia.cuda_samples_version' {{ CookbookDefaultFile }})
                 VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
                 echo cuda-samples-${VERSION}/Samples
               else
@@ -190,7 +190,7 @@ phases:
               set -v
               cuda_ver="{{ validate.CudaVersion.outputs.stdout }}"
               if [ ${cuda_ver} \> '11.4' ]; then
-                PATTERN=$(grep -F "default['cluster']['nvidia']['cuda_samples_version']" {{ CookbookDefaultFile }})
+                PATTERN=$(jq '.default.cluster.nvidia.cuda_samples_version' {{ CookbookDefaultFile }})
                 VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
                 echo cuda-samples-${VERSION}/bin
               else
@@ -203,10 +203,10 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(grep -F "default['cluster']['armpl']['major_minor_version']" {{ CookbookDefaultFile }})
+              PATTERN=$(jq '.default.cluster.armpl.major_minor_version' {{ CookbookDefaultFile }})
               MAJOR_MINOR_VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               VERSION+="${MAJOR_MINOR_VERSION}."
-              PATTERN=$(grep -F "default['cluster']['armpl']['patch_version'] = '0'" {{ CookbookDefaultFile }})
+              PATTERN=$(jq '.default.cluster.armpl.patch_version' {{ CookbookDefaultFile }})
               PATCH_VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               VERSION+="${PATCH_VERSION}"
               echo ${VERSION}
@@ -217,7 +217,7 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(grep -F "default['cluster']['armpl']['gcc']['major_minor_version']" {{ CookbookDefaultFile }})
+              PATTERN=$(jq '.default.cluster.armpl.gcc.major_minor_version' {{ CookbookDefaultFile }})
               VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo ${VERSION}
 


### PR DESCRIPTION
### Description of changes
* To make more robust the getting of attributes from the cookbook this commit exploit the newly created  attribute file `/etc/chef/node_attributes.json`

### Tests
* Tested in Jenkins

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1679

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
