### PR TITLE
Disable checks that we need to skip on RHEL8

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
@@ -181,11 +181,13 @@ phases:
               {{ test.NodeVirtualenvPath.outputs.stdout }}/bin/python -V | grep {{ test.PythonVersion.outputs.stdout }}
               [[ $? -ne 0 ]] && echo "Check node virtualenv python version failed" && exit 1
 
-              {{ test.SchedulerPluginVirtualenvPath.outputs.stdout }}/bin/python -V | grep {{ test.SchedulerPluginPythonVersion.outputs.stdout }}
-              [[ $? -ne 0 ]] && echo "Check scheduler plugin virtualenv python version failed" && exit 1
-              su -l pcluster-scheduler-plugin -c "which python" | grep envs/scheduler_plugin_virtualenv/bin/python
-              [[ $? -ne 0 ]] && echo "Check scheduler plugin virtualenv python path failed" && exit 1
-
+              if [[ {{ test.OperatingSystemName.outputs.stdout }} != 'rhel8' ]]; then
+                {{ test.SchedulerPluginVirtualenvPath.outputs.stdout }}/bin/python -V | grep {{ test.SchedulerPluginPythonVersion.outputs.stdout }}
+                [[ $? -ne 0 ]] && echo "Check scheduler plugin virtualenv python version failed" && exit 1
+                su -l pcluster-scheduler-plugin -c "which python" | grep envs/scheduler_plugin_virtualenv/bin/python
+                [[ $? -ne 0 ]] && echo "Check scheduler plugin virtualenv python path failed" && exit 1
+              fi
+              
               echo "Virtualenv test passed"
 
       - name: Pip
@@ -272,11 +274,13 @@ phases:
           commands:
             - |
               set -vx
-              Script=/usr/local/sbin/invoke-scheduler-plugin-event-handler.sh
-              if [ -x ${Script} ]; then
-                echo "Scheduler plugin handler script '${Script}' is executable."
-              else
-                echo "Scheduler plugin handler script '${Script}' is not executable." && exit 1
+              if [[ {{ test.OperatingSystemName.outputs.stdout }} != 'rhel8' ]]; then
+                Script=/usr/local/sbin/invoke-scheduler-plugin-event-handler.sh
+                if [ -x ${Script} ]; then
+                  echo "Scheduler plugin handler script '${Script}' is executable."
+                else
+                  echo "Scheduler plugin handler script '${Script}' is not executable." && exit 1
+                fi
               fi
 
       - name: Log4jPatcher

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -106,7 +106,7 @@ phases:
           commands:
             - |
               set -v
-              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} != 'arm64' ]] && echo "true" || echo "false"
+              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} != 'arm64' && {{ validate.OperatingSystemName.outputs.stdout }} != 'rhel8' ]] && echo "true" || echo "false"
 
       - name: ArmPLSupported
         action: ExecuteBash
@@ -114,7 +114,7 @@ phases:
           commands:
             - |
               set -v
-              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} == 'arm64' ]] && echo "true" || echo "false"
+              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} == 'arm64' && {{ validate.OperatingSystemName.outputs.stdout }} != 'rhel8' ]] && echo "true" || echo "false"
 
       - name: FabricManagerSupported
         action: ExecuteBash
@@ -122,7 +122,7 @@ phases:
           commands:
             - |
               set -v
-              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} == 'arm64' ]] && echo "false" || echo "true"
+              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} == 'arm64' || {{ validate.OperatingSystemName.outputs.stdout }} == 'rhel8' ]] && echo "false" || echo "true"
 
       - name: LustreSupported
         action: ExecuteBash
@@ -287,7 +287,7 @@ phases:
               set -vx
               PLATFORM='{{ validate.PlatformName.outputs.stdout }}'
 
-              if [ {{ validate.NvidiaEnabled.outputs.stdout }} == "no" ]; then
+              if [[ {{ validate.NvidiaEnabled.outputs.stdout }} == 'no' || {{ validate.OperatingSystemName.outputs.stdout }} == 'rhel8' ]]; then
                 echo "Nvidia recipe not enabled, skipping." && exit 0
               fi
               if [ {{ validate.HasGPU.outputs.stdout }} == "false" ]; then


### PR DESCRIPTION
### Description of changes
Disable checks that we need to skip on RHEL8.

**Note: this does not change the default behaviour of `pcluster build-image` as `DisableValidateAndTest`, the `DevSettings` option that controls whether these component steps are executed, is `true` by default.**

----

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
