### PR TITLE
[develop] Define a mechanism to specify the az where run the test

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -268,6 +268,22 @@ Some tox commands are offered in order to simplify the generation and validation
 * `tox -e generate-test-config my-config-file` can be used to automatically generate a configuration file pre-filled
   with the list of all available files. The config file is generated in the `tests/integration-tests/configs` directory.
 
+#### AZ override
+By default, the TestRunner will run the test in a random AZ between the ones available in the region.
+There are cases where some resources (like `instance_type` or aws services) are not available in all AZ.
+In these cases to successfully run the test it is necessary to override the AZ where the test must run.
+
+To do so you can specify a ZoneId in the regions dimension. So for example if you set
+
+```
+      dimensions:
+        - regions: ["euw1-az1", "eu-central-1"]
+```
+
+the test will be executed in
+* `eu-west-1` using the AZ with ZoneId `euw1-az1` (ZoneId is consistent across accounts)
+* `eu-central-1` using a random AZ available in the region
+
 #### Using CLI options
 
 The following options can be used to control the parametrization of test cases:

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -74,10 +74,15 @@ class CfnVpcStack(CfnStack):
         super().__init__(**kwargs)
         self.default_az_id = default_az_id
         self.az_ids = az_ids
+        self.az_override = None
         self.__public_subnet_ids = None
         self.__private_subnet_ids = None
 
-    def get_public_subnet(self):  # TODO add possibility to override default
+    def set_az_override(self, az_override):
+        """Sets the az_id to override the default AZ used to pick the subnets."""
+        self.az_override = az_override
+
+    def get_public_subnet(self):
         """Return the public subnet for a VPC stack."""
         return self._get_subnet(visibility="Public")
 
@@ -88,7 +93,7 @@ class CfnVpcStack(CfnStack):
 
         return self.__public_subnet_ids
 
-    def get_private_subnet(self):  # TODO add possibility to override default
+    def get_private_subnet(self):
         """Return the private subnet for a VPC stack."""
         return self._get_subnet(visibility="Private")
 
@@ -100,7 +105,9 @@ class CfnVpcStack(CfnStack):
         return self.__private_subnet_ids
 
     def _get_subnet(self, visibility: str = "Public"):
-        if self.default_az_id:
+        if self.az_override is not None:
+            az_id_tag = to_pascal_from_kebab_case(self.az_override)
+        elif self.default_az_id:
             az_id_tag = to_pascal_from_kebab_case(self.default_az_id)
         else:
             # get random subnet, if default is not set

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -39,6 +39,7 @@ from conftest_markers import (
     check_marker_skip_dimensions,
     check_marker_skip_list,
 )
+from conftest_networking import unmarshal_az_override
 from conftest_tests_config import apply_cli_dimensions_filtering, parametrize_from_config, remove_disabled_tests
 from constants import SCHEDULERS_SUPPORTING_IMDS_SECURED
 from filelock import FileLock
@@ -94,7 +95,6 @@ from tests.common.utils import (
     retrieve_pcluster_ami_without_standard_naming,
 )
 from tests.storage.snapshots_factory import EBSSnapshotsFactory
-from conftest_networking import unmarshal_az_override
 
 pytest_plugins = ["conftest_networking"]
 

--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -65,24 +65,36 @@ DEFAULT_AVAILABILITY_ZONE = {
 }
 
 # used to map a ZoneId to the corresponding region
-# TODO: Add missing regions
-# Nice-To-Have: a python script that creates this mapping by invoking aws describe-regions / subnets and
-# read it from a file
+# Nice-To-Have: a python script that creates this mapping by invoking aws describe-regions / subnets
+# and then read it from a file
 ZONE_ID_MAPPING = {
+    "af-south-1": "^afs1-az[0-9]",
+    "ap-east-1": "^ape1-az[0-9]",
+    "ap-northeast-1": "^apne1-az[0-9]",
+    "ap-northeast-2": "^apne2-az[0-9]",
+    "ap-northeast-3": "^apne3-az[0-9]",
+    "ap-south-1": "^aps1-az[0-9]",
+    "ap-southeast-1": "^apse1-az[0-9]",
+    "ap-southeast-2": "^apse2-az[0-9]",
+    "ca-central-1": "^cac1-az[0-9]",
+    "cn-north-1": "^cnn1-az[0-9]",
+    "cn-northwest-1": "^cnnw1-az[0-9]",
+    "eu-central-1": "^euc1-az[0-9]",
+    "eu-north-1": "^eun1-az[0-9]",
+    "eu-west-1": "^euw1-az[0-9]",
+    "eu-west-2": "^euw2-az[0-9]",
+    "eu-west-3": "^euw3-az[0-9]",
+    "eu-south-1": "^eus1-az[0-9]",
+    "me-south-1": "^mes1-az[0-9]",
+    "sa-east-1": "^sae1-az[0-9]",
     "us-east-1": "^use1-az[0-9]",
     "us-east-2": "^use2-az[0-9]",
     "us-west-1": "^usw1-az[0-9]",
-    "ap-southeast-1": "^apse1-az[0-9]",
-    "ap-southeast-2": "^apse2-az[0-9]",
-    "ap-northeast-1": "^apne1-az[0-9]",
-    "ap-northeast-2": "^apne2-az[0-9]",
-    "eu-west-1": "^euw1-az[0-9]",
-    "eu-north-1": "^eun1-az[0-9]",
-    "eu-central-1": "^euc1-az[0-9]",
-    "ca-central-1": "^cac1-az[0-9]",
-    "cn-north-1": "^cnn1-az[0-9]",
-    "sa-east-1": "^sae1-az[0-9]",
+    "us-west-2": "^usw2-az[0-9]",
+    # "us-gov-east-1": "^usge1-az[0-9]", # double check
+    # "us-gov-west-1": "^usgw1-az[0-9]", # double check
 }
+
 
 # Split the VPC address space into 32 subnets of 2046 (/21) addresses
 # to ensure that each subnets has enough IP addresses to support enough tests parallelism.
@@ -131,9 +143,7 @@ CIDR_FOR_CUSTOM_SUBNETS = [
 
 @pytest.fixture(autouse=True)
 def az_id():
-    """
-    Removes the need to declare the fixture in all tests even if not needed.
-    """
+    """Removes the need to declare the fixture in all tests even if not needed."""
     pass
 
 
@@ -145,7 +155,10 @@ def unmarshal_az_override(az_override):
         elif region == az_override.lower():
             return az_override
 
-    raise ValueError(f"Unsupported region `{az_override}`")
+    # If no mapping was found return the input parameter assuming the region value set by the user is correct.
+    # This will fail while trying to make an AZ override for a region without a proper mapping.
+    # In this case add the mapping to the list above before attempting the override.
+    return az_override
 
 
 def unmarshal_az_params(argvalues, argnames):
@@ -212,7 +225,6 @@ def get_availability_zones(region, credential):
 
 def get_az_setup_for_region(region: str, credential: list):
     """Return a default AZ ID and its name, the list of all AZ IDs and names."""
-    # TODO Region can be AZ ID, in this case convert it to Region
     # TODO remove DEFAULT_AVAILABILITY_ZONE
     az_id_to_az_name_map = get_az_id_to_az_name_map(region, credential)
     az_ids = list(az_id_to_az_name_map)  # cannot be a dict_keys

--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -13,8 +13,10 @@
 # This file has a special meaning for pytest. See https://docs.pytest.org/en/2.7.3/plugins.html for
 # additional details.
 
+import copy
 import logging
 import random
+import re
 
 import boto3
 import pytest
@@ -62,6 +64,25 @@ DEFAULT_AVAILABILITY_ZONE = {
     "cn-north-1": ["cnn1-az1", "cnn1-az2"],
 }
 
+# used to map a ZoneId to the corresponding region
+# TODO: Add missing regions
+# Nice-To-Have: a python script that creates this mapping by invoking aws describe-regions / subnets and
+# read it from a file
+ZONE_ID_MAPPING = {
+    "us-east-1": "^use1-az[0-9]",
+    "us-east-2": "^use2-az[0-9]",
+    "us-west-1": "^usw1-az[0-9]",
+    "ap-southeast-1": "^apse1-az[0-9]",
+    "ap-southeast-2": "^apse2-az[0-9]",
+    "ap-northeast-1": "^apne1-az[0-9]",
+    "ap-northeast-2": "^apne2-az[0-9]",
+    "eu-west-1": "^euw1-az[0-9]",
+    "eu-north-1": "^eun1-az[0-9]",
+    "eu-central-1": "^euc1-az[0-9]",
+    "ca-central-1": "^cac1-az[0-9]",
+    "cn-north-1": "^cnn1-az[0-9]",
+    "sa-east-1": "^sae1-az[0-9]",
+}
 
 # Split the VPC address space into 32 subnets of 2046 (/21) addresses
 # to ensure that each subnets has enough IP addresses to support enough tests parallelism.
@@ -106,6 +127,59 @@ CIDR_FOR_CUSTOM_SUBNETS = [
     "192.168.240.0/21",
     "192.168.248.0/21",
 ]
+
+
+@pytest.fixture(autouse=True)
+def az_id():
+    """
+    Removes the need to declare the fixture in all tests even if not needed.
+    """
+    pass
+
+
+def unmarshal_az_override(az_override):
+    for region, regex in ZONE_ID_MAPPING.items():
+        pattern = re.compile(regex)
+        if pattern.match(az_override.lower()):
+            return region
+        elif region == az_override.lower():
+            return az_override
+
+    raise ValueError(f"Unsupported region `{az_override}`")
+
+
+def unmarshal_az_params(argvalues, argnames):
+    """
+    Given the list of tuple parameters defining the configured test dimensions, when an az-override is specified
+    it replaces the az with the corresponding region, and fill the az field with the proper value.
+
+    E.g.
+    argvalues = [('r1az-id1', 'inst1', 'os1', 's', ''), ('r1-az-id1', 'inst1', 'os2', 's', ''),
+                 ('r1az-id2', 'inst1', 'os1', 's', ''), ('r1-az-id2', 'inst1', 'os2', 's', ''),
+                 ('region2', 'inst1', 'os1', 's', ''), ('region2', 'inst1', 'os2', 's', '')]
+
+    Produces the following output:
+    argvalues = [('region1', 'inst1', 'os1', 's', 'az-id1'), ('region1', 'inst1', 'os2', 's', 'az-id1'),
+                 ('region1', 'inst1', 'os1', 's', 'az-id2'), ('region1', 'inst1', 'os2', 's', 'az-id2'),
+                 ('region2', 'inst1', 'os1', 's', ''), ('region2', 'inst1', 'os2', 's', '')]
+    """
+
+    unmarshalled_params = []
+    for tuple in argvalues:
+        param_set = list(tuple)
+        region = unmarshal_az_override(param_set[0])
+        if region != param_set[0]:  # found an override
+            param_set.append(param_set[0])  # set AZ as last value
+            param_set[0] = region  # override first value with unmarshalled region
+        else:
+            # we could set here the default_az if there is no override, but we aren't doing so because
+            # these values are set at each test execution and we want to keep the default_az consistent
+            # across tests and retries of the same test
+            param_set.append(None)  # set AZ to none
+
+        unmarshalled_params.append((*param_set,))
+
+    return unmarshalled_params, argnames + ["az_id"]
 
 
 def subnet_name(visibility="Public", az_id=None, flavor=None):
@@ -207,8 +281,12 @@ def random_az_selector(request):
 
 
 @pytest.fixture(scope="class")
-def vpc_stack(vpc_stacks_shared, region):
-    return vpc_stacks_shared.get(region)
+def vpc_stack(vpc_stacks_shared, region, az_id):
+    # Create a local copy fo the shared vpcs to avoid
+    # undesired effects on other tests.
+    local_vpc_stack = copy.deepcopy(vpc_stacks_shared.get(region))
+    local_vpc_stack.set_az_override(az_id)
+    return local_vpc_stack
 
 
 @xdist_session_fixture(autouse=True)
@@ -224,6 +302,9 @@ def vpc_stacks_shared(cfn_stacks_factory, request, key_name):
 
     vpc_stacks_dict = {}
     for region in regions:
+        # region may contain an az_id if an override was specified
+        # here we ensure that we are using the region
+        region = unmarshal_az_override(region)
         default_az_id, default_az_name, az_id_name_dict = get_az_setup_for_region(region, credential)
 
         subnets = []

--- a/tests/integration-tests/conftest_tests_config.py
+++ b/tests/integration-tests/conftest_tests_config.py
@@ -3,6 +3,7 @@ import os
 from itertools import product
 
 from conftest_markers import DIMENSIONS_MARKER_ARGS
+from conftest_networking import unmarshal_az_override, unmarshal_az_params
 from framework.tests_configuration.config_utils import get_enabled_tests
 from xdist import get_xdist_worker_id
 
@@ -58,6 +59,8 @@ def _get_combinations_of_dimensions_values(configured_dimensions_items):
             dimensions_values.append(benchmarks_value)
         argvalues.extend(list(product(*dimensions_values)))
 
+        argvalues, argnames = unmarshal_az_params(argvalues, argnames)  # adds 'az_id' extra fixture
+
     return argnames, argvalues
 
 
@@ -89,6 +92,10 @@ def apply_cli_dimensions_filtering(config, items):
             # callspec is not set if parametrization did not happen
             if hasattr(item, "callspec"):
                 arg_value = item.callspec.params.get(dimension)
+                if dimension == "region":
+                    # arg_value may contain an az_id if an override was specified
+                    # here we ensure that we are using the region
+                    arg_value = unmarshal_az_override(arg_value)
                 if allowed_values[dimension]:
                     if arg_value not in allowed_values[dimension]:
                         items.remove(item)

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -357,7 +357,7 @@ def _delete_certificate(certificate_arn, region):
 
 
 @pytest.fixture(scope="module")
-def directory_factory(request, cfn_stacks_factory, vpc_stacks_shared, store_secret_in_secret_manager):  # noqa: C901
+def directory_factory(request, cfn_stacks_factory, vpc_stack, store_secret_in_secret_manager):  # noqa: C901
     # TODO: use external data file and file locking in order to share directories across processes
     created_directory_stacks = defaultdict(dict)
     created_certificates = defaultdict(dict)
@@ -384,7 +384,7 @@ def directory_factory(request, cfn_stacks_factory, vpc_stacks_shared, store_secr
                 directory_type,
                 test_resources_dir,
                 region,
-                vpc_stacks_shared[region],
+                vpc_stack,
             )
             directory_stack_name = directory_stack.name
             created_directory_stacks[region]["directory"] = directory_stack_name

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
@@ -440,7 +440,7 @@ def _test_cluster_config(request, region, command_executor, cluster_config, rend
             len(target_config.get("Scheduling").get("SchedulerQueues"))
         )
         with open(rendered_queue_config_path, encoding="utf-8") as rendered_queue_config:
-            private_subnet_id = request.getfixturevalue("vpc_stacks_shared").get(region).get_private_subnet()
+            private_subnet_id = request.getfixturevalue("vpc_stack").get_private_subnet()
             rendered_queue = yaml.safe_load(rendered_queue_config)
             # inject subnet id into rendered queue
             for queue in rendered_queue:

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -54,7 +54,7 @@ def test_ebs_single(
 @pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_ebs_snapshot(
     request,
-    vpc_stacks_shared,
+    vpc_stack,
     region,
     pcluster_config_reader,
     snapshots_factory,
@@ -69,7 +69,7 @@ def test_ebs_snapshot(
 
     logging.info("Creating snapshot")
 
-    snapshot_id = snapshots_factory.create_snapshot(request, vpc_stacks_shared[region].get_public_subnet(), region)
+    snapshot_id = snapshots_factory.create_snapshot(request, vpc_stack.get_public_subnet(), region)
 
     logging.info("Snapshot id: %s" % snapshot_id)
     cluster_config = pcluster_config_reader(mount_dir=mount_dir, volume_size=volume_size, snapshot_id=snapshot_id)
@@ -155,7 +155,7 @@ def _get_ebs_settings_by_name(config, name):
 @pytest.mark.usefixtures("os", "instance")
 def test_ebs_existing(
     request,
-    vpc_stacks_shared,
+    vpc_stack,
     region,
     scheduler,
     pcluster_config_reader,
@@ -168,7 +168,7 @@ def test_ebs_existing(
 
     logging.info("Creating volume")
 
-    volume_id = snapshots_factory.create_existing_volume(request, vpc_stacks_shared[region].get_public_subnet(), region)
+    volume_id = snapshots_factory.create_existing_volume(request, vpc_stack.get_public_subnet(), region)
 
     logging.info("Existing Volume id: %s" % volume_id)
     cluster_config = pcluster_config_reader(volume_id=volume_id, existing_mount_dir=existing_mount_dir)


### PR DESCRIPTION
While defining a test is now possible to ask for a specific AZ to run the test by replacing the region with the ZoneId

## Description of changes
* `regions`  dimension can now accept also ZoneIds to override the default ones
* a new `az_id` fixture has been defined that will be used transparently by all tests
* an az_id to region mapping has been added to retrieve the proper region when a zoneId is passed
* a few tests were modified to make use of the local vpc_stack instead of the collection vpc_shared_stacks

### Tests
* Changes were tested by running a small set of tests

Tested with configs like 
```
test-suites:
  storage:
    test_ebs.py::test_ebs_single:
      dimensions:
        - regions: ["euw1-az1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_ebs.py::test_ebs_existing:
      dimensions:
        - regions: ["euw1-az1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
