### PR TITLE
`[policies]` Also return a lambda role separate from the user role.

### DIFF
--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -74,6 +74,10 @@ Outputs:
   ParallelClusterClusterPolicy:
     Value: !Ref ParallelClusterClusterPolicy
 
+  ParallelClusterClusterPolicyBatch:
+    Condition: EnableBatchAccessCondition
+    Value: !Ref ParallelClusterClusterPolicyBatch
+
   FSxS3AccessPolicy:
     Condition: EnableFSxS3AccessCondition
     Value: !Ref ParallelClusterFSxS3AccessPolicy
@@ -85,11 +89,8 @@ Outputs:
     Condition: EnableIamPolicy
     Value: !Ref DefaultParallelClusterIamAdminPolicy
 
-  ParallelClusterClusterPolicyBatch:
-    Condition: EnableBatchAccessCondition
-    Value: !Ref ParallelClusterClusterPolicyBatch
-
-
+  ParallelClusterLambdaRoleArn:
+    Value: !GetAtt ParallelClusterLambdaRole.Arn
 
 Conditions:
   IsMultiRegion: !Equals [!Ref Region, '*']
@@ -112,6 +113,7 @@ Resources:
     Properties:
       Roles:
         - !Ref ParallelClusterUserRole
+        - !Ref ParallelClusterLambdaRole
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -173,6 +175,32 @@ Resources:
                 - !Ref AWS::NoValue
             Effect: Allow
             Sid: IamPolicy
+
+
+  ParallelClusterLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: lambda.amazonaws.com
+      ManagedPolicyArns:
+        # Required for Lambda logging and XRay
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSXRayDaemonWriteAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        # Required to run ParallelCluster functionalities
+        - !Ref ParallelClusterClusterPolicy
+        - !If
+          - EnableBatchAccessCondition
+          - !Ref ParallelClusterClusterPolicyBatch
+          - !Ref AWS::NoValue
+        - !Ref ParallelClusterBuildImageManagedPolicy
+        - !Ref ParallelClusterDeleteImageManagedPolicy
+        - !Ref ParallelClusterListImagesManagedPolicy
+        - !Ref ParallelClusterDescribeImageManagedPolicy
+        - !Ref ParallelClusterLogRetrievalPolicy
 
 
   ParallelClusterUserRole:

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -78,8 +78,8 @@ Outputs:
     Condition: EnableFSxS3AccessCondition
     Value: !Ref ParallelClusterFSxS3AccessPolicy
 
-  ParallelClusterUserRole:
-    Value: !Ref ParallelClusterUserRole
+  ParallelClusterUserRoleArn:
+    Value: !GetAtt ParallelClusterUserRole.Arn
 
   DefaultParallelClusterIamAdminPolicy:
     Condition: EnableIamPolicy

--- a/cloudformation/tests/test_policies.py
+++ b/cloudformation/tests/test_policies.py
@@ -89,15 +89,19 @@ def test_match_api():
     for key in policies["Resources"].keys():
         drop_keys = {"Condition"}
 
-        source_key = {"ParallelClusterFSxS3AccessPolicy": "FSxS3AccessPolicy"}.get(key, key)
+        source_key = {
+            "ParallelClusterFSxS3AccessPolicy": "FSxS3AccessPolicy",
+            "ParallelClusterLambdaRole": "ParallelClusterUserRole",
+        }.get(key, key)
         source_dict = {k: v for k, v in source["Resources"][source_key].items() if k not in drop_keys}
         dest_dict = {k: v for k, v in policies["Resources"][key].items() if k not in drop_keys}
 
-        if key == "ParallelClusterUserRole":
-            source_dict["Properties"]["ManagedPolicyArns"] = source_dict["Properties"]["ManagedPolicyArns"][2:]
+        if key in ["ParallelClusterUserRole", "ParallelClusterLambdaRole"]:
+            if key == "ParallelClusterUserRole":
+                source_dict["Properties"]["ManagedPolicyArns"] = source_dict["Properties"]["ManagedPolicyArns"][2:]
 
             def remove_batch_if(arn):
-                return arn if "Ref" in arn else arn["Fn::If"][1]
+                return arn if ("Ref" in arn or "Fn::Sub" in arn) else arn["Fn::If"][1]
 
             dest_dict["Properties"]["ManagedPolicyArns"] = list(
                 map(remove_batch_if, dest_dict["Properties"]["ManagedPolicyArns"])
@@ -106,5 +110,8 @@ def test_match_api():
         if key == "ParallelClusterFSxS3AccessPolicy":
             del source_dict["Properties"]["PolicyName"]
             del dest_dict["Properties"]["PolicyName"]
+
+        if key == "DefaultParallelClusterIamAdminPolicy":
+            source_dict["Properties"]["Roles"].append(dest_dict["Properties"]["Roles"][1])
 
         assert_that(dest_dict).is_equal_to(source_dict)


### PR DESCRIPTION
### Description of changes
* This PR changes the output of the policies stack for the user role to return the ARN which is more convenient to use directly in other CloudFormation stacks.

### Tests
See: https://github.com/aws/aws-parallelcluster/pull/4845 for more extensive description of tests that have been run on this change.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
