### PR TITLE
[CDK] Move compute node IAM resources into the Compute Fleet Construct

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -310,6 +310,10 @@ def apply_permissions_boundary(boundary, scope):
         PermissionsBoundary.of(scope).apply(boundary)
 
 
+def scheduler_is_slurm(config: BaseClusterConfig):
+    return config.scheduling.scheduler == "slurm"
+
+
 def generate_launch_template_version_cfn_parameter_hash(queue, compute_resource):
     """
     Generate 16 characters hash for compute fleet launch template version cfn parameter.


### PR DESCRIPTION
### Description of changes
* The compute node IAM profiles and roles are associated with the Cluster Stack.
* This makes it difficult to decouple the compute node resources from the main Cluster Stack
* This commit(s) moves the logic of adding compute node IAM roles & profiles into the ComputeFleet Construct. This has been done by 
    * Moving the specification of compute IAM roles into the Compute Fleet Construct
    * Creating the option to pass a scope to a SlurmConstruct method responsible for adding the Slurm policies (used for giving compute IAM roles permissions to access Route53 and DynamoDB)
    * In this commit the Slurm policies still use the cluster CDK scope but this will be swapped easily with the Compute Fleet Nested Stack scope in a subsequent PR
* This will simplify the process of converting the ComputeFleet Construct into a Nested Stack


### Tests
* Manual tests
  * Cluster creation and update works successfully with these changes
  * Compared the CloudFormation template of a cluster before and after the refactor to confirm the structure remains the same
```
» cat no-refactor-aws-parallelcluster.cfn.yaml | wc -l        
    2267

» cat after-refactor-aws-parallelcluster.cfn.yaml | wc -l          
    2267

» diff no-refactor-aws-parallelcluster.cfn.yaml after-refactor-aws-parallelcluster.cfn.yaml
37c37
<     Default: parallelcluster/3.6.0/clusters/simplecluster-no-refactor-c8nvl90p642s9t7v
---
>     Default: parallelcluster/3.6.0/clusters/simplecluster-no-refactor-fncjeb72x2obtkaw
41c41
<     Default: /aws/parallelcluster/SimpleCluster-no-refactor-202303021702
---
>     Default: /aws/parallelcluster/SimpleCluster-no-refactor-202303021722
...
# TIMESTAMP RELATED DIFFERENCES
...
```
  * If the ComputeFleet Construct is converted to a `NestedStack`, the compute node IAM roles, policies and instance profiles are associated with the nested stack
```
Resources:
  ...
  ComputeFleetNestedStackComputeFleetNestedStackResource77B9417D:
    Type: AWS::CloudFormation::Stack
    Properties:
      TemplateURL:
        Fn::Join:
          - ""
          - - https://s3.
            - Ref: AWS::Region
            - "."
            - Ref: AWS::URLSuffix
            - /
            - Ref: AssetParametersd2dd884723e647c4d4ffc9ecebdd7e32732519541b52fa0c2e66a11bb805352eS3BucketF69E25BC
            - /
            - Fn::Select:
                - 0
                - Fn::Split:
                    - "||"
                    - Ref: AssetParametersd2dd884723e647c4d4ffc9ecebdd7e32732519541b52fa0c2e66a11bb805352eS3VersionKey9D215561
            - Fn::Select:
                - 1
                - Fn::Split:
                    - "||"
                    - Ref: AssetParametersd2dd884723e647c4d4ffc9ecebdd7e32732519541b52fa0c2e66a11bb805352eS3VersionKey9D215561
      Parameters:
        referencetoSimpleClusterLimitsComputeSecurityGroup4F5EC5C0Ref:
          Ref: ComputeSecurityGroup
        referencetoSimpleClusterLimitsEFSA102d3a4c6cd976320D813BARef:
          Ref: EFSA102d3a4c6cd9763
        referencetoSimpleClusterLimitsClusterDNSDomain6C057256Ref:
          Ref: ClusterDNSDomain
        referencetoSimpleClusterLimitsRoute53HostedZone50CAD5DCRef:
          Ref: Route53HostedZone
        referencetoSimpleClusterLimitsSlurmDynamoDBTable0622A168Ref:
          Ref: SlurmDynamoDBTable
        referencetoSimpleClusterLimitsHeadNodeENID69BB2BCPrimaryPrivateIpAddress:
          Fn::GetAtt:
            - HeadNodeENI
            - PrimaryPrivateIpAddress
        referencetoSimpleClusterLimitsCleanupResourcesFunction7EA1F269Arn:
          Fn::GetAtt:
            - CleanupResourcesFunction
            - Arn
    DependsOn:
      - ComputeSecurityGroup
    UpdateReplacePolicy: Delete
    DeletionPolicy: Delete
  SlurmPoliciesHeadNode:
    ...
```

* Ran existing unit tests as this is only a refactor
* Ran some integration tests suites (cluster update and IAM tests)

### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
