### PR TITLE
[develop] Get subnets using VPC stack methods

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1502,7 +1502,7 @@ def scheduler_commands_factory(scheduler, scheduler_plugin_configuration):
 
 
 @pytest.fixture(scope="class")
-def fsx_factory(vpc_stack, cfn_stacks_factory, request, region, key_name):
+def fsx_factory(vpc_stack: CfnVpcStack, cfn_stacks_factory, request, region, key_name):
     """
     Define a fixture to manage the creation and destruction of fsx.
 
@@ -1545,7 +1545,7 @@ def fsx_factory(vpc_stack, cfn_stacks_factory, request, region, key_name):
             fsx_filesystem = FileSystem(
                 title=f"{file_system_resource_name}{i}",
                 SecurityGroupIds=[Ref(fsx_sg)],
-                SubnetIds=[vpc_stack.cfn_outputs["PublicSubnetId"]],
+                SubnetIds=[vpc_stack.get_public_subnet()],
                 FileSystemType=file_system_type,
                 **kwargs,
                 **depends_on_arg,
@@ -1746,7 +1746,7 @@ def efs_mount_target_stack_factory(cfn_stacks_factory, request, region, vpc_stac
             )
 
         # Create mount targets
-        subnet_ids = [value for key, value in vpc_stack.cfn_outputs.items() if key.endswith("SubnetId")]
+        subnet_ids = vpc_stack.get_all_public_subnets() + vpc_stack.get_all_private_subnets()
         _add_mount_targets(subnet_ids, efs_ids, security_group, template)
 
         stack_name = generate_stack_name("integ-tests-mount-targets", request.config.getoption("stackname_suffix"))

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 import boto3
 import pytest
 from assertpy import assert_that
-from cfn_stacks_factory import CfnStack
+from cfn_stacks_factory import CfnStack, CfnVpcStack
 from OpenSSL import crypto
 from OpenSSL.crypto import FILETYPE_PEM, TYPE_RSA, X509, dump_certificate, dump_privatekey
 from paramiko import RSAKey
@@ -173,7 +173,9 @@ def store_secret_in_secret_manager(request, cfn_stacks_factory):
                 secrets_manager_client.delete_secret(SecretId=secret_arn)
 
 
-def _create_directory_stack(cfn_stacks_factory, request, directory_type, test_resources_dir, region, vpc_stack):
+def _create_directory_stack(
+    cfn_stacks_factory, request, directory_type, test_resources_dir, region, vpc_stack: CfnVpcStack
+):
     directory_stack_name = generate_stack_name(
         f"integ-tests-MultiUserInfraStack{directory_type}", request.config.getoption("stackname_suffix")
     )
@@ -218,12 +220,12 @@ def _create_directory_stack(cfn_stacks_factory, request, directory_type, test_re
     with open(render_jinja_template(directory_stack_template_path, **config_args)) as directory_stack_template:
         params = [
             {"ParameterKey": "Vpc", "ParameterValue": vpc_stack.cfn_outputs["VpcId"]},
-            {"ParameterKey": "PrivateSubnetOne", "ParameterValue": vpc_stack.cfn_outputs["PrivateSubnetId"]},
+            {"ParameterKey": "PrivateSubnetOne", "ParameterValue": vpc_stack.get_private_subnet()},
             {
                 "ParameterKey": "PrivateSubnetTwo",
                 "ParameterValue": vpc_stack.cfn_outputs["PrivateAdditionalCidrSubnetId"],
             },
-            {"ParameterKey": "PublicSubnetOne", "ParameterValue": vpc_stack.cfn_outputs["PublicSubnetId"]},
+            {"ParameterKey": "PublicSubnetOne", "ParameterValue": vpc_stack.get_public_subnet()},
         ]
         directory_stack = CfnStack(
             name=directory_stack_name,

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -14,7 +14,7 @@ import re
 
 import boto3
 from assertpy import assert_that
-from cfn_stacks_factory import CfnStack
+from cfn_stacks_factory import CfnStack, CfnVpcStack
 from clusters_factory import Cluster
 from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
@@ -160,7 +160,7 @@ def test_raid_correctly_mounted(remote_command_executor, mount_dir, volume_size)
 
 
 def write_file_into_efs(
-    region, vpc_stack, efs_ids, request, key_name, cfn_stacks_factory, efs_mount_target_stack_factory
+    region, vpc_stack: CfnVpcStack, efs_ids, request, key_name, cfn_stacks_factory, efs_mount_target_stack_factory
 ):
     """Write file stack contains an instance to write an empty file with random name into each of the efs in efs_ids."""
     write_file_template = Template()
@@ -231,7 +231,7 @@ def write_file_into_efs(
             LaunchTemplate=LaunchTemplateSpecification(
                 LaunchTemplateId=Ref(launch_template), Version=GetAtt(launch_template, "LatestVersionNumber")
             ),
-            SubnetId=vpc_stack.cfn_outputs["PublicSubnetId"],
+            SubnetId=vpc_stack.get_public_subnet(),
             UserData=Base64(Sub(user_data)),
             KeyName=key_name,
             IamInstanceProfile=Ref(iam_instance_profile),


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
* Get subnets using VPC stack methods instead of retrieving them from CFN outputs. This because CFN outputs for subnets varies depending on the AZ where the subnets are created.

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
