### PR TITLE
[integ-tests] Move some test_efa dimensions to us-east-1 to avoid ICE

### DIFF
--- a/cli/.pylintrc
+++ b/cli/.pylintrc
@@ -163,6 +163,8 @@ disable=print-statement,
         # FIXME Refactor/cleanup cli code to solve following warnings
         duplicate-code,
         consider-using-f-string,
+        broad-exception-raised,
+        use-dict-literal
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/cli/src/pcluster/api/encoder.py
+++ b/cli/src/pcluster/api/encoder.py
@@ -22,7 +22,7 @@ class JSONEncoder(FlaskJSONEncoder):
 
     include_nulls = False
 
-    def default(self, obj):
+    def default(self, obj):  # pylint: disable=arguments-renamed
         """Override the base method to add support for model objects serialization."""
         if isinstance(obj, Model):
             dikt = {}

--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -120,7 +120,6 @@ def _get_subnets(conn, vpc_id):
 
 
 def configure(args):  # noqa: C901
-
     config_file_path = args.config
     # Check for invalid path (eg. a directory)
     if os.path.exists(config_file_path):

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1886,7 +1886,10 @@ class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
     @property
     def instance_types(self) -> List[str]:
         """Return list of instance type names in this compute resource."""
-        return [flexible_instance_type.instance_type for flexible_instance_type in self.instances]
+        return [
+            flexible_instance_type.instance_type
+            for flexible_instance_type in self.instances  # pylint: disable=not-an-iterable
+        ]
 
     @property
     def disable_simultaneous_multithreading_manually(self) -> bool:

--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -80,7 +80,6 @@ class Resource:
         """
 
         def __init__(self, value, default=None, update_policy=None):
-
             # If the value is None, it means that the value has not been specified in the configuration; hence it can
             # be implied from its default, if present.
             if value is None and default is not None:

--- a/cli/src/pcluster/lib/lib.py
+++ b/cli/src/pcluster/lib/lib.py
@@ -45,7 +45,6 @@ def _gen_class(model: Dict) -> Dict[str, Callable]:
         """Take the name of an operation and return the function that call the controller."""
 
         def func(_self, **kwargs):
-
             # Validate that args provided match the model
             params = model[op_name]["params"]
             expected = {to_snake_case(param["name"]) for param in params if param["required"]}

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -591,7 +591,8 @@ class Cluster:
                 # A nosec comment is appended to the following line in order to disable the B324 checks.
                 # The sha1 is used just as a hashing function.
                 # [B324:hashlib] Use of weak MD4, MD5, or SHA1 hash for security. Consider usedforsecurity=False
-                lambda value: hashlib.sha1(value.encode())  # nosec B324 nosemgrep
+                # [B303:blacklist] Use of insecure MD2, MD4, MD5, or SHA1 hash function
+                lambda value: hashlib.sha1(value.encode())  # nosec nosemgrep
                 .hexdigest()[0:16]
                 .capitalize()
             )

--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -111,7 +111,6 @@ class AwsBatchConstruct(Construct):
     # -- Resources --------------------------------------------------------------------------------------------------- #
 
     def _add_resources(self):
-
         # Augment head node instance profile with Batch-specific policies, only add policies to Role craeted by
         # ParallelCluster
         if self.head_node_instance_role:
@@ -591,7 +590,6 @@ class AwsBatchConstruct(Construct):
     def _add_manage_docker_images_lambda(self):
         manage_docker_images_lambda_execution_role = None
         if self.create_lambda_roles:
-
             manage_docker_images_lambda_execution_role = add_lambda_cfn_role(
                 scope=self.stack_scope,
                 config=self.config,
@@ -831,7 +829,6 @@ class AwsBatchConstruct(Construct):
     # -- Outputs ----------------------------------------------------------------------------------------------------- #
 
     def _add_outputs(self):
-
         CfnOutput(
             scope=self.stack_scope,
             id="BatchCliRequirements",

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -61,7 +61,7 @@ def create_hash_suffix(string_to_hash: str):
         # A nosec comment is appended to the following line in order to disable the B324 check.
         # The sha1 is used just as a hashing function.
         # [B324:hashlib] Use of weak MD4, MD5, or SHA1 hash for security. Consider usedforsecurity=False
-        else sha1(string_to_hash.encode("utf-8")).hexdigest()[:16].capitalize()  # nosec B324 nosemgrep
+        else sha1(string_to_hash.encode("utf-8")).hexdigest()[:16].capitalize()  # nosec nosemgrep
     )
 
 
@@ -321,7 +321,7 @@ def generate_launch_template_version_cfn_parameter_hash(queue, compute_resource)
     # A nosec comment is appended to the following line in order to disable the B324 check.
     # The sha1 is used just as a hashing function.
     # [B324:hashlib] Use of weak MD4, MD5, or SHA1 hash for security. Consider usedforsecurity=False
-    return hashlib.sha1((queue + compute_resource).encode()).hexdigest()[0:16].capitalize()  # nosec B324 nosemgrep
+    return hashlib.sha1((queue + compute_resource).encode()).hexdigest()[0:16].capitalize()  # nosec nosemgrep
 
 
 class NodeIamResourcesBase(Construct):

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -80,7 +80,6 @@ class CWDashboardConstruct(Construct):
     # -- Resources --------------------------------------------------------------------------------------------------- #
 
     def _add_resources(self):
-
         # Initialize a cloudwatch dashboard
         self.cloudwatch_dashboard = cloudwatch.Dashboard(
             self.stack_scope, "CloudwatchDashboard", dashboard_name=self.dashboard_name
@@ -497,7 +496,6 @@ class CWDashboardConstruct(Construct):
             if not self.empty_section:
                 self._add_text_widget(f"## {section_widgets.section_title}")
                 for log_params in section_widgets.widgets:
-
                     # Check if the log need to added
                     passed_condition = True
                     if log_params.conditions:

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -300,7 +300,6 @@ class MaxCountValidator(Validator):
     """Validate whether the number of resource exceeds the limits."""
 
     def _validate(self, resources_length, max_length, resource_name):
-
         if resources_length > max_length:
             self._add_failure(
                 "Invalid number of {resource_name} ({resources_length}) specified. Currently only supports "
@@ -318,7 +317,6 @@ class EfaValidator(Validator):
     """Check if EFA and EFA GDR are supported features in the given instance type."""
 
     def _validate(self, instance_type, efa_enabled, gdr_support, multiaz_enabled):
-
         instance_type_supports_efa = AWSApi.instance().ec2.get_instance_type_info(instance_type).is_efa_supported()
         if efa_enabled and not instance_type_supports_efa:
             self._add_failure(f"Instance type '{instance_type}' does not support EFA.", FailureLevel.ERROR)
@@ -434,7 +432,6 @@ def _check_in_out_access(security_groups_ids, port, is_cidr_optional, protocol="
     out_access = False
 
     for sec_group in AWSApi.instance().ec2.describe_security_groups(security_groups_ids):
-
         # Check all inbound rules
         for rule in sec_group.get("IpPermissions"):
             if _check_sg_rules_for_port(rule, port, protocol):
@@ -588,7 +585,6 @@ class FsxArchitectureOsValidator(Validator):
     """
 
     def _validate(self, architecture: str, os):
-
         if architecture not in FSX_SUPPORTED_ARCHITECTURES_OSES:
             self._add_failure(
                 FSX_MESSAGES["errors"]["unsupported_architecture"].format(

--- a/cli/src/pcluster/validators/ec2_validators.py
+++ b/cli/src/pcluster/validators/ec2_validators.py
@@ -50,7 +50,6 @@ class InstanceTypeAcceleratorManufacturerValidator(Validator):
     """
 
     def _validate(self, instance_type: str, instance_type_data: dict):
-
         gpu_info = instance_type_data.get("GpuInfo", {})
         if gpu_info:
             gpu_manufacturers = list({gpu.get("Manufacturer", "") for gpu in gpu_info.get("Gpus", [])})

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -78,7 +78,6 @@ class QueueSubnetsValidator(Validator):
         return {az: subnet_ids for az, subnet_ids in az_subnet_ids_mapping.items() if len(subnet_ids) > 1}
 
     def _validate(self, queue_name, subnet_ids: List[str], az_subnet_ids_mapping: dict):
-
         # Test if there are duplicate IDs in subnet_ids
         if len(set(subnet_ids)) < len(subnet_ids):
             duplicate_ids = [subnet_id for subnet_id, count in Counter(subnet_ids).items() if count > 1]
@@ -95,7 +94,6 @@ class QueueSubnetsValidator(Validator):
         try:
             azs_with_multiple_subnets = self._find_azs_with_multiple_subnets(az_subnet_ids_mapping)
             if len(azs_with_multiple_subnets) > 0:
-
                 self._add_failure(
                     "SubnetIds configured for the '{0}' queue contains two or more subnets in the same Availability "
                     "Zone: '{1}'. Please make sure all subnets configured for the queue are in different Availability"

--- a/cli/src/pcluster/validators/s3_validators.py
+++ b/cli/src/pcluster/validators/s3_validators.py
@@ -95,7 +95,6 @@ class S3BucketUriValidator(Validator):
     """S3 Bucket Url Validator."""
 
     def _validate(self, url):
-
         if get_url_scheme(url) == "s3":
             try:
                 bucket = get_bucket_name_from_s3_url(url)

--- a/cli/tests/pcluster/api/controllers/test_cluster_logs_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_logs_controller.py
@@ -224,7 +224,6 @@ class TestGetClusterStackEvents:
         ],
     )
     def test_successful_get_cluster_log_events_request(self, client, mocker, region, next_token):
-
         uid = "00000000-dddd-4444-bbbb-555555555555"
         cluster_name = "cluster"
         account_id = "012345678999"

--- a/cli/tests/pcluster/api/controllers/test_image_logs_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_logs_controller.py
@@ -67,7 +67,6 @@ class TestGetImageLogEvents:
     def test_successful_get_image_log_events_request(
         self, client, mocker, region, next_token, start_from_head, limit, start_time, end_time
     ):
-
         log_stream_name = "logstream"
         mock_log_events = [
             {
@@ -223,7 +222,6 @@ class TestGetImageStackEvents:
         ],
     )
     def test_successful_get_image_log_events_request(self, client, mocker, mock_image_stack, region, next_token):
-
         uid = "00000000-dddd-4444-bbbb-555555555555"
         image_id = "image"
         account_id = "012345678999"

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -298,7 +298,7 @@ efa:
         instances: ["p4d.24xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
-      - regions: ["eu-west-1"]
+      - regions: ["us-east-1"]
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -13,7 +13,7 @@ test-suites:
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: ["us-west-2"]
+        - regions: ["us-east-1"]
           instances: ["c5n.18xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]
@@ -21,7 +21,7 @@ test-suites:
           instances: ["p4d.24xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]
-        - regions: ["eu-west-1"]
+        - regions: ["us-east-1"]
           instances: ["c6gn.16xlarge"]
           oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -144,7 +144,6 @@ def zip_dir(path):
 
 @pytest.fixture(scope="module")
 def store_secret_in_secret_manager(request, cfn_stacks_factory):
-
     secret_arns = {}
 
     def _store_secret(region, secret_string=None, secret_binary=None):

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -173,7 +173,7 @@ def _test_create_or_update_with_warnings(run_fn):
 
     Accepts a run_fn function that will accept arguments for create / update
     """
-    for (expected_response, validation_key, args) in _validation_test_cases():
+    for expected_response, validation_key, args in _validation_test_cases():
         actual_response = run_fn({"raise_on_error": False, "log_error": False, **args})
         _check_response(actual_response, expected_response, validation_key)
 

--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -351,14 +351,12 @@ def test_iam_resource_prefix(
     s3_bucket,
     iam_resource_prefix,
 ):
-
     cli_credentials = initialize_resource_prefix_cli_creds(
         role_config_file=os_lib.path.join("..", "iam_policies", "user-role.cfn.yaml"),
         iam_resource_prefix=iam_resource_prefix,
     )
     if cli_credentials:
         for region, creds in cli_credentials.items():
-
             bucket_name = s3_bucket
             cfn_client, _, iam_client, _ = _create_boto3_clients(region)
             create_config, _ = _get_config_create_and_update(test_datadir)
@@ -676,7 +674,6 @@ def _create_iam_user_role_template(cluster_config, iam_resource_prefix):
 
     iam_path, iam_name_prefix = _split_resource_prefix(iam_resource_prefix)
     with open(cluster_config, "r", encoding="utf-8") as f:
-
         config_template = TemplateGenerator(load_yaml(f.read()))
 
     config_template.add_resource(_create_permission_boundary("IamResourcePrefixPermissionBoundary"))
@@ -734,7 +731,6 @@ def _test_iam_resource_in_cluster(cfn_client, iam_client, stack_name, iam_resour
     for resource in resources:
         resource_type = resource["ResourceType"]
         if resource_type == "AWS::IAM::Role":
-
             resource_arn_list.append(iam_client.get_role(RoleName=resource["PhysicalResourceId"])["Role"]["Arn"])
             resource_arn_list.extend(
                 iam_client.list_role_policies(RoleName=resource["PhysicalResourceId"])["PolicyNames"]

--- a/tests/integration-tests/tests/pcluster_api/test_api_infrastructure.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api_infrastructure.py
@@ -205,6 +205,8 @@ def _test_docker_image_refresh(image_builder_pipeline, lambda_name):
 )
 def _wait_for_image_build(image_builder_pipeline):
     image_builder = boto3.client("imagebuilder")
-    return image_builder.list_image_pipeline_images(imagePipelineArn=image_builder_pipeline,)[
+    return image_builder.list_image_pipeline_images(
+        imagePipelineArn=image_builder_pipeline,
+    )[
         "imageSummaryList"
     ][0]

--- a/util/upload-cookbook.py
+++ b/util/upload-cookbook.py
@@ -261,7 +261,7 @@ def main():
 
         if not args.dryrun:
             # Stores LastModified info into .tgz.date file and uploads it back to bucket
-            with (open(base_name + ".tgz.date", "w+")) as f:
+            with open(base_name + ".tgz.date", "w+") as f:
                 response = s3.head_object(Bucket=bucket_name, Key=_COOKBOOKS_DIR + "/" + base_name + ".tgz")
                 f.write(response.get("LastModified").strftime("%Y-%m-%d_%H-%M-%S"))
 


### PR DESCRIPTION
### Description of changes
- `c5n.18xlarge` and `c6gn.16xlarge` instance types are having low capacity in `us-west-2` and `eu-west-1` respectively
- It also includes some fixes on the code-linting

### Tests
* N/A

### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
