### PR TITLE
[develop] Fixes after change of creating VPC stack at regional level

### DIFF
--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -438,7 +438,7 @@ def orchestrate_pcluster_configure_stages(prompts, scheduler):
     return [prompt for prompt in prompts if scheduler != "awsbatch" or not prompt.get("skip_for_batch")]
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="class")
 def subnet_in_use1_az3(vpc_stack):
     # Subnet used to test the functionality of avoiding subnet in AZs that do not have user specified instance types
     # Hard coding implementation to run on us-east-1 and create subnet in use1_az3 without c5.xlarge

--- a/tests/integration-tests/tests/schedulers/conftest.py
+++ b/tests/integration-tests/tests/schedulers/conftest.py
@@ -4,11 +4,73 @@ import string
 from collections import defaultdict
 
 import pytest
-from cfn_stacks_factory import CfnStack
+from cfn_stacks_factory import CfnStack, CfnStacksFactory
+from conftest import get_availability_zones
+from network_template_builder import Gateways, NetworkTemplateBuilder, SubnetConfig, VPCConfig
 from utils import generate_stack_name
 
 
-def _create_database_stack(cfn_stacks_factory, request, region, vpc_stack):
+@pytest.fixture(scope="class")
+def vpc_stack_for_database(region, request):
+    """
+    Create a VPC stack to be used for testing database stack template.
+    :return: a VPC stack
+    """
+
+    logging.info("Creating VPC stack for database")
+    credential = request.config.getoption("credential")
+    stack_factory = CfnStacksFactory(request.config.getoption("credential"))
+
+    def _create_stack(request, template, region, stack_factory):
+        stack = CfnStack(
+            name=generate_stack_name("integ-tests-vpc-database", request.config.getoption("stackname_suffix")),
+            region=region,
+            template=template.to_json(),
+        )
+        stack_factory.create_stack(stack)
+        return stack
+
+    availability_zone = get_availability_zones(region, credential)[0]
+    public_subnet = SubnetConfig(
+        name="Public",
+        cidr="192.168.32.0/20",  # 4096 IPs
+        map_public_ip_on_launch=True,
+        has_nat_gateway=True,
+        availability_zone=availability_zone,
+        default_gateway=Gateways.INTERNET_GATEWAY,
+    )
+    private_subnet = SubnetConfig(
+        name="Private",
+        cidr="192.168.64.0/20",  # 4096 IPs
+        map_public_ip_on_launch=False,
+        has_nat_gateway=False,
+        availability_zone=availability_zone,
+        default_gateway=Gateways.NAT_GATEWAY,
+    )
+    vpc_config = VPCConfig(
+        cidr="192.168.0.0/17",
+        additional_cidr_blocks=["192.168.128.0/17"],
+        subnets=[
+            public_subnet,
+            private_subnet,
+        ],
+    )
+
+    template = NetworkTemplateBuilder(
+        vpc_configuration=vpc_config,
+        default_availability_zone=availability_zone,
+    ).build()
+
+    yield _create_stack(request, template, region, stack_factory)
+
+    if not request.config.getoption("no_delete"):
+        stack_factory.delete_all_stacks()
+    else:
+        logging.warning("Skipping deletion of CFN VPC database stack because --no-delete option is set")
+
+
+def _create_database_stack(stack_factory, request, region, vpc_stack_for_database):
+    logging.info("Creating VPC stack for database")
     database_stack_name = generate_stack_name("integ-tests-slurm-db", request.config.getoption("stackname_suffix"))
 
     database_stack_template_path = "../../cloudformation/database/serverless-database.yaml"
@@ -28,7 +90,7 @@ def _create_database_stack(cfn_stacks_factory, request, region, vpc_stack):
     with open(database_stack_template_path) as database_template:
         stack_parameters = [
             {"ParameterKey": "ClusterName", "ParameterValue": cluster_name},
-            {"ParameterKey": "Vpc", "ParameterValue": vpc_stack.cfn_outputs["VpcId"]},
+            {"ParameterKey": "Vpc", "ParameterValue": vpc_stack_for_database.cfn_outputs["VpcId"]},
             {"ParameterKey": "AdminPasswordSecretString", "ParameterValue": admin_password},
             {"ParameterKey": "Subnet1CidrBlock", "ParameterValue": "192.168.8.0/23"},
             {"ParameterKey": "Subnet2CidrBlock", "ParameterValue": "192.168.4.0/23"},
@@ -40,15 +102,16 @@ def _create_database_stack(cfn_stacks_factory, request, region, vpc_stack):
             parameters=stack_parameters,
             capabilities=["CAPABILITY_AUTO_EXPAND"],
         )
-    cfn_stacks_factory.create_stack(database_stack)
+    stack_factory.create_stack(database_stack)
     logging.info("Creation of stack %s complete", database_stack_name)
 
     return database_stack
 
 
-@pytest.fixture(scope="package")
-def database_factory(request, cfn_stacks_factory, vpc_stacks_shared):
+@pytest.fixture(scope="class")
+def database_factory(request, vpc_stack_for_database):
     created_database_stacks = defaultdict(dict)
+    stack_factory = CfnStacksFactory(request.config.getoption("credential"))
 
     logging.info("Setting up database_factory fixture")
 
@@ -63,7 +126,7 @@ def database_factory(request, cfn_stacks_factory, vpc_stacks_shared):
 
         if not created_database_stacks.get(region, {}).get("default"):
             logging.info("Creating default database stack")
-            database_stack = _create_database_stack(cfn_stacks_factory, request, region, vpc_stacks_shared[region])
+            database_stack = _create_database_stack(stack_factory, request, region, vpc_stack_for_database)
             created_database_stacks[region]["default"] = database_stack.name
 
         logging.info("Using database stack %s", created_database_stacks.get(region, {}).get("default"))
@@ -85,7 +148,7 @@ def database_factory(request, cfn_stacks_factory, vpc_stacks_shared):
                 stack_name,
                 region,
             )
-            cfn_stacks_factory.delete_stack(stack_name, region)
+            stack_factory.delete_stack(stack_name, region)
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
@@ -127,6 +127,7 @@ def _test_that_slurmdbd_is_running(remote_command_executor):
 def test_slurm_accounting(
     region,
     pcluster_config_reader,
+    vpc_stack_for_database,
     database_factory,
     request,
     test_datadir,
@@ -143,7 +144,11 @@ def test_slurm_accounting(
     database_stack_outputs = get_infra_stack_outputs(database_stack_name)
 
     config_params = _get_slurm_database_config_parameters(database_stack_outputs)
-    cluster_config = pcluster_config_reader(**config_params)
+    public_subnet_id = vpc_stack_for_database.cfn_outputs["public_subnet_id"]
+    private_subnet_id = vpc_stack_for_database.cfn_outputs["private_subnet_id"]
+    cluster_config = pcluster_config_reader(
+        public_subnet_id=public_subnet_id, private_subnet_id=private_subnet_id, **config_params
+    )
     cluster = clusters_factory(cluster_config)
 
     remote_command_executor = RemoteCommandExecutor(cluster)


### PR DESCRIPTION
### Description of changes
* Fix fixture scope
  
  Fixture scope cannot be broader than scope of fixture used as input.
  In this case, the fixture vpc_stack has a class scope

* Fix database stack creation

  The test_slurm_accounting is testing the database stack template through a stack creation.
  In this stack template two new subnets are being created and this creation cannot be done more than one time on a given VPC stack.
  The fix is to create an ad-hoc VPC stack for this test

### Tests
tested with following conf launched with parallelism 8

```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  schedulers:
    test_slurm_accounting.py::test_slurm_accounting:
      dimensions:
        - regions: ["us-east-1"]
          instances:  {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2", "ubuntu2004"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_scaling:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm"]
  networking:
    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
      dimensions:
        # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an
        # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  configure:
    test_pcluster_configure.py::test_pcluster_configure:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm"]
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_pcluster_configure.py::test_pcluster_configure_avoid_bad_subnets:
      dimensions:
        - regions: ["us-east-1"]  # region must be us-east-1 due to hardcoded logic for AZ selection
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_pcluster_configure.py::test_region_without_t2micro:
      dimensions:
        - regions: ["us-east-1"] # must be regions that do not have t2.micro
          oss: ["centos7"]
          schedulers: ["slurm"]
    test_pcluster_configure.py::test_efa_and_placement_group:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_EFA_SUPPORTED_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_pcluster_configure.py::test_efa_unsupported:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_EFA_UNSUPPORTED_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]

```

### References
* https://github.com/aws/aws-parallelcluster/pull/4844/

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
