### PR TITLE
`[lib]` Add a library for accessing parallelcluster.

### DIFF
--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -50,6 +50,14 @@ def re_validator(rexp_str, param, in_str):
     return in_str
 
 
+def string_validator(param, in_str):
+    """Take a string and validate the input format."""
+
+    if not isinstance(in_str, str):
+        exit_msg(f"Bad Request: Wrong type, expected 'string' for parameter '{param}'")
+    return in_str
+
+
 def read_file(_param, path):
     """Take file path, read the file and return the data as a string."""
     try:
@@ -106,6 +114,24 @@ def dispatch(model, args):
         return dispatch_func(**kwargs)
 
 
+def param_coerce(param):
+    """Takes a parameter from the model and generates the coersion for it."""
+    type_map = {"number": to_number, "boolean": to_bool, "integer": to_int,
+                "file": read_file, "string": string_validator}
+
+    def identity(_param, x_in):
+        return x_in
+
+    # handle regexp parameter validation (or perform type coercion)
+    if "pattern" in param:
+        coerce_fn = partial(re_validator, param["pattern"], param["name"])
+    elif param.get("type") in type_map:
+        coerce_fn = partial(type_map[param["type"]], param["name"])
+    else:
+        coerce_fn = identity
+    return coerce_fn
+
+
 def gen_parser(model):
     """Take a model and returns an ArgumentParser for CLI parsing."""
     desc = (
@@ -116,7 +142,6 @@ def gen_parser(model):
     parser = argparse.ArgumentParser(description=desc, epilog=epilog)
     subparsers = parser.add_subparsers(help="", title="COMMANDS", dest="operation")
     subparsers.required = True
-    type_map = {"number": to_number, "boolean": to_bool, "integer": to_int, "file": read_file}
     parser_map = {"subparser": subparsers}
 
     # Add each operation as it's onn parser with params / body as arguments
@@ -127,14 +152,6 @@ def gen_parser(model):
 
         for param in operation["params"]:
             help = param.get("description", "")
-
-            # handle regexp parameter validation (or perform type coercion)
-            if "pattern" in param:
-                type_coerce = partial(re_validator, param["pattern"], param["name"])
-            elif param.get("type") in type_map:
-                type_coerce = partial(type_map[param["type"]], param["name"])
-            else:
-                type_coerce = None
 
             abbrev_args = {
                 "cluster-name": "-n",
@@ -154,7 +171,7 @@ def gen_parser(model):
                 required=param.get("required", False),
                 choices=param.get("enum", None),
                 nargs="+" if "multi" in param else None,
-                type=type_coerce,
+                type=param_coerce(param),
                 help=help,
             )
 

--- a/cli/src/pcluster/lib/__init__.py
+++ b/cli/src/pcluster/lib/__init__.py
@@ -1,0 +1,9 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pcluster.lib.lib import ParallelCluster

--- a/cli/src/pcluster/lib/lib.py
+++ b/cli/src/pcluster/lib/lib.py
@@ -1,0 +1,92 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+import logging.config
+from functools import partial
+
+import yaml
+
+import pcluster.api.controllers.cluster_operations_controller
+import pcluster.api.errors
+import pcluster.cli.logger as pcluster_logging
+import pcluster.cli.model
+from pcluster.api import encoder
+from pcluster.cli.entrypoint import dispatch, param_coerce
+from pcluster.cli.exceptions import APIOperationException, ParameterException
+from pcluster.cli.logger import redirect_stdouterr_to_logger
+from pcluster.utils import to_snake_case
+
+
+def _gen_class(model):
+    """A function that accepts a model in the shape of the CLI model
+    to generate a dictionary mapping function names to dispatch functions."""
+
+    class Args():
+        """An Args class that has the appropriate structure to be used during
+        dispatch, which effectively just has a __dict__ in it."""
+        def __init__(self, args):
+            self.__dict__ = args
+
+    def make_func(op_name):
+        """Takes the name of an operation and generates the function that will
+        call the underlying controler ensuring that default arguments are
+        provided and that arguments are coerced."""
+        def func(_self, **kwargs):
+
+            # Validate that the input args match the model as this is normally done either
+            # in the api or in the arg parsing in the CLI
+            params = model[op_name]["params"]
+            expected = {to_snake_case(param["name"]) for param in params if param["required"]}
+            missing = expected - set(kwargs.keys())
+            if missing:
+                raise TypeError(f"<{op_name}> missing required arguments: {missing}")
+
+            all_args = {to_snake_case(param["name"]) for param in params}
+            unexpected = set(kwargs.keys()) - all_args - {"query", "debug"}
+            if unexpected:
+                raise TypeError(f"<{op_name}> got unexpected arguments: {unexpected}")
+
+            kwargs["func"] = None
+            kwargs["operation"] = op_name
+            for param in model[op_name]["params"]:
+                param_name = to_snake_case(param["name"])
+                if param_name not in kwargs:
+                    kwargs[param_name] = None
+                # Convert python data-structures into strings for those args
+                # which are of type "file"
+                elif not isinstance(kwargs.get(param_name), str) and param['type'] == 'file':
+                    kwargs[param_name] = yaml.dump(kwargs[param_name])
+                else:
+                    kwargs[param_name] = param_coerce(param)(kwargs[param_name])
+
+            return dispatch(model, Args(kwargs))
+
+        return func
+
+    return {to_snake_case(op): make_func(op) for op in model}
+
+
+def _load_model():
+    """Loads the ParallelCluster model from the package spec."""
+    spec = pcluster.cli.model.package_spec()
+    return pcluster.cli.model.load_model(spec)
+
+
+def _make_class(model):
+    """Creates a python class from a provided model."""
+    return type("ParallelCluster", (object, ), _gen_class(model))
+
+
+ParallelCluster = _make_class(_load_model())

--- a/cli/tests/pcluster/api/test_lib.py
+++ b/cli/tests/pcluster/api/test_lib.py
@@ -1,0 +1,190 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import yaml
+from assertpy import assert_that
+
+from pcluster.cli.exceptions import ParameterException
+from pcluster.lib import lib
+
+
+def _gen_model(funcs):
+    def _gen_func_def(func, params):
+        has_body = any(x["body"] for x in params)
+        return {"func": func, "params": params, **({"body_name": "body"} if has_body else {})}
+    return {func: _gen_func_def(func, ps) for func, ps in funcs.items()}
+
+
+class TestParallelClusterLib:
+    @pytest.mark.parametrize("model, func, kwargs, expected", [
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"},
+                 {"body": True, "name": "body_param", "required": False, "type": "number"}]},
+         lambda body, param=None: [body, param],
+         {"param": 1, "body_param": 2},
+         [{'bodyParam': 2}, 1]),
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"},
+                 {"body": True, "name": "body_param", "required": False, "type": "number"}]},
+         lambda body, param=None: [body, param],
+         {"param": 1},
+         [{"bodyParam": None}, 1]),
+        ({"op": [{"body": False, "name": "param", "required": False, "type": "number"}]},
+         lambda param=None: param,
+         {"param": 1},
+         1),
+        ({"op": [{"body": False, "name": "param", "required": False, "type": "number"}]},
+         lambda param=None: param,
+         {},
+         None),
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"}]},
+         lambda param: param,
+         {"param": 1},
+         1),
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"},
+                 {"body": False, "name": "param2", "required": True, "type": "number"}]},
+         lambda param, param2: [param, param2],
+         {"param": 1, "param2": 2},
+         [1, 2]),
+        ({"op":[]},
+         lambda: True,
+         {},
+         True)
+    ])
+    def test_args(self, mocker, model, func, kwargs, expected):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=func)
+        model = _gen_model(model)
+        pc_obj = lib._make_class(model)() # pylint: disable=protected-access
+        assert_that(pc_obj.op(**kwargs)).is_equal_to(expected)
+
+
+    @pytest.mark.parametrize("model, func, kwargs", [
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"},
+                 {"body": True, "name": "body_param", "required": False, "type": "number"}]},
+         lambda body, param=None: [body, param],
+         {"param_extra": 3}),
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"},
+                 {"body": True, "name": "body_param", "required": False, "type": "number"}]},
+         lambda body, param=None: [body, param],
+         {"body_param": 2, "param_extra": 3}),
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"}]},
+         lambda param: param,
+         {"param_extra": 1}),
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"}]},
+         lambda param: param,
+         {}),
+    ])
+    def test_args_missing(self, mocker, model, func, kwargs):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=func)
+        model = _gen_model(model)
+        pc_obj = lib._make_class(model)() # pylint: disable=protected-access
+        with pytest.raises(TypeError) as exc_info:
+            pc_obj.op(**kwargs)
+        assert_that(str(exc_info.value)).starts_with("<op> missing required arguments")
+
+
+    @pytest.mark.parametrize("model, func, kwargs", [
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"},
+                 {"body": True, "name": "body_param", "required": False, "type": "number"}]},
+         lambda body, param=None: [body, param],
+         {"param": 1, "body_param": 2, "param_extra": 3}),
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"},
+                 {"body": True, "name": "body_param", "required": False, "type": "number"}]},
+         lambda body, param=None: [body, param],
+         {"param": 1, "param_extra": 3}),
+        ({"op": [{"body": False, "name": "param", "required": False, "type": "number"}]},
+         lambda param=None: param,
+         {"param": 1, "param_extra": 2}),
+        ({"op": [{"body": False, "name": "param", "required": False, "type": "number"}]},
+         lambda param=None: param,
+         {"param_extra": 1}),
+        ({"op": [{"body": False, "name": "param", "required": True, "type": "number"},
+                 {"body": False, "name": "param2", "required": True, "type": "number"}]},
+         lambda param, param2: [param, param2],
+         {"param": 1, "param2": 2, "param_extra": 3}),
+        ({"op":[]},
+         lambda: True,
+         {"param_extra": 2})
+    ])
+    def test_args_unexcpected(self, mocker, model, func, kwargs):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=func)
+        model = _gen_model(model)
+        pc_obj = lib._make_class(model)() # pylint: disable=protected-access
+        with pytest.raises(TypeError) as exc_info:
+            pc_obj.op(**kwargs)
+        assert_that(str(exc_info.value)).starts_with("<op> got unexpected arguments")
+
+
+    @pytest.mark.parametrize("type_, input_, expected", [
+        ({"type": "number"}, 1.0, 1.0),
+        ({"type": "number"}, 0, 0.0),
+        ({"type": "number"}, "0.0", 0.0),
+        ({"type": "integer"}, 0, 0),
+        ({"type": "integer"}, "0", 0),
+        ({"type": "boolean"}, "True", True),
+        ({"type": "boolean"}, "False", False),
+        ({"type": "boolean"}, "true", True),
+        ({"type": "boolean"}, "false", False),
+        ({"type": "boolean"}, True, True),
+        ({"type": "boolean"}, False, False),
+        ({"type": "string"}, "asdf", "asdf"),
+        ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "ALL", "ALL"),
+        ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "type:ASDF", "type:ASDF"),
+        ({"type": "file"}, {"a": 1, "b": [2, 3]}, "a: 1\nb:\n- 2\n- 3\n"),
+        ({"type": "file"}, "filename", "filedata")
+
+    ])
+    def test_parameter_checks(self, mocker, type_, input_, expected):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=lambda x: x)
+        mocker.patch("pcluster.cli.entrypoint.read_file", return_value="filedata")
+        model = _gen_model({"op": [{"name": "x", "required": True, "body": False, **type_}]})
+        pc_obj = lib._make_class(model)() # pylint: disable=protected-access
+        assert_that(pc_obj.op(x = input_)).is_equal_to(expected)
+
+
+    @pytest.mark.parametrize("type_, input_", [
+        ({"type": "number"}, "a"),
+        ({"type": "number"}, lambda: True),
+        ({"type": "number"}, {"a": 0}),
+        ({"type": "integer"}, "4.5"),
+        ({"type": "integer"}, "a"),
+        ({"type": "integer"}, lambda: True),
+        ({"type": "integer"}, {"a": 0}),
+        ({"type": "boolean"}, "a"),
+        ({"type": "boolean"}, "4.5"),
+        ({"type": "boolean"}, "a"),
+        ({"type": "boolean"}, lambda: True),
+        ({"type": "boolean"}, {"a": 0}),
+    ])
+    def test_parameter_invalid_type(self, mocker, type_, input_):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=lambda x: x)
+        model = _gen_model({"op": [{"name": "x", "required": True, "body": False, **type_}]})
+        pc_obj = lib._make_class(model)() # pylint: disable=protected-access
+        with pytest.raises( (ParameterException, TypeError) ) as exc_info:
+            pc_obj.op(x = input_)
+
+
+    @pytest.mark.parametrize("type_, input_", [
+        ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "ALL|"),
+        ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "type"),
+        ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "type:"),
+        ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "type:-"),
+
+    ])
+    def test_parameter_invalid_regex(self, mocker, type_, input_):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=lambda x: x)
+        model = _gen_model({"op": [{"name": "x", "required": True, "body": False, **type_}]})
+        pc_obj = lib._make_class(model)() # pylint: disable=protected-access
+        # with pytest.raises( (ParameterException, TypeError) ) as exc_info:
+        with pytest.raises( ParameterException ) as exc_info:
+            pc_obj.op(x = input_)

--- a/cli/tests/pcluster/cli/test_model.py
+++ b/cli/tests/pcluster/cli/test_model.py
@@ -26,9 +26,7 @@ def _run_model(model, params):
 @pytest.fixture
 def identity_dispatch(mocker):
     def _identity(body, **kwargs):
-        ret = {"body": body}
-        ret.update(kwargs)
-        return ret
+        return {"body": body, **kwargs}
 
     mocker.patch("pcluster.cli.model.get_function_from_name", return_value=_identity)
 


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

This commit adds a library for accessing parallelcluster by generating the class from the spec. It does more type checking as the CLI is able to do that portion through the argument parsing library, as well as accepting Python datastructures for those parameters of type "file" such as cluster and image configuration.

* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.

Manual tests for exercising the code against AWS resources:

```
#!/usr/bin/env python3
# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
#
# Licensed under the Apache License, Version 2.0 (the "License"). You may not
# use this file except in compliance with the License. A copy of the License is
# located at
#
# http://aws.amazon.com/apache2.0/
#
# or in the "LICENSE.txt" file accompanying this file. This file is distributed
# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
# implied. See the License for the specific language governing permissions and
# limitations under the License.

import os
import pprint
import subprocess
import sys
import time

import yaml
from pcluster.lib import ParallelCluster

CONFIG_TEMPLATE = "cluster-config.yaml.templ"
HEAD_NODE_SUBNET = "[REDACTED]"
COMPUTE_NODE_SUBNET = "[REDACTED]"
KEYNAME = "[REDACTED]"
CLUSTER_NAME = "mycluster"

pp = pprint.PrettyPrinter(indent=2)

def cluster_config():
    env = {"HEAD_NODE_SUBNET": HEAD_NODE_SUBNET,
           "COMPUTE_NODE_SUBNET": COMPUTE_NODE_SUBNET,
           "KEYNAME": KEYNAME,
           **os.environ.copy()}

    with open(CONFIG_TEMPLATE,"r", encoding="utf-8") as inf:
        proc = subprocess.Popen("envsubst", stdout=subprocess.PIPE, stdin=inf, env=env)
        proc.wait()
        return yaml.load(proc.stdout.read())

def cluster_log_test():
    log_streams = pc.list_cluster_log_streams(cluster_name=CLUSTER_NAME)
    assert len(log_streams['logStreams']) > 0

    stream_name = log_streams['logStreams'][0]['logStreamName']

    log_events = pc.get_cluster_log_events(cluster_name=CLUSTER_NAME, log_stream_name=stream_name)

    assert len(log_events["events"]) > 0

def cluster_fleet_test():
    pc.update_compute_fleet(cluster_name=CLUSTER_NAME,status="STOP_REQUESTED")

    fleet_status = pc.describe_compute_fleet(cluster_name=CLUSTER_NAME)["status"]
    while fleet_status == "STOP_REQUESTED":
        print("Waiting to stop compute fleet...")
        time.sleep(1)
        fleet_status = pc.describe_compute_fleet(cluster_name=CLUSTER_NAME)["status"]

    pc.update_compute_fleet(cluster_name=CLUSTER_NAME,status="START_REQUESTED")

    fleet_status = pc.describe_compute_fleet(cluster_name=CLUSTER_NAME)["status"]
    while fleet_status == "START_REQUESTED":
        print("Waiting to start compute fleet...")
        time.sleep(1)
        fleet_status = pc.describe_compute_fleet(cluster_name=CLUSTER_NAME)["status"]

    assert pc.describe_compute_fleet(cluster_name=CLUSTER_NAME)["status"] in {"STARTING", "RUNNING"}


def cluster_test(config):
    "Takes a config and tests the library on that config"

    pc = ParallelCluster()

    pp.pprint(pc.create_cluster(cluster_name=CLUSTER_NAME, cluster_configuration=config))

    status = pc.describe_cluster(cluster_name=CLUSTER_NAME)
    while status['clusterStatus'] == "CREATE_IN_PROGRESS":
        print("Waiting for cluster to start...")
        time.sleep(1)
        status = pc.describe_cluster(cluster_name=CLUSTER_NAME)

    cluster = pc.list_clusters(query=f"clusters[?clusterName=='{CLUSTER_NAME}']|[0]")

    assert cluster['clusterName'] == CLUSTER_NAME

    # cluster_log_test()
    # cluster_fleet_test()

    instances = pc.describe_cluster_instances(cluster_name=CLUSTER_NAME)["instances"]

    assert len(instances) > 0

    events = pc.get_cluster_stack_events(cluster_name=CLUSTER_NAME)["events"]

    assert len(events) > 0

    pp.pprint((pc.delete_cluster(cluster_name=CLUSTER_NAME)))


def image_test():

    pc = ParallelCluster()
    images = pc.list_images(image_status="AVAILABLE")["images"]

    assert len(images) > 0
    assert pc.describe_image(image_id=images[0]["imageId"])["imageBuildStatus"] == "BUILD_COMPLETE"


if __name__ == "__main__":
    cluster_test(cluster_config())
    image_test()
```

Using this cluster template:

```
Image:
  Os: alinux2
HeadNode:
  InstanceType: t2.large
  Networking:
    SubnetId: ${HEAD_NODE_SUBNET}
  Ssh:
    KeyName: ${KEYNAME}
Scheduling:
  Scheduler: slurm
  SlurmQueues:
  - Name: queue0
    ComputeResources:
    - Name: queue0-i0
      InstanceType: t2.micro
      MinCount: 0
      MaxCount: 10
    Networking:
      SubnetIds:
      - ${COMPUTE_NODE_SUBNET}
```

* Describe the added/modified tests.
Unit tests are added to test the parameter validation and resolution to the underlying code and type coersion.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
