### PR TITLE
[develop] Fix name of vpc stack outputs

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
@@ -144,8 +144,8 @@ def test_slurm_accounting(
     database_stack_outputs = get_infra_stack_outputs(database_stack_name)
 
     config_params = _get_slurm_database_config_parameters(database_stack_outputs)
-    public_subnet_id = vpc_stack_for_database.cfn_outputs["public_subnet_id"]
-    private_subnet_id = vpc_stack_for_database.cfn_outputs["private_subnet_id"]
+    public_subnet_id = vpc_stack_for_database.cfn_outputs["PublicSubnetId"]
+    private_subnet_id = vpc_stack_for_database.cfn_outputs["PrivateSubnetId"]
     cluster_config = pcluster_config_reader(
         public_subnet_id=public_subnet_id, private_subnet_id=private_subnet_id, **config_params
     )


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
* Fix name of vpc stack outputs

### Tests
n/a

### References
* https://github.com/aws/aws-parallelcluster/pull/4858

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
