### PR TITLE
Change failing test OS to ubuntu2004 on Arm from Centos7

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -162,7 +162,7 @@ create:
       - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         schedulers: ["slurm"]
-        oss: ["centos7"]
+        oss: ["ubuntu2004"]
   test_create.py::test_cluster_creation_timeout:
     dimensions:
       - regions: ["ap-northeast-2"]


### PR DESCRIPTION
### Description of changes
* Failing test was targeting ARM Centos7 which is a platform we don't release.
* Changed the target OS to ubuntu2004.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
