### PR TITLE
integ-tests-3.4.1: Use custom cookbook to solve the Ubuntu20 build failure due to MySQL installation

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -25,3 +25,7 @@ DeploymentSettings:
         - {{ private_subnet_id }}
         SecurityGroupIds:
         - {{ default_vpc_security_group_id }}
+
+DevSettings:
+    Cookbook:
+        ChefCookbook: s3://us-east-1-aws-parallelcluster/patches/3.4.1/aws-parallelcluster-cookbook-3.4.1.tgz


### PR DESCRIPTION
### Description of changes

Build of Ubuntu 20.04 x86_64 custom images started to fail on 25 January, because an updated version of MySQL packages (8.0.32) has been released in the Ubuntu OS repository.

This package is installed in the system by the initial phases of the build AMI process and then the install_mysql_client recipe code tries to install the old 8.0.31 version on top of the updated version, causing the installation steps to fail.

This patched cookbook solves the issue and it is the suggested workaround for our customers.

### Tests
* Manual test of Ubuntu 20 build ami process using the linked CustomCookbook.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1687
* https://github.com/aws/aws-parallelcluster-cookbook/pull/1694

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
