### PR TITLE
[integ-tests-3.5.0] Remove constraint on instance type for test_update_slurm

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -141,7 +141,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     _check_script(command_executor, slurm_commands, initial_compute_nodes[0], "postinstall", "RTY")
 
     # Submit a job in order to verify that jobs are not affected by an update of the queue size
-    result = slurm_commands.submit_command("sleep infinity", constraint="static&c5.xlarge")
+    result = slurm_commands.submit_command("sleep infinity", constraint="static")
     job_id = slurm_commands.assert_job_submitted(result.stdout)
 
     # Update cluster with new configuration

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -87,7 +87,13 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
                     "instances": [
                         {
                             "instance_type": "c5.xlarge",
-                        }
+                        },
+                        {
+                            "instance_type": "c5a.xlarge",
+                        },
+                        {
+                            "instance_type": "c5d.xlarge",
+                        },
                     ],
                     "expected_running_instances": 1,
                     "expected_power_saved_instances": 1,
@@ -163,7 +169,13 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
                     "instances": [
                         {
                             "instance_type": "c5.xlarge",
-                        }
+                        },
+                        {
+                            "instance_type": "c5a.xlarge",
+                        },
+                        {
+                            "instance_type": "c5d.xlarge",
+                        },
                     ],
                     "expected_running_instances": 2,
                     "expected_power_saved_instances": 2,

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -47,6 +47,8 @@ Scheduling:
         - Name: queue1-i1
           Instances:
             - InstanceType: c5.xlarge
+            - InstanceType: c5a.xlarge
+            - InstanceType: c5d.xlarge
           MinCount: 2
           MaxCount: 4
         - Name: queue1-i2

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.yaml
@@ -44,6 +44,8 @@ Scheduling:
         - Name: queue1-i1
           Instances:
             - InstanceType: c5.xlarge
+            - InstanceType: c5a.xlarge
+            - InstanceType: c5d.xlarge
           MinCount: 1
           MaxCount: 2
         - Name: queue1-i2


### PR DESCRIPTION
### Description of changes
Remove constraint on instance type for test_update_slurm, after the static capacity have been changed to be provisioned using flexible instance types

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
