### PR TITLE
[Isolated Regions] Add integration tests configuration for US isolated regions: 'isolated_regions.yaml' and CHANGELOG fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 3.5.1
 -----
+**ENHANCEMENTS**
 - Add support for US isolated regions: us-iso-* and us-isob-*.
 
 3.5.0

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -1,0 +1,76 @@
+{%- import 'common.jinja2' as common with context -%}
+{%- set REGIONS = ["us-isob-east-1"] -%}
+{%- set INSTANCES = ["c5.xlarge"] -%}
+{%- set OSS = ["alinux2"] -%}
+{%- set SCHEDULERS = ["slurm"] -%}
+---
+test-suites:
+  cli_commands:
+    test_cli_commands.py::test_slurm_cli_commands:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+  cloudwatch_logging:
+    test_cloudwatch_logging.py::test_cloudwatch_logging:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+  configure:
+    test_pcluster_configure.py::test_pcluster_configure:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+  dashboard:
+    test_dashboard.py::test_dashboard:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+  dns:
+    test_dns.py::test_hit_no_cluster_dns_mpi:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+  iam:
+    test_iam.py::test_iam_policies:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+  resource_bucket:
+    test_resource_bucket.py::test_resource_bucket:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+  scaling:
+    test_mpi.py::test_mpi:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+  storage:
+    test_efs.py::test_efs_compute_az:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+    test_ebs.py::test_ebs_multiple:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}


### PR DESCRIPTION
### Description of changes
* Add integration tests configuration for US isolated regions: 'isolated_regions.yaml'.
* Fix CHANGELOG for 3.5.1: declaring the support for US isolated regions as an enhancement.

Notes: on the long run US isolated regions will be validated with more integration tests, but for the time being the ones proposed in this PR are those considered valuable by the team.

### Tests
* Integ test configuration is the one currently used to validate changes in us-isob-east-1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
