### PR TITLE
[3.x] Add Python version parameter in create-attribution-doc.sh

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,5 +1,5 @@
 Flask
-2.2.2
+2.2.3
 BSD License
 Armin Ronacher
 https://palletsprojects.com/p/flask
@@ -131,7 +131,7 @@ SOFTWARE.
 
 
 Werkzeug
-2.2.2
+2.2.3
 BSD License
 Armin Ronacher
 https://palletsprojects.com/p/werkzeug/
@@ -219,7 +219,7 @@ SOFTWARE.
 
 
 boto3
-1.26.56
+1.26.76
 Apache Software License
 Amazon Web Services
 https://github.com/boto/boto3
@@ -403,7 +403,7 @@ https://github.com/boto/boto3
 
 
 botocore
-1.29.56
+1.29.76
 Apache Software License
 Amazon Web Services
 https://github.com/boto/botocore
@@ -703,7 +703,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 
 constructs
-3.4.225
+3.4.251
 Apache-2.0
 Amazon Web Services
 https://github.com/aws/constructs
@@ -1209,7 +1209,7 @@ IN THE SOFTWARE.
 
 
 jsii
-1.73.0
+1.75.0
 Apache Software License
 Amazon Web Services
 https://github.com/aws/jsii
@@ -2110,7 +2110,7 @@ SOFTWARE.
 
 
 zipp
-3.11.0
+3.14.0
 MIT License
 Jason R. Coombs
 https://github.com/jaraco/zipp
@@ -2285,7 +2285,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 typing_extensions 
-4.4.0 
+4.5.0 
 Python Software Foundation License 
 https://github.com/python/typing_extensions
 A. HISTORY OF THE SOFTWARE
@@ -3746,7 +3746,7 @@ Apache License 2.0
 
 
 aws-cdk 
-1.189.0 
+1.193.0 
 Apache License 
 https://raw.githubusercontent.com/aws/aws-cdk/main/LICENSE
                                  Apache License

--- a/util/create-attribution-doc.sh
+++ b/util/create-attribution-doc.sh
@@ -1,53 +1,13 @@
 #!/bin/bash
 
-set -ex
-# Install the python version if it doesnt exist
-if test ! -d ${PYENV_ROOT}/versions/3.9.10;
-then 
-  env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.9.10
-fi
-
-pyenv virtualenv 3.9.10 attribution-doc-env
-# switch to a specific virtual env
-source ${PYENV_ROOT}/versions/attribution-doc-env/bin/activate
-
-# Update Pip
-pip3 install --upgrade pip
-
-# Installing PyInstaller
-pip3 install pyinstaller
-# Install pip-licenses
-pip3 install pip-licenses
-
-# install pcluster via source
-cd ..
-pip3 install -e cli
-#pip3 install -r requirements.txt
-
-final_license_file=THIRD-PARTY-LICENSES.txt
-
-# Create a list of aws cdk Sub-packages we want to ignore 
-aws_cdk_ignore_subpackages=$(pip list | grep cdk | awk '{print $1}') 
-aws_cdk_version=$(pip list | grep cdk | awk '{print $2}'| head -n 1)
-
-packaging_version=$(pip list | grep packaging | awk '{print $2}')
-exception_group_version=$(pip list | grep exceptiongroup | awk '{print $2}')
-idna_version=$(pip list | grep idna | awk '{print $2}')
-typing_extentions_version=$(pip list | grep typing_extensions | awk '{print $2}')
-# Create a pip License document
-pip-licenses -i $aws_cdk_ignore_subpackages aws-parallelcluster pip-licenses packaging pyinstaller-hooks-contrib pyinstaller exceptiongroup idna typing_extensions certifi --format=plain-vertical --with-license-file --with-urls --no-license-path --with-authors --output-file=$final_license_file
+set -e -o xtrace
 
 
-#Getting python version
-cpy_version=$(python -V |  grep -Eo '([0-9]+)(\.?[0-9]+)' | head -1) 
-
-
-# Function to Append Package Details to the THIRD-PARTY-LICENSES file
 append_package_details_to_final_license_file(){
-  
+  # Function to Append Package Details to the THIRD-PARTY-LICENSES file
   #Arguments ->  1- Package Name, 2- Package Version, 3- License Type , 4- URL for package, 5,6,7- URL for License
   # Adding a header to final License file with Package Name, Package Version, License Type , URL for package
-  echo -e "\n\n\n$1 \n$2 \n$3 \n$4" >> $final_license_file
+  echo "\n\n\n$1 \n$2 \n$3 \n$4" >> $final_license_file
   # Appending License
   curl $5 >> $final_license_file
   # Adding Dual Licenses if they exist 
@@ -56,38 +16,125 @@ append_package_details_to_final_license_file(){
       curl $6 >> $final_license_file
       curl $7 >> $final_license_file
   fi
+
+}
+
+function create_attribution_doc() {
+  ATTR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+  # Install the python version if it doesnt exist
+  if test ! -d ${PYENV_ROOT}/versions/${PYTHON_VERSION};
+  then 
+    env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION}
+  fi
   
+  pyenv virtualenv ${PYTHON_VERSION} attribution-doc-env
+  # switch to a specific virtual env
+  source ${PYENV_ROOT}/versions/attribution-doc-env/bin/activate
+  
+  # Update Pip
+  pip3 install --upgrade pip
+  
+  # Installing PyInstaller
+  pip3 install pyinstaller
+  # Install pip-licenses
+  pip3 install pip-licenses
+  
+  # install pcluster via source
+  
+  pip3 install -e $(dirname $ATTR_SCRIPT_DIR )/cli
+  #pip3 install -r requirements.txt
+  
+  final_license_file=$(dirname $ATTR_SCRIPT_DIR )/THIRD-PARTY-LICENSES.txt
+  
+  # Create a list of aws cdk Sub-packages we want to ignore 
+  aws_cdk_ignore_subpackages=$(pip list | grep cdk | awk '{print $1}') 
+  aws_cdk_version=$(pip list | grep cdk | awk '{print $2}'| head -n 1)
+  
+  packaging_version=$(pip list | grep packaging | awk '{print $2}')
+  exception_group_version=$(pip list | grep exceptiongroup | awk '{print $2}')
+  idna_version=$(pip list | grep idna | awk '{print $2}')
+  typing_extentions_version=$(pip list | grep typing_extensions | awk '{print $2}')
+  # Create a pip License document
+  pip-licenses -i $aws_cdk_ignore_subpackages aws-parallelcluster pip-licenses packaging pyinstaller-hooks-contrib pyinstaller exceptiongroup idna typing_extensions certifi --format=plain-vertical --with-license-file --with-urls --no-license-path --with-authors --output-file=$final_license_file
+  
+  
+  #Getting python version
+  cpy_version=$(python -V |  grep -Eo '([0-9]+)(\.?[0-9]+)' | head -1) 
+
+  
+  # certifi 
+  append_package_details_to_final_license_file "certifi" "2022.12.07" "Mozilla Public License 2.0 (MPL 2.0)" "https://github.com/certifi/python-certifi/tree/2022.12.07" "https://raw.githubusercontent.com/certifi/python-certifi/2022.12.07/LICENSE"
+  
+  # exception_group 
+  append_package_details_to_final_license_file "exceptiongroup" $exception_group_version "MIT License" "https://github.com/agronholm/exceptiongroup" "https://raw.githubusercontent.com/agronholm/exceptiongroup/main/LICENSE"
+  
+  # idna 
+  append_package_details_to_final_license_file "idna" $idna_version "BSD License" "https://github.com/kjd/idna" "https://raw.githubusercontent.com/kjd/idna/master/LICENSE.md"
+  
+  # typing_extentions
+  append_package_details_to_final_license_file "typing_extensions" $typing_extentions_version "Python Software Foundation License" "https://github.com/python/typing_extensions" "https://raw.githubusercontent.com/python/typing_extensions/main/LICENSE"
+  
+  # Packaging
+  append_package_details_to_final_license_file "packaging" $packaging_version "Apache Software License; BSD License" "https://github.com/pypa/packaging" "https://raw.githubusercontent.com/pypa/packaging/main/LICENSE" "https://raw.githubusercontent.com/pypa/packaging/main/LICENSE.APACHE" "https://raw.githubusercontent.com/pypa/packaging/main/LICENSE.BSD"
+  
+  # pyinstaller-hooks-contrib
+  append_package_details_to_final_license_file "pyinstaller-hooks-contrib" "2022.15" "Apache License 2.0; GNU General Public License" "https://github.com/pyinstaller/pyinstaller-hooks-contrib/archive/refs/tags/2022.15.tar.gz." "https://raw.githubusercontent.com/pyinstaller/pyinstaller-hooks-contrib/2022.15/LICENSE" "https://raw.githubusercontent.com/pyinstaller/pyinstaller-hooks-contrib/2022.15/LICENSE.APL.txt" "https://raw.githubusercontent.com/pyinstaller/pyinstaller-hooks-contrib/2022.15/LICENSE.GPL.txt"
+  
+  # pyinstaller
+  append_package_details_to_final_license_file "pyinstaller" "5.7.0" "GNU General Public License v2 (GPLv2)" "https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v5.7.0.tar.gz." "https://raw.githubusercontent.com/pyinstaller/pyinstaller/v5.7.0/COPYING.txt"
+  
+  # aws-cdk 
+  append_package_details_to_final_license_file "aws-cdk" $aws_cdk_version "Apache License" "https://raw.githubusercontent.com/aws/aws-cdk/main/LICENSE" "https://raw.githubusercontent.com/aws/aws-cdk/main/LICENSE"
+  
+  # Python
+  append_package_details_to_final_license_file "Python" $cpy_version "PSF License Version 2; Zero-Clause BSD license" "https://raw.githubusercontent.com/python/cpython/$cpy_version/LICENSE" "https://raw.githubusercontent.com/python/cpython/$cpy_version/LICENSE"
+  
+  
+  deactivate
+  pyenv virtualenv-delete -f attribution-doc-env
 
 }
 
 
-# certifi 
-append_package_details_to_final_license_file "certifi" "2022.12.07" "Mozilla Public License 2.0 (MPL 2.0)" "https://github.com/certifi/python-certifi/tree/2022.12.07" "https://raw.githubusercontent.com/certifi/python-certifi/2022.12.07/LICENSE"
+_error_exit() {
+   echo "$1"
+   exit 1
+}
 
-# exception_group 
-append_package_details_to_final_license_file "exceptiongroup" $exception_group_version "MIT License" "https://github.com/agronholm/exceptiongroup" "https://raw.githubusercontent.com/agronholm/exceptiongroup/main/LICENSE"
+_help() {
+    local -- _cmd=$(basename "$0")
 
-# idna 
-append_package_details_to_final_license_file "idna" $idna_version "BSD License" "https://github.com/kjd/idna" "https://raw.githubusercontent.com/kjd/idna/master/LICENSE.md"
-
-# typing_extentions
-append_package_details_to_final_license_file "typing_extensions" $typing_extentions_version "Python Software Foundation License" "https://github.com/python/typing_extensions" "https://raw.githubusercontent.com/python/typing_extensions/main/LICENSE"
-
-# Packaging
-append_package_details_to_final_license_file "packaging" $packaging_version "Apache Software License; BSD License" "https://github.com/pypa/packaging" "https://raw.githubusercontent.com/pypa/packaging/main/LICENSE" "https://raw.githubusercontent.com/pypa/packaging/main/LICENSE.APACHE" "https://raw.githubusercontent.com/pypa/packaging/main/LICENSE.BSD"
-
-# pyinstaller-hooks-contrib
-append_package_details_to_final_license_file "pyinstaller-hooks-contrib" "2022.15" "Apache License 2.0; GNU General Public License" "https://github.com/pyinstaller/pyinstaller-hooks-contrib/archive/refs/tags/2022.15.tar.gz." "https://raw.githubusercontent.com/pyinstaller/pyinstaller-hooks-contrib/2022.15/LICENSE" "https://raw.githubusercontent.com/pyinstaller/pyinstaller-hooks-contrib/2022.15/LICENSE.APL.txt" "https://raw.githubusercontent.com/pyinstaller/pyinstaller-hooks-contrib/2022.15/LICENSE.GPL.txt"
-
-# pyinstaller
-append_package_details_to_final_license_file "pyinstaller" "5.7.0" "GNU General Public License v2 (GPLv2)" "https://github.com/pyinstaller/pyinstaller/archive/refs/tags/v5.7.0.tar.gz." "https://raw.githubusercontent.com/pyinstaller/pyinstaller/v5.7.0/COPYING.txt"
-
-# aws-cdk 
-append_package_details_to_final_license_file "aws-cdk" $aws_cdk_version "Apache License" "https://raw.githubusercontent.com/aws/aws-cdk/main/LICENSE" "https://raw.githubusercontent.com/aws/aws-cdk/main/LICENSE"
-
-# Python
-append_package_details_to_final_license_file "Python" $cpy_version "PSF License Version 2; Zero-Clause BSD license" "https://raw.githubusercontent.com/python/cpython/$cpy_version/LICENSE" "https://raw.githubusercontent.com/python/cpython/$cpy_version/LICENSE"
+    cat <<EOF
+  This script will create the THIRD_PARTY_LICENSE.txt file assuming you have already installed Pyenv
+  Usage: ${_cmd} [OPTION]...
 
 
-deactivate
-pyenv virtualenv-delete attribution-doc-env
+  --python-version <version>                                        Python version with which you want to create the attribution document.
+  -h, --help                                                        Print this help message
+  
+  Examples:
+  ${_cmd}
+  $_cmd --python-version 3.9.10
+EOF
+}
+
+function parse_options () {
+  
+   while [ $# -gt 0 ] ; do
+          case "$1" in
+              --python-version)                      PYTHON_VERSION="$2"; shift;;
+              -h|--help|help)                       _help; exit 0;;
+              *)                                    _help; _error_exit "[error] Unrecognized option '$1'";;
+          esac
+          shift
+      done
+
+}
+
+function main() {
+  parse_options "$@"
+  create_attribution_doc
+}
+
+main "$@"


### PR DESCRIPTION

### Description of changes
* Update create-attribution-doc.sh to take Python version as parameter


### Tests
* Tested Locally by running ` sh util/create-attribution-doc.sh     `

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
