### PR TITLE
Add integration test for interaction of scontrol reboot with EC2 status checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Add check in the validators to verify that the cluster name is not longer than 40 characters when Slurm accounting is enabled.
+- Fix an issue in clustermgtd that caused compute nodes rebooted via Slurm to be treated as unhealthy if the EC2 instance status checks fail (see https://github.com/aws/aws-parallelcluster/issues/4751)
 
 3.4.1
 -----

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -539,6 +539,12 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004"]
         schedulers: ["slurm"]
+  test_slurm.py::test_scontrol_reboot_ec2_health_checks:
+    dimensions:
+      - regions: ["us-east-2"]
+        instances: ["t2.medium"]
+        oss: ["ubuntu2004"]
+        schedulers: ["slurm"]
   test_slurm.py::test_slurm_overrides:
     dimensions:
       - regions: ["me-south-1"]

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -559,7 +559,6 @@ def test_scontrol_reboot_ec2_health_checks(
 
     # 2 iterations to cover the two scenarios described in the test description
     for scenario in range(1, 3):
-
         if scenario == 2:
             # Remove delay in startup of slurmd on the compute nodes.
             # TODO: generalize it for multiple nodes (it requires a parallel ssh utility such as clush)

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -33,6 +33,7 @@ from tests.common.assertions import (
     assert_num_instances_in_cluster,
     assert_scaling_worked,
     wait_for_num_instances_in_cluster,
+    wait_for_slurm_rebooted_nodes,
 )
 from tests.common.hit_common import (
     assert_compute_node_reasons,
@@ -485,6 +486,112 @@ def test_scontrol_reboot(
         slurm_commands,
         "queue1-st-t2micro-2",
     )
+
+
+@pytest.mark.usefixtures("region", "os", "instance", "scheduler")
+@pytest.mark.slurm_scontrol_reboot
+def test_scontrol_reboot_ec2_health_checks(
+    pcluster_config_reader,
+    clusters_factory,
+    test_datadir,
+    scheduler_commands_factory,
+):
+    """
+    Test that scontrol reboot does not trigger node replacements due to EC2 health check failures.
+
+    Two scenarios must be covered:
+    1.  the EC2 health checks are seen as failing while the compute node is in `REBOOT_ISSUED` state.
+        In order to keep the node in REBOOT_ISSUED for a longer time, a delay in the start of slurmd
+        is introduced.
+    2.  the EC2 health checks are seen as failing after the node has come back from reboot, because
+        EC2 takes a while before running the health checks and updating the health check status. This
+        is usually the case with t2.medium and Ubuntu 20.04.
+
+    This test is OS- and instance type dependent. Currently it is possible to reproduce the issue
+    only with Ubuntu 20.04.
+
+    See https://github.com/aws/aws-parallelcluster/issues/4751
+    """
+
+    cluster_config = pcluster_config_reader()
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    slurm_commands = scheduler_commands_factory(remote_command_executor)
+    clustermgtd_config = dict()
+    clustermgtd_config["loop_time"] = "15"
+    clustermgtd_config["health_check_timeout"] = "15"
+    clustermgtd_config["health_check_timeout_after_slurmdstarttime"] = "180"
+
+    # Set shorter loop time and health check timeout to trigger failures due to EC2 health checks more easily
+    for key, val in clustermgtd_config.items():
+        remote_command_executor.run_remote_command(
+            f"sudo sed -i '/{key}/d' /etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
+        )
+        remote_command_executor.run_remote_command(
+            f'echo "{key} = {val}" | sudo tee -a ' "/etc/parallelcluster/slurm_plugin/parallelcluster_clustermgtd.conf"
+        )
+
+    # Get compute nodes in the cluster
+    compute_nodes = slurm_commands.get_compute_nodes()
+
+    # Wait for compute nodes to be fully up and running
+    wait_for_compute_nodes_states(
+        slurm_commands,
+        compute_nodes,
+        "idle",
+        stop_max_delay_secs=300,
+    )
+
+    # Add drop-in file to delay startup of slurmd on the compute nodes. This will cause the compute node to
+    # stay longer in REBOOT_ISSUED state.
+    # TODO: generalize it for multiple nodes (it requires a parallel ssh utility such as clush).
+    # Currently the test uses only one compute node, so this is enough.
+    script = "add_sleep_to_slurmd_service_compute.sh"
+    remote_command_executor.run_remote_command(
+        f"rsync -a {script} {str(compute_nodes[0])}:~/", additional_files=[str(test_datadir / script)]
+    )
+    remote_command_executor.run_remote_command(f'ssh {str(compute_nodes[0])} "chmod +x {script}"')
+    remote_command_executor.run_remote_command(f'ssh {str(compute_nodes[0])} "./{script}"')
+
+    # Clear clustermgtd and slurmctld logs before starting the tests
+    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/slurmctld.log")
+    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
+
+    # 2 iterations to cover the two scenarios described in the test description
+    for scenario in range(1, 3):
+
+        if scenario == 2:
+            # Remove delay in startup of slurmd on the compute nodes.
+            # TODO: generalize it for multiple nodes (it requires a parallel ssh utility such as clush)
+            # Currently the test uses only one compute node, so it's not necessary.
+            script = "reset_sleep_slurmd_service_compute.sh"
+            remote_command_executor.run_remote_command(
+                f"rsync -a {script} {str(compute_nodes[0])}:~/", additional_files=[str(test_datadir / script)]
+            )
+            remote_command_executor.run_remote_command(f'ssh {str(compute_nodes[0])} "chmod +x {script}"')
+            remote_command_executor.run_remote_command(f'ssh {str(compute_nodes[0])} "./{script}"')
+
+        # Reboot static compute nodes
+        for node in compute_nodes:
+            slurm_commands.reboot_compute_node(node, asap=True)
+
+        # Wait for compute nodes to reply to slurmctld after rebooting
+        wait_for_slurm_rebooted_nodes(compute_nodes, remote_command_executor, stop_max_delay_secs=600)
+
+        # Check that the nodes are not marked as unhealthy in the following minutes
+        time.sleep(300)
+        assert_no_msg_in_logs(
+            remote_command_executor,
+            ["/var/log/parallelcluster/clustermgtd"],
+            ["Setting nodes failing health check type ec2_health_check to DRAIN"],
+        )
+
+        # Final check on the state of the compute nodes
+        assert_compute_node_states(slurm_commands, compute_nodes, "idle")
+
+        # Reset the slurmctld and clustermgtd logs
+        remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/slurmctld.log")
+        remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
 
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot_ec2_health_checks/add_sleep_to_slurmd_service_compute.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot_ec2_health_checks/add_sleep_to_slurmd_service_compute.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# This script creates a dummy systemd service that sleeps for a given time, and
+# makes it a dependency for the slurmd service. This way it's possible to simulate
+# a longer rebooting time of the node via scontrol reboot.
+
+# TODO: consider disabling the network during the sleep in order to simulate the
+# non-responsiveness to the EC2 status checks of the rebooted node.
+#
+# It doesn't seem to be possible to add a `ifconfig eth0 down` and `ifconfig eth0 up`
+# in the following systemd service: the first command completely kills the instance
+# and the second command doesn't seem to reactivate the network interface.
+
+sudo mkdir /etc/systemd/system/slurmd.service.d
+
+cat <<DELAY_SERVICE | sudo tee /etc/systemd/system/slurmd_delay.service
+[Unit]
+Description=Dummy Slurmd delay
+Before=slurmd.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+TimeoutSec=180s
+ExecStartPre=sleep 120
+ExecStart=sleep 1
+
+[Install]
+WantedBy=multi-user.target
+DELAY_SERVICE
+
+cat <<SLURMD_DROP_IN | sudo tee /etc/systemd/system/slurmd.service.d/add_delay.conf
+[Unit]
+After=slurmd_delay.service
+Requires=slurmd_delay.service
+SLURMD_DROP_IN
+
+sudo systemctl daemon-reload

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot_ec2_health_checks/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot_ec2_health_checks/pcluster.config.yaml
@@ -1,0 +1,21 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  {{ scheduler_prefix }}Queues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: compute-resource-1
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot_ec2_health_checks/reset_sleep_slurmd_service_compute.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_scontrol_reboot_ec2_health_checks/reset_sleep_slurmd_service_compute.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Reset state of the daemons after running add_sleep_to_slurmd_service_compute.sh
+
+sudo rm /etc/systemd/system/slurmd_delay.service
+sudo rm /etc/systemd/system/slurmd.service.d/add_delay.conf
+sudo systemctl daemon-reload


### PR DESCRIPTION
### Description of changes
* Add an integration test to check the logic to allow compute nodes rebooted via Slurm not to be drained due to EC2 status checks failures (not yet added to the daily integ tests).

### Tests
* The test covers the two ways a node rebooted via `scontrol reboot` may be treated as unhealthy by `clustermgtd` if EC2 status checks fail during the reboot process:
  1. the EC2 status checks report failure while the node is still rebooting (in `REBOOT_ISSUED` state);
  2. the EC2 status checks report failure after the node has already restarted Slurmd, due to the time it takes EC2 to publish the EC2 status check state.

### References
* https://github.com/aws/aws-parallelcluster-node/pull/490

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
