### PR TITLE
[Isolated Regions] Add validator FeatureRegionValidator to fail fast when a requested feature is not supported in the given region.

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -8,6 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+from enum import Enum
 
 from pkg_resources import packaging
 
@@ -209,3 +210,31 @@ LAMBDA_VPC_ACCESS_MANAGED_POLICY = "arn:${AWS::Partition}:iam::aws:policy/servic
 
 IAM_NAME_PREFIX_LENGTH_LIMIT = 30
 IAM_PATH_LENGTH_LIMIT = 512
+
+
+# Features support
+# By default, all features are considered supported.
+# To mark a feature as unsupported for certain regions,
+# add the entry to the map below by region prefixes.
+class Feature(Enum):
+    """
+    Enumeration of features.
+
+    We do not expect this enumeration to list all the features,
+    but at least those that are considered for feature flagging.
+    """
+
+    BATCH = "AWS Batch scheduler"
+    DCV = "NICE DCV"
+    FSX_LUSTRE = "FSx Lustre"
+    FSX_ONTAP = "FSx ONTAP"
+    FSX_OPENZFS = "FSx OpenZfs"
+
+
+UNSUPPORTED_FEATURES_MAP = {
+    Feature.BATCH: ["ap-northeast-3", "us-iso"],
+    Feature.DCV: ["us-iso"],
+    Feature.FSX_LUSTRE: ["us-iso"],
+    Feature.FSX_ONTAP: ["us-iso"],
+    Feature.FSX_OPENZFS: ["us-iso"],
+}

--- a/cli/src/pcluster/validators/awsbatch_validators.py
+++ b/cli/src/pcluster/validators/awsbatch_validators.py
@@ -19,19 +19,6 @@ from pcluster.validators.common import FailureLevel, Validator
 LOGGER = logging.getLogger(__name__)
 
 
-class AwsBatchRegionValidator(Validator):
-    """
-    AWS Batch region validator.
-
-    Validate if the region is supported by AWS Batch.
-    """
-
-    def _validate(self, region: str):
-        # TODO use dryrun
-        if region in ["ap-northeast-3"]:
-            self._add_failure(f"AWS Batch scheduler is not supported in region '{region}'.", FailureLevel.ERROR)
-
-
 class AwsBatchComputeResourceSizeValidator(Validator):
     """
     AwsBatch compute resource size validator.

--- a/cli/src/pcluster/validators/feature_validators.py
+++ b/cli/src/pcluster/validators/feature_validators.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This module contains all the classes representing the Resources objects.
+# These objects are obtained from the configuration file through a conversion based on the Schema classes.
+from pcluster.aws.common import get_region
+from pcluster.constants import UNSUPPORTED_FEATURES_MAP, Feature
+from pcluster.validators.common import FailureLevel, Validator
+
+
+class FeatureRegionValidator(Validator):
+    """Validate if a feature is supported in the given region."""
+
+    def _validate(self, feature: Feature, region: str):
+        if not self._is_feature_supported(feature, region):
+            self._add_failure(f"{feature.value} is not supported in region '{region}'.", FailureLevel.ERROR)
+
+    @staticmethod
+    def _is_feature_supported(feature: Feature, region: str):
+        """
+        Check if a feature is supported for the given region.
+
+        If region is None, consider the region set in the environment.
+        """
+        _region = get_region() if region is None else region
+        prefixes_of_unsupported_regions = UNSUPPORTED_FEATURES_MAP.get(feature, [])
+        return all(not _region.startswith(region_prefix) for region_prefix in prefixes_of_unsupported_regions)

--- a/cli/tests/pcluster/validators/test_all_validators/test_scheduler_plugin_all_validators_are_called/scheduler_plugin_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_scheduler_plugin_all_validators_are_called/scheduler_plugin_1.yaml
@@ -233,6 +233,16 @@ SharedStorage:
       AutoImportPolicy: NEW  # NEW | NEW_CHANGED | NEW_CHANGED_DELETED
       DriveCacheType: READ  # READ
       StorageType: HDD  # HDD | SSD
+  - MountDir: /my/mount/point4
+    Name: name4
+    StorageType: FsxOntap
+    FsxOntapSettings:
+      VolumeId: "fsvol-00e6e91b8898ec4ef"
+  - MountDir: /my/mount/point5
+    Name: name5
+    StorageType: FsxOpenZfs
+    FsxOpenZfsSettings:
+      VolumeId: "fsvol-00e6e91b8898ec4ef"
 Iam:
   PermissionsBoundary: arn:aws:iam::aws:policy/boundary
   ResourcePrefix: /path-prefix/name-prefix

--- a/cli/tests/pcluster/validators/test_all_validators/test_scheduler_plugin_validators_are_called_with_correct_argument/scheduler_plugin.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_scheduler_plugin_validators_are_called_with_correct_argument/scheduler_plugin.yaml
@@ -10,6 +10,8 @@ HeadNode:
   LocalStorage:
     EphemeralVolume:
       MountDir: /scratch_head
+  Dcv:
+    Enabled: true
 Scheduling:
   Scheduler: plugin
   SchedulerSettings:
@@ -178,3 +180,13 @@ SharedStorage:
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: 3600
+  - MountDir: /my/mount/point4
+    Name: name4
+    StorageType: FsxOntap
+    FsxOntapSettings:
+      VolumeId: "fsvol-00e6e91b8898ec4ef"
+  - MountDir: /my/mount/point5
+    Name: name5
+    StorageType: FsxOpenZfs
+    FsxOpenZfsSettings:
+      VolumeId: "fsvol-00e6e91b8898ec4ef"

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -160,6 +160,16 @@ SharedStorage:
       AutoImportPolicy: NEW  # NEW | NEW_CHANGED | NEW_CHANGED_DELETED
       DriveCacheType: READ  # READ
       StorageType: HDD  # HDD | SSD
+  - MountDir: /my/mount/point4
+    Name: name4
+    StorageType: FsxOntap
+    FsxOntapSettings:
+      VolumeId: "fsvol-00e6e91b8898ec4ef"
+  - MountDir: /my/mount/point5
+    Name: name5
+    StorageType: FsxOpenZfs
+    FsxOpenZfsSettings:
+      VolumeId: "fsvol-00e6e91b8898ec4ef"
 Iam:
   PermissionsBoundary: arn:aws:iam::aws:policy/boundary
   ResourcePrefix: /path-prefix/name-prefix

--- a/cli/tests/pcluster/validators/test_awsbatch_validators.py
+++ b/cli/tests/pcluster/validators/test_awsbatch_validators.py
@@ -26,7 +26,6 @@ from pcluster.validators.awsbatch_validators import (
     AwsBatchComputeResourceSizeValidator,
     AwsBatchFsxValidator,
     AwsBatchInstancesArchitectureCompatibilityValidator,
-    AwsBatchRegionValidator,
 )
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.utils import MockedBoto3Request
@@ -38,18 +37,6 @@ from .utils import assert_failure_messages
 def boto3_stubber_path():
     """Specify that boto3_mocker should stub calls to boto3 for the pcluster.utils module."""
     return "pcluster.aws.common.boto3"
-
-
-@pytest.mark.parametrize(
-    "region, expected_message",
-    [
-        ("eu-west-1", None),
-        ("ap-northeast-3", "AWS Batch scheduler is not supported in.*region"),
-    ],
-)
-def test_awsbatch_region_validator(region, expected_message):
-    actual_failures = AwsBatchRegionValidator().execute(region)
-    assert_failure_messages(actual_failures, expected_message)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/validators/test_feature_validators.py
+++ b/cli/tests/pcluster/validators/test_feature_validators.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from pcluster.constants import Feature
+from pcluster.validators.feature_validators import FeatureRegionValidator
+
+from .utils import assert_failure_messages
+
+
+@pytest.mark.parametrize(
+    "feature, region, expected_message",
+    [
+        (Feature.BATCH, "ap-northeast-3", "AWS Batch scheduler is not supported in region 'ap-northeast-3'"),
+        (Feature.BATCH, "us-iso-east-1", "AWS Batch scheduler is not supported in region 'us-iso-east-1'"),
+        (Feature.BATCH, "us-iso-west-1", "AWS Batch scheduler is not supported in region 'us-iso-west-1'"),
+        (Feature.BATCH, "us-isob-east-1", "AWS Batch scheduler is not supported in region 'us-isob-east-1'"),
+        (Feature.BATCH, "us-isoWHATEVER", "AWS Batch scheduler is not supported in region 'us-isoWHATEVER'"),
+        (Feature.DCV, "us-iso-east-1", "NICE DCV is not supported in region 'us-iso-east-1'"),
+        (Feature.DCV, "us-iso-west-1", "NICE DCV is not supported in region 'us-iso-west-1'"),
+        (Feature.DCV, "us-isob-east-1", "NICE DCV is not supported in region 'us-isob-east-1'"),
+        (Feature.DCV, "us-isoWHATEVER", "NICE DCV is not supported in region 'us-isoWHATEVER'"),
+        (Feature.FSX_LUSTRE, "us-iso-east-1", "FSx Lustre is not supported in region 'us-iso-east-1'"),
+        (Feature.FSX_LUSTRE, "us-iso-west-1", "FSx Lustre is not supported in region 'us-iso-west-1'"),
+        (Feature.FSX_LUSTRE, "us-isob-east-1", "FSx Lustre is not supported in region 'us-isob-east-1'"),
+        (Feature.FSX_LUSTRE, "us-isoWHATEVER", "FSx Lustre is not supported in region 'us-isoWHATEVER'"),
+        (Feature.FSX_ONTAP, "us-iso-east-1", "FSx ONTAP is not supported in region 'us-iso-east-1'"),
+        (Feature.FSX_ONTAP, "us-iso-west-1", "FSx ONTAP is not supported in region 'us-iso-west-1'"),
+        (Feature.FSX_ONTAP, "us-isob-east-1", "FSx ONTAP is not supported in region 'us-isob-east-1'"),
+        (Feature.FSX_ONTAP, "us-isoWHATEVER", "FSx ONTAP is not supported in region 'us-isoWHATEVER'"),
+        (Feature.FSX_OPENZFS, "us-iso-east-1", "FSx OpenZfs is not supported in region 'us-iso-east-1'"),
+        (Feature.FSX_OPENZFS, "us-iso-west-1", "FSx OpenZfs is not supported in region 'us-iso-west-1'"),
+        (Feature.FSX_OPENZFS, "us-isob-east-1", "FSx OpenZfs is not supported in region 'us-isob-east-1'"),
+        (Feature.FSX_OPENZFS, "us-isoWHATEVER", "FSx OpenZfs is not supported in region 'us-isoWHATEVER'"),
+        (Feature.BATCH, "WHATEVER-ELSE", None),
+        (Feature.DCV, "WHATEVER-ELSE", None),
+        (Feature.FSX_LUSTRE, "WHATEVER-ELSE", None),
+        (Feature.FSX_ONTAP, "WHATEVER-ELSE", None),
+        (Feature.FSX_OPENZFS, "WHATEVER-ELSE", None),
+    ],
+)
+def test_feature_region_validator(feature, region, expected_message):
+    actual_failures = FeatureRegionValidator().execute(feature=feature, region=region)
+    assert_failure_messages(actual_failures, expected_message)


### PR DESCRIPTION
*Cherry Pick from https://github.com/aws/aws-parallelcluster/pull/4812*

### Description of changes
Add validators to check features support by region. In particular, the following features are set as unsupported:
* AWS Batch in ap-northeast-3 and us-iso* regions
* NICE DCV in us-iso* regions
* FSx Lustre in us-iso* regions
* FSx ONTAP in us-iso* regions
* FSx OpenZfs in us-iso* regions

### Tests
Tests executed on the cherry-picked PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
