### PR TITLE
3.x Add retry to Spot static node assertion

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -153,7 +153,9 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     # the cluster:
     # queue1-st-c5xlarge-1
     # queue1-st-c5xlarge-2
-    assert_initial_conditions(slurm_commands, 2, 0, partition="queue1")
+    retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))(assert_initial_conditions)(
+        slurm_commands, 2, 0, partition="queue1"
+    )
 
     updated_queues_config = {
         "queue1": {


### PR DESCRIPTION
### Description of changes
* This change will allow 5 minutes for the additional Spot nodes to be allocated durning the test_update integration test

### Tests
* Ran integration test in personal account.
* Test did fail, but after the changed code due to the test expecting a successful rollback, but due to my test configuration, rollback was prevented.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
