### PR TITLE
[integ-test] Change ODCR instance type

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1177,7 +1177,7 @@ def odcr_stack(request, region, placement_group_stack, cfn_stacks_factory, vpc_s
         AvailabilityZone=availability_zone,
         InstanceCount=4,
         InstancePlatform="Linux/UNIX",
-        InstanceType="c5.xlarge",
+        InstanceType="m5.2xlarge",
     )
     target_odcr = ec2.CapacityReservation(
         "integTestsTargetOdcr",

--- a/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_on_demand_capacity_reservation/test_on_demand_capacity_reservation/pcluster.config.yaml
@@ -12,19 +12,19 @@ Scheduling:
     - Name: open-odcr-q
       ComputeResources:
         - Name: open-odcr-id-cr
-          InstanceType: c5.xlarge
+          InstanceType: m5.2xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
             CapacityReservationId: {{ open_capacity_reservation_id }}
         - Name: open-odcr-arn-cr
-          InstanceType: c5.xlarge
+          InstanceType: m5.2xlarge
           MinCount: 1
           MaxCount: 10
           CapacityReservationTarget:
             CapacityReservationResourceGroupArn: {{ open_capacity_reservation_arn }}
         - Name: open-odcr-id-pg-cr
-          InstanceType: c5.xlarge
+          InstanceType: m5.2xlarge
           MinCount: 1
           MaxCount: 10
           Networking:
@@ -33,7 +33,7 @@ Scheduling:
           CapacityReservationTarget:
             CapacityReservationId: {{ open_capacity_reservation_id }}
         - Name: open-odcr-arn-pg-cr
-          InstanceType: c5.xlarge
+          InstanceType: m5.2xlarge
           MinCount: 1
           MaxCount: 10
           Networking:


### PR DESCRIPTION
test_on_demand_capacity_reservation was using c5.xlarge as one of the open ODCRs. However, open ODCRs can be shared with other tests in the same availability zone, causing test_on_demand_capacity_reservation failing because of insufficient reservation capacity. Therefore,to avoid other tests using ODCR mistakenly, this commit changes the instance type to m5.2xlarge, which is not widely used in our integration tests

This PR is cherry picked from https://github.com/aws/aws-parallelcluster/pull/4908

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
