### PR TITLE
3.x Fix exception when 'failures' missing

### DIFF
--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -47,10 +47,10 @@ class SetupError(BaseException):
     @staticmethod
     def _format_message(message, stack_events, cluster_details) -> str:
         formatted_message = message if message else "Error during setup."
-        if cluster_details:
+        if cluster_details and "failures" in cluster_details:
             details_string = "\n\t".join(
                 [
-                    f"* {failure['failureCode']}:\n\t\t{failure.get('failureReason')}"
+                    f"* {failure.get('failureCode')}:\n\t\t{failure.get('failureReason')}"
                     for failure in cluster_details.get("failures")
                 ],
             )
@@ -59,7 +59,7 @@ class SetupError(BaseException):
         if stack_events:
             events_string = "\n\t".join(
                 [
-                    f"* {event['LogicalResourceId']}:\n\t\t{event.get('ResourceStatusReason')}"
+                    f"* {event.get('LogicalResourceId')}:\n\t\t{event.get('ResourceStatusReason')}"
                     for event in stack_events
                     if event.get("ResourceStatus") == "CREATE_FAILED"
                 ]


### PR DESCRIPTION
### Description of changes
* If a cluster fails to create during an integration test but their was not 'failures' property returned by
describe-cluster, the SetupException message builder would throw an exception.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
