### PR TITLE
`[lib]` Move library functionality to module level

### DIFF
--- a/cli/src/pcluster/lib/__init__.py
+++ b/cli/src/pcluster/lib/__init__.py
@@ -6,6 +6,15 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Prevent the "ParallelCluster imported but not used" error
+# This series of imports and functions is to move parallelcluster functionality
+# to the module level.
 # flake8: noqa
-from pcluster.lib.lib import ParallelCluster
+from pcluster.lib import lib
+
+# Dynamically add pcluster functions to the pcluster module
+# pylint: disable=protected-access
+lib._add_functions(lib._load_model(), lib)
+
+# Now import the additional functions into this module.
+# pylint: disable=wrong-import-position
+from pcluster.lib.lib import *

--- a/cli/src/pcluster/lib/lib.py
+++ b/cli/src/pcluster/lib/lib.py
@@ -24,7 +24,7 @@ from pcluster.utils import to_snake_case
 
 
 # The definition of the shape of model is defined in pcluster.cli.model
-def _gen_class(model: Dict) -> Dict[str, Callable]:
+def _gen_func_map(model: Dict) -> Dict[str, Callable]:
     """Generate a dict mapping function names to dispatch functions."""
 
     class Args:
@@ -44,7 +44,7 @@ def _gen_class(model: Dict) -> Dict[str, Callable]:
     def make_func(op_name: str) -> Callable:
         """Take the name of an operation and return the function that call the controller."""
 
-        def func(_self, **kwargs):
+        def func(**kwargs):
             # Validate that args provided match the model
             params = model[op_name]["params"]
             expected = {to_snake_case(param["name"]) for param in params if param["required"]}
@@ -82,9 +82,7 @@ def _load_model():
     return pcluster.cli.model.load_model(spec)
 
 
-def _make_class(model):
-    """Create a python class from a provided model."""
-    return type("ParallelCluster", (object,), _gen_class(model))
-
-
-ParallelCluster = _make_class(_load_model())
+def _add_functions(model, obj):
+    """Add parallel cluster functionality to the module."""
+    for func_name, func in _gen_func_map(model).items():
+        setattr(obj, func_name, func)

--- a/cli/tests/pcluster/lib/test_lib.py
+++ b/cli/tests/pcluster/lib/test_lib.py
@@ -16,7 +16,7 @@ import pytest
 from assertpy import assert_that
 
 from pcluster.cli.exceptions import ParameterException
-from pcluster.lib import lib
+from pcluster.lib import lib as pcluster
 
 
 def _gen_model(funcs):
@@ -88,8 +88,8 @@ class TestParallelClusterLib:
     def test_args(self, mocker, model, func, kwargs, expected):
         mocker.patch("pcluster.cli.model.get_function_from_name", return_value=func)
         model = _gen_model(model)
-        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
-        assert_that(pc_obj.op(**kwargs)).is_equal_to(expected)
+        pcluster._add_functions(model, pcluster)  # pylint: disable=protected-access
+        assert_that(pcluster.op(**kwargs)).is_equal_to(expected)
 
     @pytest.mark.parametrize(
         "model, func, kwargs",
@@ -125,11 +125,11 @@ class TestParallelClusterLib:
     def test_args_missing(self, mocker, model, func, kwargs):
         mocker.patch("pcluster.cli.model.get_function_from_name", return_value=func)
         model = _gen_model(model)
-        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
+        pcluster._add_functions(model, pcluster)  # pylint: disable=protected-access
 
         # flake8: noqa
         with pytest.raises(TypeError) as exc_info:
-            pc_obj.op(**kwargs)
+            pcluster.op(**kwargs)
         assert_that(str(exc_info.value)).starts_with("<op> missing required arguments")
 
     @pytest.mark.parametrize(
@@ -181,9 +181,9 @@ class TestParallelClusterLib:
     def test_args_unexcpected(self, mocker, model, func, kwargs):
         mocker.patch("pcluster.cli.model.get_function_from_name", return_value=func)
         model = _gen_model(model)
-        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
+        pcluster._add_functions(model, pcluster)  # pylint: disable=protected-access
         with pytest.raises(TypeError) as exc_info:
-            pc_obj.op(**kwargs)
+            pcluster.op(**kwargs)
         assert_that(str(exc_info.value)).starts_with("<op> got unexpected arguments")
 
     @pytest.mark.parametrize(
@@ -211,8 +211,8 @@ class TestParallelClusterLib:
         mocker.patch("pcluster.cli.model.get_function_from_name", return_value=lambda x: x)
         mocker.patch("pcluster.cli.entrypoint.read_file", return_value="filedata")
         model = _gen_model({"op": [{"name": "x", "required": True, "body": False, **type_}]})
-        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
-        assert_that(pc_obj.op(x=input_)).is_equal_to(expected)
+        pcluster._add_functions(model, pcluster)  # pylint: disable=protected-access
+        assert_that(pcluster.op(x=input_)).is_equal_to(expected)
 
     @pytest.mark.parametrize(
         "type_, input_",
@@ -234,9 +234,9 @@ class TestParallelClusterLib:
     def test_parameter_invalid_type(self, mocker, type_, input_):
         mocker.patch("pcluster.cli.model.get_function_from_name", return_value=lambda x: x)
         model = _gen_model({"op": [{"name": "x", "required": True, "body": False, **type_}]})
-        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
+        pcluster._add_functions(model, pcluster)  # pylint: disable=protected-access
         with pytest.raises((ParameterException, TypeError)) as exc_info:
-            pc_obj.op(x=input_)
+            pcluster.op(x=input_)
 
     @pytest.mark.parametrize(
         "type_, input_",
@@ -250,7 +250,7 @@ class TestParallelClusterLib:
     def test_parameter_invalid_regex(self, mocker, type_, input_):
         mocker.patch("pcluster.cli.model.get_function_from_name", return_value=lambda x: x)
         model = _gen_model({"op": [{"name": "x", "required": True, "body": False, **type_}]})
-        pc_obj = lib._make_class(model)()  # pylint: disable=protected-access
+        pcluster._add_functions(model, pcluster)  # pylint: disable=protected-access
         # with pytest.raises( (ParameterException, TypeError) ) as exc_info:
         with pytest.raises(ParameterException) as exc_info:
-            pc_obj.op(x=input_)
+            pcluster.op(x=input_)


### PR DESCRIPTION
### Description of changes
* This PR moves the library functionality to the module level so that an object doesn't need to be created each time the library is used.

### Tests
* Unit tests are updated to reflect the new interface

```
$ python3
Python 3.9.6 (default, Sep 26 2022, 11:37:49)
[Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pcluster.lib as pcluster
>>> pcluster.list_clusters()
{'clusters': [{'clusterName': 'c-pc-api-5ebc8', 'cloudformationStackStatus': 'CREATE_COMPLETE', 'cloudformationStackArn': 'arn:aws:cloudformation:us-east-2:000000000000:stack/c-pc-api-5ebc8/53c13c30-a2b0-11ed-87f5-060859e92636', 'region': 'us-east-2', 'version': '3.4.1', 'clusterStatus': 'CREATE_COMPLETE', 'scheduler': {'type': 'slurm'}}, {'clusterName': 'mycluster36', 'cloudformationStackStatus': 'CREATE_COMPLETE', 'cloudformationStackArn': 'arn:aws:cloudformation:us-east-2:000000000000:stack/mycluster36/5471a6d0-a047-11ed-a617-06150dfe4b83', 'region': 'us-east-2', 'version': '3.4.1', 'clusterStatus': 'CREATE_COMPLETE', 'scheduler': {'type': 'slurm'}}, {'clusterName': 'mycluster6', 'cloudformationStackStatus': 'DELETE_FAILED', 'cloudformationStackArn': 'arn:aws:cloudformation:us-east-2:00000000000:stack/mycluster6/13fc7040-dc2e-11ec-bec5-0650d36718a6', 'region': 'us-east-2', 'version': '3.1.0b1', 'clusterStatus': 'DELETE_FAILED', 'scheduler': {'type': 'slurm'}}]}
>>>
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
