### PR TITLE
[develop] Create test subnets in all the avail AZ

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -765,8 +765,9 @@ def _get_default_template_values(vpc_stack: CfnVpcStack, request):
     """Build a dictionary of default values to inject in the jinja templated cluster configs."""
     default_values = get_vpc_snakecase_value(vpc_stack)
     default_values["public_subnet_id"] = vpc_stack.get_public_subnet()  # TODO possibility to override default AZ
+    default_values["public_subnet_ids"] = vpc_stack.get_all_public_subnets()
     default_values["private_subnet_id"] = vpc_stack.get_private_subnet()  # TODO possibility to override default AZ
-    # TODO inject variable containing N subnets
+    default_values["private_subnet_ids"] = vpc_stack.get_all_private_subnets()
     default_values.update({dimension: request.node.funcargs.get(dimension) for dimension in DIMENSIONS_MARKER_ARGS})
     default_values["key_name"] = request.config.getoption("key_name")
 

--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging/test_cloudwatch_logging/pcluster.config.yaml
@@ -24,9 +24,9 @@ Scheduling:
           {% if scheduler == "awsbatch" %}DesiredvCpus:{% else %}MinCount:{% endif %} {{ queue_size }}
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
           {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
           {% endif %}
 Monitoring:
   Logs:

--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -124,7 +124,7 @@ def test_cluster_in_no_internet_subnet(
     )
     cluster_config = pcluster_config_reader(
         default_vpc_security_group_id=vpc_stack_with_endpoints.cfn_outputs["DefaultVpcSecurityGroupId"],
-        no_internet_subnet_id=vpc_stack_with_endpoints.cfn_outputs["NoInternetSubnetId"],
+        no_internet_subnet_id=vpc_stack_with_endpoints.cfn_outputs["PrivateNoInternetSubnetId"],
         vpc_default_security_group_id=vpc_default_security_group_id,
         bucket_name=bucket_name,
         architecture=architecture,

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
@@ -440,9 +440,7 @@ def _test_cluster_config(request, region, command_executor, cluster_config, rend
             len(target_config.get("Scheduling").get("SchedulerQueues"))
         )
         with open(rendered_queue_config_path, encoding="utf-8") as rendered_queue_config:
-            private_subnet_id = (
-                request.getfixturevalue("vpc_stacks_shared").get(region).cfn_outputs.get("PrivateSubnetId")
-            )
+            private_subnet_id = request.getfixturevalue("vpc_stacks_shared").get(region).get_private_subnet()
             rendered_queue = yaml.safe_load(rendered_queue_config)
             # inject subnet id into rendered queue
             for queue in rendered_queue:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.broken.yaml
@@ -17,9 +17,9 @@ Scheduling:
     - Name: broken
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
           {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
           {% endif %}
       CustomActions:
         OnNodeStart:
@@ -42,9 +42,9 @@ Scheduling:
     - Name: half-broken
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
           {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
           {% endif %}
       CustomActions:
         OnNodeStart:
@@ -75,9 +75,9 @@ Scheduling:
     - Name: normal
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
           {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
           {% endif %}
       CustomActions:
         OnNodeStart:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.recover.yaml
@@ -17,9 +17,9 @@ Scheduling:
     - Name: broken
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
           {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
           {% endif %}
       ComputeResources:
         - Name: broken-static
@@ -37,9 +37,9 @@ Scheduling:
     - Name: half-broken
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
           {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
           {% endif %}
       ComputeResources:
         - Name: broken-dynamic
@@ -63,9 +63,9 @@ Scheduling:
     - Name: normal
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
           {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
           {% endif %}
       ComputeResources:
         - Name: normal

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_protected_mode/pcluster.config.yaml
@@ -17,9 +17,9 @@ Scheduling:
     - Name: broken
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
           {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
           {% endif %}
       ComputeResources:
         - Name: broken-static
@@ -36,9 +36,9 @@ Scheduling:
     - Name: half-broken
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
           {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
           {% endif %}
       ComputeResources:
         - Name: broken-dynamic
@@ -62,9 +62,9 @@ Scheduling:
     - Name: normal
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
           {% if scheduler == "slurm" %}
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
           {% endif %}
       ComputeResources:
         - Name: normal

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
@@ -144,8 +144,8 @@ def test_slurm_accounting(
     database_stack_outputs = get_infra_stack_outputs(database_stack_name)
 
     config_params = _get_slurm_database_config_parameters(database_stack_outputs)
-    public_subnet_id = vpc_stack_for_database.cfn_outputs["PublicSubnetId"]
-    private_subnet_id = vpc_stack_for_database.cfn_outputs["PrivateSubnetId"]
+    public_subnet_id = vpc_stack_for_database.get_public_subnet()
+    private_subnet_id = vpc_stack_for_database.get_private_subnet()
     cluster_config = pcluster_config_reader(
         public_subnet_id=public_subnet_id, private_subnet_id=private_subnet_id, **config_params
     )
@@ -181,8 +181,8 @@ def test_slurm_accounting_disabled_to_enabled_update(
     )
 
     database_stack_outputs = get_infra_stack_outputs(database_stack_name)
-    public_subnet_id = vpc_stack_for_database.cfn_outputs["PublicSubnetId"]
-    private_subnet_id = vpc_stack_for_database.cfn_outputs["PrivateSubnetId"]
+    public_subnet_id = vpc_stack_for_database.get_public_subnet()
+    private_subnet_id = vpc_stack_for_database.get_private_subnet()
 
     # First create a cluster without Slurm Accounting enabled
     cluster_config = pcluster_config_reader(public_subnet_id=public_subnet_id, private_subnet_id=private_subnet_id)

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -69,9 +69,7 @@ def test_ebs_snapshot(
 
     logging.info("Creating snapshot")
 
-    snapshot_id = snapshots_factory.create_snapshot(
-        request, vpc_stacks_shared[region].cfn_outputs["PublicSubnetId"], region
-    )
+    snapshot_id = snapshots_factory.create_snapshot(request, vpc_stacks_shared[region].get_public_subnet(), region)
 
     logging.info("Snapshot id: %s" % snapshot_id)
     cluster_config = pcluster_config_reader(mount_dir=mount_dir, volume_size=volume_size, snapshot_id=snapshot_id)
@@ -170,9 +168,7 @@ def test_ebs_existing(
 
     logging.info("Creating volume")
 
-    volume_id = snapshots_factory.create_existing_volume(
-        request, vpc_stacks_shared[region].cfn_outputs["PublicSubnetId"], region
-    )
+    volume_id = snapshots_factory.create_existing_volume(request, vpc_stacks_shared[region].get_public_subnet(), region)
 
     logging.info("Existing Volume id: %s" % volume_id)
     cluster_config = pcluster_config_reader(volume_id=volume_id, existing_mount_dir=existing_mount_dir)

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
@@ -25,7 +25,7 @@ Scheduling:
           {% endif %}
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
     {% if scheduler == "slurm" %}
     - Name: queue-1
       ComputeResources:
@@ -36,7 +36,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_az3_subnet_id }}
+          - {{ private_subnet_ids[1] }}
     {% endif %}
 SharedStorage:
   - MountDir: {{ existing_mount_dir }}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -41,7 +41,7 @@ Scheduling:
           {% endif %}
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
     {% if scheduler == "slurm" %}
     - Name: queue-1
       ComputeSettings:
@@ -59,7 +59,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_az3_subnet_id }}
+          - {{ private_subnet_ids[1] }}
     {% endif %}
 SharedStorage:
   - MountDir: {{ mount_dirs[0] }}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -28,7 +28,7 @@ Scheduling:
           {% endif %}
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
       {% if scheduler != "awsbatch" %}
       Iam:
         InstanceRole: {{ ec2_iam_role }}
@@ -43,7 +43,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_az3_subnet_id }}
+          - {{ private_subnet_ids[1] }}
     {% endif %}
 SharedStorage:
   - MountDir: {{ mount_dir }}

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
@@ -26,7 +26,7 @@ Scheduling:
           {% endif %}
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
     {% if scheduler == "slurm" %}
     - Name: queue-1
       ComputeResources:
@@ -37,7 +37,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_az3_subnet_id }}
+          - {{ private_subnet_ids[1] }}
     {% endif %}
 SharedStorage:
   - MountDir: {{ mount_dir }}

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
@@ -38,7 +38,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_az3_subnet_id }}
+          - {{ private_subnet_id }}
     {% endif %}
 # This compute subnet would be in a different AZ than head node for regions defined in AVAILABILITY_ZONE_OVERRIDES
 # See conftest for details

--- a/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
@@ -38,7 +38,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_az3_subnet_id }}
+          - {{ private_subnet_id }}
     {% endif %}
 # This compute subnet would be in a different AZ than head node for regions defined in AVAILABILITY_ZONE_OVERRIDES
 # See conftest for details

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-managed-fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-managed-fsx.config.yaml
@@ -26,7 +26,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
     - Name: queue-1
       Iam:
         S3Access:
@@ -39,7 +39,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
 SharedStorage:
   - MountDir: test-managed-fsx
     Name: fsx1

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-unmanaged-fsx.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_multi_az_fsx/pcluster-unmanaged-fsx.config.yaml
@@ -26,7 +26,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_subnet_id }}
+          - {{ private_subnet_ids[0] }}
     - Name: queue-1
       Iam:
         S3Access:
@@ -39,7 +39,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_az2_subnet_id }}
+          - {{ private_subnet_ids[1] }}
 SharedStorage:
   - MountDir: {{ fsx_lustre_mount_dir }}
     Name: existingfsx

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_create.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_create.config.yaml
@@ -20,8 +20,8 @@ Scheduling:
             CapacityReservationResourceGroupArn: {{ multi_az_capacity_reservation_arn }}
       Networking:
         SubnetIds:
-          - {{ public_subnet_id }}
-          - {{ public_az2_subnet_id }}
+          - {{ public_subnet_ids[0] }}
+          - {{ public_subnet_ids[1] }}
     - Name: queue2
       ComputeResources:
         - Name: compute-resource-2

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_1.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_1.config.yaml
@@ -20,8 +20,8 @@ Scheduling:
             CapacityReservationResourceGroupArn: {{ multi_az_capacity_reservation_arn }}
       Networking:
         SubnetIds:
-          - {{ public_subnet_id }}
-          - {{ public_az2_subnet_id }}
+          - {{ public_subnet_ids[0] }}
+          - {{ public_subnet_ids[1] }}
     - Name: queue2
       ComputeResources:
         - Name: compute-resource-2
@@ -31,5 +31,5 @@ Scheduling:
           MaxCount: 4
       Networking:
         SubnetIds:
-          - {{ public_az3_subnet_id }}
-          - {{ public_az2_subnet_id }}
+          - {{ public_subnet_ids[2] }}
+          - {{ public_subnet_ids[1] }}

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_2.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_2.config.yaml
@@ -20,8 +20,8 @@ Scheduling:
             CapacityReservationResourceGroupArn: {{ multi_az_capacity_reservation_arn }}
       Networking:
         SubnetIds:
-          - {{ public_subnet_id }}
-          - {{ public_az2_subnet_id }}
+          - {{ public_subnet_ids[0] }}
+          - {{ public_subnet_ids[1] }}
     - Name: queue2
       ComputeResources:
         - Name: compute-resource-2
@@ -31,4 +31,4 @@ Scheduling:
           MaxCount: 4
       Networking:
         SubnetIds:
-          - {{ public_az3_subnet_id }}
+          - {{ public_subnet_ids[2] }}

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -305,6 +305,18 @@ def to_snake_case(input):
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
 
 
+def to_pascal_case(snake_case_word):
+    """Convert the given snake case word into a PascalCase one."""
+    parts = iter(snake_case_word.split("_"))
+    return "".join(word.title() for word in parts)
+
+
+def to_pascal_from_kebab_case(kebab_case_word):
+    """Convert the given kebab case word into a PascalCase one."""
+    parts = iter(kebab_case_word.split("-"))
+    return "".join(word.title() for word in parts)
+
+
 def create_s3_bucket(bucket_name, region):
     """
     Create a new S3 bucket.


### PR DESCRIPTION
### Description of changes
* Create test subnets in all the avail AZ
  
  Create test subnets in all the avail AZ for a region
  Also create child class of `CfnStack` called `CfnVpcStack`, which does have two methods to retrieve public and private subnets.
  
  The public and private subnets returned by the `CfnVpcStack` are located in the default AZ, if the `DEFAULT_AVAILABILITY_ZONE` map contains an entry for the region, otherwise are in a random AZ.
  
  The Jinja test variables `public_subnet_id` and `private_subnet_id` are set with the values retrieved from `get_public_subnet` and `get_private_subnet` exposed by the new class `CfnVpcStack`.
  
  This change is an intermediate step to be able to specify an AZ as dimension of the test configuration.
 
* Create test variables with a list of all subnets (public and private)

  Create test variables with a list of all subnets (public and private).
  These variables contain a shuffled list of subnet ids that can be used for multi-az testing.

### Tests
Changes tested with following conf
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  schedulers:
    test_slurm_accounting.py::test_slurm_accounting:
      dimensions:
        - regions: ["us-east-1"]
          instances:  {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_scaling:
      dimensions:
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: {{ common.OSS_ONE_PER_DISTRO }}
          schedulers: ["slurm"]
    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
      dimensions:
        # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an
        # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
        - regions: ["us-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
