### PR TITLE
Remove obfuscation of Expiration field in the print of credentials

### DIFF
--- a/tests/integration-tests/framework/credential_providers.py
+++ b/tests/integration-tests/framework/credential_providers.py
@@ -146,7 +146,10 @@ def obfuscate_credentials(creds_dict):
     obfuscated_dict = {}
     for key, value in creds_dict.items():
         if value:
-            obfuscated_dict[key] = value[0:3] + "*" * (len(value) - 3)
+            if key == "Expiration":
+                obfuscated_dict[key] = str(value)
+            else:
+                obfuscated_dict[key] = value[0:3] + "*" * (len(value) - 3)
         else:
             obfuscated_dict[key] = value
     return obfuscated_dict


### PR DESCRIPTION
The obfuscate_credentials function cannot be executed for the Expiration element
because it is a datetime and not a string.


Test:
```
>>> now = datetime.datetime.now()
>>> now_str = str(now)
>>> now_str
'2023-02-22 10:08:28.791525'
```
