### PR TITLE
[integ-3.4.1] Add skip_ice flag to ignore InsufficientInstanceCapacity errors

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -32,7 +32,7 @@ def assert_instance_replaced_or_terminating(instance_id, region):
     assert_that(ec2_response["Reservations"][0]["Instances"][0]["State"]["Name"]).is_in("shutting-down", "terminated")
 
 
-def assert_no_errors_in_logs(remote_command_executor, scheduler):
+def assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=False):
     __tracebackhide__ = True
     if scheduler == "slurm":
         log_files = [
@@ -51,6 +51,8 @@ def assert_no_errors_in_logs(remote_command_executor, scheduler):
 
     for log_file in log_files:
         log = remote_command_executor.run_remote_command("sudo cat {0}".format(log_file), hide=True).stdout
+        if skip_ice:
+            log = "\n".join([line for line in log.splitlines() if "InsufficientInstanceCapacity" not in line])
         for error_level in ["CRITICAL", "ERROR"]:
             assert_that(log).does_not_contain(error_level)
 

--- a/tests/integration-tests/tests/common/mpi_common.py
+++ b/tests/integration-tests/tests/common/mpi_common.py
@@ -81,4 +81,4 @@ def _test_mpi(
     assert_that(mpi_out).contains("Process 0 received token -1 from process 1")
     assert_that(mpi_out).contains("Process 1 received token -1 from process 0")
 
-    assert_no_errors_in_logs(remote_command_executor, scheduler)
+    assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=True)

--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -110,7 +110,7 @@ def test_efa(
     if instance == "p4d.24xlarge" and os != "centos7":
         _test_nccl_benchmarks(remote_command_executor, test_datadir, "openmpi", scheduler_commands)
 
-    assert_no_errors_in_logs(remote_command_executor, scheduler)
+    assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=True)
 
 
 def _test_efa_installation(scheduler_commands, remote_command_executor, efa_installed=True, partition=None):


### PR DESCRIPTION
### Description of changes
* Add skip_ice flag to ignore InsufficientInstanceCapacity errors

### Tests
* Locally tested with 
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  efa:
    test_efa.py::test_efa:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["c5n.9xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### References
* cherry-pick https://github.com/aws/aws-parallelcluster/pull/4896

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
