### PR TITLE
Fix integration test: update the filename of the cloudwatch agent configuration

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -186,8 +186,8 @@ class CloudWatchLoggingClusterState:
         LOGGER.debug("After getting initial cluster state:\n{0}".format(self._dump_cluster_log_state()))
 
     def _read_log_configs_from_head_node(self):
-        """Read the log configs file at /usr/local/etc/cloudwatch_log_files.json."""
-        read_cmd = "cat /usr/local/etc/cloudwatch_log_files.json"
+        """Read the log configs file at /usr/local/etc/cloudwatch_agent_config.json."""
+        read_cmd = "cat /usr/local/etc/cloudwatch_agent_config.json"
         config = json.loads(self._run_command_on_head_node(read_cmd))
         return config.get("log_configs")
 


### PR DESCRIPTION
### Description of changes
* Since the file `cloudwatch_log_files.json` has been renamed to `cloudwatch_agent_config.json` in [this PR](https://github.com/aws/aws-parallelcluster-cookbook/pull/1732), we correct the file name in the integration test.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* The related cookbook PR that changed the file name: https://github.com/aws/aws-parallelcluster-cookbook/pull/1732

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
