### PR TITLE
[release-3.5] Revert no-delete flag for ODCR stack

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1380,10 +1380,7 @@ def placement_group_stack(cfn_stacks_factory, request, region):
 
     yield stack
 
-    if not request.config.getoption("no_delete"):
-        cfn_stacks_factory.delete_stack(stack.name, region)
-    else:
-        logging.warning("Skipping deletion of CFN stacks because --no-delete option is set")
+    cfn_stacks_factory.delete_stack(stack.name, region)
 
 
 @pytest.fixture(scope="class")
@@ -1524,10 +1521,7 @@ def odcr_stack(request, region, placement_group_stack, cfn_stacks_factory, vpc_s
 
     yield stack
 
-    if not request.config.getoption("no_delete"):
-        cfn_stacks_factory.delete_all_stacks()
-    else:
-        logging.warning("Skipping deletion of CFN stacks because --no-delete option is set")
+    cfn_stacks_factory.delete_stack(stack.name, region)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Signed-off-by: Luca Carrogu <carrogu@amazon.com>


### Description of changes
Revert https://github.com/aws/aws-parallelcluster/commit/a4a04ba734eab12465afa82cbc0e46be35702524 Reason is that it is bad to use the cfn_stacks_factory session fixture from a class fixture: this can cause underlying session resources being deleted between test executions


### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
