### PR TITLE
`[cloudformation]` Add ability to create VPC in networking CFN stacks.

### DIFF
--- a/cloudformation/networking/public-private.cfn.json
+++ b/cloudformation/networking/public-private.cfn.json
@@ -9,6 +9,14 @@
         ""
       ]
     },
+    "CreateVpc": {
+      "Fn::Equals": [
+        {
+          "Ref": "VpcId"
+        },
+        ""
+      ]
+    },
     "ExistingInternetGateway": {
       "Fn::Not": [
         {
@@ -22,8 +30,34 @@
       ]
     }
   },
-  "Description": "Network build by NetworkTemplateBuilder",
+  "Description": "Public/Private Network for AWS ParallelCluster",
   "Outputs": {
+    "VpcId": {
+      "Value": {
+        "Fn::If": [
+          "CreateVpc",
+          {
+            "Ref": "Vpc"
+          },
+          {
+            "Ref": "VpcId"
+          }
+        ]
+      }
+    },
+    "InternetGatewayId": {
+      "Value": {
+        "Fn::If": [
+          "CreateInternetGateway",
+          {
+            "Ref": "InternetGateway"
+          },
+          {
+            "Ref": "InternetGatewayId"
+          }
+        ]
+      }
+    },
     "PrivateSubnetId": {
       "Value": {
         "Ref": "Private"
@@ -41,25 +75,44 @@
       "Type": "String"
     },
     "InternetGatewayId": {
-      "Description": "(Optional) The id of the gateway (will be created if not specified)",
-      "Type": "String"
+      "Description": "(Optional) The id of the gateway (will be created if not specified). Rquired if VpcId is specified.",
+      "Type": "String",
+      "Default": ""
     },
     "PrivateCIDR": {
       "AllowedPattern": "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/(1[6-9]|2[0-9]|3[0-2])$",
       "Description": "The CIDR of the Private",
+      "Default": "10.0.16.0/20",
       "Type": "String"
     },
     "PublicCIDR": {
       "AllowedPattern": "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/(1[6-9]|2[0-9]|3[0-2])$",
       "Description": "The CIDR of the Public",
+      "Default": "10.0.0.0/24",
       "Type": "String"
     },
     "VpcId": {
-      "Description": "The vpc id",
+      "Description": "(Optional) The VPC id to create subnets in. (will be created if not specified)",
+      "Default": "",
+      "Type": "String"
+    },
+    "VpcCIDR": {
+      "Description": "(Optional) The CIDR for the VPC if it will be created (only valid if VpcId is left blank)",
+      "Default": "10.0.0.0/16",
       "Type": "String"
     }
   },
   "Resources": {
+    "Vpc": {
+      "Condition": "CreateVpc",
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": {
+          "Ref": "VpcCIDR"
+        },
+        "EnableDnsHostnames": true
+      }
+    },
     "DefaultRouteDependsOnPublic": {
       "Condition": "CreateInternetGateway",
       "DependsOn": "VPCGatewayAttachment",
@@ -175,7 +228,15 @@
           }
         ],
         "VpcId": {
-          "Ref": "VpcId"
+          "Fn::If": [
+            "CreateVpc",
+            {
+              "Ref": "Vpc"
+            },
+            {
+              "Ref": "VpcId"
+            }
+          ]
         }
       },
       "Type": "AWS::EC2::Subnet"
@@ -202,7 +263,15 @@
           }
         ],
         "VpcId": {
-          "Ref": "VpcId"
+          "Fn::If": [
+            "CreateVpc",
+            {
+              "Ref": "Vpc"
+            },
+            {
+              "Ref": "VpcId"
+            }
+          ]
         }
       },
       "Type": "AWS::EC2::Subnet"
@@ -244,7 +313,15 @@
           }
         ],
         "VpcId": {
-          "Ref": "VpcId"
+          "Fn::If": [
+            "CreateVpc",
+            {
+              "Ref": "Vpc"
+            },
+            {
+              "Ref": "VpcId"
+            }
+          ]
         }
       },
       "Type": "AWS::EC2::RouteTable"
@@ -264,7 +341,15 @@
           }
         ],
         "VpcId": {
-          "Ref": "VpcId"
+          "Fn::If": [
+            "CreateVpc",
+            {
+              "Ref": "Vpc"
+            },
+            {
+              "Ref": "VpcId"
+            }
+          ]
         }
       },
       "Type": "AWS::EC2::RouteTable"
@@ -276,7 +361,15 @@
           "Ref": "InternetGateway"
         },
         "VpcId": {
-          "Ref": "VpcId"
+          "Fn::If": [
+            "CreateVpc",
+            {
+              "Ref": "Vpc"
+            },
+            {
+              "Ref": "VpcId"
+            }
+          ]
         }
       },
       "Type": "AWS::EC2::VPCGatewayAttachment"

--- a/cloudformation/networking/public.cfn.json
+++ b/cloudformation/networking/public.cfn.json
@@ -9,6 +9,14 @@
         ""
       ]
     },
+    "CreateVpc": {
+      "Fn::Equals": [
+        {
+          "Ref": "VpcId"
+        },
+        ""
+      ]
+    },
     "ExistingInternetGateway": {
       "Fn::Not": [
         {
@@ -22,8 +30,34 @@
       ]
     }
   },
-  "Description": "Network build by NetworkTemplateBuilder",
+  "Description": "Public Network for AWS ParallelCluster",
   "Outputs": {
+    "VpcId": {
+      "Value": {
+        "Fn::If": [
+          "CreateVpc",
+          {
+            "Ref": "Vpc"
+          },
+          {
+            "Ref": "VpcId"
+          }
+        ]
+      }
+    },
+    "InternetGatewayId": {
+      "Value": {
+        "Fn::If": [
+          "CreateInternetGateway",
+          {
+            "Ref": "InternetGateway"
+          },
+          {
+            "Ref": "InternetGatewayId"
+          }
+        ]
+      }
+    },
     "PublicSubnetId": {
       "Value": {
         "Ref": "Public"
@@ -36,20 +70,38 @@
       "Type": "String"
     },
     "InternetGatewayId": {
-      "Description": "(Optional) The id of the gateway (will be created if not specified)",
-      "Type": "String"
+      "Description": "(Optional) The id of the gateway (will be created if not specified). Rquired if VpcId is specified.",
+      "Type": "String",
+      "Default": ""
     },
     "PublicCIDR": {
       "AllowedPattern": "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}/(1[6-9]|2[0-9]|3[0-2])$",
       "Description": "The CIDR of the Public",
+      "Default": "10.0.0.0/16",
       "Type": "String"
     },
     "VpcId": {
-      "Description": "The vpc id",
+      "Description": "(Optional) The VPC id to create subnets in. (will be created if not specified)",
+      "Default": "",
+      "Type": "String"
+    },
+    "VpcCIDR": {
+      "Description": "(Optional) The CIDR for the VPC if it will be created (only valid if VpcId is left blank)",
+      "Default": "10.0.0.0/16",
       "Type": "String"
     }
   },
   "Resources": {
+    "Vpc": {
+      "Condition": "CreateVpc",
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": {
+          "Ref": "VpcCIDR"
+        },
+        "EnableDnsHostnames": true
+      }
+    },
     "DefaultRouteDependsOnPublic": {
       "Condition": "CreateInternetGateway",
       "DependsOn": "VPCGatewayAttachment",
@@ -133,7 +185,15 @@
           }
         ],
         "VpcId": {
-          "Ref": "VpcId"
+          "Fn::If": [
+            "CreateVpc",
+            {
+              "Ref": "Vpc"
+            },
+            {
+              "Ref": "VpcId"
+            }
+          ]
         }
       },
       "Type": "AWS::EC2::Subnet"
@@ -164,7 +224,15 @@
           }
         ],
         "VpcId": {
-          "Ref": "VpcId"
+          "Fn::If": [
+            "CreateVpc",
+            {
+              "Ref": "Vpc"
+            },
+            {
+              "Ref": "VpcId"
+            }
+          ]
         }
       },
       "Type": "AWS::EC2::RouteTable"
@@ -176,7 +244,15 @@
           "Ref": "InternetGateway"
         },
         "VpcId": {
-          "Ref": "VpcId"
+          "Fn::If": [
+            "CreateVpc",
+            {
+              "Ref": "Vpc"
+            },
+            {
+              "Ref": "VpcId"
+            }
+          ]
         }
       },
       "Type": "AWS::EC2::VPCGatewayAttachment"

--- a/cloudformation/tests/conftest.py
+++ b/cloudformation/tests/conftest.py
@@ -1,4 +1,27 @@
+"""Additional pytest configuration."""
+import random
+import string
+
+import boto3
+import pytest
+
+
 def pytest_collection_modifyitems(items, config):
+    """Augment the tests to add unmarked marker to tests that aren't marked."""
     for item in items:
         if not any(item.iter_markers()):
             item.add_marker("unmarked")
+
+
+@pytest.fixture(name="random_stack_name")
+def random_stack_name_fixture():
+    """Provide a short random id that can be used in a aack name."""
+    alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
+    return "".join(random.choice(alnum) for _ in range(8))
+
+
+@pytest.fixture(scope="session", name="cfn")
+def cfn_fixture():
+    """Create a CloudFormation Boto3 client."""
+    client = boto3.client("cloudformation")
+    return client

--- a/cloudformation/tests/test_networking.py
+++ b/cloudformation/tests/test_networking.py
@@ -1,0 +1,107 @@
+"""Test the CloudFormation Template for networking."""
+
+import boto3
+import pytest
+from assertpy import assert_that
+
+PUBPRIV_TEMPLATE = "../networking/public-private.cfn.json"
+PUBLIC_TEMPLATE = "../networking/public.cfn.json"
+
+
+def _stack_output(cfn, stack_name, output_key):
+    """Retrieve the output value for output_key from stack_name."""
+    outputs = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]["Outputs"]
+    return next(filter(lambda x: x["OutputKey"] == output_key, outputs)).get("OutputValue")
+
+
+# pylint: disable=too-many-arguments
+def _create_vpc(cfn, stack_name, template_file, public_cidr, private_cidr=None, vpc_id=None, igw_id=None):
+    """Create a networking configuration using the template,  wait for it to start and yield it."""
+    ec2 = boto3.client("ec2")
+    azs = ec2.describe_availability_zones()["AvailabilityZones"]
+    availability_zone = azs[0]["ZoneName"]
+    parameters = {
+        "AvailabilityZone": availability_zone,
+        "PublicCIDR": public_cidr,
+        **({"PrivateCIDR": private_cidr} if private_cidr else {}),
+        **({"VpcId": vpc_id} if vpc_id else {}),
+        **({"InternetGatewayId": igw_id} if igw_id else {}),
+    }
+
+    with open(template_file, encoding="utf-8") as templ:
+        template = templ.read()
+
+    # Create networking using CloudFormation, block on completion
+    cfn.create_stack(
+        StackName=stack_name,
+        TemplateBody=template,
+        Capabilities=["CAPABILITY_IAM"],
+        Parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items()],
+    )
+    cfn.get_waiter("stack_create_complete").wait(StackName=stack_name)
+
+    try:
+        yield stack_name
+
+        # Delete the stack through CFN and wait for delete to complete
+        cfn.delete_stack(StackName=stack_name)
+        cfn.get_waiter("stack_delete_complete").wait(StackName=stack_name)
+    except Exception as exc:
+        cfn.delete_stack(StackName=stack_name)
+        raise exc
+
+
+@pytest.fixture(name="pubpriv")
+def pubpriv_fixture(cfn, random_stack_name):
+    """Create a networking configuration using the template,  wait for it to start and yield it."""
+    stack_name = f"pc-net-{random_stack_name}"
+    yield from _create_vpc(cfn, stack_name, PUBPRIV_TEMPLATE, "10.0.0.0/28", "10.0.0.16/28")
+
+
+@pytest.fixture(name="public")
+def public_fixture(cfn, random_stack_name):
+    """Create a networking configuration using the template,  wait for it to start and yield it."""
+    stack_name = f"pc-net-{random_stack_name}"
+    yield from _create_vpc(cfn, stack_name, PUBLIC_TEMPLATE, "10.0.0.0/28")
+
+
+@pytest.mark.local
+def test_pubpriv_vpc_created(cfn, pubpriv):
+    """Validate that a VPC is created by default."""
+    assert_that(_stack_output(cfn, pubpriv, "VpcId")).is_not_none()
+
+
+@pytest.mark.local
+def test_public_vpc_created(cfn, public):
+    """Validate that a VPC is created by default."""
+    assert_that(_stack_output(cfn, public, "VpcId")).is_not_none()
+
+
+@pytest.mark.local
+def test_pubpriv_existing_vpc(cfn, pubpriv):
+    """Validate that we can provide a VPC and IGW to create networking in Public / Private networking."""
+    vpc_id = _stack_output(cfn, pubpriv, "VpcId")
+    igw_id = _stack_output(cfn, pubpriv, "InternetGatewayId")
+
+    # Create a new stack using existing VPC / IGW
+    stack_name = f"{pubpriv}-2"
+    vpc_gen = _create_vpc(cfn, stack_name, PUBPRIV_TEMPLATE, "10.0.0.48/28", "10.0.0.32/28", vpc_id, igw_id)
+    next(vpc_gen)
+    new_vpc_id = _stack_output(cfn, stack_name, "VpcId")
+    assert_that(new_vpc_id).is_equal_to(vpc_id)
+    next(vpc_gen, None)  # Release vpc to have it reaped
+
+
+@pytest.mark.local
+def test_public_existing_vpc(cfn, public):
+    """Validate that we can provide a VPC and IGW to create networking in Public networking."""
+    vpc_id = _stack_output(cfn, public, "VpcId")
+    igw_id = _stack_output(cfn, public, "InternetGatewayId")
+
+    # Create a new stack using existing VPC / IGW
+    stack_name = f"{public}-2"
+    vpc_gen = _create_vpc(cfn, stack_name, PUBLIC_TEMPLATE, public_cidr="10.0.0.16/28", vpc_id=vpc_id, igw_id=igw_id)
+    next(vpc_gen)
+    new_vpc_id = _stack_output(cfn, stack_name, "VpcId")
+    assert_that(new_vpc_id).is_equal_to(vpc_id)
+    next(vpc_gen, None)  # Release vpc to have it reaped

--- a/cloudformation/tests/test_policies.py
+++ b/cloudformation/tests/test_policies.py
@@ -1,28 +1,11 @@
 """Test the CloudFormation Template for policies."""
-import random
-import string
 
-import boto3
 import botocore
 import pytest
 from assertpy import assert_that
 from cfn_flip import load_yaml
 
 TEMPLATE = "../policies/parallelcluster-policies.yaml"
-
-
-@pytest.fixture(name="random_stack_name")
-def random_stack_name_fixture():
-    """Provide a short random id that can be used in a aack name."""
-    alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
-    return "".join(random.choice(alnum) for _ in range(8))
-
-
-@pytest.fixture(scope="session", name="cfn")
-def cfn_fixture():
-    """Create a CloudFormation Boto3 client."""
-    client = boto3.client("cloudformation")
-    return client
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of changes
* This change adds the ability to specify a VPC and InternetGatewayId, or not -- if not specified then the VPC will be created.
* This allows the stack to more easily be used in a manner where the VPC is created (as can be done in `pcluster config` however doing-so without the CLI which is beneficial in library / lambda / cfn types of integrations).

### Tests
Added tests that can be run locally which create the stack with and without an external VPC:
```
============================================================ test session starts ============================================================
platform linux -- Python 3.10.10, pytest-7.2.1, pluggy-1.0.0
rootdir: /home/ANT.AMAZON.COM/[REDACTED]/src/aws-parallelcluster/cloudformation/tests, configfile: pytest.ini
plugins: typeguard-2.13.3
collected 4 items

test_networking.py ....

======================================== 4 passed in 1323.11s (0:22:03) =====================================================================
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
