### PR TITLE
New entry in CHANGELOG for increased verbosity in Slurm logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 
 **CHANGES**
 - Upgrade Slurm to version 22.05.8.
+- Make Slurm controller logs more verbose and enable additional logging for the Slurm power save plugin.
 
 **BUG FIXES**
 - Add check in the validators to verify that the cluster name is not longer than 40 characters when Slurm accounting is enabled.


### PR DESCRIPTION
### Description of changes
* New entry in CHANGELOG for increased verbosity in Slurm logs

### References
- https://github.com/aws/aws-parallelcluster-cookbook/pull/1721

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
