### PR TITLE
Use more readily available instance types for the compute ami update test

### DIFF
--- a/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.update.yaml
@@ -23,7 +23,8 @@ Scheduling:
           MaxCount: 2
         - Name: queue1-i2
           Instances:
-            - InstanceType: t2.micro
+            - InstanceType: t2.medium
+            - InstanceType: t3.micro
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_compute_ami/pcluster.config.yaml
@@ -19,7 +19,8 @@ Scheduling:
           MaxCount: 2
         - Name: queue1-i2
           Instances:
-            - InstanceType: t2.micro
+            - InstanceType: t2.medium
+            - InstanceType: t3.micro
           MinCount: 1
           MaxCount: 2
       Networking:


### PR DESCRIPTION
The update_compute_ami test uses t2.micro instances for one of the queues they are out of capacity in eu-west-1. To leverage flexible instance types, we needed to move away from t2.micro because there are no other similar instances that have only one vCPU. Instead use t2.medium and t3.micro with 2 vCPUs

### Description of changes
replace t2.micro instances with t2.medium and t3.micro
### Tests
ran the integration test locally against 3.4.0

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
