### PR TITLE
[Multi User] Add support for AD password as SSM Parameter.

### DIFF
--- a/cli/src/pcluster/aws/aws_api.py
+++ b/cli/src/pcluster/aws/aws_api.py
@@ -25,6 +25,7 @@ from pcluster.aws.route53 import Route53Client
 from pcluster.aws.s3 import S3Client
 from pcluster.aws.s3_resource import S3Resource
 from pcluster.aws.secretsmanager import SecretsManagerClient
+from pcluster.aws.ssm import SsmClient
 from pcluster.aws.sts import StsClient
 
 
@@ -58,6 +59,7 @@ class AWSApi:
         self._logs = None
         self._route53 = None
         self._secretsmanager = None
+        self._ssm = None
         self._resource_groups = None
 
     @property
@@ -164,6 +166,13 @@ class AWSApi:
         if not self._secretsmanager:
             self._secretsmanager = SecretsManagerClient()
         return self._secretsmanager
+
+    @property
+    def ssm(self):
+        """SSM client."""
+        if not self._ssm:
+            self._ssm = SsmClient()
+        return self._ssm
 
     @property
     def resource_groups(self):

--- a/cli/src/pcluster/aws/ssm.py
+++ b/cli/src/pcluster/aws/ssm.py
@@ -1,0 +1,28 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from pcluster.aws.common import AWSExceptionHandler, Boto3Client
+
+
+class SsmClient(Boto3Client):
+    """SSM Boto3 client."""
+
+    def __init__(self):
+        super().__init__("ssm")
+
+    @AWSExceptionHandler.handle_client_exception
+    def get_parameter(self, name: str):
+        """
+        Retrieve a Parameter.
+
+        :param name: Parameter name.
+        :return: Parameter info
+        """
+        return self._client.get_parameter(Name=name)

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1945,7 +1945,7 @@ class DirectoryServiceSchema(BaseSchema):
     domain_addr = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
     password_secret_arn = fields.Str(
         required=True,
-        validate=validate.Regexp(r"^arn:.*:secret"),
+        validate=validate.Regexp(r"^arn:.*:(secretsmanager:.*:.*:secret:|ssm:.*:.*:parameter\/).*$"),
         metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP},
     )
     domain_read_only_user = fields.Str(required=True, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -9,6 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from datetime import datetime
 
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.aws_resources import FsxFileSystemInfo, InstanceTypeInfo
@@ -26,6 +27,7 @@ from pcluster.aws.route53 import Route53Client
 from pcluster.aws.s3 import S3Client
 from pcluster.aws.s3_resource import S3Resource
 from pcluster.aws.secretsmanager import SecretsManagerClient
+from pcluster.aws.ssm import SsmClient
 from pcluster.aws.sts import StsClient
 
 
@@ -105,6 +107,7 @@ class _DummyAWSApi(AWSApi):
         self._route53 = _DummyRoute53Client()
         self._resource_groups = _DummyResourceGroupsClient()
         self._secretsmanager = _DummySecretsManagerClient()
+        self._ssm = _DummySsmClient()
 
 
 class _DummyCfnClient(CfnClient):
@@ -340,6 +343,25 @@ class _DummySecretsManagerClient(SecretsManagerClient):
             "Tags": [],
             "VersionIdsToStages": {"12345678-1234-abcd-1234-567890abcdef": ["AWSCURRENT"]},
             "CreatedDate": "2022-08-01T10:00:00+00:00",
+        }
+
+
+class _DummySsmClient(SsmClient):
+    def __init__(self):
+        """Override parent constructor. No real boto3 client is created."""
+        self._client = None
+
+    def get_parameter(self, parameter_name):
+        return {
+            "Parameter": {
+                "Name": parameter_name,
+                "Type": "SecureString",
+                "Value": "EncryptedValue",
+                "Version": 1,
+                "LastModifiedDate": datetime(2023, 3, 3),
+                "ARN": f"arn:aws:ssm:us-east-1:111111111111:parameter/{parameter_name}",
+                "DataType": "text",
+            }
         }
 
 

--- a/cli/tests/pcluster/aws/test_ssm.py
+++ b/cli/tests/pcluster/aws/test_ssm.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.aws.ssm import SsmClient
+from tests.utils import MockedBoto3Request
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    return "pcluster.aws.common.boto3"
+
+
+def test_get_parameter(boto3_stubber):
+    parameter_name = "mocked_parameter_name"
+    expected_response = {
+        "Parameter": {
+            "Name": parameter_name,
+            "Type": "string",
+            "Value": "string",
+            "Version": 123,
+            "LastModifiedDate": datetime(2023, 3, 3),
+            "ARN": "string",
+            "DataType": "string",
+        }
+    }
+    mocked_requests = [
+        MockedBoto3Request(
+            method="get_parameter",
+            expected_params={"Name": parameter_name},
+            response=expected_response,
+            generate_error=False,
+            error_code=None,
+        ),
+    ]
+    boto3_stubber("ssm", mocked_requests)
+    actual_response = SsmClient().get_parameter(parameter_name)
+    assert_that(actual_response).is_equal_to(expected_response)

--- a/cli/tests/pcluster/templates/test_directory_service.py
+++ b/cli/tests/pcluster/templates/test_directory_service.py
@@ -21,12 +21,33 @@ from tests.pcluster.utils import get_head_node_policy, get_statement_by_sid
 
 
 @pytest.mark.parametrize(
-    "config_file_name",
+    "config_file_name, head_node_permissions",
     [
-        ("config.yaml"),
+        pytest.param(
+            "config.yaml",
+            [
+                {
+                    "Sid": "AllowGettingDirectorySecretValue",
+                    "Action": "secretsmanager:GetSecretValue",
+                    "Resource": "arn:aws:secretsmanager:eu-west-1:123456789:secret:a-secret-name",
+                }
+            ],
+            id="DirectoryService with PasswordSecretArn as Secret in Secrets Manager",
+        ),
+        pytest.param(
+            "config-ssm.yaml",
+            [
+                {
+                    "Sid": "AllowGettingDirectorySecretValue",
+                    "Action": "ssm:GetParameter",
+                    "Resource": "arn:aws:ssm:eu-west-1:123456789:parameter/a-parameter-name",
+                }
+            ],
+            id="DirectoryService with PasswordSecretArn as Parameter in SSM",
+        ),
     ],
 )
-def test_head_node_permissions(mocker, test_datadir, config_file_name):
+def test_head_node_permissions(mocker, test_datadir, config_file_name, head_node_permissions):
     mock_aws_api(mocker)
 
     input_yaml = load_yaml_dict(test_datadir / config_file_name)
@@ -38,7 +59,9 @@ def test_head_node_permissions(mocker, test_datadir, config_file_name):
     )
 
     head_node_policy = get_head_node_policy(generated_template)
-    statement = get_statement_by_sid(policy=head_node_policy, sid="AllowGettingDirectorySecretValue")
-    assert_that(statement["Effect"]).is_equal_to("Allow")
-    assert_that(statement["Action"]).is_equal_to("secretsmanager:GetSecretValue")
-    assert_that(statement["Resource"]).is_equal_to("arn:aws:secretsmanager:eu-west-1:123456789:secret:a-secret-name")
+
+    for head_node_permission in head_node_permissions:
+        statement = get_statement_by_sid(policy=head_node_policy, sid=head_node_permission["Sid"])
+        assert_that(statement["Effect"]).is_equal_to("Allow")
+        assert_that(statement["Action"]).is_equal_to(head_node_permission["Action"])
+        assert_that(statement["Resource"]).is_equal_to(head_node_permission["Resource"])

--- a/cli/tests/pcluster/templates/test_directory_service/test_head_node_permissions/config-ssm.yaml
+++ b/cli/tests/pcluster/templates/test_directory_service/test_head_node_permissions/config-ssm.yaml
@@ -1,0 +1,22 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+DirectoryService:
+  DomainName: corp.something.com
+  DomainAddr: ldaps://corp.something.com
+  PasswordSecretArn: arn:aws:ssm:eu-west-1:123456789:parameter/a-parameter-name
+  DomainReadOnlyUser: cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=something,dc=com
+  LdapTlsCaCert: /path/to/domain-certificate.crt

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -498,6 +498,16 @@ Resources:
             Resource: '*'
             Effect: Allow
             Sid: ResourceGroupRead
+          - Action:
+              - !Sub arn:${AWS::Partition}:secretsmanager:${Region}:${AWS::AccountId}:secret:*
+            Resource: '*'
+            Effect: Allow
+            Sid: DirectoryServicePasswordReadFromSecretsManager
+          - Action:
+              - !Sub arn:${AWS::Partition}:ssm:${Region}:${AWS::AccountId}:parameter/
+            Resource: '*'
+            Effect: Allow
+            Sid: DirectoryServicePasswordReadFromSsm
 
   ### IMAGE ACTIONS POLICIES
 


### PR DESCRIPTION
### Description of changes
Add support for AD password as SSM Parameter.
With this extension we will be able to provide the multi-user feature in those regions where Secrets Manager is not supported, but SSM is.

#### Customer Experience
With this change the customer will be able to specify the AD password in [DirectoryService/PasswordSecretArn](https://docs.aws.amazon.com/parallelcluster/latest/ug/DirectoryService-v3.html#yaml-DirectoryService-PasswordSecretArn) both as a secret in Secrets Manager (current behaviour) and a parameter in SSM.

### Tests
* Cluster creation + AD user login with AD password specified as a secret in Secrets Manager.
* Cluster creation + AD user login with AD password specified as a parameter in SSM.
* Unhappy validation cases

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>