### PR TITLE
Save AWS_CREDENTIAL_EXPIRATION environment variable in ISO format

### DIFF
--- a/tests/integration-tests/framework/credential_providers.py
+++ b/tests/integration-tests/framework/credential_providers.py
@@ -67,7 +67,7 @@ def sts_credential_provider(region, credential_arn, credential_external_id=None,
         os.environ["AWS_ACCESS_KEY_ID"] = aws_credentials["AccessKeyId"]
         os.environ["AWS_SECRET_ACCESS_KEY"] = aws_credentials["SecretAccessKey"]
         os.environ["AWS_SESSION_TOKEN"] = aws_credentials["SessionToken"]
-        os.environ["AWS_CREDENTIAL_EXPIRATION"] = aws_credentials["Expiration"]
+        os.environ["AWS_CREDENTIAL_EXPIRATION"] = aws_credentials["Expiration"].isoformat()
         boto3.setup_default_session()
 
         yield aws_credentials


### PR DESCRIPTION
Test was failing with:
```
str expected, not datetime
```

AWS_CREDENTIAL_EXPIRATION - The expiration time of the credentials contained in the environment variables described above. This value must be in a format compatible with the [ISO-8601 standard](https://en.wikipedia.org/wiki/ISO_8601) and is only needed when you are using temporary credentials.

### Tests


```
>>> from datetime import datetime
>>> now = datetime.now()
>>> now
datetime.datetime(2023, 2, 22, 11, 1, 7, 911283)
>>> now.isoformat()
'2023-02-22T11:01:07.911283'
```

Launched a local integration test:
```
2023-02-22 11:31:52,558 - INFO - 79433 - test_mpi[eu-west-1-c5.xlarge-alinux2-slurm] - credential_providers - Assuming STS credentials for region eu-west-1 and role arn:aws:iam::xxx:role/parallelcluster/integ-tests-iam-user-role-ParallelClusterUserRole-xxx
2023-02-22 11:31:53,180 - INFO - 79433 - test_mpi[eu-west-1-c5.xlarge-alinux2-slurm] - credential_providers - Retrieved credentials {'AccessKeyId': 'ASI***********', 'SecretAccessKey': 'inA***********', 'SessionToken': 'Fwo********************', 'Expiration': '2023-02-22 11:31:53+00:00'}
2023-02-22 11:31:53,180 - INFO - 79433 - test_mpi[eu-west-1-c5.xlarge-alinux2-slurm] - credential_providers - Unsetting current credentials {'AWS_ACCESS_KEY_ID': None, 'AWS_SECRET_ACCESS_KEY': None, 'AWS_SESSION_TOKEN': None, 'AWS_PROFILE': None}
...
============================== slowest durations ===============================
1014.00s call     scaling/test_mpi.py::test_mpi[eu-west-1-c5.xlarge-alinux2-slurm]
1010.82s call     scaling/test_mpi.py::test_mpi[eu-west-1-c5.xlarge-alinux2-slurm]
3.15s setup    scaling/test_mpi.py::test_mpi[eu-west-1-c5.xlarge-alinux2-slurm]
================== 1 passed, 2 warnings in 1016.20s (0:16:56) ==================
```