### PR TITLE
[develop] Fix wrong version error message

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -177,8 +177,8 @@ write_files:
       if [ -f /opt/parallelcluster/.bootstrapped ]; then
         installed_version=$(cat /opt/parallelcluster/.bootstrapped)
         if [ "${!cookbook_version}" != "${!installed_version}" ]; then
-          cookbook_version_number=$(echo ${!cookbook_version} | cut -d "-" -f 4)
-          installed_version_number=$(echo ${!installed_version} | cut -d "-" -f 4)
+          cookbook_version_number=$(echo ${!cookbook_version} | awk -F- '{print $NF}')
+          installed_version_number=$(echo ${!installed_version} | awk -F- '{print $NF}')
           error_exit "This AMI was created with ParallelCluster ${!installed_version_number}, but is trying to be used with ParallelCluster ${!cookbook_version_number}. Please either use an AMI created with ParallelCluster ${!cookbook_version_number} or change your ParallelCluster to ${!installed_version_number}"
         fi
       else

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -118,8 +118,8 @@ export berkshelf_version=${BerkshelfVersion}
 if [ -f /opt/parallelcluster/.bootstrapped ]; then
   installed_version=$(cat /opt/parallelcluster/.bootstrapped)
   if [ "${!cookbook_version}" != "${!installed_version}" ]; then
-    cookbook_version_number=$(echo ${!cookbook_version} | cut -d "-" -f 4)
-    installed_version_number=$(echo ${!installed_version} | cut -d "-" -f 4)
+    cookbook_version_number=$(echo ${!cookbook_version} | awk -F- '{print $NF}')
+    installed_version_number=$(echo ${!installed_version} | awk -F- '{print $NF}')
     error_exit "This AMI was created with ${!installed_version_number}, but is trying to be used with ${!cookbook_version_number}. Please either use an AMI created with ${!cookbook_version_number} or change your ParallelCluster to ${!installed_version_number}"
   fi
 else


### PR DESCRIPTION
In ParallelCluster < 2.10.0, we wrote aws-parallelcluster-x.x.x in /opt/parallelcluster/.bootstrapped. In ParallelCluster >= 2.10.0, we write aws-parallelcluster-cookbook-x.x.x in /opt/parallelcluster/.bootstrapped. Therefore, when doing string process to get the version number string, we need to get the last item after splitting with `-`.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
Manually tested by creating a Alinux2 and a Ubuntu1804 cluster with wrong AMI versions
Integration test test_create_wrong_pcluster_version on Alinux2 is successful

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
