### PR TITLE
[develop] Remove caching of AZ map

### DIFF
--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -15,7 +15,6 @@
 
 import logging
 import random
-from functools import lru_cache
 
 import boto3
 import pytest
@@ -137,7 +136,6 @@ def get_availability_zones(region, credential):
     return az_list
 
 
-@lru_cache(maxsize=128)
 def get_az_id_to_az_name_map(region, credential):
     """Return a dict mapping AZ IDs (e.g, 'use1-az2') to AZ names (e.g., 'us-east-1c')."""
     # credentials are managed manually rather than via setup_sts_credentials because this function


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Remove caching of AZ map since credential is of type list and it's not hashable. Solve
```
>           az_id_to_az_name_map = get_az_id_to_az_name_map(region, credential)
E           TypeError: unhashable type: 'list'
```


### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
