### PR TITLE
[3.5] Add skip_ice flag to ignore InsufficientInstanceCapacity errors 

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -33,7 +33,7 @@ def assert_instance_replaced_or_terminating(instance_id, region):
     assert_that(ec2_response["Reservations"][0]["Instances"][0]["State"]["Name"]).is_in("shutting-down", "terminated")
 
 
-def assert_no_errors_in_logs(remote_command_executor, scheduler):
+def assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=False):
     __tracebackhide__ = True
     if scheduler == "slurm":
         log_files = [
@@ -52,6 +52,8 @@ def assert_no_errors_in_logs(remote_command_executor, scheduler):
 
     for log_file in log_files:
         log = remote_command_executor.run_remote_command("sudo cat {0}".format(log_file), hide=True).stdout
+        if skip_ice:
+            log = "\n".join([line for line in log.splitlines() if "InsufficientInstanceCapacity" not in line])
         for error_level in ["CRITICAL", "ERROR"]:
             assert_that(log).does_not_contain(error_level)
 

--- a/tests/integration-tests/tests/common/mpi_common.py
+++ b/tests/integration-tests/tests/common/mpi_common.py
@@ -81,4 +81,4 @@ def _test_mpi(
     assert_that(mpi_out).contains("Process 0 received token -1 from process 1")
     assert_that(mpi_out).contains("Process 1 received token -1 from process 0")
 
-    assert_no_errors_in_logs(remote_command_executor, scheduler)
+    assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=True)

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -110,7 +110,7 @@ def test_efa(
     if instance == "p4d.24xlarge" and os != "centos7":
         _test_nccl_benchmarks(remote_command_executor, test_datadir, "openmpi", scheduler_commands)
 
-    assert_no_errors_in_logs(remote_command_executor, scheduler)
+    assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=True)
 
 
 def _test_efa_installation(scheduler_commands, remote_command_executor, efa_installed=True, partition=None):

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -264,7 +264,7 @@ def test_efs_correctly_mounted(remote_command_executor, mount_dir, tls=False, ia
     # The value of the two parameters should be set according to cluster configuration parameters.
     logging.info("Checking efs {0} is correctly mounted".format(mount_dir))
     # Following EFS instruction to check https://docs.aws.amazon.com/efs/latest/ug/encryption-in-transit.html
-    result = remote_command_executor.run_remote_command("mount | column -t | grep '{0}'".format(mount_dir))
+    result = remote_command_executor.run_remote_command("mount")
     assert_that(result.stdout).contains(mount_dir)
     if tls:
         logging.info("Checking efs {0} enables in-transit encryption".format(mount_dir))


### PR DESCRIPTION
### Description of changes
* Add skip_ice flag to ignore InsufficientInstanceCapacity errors

### Tests
* Locally tested with 
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  efa:
    test_efa.py::test_efa:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5n.9xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### References
* cherry-pick https://github.com/aws/aws-parallelcluster/pull/4896

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
