### PR TITLE
3.x Provide better diagnostics on test setup failure

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -373,46 +373,6 @@ def _add_properties_to_report(item):
             item.user_properties.append(dimension_value_pair)
 
 
-def _add_setup_exception_details_to_report(item, report, exception_info):
-    props = []
-
-    if not isinstance(exception_info.value, SetupError):
-        return
-
-    props.append(("failure-type", "setup"))
-    if exception_info.value.cluster_details:
-        logging.info("Cluster details: %s", json.dumps(exception_info.value.cluster_details, indent=2))
-        props.append(
-            (
-                "failure-codes",
-                json.dumps(
-                    [
-                        {failure["failureCode"]: failure["failureReason"]}
-                        for failure in exception_info.value.cluster_details["failures"]
-                    ]
-                ),
-            )
-        )
-    if exception_info.value.stack_events:
-        logging.info("Stack events: %s", json.dumps(exception_info.value.stack_events, indent=2))
-        props.append(
-            (
-                "failure-events",
-                json.dumps(
-                    [
-                        {
-                            event["logicalResourceId"]: event["resourceStatusReason"],
-                        }
-                        for event in exception_info.value.stack_events["events"]
-                        if event["resourceStatus"] == "CREATE_FAILED"
-                    ]
-                ),
-            )
-        )
-    for prop in props:
-        item.user_properties.append(prop)
-
-
 @pytest.fixture(scope="class")
 @pytest.mark.usefixtures("setup_credentials")
 def clusters_factory(request, region):

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -50,8 +50,8 @@ class SetupError(BaseException):
         if cluster_details:
             details_string = "\n\t".join(
                 [
-                    f"* {failure['failureCode']}:\n\t\t{failure['failureReason']}"
-                    for failure in cluster_details["failures"]
+                    f"* {failure['failureCode']}:\n\t\t{failure.get('failureReason')}"
+                    for failure in cluster_details.get("failures")
                 ],
             )
             formatted_message += f"\n\n- Cluster Errors:\n\t{details_string}"
@@ -59,9 +59,9 @@ class SetupError(BaseException):
         if stack_events:
             events_string = "\n\t".join(
                 [
-                    f"* {event['LogicalResourceId']}:\n\t\t{event['ResourceStatusReason']}"
+                    f"* {event['LogicalResourceId']}:\n\t\t{event.get('ResourceStatusReason')}"
                     for event in stack_events
-                    if event["ResourceStatus"] == "CREATE_FAILED"
+                    if event.get("ResourceStatus") == "CREATE_FAILED"
                 ]
             )
             formatted_message += f"\n\n- Stack Events:\n\t{events_string}"


### PR DESCRIPTION
### Description of changes
* This change tries to differentiate cluster creation failures from test failures. It marks the creation failure as being a setup failure and provides some extra details, if possible from CloudFormation and describe-cluster output.
* Sample failure output:
```
failed on setup with "utils.SetupError: SetupError: Cluster creation failed for integ-tests-05hc6sjduszmupsi-develop

- Cluster Errors:
	* OnNodeStartExecutionFailure:
		Failed to execute OnNodeStart script.

- Stack Events:
	* integ-tests-05hc6sjduszmupsi-develop:
		The following resource(s) failed to create: [HeadNodeWaitCondition20230209170704]. 
	* HeadNodeWaitCondition20230209170704:
		WaitCondition received failed message: 'Failed to execute OnNodeStart script, return code: 1. Please check /var/log/cfn-init.log in the head node, or check the cfn-init.log in CloudWatch logs. Please refer to https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for more details on ParallelCluster logs.' for uniqueId: i-0272f0ecbfc761811"
```

### Tests
* Created a test config with one test that failed an assertion and one test that failed during cluster creation.
* Ran integration tests build with custom test config to verify failure details were communicated as expected.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
