### PR TITLE
Fix DEFAULT_RETENTION_DAYS in integration test to be 180

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -28,7 +28,7 @@ from tests.common.schedulers_common import get_scheduler_commands
 
 LOGGER = logging.getLogger(__name__)
 DEFAULT_SHARED_DIR = "/shared"
-DEFAULT_RETENTION_DAYS = 14
+DEFAULT_RETENTION_DAYS = 180
 NODE_CONFIG_PATH = "/etc/chef/dna.json"
 HEAD_NODE_ROLE_NAME = "HeadNode"
 COMPUTE_NODE_ROLE_NAME = "ComputeFleet"


### PR DESCRIPTION
### Description of changes
* After increasing RetentionInDays through https://github.com/aws/aws-parallelcluster/pull/4805, integration test value need to be fixed accordingly

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
