### PR TITLE
[3.x] Make cluster name case insensitive

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -166,7 +166,7 @@ class Cluster:
     """Represent a running cluster, composed by a ClusterConfig and a ClusterStack."""
 
     def __init__(self, name: str, config: str = None, stack: ClusterStack = None):
-        self.name = name
+        self.name = name.lower()
         self.__source_config_text = config
         self.__stack = stack
         self.__bucket = None


### PR DESCRIPTION
### Description of changes
* Make cluster name case insensitive
* This is important because Route53 behind the scene is case insensitive

### Tests
* Junits
* Before change

```
pcluster create-cluster -n test-case -c hello-world-updated.yaml -r eu-west-1
{
  "cluster": {
    "clusterName": "test-case",
    "cloudformationStackStatus": "CREATE_IN_PROGRESS",
    "cloudformationStackArn": "arn:aws:cloudformation:eu-west-1:982587310963:stack/test-case/9029f250-b2bb-11ed-8411-02e93e804991",
    "region": "eu-west-1",
    "version": "3.6.0",
    "clusterStatus": "CREATE_IN_PROGRESS",
    "scheduler": {
      "type": "slurm"
    }
  },
(eantonin-venv-3.9.7)  eantonin-admin 147dda7528fa:aws-parallelcluster eantonin$ pcluster create-cluster -n TEST-case -c hello-world-updated.yaml -r eu-west-1
{
  "cluster": {
    "clusterName": "TEST-case",
    "cloudformationStackStatus": "CREATE_IN_PROGRESS",
    "cloudformationStackArn": "arn:aws:cloudformation:eu-west-1:982587310963:stack/TEST-case/9d6fc610-b2bb-11ed-91f9-0244c340d687",
    "region": "eu-west-1",
    "version": "3.6.0",
    "clusterStatus": "CREATE_IN_PROGRESS",
    "scheduler": {
      "type": "slurm"
    }
  },
-> this will then brake on CF side

(eantonin-venv-3.9.7)  eantonin-admin 147dda7528fa:aws-parallelcluster eantonin$ pcluster create-cluster -n TEST-CASE -c hello-world-updated.yaml -r eu-west-1
{
  "cluster": {
    "clusterName": "TEST-CASE",
    "cloudformationStackStatus": "CREATE_IN_PROGRESS",
    "cloudformationStackArn": "arn:aws:cloudformation:eu-west-1:982587310963:stack/TEST-CASE/03650020-b2bc-11ed-a9c9-02b29b3f7e05",
    "region": "eu-west-1",
    "version": "3.6.0",
    "clusterStatus": "CREATE_IN_PROGRESS",
    "scheduler": {
      "type": "slurm"
    }
  },
  -> this will then brake on CF side

```

* After change

```

(eantonin-venv-3.9.7)  eantonin-admin 147dda7528fa:aws-parallelcluster eantonin$ pcluster create-cluster -n TEST-CASE -c hello-world-updated.yaml -r eu-west-1
{
  "message": "Bad Request: Cluster test-case already exists."
}
(eantonin-venv-3.9.7)  eantonin-admin 147dda7528fa:aws-parallelcluster eantonin$ pcluster create-cluster -n test-CASE -c hello-world-updated.yaml -r eu-west-1
{
  "message": "Bad Request: Cluster test-case already exists."
```
 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
