### PR TITLE
[develop] Add unmarshal_az to cli_dimension_filtering

### DIFF
--- a/tests/integration-tests/conftest_tests_config.py
+++ b/tests/integration-tests/conftest_tests_config.py
@@ -86,7 +86,12 @@ def apply_cli_dimensions_filtering(config, items):
     """Filter tests based on dimensions passed as cli arguments."""
     allowed_values = {}
     for dimension in DIMENSIONS_MARKER_ARGS:
-        allowed_values[dimension] = config.getoption(dimension + "s")
+        value = config.getoption(dimension + "s")
+        if dimension == "region":
+            # value may contain a list of az_id/regions.
+            # We have to unmarshal any fo them in case if one or more overrides were specified
+            value = [unmarshal_az_override(v) for v in value]
+        allowed_values[dimension] = value
     for item in list(items):
         for dimension in DIMENSIONS_MARKER_ARGS:
             # callspec is not set if parametrization did not happen


### PR DESCRIPTION
### Description of changes
When filtering the tests to run based on the input configuration, the `regions` dimensions used to populate the allowed values my contain a list of regions/az_id.
Here we apply the unmarshal_az functions to all the values to ensure that every override is properly handled and a valid list of regions is used to filter the tests.

### Tests
* Verified locally that when multiple dimensions are specified the overrides are properly handled.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
