### PR TITLE
`[lib]` Add a library for accessing parallelcluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 **ENHANCEMENTS**
+- Add a library interface to ParallelCluster functionality.
 - Add logging of compute node console output to CloudWatch on compute node bootstrap failure.
 - Add failures field containing failure code and reason to `describe-cluster` output when cluster creation fails.
 

--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -50,6 +50,13 @@ def re_validator(rexp_str, param, in_str):
     return in_str
 
 
+def string_validator(param, in_str):
+    """Take a string and validate the input format."""
+    if not isinstance(in_str, str):
+        exit_msg(f"Bad Request: Wrong type, expected 'string' for parameter '{param}'")
+    return in_str
+
+
 def read_file(_param, path):
     """Take file path, read the file and return the data as a string."""
     try:
@@ -106,6 +113,29 @@ def dispatch(model, args):
         return dispatch_func(**kwargs)
 
 
+def param_coerce(param):
+    """Take a parameter from the model and return a function that coerces it."""
+    type_map = {
+        "number": to_number,
+        "boolean": to_bool,
+        "integer": to_int,
+        "file": read_file,
+        "string": string_validator,
+    }
+
+    def identity(_param, x_in):
+        return x_in
+
+    # handle regexp parameter validation (or perform type coercion)
+    if "pattern" in param:
+        coerce_fn = partial(re_validator, param["pattern"], param["name"])
+    elif param.get("type") in type_map:
+        coerce_fn = partial(type_map[param["type"]], param["name"])
+    else:
+        coerce_fn = identity
+    return coerce_fn
+
+
 def gen_parser(model):
     """Take a model and returns an ArgumentParser for CLI parsing."""
     desc = (
@@ -116,7 +146,6 @@ def gen_parser(model):
     parser = argparse.ArgumentParser(description=desc, epilog=epilog)
     subparsers = parser.add_subparsers(help="", title="COMMANDS", dest="operation")
     subparsers.required = True
-    type_map = {"number": to_number, "boolean": to_bool, "integer": to_int, "file": read_file}
     parser_map = {"subparser": subparsers}
 
     # Add each operation as it's onn parser with params / body as arguments
@@ -127,14 +156,6 @@ def gen_parser(model):
 
         for param in operation["params"]:
             help = param.get("description", "")
-
-            # handle regexp parameter validation (or perform type coercion)
-            if "pattern" in param:
-                type_coerce = partial(re_validator, param["pattern"], param["name"])
-            elif param.get("type") in type_map:
-                type_coerce = partial(type_map[param["type"]], param["name"])
-            else:
-                type_coerce = None
 
             abbrev_args = {
                 "cluster-name": "-n",
@@ -154,7 +175,7 @@ def gen_parser(model):
                 required=param.get("required", False),
                 choices=param.get("enum", None),
                 nargs="+" if "multi" in param else None,
-                type=type_coerce,
+                type=param_coerce(param),
                 help=help,
             )
 

--- a/cli/src/pcluster/lib/__init__.py
+++ b/cli/src/pcluster/lib/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at http://aws.amazon.com/apache2.0/
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Prevent the "ParallelCluster imported but not used" error
+# flake8: noqa
+from pcluster.lib.lib import ParallelCluster

--- a/cli/src/pcluster/lib/lib.py
+++ b/cli/src/pcluster/lib/lib.py
@@ -1,0 +1,91 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Callable, Dict
+
+import yaml
+
+import pcluster.api.controllers.cluster_operations_controller
+import pcluster.api.errors
+import pcluster.cli.model
+from pcluster.cli.entrypoint import dispatch, param_coerce
+from pcluster.utils import to_snake_case
+
+
+# The definition of the shape of model is defined in pcluster.cli.model
+def _gen_class(model: Dict) -> Dict[str, Callable]:
+    """Generate a dict mapping function names to dispatch functions."""
+
+    class Args:
+        """An Args class with  structure to be used during dispatch."""
+
+        def __init__(self, args):
+            self.__dict__ = args
+
+    # Much like the CLI, we add wait commands for these cluster options to
+    # allow the user to have these be synchronous. This is done at the argument
+    # parser level on the CLI side.
+    wait_ops = ["create-cluster", "delete-cluster", "update-cluster"]
+    for op_name in filter(lambda x: x in model, wait_ops):
+        wait_param = {"body": False, "type": "boolean", "name": "wait", "required": False}
+        model[op_name]["params"].append(wait_param)
+
+    def make_func(op_name: str) -> Callable:
+        """Take the name of an operation and return the function that call the controller."""
+
+        def func(_self, **kwargs):
+
+            # Validate that args provided match the model
+            params = model[op_name]["params"]
+            expected = {to_snake_case(param["name"]) for param in params if param["required"]}
+            missing = expected - set(kwargs.keys())
+            if missing:
+                raise TypeError(f"<{op_name}> missing required arguments: {missing}")
+
+            all_args = {to_snake_case(param["name"]) for param in params}
+            unexpected = set(kwargs.keys()) - all_args - {"query", "debug"}
+            if unexpected:
+                raise TypeError(f"<{op_name}> got unexpected arguments: {unexpected}")
+
+            kwargs["func"] = None
+            kwargs["operation"] = op_name
+            for param in model[op_name]["params"]:
+                param_name = to_snake_case(param["name"])
+                if param_name not in kwargs:
+                    kwargs[param_name] = None
+                # Convert python data to strings for args of type "file"
+                elif not isinstance(kwargs.get(param_name), str) and param["type"] == "file":
+                    kwargs[param_name] = yaml.dump(kwargs[param_name])
+                else:
+                    kwargs[param_name] = param_coerce(param)(kwargs[param_name])
+
+            return dispatch(model, Args(kwargs))
+
+        return func
+
+    return {to_snake_case(op): make_func(op) for op in model}
+
+
+def _load_model():
+    """Load the ParallelCluster model from the package spec."""
+    spec = pcluster.cli.model.package_spec()
+    return pcluster.cli.model.load_model(spec)
+
+
+def _make_class(model):
+    """Create a python class from a provided model."""
+    return type("ParallelCluster", (object,), _gen_class(model))
+
+
+ParallelCluster = _make_class(_load_model())

--- a/cli/tests/pcluster/cli/test_model.py
+++ b/cli/tests/pcluster/cli/test_model.py
@@ -26,9 +26,7 @@ def _run_model(model, params):
 @pytest.fixture
 def identity_dispatch(mocker):
     def _identity(body, **kwargs):
-        ret = {"body": body}
-        ret.update(kwargs)
-        return ret
+        return {"body": body, **kwargs}
 
     mocker.patch("pcluster.cli.model.get_function_from_name", return_value=_identity)
 

--- a/cli/tests/pcluster/lib/test_lib.py
+++ b/cli/tests/pcluster/lib/test_lib.py
@@ -1,0 +1,256 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not
+# use this file except in compliance with the License. A copy of the License is
+# located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
+# implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.cli.exceptions import ParameterException
+from pcluster.lib import lib
+
+
+def _gen_model(funcs):
+    def _gen_func_def(func, params):
+        has_body = any(x["body"] for x in params)
+        return {"func": func, "params": params, **({"body_name": "body"} if has_body else {})}
+
+    return {func: _gen_func_def(func, ps) for func, ps in funcs.items()}
+
+
+class TestParallelClusterLib:
+    @pytest.mark.parametrize(
+        "model, func, kwargs, expected",
+        [
+            (
+                {
+                    "op": [
+                        {"body": False, "name": "param", "required": True, "type": "number"},
+                        {"body": True, "name": "body_param", "required": False, "type": "number"},
+                    ]
+                },
+                lambda body, param=None: [body, param],
+                {"param": 1, "body_param": 2},
+                [{"bodyParam": 2}, 1],
+            ),
+            (
+                {
+                    "op": [
+                        {"body": False, "name": "param", "required": True, "type": "number"},
+                        {"body": True, "name": "body_param", "required": False, "type": "number"},
+                    ]
+                },
+                lambda body, param=None: [body, param],
+                {"param": 1},
+                [{"bodyParam": None}, 1],
+            ),
+            (
+                {"op": [{"body": False, "name": "param", "required": False, "type": "number"}]},
+                lambda param=None: param,
+                {"param": 1},
+                1,
+            ),
+            (
+                {"op": [{"body": False, "name": "param", "required": False, "type": "number"}]},
+                lambda param=None: param,
+                {},
+                None,
+            ),
+            (
+                {"op": [{"body": False, "name": "param", "required": True, "type": "number"}]},
+                lambda param: param,
+                {"param": 1},
+                1,
+            ),
+            (
+                {
+                    "op": [
+                        {"body": False, "name": "param", "required": True, "type": "number"},
+                        {"body": False, "name": "param2", "required": True, "type": "number"},
+                    ]
+                },
+                lambda param, param2: [param, param2],
+                {"param": 1, "param2": 2},
+                [1, 2],
+            ),
+            ({"op": []}, lambda: True, {}, True),
+        ],
+    )
+    def test_args(self, mocker, model, func, kwargs, expected):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=func)
+        model = _gen_model(model)
+        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
+        assert_that(pc_obj.op(**kwargs)).is_equal_to(expected)
+
+    @pytest.mark.parametrize(
+        "model, func, kwargs",
+        [
+            (
+                {
+                    "op": [
+                        {"body": False, "name": "param", "required": True, "type": "number"},
+                        {"body": True, "name": "body_param", "required": False, "type": "number"},
+                    ]
+                },
+                lambda body, param=None: [body, param],
+                {"param_extra": 3},
+            ),
+            (
+                {
+                    "op": [
+                        {"body": False, "name": "param", "required": True, "type": "number"},
+                        {"body": True, "name": "body_param", "required": False, "type": "number"},
+                    ]
+                },
+                lambda body, param=None: [body, param],
+                {"body_param": 2, "param_extra": 3},
+            ),
+            (
+                {"op": [{"body": False, "name": "param", "required": True, "type": "number"}]},
+                lambda param: param,
+                {"param_extra": 1},
+            ),
+            ({"op": [{"body": False, "name": "param", "required": True, "type": "number"}]}, lambda param: param, {}),
+        ],
+    )
+    def test_args_missing(self, mocker, model, func, kwargs):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=func)
+        model = _gen_model(model)
+        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
+
+        # flake8: noqa
+        with pytest.raises(TypeError) as exc_info:
+            pc_obj.op(**kwargs)
+        assert_that(str(exc_info.value)).starts_with("<op> missing required arguments")
+
+    @pytest.mark.parametrize(
+        "model, func, kwargs",
+        [
+            (
+                {
+                    "op": [
+                        {"body": False, "name": "param", "required": True, "type": "number"},
+                        {"body": True, "name": "body_param", "required": False, "type": "number"},
+                    ]
+                },
+                lambda body, param=None: [body, param],
+                {"param": 1, "body_param": 2, "param_extra": 3},
+            ),
+            (
+                {
+                    "op": [
+                        {"body": False, "name": "param", "required": True, "type": "number"},
+                        {"body": True, "name": "body_param", "required": False, "type": "number"},
+                    ]
+                },
+                lambda body, param=None: [body, param],
+                {"param": 1, "param_extra": 3},
+            ),
+            (
+                {"op": [{"body": False, "name": "param", "required": False, "type": "number"}]},
+                lambda param=None: param,
+                {"param": 1, "param_extra": 2},
+            ),
+            (
+                {"op": [{"body": False, "name": "param", "required": False, "type": "number"}]},
+                lambda param=None: param,
+                {"param_extra": 1},
+            ),
+            (
+                {
+                    "op": [
+                        {"body": False, "name": "param", "required": True, "type": "number"},
+                        {"body": False, "name": "param2", "required": True, "type": "number"},
+                    ]
+                },
+                lambda param, param2: [param, param2],
+                {"param": 1, "param2": 2, "param_extra": 3},
+            ),
+            ({"op": []}, lambda: True, {"param_extra": 2}),
+        ],
+    )
+    def test_args_unexcpected(self, mocker, model, func, kwargs):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=func)
+        model = _gen_model(model)
+        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
+        with pytest.raises(TypeError) as exc_info:
+            pc_obj.op(**kwargs)
+        assert_that(str(exc_info.value)).starts_with("<op> got unexpected arguments")
+
+    @pytest.mark.parametrize(
+        "type_, input_, expected",
+        [
+            ({"type": "number"}, 1.0, 1.0),
+            ({"type": "number"}, 0, 0.0),
+            ({"type": "number"}, "0.0", 0.0),
+            ({"type": "integer"}, 0, 0),
+            ({"type": "integer"}, "0", 0),
+            ({"type": "boolean"}, "True", True),
+            ({"type": "boolean"}, "False", False),
+            ({"type": "boolean"}, "true", True),
+            ({"type": "boolean"}, "false", False),
+            ({"type": "boolean"}, True, True),
+            ({"type": "boolean"}, False, False),
+            ({"type": "string"}, "asdf", "asdf"),
+            ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "ALL", "ALL"),
+            ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "type:ASDF", "type:ASDF"),
+            ({"type": "file"}, {"a": 1, "b": [2, 3]}, "a: 1\nb:\n- 2\n- 3\n"),
+            ({"type": "file"}, "filename", "filedata"),
+        ],
+    )
+    def test_parameter_checks(self, mocker, type_, input_, expected):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=lambda x: x)
+        mocker.patch("pcluster.cli.entrypoint.read_file", return_value="filedata")
+        model = _gen_model({"op": [{"name": "x", "required": True, "body": False, **type_}]})
+        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
+        assert_that(pc_obj.op(x=input_)).is_equal_to(expected)
+
+    @pytest.mark.parametrize(
+        "type_, input_",
+        [
+            ({"type": "number"}, "a"),
+            ({"type": "number"}, lambda: True),
+            ({"type": "number"}, {"a": 0}),
+            ({"type": "integer"}, "4.5"),
+            ({"type": "integer"}, "a"),
+            ({"type": "integer"}, lambda: True),
+            ({"type": "integer"}, {"a": 0}),
+            ({"type": "boolean"}, "a"),
+            ({"type": "boolean"}, "4.5"),
+            ({"type": "boolean"}, "a"),
+            ({"type": "boolean"}, lambda: True),
+            ({"type": "boolean"}, {"a": 0}),
+        ],
+    )
+    def test_parameter_invalid_type(self, mocker, type_, input_):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=lambda x: x)
+        model = _gen_model({"op": [{"name": "x", "required": True, "body": False, **type_}]})
+        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
+        with pytest.raises((ParameterException, TypeError)) as exc_info:
+            pc_obj.op(x=input_)
+
+    @pytest.mark.parametrize(
+        "type_, input_",
+        [
+            ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "ALL|"),
+            ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "type"),
+            ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "type:"),
+            ({"type": "string", "pattern": "^(ALL|type:[A-Za-z0-9]+)$"}, "type:-"),
+        ],
+    )
+    def test_parameter_invalid_regex(self, mocker, type_, input_):
+        mocker.patch("pcluster.cli.model.get_function_from_name", return_value=lambda x: x)
+        model = _gen_model({"op": [{"name": "x", "required": True, "body": False, **type_}]})
+        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
+        # with pytest.raises( (ParameterException, TypeError) ) as exc_info:
+        with pytest.raises(ParameterException) as exc_info:
+            pc_obj.op(x=input_)


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

This commit adds a library for accessing parallelcluster by generating the class from the spec. It does more type checking as the CLI is able to do that portion through the argument parsing library, as well as accepting Python datastructures for those parameters of type "file" such as cluster and image configuration.

### Tests

Manual tests for exercising the code against AWS resources:

```.py
#!/usr/bin/env python3
# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
#
# Licensed under the Apache License, Version 2.0 (the "License"). You may not
# use this file except in compliance with the License. A copy of the License is
# located at
#
# http://aws.amazon.com/apache2.0/
#
# or in the "LICENSE.txt" file accompanying this file. This file is distributed
# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or
# implied. See the License for the specific language governing permissions and
# limitations under the License.

import pprint
import time

import yaml
from pcluster.lib import ParallelCluster

CONFIG_TEMPLATE = "cluster-config.yaml.templ"
HEAD_NODE_SUBNET = "[REDACTED]"
COMPUTE_NODE_SUBNET = "[REDACTED]"
KEYNAME = "[REDACTED]"
CLUSTER_NAME = "mycluster"

pp = pprint.PrettyPrinter(indent=2)

def cluster_config():
    with open(CONFIG_TEMPLATE, "r", encoding="utf-8") as inf:
        config = yaml.loads(inf.read())

    config["HeadNode"]["Networking"]["SubnetId"] = COMPUTE_NODE_SUBNET
    config["HeadNode"]["Ssh"]["KeyName"] = KEYNAME
    queue0 = config["Scheduling"]["SlurmQueues"][0]
    queue0["ComputeResources"][0]["Networkin"]["SubnetIds"][0] = COMPUTE_NODE_SUBNET
    return config

def cluster_log_test(pc):
    log_streams = pc.list_cluster_log_streams(cluster_name=CLUSTER_NAME)
    assert len(log_streams['logStreams']) > 0

    stream_name = log_streams['logStreams'][0]['logStreamName']

    log_events = pc.get_cluster_log_events(cluster_name=CLUSTER_NAME, log_stream_name=stream_name)

    assert len(log_events["events"]) > 0

def cluster_fleet_test(pc):
    pc.update_compute_fleet(cluster_name=CLUSTER_NAME,status="STOP_REQUESTED")

    fleet_status = pc.describe_compute_fleet(cluster_name=CLUSTER_NAME)["status"]
    while fleet_status == "STOP_REQUESTED":
        print("Waiting to stop compute fleet...")
        time.sleep(1)
        fleet_status = pc.describe_compute_fleet(cluster_name=CLUSTER_NAME)["status"]

    pc.update_compute_fleet(cluster_name=CLUSTER_NAME,status="START_REQUESTED")

    fleet_status = pc.describe_compute_fleet(cluster_name=CLUSTER_NAME)["status"]
    while fleet_status == "START_REQUESTED":
        print("Waiting to start compute fleet...")
        time.sleep(1)
        fleet_status = pc.describe_compute_fleet(cluster_name=CLUSTER_NAME)["status"]

    assert pc.describe_compute_fleet(cluster_name=CLUSTER_NAME)["status"] in {"STARTING", "RUNNING"}

def cluster_test(config):
    pc = ParallelCluster()

    print(f"Creating cluster [{CLUSTER_NAME}]...")
    pp.pprint(pc.create_cluster(cluster_name=CLUSTER_NAME, cluster_configuration=config, wait=True))

    status = pc.describe_cluster(cluster_name=CLUSTER_NAME)
    while status['clusterStatus'] == "CREATE_IN_PROGRESS":
        time.sleep(1)
        status = pc.describe_cluster(cluster_name=CLUSTER_NAME)

    cluster = pc.list_clusters(query=f"clusters[?clusterName=='{CLUSTER_NAME}']|[0]")
    assert cluster['clusterName'] == CLUSTER_NAME

    cluster_log_test(pc)
    cluster_fleet_test(pc)

    assert len(pc.describe_cluster_instances(cluster_name=CLUSTER_NAME)["instances"]) > 0
    assert len(pc.get_cluster_stack_events(cluster_name=CLUSTER_NAME)["events"]) > 0
    pp.pprint((pc.delete_cluster(cluster_name=CLUSTER_NAME)))

def image_test():
    pc = ParallelCluster()
    assert len(pc.list_images(image_status="AVAILABLE")["images"]) > 0
    assert pc.describe_image(image_id=images[0]["imageId"])["imageBuildStatus"] == "BUILD_COMPLETE"

if __name__ == "__main__":
    cluster_test(cluster_config())
    image_test()
```

`cluster-config.yaml.templ`:

```.yaml
Image:
  Os: alinux2
HeadNode:
  InstanceType: t2.large
  Networking:
    SubnetId: ${HEAD_NODE_SUBNET}
  Ssh:
    KeyName: ${KEYNAME}
Scheduling:
  Scheduler: slurm
  SlurmQueues:
  - Name: queue0
    ComputeResources:
    - Name: queue0-i0
      InstanceType: t2.micro
      MinCount: 0
      MaxCount: 10
    Networking:
      SubnetIds:
      - ${COMPUTE_NODE_SUBNET}
```

* Describe the added/modified tests.
Unit tests are added to test the parameter validation and resolution to the underlying code and type coersion.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
