### PR TITLE
Fix integration test: add alarm actions to permission boundary of the iam integration test

### DIFF
--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -587,6 +587,9 @@ def _create_permission_boundary(permission_boundary_name):
                         "cloudwatch:ListDashboards",
                         "cloudwatch:DeleteDashboards",
                         "cloudwatch:GetDashboard",
+                        "cloudwatch:PutMetricAlarm",
+                        "cloudwatch:DeleteAlarms",
+                        "cloudwatch:DescribeAlarms",
                     ],
                     "Condition": {
                         "Fn::If": [


### PR DESCRIPTION
### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
