### PR TITLE
[3.x] Add basic cli changes for RH8 for create_cluster/configure/ssh

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -24,7 +24,7 @@ CIDR_ALL_IPS = "0.0.0.0/0"
 
 SUPPORTED_SCHEDULERS = ["slurm", "awsbatch"]
 SCHEDULERS_SUPPORTING_IMDS_SECURED = ["slurm", "plugin"]
-SUPPORTED_OSES = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004"]
+SUPPORTED_OSES = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"]
 SUPPORTED_OSES_FOR_SCHEDULER = {"slurm": SUPPORTED_OSES, "plugin": SUPPORTED_OSES, "awsbatch": ["alinux2"]}
 DELETE_POLICY = "Delete"
 RETAIN_POLICY = "Retain"
@@ -40,6 +40,7 @@ OS_MAPPING = {
     "alinux2": {"user": "ec2-user", "root-device": "/dev/xvda"},
     "ubuntu1804": {"user": "ubuntu", "root-device": "/dev/sda1"},
     "ubuntu2004": {"user": "ubuntu", "root-device": "/dev/sda1"},
+    "rhel8": {"user": "ec2-user", "root-device": "/dev/sda1"},
 }
 
 OS_TO_IMAGE_NAME_PART_MAP = {

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -464,7 +464,7 @@ class CWDashboardConstruct(Construct):
                 [
                     self._new_cw_log_widget(
                         title="system-messages",
-                        conditions=[Condition(["alinux2", "centos7"], base_os)],
+                        conditions=[Condition(["alinux2", "centos7", "rhel8"], base_os)],
                         filters=[self._new_filter(pattern=f"{head_private_ip}.*system-messages")],
                     ),
                     self._new_cw_log_widget(

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -61,7 +61,7 @@ EFS_MESSAGES = {
 
 FSX_SUPPORTED_ARCHITECTURES_OSES = {
     "x86_64": SUPPORTED_OSES,
-    "arm64": ["ubuntu1804", "ubuntu2004", "alinux2", "centos7"],
+    "arm64": SUPPORTED_OSES,
 }
 
 FSX_MESSAGES = {

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_efa_not_supported/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_efa_not_supported/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 Allowed values for VPC ID:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 Allowed values for VPC ID:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 ERROR: non-existent-test-pg is not an acceptable value for Placement Group name

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 Allowed values for Availability Zone:
 1. eu-west-1a
 2. eu-west-1b

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 There are no VPC for the given region. Starting automatic creation of VPC and subnets...
 Allowed values for Availability Zone:
 1. eu-west-1a

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
@@ -34,6 +34,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 There are no VPC for the given region. Starting automatic creation of VPC and subnets...
 Allowed values for Availability Zone:
 1. eu-west-1a

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/output.txt
@@ -17,6 +17,7 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
+5. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -27,6 +27,7 @@ from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket, mock_buc
     "config_file_name",
     [
         "centos7.slurm.full.yaml",
+        "rhel8.slurm.full.yaml",
         "alinux2.slurm.conditional_vol.yaml",
         "ubuntu18.slurm.simple.yaml",
         "alinux2.batch.no_head_node_log.yaml",
@@ -137,7 +138,7 @@ def _verify_head_node_logs_conditions(cluster_config, output_yaml):
         assert_that(output_yaml).does_not_contain("NICE DCV integration logs")
 
     # Conditional System logs
-    if cluster_config.image.os in ["alinux2", "centos7"]:
+    if cluster_config.image.os in ["alinux2", "centos7", "rhel8"]:
         assert_that(output_yaml).contains("system-messages")
         assert_that(output_yaml).does_not_contain("syslog")
     elif cluster_config.image.os in ["ubuntu1804"]:

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/rhel8.slurm.full.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/rhel8.slurm.full.yaml
@@ -1,0 +1,101 @@
+Image:
+  Os: rhel8
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+  Dcv:
+    Enabled: true
+    Port: 8443
+    AllowedIps: 0.0.0.0/0
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+        - Name: compute_resource2
+          InstanceType: c4.2xlarge
+    - Name: queue2
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+          MaxCount: 5
+        - Name: compute_resource2
+          InstanceType: c4.2xlarge
+SharedStorage:
+  - MountDir: /my/mount/ebs1
+    Name: name1
+    StorageType: Ebs
+    EbsSettings:
+      VolumeType: gp2
+      Size: 150
+      Encrypted: True
+  - MountDir: /my/mount/ebs2
+    Name: name2
+    StorageType: Ebs
+    EbsSettings:
+      VolumeType: io1
+      Size: 150
+      Encrypted: True
+  - MountDir: /my/mount/ebs3
+    Name: name3
+    StorageType: Ebs
+    EbsSettings:
+      VolumeType: sc1
+      Size: 150
+      Encrypted: True
+  - MountDir: /my/mount/ebs4
+    Name: name4
+    StorageType: Ebs
+    EbsSettings:
+      VolumeType: st1
+      Encrypted: True
+  - MountDir: /my/mount/ebs5
+    Name: name5
+    StorageType: Ebs
+    EbsSettings:
+      VolumeType: gp2
+      Encrypted: True
+  - MountDir: /my/mount/raid1
+    Name: name6
+    StorageType: Ebs
+    EbsSettings:
+      VolumeType: gp2
+      Size: 20
+      Iops: 100
+      Encrypted: False
+      Raid:
+        Type: 1
+        NumberOfVolumes: 2
+  - MountDir: /my/mount/efs1
+    Name: name7
+    StorageType: Efs
+    EfsSettings:
+      ThroughputMode: bursting
+      PerformanceMode: generalPurpose
+      Encrypted: False
+  - MountDir: /my/mount/fsx1
+    Name: name8
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 1200
+      WeeklyMaintenanceStartTime: "1:00:00"
+Monitoring:
+  DetailedMonitoring: true
+  Logs:
+    CloudWatch:
+      Enabled: true
+      RetentionInDays: 180
+  Dashboards:
+    CloudWatch:
+      Enabled: true

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -82,8 +82,8 @@ def test_generate_random_prefix():
 @pytest.mark.parametrize(
     "architecture, supported_oses",
     [
-        ("x86_64", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004"]),
-        ("arm64", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004"]),
+        ("x86_64", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"]),
+        ("arm64", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"]),
     ],
 )
 def test_get_supported_os_for_architecture(architecture, supported_oses):
@@ -96,7 +96,7 @@ def test_get_supported_os_for_architecture(architecture, supported_oses):
 @pytest.mark.parametrize(
     "scheduler, supported_oses",
     [
-        ("slurm", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004"]),
+        ("slurm", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"]),
         ("awsbatch", ["alinux2"]),
     ],
 )

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -204,7 +204,9 @@ def test_region_validator(region, expected_message):
         ("ubuntu1804", "slurm", None),
         ("ubuntu2004", "slurm", None),
         ("alinux2", "slurm", None),
+        ("rhel8", "slurm", None),
         ("centos7", "awsbatch", "scheduler supports the following operating systems"),
+        ("rhel8", "awsbatch", "scheduler supports the following operating systems"),
         ("ubuntu1804", "awsbatch", "scheduler supports the following operating systems"),
         ("ubuntu2004", "awsbatch", "scheduler supports the following operating systems"),
         ("alinux2", "awsbatch", None),
@@ -531,6 +533,8 @@ def test_efa_security_group_validator(
         (True, "ubuntu1804", "arm64", None),
         (True, "ubuntu2004", "x86_64", None),
         (True, "ubuntu2004", "arm64", None),
+        (True, "rhel8", "x86_64", None),
+        (True, "rhel8", "arm64", None),
     ],
 )
 def test_efa_os_architecture_validator(efa_enabled, os, architecture, expected_message):
@@ -564,11 +568,13 @@ def test_efa_multi_az_validator(multi_az_enabled, efa_enabled, expected_message)
         # All OSes supported for x86_64
         ("alinux2", "x86_64", None, None, None),
         ("alinux2", "x86_64", "custom-ami", None, None),
+        ("rhel8", "x86_64", None, None, None),
+        ("rhel8", "x86_64", "custom-ami", None, None),
         ("centos7", "x86_64", None, None, None),
         ("centos7", "x86_64", "custom-ami", None, None),
         ("ubuntu1804", "x86_64", None, None, None),
         ("ubuntu2004", "x86_64", None, None, None),
-        # All OSes supported for x86_64
+        # All OSes supported for ARM
         ("alinux2", "arm64", None, None, None),
         ("alinux2", "arm64", "custom-ami", None, None),
         (
@@ -582,6 +588,8 @@ def test_efa_multi_az_validator(multi_az_enabled, efa_enabled, expected_message)
         ("centos7", "arm64", "custom-ami", None, None),
         ("ubuntu1804", "arm64", None, None, None),
         ("ubuntu2004", "arm64", None, None, None),
+        ("rhel8", "arm64", None, None, None),
+        ("rhel8", "arm64", "custom-ami", None, None),
     ],
 )
 def test_architecture_os_validator(os, architecture, custom_ami, ami_search_filters, expected_message):
@@ -976,10 +984,12 @@ def test_fsx_network_validator(
         # Supported combinations
         ("x86_64", "alinux2", None),
         ("x86_64", "centos7", None),
+        ("x86_64", "rhel8", None),
         ("x86_64", "ubuntu1804", None),
         ("x86_64", "ubuntu2004", None),
         ("arm64", "ubuntu1804", None),
         ("arm64", "ubuntu2004", None),
+        ("arm64", "rhel8", None),
         ("arm64", "alinux2", None),
         # Unsupported combinations
         (
@@ -1151,6 +1161,7 @@ def test_shared_storage_mount_dir_validator(mount_dir, expected_message):
     [
         (True, "centos7", "t2.medium", None, None, None),
         (True, "ubuntu1804", "t2.medium", None, None, None),
+        (True, "rhel8", "t2.medium", None, None, None),
         (True, "ubuntu1804", "t2.medium", None, "1.2.3.4/32", None),
         (True, "ubuntu2004", "t2.medium", None, None, None),
         (True, "centos7", "t2.medium", "0.0.0.0/0", 8443, "port 8443 to the world"),
@@ -1160,6 +1171,7 @@ def test_shared_storage_mount_dir_validator(mount_dir, expected_message):
         (False, "alinux2", "t2.micro", None, None, None),  # doesn't fail because DCV is disabled
         (True, "ubuntu1804", "m6g.xlarge", None, None, None),
         (True, "alinux2", "m6g.xlarge", None, None, None),
+        (True, "rhel8", "m6g.xlarge", None, None, "Please double check the os configuration"),
         (True, "ubuntu2004", "m6g.xlarge", None, None, "Please double check the os configuration"),
     ],
 )
@@ -1197,6 +1209,7 @@ def test_intel_hpc_architecture_validator(architecture, expected_message):
         ("alinux2", "the operating system is required to be set"),
         ("ubuntu1804", "the operating system is required to be set"),
         ("ubuntu2004", "the operating system is required to be set"),
+        ("rhel8", "the operating system is required to be set"),
         # TODO migrate the parametrization below to unit test for the whole model
         # intel hpc disabled, you can use any os
         # ({"enable_intel_hpc_platform": "false", "base_os": "alinux"}, None),


### PR DESCRIPTION
### Description of changes
* Add basic cli changes for RH8 for create_cluster/configure/ssh
* Won't add now the changelog line for rhel 8
* Documentation for this will not be changed now
* The branch https://github.com/eantonin/aws-parallelcluster/tree/wip/rh8-cli-eantonin contains this changes plus others that are not needed now but could be useful in future 
### Tests
- Run `create-cluster` with both ARM and x86 configs
  - Headnode is up an running, slurm commands are available
  - Compute nodes are not working (but this is because we haven't completed work on the config recipes)
  - CW dashboard is created
  - Logs are basically clean apart form the `slurmctld` (but also this is probably related to some missing work on the recipes)
  - The command works only if a custom AMI is provided
- Launched `pcluster configure`, setting up a cluster with rhel8  
  - Launched a cluster with the created config successfully (after adding IMDSv2 and custom AMI parameters)
- Connected with SSH both manually and with `pcluster ssh`

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
