### PR TITLE
Improve wrong version error message in userdata

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -177,7 +177,9 @@ write_files:
       if [ -f /opt/parallelcluster/.bootstrapped ]; then
         installed_version=$(cat /opt/parallelcluster/.bootstrapped)
         if [ "${!cookbook_version}" != "${!installed_version}" ]; then
-          error_exit "This AMI was created with ${!installed_version}, but is trying to be used with ${!cookbook_version}. Please either use an AMI created with ${!cookbook_version} or change your ParallelCluster to ${!installed_version}"
+          cookbook_version_number=$(echo ${!cookbook_version} | cut -d "-" -f 4)
+          installed_version_number=$(echo ${!installed_version} | cut -d "-" -f 4)
+          error_exit "This AMI was created with ParallelCluster ${!installed_version_number}, but is trying to be used with ParallelCluster ${!cookbook_version_number}. Please either use an AMI created with ParallelCluster ${!cookbook_version_number} or change your ParallelCluster to ${!installed_version_number}"
         fi
       else
         error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -118,7 +118,9 @@ export berkshelf_version=${BerkshelfVersion}
 if [ -f /opt/parallelcluster/.bootstrapped ]; then
   installed_version=$(cat /opt/parallelcluster/.bootstrapped)
   if [ "${!cookbook_version}" != "${!installed_version}" ]; then
-    error_exit "This AMI was created with ${!installed_version}, but is trying to be used with ${!cookbook_version}. Please either use an AMI created with ${!cookbook_version} or change your ParallelCluster to ${!installed_version}"
+    cookbook_version_number=$(echo ${!cookbook_version} | cut -d "-" -f 4)
+    installed_version_number=$(echo ${!installed_version} | cut -d "-" -f 4)
+    error_exit "This AMI was created with ${!installed_version_number}, but is trying to be used with ${!cookbook_version_number}. Please either use an AMI created with ${!cookbook_version_number} or change your ParallelCluster to ${!installed_version_number}"
   fi
 else
   error_exit "This AMI was not baked by ParallelCluster. Please use pcluster build-image command to create an AMI by providing your AMI as parent image."


### PR DESCRIPTION
Old message: This AMI was created with aws-parallelcluster-cookbook-3.6.0, but is trying to be used with aws-parallelcluster-cookbook-3.5.0. Please either use an AMI created with aws-parallelcluster-cookbook-3.5.0 or change your ParallelCluster to aws-parallelcluster-cookbook-3.6.0

New message: This AMI was created with ParallelCluster 3.5.0, but is trying to be used with ParallelCluster 3.6.0. Please either use an AMI created with ParallelCluster 3.6.0 or change your ParallelCluster to 3.5.0

Signed-off-by: Hanwen <hanwenli@amazon.com>

### Tests
Manually tested by creating a Alinux2 and a Ubuntu2004 cluster with wrong AMI versions

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
