### PR TITLE
3.x Add details to integration test setup failures

### DIFF
--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -17,7 +17,14 @@ from assertpy import assert_that
 from botocore.exceptions import ClientError
 from framework.credential_providers import aws_credential_provider
 from retrying import retry
-from utils import retrieve_cfn_outputs, retrieve_cfn_resources, to_pascal_from_kebab_case
+from utils import (
+    StackError,
+    StackSetupError,
+    get_cfn_events,
+    retrieve_cfn_outputs,
+    retrieve_cfn_resources,
+    to_pascal_from_kebab_case,
+)
 
 
 class CfnStack:
@@ -130,11 +137,12 @@ class CfnStacksFactory:
         self.__created_stacks = OrderedDict()
         self.__credentials = credentials
 
-    def create_stack(self, stack):
+    def create_stack(self, stack, stack_is_under_test=False):
         """
         Create a cfn stack with a given template.
 
         :param stack: stack to create.
+        :param stack_is_under_test: indicates whether the creation of the stack is being tested or not.
         """
         name = stack.name
         region = stack.region
@@ -166,7 +174,11 @@ class CfnStacksFactory:
                 self.__created_stacks[id] = stack
                 final_status = self.__wait_for_stack_creation(stack.cfn_stack_id, cfn_client)
                 self.__assert_stack_status(
-                    final_status, "CREATE_COMPLETE", cfn_client=cfn_client, name=stack.cfn_stack_id
+                    final_status,
+                    "CREATE_COMPLETE",
+                    region=region,
+                    stack_name=stack.cfn_stack_id,
+                    stack_is_under_test=stack_is_under_test,
                 )
                 # Initialize the stack data while still in the credential context
                 stack.init_stack_data()
@@ -184,21 +196,23 @@ class CfnStacksFactory:
     def delete_stack(self, name, region):
         """Destroy a created cfn stack."""
         with aws_credential_provider(region, self.__credentials):
-            id = self.__get_stack_internal_id(name, region)
-            if id in self.__created_stacks:
+            internal_id = self.__get_stack_internal_id(name, region)
+            if internal_id in self.__created_stacks:
                 logging.info("Destroying stack {0} in region {1}".format(name, region))
                 try:
-                    stack = self.__created_stacks[id]
+                    stack = self.__created_stacks[internal_id]
                     cfn_client = boto3.client("cloudformation", region_name=stack.region)
                     cfn_client.delete_stack(StackName=stack.name)
                     final_status = self.__wait_for_stack_deletion(stack.cfn_stack_id, cfn_client)
-                    self.__assert_stack_status(final_status, "DELETE_COMPLETE")
                 except Exception as e:
                     logging.error(
                         "Deletion of stack {0} in region {1} failed with exception: {2}".format(name, region, e)
                     )
                     raise
-                del self.__created_stacks[id]
+                self.__assert_stack_status(
+                    final_status, "DELETE_COMPLETE", stack_name=stack.cfn_stack_id, region=region
+                )
+                del self.__created_stacks[internal_id]
                 logging.info("Stack {0} deleted successfully in region {1}".format(name, region))
             else:
                 logging.warning(
@@ -239,27 +253,17 @@ class CfnStacksFactory:
         return cfn_client.describe_stacks(StackName=name).get("Stacks")[0].get("StackStatus")
 
     @staticmethod
-    def __get_stack_resource_failures(name, cfn_client):
-        resources = cfn_client.list_stack_resources(StackName=name).get("StackResourceSummaries")
-        return (
-            {resource.get("LogicalResourceId"): resource.get("ResourceStatusReason")}
-            for resource in resources
-            if resource.get("ResourceStatus") == "CREATE_FAILED"
-        )
-
-    @staticmethod
-    def __assert_stack_status(status, expected_status, cfn_client=None, name=None):
+    def __assert_stack_status(status, expected_status, region, stack_name=None, stack_is_under_test=False):
         if status != expected_status:
-            if cfn_client and name:
-                failures = "\n\t".join(
-                    str(failure) for failure in CfnStacksFactory.__get_stack_resource_failures(name, cfn_client)
-                )
-                raise Exception(
-                    "Stack status {0} for {1} differs from expected one {2}:\n\t{3}".format(
-                        status, name, expected_status, failures
-                    )
-                )
-            raise Exception("Stack status {0} differs from expected one {1}".format(status, expected_status))
+            message = (
+                f"Stack status {status} for {stack_name} differs "
+                f"from the expected status of {expected_status} in region {region}"
+            )
+            stack_events = get_cfn_events(stack_name, region=region)
+            if stack_is_under_test:
+                raise StackError(message, stack_events=stack_events)
+            else:
+                raise StackSetupError(message, stack_events=stack_events)
 
     @staticmethod
     def __get_stack_internal_id(name, region):

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -204,14 +204,14 @@ class CfnStacksFactory:
                     cfn_client = boto3.client("cloudformation", region_name=stack.region)
                     cfn_client.delete_stack(StackName=stack.name)
                     final_status = self.__wait_for_stack_deletion(stack.cfn_stack_id, cfn_client)
+                    self.__assert_stack_status(
+                        final_status, "DELETE_COMPLETE", stack_name=stack.cfn_stack_id, region=region
+                    )
                 except Exception as e:
                     logging.error(
                         "Deletion of stack {0} in region {1} failed with exception: {2}".format(name, region, e)
                     )
                     raise
-                self.__assert_stack_status(
-                    final_status, "DELETE_COMPLETE", stack_name=stack.cfn_stack_id, region=region
-                )
                 del self.__created_stacks[internal_id]
                 logging.info("Stack {0} deleted successfully in region {1}".format(name, region))
             else:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -804,7 +804,9 @@ def parameterized_cfn_stacks_factory(request):
     """Define a fixture that returns a parameterized stack factory and manages the stack creation and deletion."""
     factory = CfnStacksFactory(request.config.getoption("credential"))
 
-    def _create_stack(region, template_path, stack_prefix="", parameters=None, capabilities=None):
+    def _create_stack(
+        region, template_path, stack_prefix="", parameters=None, capabilities=None, stack_is_under_test=False
+    ):
         file_content = extract_template(template_path)
         stack = CfnStack(
             name=generate_stack_name(stack_prefix, request.config.getoption("stackname_suffix")),
@@ -813,7 +815,7 @@ def parameterized_cfn_stacks_factory(request):
             parameters=parameters or [],
             capabilities=capabilities or [],
         )
-        factory.create_stack(stack)
+        factory.create_stack(stack, stack_is_under_test=stack_is_under_test)
         return stack
 
     def extract_template(template_path):

--- a/tests/integration-tests/tests/cloudwatch_logging/test_compute_console_output_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_compute_console_output_logging.py
@@ -136,7 +136,7 @@ def test_custom_action_error(
     bucket.upload_file(str(test_datadir / script), script_path)
 
     cluster_config = pcluster_config_reader(bucket=bucket_name, script_path=script_path)
-    cluster: Cluster = clusters_factory(cluster_config, raise_on_error=False, wait=False)
+    cluster: Cluster = clusters_factory(cluster_config, raise_on_error=True, wait=False)
 
     _verify_compute_console_output_log_exists_in_log_group(cluster)
 

--- a/tests/integration-tests/tests/networking/test_networking.py
+++ b/tests/integration-tests/tests/networking/test_networking.py
@@ -28,7 +28,7 @@ def test_public_network_topology(region, vpc_stack, parameterized_cfn_stacks_fac
     )
     path = os.path.join("..", "..", "cloudformation", "networking", "public.cfn.json")
     stack_prefix = "integ-tests-networking"
-    stack = parameterized_cfn_stacks_factory(region, path, stack_prefix, parameters)
+    stack = parameterized_cfn_stacks_factory(region, path, stack_prefix, parameters, stack_is_under_test=True)
 
     public_subnet_id = stack.cfn_outputs["PublicSubnetId"]
     _assert_subnet_cidr(ec2_client, public_subnet_id, expected_subnet_cidr=public_subnet_cidr)
@@ -56,7 +56,7 @@ def test_public_private_network_topology(region, vpc_stack, parameterized_cfn_st
     )
     path = os.path.join("..", "..", "cloudformation", "networking", "public-private.cfn.json")
     stack_prefix = "integ-tests-networking"
-    stack = parameterized_cfn_stacks_factory(region, path, stack_prefix, parameters)
+    stack = parameterized_cfn_stacks_factory(region, path, stack_prefix, parameters, stack_is_under_test=True)
 
     public_subnet_id = stack.cfn_outputs["PublicSubnetId"]
     private_subnet_id = stack.cfn_outputs["PrivateSubnetId"]

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -43,6 +43,17 @@ def _format_stack_error(message, stack_events=None, cluster_details=None) -> str
         if "message" in cluster_details:
             message += f"\n\n- Message:\n\t{cluster_details.get('message')}"
 
+        if "configurationValidationErrors" in cluster_details:
+            validation_string = "\n\t".join(
+                [
+                    f"* {validation.get('level')} - {validation.get('type')}:\n\t\t{validation.get('message')}"
+                    for validation in cluster_details.get("configurationValidationErrors")
+                ],
+            )
+
+            if validation_string:
+                message += f"\n\n- Validation Failures:\n\t{validation_string}"
+
         if "failures" in cluster_details:
             details_string = "\n\t".join(
                 [

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -38,37 +38,75 @@ PARTITION_MAP = {
 }
 
 
-class SetupError(BaseException):
-    """Exception to throw from infrastructure factory fixtures if the infrastructure setup fails"""
+def _format_stack_error(message, stack_events=None, cluster_details=None) -> str:
+    if cluster_details:
+        if "message" in cluster_details:
+            message += f"\n\n- Message:\n\t{cluster_details.get('message')}"
 
-    def __init__(self, *args, stack_events=None, cluster_details=None):
-        self.message = self._format_message(args[0], stack_events, cluster_details)
-
-    @staticmethod
-    def _format_message(message, stack_events, cluster_details) -> str:
-        formatted_message = message if message else "Error during setup."
-        if cluster_details and "failures" in cluster_details:
+        if "failures" in cluster_details:
             details_string = "\n\t".join(
                 [
                     f"* {failure.get('failureCode')}:\n\t\t{failure.get('failureReason')}"
                     for failure in cluster_details.get("failures")
                 ],
             )
-            formatted_message += f"\n\n- Cluster Errors:\n\t{details_string}"
+            if details_string:
+                message += f"\n\n- Cluster Errors:\n\t{details_string}"
 
-        if stack_events:
-            events_string = "\n\t".join(
-                [
-                    f"* {event.get('LogicalResourceId')}:\n\t\t{event.get('ResourceStatusReason')}"
-                    for event in stack_events
-                    if event.get("ResourceStatus") == "CREATE_FAILED"
-                ]
-            )
-            formatted_message += f"\n\n- Stack Events:\n\t{events_string}"
-        return formatted_message
+    if stack_events:
+        events_string = "\n\t".join(
+            [
+                f"* {event.get('LogicalResourceId')}:\n\t\t{event.get('ResourceStatusReason')}"
+                for event in stack_events
+                if event.get("ResourceStatus") == "CREATE_FAILED"
+            ]
+        )
+        if events_string:
+            message += f"\n\n- Stack Events:\n\t{events_string}"
+    return message
+
+
+class StackError(BaseException):
+    """Exception to throw when stack creation stack fails as part of a test."""
+
+    def __init__(self, message, stack_events=None):
+        message = message if message else "StackError has been raised"
+        self.message = _format_stack_error(message, stack_events=stack_events)
 
     def __str__(self):
-        return "SetupError: {0} ".format(self.message) if self.message else "SetupError has been raised"
+        return f"StackError: {self.message}"
+
+
+class SetupError(BaseException):
+    """Exception to throw if an error occurred during test setup."""
+
+    def __init__(self, message):
+        self.message = message if message else "SetupError has been raised"
+
+    def __str__(self):
+        return f"SetupError: {self.message}"
+
+
+class StackSetupError(SetupError):
+    """Exception to throw when stack creation fails during test setup."""
+
+    def __init__(self, message, stack_events):
+        message = message if message else "StackSetupError has been raised"
+        super().__init__(_format_stack_error(message, stack_events=stack_events))
+
+    def __str__(self):
+        return f"StackSetupError: {self.message}"
+
+
+class ClusterCreationError(SetupError):
+    """Exception to throw when cluster creation fails during test setup."""
+
+    def __init__(self, message, stack_events=None, cluster_details=None):
+        message = message if message else "ClusterCreationError has been raised"
+        super().__init__(_format_stack_error(message, stack_events=stack_events, cluster_details=cluster_details))
+
+    def __str__(self):
+        return f"ClusterCreationError: {self.message}"
 
 
 class InstanceTypesData:


### PR DESCRIPTION
### Description of changes
* This change adds more detail to the failure message when a CloudFormation stack fails to create while setting up an integration test.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
