### PR TITLE
[develop] Fix typo: call unmarshal_params only once

### DIFF
--- a/tests/integration-tests/conftest_tests_config.py
+++ b/tests/integration-tests/conftest_tests_config.py
@@ -59,7 +59,7 @@ def _get_combinations_of_dimensions_values(configured_dimensions_items):
             dimensions_values.append(benchmarks_value)
         argvalues.extend(list(product(*dimensions_values)))
 
-        argvalues, argnames = unmarshal_az_params(argvalues, argnames)  # adds 'az_id' extra fixture
+    argvalues, argnames = unmarshal_az_params(argvalues, argnames)  # adds 'az_id' extra fixture
 
     return argnames, argvalues
 


### PR DESCRIPTION
### Description of changes
* call `unmarshal_params` only once.

A typo caused multiple calls to this method that generated errors like 

```
networking/test_cluster_networking.py::test_cluster_in_no_internet_subnet: in "parametrize" the number of names (8):
  ['region', 'instance', 'os', 'scheduler', 'az_id', 'az_id', 'az_id', 'az_id']
must be equal to the number of values (7):
  ('us-east-1', 'm6g.xlarge', 'alinux2', 'slurm', None, None, None)
```

### Tests
* Checked locally that even when multiple dimensions are specified this method is called only once.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
