### PR TITLE
[develop] Fix logic for subnet with additional CIDR and no Internet

### DIFF
--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -254,13 +254,15 @@ def vpc_stacks_shared(cfn_stacks_factory, request, key_name):
             if index == 0:
                 # Creating private_subnet_different_cidr in a different AZ for test_efs
                 # TODO isolate this logic and create a compute subnet in different AZ than head node in test_efs
+                az_names_without_default = list(az_id_name_dict.values())
+                az_names_without_default.remove(default_az_name)
                 subnets.append(
                     SubnetConfig(
                         name=subnet_name(visibility="Private", flavor="AdditionalCidr"),
                         cidr=CIDR_FOR_CUSTOM_SUBNETS[index],
                         map_public_ip_on_launch=False,
                         has_nat_gateway=False,
-                        availability_zone=list(az_id_name_dict.values())[index + 1],
+                        availability_zone=random.choice(az_names_without_default),
                         default_gateway=Gateways.NAT_GATEWAY,
                     )
                 )
@@ -270,7 +272,7 @@ def vpc_stacks_shared(cfn_stacks_factory, request, key_name):
                         cidr=CIDR_FOR_CUSTOM_SUBNETS[index + 1],
                         map_public_ip_on_launch=False,
                         has_nat_gateway=False,
-                        availability_zone=az_name,
+                        availability_zone=default_az_name,
                         default_gateway=Gateways.NONE,
                     )
                 )


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
For backward compatibility, the subnet with additional CIDR must be created in an AZ different from the default subnet. The same is valid for the subnet with no Internet. In the future, it is expected that these two subnets will not be created anymore, since we are now creating a subnet for each AZ, but this would require to change the logic of the tests currently using them

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
