### PR TITLE
Fix flake8 repo in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-added-large-files
@@ -20,8 +20,9 @@ repos:
       - id: mixed-line-ending
         args: ['--fix=no']
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
+  - repo: https://github.com/PyCQA/flake8
+    # https://gitlab.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-docstrings, flake8-bugbear, flake8-mypy, flake8-colors, pep8-naming]
@@ -31,19 +32,19 @@ repos:
 
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ['-rc', '-w 120', '--settings-path=cli/.isort.cfg']
 
   - repo: https://github.com/ambv/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
       - id: black
         args: ['-l 120']
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.0
+    rev: 1.7.4
     hooks:
       - id: bandit
         args: ['-r', '-c', 'cli/.bandit.ini', '--exclude', 'tests,cli/tests,cloudformation/tests']


### PR DESCRIPTION
### Description of changes
* This change is to fix the flake8 repository and upgrade to the hooks to the current versions in the pre-commit config.
* Flake8 changed its repo which caused the current pre-commit config to fail during upgrading
* The version of Flake8 previously configured quit working with the current configuration.

### References
* [Flake8 Move](https://flake8.pycqa.org/en/latest/release-notes/4.0.0.html)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
