### PR TITLE
3.x Increase timeout on scontrol reboot test

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -2166,7 +2166,7 @@ def _test_scontrol_reboot_nodes(
         wait_for_compute_nodes_states(slurm_commands, nodes_in_queue, expected_states=["reboot^"])
 
     # Wait that nodes come back after a while, without having triggered clustermgtd
-    wait_for_compute_nodes_states(slurm_commands, nodes_in_queue, expected_states=["idle"])
+    wait_for_compute_nodes_states(slurm_commands, nodes_in_queue, expected_states=["idle"], stop_max_delay_secs=600)
     assert_no_msg_in_logs(
         remote_command_executor,
         ["/var/log/parallelcluster/clustermgtd"],


### PR DESCRIPTION
### Description of changes
* The change increases the timeout for waiting for a compute node reboot to succeed.
* Test was occasionally failing due to the node taking longer than 5 minutes to reboot.

### Tests
* Manually ran integration test

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
