### PR TITLE
3.x Add integration test for create cluster failure on PROTECTED mode

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -149,14 +149,21 @@ write_files:
       [ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh
       custom_cookbook=${CustomChefCookbook}
       export _region=${AWS::Region}
+      cookbook_retry_strategy=--retry 3
       s3_url=${AWS::URLSuffix}
       if [ "${!custom_cookbook}" != "NONE" ]; then
         if [[ "${!custom_cookbook}" =~ ^s3://([^/]*)(.*) ]]; then
-          bucket_region=$(aws s3api get-bucket-location --bucket ${!BASH_REMATCH[1]} | jq -r '.LocationConstraint')
+          export AWS_RETRY_MODE=standard
+          export AWS_MAX_ATTEMPTS=2
+          # S3API_RESULT=$(aws s3api get-bucket-location --debug --cli-connect-timeout 60 --bucket ${!BASH_REMATCH[1]} 2>&1 | tee -a /var/log/aws.log) || error_exit "${!S3API_RESULT}"
+          S3API_RESULT=$(aws s3api get-bucket-location --cli-connect-timeout 15 --bucket ${!BASH_REMATCH[1]} 2>&1) || error_exit "${!S3API_RESULT}"
+          bucket_region=$(echo "${!S3API_RESULT}" | jq -r '.LocationConstraint')
           if [[ "${!bucket_region}" == null ]]; then
             bucket_region="us-east-1"
           fi
           cookbook_url=$(aws s3 presign "${!custom_cookbook}" --region "${!bucket_region}")
+          # Use a more aggressive timeout for s3 endpoints
+          cookbook_retry_strategy=${!cookbook_retry_strategy} --connect-timeout 60
         else
           cookbook_url=${!custom_cookbook}
         fi
@@ -175,7 +182,7 @@ write_files:
         error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."
       fi
       if [ "${!custom_cookbook}" != "NONE" ]; then
-        curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
+        curl ${!cookbook_retry_strategy} -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url} || error_exit "Failed to download custom cookbook from ${!cookbook_url}"
         vendor_cookbook
       fi
       cd /tmp

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -149,21 +149,21 @@ write_files:
       [ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh
       custom_cookbook=${CustomChefCookbook}
       export _region=${AWS::Region}
-      cookbook_retry_strategy=--retry 3
+
       s3_url=${AWS::URLSuffix}
       if [ "${!custom_cookbook}" != "NONE" ]; then
         if [[ "${!custom_cookbook}" =~ ^s3://([^/]*)(.*) ]]; then
-          export AWS_RETRY_MODE=standard
-          export AWS_MAX_ATTEMPTS=2
-          # S3API_RESULT=$(aws s3api get-bucket-location --debug --cli-connect-timeout 60 --bucket ${!BASH_REMATCH[1]} 2>&1 | tee -a /var/log/aws.log) || error_exit "${!S3API_RESULT}"
-          S3API_RESULT=$(aws s3api get-bucket-location --cli-connect-timeout 15 --bucket ${!BASH_REMATCH[1]} 2>&1) || error_exit "${!S3API_RESULT}"
+          # Set the socket connection timeout to 15s. Emperically, it seems like the actual
+          # timeout is 8x(cli-connect-timeout). i.e. if cli-connection-timeout is set to
+          # 60s, the call will timeout the connect attempt at 8m. Setting it to 15s, causes
+          # each attempt to take 240s, so 2m * 3 attempts will result in a failure after 6
+          # minutes.
+          S3API_RESULT=$(AWS_RETRY_MODE=standard aws s3api get-bucket-location --cli-connect-timeout 15 --bucket ${!BASH_REMATCH[1]} 2>&1) || error_exit "${!S3API_RESULT}"
           bucket_region=$(echo "${!S3API_RESULT}" | jq -r '.LocationConstraint')
           if [[ "${!bucket_region}" == null ]]; then
             bucket_region="us-east-1"
           fi
           cookbook_url=$(aws s3 presign "${!custom_cookbook}" --region "${!bucket_region}")
-          # Use a more aggressive timeout for s3 endpoints
-          cookbook_retry_strategy=${!cookbook_retry_strategy} --connect-timeout 60
         else
           cookbook_url=${!custom_cookbook}
         fi
@@ -182,7 +182,7 @@ write_files:
         error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."
       fi
       if [ "${!custom_cookbook}" != "NONE" ]; then
-        curl ${!cookbook_retry_strategy} -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url} || error_exit "Failed to download custom cookbook from ${!cookbook_url}"
+        curl --retry 3 -v -L -o /etc/chef/aws-parallelcluster-cookbook.tgz ${!cookbook_url}
         vendor_cookbook
       fi
       cd /tmp

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -515,6 +515,12 @@ schedulers:
 #        oss: ["alinux2"]
 #        schedulers: ["slurm_plugin"]
 #{%- endif %}
+  test_slurm.py::test_slurm_protected_mode_on_cluster_create:
+    dimensions:
+      - regions: ["ap-east-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
   test_slurm.py::test_fast_capacity_failover:
     dimensions:
       - regions: ["ap-east-1"]

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -311,6 +311,13 @@ def test_slurm_protected_mode_on_cluster_create(
     cluster = clusters_factory(cluster_config, raise_on_error=False, wait=False)
     remote_command_executor = _wait_until_protected_mode_failure_count_set(cluster)
     _test_compute_fleet_status(remote_command_executor, expected_status="PROTECTED")
+    assert_lines_in_logs(
+        remote_command_executor,
+        ["/var/log/parallelcluster/clustermgtd"],
+        [
+            "Updating compute fleet status from RUNNING to PROTECTED",
+        ],
+    )
     _test_cluster_creation_failure(cluster)
 
 

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode_on_cluster_create/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode_on_cluster_create/pcluster.config.yaml
@@ -1,0 +1,39 @@
+Image:
+  Os: {{ os }}
+CustomS3Bucket: {{ bucket }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket }}
+        EnableWriteAccess: true
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: queue
+      ComputeResources:
+        - Name: compute
+          {% if scheduler == "plugin" %}
+          InstanceType: c5.large # instance type has bootstrap failure
+          {% else %}
+          Instances:
+            - InstanceType: c5.large # instance type has bootstrap failure
+          {% endif %}
+          MinCount: 3
+          MaxCount: 10
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      CustomActions:
+        OnNodeStart:
+          Script: s3://{{ bucket }}/scripts/preinstall.sh
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket }}
+            EnableWriteAccess: true

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode_on_cluster_create/preinstall.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode_on_cluster_create/preinstall.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 1


### PR DESCRIPTION
### Description of changes
* This change adds an integration test to make sure that if the cluster enters protected mode, the cluster will fail creation before the cluster timeout expires.
* This change also adds shorter timeouts to custom cookbook retrieval on compute node launch.

### Tests
* Manually tested reducing timeout of custom cookbooks by deploying a static compute fleet into an isolated subnet.
* Ran the new integration test in us-east-1 with a manual test configuration.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
