### PR TITLE
[develop] Defines a mechanism to define the az where run the test

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -268,6 +268,22 @@ Some tox commands are offered in order to simplify the generation and validation
 * `tox -e generate-test-config my-config-file` can be used to automatically generate a configuration file pre-filled
   with the list of all available files. The config file is generated in the `tests/integration-tests/configs` directory.
 
+#### AZ override
+By default, the TestRunner will run the test in a random AZ between the ones available in the region.
+There are cases where some resources (like `instance_type` or aws services) are not available in all AZ.
+In these cases to successfully run the test it is necessary to override the AZ where the test must run.
+
+To do so you can specify a ZoneId in the regions dimension. So for example if you set
+
+```
+      dimensions:
+        - regions: ["euw1-az1", "eu-central-1"]
+```
+
+the test will be executed in
+* `eu-west-1` using the AZ with ZoneId `euw1-az1` (ZoneId is consistent across accounts)
+* `eu-central-1` using a random AZ available in the region
+
 #### Using CLI options
 
 The following options can be used to control the parametrization of test cases:

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -74,10 +74,15 @@ class CfnVpcStack(CfnStack):
         super().__init__(**kwargs)
         self.default_az_id = default_az_id
         self.az_ids = az_ids
+        self.az_override = None
         self.__public_subnet_ids = None
         self.__private_subnet_ids = None
 
-    def get_public_subnet(self):  # TODO add possibility to override default
+    def set_az_override(self, az_override):
+        """Sets the az_id to override the default AZ used to pick the subnets."""
+        self.az_override = az_override
+
+    def get_public_subnet(self):
         """Return the public subnet for a VPC stack."""
         return self._get_subnet(visibility="Public")
 
@@ -88,7 +93,7 @@ class CfnVpcStack(CfnStack):
 
         return self.__public_subnet_ids
 
-    def get_private_subnet(self):  # TODO add possibility to override default
+    def get_private_subnet(self):
         """Return the private subnet for a VPC stack."""
         return self._get_subnet(visibility="Private")
 
@@ -100,7 +105,9 @@ class CfnVpcStack(CfnStack):
         return self.__private_subnet_ids
 
     def _get_subnet(self, visibility: str = "Public"):
-        if self.default_az_id:
+        if self.az_override is not None:
+            az_id_tag = to_pascal_from_kebab_case(self.az_override)
+        elif self.default_az_id:
             az_id_tag = to_pascal_from_kebab_case(self.default_az_id)
         else:
             # get random subnet, if default is not set

--- a/tests/integration-tests/conftest_networking.py
+++ b/tests/integration-tests/conftest_networking.py
@@ -91,8 +91,8 @@ ZONE_ID_MAPPING = {
     "us-east-2": "^use2-az[0-9]",
     "us-west-1": "^usw1-az[0-9]",
     "us-west-2": "^usw2-az[0-9]",
-    # "us-gov-east-1": "^usge1-az[0-9]", # double check
-    # "us-gov-west-1": "^usgw1-az[0-9]", # double check
+    "us-gov-east-1": "^usge1-az[0-9]",
+    "us-gov-west-1": "^usgw1-az[0-9]",
 }
 
 

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -23,6 +23,7 @@ import argparse
 import boto3
 import pytest
 from assertpy import assert_that
+from conftest_networking import unmarshal_az_override
 from framework.tests_configuration.config_renderer import dump_rendered_config_file, read_config_file
 from framework.tests_configuration.config_utils import get_all_regions
 from framework.tests_configuration.config_validator import assert_valid_config
@@ -645,7 +646,14 @@ def _run_parallel(args):
         enabled_regions = args.regions
     else:
         enabled_regions = get_all_regions(args.tests_config)
-    for region in enabled_regions:
+
+    # unmarshal az and collect unique regions
+    unique_regions = set()
+    for az in enabled_regions:
+        unmarshalled_region = unmarshal_az_override(az)
+        unique_regions.add(unmarshalled_region)
+
+    for region in unique_regions:
         p = multiprocessing.Process(target=_run_test_in_region, args=(region, args, OUT_DIR, LOGS_DIR))
         jobs.append(p)
         p.start()

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -357,7 +357,7 @@ def _delete_certificate(certificate_arn, region):
 
 
 @pytest.fixture(scope="module")
-def directory_factory(request, cfn_stacks_factory, vpc_stacks_shared, store_secret_in_secret_manager):  # noqa: C901
+def directory_factory(request, cfn_stacks_factory, vpc_stack, store_secret_in_secret_manager):  # noqa: C901
     # TODO: use external data file and file locking in order to share directories across processes
     created_directory_stacks = defaultdict(dict)
     created_certificates = defaultdict(dict)
@@ -384,7 +384,7 @@ def directory_factory(request, cfn_stacks_factory, vpc_stacks_shared, store_secr
                 directory_type,
                 test_resources_dir,
                 region,
-                vpc_stacks_shared[region],
+                vpc_stack,
             )
             directory_stack_name = directory_stack.name
             created_directory_stacks[region]["directory"] = directory_stack_name

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin.py
@@ -440,7 +440,7 @@ def _test_cluster_config(request, region, command_executor, cluster_config, rend
             len(target_config.get("Scheduling").get("SchedulerQueues"))
         )
         with open(rendered_queue_config_path, encoding="utf-8") as rendered_queue_config:
-            private_subnet_id = request.getfixturevalue("vpc_stacks_shared").get(region).get_private_subnet()
+            private_subnet_id = request.getfixturevalue("vpc_stack").get_private_subnet()
             rendered_queue = yaml.safe_load(rendered_queue_config)
             # inject subnet id into rendered queue
             for queue in rendered_queue:

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -54,7 +54,7 @@ def test_ebs_single(
 @pytest.mark.usefixtures("os", "instance", "scheduler")
 def test_ebs_snapshot(
     request,
-    vpc_stacks_shared,
+    vpc_stack,
     region,
     pcluster_config_reader,
     snapshots_factory,
@@ -69,7 +69,7 @@ def test_ebs_snapshot(
 
     logging.info("Creating snapshot")
 
-    snapshot_id = snapshots_factory.create_snapshot(request, vpc_stacks_shared[region].get_public_subnet(), region)
+    snapshot_id = snapshots_factory.create_snapshot(request, vpc_stack.get_public_subnet(), region)
 
     logging.info("Snapshot id: %s" % snapshot_id)
     cluster_config = pcluster_config_reader(mount_dir=mount_dir, volume_size=volume_size, snapshot_id=snapshot_id)
@@ -155,7 +155,7 @@ def _get_ebs_settings_by_name(config, name):
 @pytest.mark.usefixtures("os", "instance")
 def test_ebs_existing(
     request,
-    vpc_stacks_shared,
+    vpc_stack,
     region,
     scheduler,
     pcluster_config_reader,
@@ -168,7 +168,7 @@ def test_ebs_existing(
 
     logging.info("Creating volume")
 
-    volume_id = snapshots_factory.create_existing_volume(request, vpc_stacks_shared[region].get_public_subnet(), region)
+    volume_id = snapshots_factory.create_existing_volume(request, vpc_stack.get_public_subnet(), region)
 
     logging.info("Existing Volume id: %s" % volume_id)
     cluster_config = pcluster_config_reader(volume_id=volume_id, existing_mount_dir=existing_mount_dir)


### PR DESCRIPTION
### Description of changes
The region dimension in the test configuration can be used to specify the AZ where test must run.
These changes define a new AZ fixture that must be declared by all existing tests.

* `regions`  dimension can now accept also ZoneIds to override the default ones
* a new `az_id` fixture has been defined that will be used transparently by all tests
* an az_id to region mapping has been added to retrieve the proper region when a zoneId is passed
* a few tests were modified to make use of the local vpc_stack instead of the collection vpc_shared_stacks
* test_runner parallel mode was updated to unmarshal az_override and select unique regions only
* 
### Tests
* Changes were tested by running a small set of tests

Tested with configs like 
```
test-suites:
  storage:
    test_ebs.py::test_ebs_single:
      dimensions:
        - regions: ["euw1-az1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_ebs.py::test_ebs_existing:
      dimensions:
        - regions: ["euw1-az2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
