### PR TITLE
[develop] Refactor AZ setup for region and misc fix

### DIFF
--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -17,7 +17,6 @@ import pexpect
 import pytest
 import yaml
 from assertpy import assert_that
-
 from cfn_stacks_factory import CfnVpcStack
 from conftest import inject_additional_config_settings
 from conftest_networking import CIDR_FOR_CUSTOM_SUBNETS
@@ -99,7 +98,9 @@ def test_pcluster_configure_avoid_bad_subnets(
     assert_config_contains_expected_values(key_name, scheduler, os, instance, region, None, None, config_path)
 
 
-def test_region_without_t2micro(vpc_stack: CfnVpcStack, pcluster_config_reader, key_name, region, os, scheduler, test_datadir):
+def test_region_without_t2micro(
+    vpc_stack: CfnVpcStack, pcluster_config_reader, key_name, region, os, scheduler, test_datadir
+):
     """
     Verify the default instance type (free tier) is retrieved dynamically according to region.
     In other words, t3.micro is retrieved when the region does not contain t2.micro
@@ -193,7 +194,9 @@ def test_efa_unsupported(vpc_stack, key_name, region, os, instance, scheduler, c
     _create_and_test_standard_configuration(config_path, region, key_name, scheduler, os, instance, vpc_stack)
 
 
-def _create_and_test_standard_configuration(config_path, region, key_name, scheduler, os, instance, vpc_stack: CfnVpcStack):
+def _create_and_test_standard_configuration(
+    config_path, region, key_name, scheduler, os, instance, vpc_stack: CfnVpcStack
+):
     standard_prompts = (
         standard_first_stage_prompts(region, key_name, scheduler, os, instance)
         + standard_queue_prompts(scheduler, instance, region)
@@ -465,7 +468,7 @@ def subnet_in_use1_az3(vpc_stack):
     )
     assert_that(offerings).is_empty()
     subnet_id = ec2_client.create_subnet(
-        AvailabilityZoneId="use1-az3", CidrBlock="192.168.0.0/21", VpcId=vpc_stack.cfn_outputs["VpcId"]
+        AvailabilityZoneId="use1-az3", CidrBlock=CIDR_FOR_CUSTOM_SUBNETS[-1], VpcId=vpc_stack.cfn_outputs["VpcId"]
     )["Subnet"]["SubnetId"]
     yield subnet_id
     ec2_client.delete_subnet(SubnetId=subnet_id)

--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -17,7 +17,10 @@ import pexpect
 import pytest
 import yaml
 from assertpy import assert_that
+
+from cfn_stacks_factory import CfnVpcStack
 from conftest import inject_additional_config_settings
+from conftest_networking import CIDR_FOR_CUSTOM_SUBNETS
 from utils import get_instance_info
 
 PROMPTS = {
@@ -96,7 +99,7 @@ def test_pcluster_configure_avoid_bad_subnets(
     assert_config_contains_expected_values(key_name, scheduler, os, instance, region, None, None, config_path)
 
 
-def test_region_without_t2micro(vpc_stack, pcluster_config_reader, key_name, region, os, scheduler, test_datadir):
+def test_region_without_t2micro(vpc_stack: CfnVpcStack, pcluster_config_reader, key_name, region, os, scheduler, test_datadir):
     """
     Verify the default instance type (free tier) is retrieved dynamically according to region.
     In other words, t3.micro is retrieved when the region does not contain t2.micro
@@ -115,8 +118,8 @@ def test_region_without_t2micro(vpc_stack, pcluster_config_reader, key_name, reg
         os,
         "",
         region,
-        vpc_stack.cfn_outputs["PublicSubnetId"],
-        vpc_stack.cfn_outputs["PrivateSubnetId"],
+        vpc_stack.get_public_subnet(),
+        vpc_stack.get_private_subnet(),
         config_path,
     )
 
@@ -131,7 +134,7 @@ def test_region_without_t2micro(vpc_stack, pcluster_config_reader, key_name, reg
 )
 def test_efa_and_placement_group(
     request,
-    vpc_stack,
+    vpc_stack: CfnVpcStack,
     key_name,
     region,
     os,
@@ -175,8 +178,8 @@ def test_efa_and_placement_group(
         os,
         instance,
         region,
-        vpc_stack.cfn_outputs["PublicSubnetId"],
-        vpc_stack.cfn_outputs["PrivateSubnetId"],
+        vpc_stack.get_public_subnet(),
+        vpc_stack.get_private_subnet(),
         config_path,
         efa_config=efa_config,
         placement_group_config=placement_group_config["configuration"],
@@ -190,7 +193,7 @@ def test_efa_unsupported(vpc_stack, key_name, region, os, instance, scheduler, c
     _create_and_test_standard_configuration(config_path, region, key_name, scheduler, os, instance, vpc_stack)
 
 
-def _create_and_test_standard_configuration(config_path, region, key_name, scheduler, os, instance, vpc_stack):
+def _create_and_test_standard_configuration(config_path, region, key_name, scheduler, os, instance, vpc_stack: CfnVpcStack):
     standard_prompts = (
         standard_first_stage_prompts(region, key_name, scheduler, os, instance)
         + standard_queue_prompts(scheduler, instance, region)
@@ -204,8 +207,8 @@ def _create_and_test_standard_configuration(config_path, region, key_name, sched
         os,
         instance,
         region,
-        vpc_stack.cfn_outputs["PublicSubnetId"],
-        vpc_stack.cfn_outputs["PrivateSubnetId"],
+        vpc_stack.get_public_subnet(),
+        vpc_stack.get_private_subnet(),
         config_path,
     )
 
@@ -254,15 +257,15 @@ def standard_queue_prompts(scheduler, instance, region, size=""):
     return queue_prompts
 
 
-def standard_vpc_subnet_prompts(vpc_stack):
+def standard_vpc_subnet_prompts(vpc_stack: CfnVpcStack):
     return [
         PROMPTS["vpc_creation"]("n"),
         PROMPTS["vpc_id"](vpc_stack.cfn_outputs["VpcId"]),
         PROMPTS["subnet_creation"]("n"),
-        prompt_head_node_subnet_id(subnet_id=vpc_stack.cfn_outputs["PublicSubnetId"]),
+        prompt_head_node_subnet_id(subnet_id=vpc_stack.get_public_subnet()),
         prompt_compute_node_subnet_id(
-            subnet_id=vpc_stack.cfn_outputs["PrivateSubnetId"],
-            head_node_subnet_id=vpc_stack.cfn_outputs["PublicSubnetId"],
+            subnet_id=vpc_stack.get_private_subnet(),
+            head_node_subnet_id=vpc_stack.get_public_subnet(),
         ),
     ]
 

--- a/tests/integration-tests/tests/networking/test_networking.py
+++ b/tests/integration-tests/tests/networking/test_networking.py
@@ -13,12 +13,13 @@ import os
 
 import boto3
 from assertpy import assert_that
+from conftest_networking import CIDR_FOR_CUSTOM_SUBNETS, CIDR_FOR_PRIVATE_SUBNETS, CIDR_FOR_PUBLIC_SUBNETS
 
 
 def test_public_network_topology(region, vpc_stack, parameterized_cfn_stacks_factory, random_az_selector):
     ec2_client = boto3.client("ec2", region_name=region)
     vpc_id = vpc_stack.cfn_outputs["VpcId"]
-    public_subnet_cidr = "192.168.3.0/24"
+    public_subnet_cidr = CIDR_FOR_CUSTOM_SUBNETS[-1]
     availability_zone = random_az_selector(region, default_value="")
     internet_gateway_id = vpc_stack.cfn_resources["InternetGateway"]
 
@@ -41,8 +42,8 @@ def test_public_network_topology(region, vpc_stack, parameterized_cfn_stacks_fac
 def test_public_private_network_topology(region, vpc_stack, parameterized_cfn_stacks_factory, random_az_selector):
     ec2_client = boto3.client("ec2", region_name=region)
     vpc_id = vpc_stack.cfn_outputs["VpcId"]
-    public_subnet_cidr = "192.168.5.0/24"
-    private_subnet_cidr = "192.168.4.0/24"
+    public_subnet_cidr = CIDR_FOR_PUBLIC_SUBNETS[-1]
+    private_subnet_cidr = CIDR_FOR_PRIVATE_SUBNETS[-1]
     availability_zone = random_az_selector(region, default_value="")
     internet_gateway_id = vpc_stack.cfn_resources["InternetGateway"]
 

--- a/tests/integration-tests/tests/schedulers/conftest.py
+++ b/tests/integration-tests/tests/schedulers/conftest.py
@@ -5,7 +5,13 @@ from collections import defaultdict
 
 import pytest
 from cfn_stacks_factory import CfnStack, CfnStacksFactory, CfnVpcStack
-from conftest_networking import CIDR_FOR_PRIVATE_SUBNETS, CIDR_FOR_PUBLIC_SUBNETS, get_az_setup_for_region, subnet_name
+from conftest_networking import (
+    CIDR_FOR_CUSTOM_SUBNETS,
+    CIDR_FOR_PRIVATE_SUBNETS,
+    CIDR_FOR_PUBLIC_SUBNETS,
+    get_az_setup_for_region,
+    subnet_name,
+)
 from network_template_builder import Gateways, NetworkTemplateBuilder, SubnetConfig, VPCConfig
 from utils import generate_stack_name
 
@@ -96,8 +102,8 @@ def _create_database_stack(stack_factory, request, region, vpc_stack_for_databas
             {"ParameterKey": "ClusterName", "ParameterValue": cluster_name},
             {"ParameterKey": "Vpc", "ParameterValue": vpc_stack_for_database.cfn_outputs["VpcId"]},
             {"ParameterKey": "AdminPasswordSecretString", "ParameterValue": admin_password},
-            {"ParameterKey": "Subnet1CidrBlock", "ParameterValue": "192.168.8.0/23"},
-            {"ParameterKey": "Subnet2CidrBlock", "ParameterValue": "192.168.4.0/23"},
+            {"ParameterKey": "Subnet1CidrBlock", "ParameterValue": CIDR_FOR_CUSTOM_SUBNETS[-1]},
+            {"ParameterKey": "Subnet2CidrBlock", "ParameterValue": CIDR_FOR_CUSTOM_SUBNETS[-2]},
         ]
         database_stack = CfnStack(
             name=database_stack_name,

--- a/tests/integration-tests/tests/schedulers/conftest.py
+++ b/tests/integration-tests/tests/schedulers/conftest.py
@@ -5,13 +5,7 @@ from collections import defaultdict
 
 import pytest
 from cfn_stacks_factory import CfnStack, CfnStacksFactory, CfnVpcStack
-from conftest_networking import (
-    CIDR_FOR_PRIVATE_SUBNETS,
-    CIDR_FOR_PUBLIC_SUBNETS,
-    DEFAULT_AVAILABILITY_ZONE,
-    get_az_id_to_az_name_map,
-    subnet_name,
-)
+from conftest_networking import CIDR_FOR_PRIVATE_SUBNETS, CIDR_FOR_PUBLIC_SUBNETS, get_az_setup_for_region, subnet_name
 from network_template_builder import Gateways, NetworkTemplateBuilder, SubnetConfig, VPCConfig
 from utils import generate_stack_name
 
@@ -39,9 +33,7 @@ def vpc_stack_for_database(region, request):
         return stack
 
     # tests with database are not using multi-AZ
-    az_id_to_az_name_map = get_az_id_to_az_name_map(region, credential)
-    default_az_id = random.choice(DEFAULT_AVAILABILITY_ZONE.get(region))
-    default_az_name = az_id_to_az_name_map.get(default_az_id)
+    default_az_id, default_az_name, _ = get_az_setup_for_region(region, credential)
 
     public_subnet = SubnetConfig(
         name=subnet_name(visibility="Public", az_id=default_az_id),


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>

### Description of changes
* Refactor AZ setup for region

  Refactor AZ setup, so that if a default AZ is set for a given region, return it, otherwise return a random AZ

*  Get subnets using VPC stack methods

    Get subnets using VPC stack methods instead of retrieving them from CFN outputs. This because CFN outputs for subnets varies depending on the AZ where the subnets are created.

* Use CIDR from the defined list

  Use CIDR from the defined list so to avoid conflicts.

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
