### PR TITLE
integ tests: set in the environment AWS_CREDENTIAL_EXPIRATION

### DIFF
--- a/tests/integration-tests/framework/credential_providers.py
+++ b/tests/integration-tests/framework/credential_providers.py
@@ -58,6 +58,7 @@ def sts_credential_provider(region, credential_arn, credential_external_id=None,
 
     logging.info("Assuming STS credentials for region %s and role %s", region, credential_arn)
     aws_credentials = _retrieve_sts_credential(region, credential_arn, credential_external_id, credential_endpoint)
+    logging.info("Retrieved credentials %s", obfuscate_credentials(aws_credentials))
 
     try:
         logging.info("Unsetting current credentials %s", obfuscate_credentials(credentials_to_backup))
@@ -66,6 +67,7 @@ def sts_credential_provider(region, credential_arn, credential_external_id=None,
         os.environ["AWS_ACCESS_KEY_ID"] = aws_credentials["AccessKeyId"]
         os.environ["AWS_SECRET_ACCESS_KEY"] = aws_credentials["SecretAccessKey"]
         os.environ["AWS_SESSION_TOKEN"] = aws_credentials["SessionToken"]
+        os.environ["AWS_CREDENTIAL_EXPIRATION"] = aws_credentials["Expiration"]
         boto3.setup_default_session()
 
         yield aws_credentials


### PR DESCRIPTION
We saw strange behaviours when the credentials are expired. According to the code we should see the "Unsetting current credentials" message, right after the "Assuming STS credentials" message but the "Unsetting" message is missing:

```
credential_providers - Assuming STS credentials for region eu-south-1 and role arn:aws:iam::xxx:role/parallelcluster/xxx
credentials - Found credentials in environment variables.
clusters_factory - Failed when deleting cluster integ-tests-yibbdar9ut1depoo-redhat8 with error An error occurred (ExpiredToken)
```

Internally botocore logs the message "Found credentials in environment variables" and looking at botocore code there are two paths depending on `AWS_CREDENTIAL_EXPIRATION` is set or not. In one case it returns `RefreshableCredentials`, in the second case it returns simple `Credentials`.

By adding the `AWS_CREDENTIAL_EXPIRATION` in the environment we're correctly saving an existing information so that it can be re-used by botocore.
