### PR TITLE
`[cloudformation/policies]` Add ParallelCluster Policies as CFN Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 **ENHANCEMENTS**
+- Add a CloudFormation template for the policies needed for ParallelCluster functionality.
 - Add a library interface to ParallelCluster functionality.
 - Add logging of compute node console output to CloudWatch on compute node bootstrap failure.
 - Add failures field containing failure code and reason to `describe-cluster` output when cluster creation fails.

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -1,0 +1,806 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Template for the ParallelCluster Policies'
+
+Parameters:
+  Region:
+    Description: When set to a given region name (e.g. eu-west-1), the API can control resources in that region only. Set to '*' to control all regions.
+    Type: String
+    Default: '*'
+
+  EnableFSxS3Access:
+    Description: |
+      When set to true the ParallelCluster ParallelClusterFSxS3AccessPolicy is created which can access, write to the S3 buckets
+      specified in the Filed FsxS3Bucket, it is needed to import/export from/to S3 when creating an FSx filesystem. NOTE - setting this
+      to true grants the Lambda function S3 Get*, List* and PutObject privileges on the buckets specified in FsxS3Buckets.
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+
+  EnableIamAdminAccess:
+    Description: |
+      When set to true the ParallelCluster API takes care of IAM resource creation when deploying clusters or generating custom AMIs.
+      WARNING - setting this to true grants IAM admin privileges to the Lambda function
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+
+  FsxS3Buckets:
+    Description: |
+      Comma separated list of S3 bucket ARNs, to allow the lambda function to import/export from/to S3 when creating an FSx filesystem.
+      NOTE - The setting is used only when EnableFSxS3Access is set to true. (example arn:aws:s3:::<S3_BUCKET_1>,arn:aws:s3:::<S3_BUCKET_2>)
+    Type: String
+    Default: ''
+    AllowedPattern: ^((arn:[a-z\-\*]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/]+)?(,arn:[a-z\-\*]*:s3:[a-z0-9\-]*:([0-9]{12})*:[^,\s\/]+)*)$|^\*$
+    ConstraintDescription: |
+      The list of S3 buckets is incorrectly formatted. The list should have the format: arn:<PARTITION>:s3:<REGION>:<ACCOUNT_ID>:<BUCKET_NAME>[,arn:<PARTITION>:s3:<REGION>:<ACCOUNT_ID>:<BUCKET_NAME>,...]
+      Example: arn:aws:s3:::test-bucket-1,arn:aws:s3:::test-bucket-2,arn:aws:s3:::test-bucket-3
+
+  PermissionsBoundaryPolicy:
+    Description: |
+      ARN of a IAM policy to use as PermissionsBoundary for all IAM resources created by ParallelCluster API.
+      When specified, IAM permissions assumed by the API are conditionally restricted to the usage of the given PermissionsBoundary
+    Type: String
+    Default: ''
+
+  EnableBatchAccess:
+    Description: |
+      When set to true the ParallelCluster ParallelClusterClusterPolicyBatch is created which can access Batch actions and resources.
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
+
+Outputs:
+  ParallelClusterLogRetrievalPolicy:
+    Value: !Ref ParallelClusterLogRetrievalPolicy
+
+  ParallelClusterDescribeImageManagedPolicy:
+    Value: !Ref ParallelClusterDescribeImageManagedPolicy
+
+  ParallelClusterListImagesManagedPolicy:
+    Value: !Ref ParallelClusterListImagesManagedPolicy
+
+  ParallelClusterDeleteImageManagedPolicy:
+    Value: !Ref ParallelClusterDeleteImageManagedPolicy
+
+  ParallelClusterBuildImageManagedPolicy:
+    Value: !Ref ParallelClusterBuildImageManagedPolicy
+
+  ParallelClusterClusterPolicy:
+    Value: !Ref ParallelClusterClusterPolicy
+
+  FSxS3AccessPolicy:
+    Condition: EnableFSxS3AccessCondition
+    Value: !Ref ParallelClusterFSxS3AccessPolicy
+
+  ParallelClusterUserRole:
+    Value: !Ref ParallelClusterUserRole
+
+  DefaultParallelClusterIamAdminPolicy:
+    Condition: EnableIamPolicy
+    Value: !Ref DefaultParallelClusterIamAdminPolicy
+
+  ParallelClusterClusterPolicyBatch:
+    Condition: EnableBatchAccessCondition
+    Value: !Ref ParallelClusterClusterPolicyBatch
+
+
+
+Conditions:
+  IsMultiRegion: !Equals [!Ref Region, '*']
+  EnableFSxS3AccessCondition: !Equals [!Ref EnableFSxS3Access, true]
+  EnableBatchAccessCondition: !Equals [!Ref EnableBatchAccess, true]
+  EnablePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicy, '']]
+  EnablePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicy, '']]
+  UseAllBucketsForFSxS3: !Equals [!Ref FsxS3Buckets, "*"]
+  EnablePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicy, '']]
+  EnableIamPolicy: !Or
+    - !Equals [!Ref EnableIamAdminAccess, true]
+    - !Condition EnablePermissionsBoundary
+
+Resources:
+  ### IAM POLICIES
+
+  DefaultParallelClusterIamAdminPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: EnableIamPolicy
+    Properties:
+      Roles:
+        - !Ref ParallelClusterUserRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - iam:CreateServiceLinkedRole
+              - iam:DeleteRole
+              - iam:TagRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
+            Effect: Allow
+            Sid: IamRole
+          - Action:
+              - iam:CreateRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
+            Effect: Allow
+            Condition: !If
+              - EnablePermissionsBoundary
+              - StringEquals:
+                  iam:PermissionsBoundary:
+                    - !Ref PermissionsBoundaryPolicy
+              - !Ref AWS::NoValue
+            Sid: IamCreateRole
+          - Action:
+              - iam:PutRolePolicy
+              - iam:DeleteRolePolicy
+            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
+            Effect: Allow
+            Sid: IamInlinePolicy
+            Condition: !If
+              - EnablePermissionsBoundary
+              - StringEquals:
+                  iam:PermissionsBoundary:
+                    - !Ref PermissionsBoundaryPolicy
+              - !Ref AWS::NoValue
+          - Action:
+              - iam:AttachRolePolicy
+              - iam:DetachRolePolicy
+            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
+            Condition:
+              ArnLike:
+                iam:PolicyARN:
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/parallelcluster*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/parallelcluster/*
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSBatchFullAccess
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3ReadOnlyAccess
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSBatchServiceRole
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+              StringEquals: !If
+                - EnablePermissionsBoundary
+                - iam:PermissionsBoundary:
+                    - !Ref PermissionsBoundaryPolicy
+                - !Ref AWS::NoValue
+            Effect: Allow
+            Sid: IamPolicy
+
+
+  ParallelClusterUserRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: lambda.amazonaws.com
+      ManagedPolicyArns:
+        # Required to run ParallelCluster functionalities
+        - !Ref ParallelClusterClusterPolicy
+        - !If
+          - EnableBatchAccessCondition
+          - !Ref ParallelClusterClusterPolicyBatch
+          - !Ref AWS::NoValue
+        - !Ref ParallelClusterBuildImageManagedPolicy
+        - !Ref ParallelClusterDeleteImageManagedPolicy
+        - !Ref ParallelClusterListImagesManagedPolicy
+        - !Ref ParallelClusterDescribeImageManagedPolicy
+        - !Ref ParallelClusterLogRetrievalPolicy
+
+  ### CLUSTER ACTIONS POLICIES
+
+  ParallelClusterClusterPolicyBatch:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: EnableBatchAccessCondition
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - iam:PassRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
+            Effect: Allow
+            Condition:
+              StringEqualsIfExists:
+                iam:PassedToService:
+                  - ecs-tasks.amazonaws.com
+                  - batch.amazonaws.com
+                  - codebuild.amazonaws.com
+            Sid: IamPassRole
+          - Action:
+              - iam:CreateServiceLinkedRole
+              - iam:DeleteServiceLinkedRole
+            Resource:
+              # AWS Batch creates a service linked role automatically for the ComputeEnvironment
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/batch.amazonaws.com/*
+            Effect: Allow
+            Condition:
+              StringEquals:
+                iam:AWSServiceName:
+                  - batch.amazonaws.com
+          - Action:
+              - codebuild:*
+            Resource: !Sub arn:${AWS::Partition}:codebuild:${Region}:${AWS::AccountId}:project/pcluster-*
+            Effect: Allow
+          - Action:
+              - ecr:*
+            Resource: '*'
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Sid: ECR
+          - Action:
+              - batch:*
+            Resource: '*'
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Sid: Batch
+          - Action:
+              - events:*
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Resource: '*'
+            Sid: AmazonCloudWatchEvents
+          - Action:
+              - ecs:DescribeContainerInstances
+              - ecs:ListContainerInstances
+            Resource: '*'
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Sid: ECS
+
+  ParallelClusterFSxS3AccessPolicy:
+    Type: AWS::IAM::Policy
+    Condition: EnableFSxS3AccessCondition
+    Properties:
+      PolicyName: ParallelClusterFSxS3AccessPolicy
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - iam:CreateServiceLinkedRole
+              - iam:AttachRolePolicy
+              - iam:PutRolePolicy
+            Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/s3.data-source.lustre.fsx.amazonaws.com/*
+            Effect: Allow
+            Sid: FSxS3PoliciesAttach
+          - Action:
+              - s3:Get*
+              - s3:List*
+              - s3:PutObject
+            Resource: !Split
+              - ","
+              - !If
+                - UseAllBucketsForFSxS3
+                - "*"
+                - !Sub ["${FsxS3Buckets},${FsxS3BucketsObjects}", FsxS3BucketsObjects: !Join ["/*,", !Split [",", !Sub "${FsxS3Buckets}/*"]]]
+            Effect: Allow
+            Sid: EnableFSxS3Access
+      Roles:
+        - !Ref ParallelClusterUserRole
+
+  ParallelClusterClusterPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - ec2:Describe*
+            Resource: '*'
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Sid: EC2Read
+          - Action:
+              - ec2:AllocateAddress
+              - ec2:AssociateAddress
+              - ec2:AttachNetworkInterface
+              - ec2:AuthorizeSecurityGroupEgress
+              - ec2:AuthorizeSecurityGroupIngress
+              - ec2:CreateFleet
+              - ec2:CreateLaunchTemplate
+              - ec2:CreateLaunchTemplateVersion
+              - ec2:CreateNetworkInterface
+              - ec2:CreatePlacementGroup
+              - ec2:CreateSecurityGroup
+              - ec2:CreateSnapshot
+              - ec2:CreateTags
+              - ec2:CreateVolume
+              - ec2:DeleteLaunchTemplate
+              - ec2:DeleteNetworkInterface
+              - ec2:DeletePlacementGroup
+              - ec2:DeleteSecurityGroup
+              - ec2:DeleteVolume
+              - ec2:DisassociateAddress
+              - ec2:ModifyLaunchTemplate
+              - ec2:ModifyNetworkInterfaceAttribute
+              - ec2:ModifyVolume
+              - ec2:ModifyVolumeAttribute
+              - ec2:ReleaseAddress
+              - ec2:RevokeSecurityGroupEgress
+              - ec2:RevokeSecurityGroupIngress
+              - ec2:RunInstances
+              - ec2:TerminateInstances
+            Resource: '*'
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Sid: EC2Write
+          - Action:
+              - dynamodb:DescribeTable
+              - dynamodb:ListTagsOfResource
+              - dynamodb:CreateTable
+              - dynamodb:DeleteTable
+              - dynamodb:GetItem
+              - dynamodb:PutItem
+              - dynamodb:UpdateItem
+              - dynamodb:Query
+              - dynamodb:TagResource
+            Resource: !Sub arn:${AWS::Partition}:dynamodb:${Region}:${AWS::AccountId}:table/parallelcluster-*
+            Effect: Allow
+            Sid: DynamoDB
+          - Action:
+              - route53:ChangeResourceRecordSets
+              - route53:ChangeTagsForResource
+              - route53:CreateHostedZone
+              - route53:DeleteHostedZone
+              - route53:GetChange
+              - route53:GetHostedZone
+              - route53:ListResourceRecordSets
+              - route53:ListQueryLoggingConfigs
+            Resource: '*'
+            Effect: Allow
+            Sid: Route53HostedZones
+          - Action:
+              - cloudformation:*
+            Resource: '*'
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Sid: CloudFormation
+          - Action:
+              - cloudwatch:PutDashboard
+              - cloudwatch:ListDashboards
+              - cloudwatch:DeleteDashboards
+              - cloudwatch:GetDashboard
+            Resource: '*'
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Sid: CloudWatch
+          - Action:
+              - iam:GetRole
+              - iam:GetRolePolicy
+              - iam:GetPolicy
+              - iam:SimulatePrincipalPolicy
+              - iam:GetInstanceProfile
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*
+              - !Sub arn:${AWS::Partition}:iam::aws:policy/*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/*
+            Effect: Allow
+            Sid: IamRead
+          - Action:
+              - iam:CreateInstanceProfile
+              - iam:DeleteInstanceProfile
+              - iam:AddRoleToInstanceProfile
+              - iam:RemoveRoleFromInstanceProfile
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*
+            Effect: Allow
+            Sid: IamInstanceProfile
+          - Action:
+              - iam:PassRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*
+            Effect: Allow
+            Condition:
+              StringEqualsIfExists:
+                iam:PassedToService:
+                  - lambda.amazonaws.com
+                  - ec2.amazonaws.com
+                  - ec2.amazonaws.com.cn
+                  - spotfleet.amazonaws.com
+            Sid: IamPassRole
+          - Action:
+              - iam:CreateServiceLinkedRole
+              - iam:DeleteServiceLinkedRole
+            Resource: '*'
+            Effect: Allow
+            Condition:
+              StringEquals:
+                iam:AWSServiceName:
+                  - fsx.amazonaws.com
+                  - s3.data-source.lustre.fsx.amazonaws.com
+          - Action:
+              - lambda:CreateFunction
+              - lambda:TagResource
+              - lambda:DeleteFunction
+              - lambda:GetFunctionConfiguration
+              - lambda:GetFunction
+              - lambda:InvokeFunction
+              - lambda:AddPermission
+              - lambda:RemovePermission
+              - lambda:UpdateFunctionConfiguration
+              - lambda:ListTags
+              - lambda:UntagResource
+            Resource:
+              - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:parallelcluster-*
+              - !Sub arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:pcluster-*
+            Effect: Allow
+            Sid: Lambda
+          - Action:
+              - s3:*
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::parallelcluster-*
+              - !Sub arn:${AWS::Partition}:s3:::aws-parallelcluster-*
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Sid: S3ResourcesBucket
+          - Action:
+              - s3:Get*
+              - s3:List*
+            Resource: !Sub arn:${AWS::Partition}:s3:::${Region}-aws-parallelcluster*
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Sid: S3ParallelClusterReadOnly
+          - Action:
+              - fsx:*
+            Resource:
+              - !Sub arn:${AWS::Partition}:fsx:${Region}:${AWS::AccountId}:*
+            Effect: Allow
+            Sid: FSx
+          - Action:
+              - elasticfilesystem:*
+            Resource:
+              - !Sub arn:${AWS::Partition}:elasticfilesystem:${Region}:${AWS::AccountId}:*
+            Effect: Allow
+            Sid: EFS
+          - Action:
+              - logs:DeleteLogGroup
+              - logs:PutRetentionPolicy
+              - logs:DescribeLogGroups
+              - logs:CreateLogGroup
+              - logs:TagResource
+              - logs:UntagResource
+            Resource: '*'
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region
+            Sid: CloudWatchLogs
+          - Action:
+              - resource-groups:ListGroupResources
+              - resource-groups:GetGroupConfiguration
+            Resource: '*'
+            Effect: Allow
+            Sid: ResourceGroupRead
+
+
+  # ### IMAGE ACTIONS POLICIES
+
+  ParallelClusterBuildImageManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy to execute pcluster build-image command without IAM permission
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EC2
+            Effect: Allow
+            Action:
+              - ec2:DescribeImages
+              - ec2:DescribeInstanceTypeOfferings
+              - ec2:DescribeInstanceTypes
+            Resource: '*'
+          - Sid: IAM
+            Effect: Allow
+            Action:
+              - iam:CreateInstanceProfile
+              - iam:AddRoleToInstanceProfile
+              - iam:GetRole
+              - iam:GetRolePolicy
+              - iam:GetInstanceProfile
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/ParallelClusterImage*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+          - Sid: IAMPassRole
+            Effect: Allow
+            Action:
+              - iam:PassRole
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+            Condition:
+              StringEquals:
+                iam:PassedToService:
+                  - lambda.amazonaws.com
+                  - ec2.amazonaws.com
+                  - ec2.amazonaws.com.cn
+          - Sid: CloudWatch
+            Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:TagResource
+              - logs:UntagResource
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:logs:${Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*'
+          - Sid: CloudFormation
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+              - cloudformation:CreateStack
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:cloudformation:${Region}:${AWS::AccountId}:stack/*'
+          - Sid: Lambda
+            Effect: Allow
+            Action:
+              - lambda:CreateFunction
+              - lambda:TagResource
+              - lambda:GetFunction
+              - lambda:AddPermission
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:ParallelClusterImage-*'
+          - Sid: ImageBuilderGet
+            Effect: Allow
+            Action:
+              - imagebuilder:Get*
+            Resource: '*'
+          - Sid: ImageBuilder
+            Effect: Allow
+            Action:
+              - imagebuilder:CreateImage
+              - imagebuilder:TagResource
+              - imagebuilder:CreateImageRecipe
+              - imagebuilder:CreateComponent
+              - imagebuilder:CreateDistributionConfiguration
+              - imagebuilder:CreateInfrastructureConfiguration
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:image/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:image-recipe/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:component/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:infrastructure-configuration/parallelclusterimage-*'
+          - Sid: S3Bucket
+            Effect: Allow
+            Action:
+              - s3:CreateBucket
+              - s3:ListBucket
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*'
+          - Sid: SNS
+            Effect: Allow
+            Action:
+              - sns:GetTopicAttributes
+              - sns:TagResource
+              - sns:CreateTopic
+              - sns:Subscribe
+              - sns:Publish
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:sns:${Region}:${AWS::AccountId}:ParallelClusterImage-*'
+          - Sid: S3Objects
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*/*'
+          - Action:
+              - iam:CreateServiceLinkedRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/imagebuilder.amazonaws.com/AWSServiceRoleForImageBuilder
+            Effect: Allow
+            Condition:
+              StringLike:
+                iam:AWSServiceName:
+                  - imagebuilder.amazonaws.com
+
+  ParallelClusterDeleteImageManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy to execute pcluster delete-image command without IAM permission
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EC2
+            Effect: Allow
+            Action:
+              - ec2:DeregisterImage
+              - ec2:DescribeImages
+              - ec2:DeleteSnapshot
+            Resource: '*'
+          - Sid: IAM
+            Effect: Allow
+            Action:
+              - iam:RemoveRoleFromInstanceProfile
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/parallelcluster/*'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/parallelcluster/*'
+          - Sid: ImageBuilder
+            Effect: Allow
+            Action:
+              - imagebuilder:DeleteImage
+              - imagebuilder:GetImage
+              - imagebuilder:CancelImageCreation
+              - imagebuilder:DeleteComponent
+              - imagebuilder:DeleteImageRecipe
+              - imagebuilder:DeleteInfrastructureConfiguration
+              - imagebuilder:DeleteDistributionConfiguration
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:image/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:image-recipe/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:component/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:distribution-configuration/parallelclusterimage-*'
+              - !Sub 'arn:${AWS::Partition}:imagebuilder:${Region}:${AWS::AccountId}:infrastructure-configuration/parallelclusterimage-*'
+          - Sid: CloudFormation
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+              - cloudformation:DeleteStack
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:cloudformation:${Region}:${AWS::AccountId}:stack/*'
+          - Sid: Lambda
+            Effect: Allow
+            Action:
+              - lambda:RemovePermission
+              - lambda:DeleteFunction
+              - lambda:AddPermission
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:lambda:${Region}:${AWS::AccountId}:function:ParallelClusterImage-*'
+          - Sid: SNS
+            Effect: Allow
+            Action:
+              - SNS:DeleteTopic
+              - SNS:Unsubscribe
+              - SNS:GetTopicAttributes
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:sns:${Region}:${AWS::AccountId}:ParallelClusterImage-*'
+          - Sid: S3Bucket
+            Effect: Allow
+            Action:
+              - s3:ListBucket
+              - s3:ListBucketVersions
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*'
+          - Sid: S3Objects
+            Effect: Allow
+            Action:
+              - s3:PutObject
+              - s3:GetObject
+              - s3:GetObjectVersion
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::parallelcluster-*/*'
+          - Sid: CloudWatch
+            Effect: Allow
+            Action:
+              - logs:DeleteLogGroup
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:logs:${Region}:${AWS::AccountId}:log-group:/aws/imagebuilder/ParallelClusterImage-*'
+              - !Sub 'arn:${AWS::Partition}:logs:${Region}:${AWS::AccountId}:log-group:/aws/lambda/ParallelClusterImage-*'
+
+  ParallelClusterListImagesManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy to execute pcluster list-images command
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EC2
+            Effect: Allow
+            Action:
+              - ec2:DescribeImages
+            Resource: '*'
+          - Sid: CloudFormation
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+            Resource:
+              - '*'
+
+  ParallelClusterDescribeImageManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Managed policy to execute pcluster describe-image command
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EC2
+            Effect: Allow
+            Action:
+              - ec2:DescribeImages
+            Resource: '*'
+          - Sid: CloudFormation
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:cloudformation:${Region}:${AWS::AccountId}:stack/*'
+
+  ### LOG COMMANDS
+
+  ParallelClusterLogRetrievalPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Policies needed to retrieve cluster and images logs
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+            - logs:DescribeLogGroups
+            - logs:FilterLogEvents
+            - logs:GetLogEvents
+            - logs:CreateExportTask
+            - logs:DescribeLogStreams
+            - logs:DescribeExportTasks
+            Resource: '*'
+            Effect: Allow
+            Condition: !If
+              - IsMultiRegion
+              - !Ref AWS::NoValue
+              - StringEquals:
+                  aws:RequestedRegion:
+                    - !Ref Region

--- a/cloudformation/tests/conftest.py
+++ b/cloudformation/tests/conftest.py
@@ -1,0 +1,4 @@
+def pytest_collection_modifyitems(items, config):
+    for item in items:
+        if not any(item.iter_markers()):
+            item.add_marker("unmarked")

--- a/cloudformation/tests/pytest.ini
+++ b/cloudformation/tests/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -m "not local"
+markers =
+    local: marks tests that can only be run locally

--- a/cloudformation/tests/requirements.txt
+++ b/cloudformation/tests/requirements.txt
@@ -1,5 +1,7 @@
 pytest
-jinja2
+jinja2~=3.0
 cfn-lint
 cfn-flip
 assertpy
+boto3
+PyYAML~=5.3

--- a/cloudformation/tests/test_cfn_validation.py
+++ b/cloudformation/tests/test_cfn_validation.py
@@ -1,19 +1,29 @@
+"""Test that all of the templates are in a valid format."""
 import json
 import os
+
+import boto3
+import pytest
+from assertpy import assert_that
 
 
 def test_valid_json():
     """Verify cfn templates are correctly formatted."""
-    invalid_json = False
     for filename in os.listdir("../networking"):
         if filename.endswith(".cfn.json"):
-            print("Validating json file: %s" % filename)
-            with open(f"../networking/{filename}", encoding="utf-8") as f:
-                try:
-                    json.load(f)
-                    print("SUCCESS: Valid json.")
-                except ValueError as e:
-                    print("ERROR: Invalid json: %s" % e)
-                    invalid_json = True
+            with open(f"../networking/{filename}", encoding="utf-8") as inf:
+                data = json.load(inf)
+                assert_that(data).is_not_none()
 
-    assert not invalid_json
+
+@pytest.mark.parametrize("directory", [("../networking"), ("../policies"), ("../ad"), ("../database")])
+@pytest.mark.local
+def test_valid_template(directory):
+    """Verify cfn templates are correctly formatted."""
+    cfn = boto3.client("cloudformation")
+    for filename in os.listdir(directory):
+        if filename.endswith(".cfn.json") or filename.endswith(".yaml"):
+            print(f"Validating json file: {directory}/{filename}")
+            with open(f"{directory}/{filename}", encoding="utf-8") as inf:
+                response = cfn.validate_template(TemplateBody=inf.read())
+                assert_that(response).is_not_none()

--- a/cloudformation/tests/test_policies.py
+++ b/cloudformation/tests/test_policies.py
@@ -1,0 +1,110 @@
+"""Test the CloudFormation Template for policies."""
+import random
+import string
+
+import boto3
+import botocore
+import pytest
+from assertpy import assert_that
+from cfn_flip import load_yaml
+
+TEMPLATE = "../policies/parallelcluster-policies.yaml"
+
+
+@pytest.fixture(name="random_stack_name")
+def random_stack_name_fixture():
+    """Provide a short random id that can be used in a aack name."""
+    alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
+    return "".join(random.choice(alnum) for _ in range(8))
+
+
+@pytest.fixture(scope="session", name="cfn")
+def cfn_fixture():
+    """Create a CloudFormation Boto3 client."""
+    client = boto3.client("cloudformation")
+    return client
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        ({"Region": "*"}),
+        ({"Region": "us-east-1"}),
+        ({"EnableFSxS3Access": "true", "FsxS3Buckets": "*"}),
+        ({"EnableFSxS3Access": "false"}),
+        ({"EnableIamAdminAccess": "true"}),
+        ({"EnableFSxS3Access": "true", "FsxS3Buckets": "arn:aws:s3:::bucket"}),
+        ({"EnableBatchAccess": "true"}),
+    ],
+)
+@pytest.mark.local
+def test_policies(cfn, random_stack_name, parameters):
+    """Test various parameter combinations."""
+    stack_name = f"pc-cfn-{random_stack_name}"
+
+    with open(TEMPLATE, encoding="utf-8") as inf:
+        cfn.create_stack(
+            StackName=stack_name,
+            TemplateBody=inf.read(),
+            Capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
+            Parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items()],
+        )
+
+    try:
+        cfn.get_waiter("stack_create_complete").wait(StackName=stack_name)
+    except botocore.exceptions.WaiterError as exc:
+        # Ensure that we always delete the stack even an exception is thrown
+        cfn.delete_stack(StackName=stack_name)
+        cfn.get_waiter("stack_delete_complete").wait(StackName=stack_name)
+        raise exc
+
+    stack = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]
+    stack_id = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]["StackId"]
+    status = stack["StackStatus"]
+    assert_that(status).is_equal_to("CREATE_COMPLETE")
+    cfn.delete_stack(StackName=stack_name)
+    cfn.get_waiter("stack_delete_complete").wait(StackName=stack_name)
+    status = cfn.describe_stacks(StackName=stack_id)["Stacks"][0]["StackStatus"]
+    assert_that(status).is_equal_to("DELETE_COMPLETE")
+
+
+def test_match_api():
+    """Validate minimal changes with the API's yaml."""
+    source_path = "../../api/infrastructure/parallelcluster-api.yaml"
+    policies_path = "../policies/parallelcluster-policies.yaml"
+
+    with open(source_path, encoding="utf-8") as source_file:
+        source = load_yaml(source_file.read())
+
+    with open(policies_path, encoding="utf-8") as policies_file:
+        policies = load_yaml(policies_file.read())
+
+    # These params match except for the description
+    for key in ["Region", "EnableFSxS3Access", "FsxS3Buckets", "PermissionsBoundaryPolicy"]:
+        drop_keys = {"Description"}
+        dest_dict = {k: v for k, v in policies["Parameters"][key].items() if k not in drop_keys}
+        source_dict = {k: v for k, v in source["Parameters"][key].items() if k not in drop_keys}
+        assert_that(dest_dict).is_equal_to(source_dict)
+
+    for key in policies["Resources"].keys():
+        drop_keys = {"Condition"}
+
+        source_key = {"ParallelClusterFSxS3AccessPolicy": "FSxS3AccessPolicy"}.get(key, key)
+        source_dict = {k: v for k, v in source["Resources"][source_key].items() if k not in drop_keys}
+        dest_dict = {k: v for k, v in policies["Resources"][key].items() if k not in drop_keys}
+
+        if key == "ParallelClusterUserRole":
+            source_dict["Properties"]["ManagedPolicyArns"] = source_dict["Properties"]["ManagedPolicyArns"][2:]
+
+            def remove_batch_if(arn):
+                return arn if "Ref" in arn else arn["Fn::If"][1]
+
+            dest_dict["Properties"]["ManagedPolicyArns"] = list(
+                map(remove_batch_if, dest_dict["Properties"]["ManagedPolicyArns"])
+            )
+
+        if key == "ParallelClusterFSxS3AccessPolicy":
+            del source_dict["Properties"]["PolicyName"]
+            del dest_dict["Properties"]["PolicyName"]
+
+        assert_that(dest_dict).is_equal_to(source_dict)


### PR DESCRIPTION
### Description of changes
* This PR adds a template for creating the policies required for performing ParallelCluster operations
* This is advantageous to the customer because it provides a well-defined location for capturing the policies that can be retrieved from a nested stack without having to copy the code.
* This code was copied from the API cloudformation template with the policies (and names) kept in place while additional parameterization was added for the convenience of the customer.

### Tests
* Testing was added for generic template validation of this and other templates that can be run locally.
* Additionally, specific unit tests were added for the various parameters.
* A test was also added to programmatically compare the new template to the one from the API where it was generated from to ensure that they remain functionally equivalent until they can be combined.

The tests are run locally in the `cloudformation/tests` directory by running the command: `pytest . -m "local or unmarked"`

Output of a local run:

```.bash
$ pytest . -m "local or unmarked"
Test session starts (platform: linux, Python 3.8.10, pytest 7.1.2, pytest-sugar 0.9.4)
rootdir: /home/ANT.AMAZON.COM/cgruenwa/src/aws-parallelcluster/cloudformation/tests, configfile: pytest.ini
plugins: forked-1.3.0, mock-3.10.0, html-3.1.1, xdist-2.3.0, datadir-1.3.1, cov-4.0.0, sugar-0.9.4, typeguard-2.13.3, metadata-1.11.0, rerunfailures-10.1
collecting ... 
 test_cfn_validation.py ✓✓✓✓✓                                                                                          38% ███▉      
 test_policies.py ✓✓✓✓✓✓✓✓                                                                                            100% ██████████
========================================================= warnings summary ==========================================================
../../../../.local/lib/python3.8/site-packages/_pytest/nodes.py:351
  /home/ANT.AMAZON.COM/cgruenwa/.local/lib/python3.8/site-packages/_pytest/nodes.py:351: PytestUnknownMarkWarning: Unknown pytest.mark.unmarked - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    marker_ = getattr(MARK_GEN, marker)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

Results (650.40s):
      13 passed
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
