### PR TITLE
Add integration test for surface headnode bootstrap failure

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -157,6 +157,24 @@ create:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{common.OSS_COMMERCIAL_X86}}
         schedulers: ["slurm"]
+  test_create.py::test_cluster_creation_with_problematic_preinstall_script:
+    dimensions:
+      - regions: ["ap-south-1"]
+        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        schedulers: ["slurm"]
+        oss: ["centos7"]
+  test_create.py::test_cluster_creation_timeout:
+    dimensions:
+      - regions: ["ap-northeast-2"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        schedulers: ["slurm", "awsbatch"]
+        oss: ["alinux2"]
+  test_create.py::test_cluster_creation_with_invalid_ebs:
+    dimensions:
+      - regions: ["ap-south-1"]
+        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        schedulers: ["slurm"]
+        oss: ["ubuntu1804", "ubuntu2004"]
 createami:
   test_createami.py::test_invalid_config:
     dimensions:

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
 
+import boto3
 import pytest
 from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
@@ -72,6 +73,15 @@ def test_create_wrong_pcluster_version(
         ["/var/log/cloud-init-output.log"],
         ["error_exit", rf"AMI was created.+{wrong_version}.+is.+used.+{current_version}"],
     )
+    logging.info("Verifying failures in describe-clusters output")
+    expected_failures = [
+        {
+            "failureCode": "AmiVersionMismatch",
+            "failureReason": "ParallelCluster version of the custom AMI is different than the cookbook. Please make "
+            "them consistent.",
+        }
+    ]
+    assert_that(cluster.creation_response.get("failures")).is_equal_to(expected_failures)
 
 
 @pytest.mark.usefixtures("instance", "scheduler")
@@ -103,3 +113,124 @@ def test_create_imds_secured(
     assert_head_node_is_running(region, cluster)
     assert_aws_identity_access_is_correct(cluster, users_allow_list)
     assert_cluster_imds_v2_requirement_status(region, cluster, status)
+
+
+@pytest.mark.usefixtures("instance", "os", "scheduler")
+def test_cluster_creation_with_problematic_preinstall_script(
+    region, pcluster_config_reader, s3_bucket_factory, clusters_factory, test_datadir
+):
+    """Test cluster creation fail with OnNodeStart Script."""
+    bucket_name = s3_bucket_factory()
+    bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+    script_name = "pre_install.sh"
+    bucket.upload_file(str(test_datadir / script_name), f"scripts/{script_name}")
+    cluster_config = pcluster_config_reader(resource_bucket=bucket_name)
+    cluster = clusters_factory(cluster_config, raise_on_error=False)
+
+    assert_head_node_is_running(region, cluster)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+
+    logging.info("Verifying error in logs")
+    assert_lines_in_logs(
+        remote_command_executor,
+        ["/var/log/cfn-init.log"],
+        [f"Failed to execute OnNodeStart script s3://{ bucket_name }/scripts/{script_name}"],
+    )
+    logging.info("Verifying error in cloudformation failure reason")
+    stack_events = cluster.get_stack_events().get("events")
+    cfn_failure_reason = _get_failure_reason(stack_events)
+    expected_cfn_failure_reason = (
+        "Failed to execute OnNodeStart script, "
+        "return code: 1. Please check /var/log/cfn-init.log in the head node, or check the "
+        "cfn-init.log in CloudWatch logs. Please refer to https://docs.aws.amazon.com/"
+        "parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for "
+        "more details on ParallelCluster logs."
+    )
+
+    assert_that(cfn_failure_reason).contains(expected_cfn_failure_reason)
+    assert_that(cfn_failure_reason).does_not_contain(f"s3://{ bucket_name }/scripts/{script_name}")
+
+    logging.info("Verifying failures in describe-clusters output")
+    expected_failures = [
+        {
+            "failureCode": "OnNodeStartExecutionFailure",
+            "failureReason": "Failed to execute OnNodeStart script.",
+        }
+    ]
+    assert_that(cluster.creation_response.get("failures")).is_equal_to(expected_failures)
+
+
+@pytest.mark.usefixtures("instance", "os", "scheduler")
+def test_cluster_creation_timeout(region, pcluster_config_reader, s3_bucket_factory, clusters_factory, test_datadir):
+    """Test cluster creation fail with cluster creation timeout."""
+    cluster_config = pcluster_config_reader()
+    cluster = clusters_factory(cluster_config, raise_on_error=False)
+
+    assert_head_node_is_running(region, cluster)
+    logging.info("Verifying error in cloudformation failure reason")
+    stack_events = cluster.get_stack_events().get("events")
+    cfn_failure_reason = _get_failure_reason(stack_events)
+    expected_cfn_failure_reason = "WaitCondition timed out. Received 0 conditions when expecting 1"
+
+    assert_that(cfn_failure_reason).is_equal_to(expected_cfn_failure_reason)
+
+    logging.info("Verifying failures in describe-clusters output")
+    expected_failures = [
+        {
+            "failureCode": "HeadNodeBootstrapFailure",
+            "failureReason": "Cluster creation timed out.",
+        }
+    ]
+    assert_that(cluster.creation_response.get("failures")).is_equal_to(expected_failures)
+
+
+@pytest.mark.usefixtures("instance", "os", "scheduler")
+def test_cluster_creation_with_invalid_ebs(
+    region, pcluster_config_reader, s3_bucket_factory, clusters_factory, test_datadir
+):
+    """Test cluster creation fail with cluster creation timeout."""
+    cluster_config = pcluster_config_reader(problematic_volume_id="vol-00000000000000000")
+    cluster = clusters_factory(cluster_config, raise_on_error=False, suppress_validators="ALL")
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    assert_head_node_is_running(region, cluster)
+    logging.info("Verifying error in logs")
+    assert_lines_in_logs(
+        remote_command_executor,
+        ["/var/log/chef-client.log"],
+        [r"Error executing action `mount` on resource 'manage_ebs\[add ebs\]'"],
+    )
+    logging.info("Verifying error in cloudformation failure reason")
+    stack_events = cluster.get_stack_events().get("events")
+    cfn_failure_reason = _get_failure_reason(stack_events)
+    expected_cfn_failure_reason = (
+        "Failed to mount EBS volume. Please check /var/log/chef-client.log in the head "
+        "node, or check the chef-client.log in CloudWatch logs. Please refer to "
+        "https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#"
+        "troubleshooting-v3-get-logs for more details on ParallelCluster logs."
+    )
+
+    assert_that(cfn_failure_reason).contains(expected_cfn_failure_reason)
+
+    logging.info("Verifying failures in describe-clusters output")
+    expected_failures = [
+        {
+            "failureCode": "EbsMountFailure",
+            "failureReason": "Failed to mount EBS volume.",
+        }
+    ]
+    assert_that(cluster.creation_response.get("failures")).is_equal_to(expected_failures)
+
+
+def _get_failure_reason(events):
+    """Reason of the failure when the cluster_status is in CREATE_FAILED."""
+
+    def _is_failed_wait(event):
+        if (
+            event.get("resourceType") == "AWS::CloudFormation::WaitCondition"
+            and event.get("resourceStatus") == "CREATE_FAILED"
+        ):
+            return True
+        return False
+
+    failure_event = next(filter(_is_failed_wait, events), None)
+    return failure_event.get("resourceStatusReason") if failure_event else None

--- a/tests/integration-tests/tests/create/test_create/test_cluster_creation_timeout/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_cluster_creation_timeout/pcluster.config.yaml
@@ -1,0 +1,29 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
+    - Name: queue-0
+      ComputeResources:
+        - Name: compute-resource-0
+          {% if scheduler == "awsbatch" %}
+          InstanceTypes:
+            - {{ instance }}
+          {% else %}
+          Instances:
+            - InstanceType: {{ instance }}
+          {% endif %}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+DevSettings:
+  Timeouts:
+    HeadNodeBootstrapTimeout: 100

--- a/tests/integration-tests/tests/create/test_create/test_cluster_creation_with_invalid_ebs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_cluster_creation_with_invalid_ebs/pcluster.config.yaml
@@ -1,0 +1,35 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
+    - Name: queue-0
+      ComputeResources:
+        - Name: compute-resource-0
+          {% if scheduler == "awsbatch" %}
+          InstanceTypes:
+            - {{ instance }}
+          {% else %}
+          Instances:
+            - InstanceType: {{ instance }}
+          {% endif %}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+SharedStorage:
+  - MountDir: /problematic_ebs
+    Name: problematic_ebs
+    StorageType: Ebs
+    EbsSettings:
+      VolumeType: gp2
+      VolumeId: {{ problematic_volume_id }}
+
+

--- a/tests/integration-tests/tests/create/test_create/test_cluster_creation_with_problematic_preinstall_script/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_cluster_creation_with_problematic_preinstall_script/pcluster.config.yaml
@@ -1,0 +1,33 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+  Iam:
+    S3Access:
+      - BucketName: {{ resource_bucket }}
+        EnableWriteAccess: true
+  CustomActions:
+    OnNodeStart:
+      Script: s3://{{ resource_bucket }}/scripts/pre_install.sh
+Scheduling:
+  Scheduler: {{ scheduler }}
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
+  - Name: queue-0
+    ComputeResources:
+      - Name: compute-resource-0
+        {% if scheduler == "awsbatch" %}
+        InstanceTypes:
+          - {{ instance }}
+        {% else %}
+        Instances:
+          - InstanceType: {{ instance }}
+        {% endif %}
+    Networking:
+      SubnetIds:
+        - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/create/test_create/test_cluster_creation_with_problematic_preinstall_script/pre_install.sh
+++ b/tests/integration-tests/tests/create/test_create/test_cluster_creation_with_problematic_preinstall_script/pre_install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+echo "Test head node bootstrap error caused by OnNodeStart Script."
+exit 1
+


### PR DESCRIPTION
### Description of changes
* Tests failures are surface to `describe-clusters` output when cluster creation fail.  

### Tests
* Tests the following cases with both slurm and awsbatch scheduler:
  * AmiVersionMismatch: ParallelCluster version of the custom AMI is different than the cookbook.
  * EbsMountFailure: Failed to mount EBS volume.
  * OnNodeStartExecutionFailure:  cluster creation with problematic preinstall script
  * test cluster creation timeout

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
