### PR TITLE
3.x Disable placement group in EFA c6gn.16xlarge tests

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -15,7 +15,7 @@ Scheduling:
     - Name: efa-enabled
       Networking:
         PlacementGroup:
-          Enabled: {% if instance != "p4d.24xlarge" %}true{% else %}false{% endif %}
+          Enabled: {% if instance not in ["p4d.24xlarge", "c6gn.16xlarge"] %}true{% else %}false{% endif %}
         SubnetIds:
           - {{ private_subnet_id }}
       ComputeResources:


### PR DESCRIPTION
### Description of changes
* This change disables using a placement group for EFA integration tests that use  c6gn.16xlarge instances.
* The commercial Jenkins dev account has an ODCR for this test to ensure we have the capacity to run this test
* Because the test for this instance type was using a placement group, the test was not always able to find the capacity in a single placement.
* Removing placement group should allow the tests to be more flexible about where the instances are placed.

### Tests
* Ran integration test `test_efa.py-test_efa[us-east-1-c6gn.16xlarge-ubuntu2004-slurm]`

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
