### PR TITLE
Improve Existing EFS, FSx Security Groups Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Fix an issue where compute nodes could not launch with capacity reservations shared by other accounts because of a wrong IAM policy on head node.
+- Fix EFS, FSx network security groups validators to avoid reporting false errors.
 
 3.5.0
 -----

--- a/cli/src/pcluster/aws/aws_resources.py
+++ b/cli/src/pcluster/aws/aws_resources.py
@@ -37,6 +37,7 @@ class StackInfo:
         self._params = self._stack_data.get("Parameters", [])
         self.tags = self._stack_data.get("Tags", [])
         self.outputs = self._stack_data.get("Outputs", [])
+        self.__resources = None
 
     @property
     def id(self):
@@ -47,6 +48,15 @@ class StackInfo:
     def name(self):
         """Return the name of the stack."""
         return self._stack_data.get("StackName")
+
+    @property
+    def resources(self):
+        """Return the resources of the stack."""
+        if not self.__resources:
+            from pcluster.aws.aws_api import AWSApi  # noqa: F401 pylint: disable=import-outside-toplevel
+
+            self.__resources = AWSApi.instance().cfn.describe_stack_resources(self.name)
+        return self.__resources
 
     @property
     def status(self):
@@ -89,6 +99,14 @@ class StackInfo:
         """
         param_value = next((par["ParameterValue"] for par in self._params if par["ParameterKey"] == key_name), None)
         return None if param_value is None else param_value.strip()
+
+    def get_resource_physical_id(self, resource_logical_id: str):
+        """Return the resource information."""
+        resource = self.resources.get(resource_logical_id)
+        if resource:
+            return resource["PhysicalResourceId"]
+        else:
+            return None
 
 
 class InstanceInfo:

--- a/cli/src/pcluster/aws/cfn.py
+++ b/cli/src/pcluster/aws/cfn.py
@@ -148,6 +148,12 @@ class CfnClient(Boto3Client):
             )
 
     @AWSExceptionHandler.handle_client_exception
+    def describe_stack_resources(self, stack_name: str):
+        """Get stack resources information."""
+        response = self._client.describe_stack_resources(StackName=stack_name).get("StackResources")
+        return {resource["LogicalResourceId"]: resource for resource in response}  # Build dictionary for better query.
+
+    @AWSExceptionHandler.handle_client_exception
     def get_imagebuilder_stacks(self, next_token=None):
         """List existing imagebuilder stacks."""
         return self._list_parentless_stacks_with_tag(PCLUSTER_IMAGE_ID_TAG, next_token)

--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -136,7 +136,7 @@ class Ec2Client(Boto3Client):
     @Cache.cached
     def get_subnet_cidr(self, subnet_id):
         """Return cidr block  of the given subnet."""
-        subnets = self._client.describe_subnets(SubnetIds=[subnet_id]).get("Subnets")
+        subnets = self.describe_subnets([subnet_id])
         if subnets:
             return subnets[0].get("CidrBlock")
         raise AWSClientError(function_name="describe_subnets", message=f"Subnet {subnet_id} not found")

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -81,6 +81,8 @@ FSX_PORTS = {
     ONTAP: {"tcp": [111, 635, 2049, 4046], "udp": [111, 635, 2049, 4046]},
 }
 
+EFS_PORT = 2049
+
 EBS_VOLUME_TYPE_IOPS_DEFAULT = {
     "io1": 100,
     "io2": 100,

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -440,6 +440,9 @@ class Cluster:
             Cluster._load_additional_instance_type_data(cluster_config_dict)
             config = self._load_config(cluster_config_dict)
             config.official_ami = self.__official_ami
+            if context.during_update:
+                config.managed_head_node_security_group = self.stack.get_resource_physical_id("HeadNodeSecurityGroup")
+                config.managed_compute_security_group = self.stack.get_resource_physical_id("ComputeSecurityGroup")
 
             validation_failures = config.validate(validator_suppressors, context)
             if any(f.level.value >= FailureLevel(validation_failure_level).value for f in validation_failures):
@@ -851,7 +854,7 @@ class Cluster:
             validator_suppressors=validator_suppressors,
             validation_failure_level=validation_failure_level,
             config_text=target_source_config,
-            context=ValidatorContext(head_node_instance_id=self.head_node_instance.id),
+            context=ValidatorContext(head_node_instance_id=self.head_node_instance.id, during_update=True),
         )
         changes = self._validate_patch(force, target_config)
 

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -12,7 +12,7 @@ import math
 import re
 from collections import defaultdict
 from enum import Enum
-from ipaddress import ip_network
+from ipaddress import collapse_addresses, ip_network
 from itertools import combinations, product
 from typing import List
 
@@ -23,6 +23,7 @@ from pcluster.cli.commands.dcv_util import get_supported_dcv_os
 from pcluster.constants import (
     CIDR_ALL_IPS,
     DELETE_POLICY,
+    EFS_PORT,
     FSX_PORTS,
     PCLUSTER_IMAGE_BUILD_STATUS_TAG,
     PCLUSTER_NAME_MAX_LENGTH,
@@ -417,42 +418,87 @@ class EfaMultiAzValidator(Validator):
 # --------------- Storage validators --------------- #
 
 
-def _check_in_out_access(security_groups_ids, port, is_cidr_optional, protocol="tcp"):
+def _is_access_allowed(security_groups_ids, subnets, port, security_groups_by_nodes, protocol="tcp"):
     """
     Verify given list of security groups to check if they allow in and out access on the given port.
 
     :param security_groups_ids: list of security groups to verify
     :param port: port to verify
-    :param is_cidr_optional: if it is True, don't enforce check on CIDR.
+    :param security_groups_by_nodes: all security groups from cluster. This is a set of frozen sets.
+    Each frozen set contains sg combination of a queue.
     :param protocol: the IP protocol to be checked.
     :return: True if both in and out access are allowed
     :raise: ClientError if a given security group doesn't exist
     """
     in_access = False
     out_access = False
+    src_ip_ranges = []
+    dst_ip_ranges = []
+    src_security_groups = set()
+    dst_security_groups = set()
 
     for sec_group in AWSApi.instance().ec2.describe_security_groups(security_groups_ids):
         # Check all inbound rules
         for rule in sec_group.get("IpPermissions"):
-            if _check_sg_rules_for_port(rule, port, protocol):
-                if is_cidr_optional or rule.get("IpRanges") or rule.get("PrefixListIds"):
-                    in_access = True
-                    break
+            if in_access:
+                break
+            if _is_port_allowed_by_sg_rule(rule, port, protocol):
+                in_access = _populate_allowed_src_or_dst(rule, src_ip_ranges, src_security_groups)
 
         # Check all outbound rules
         for rule in sec_group.get("IpPermissionsEgress"):
-            if _check_sg_rules_for_port(rule, port, protocol):
-                if is_cidr_optional or rule.get("IpRanges") or rule.get("PrefixListIds"):
-                    out_access = True
-                    break
+            if out_access:
+                break
+            if _is_port_allowed_by_sg_rule(rule, port, protocol):
+                out_access = _populate_allowed_src_or_dst(rule, dst_ip_ranges, dst_security_groups)
 
         if in_access and out_access:
             return True
+    # If in_access or out_access is still False, check allowed ip ranges and security groups.
+    # The in_access or out_access could only have been true, if previous logics had found prefix list in SG rules.
+    # Rules of ip ranges have to be checked at the end because the union of all ip ranges may cover the subnets,
+    # even when individual ip ranges do not cover the subnets. The same reason applies to allowed security groups.
+    in_access = in_access or _are_ip_ranges_and_sg_accessible(
+        security_groups_by_nodes, src_ip_ranges, src_security_groups, subnets
+    )
+    out_access = out_access or _are_ip_ranges_and_sg_accessible(
+        security_groups_by_nodes, dst_ip_ranges, dst_security_groups, subnets
+    )
+    return in_access and out_access
 
+
+def _are_ip_ranges_and_sg_accessible(security_groups_by_nodes, allowed_ip_ranges, allowed_security_groups, subnets):
+    # For all cluster nodes, at least one of the security groups attached need to be in the UserIdGroupPairs.
+    return all(
+        node_security_groups & allowed_security_groups for node_security_groups in security_groups_by_nodes
+    ) or _are_subnets_covered_by_cidrs(allowed_ip_ranges, subnets)
+
+
+def _populate_allowed_src_or_dst(rule, ip_ranges, allowed_security_groups):
+    """
+    Collect Ip ranges or security groups allowed by the rule.
+
+    :param rule: A rule of a security group
+    :param ip_ranges: A list of ip ranges.
+    :param allowed_security_groups: A list of allowed security group.
+    :return: True if we can determine the current rule allows connection.
+    False if it does not allow connection or cannot be determined.
+    """
+    if rule.get("PrefixListIds"):
+        return True  # Always assume prefix list is properly set for code simplicity
+    elif rule.get("IpRanges"):
+        ip_ranges.extend(rule.get("IpRanges"))
+        return False  # Ip Ranges have to be checked later. Return False because the rule allowance is not determined.
+    elif rule.get("UserIdGroupPairs"):
+        allowed_security_groups.update(
+            {user_id_group_pair.get("GroupId") for user_id_group_pair in rule.get("UserIdGroupPairs")}
+        )
+        # Security groups have to be checked later. Return False because the rule allowance is not determined.
+        return False
     return False
 
 
-def _check_sg_rules_for_port(rule, port_to_check, protocol):
+def _is_port_allowed_by_sg_rule(rule, port_to_check, protocol):
     """
     Verify if the security group rule accepts connections on the given port.
 
@@ -483,6 +529,23 @@ def _check_sg_rules_for_port(rule, port_to_check, protocol):
     return False
 
 
+def _are_subnets_covered_by_cidrs(ip_ranges, subnets):
+    """Verify given list of security groups to check if they allow in and out access on cluster subnet CIDRs."""
+    # Collapse ip ranges for better performance and correctness
+    collapsed_ip_ranges = list(collapse_addresses([ip_network(ip_range["CidrIp"]) for ip_range in ip_ranges]))
+
+    for subnet in subnets:
+        subnet_cidr = ip_network(AWSApi.instance().ec2.get_subnet_cidr(subnet))
+        covered = False
+        for ip_range in collapsed_ip_ranges:
+            if ip_range.supernet_of(subnet_cidr):
+                covered = True
+                break
+        if not covered:
+            return False
+    return True
+
+
 class ExistingFsxNetworkingValidator(Validator):
     """
     FSx networking validator.
@@ -504,27 +567,23 @@ class ExistingFsxNetworkingValidator(Validator):
         else:
             return {}
 
-    def _validate(self, file_system_ids, head_node_subnet_id, are_all_security_groups_customized):
+    def _validate(self, file_system_ids, subnet_ids, security_groups_by_nodes):
         try:
-            # Check to see if there is any existing mt on the fs
             file_systems = AWSApi.instance().fsx.get_file_systems_info(file_system_ids)
-
-            vpc_id = AWSApi.instance().ec2.get_subnet_vpc(head_node_subnet_id)
-
-            network_interfaces_data = self._describe_network_interfaces(file_systems)
-
-            self._check_file_systems(are_all_security_groups_customized, file_systems, network_interfaces_data, vpc_id)
+            self._check_file_systems(security_groups_by_nodes, file_systems, subnet_ids)
         except AWSClientError as e:
             self._add_failure(str(e), FailureLevel.ERROR)
 
-    def _check_file_systems(self, are_all_security_groups_customized, file_systems, network_interfaces_data, vpc_id):
+    def _check_file_systems(self, security_groups_by_nodes, file_systems, subnet_ids):
+        vpc_id = AWSApi.instance().ec2.get_subnet_vpc(subnet_ids[0])
+        network_interfaces_data = self._describe_network_interfaces(file_systems)
         for file_system in file_systems:
             # Check to see if fs is in the same VPC as the stack
             file_system_id = file_system.file_system_id
             if file_system.vpc_id != vpc_id:
                 self._add_failure(
                     "Currently only support using FSx file system that is in the same VPC as the cluster. "
-                    "The file system provided is in {0}.".format(file_system.vpc_id),
+                    f"The file system {file_system_id} is in {file_system.vpc_id}.",
                     FailureLevel.ERROR,
                 )
 
@@ -545,7 +604,7 @@ class ExistingFsxNetworkingValidator(Validator):
 
                 for protocol, ports in FSX_PORTS[file_system.file_system_type].items():
                     missing_ports = self._get_missing_ports(
-                        are_all_security_groups_customized, network_interfaces, ports, protocol
+                        security_groups_by_nodes, subnet_ids, network_interfaces, ports, protocol
                     )
 
                     if missing_ports:
@@ -557,17 +616,18 @@ class ExistingFsxNetworkingValidator(Validator):
                             FailureLevel.ERROR,
                         )
 
-    def _get_missing_ports(self, are_all_security_groups_customized, network_interfaces, ports, protocol):
+    def _get_missing_ports(self, security_groups_by_nodes, subnet_ids, network_interfaces, ports, protocol):
         missing_ports = []
         for port in ports:
             fs_access = False
             for network_interface in network_interfaces:
                 # Get list of security group IDs
                 sg_ids = [sg.get("GroupId") for sg in network_interface.get("Groups")]
-                if _check_in_out_access(
+                if _is_access_allowed(
                     sg_ids,
+                    subnet_ids,
                     port=port,
-                    is_cidr_optional=are_all_security_groups_customized,
+                    security_groups_by_nodes=security_groups_by_nodes,
                     protocol=protocol,
                 ):
                     fs_access = True
@@ -743,7 +803,7 @@ class EfsIdValidator(Validator):  # TODO add tests
     Validate if there are existing mount target in the cluster (head and computes) availability zone
     """
 
-    def _validate(self, efs_id, avail_zones_mapping: dict, are_all_security_groups_customized):
+    def _validate(self, efs_id, avail_zones_mapping: dict, security_groups_by_nodes):
         availability_zones = avail_zones_mapping.keys()
         if len(availability_zones) > 1 and not AWSApi.instance().efs.is_efs_standard(efs_id):
             self._add_failure(
@@ -760,7 +820,9 @@ class EfsIdValidator(Validator):  # TODO add tests
             if head_node_target_id:
                 # Get list of security group IDs of the mount target
                 sg_ids = AWSApi.instance().efs.get_efs_mount_target_security_groups(head_node_target_id)
-                if not _check_in_out_access(sg_ids, port=2049, is_cidr_optional=are_all_security_groups_customized):
+                if not _is_access_allowed(
+                    sg_ids, subnets, port=EFS_PORT, security_groups_by_nodes=security_groups_by_nodes
+                ):
                     self._add_failure(
                         "There is an existing Mount Target {0} in the Availability Zone {1} for EFS {2}, "
                         "but it does not have a security group that allows inbound and outbound rules to support NFS. "
@@ -769,8 +831,6 @@ class EfsIdValidator(Validator):  # TODO add tests
                         ),
                         FailureLevel.ERROR,
                     )
-                if not are_all_security_groups_customized:
-                    self._check_cidrs_cover_subnets(head_node_target_id, avail_zone, sg_ids, efs_id, subnets)
             else:
                 if AWSApi.instance().efs.is_efs_standard(efs_id):
                     avail_zones_missing_mount_target_for_efs_standard.append(avail_zone)
@@ -782,42 +842,6 @@ class EfsIdValidator(Validator):  # TODO add tests
                 ),
                 FailureLevel.ERROR,
             )
-
-    def _check_subnet_access(self, security_groups_ids, subnet_cidr, access_type):
-        permission = "IpPermissions" if access_type == "in" else "IpPermissionsEgress"
-        access = False
-        for sec_group in security_groups_ids:
-            for rule in sec_group.get(permission):
-                if rule.get("PrefixListIds"):
-                    access = True
-                    break
-                if rule.get("IpRanges"):
-                    for ip_range in rule.get("IpRanges"):
-                        if ip_network(ip_range.get("CidrIp")).supernet_of(subnet_cidr):
-                            access = True
-                            break
-        return access
-
-    def _check_cidrs_cover_subnets(self, head_node_target_id, avail_zone, security_groups_ids, efs_id, subnets):
-        """Verify given list of security groups to check if they allow in and out access on cluster subnet CIDRs."""
-        security_groups_ids = AWSApi.instance().ec2.describe_security_groups(security_groups_ids)
-        for subnet in subnets:
-            subnet_cidr = ip_network(AWSApi.instance().ec2.get_subnet_cidr(subnet))
-            in_access, out_access = self._check_subnet_access(
-                security_groups_ids, subnet_cidr, "in"
-            ), self._check_subnet_access(security_groups_ids, subnet_cidr, "out")
-
-            if not in_access or not out_access:
-                self._add_failure(
-                    "There is an existing Mount Target {0} in the Availability Zone {1} for EFS {2}, "
-                    "but it does not have a security group that allows inbound and outbound rules to allow traffic of "
-                    "subnet {3}. Please modify the Mount Target's security group, to allow traffic on subnet.".format(
-                        head_node_target_id, avail_zone, efs_id, subnet
-                    ),
-                    FailureLevel.WARNING,
-                )
-
-        return False
 
 
 class SharedStorageNameValidator(Validator):

--- a/cli/src/pcluster/validators/common.py
+++ b/cli/src/pcluster/validators/common.py
@@ -69,5 +69,6 @@ class Validator(ABC):
 class ValidatorContext:
     """Context containing information about cluster environment meant to be passed to validators."""
 
-    def __init__(self, head_node_instance_id: str = None):
+    def __init__(self, head_node_instance_id: str = None, during_update: bool = None):
         self.head_node_instance_id = head_node_instance_id
+        self.during_update = during_update

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -8,6 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import ipaddress
 import os
 
 from pcluster.aws.aws_api import AWSApi
@@ -172,6 +173,14 @@ class _DummyEc2Client(Ec2Client):
 
     def get_eip_allocation_id(self, eip):
         return "eipalloc-123"
+
+    def get_subnet_cidr(self, subnet):
+        try:  # If the value of subnet is a CIDR, we know the test wants to mock the request.
+            # Therefore, we return the value directly.
+            ipaddress.ip_network(subnet)
+            return subnet
+        except ValueError:  # Otherwise, we call the real method
+            return super().get_subnet_cidr(subnet)
 
 
 class _DummyEfsClient(EfsClient):

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -112,6 +112,9 @@ class _DummyCfnClient(CfnClient):
         """Override Parent constructor. No real boto3 client is created."""
         pass
 
+    def describe_stack_resources(self, stack_name: str):
+        return {}
+
 
 class _DummyEc2Client(Ec2Client):
     def __init__(self):


### PR DESCRIPTION
In addition to existing checks on port and CIDR, this commit adds checks on allowed security groups. This improvement will fix false warning during `pcluster update-cluster`. 

In other words, there are three ways to specify src/dst in a security group rule: CIDR, security groups, prefix list. Before this commit, only CIDR was properly checked. This commit adds proper checks for security groups. This commit does not change the behavior of prefix list .

This commit also refactors the code for clarity and reduces redundant EFS error messages

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
* Unit tests have been created and modified
#### Manual testing:
When creating clusters with bad EFS and FSx security groups, the error messages are correctly displayed and only appear once:
```
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "EfsIdValidator",
      "message": "There is an existing Mount Target fsmt-xxx in the Availability Zone us-east-1b for EFS fs-xxx, but it does not have a security group that allows inbound and outbound rules to support NFS. Please modify the Mount Target's security group, to allow traffic on port 2049."
    },
    {
      "level": "ERROR",
      "type": "ExistingFsxNetworkingValidator",
      "message": "The current security group settings on file system 'fs-xxx' does not satisfy mounting requirement. The file system must be associated to a security group that allows inbound and outbound TCP traffic through ports [988]. Missing ports: [988]"
    }
  ],
  "message": "Invalid cluster configuration."
}
```
When updating cluster with EFS and FSx with security groups allowing connections from cluster security groups, the validator no longer shows false error messages
```
{
  "message": "Request would have succeeded, but DryRun flag is set.",
  "changeSet": [
    {
      "parameter": "SharedStorage",
      "requestedValue": {
        "MountDir": "/efs1",
        "Name": "efs1",
        "StorageType": "Efs",
        "EfsSettings": {
          "FileSystemId": "fs-01cf0078e64e83b54"
        }
      },
      "currentValue": "-"
    },
    {
      "parameter": "SharedStorage",
      "requestedValue": {
        "MountDir": "/fsx1",
        "Name": "fsx1",
        "StorageType": "FsxLustre",
        "FsxLustreSettings": {
          "FileSystemId": "fs-01fef606ec594d3b3"
        }
      },
      "currentValue": "-"
    }
  ]
}

```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
