### PR TITLE
[integ-test] Prepare for testing with ParallelCluster executable

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -8,6 +8,7 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import logging
 import os
 import pathlib
@@ -22,7 +23,7 @@ from botocore.exceptions import ClientError
 from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
 from time_utils import seconds
-from utils import get_instance_info
+from utils import get_instance_info, run_command
 
 LOGGER = logging.getLogger(__name__)
 
@@ -170,7 +171,11 @@ def _assert_ami_is_available(region, ami_id):
 
 def get_installed_parallelcluster_version():
     """Get the version of the installed aws-parallelcluster package."""
-    return pkg_resources.get_distribution("aws-parallelcluster").version
+    try:
+        return pkg_resources.get_distribution("aws-parallelcluster").version
+    except Exception:
+        logging.info("aws-parallelcluster is not installed through Python. Getting version from `pcluster version`.")
+        return json.loads(run_command(["pcluster", "version"]).stdout.strip())["version"]
 
 
 def get_installed_parallelcluster_base_version():


### PR DESCRIPTION
After this change, test_runner can be executed without ParallelCluster installed in the Python environment. Instead, we can provide the executable of ParallelCluster executable through PATH: "${PATH}:${DIR_OF_PCLUSTER_EXECUTABLE} python -u -m test_runner ${ARGS}"


### References
This is a cherry pick from https://github.com/aws/aws-parallelcluster/pull/4889

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
