### PR TITLE
[integ-tests-3.5.0][Fix] use PrivateSubnetId and PrivateAz2SubnetId for external-shared-storage-stack

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -845,19 +845,10 @@ def external_shared_storage_stack(request, test_datadir, region, vpc_stack, cfn_
             if request.config.getoption(option):
                 stack = CfnStack(name=request.config.getoption(option), region=region, template=template)
             else:
-                # Choose subnets from different availability zones
-                subnet_ids = [value for key, value in vpc_stack.cfn_outputs.items() if key.endswith("SubnetId")]
-                subnets = boto3.client("ec2").describe_subnets(SubnetIds=subnet_ids)["Subnets"]
-                available_subnet_ids = [subnets[0]["SubnetId"]]
-                for subnet in subnets:
-                    if subnet["AvailabilityZone"] != subnets[0]["AvailabilityZone"]:
-                        available_subnet_ids.append(subnet["SubnetId"])
-                        break
-
                 vpc = vpc_stack.cfn_outputs["VpcId"]
                 public_subnet_id = vpc_stack.cfn_outputs["PublicSubnetId"]
-                subnet_id0 = available_subnet_ids[0]
-                subnet_id1 = available_subnet_ids[1]
+                subnet_id0 = vpc_stack.cfn_outputs["PrivateSubnetId"]
+                subnet_id1 = vpc_stack.cfn_outputs["PublicAz2SubnetId"]
                 import_path = "s3://{0}".format(bucket_name)
                 export_path = "s3://{0}/export_dir".format(bucket_name)
                 params = [

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -848,7 +848,7 @@ def external_shared_storage_stack(request, test_datadir, region, vpc_stack, cfn_
                 vpc = vpc_stack.cfn_outputs["VpcId"]
                 public_subnet_id = vpc_stack.cfn_outputs["PublicSubnetId"]
                 subnet_id0 = vpc_stack.cfn_outputs["PrivateSubnetId"]
-                subnet_id1 = vpc_stack.cfn_outputs["PublicAz2SubnetId"]
+                subnet_id1 = vpc_stack.cfn_outputs["PrivateAz2SubnetId"]
                 import_path = "s3://{0}".format(bucket_name)
                 export_path = "s3://{0}/export_dir".format(bucket_name)
                 params = [


### PR DESCRIPTION
### Description of changes
* use PrivateSubnetId and PrivateAz2SubnetId for external-shared-storage-stack to align subnets with cluster

### Tests
* passed test_update.py::test_dynamic_file_systems_update

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
