### PR TITLE
[headnode metric graphs] add disk and memory graphs for headnode CloudWatch dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 3.6.0
 ----
+**ENHANCEMENTS**
+- Add CloudWatch metrics, dashboard graphs and alarms to monitor head node memory and root volume disk utilization.
 
 **ENHANCEMENTS**
 - Add log rotation support for ParallelCluster managed logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 3.6.0
 ----
 **ENHANCEMENTS**
-- Add CloudWatch metrics, dashboard graphs and alarms to monitor head node memory and root volume disk utilization.
+- Add `mem_used_percent` and `disk_used_percent` metrics for head node memory and root volume disk utilization tracking on the ParallelCluster CloudWatch dashboard, and set up alarms for monitoring these metrics.
 
 **ENHANCEMENTS**
 - Add log rotation support for ParallelCluster managed logs.

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -37,7 +37,7 @@ _CWLogWidget = namedtuple(
 )
 
 
-def new_pcluster_metric(title=None, metrics=None, supported_vol_types=None, namespace=None, additional_dimensions={}):
+def new_pcluster_metric(title=None, metrics=None, supported_vol_types=None, namespace=None, additional_dimensions=None):
     return _PclusterMetric(title, metrics, supported_vol_types, namespace, additional_dimensions)
 
 
@@ -188,7 +188,7 @@ class CWDashboardConstruct(Construct):
     def _generate_metrics_list(self, metrics_param):
         metric_list = []
         dimensions_map = {"InstanceId": self.head_node_instance.ref}
-        dimensions_map.update(metrics_param.additional_dimensions)
+        dimensions_map.update(metrics_param.additional_dimensions if metrics_param.additional_dimensions else {})
         for metric in metrics_param.metrics:
             cloudwatch_metric = cloudwatch.Metric(
                 namespace=metrics_param.namespace, metric_name=metric, dimensions_map=dimensions_map

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -289,23 +289,30 @@ class CWDashboardConstruct(Construct):
         # Create a text widget for subtitle "Head Node Instance Metrics"
         self._add_text_widget("## Head Node Instance Metrics")
 
-        # EC2 metrics graph for head node instance
+        # EC2 metrics for graph for head node instance
         ec2_metrics = [
             new_pcluster_metric(title="CPU Utilization", metrics=["CPUUtilization"], namespace="AWS/EC2"),
-            new_pcluster_metric(title="Network Packets In/Out", metrics=["NetworkPacketsIn", "NetworkPacketsOut"], namespace="AWS/EC2"),
+            new_pcluster_metric(
+                title="Network Packets In/Out", metrics=["NetworkPacketsIn", "NetworkPacketsOut"], namespace="AWS/EC2"
+            ),
             new_pcluster_metric(title="Network In and Out", metrics=["NetworkIn", "NetworkOut"], namespace="AWS/EC2"),
-            new_pcluster_metric(title="Disk Read/Write Bytes", metrics=["DiskReadBytes", "DiskWriteBytes"], namespace="AWS/EC2"),
-            new_pcluster_metric(title="Disk Read/Write Ops", metrics=["DiskReadOps", "DiskWriteOps"], namespace="AWS/EC2"),
+            new_pcluster_metric(
+                title="Disk Read/Write Bytes", metrics=["DiskReadBytes", "DiskWriteBytes"], namespace="AWS/EC2"
+            ),
+            new_pcluster_metric(
+                title="Disk Read/Write Ops", metrics=["DiskReadOps", "DiskWriteOps"], namespace="AWS/EC2"
+            ),
         ]
 
+        # CW Agent metrics for graph for head node instance
         cwagent_metrics = [
             new_pcluster_metric(title="Disk Used Percent", metrics=["disk_used_percent"], namespace="CWAgent"),
             new_pcluster_metric(title="Memory Used Percent", metrics=["mem_used_percent"], namespace="CWAgent"),
         ]
 
-        # Create EC2 metrics graphs and update coordinates
+        # Create graphs for EC2 metrics and CW Agent metrics and update coordinates
         widgets_list = []
-        for metrics_param in (ec2_metrics + cwagent_metrics):
+        for metrics_param in ec2_metrics + cwagent_metrics:
             metrics_list = self._generate_metrics_list(metrics_param.metrics, metrics_param.namespace)
             graph_widget = self._generate_graph_widget(metrics_param.title, metrics_list)
             widgets_list.append(graph_widget)

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -53,6 +53,10 @@ def test_cw_dashboard_builder(mocker, test_datadir, config_file_name):
     print(output_yaml)
 
     if cluster_config.is_cw_dashboard_enabled:
+        assert_that(output_yaml).contains("CloudwatchDashboard")
+        assert_that(output_yaml).contains("Head Node EC2 Metrics")
+        _verify_head_node_instance_metrics_graphs(output_yaml)
+
         if cluster_config.shared_storage:
             _verify_ec2_metrics_conditions(cluster_config, output_yaml)
 
@@ -60,6 +64,21 @@ def test_cw_dashboard_builder(mocker, test_datadir, config_file_name):
             _verify_head_node_logs_conditions(cluster_config, output_yaml)
         else:
             assert_that(output_yaml).does_not_contain("Head Node Logs")
+    else:
+        assert_that(output_yaml).does_not_contain("CloudwatchDashboard")
+        assert_that(output_yaml).does_not_contain("Head Node EC2 Metrics")
+
+
+def _verify_head_node_instance_metrics_graphs(output_yaml):
+    """Verify CloudWatch graphs within the Head Node Instance Metrics section."""
+    assert_that(output_yaml).contains("Head Node Instance Metrics")
+    assert_that(output_yaml).contains("CPU Utilization")
+    assert_that(output_yaml).contains("Network Packets In/Out")
+    assert_that(output_yaml).contains("Network In and Out")
+    assert_that(output_yaml).contains("Disk Read/Write Bytes")
+    assert_that(output_yaml).contains("Disk Read/Write Ops")
+    assert_that(output_yaml).contains("Disk Used Percent")
+    assert_that(output_yaml).contains("Memory Used Percent")
 
 
 def _verify_ec2_metrics_conditions(cluster_config, output_yaml):


### PR DESCRIPTION
### Description of changes
* Add new graphs `Disk Used Percent` and `Memory Used Percent` to CloudWatch Dashboard of a cluster to monitor memory usage and disk usage of the root volume on the head node.

### Tests
* Manual test: 
  * After code change, create a new cluster, and verify that new graphs `Disk Used Percent` and `Memory Used Percent` (within the `Head Node EC2 Metrics` - `Head Node Instance Metrics` section) show up in CloudWatch Dashboard as expected. 
  * For a head node of c5.large Nitro instance, "reboot" of the head node didn't affect the disk usage metric and graph.
  * Update the cluster to have Monitoring - Dashboards - CloudWatch disabled using the following configuration section, then observed that the dashboard was deleted; update the cluster again with default configuration (Enabled: true), and observed that the dashboard showed up again.
```
Monitoring:
  Dashboards:
    CloudWatch:
      Enabled: false  # true
```
* Unit tests added to verify the dashboard and graphs exist in the CloudFormation template when `Monitoring` - `Dashboards` - `CloudWatch` - `Enabled` is set to `true` (default) in the cluster configuration file.

### References
* PR that adds the disk and memory metrics: https://github.com/aws/aws-parallelcluster-cookbook/pull/1732
* PR that adds the disk and memory alarms: https://github.com/aws/aws-parallelcluster/pull/4877

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
