### PR TITLE
`[policies]` Return the Arn of ParallelClusterLambdaRole in output of policies substack

### DIFF
--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -78,8 +78,8 @@ Outputs:
     Condition: EnableFSxS3AccessCondition
     Value: !Ref ParallelClusterFSxS3AccessPolicy
 
-  ParallelClusterUserRoleArn:
-    Value: !GetAtt ParallelClusterUserRole.Arn
+  ParallelClusterLambdaRoleArn:
+    Value: !GetAtt ParallelClusterLambdaRole.Arn
 
   DefaultParallelClusterIamAdminPolicy:
     Condition: EnableIamPolicy
@@ -111,7 +111,7 @@ Resources:
     Condition: EnableIamPolicy
     Properties:
       Roles:
-        - !Ref ParallelClusterUserRole
+        - !Ref ParallelClusterLambdaRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -175,7 +175,7 @@ Resources:
             Sid: IamPolicy
 
 
-  ParallelClusterUserRole:
+  ParallelClusterLambdaRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -185,6 +185,9 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
       ManagedPolicyArns:
+        # Required for Lambda logging and XRay
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSXRayDaemonWriteAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         # Required to run ParallelCluster functionalities
         - !Ref ParallelClusterClusterPolicy
         - !If
@@ -307,7 +310,7 @@ Resources:
             Effect: Allow
             Sid: EnableFSxS3Access
       Roles:
-        - !Ref ParallelClusterUserRole
+        - !Ref ParallelClusterLambdaRole
 
   ParallelClusterClusterPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -78,8 +78,8 @@ Outputs:
     Condition: EnableFSxS3AccessCondition
     Value: !Ref ParallelClusterFSxS3AccessPolicy
 
-  ParallelClusterUserRole:
-    Value: !Ref ParallelClusterUserRole
+  ParallelClusterUserRoleArn:
+    Value: !GetAtt ParallelClusterUserRole.Arn
 
   DefaultParallelClusterIamAdminPolicy:
     Condition: EnableIamPolicy


### PR DESCRIPTION

### Description of changes
* This PR changes the output of the policies stack for the user role to return the ARN which is more convenient to use directly in other CloudFormation stacks.

### Tests
See: https://github.com/aws/aws-parallelcluster/pull/4845 for more extensive description of tests that have been run on this change.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
