### PR TITLE
Use ARNs of capacity reservations from boto3 instead of formatting from capacity reservation id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
 **BUG FIXES**
 - Fix cluster DB creation by verifying the cluster name is no longer than 40 characters when Slurm accounting is enabled.
 - Fix an issue in clustermgtd that caused compute nodes rebooted via Slurm to be replaced if the EC2 instance status checks fail.
+- Fix an issue where compute nodes could not launch with capacity reservations shared by other accounts because of a wrong IAM policy on head node.
 
 3.4.1
 -----

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2752,6 +2752,16 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
         return list(result)
 
     @property
+    def capacity_reservation_arns(self):
+        """Return a list of capacity reservation ARNs specified in the config."""
+        return [
+            capacity_reservation["CapacityReservationArn"]
+            for capacity_reservation in AWSApi.instance().ec2.describe_capacity_reservations(
+                self.capacity_reservation_ids
+            )
+        ]
+
+    @property
     def capacity_reservation_resource_group_arns(self):
         """Return a list of capacity reservation resource group in the config."""
         result = set()

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -707,13 +707,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                         sid="AllowRunningReservedCapacity",
                         actions=["ec2:RunInstances"],
                         effect=iam.Effect.ALLOW,
-                        resources=[
-                            self._format_arn(
-                                service="ec2",
-                                resource=f"capacity-reservation/{capacity_reservation_id}",
-                            )
-                            for capacity_reservation_id in capacity_reservation_ids
-                        ],
+                        resources=self._config.capacity_reservation_arns,
                     )
                 )
             capacity_reservation_resource_group_arns = self._config.capacity_reservation_resource_group_arns

--- a/cli/tests/pcluster/templates/test_capacity_reservation.py
+++ b/cli/tests/pcluster/templates/test_capacity_reservation.py
@@ -24,9 +24,7 @@ from tests.pcluster.utils import get_head_node_policy, get_statement_by_sid
 
 @pytest.mark.parametrize(
     "config_file_name,",
-    [
-        ("config.yaml"),
-    ],
+    ["config.yaml"],
 )
 def test_capacity_reservation_id_permissions(mocker, test_datadir, config_file_name):
     mock_aws_api(mocker)
@@ -35,6 +33,7 @@ def test_capacity_reservation_id_permissions(mocker, test_datadir, config_file_n
         "pcluster.aws.ec2.Ec2Client.describe_capacity_reservations",
         return_value=[
             {
+                "CapacityReservationArn": "arn:partition:service:region:account-id:capacity-reservation/cr-12345",
                 "InstanceType": "c5.xlarge",
                 "AvailabilityZone": "us-east-1a",
             }


### PR DESCRIPTION
This commit fixes usage of shared capacity reservations from other accounts. Before this commit, the IAM RunInstances policy resources were not properly set if the capacity reservations were shared from other accounts.

Signed-off-by: Hanwen <hanwenli@amazon.com>

### References
This PR is a backport of https://github.com/aws/aws-parallelcluster/pull/4864

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
