### PR TITLE
[develop] Fix tests for opt-in regions

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -91,6 +91,7 @@ from tests.common.storage.fsx_utils import delete_fsx_filesystem
 from tests.common.utils import (
     fetch_instance_slots,
     get_installed_parallelcluster_version,
+    retrieve_latest_ami,
     retrieve_pcluster_ami_without_standard_naming,
 )
 from tests.storage.snapshots_factory import EBSSnapshotsFactory
@@ -1085,11 +1086,15 @@ def vpc_stacks_shared(cfn_stacks_factory, request, key_name):
                 private_subnet_az3,
             ],
         )
+
+        with aws_credential_provider(region, credential):
+            bastion_image_id = retrieve_latest_ami(region, "alinux2")
         template = NetworkTemplateBuilder(
             vpc_configuration=vpc_config,
             default_availability_zone=availability_zones[0],
             create_bastion_instance=True,
             bastion_key_name=key_name,
+            bastion_image_id=bastion_image_id,
             region=region,
         ).build()
         vpc_stacks_dict[region] = _create_vpc_stack(request, template, region, cfn_stacks_factory)
@@ -1149,11 +1154,15 @@ def vpc_stack_with_endpoints(region, request, key_name):
         ],
     )
 
+    with aws_credential_provider(region, credential):
+        bastion_image_id = retrieve_latest_ami(region, "alinux2")
+
     template = NetworkTemplateBuilder(
         vpc_configuration=vpc_config,
         default_availability_zone=availability_zone,
         create_vpc_endpoints=True,
         bastion_key_name=key_name,
+        bastion_image_id=bastion_image_id,
         region=region,
     ).build()
 

--- a/tests/integration-tests/network_template_builder.py
+++ b/tests/integration-tests/network_template_builder.py
@@ -28,8 +28,6 @@ from troposphere.ec2 import (
     VPCGatewayAttachment,
 )
 
-from tests.common.utils import retrieve_latest_ami
-
 TAGS_PREFIX = "ParallelCluster"
 BASTION_INSTANCE_TYPE = "c5.large"
 
@@ -101,6 +99,7 @@ class NetworkTemplateBuilder:
         create_vpc_endpoints: bool = False,
         create_bastion_instance: bool = False,
         bastion_key_name: str = None,
+        bastion_image_id: str = None,
         region: str = None,
     ):
         self.__template = Template()
@@ -120,6 +119,7 @@ class NetworkTemplateBuilder:
         self.__create_vpc_endpoints = create_vpc_endpoints
         self.__create_bastion_instance = create_bastion_instance
         self.__bastion_key_name = bastion_key_name
+        self.__bastion_image_id = bastion_image_id
 
     def __get_vpc(self, existing_vpc):
         if existing_vpc:
@@ -178,6 +178,7 @@ class NetworkTemplateBuilder:
         if self.__create_bastion_instance or self.__create_vpc_endpoints:
             assert_that(bastion_subnet_ref).is_not_none()
             assert_that(self.__bastion_key_name).is_not_none()
+            assert_that(self.__bastion_image_id).is_not_none()
             assert_that(self.__region).is_not_none()
             self.__build_bastion_instance(bastion_subnet_ref)
 
@@ -297,7 +298,7 @@ class NetworkTemplateBuilder:
         instance = ec2.Instance(
             "NetworkingBastionInstance",
             InstanceType=BASTION_INSTANCE_TYPE,
-            ImageId=retrieve_latest_ami(self.__region, "alinux2"),
+            ImageId=self.__bastion_image_id,
             KeyName=self.__bastion_key_name,
             SecurityGroupIds=[Ref(bastion_sg)],
             LaunchTemplate=ec2.LaunchTemplateSpecification(

--- a/tests/integration-tests/tests/schedulers/conftest.py
+++ b/tests/integration-tests/tests/schedulers/conftest.py
@@ -70,7 +70,7 @@ def vpc_stack_for_database(region, request):
 
 
 def _create_database_stack(stack_factory, request, region, vpc_stack_for_database):
-    logging.info("Creating VPC stack for database")
+    logging.info("Creating stack for database")
     database_stack_name = generate_stack_name("integ-tests-slurm-db", request.config.getoption("stackname_suffix"))
 
     database_stack_template_path = "../../cloudformation/database/serverless-database.yaml"


### PR DESCRIPTION
### Description of changes
* Fix credentials scope when retrieving AMI for bastion host

  The retrieve of the image id to create a bastion host inside the NetworkTemplateBuilder, requires credentials to be set in order to perform an API DescribeImages call.
  
  The fix is to pass the AMI id to the NetworkTemplateBuilder, which is better than passing the credentials to the NetworkTemplateBuilder.

* Fix logging string

### Tests
n/a

### References
* https://github.com/aws/aws-parallelcluster/pull/4844

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
