### PR TITLE
[integ-tests] Highlight usage of Capacity Reservations for EFA tests

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -298,6 +298,8 @@ efa:
         instances: ["p4d.24xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]
+      # Capacity Reservation for `c6gn.16xlarge` created in `us-east-1a` do not move unless the target region also
+      # has a Capacity Reservation for `c6gn.16xlarge`
       - regions: ["us-east-1"]
         instances: ["c6gn.16xlarge"]
         oss: ["alinux2", "ubuntu1804", "ubuntu2004"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -13,6 +13,8 @@ test-suites:
   efa:
     test_efa.py::test_efa:
       dimensions:
+        # Capacity Reservation for `c5n.18xlarge` created in `us-east-1a` do not move unless the target region/AZ also
+        # has a Capacity Reservation for `c5n.18xlarge`
         - regions: ["us-east-1"]
           instances: ["c5n.18xlarge"]
           oss: ["alinux2"]
@@ -21,6 +23,8 @@ test-suites:
           instances: ["p4d.24xlarge"]
           oss: ["alinux2"]
           schedulers: ["slurm"]
+        # Capacity Reservation for `c6gn.16xlarge` created in `us-east-1a` do not move unless the target region/AZ also
+        # has a Capacity Reservation for `c6gn.16xlarge`
         - regions: ["us-east-1"]
           instances: ["c6gn.16xlarge"]
           oss: ["alinux2", "ubuntu1804", "ubuntu2004"]


### PR DESCRIPTION
### Description of changes
* The region used to run EFA tests has been changed in the past without awareness of existing capacity reservations
* This commit adds a comment to ensure modifications are made with the awareness that capacity reservations already exist in that region

### Tests
* N/A

### References
* #4850 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
