### PR TITLE
integ-tests-3.4.1: Use https url for custom chef cookbook

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
+++ b/tests/integration-tests/tests/createami/test_createami/test_build_image/image.config.yaml
@@ -28,4 +28,4 @@ DeploymentSettings:
 
 DevSettings:
     Cookbook:
-        ChefCookbook: s3://us-east-1-aws-parallelcluster/patches/3.4.1/aws-parallelcluster-cookbook-3.4.1.tgz
+        ChefCookbook: https://us-east-1-aws-parallelcluster.s3.amazonaws.com/patches/3.4.1/aws-parallelcluster-cookbook-3.4.1.tgz


### PR DESCRIPTION
### Description of changes
* S3 is supported only when the cluster is created in the same region of the bucket.

### Tests
* Tested creating an image in eu-west-3 with `s3` and `https` url, only the `https` one works

### References
* https://github.com/aws/aws-parallelcluster/pull/4834

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
