### PR TITLE
Fix variable expansions in the RHEL8 case

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -53,7 +53,7 @@ phases:
                 OS='ubuntu1804'
               elif [ $(echo "${RELEASE}" | grep '^ubuntu\.20') ]; then
                 OS='ubuntu2004'
-              elif [ `echo "${!RELEASE}" | grep '^rhel\.8'` ]; then
+              elif [ $(echo "${RELEASE}" | grep '^rhel\.8') ]; then
                 OS='rhel8'
               fi
 

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
@@ -42,7 +42,7 @@ phases:
                 OS='ubuntu1804'
               elif [ `echo "${RELEASE}" | grep '^ubuntu\.20'` ]; then
                 OS='ubuntu2004'
-              elif [ `echo "${!RELEASE}" | grep '^rhel\.8'` ]; then
+              elif [ `echo "${RELEASE}" | grep '^rhel\.8'` ]; then
                 OS='rhel8'
               else
                 echo "Operating System '${RELEASE}' is not supported. Failing build." && exit 1

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -42,7 +42,7 @@ phases:
                 OS='ubuntu1804'
               elif [ `echo "${RELEASE}" | grep '^ubuntu\.20'` ]; then
                 OS='ubuntu2004'
-              elif [ `echo "${!RELEASE}" | grep '^rhel\.8'` ]; then
+              elif [ `echo "${RELEASE}" | grep '^rhel\.8'` ]; then
                 OS='rhel8'
               else
                 echo "Operating System '${RELEASE}' is not supported. Failing build." && exit 1


### PR DESCRIPTION
### Description of changes
Delayed expansion of RELEASE variable was added due to a wrong cut and paste.

The symptom was that in the created ami the description was broken:
```
  "ec2AmiInfo": {
    "amiName": "rhel8-wip 2023-02-15T10-24-48.583Z",
    "amiId": "ami-xxx",
    "description": "AWS ParallelCluster AMI for , kernel-4.18.0-425.10.1.el8_7.x86_64, efa-2.1.1-1.el8.x86_64, slurm-22-05-8-1",
    "state": "AVAILABLE",
```

### Tests
* Manually tested executing build-image and enabling `update_and_reboot` (see `UpdateOsPackages/Enabled: true`), `parallelcluster_test` and `parallelcluster_validate` components (see `DisableValidateAndTest: False`) and verifying the description field is correct.
``` 
Build:
  InstanceType: c5.xlarge
  ParentImage: ami-0be9515573a59f685 #rhel8 image in eu-west-1
  UpdateOsPackages:
    Enabled: true
DevSettings:
  Cookbook:
    ChefCookbook: https://github.com/aws/aws-parallelcluster-cookbook/tarball/refs/heads/redhat8
  NodePackage: https://github.com/aws/aws-parallelcluster-node/tarball/refs/heads/develop
  AwsBatchCliPackage: https://github.com/aws/aws-parallelcluster/tarball/refs/heads/develop
  DisableValidateAndTest: False
``` 

