### PR TITLE
[Integ-tests] Improve integration tests ARNs to be compatible with other AWS partitions

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -21,6 +21,7 @@ from framework.credential_providers import run_pcluster_command
 from retrying import retry
 from utils import (
     dict_add_nested_key,
+    get_arn_partition,
     get_stack_id_tag_filter,
     kebab_case,
     retrieve_cfn_outputs,
@@ -49,6 +50,7 @@ class Cluster:
         self.config_file = config_file
         self.ssh_key = ssh_key
         self.region = region
+        self.partition = get_arn_partition(region)
         with open(config_file, encoding="utf-8") as conf_file:
             self.config = yaml.safe_load(conf_file)
         self.has_been_deleted = False

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -765,6 +765,7 @@ def _get_default_template_values(vpc_stack, request):
     """Build a dictionary of default values to inject in the jinja templated cluster configs."""
     default_values = get_vpc_snakecase_value(vpc_stack)
     default_values.update({dimension: request.node.funcargs.get(dimension) for dimension in DIMENSIONS_MARKER_ARGS})
+    default_values["partition"] = get_arn_partition(default_values["region"])
     default_values["key_name"] = request.config.getoption("key_name")
 
     if default_values.get("scheduler") in request.config.getoption("tests_config", default={}).get(

--- a/tests/integration-tests/tests/cli_commands/test_cli_commands.py
+++ b/tests/integration-tests/tests/cli_commands/test_cli_commands.py
@@ -310,13 +310,13 @@ def _test_pcluster_export_cluster_logs(s3_bucket_factory, cluster):
             {
                 "Action": "s3:GetBucketAcl",
                 "Effect": "Allow",
-                "Resource": f"arn:aws:s3:::{bucket_name}",
+                "Resource": f"arn:{cluster.partition}:s3:::{bucket_name}",
                 "Principal": {"Service": f"logs.{cluster.region}.amazonaws.com"},
             },
             {
                 "Action": "s3:PutObject",
                 "Effect": "Allow",
-                "Resource": f"arn:aws:s3:::{bucket_name}/*",
+                "Resource": f"arn:{cluster.partition}:s3:::{bucket_name}/*",
                 "Condition": {"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}},
                 "Principal": {"Service": f"logs.{cluster.region}.amazonaws.com"},
             },

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -377,9 +377,10 @@ def build_image_custom_resource(cfn_stacks_factory, region, request):
         custom_resource_template.set_description("Create build image custom resource stack")
 
         # Create a instance role
+        partition = get_arn_partition(region)
         managed_policy_arns = [
-            "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
-            "arn:aws:iam::aws:policy/EC2InstanceProfileForImageBuilder",
+            f"arn:{partition}:iam::aws:policy/AmazonSSMManagedInstanceCore",
+            f"arn:{partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder",
         ]
 
         policy_document = iam.Policy(

--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -24,7 +24,7 @@ from remote_command_executor import RemoteCommandExecutor
 from s3_common_utils import check_s3_read_resource, check_s3_read_write_resource, get_policy_resources
 from troposphere.iam import ManagedPolicy
 from troposphere.template_generator import TemplateGenerator
-from utils import generate_stack_name, wait_for_computefleet_changed
+from utils import generate_stack_name, get_arn_partition, wait_for_computefleet_changed
 
 from tests.common.assertions import assert_no_errors_in_logs
 from tests.schedulers.test_awsbatch import _test_job_submission as _test_job_submission_awsbatch
@@ -291,7 +291,9 @@ def _get_resource_name_from_resource_arn(resource_arn):
 @pytest.mark.usefixtures("os", "instance")
 def test_iam_policies(region, scheduler, pcluster_config_reader, clusters_factory):
     """Test IAM Policies"""
-    cluster_config = pcluster_config_reader(iam_policies=["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"])
+    cluster_config = pcluster_config_reader(
+        iam_policies=[f"arn:{get_arn_partition(region)}:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+    )
     cluster = clusters_factory(cluster_config)
     remote_command_executor = RemoteCommandExecutor(cluster)
 
@@ -365,7 +367,7 @@ def test_iam_resource_prefix(
             )
 
             cluster = clusters_factory(cluster_config, custom_cli_credentials=creds)
-            _test_iam_resource_in_cluster(cfn_client, iam_client, cluster.name, iam_resource_prefix)
+            _test_iam_resource_in_cluster(region, cfn_client, iam_client, cluster.name, iam_resource_prefix)
 
 
 def _update_paramters_and_conditions(parameters, conditions, iam_path, iam_name_prefix):
@@ -703,11 +705,11 @@ def _split_resource_prefix(resource_prefix):
     return None, None
 
 
-def _check_iam_resource_prefix(resource_arn_list, iam_resource_prefix):
+def _check_iam_resource_prefix(region, resource_arn_list, iam_resource_prefix):
     """Check the path and name of IAM resource ( Roles, policy and Instance profiles)."""
     iam_path, iam_name_prefix = _split_resource_prefix(iam_resource_prefix)
     for resource in resource_arn_list:
-        if "arn:aws:iam:" in resource:
+        if f"arn:{get_arn_partition(region)}:iam:" in resource:
             if iam_path:
                 assert_that(resource).contains(iam_path)
             else:
@@ -716,7 +718,7 @@ def _check_iam_resource_prefix(resource_arn_list, iam_resource_prefix):
             assert_that(resource).contains(iam_name_prefix)
 
 
-def _test_iam_resource_in_cluster(cfn_client, iam_client, stack_name, iam_resource_prefix):
+def _test_iam_resource_in_cluster(region, cfn_client, iam_client, stack_name, iam_resource_prefix):
     """Test IAM resources by checking the path and name prefix in AWS IAM and check cluster is created."""
 
     # Check for cluster Status
@@ -741,7 +743,7 @@ def _test_iam_resource_in_cluster(cfn_client, iam_client, stack_name, iam_resour
                     "Arn"
                 ]
             )
-    _check_iam_resource_prefix(resource_arn_list, iam_resource_prefix)
+    _check_iam_resource_prefix(region, resource_arn_list, iam_resource_prefix)
 
 
 @pytest.fixture(scope="class")

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update.yaml
@@ -8,7 +8,7 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
 Scheduling:
   Scheduler: slurm
   SlurmQueues:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update_scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_config_update/pcluster.config.update_scheduling.yaml
@@ -8,7 +8,7 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
 Scheduling:
   Scheduler: slurm
   SlurmQueues:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
@@ -8,7 +8,7 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
 Scheduling:
   Scheduler: slurm
   SlurmSettings:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
@@ -8,7 +8,7 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
 Scheduling:
   Scheduler: slurm
   SlurmSettings:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
@@ -8,7 +8,7 @@ HeadNode:
     KeyName: {{ key_name }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
 Scheduling:
   Scheduler: slurm
   SlurmQueues:

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -351,7 +351,12 @@ def assert_subnet_az_relations_from_config(
 
     if expected_in_same_az:
         assert_that(set(cluster_avail_zones)).is_length(1)
+    # If caller does not expect same az, we expect more availability zones.
+    elif "-iso" in region:
+        # For isolated regions, we only impose a weak check to make sure there are two or more availability zones.
+        assert_that(len(set(cluster_avail_zones))).is_greater_than_or_equal_to(2)
     else:
+        # For other regions, we impose a strong check to make sure each subnet is in a different availability zone.
         assert_that(len(set(cluster_avail_zones))).is_equal_to(len(cluster_avail_zones))
 
 

--- a/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ephemeral/test_head_node_stop/pcluster.config.yaml
@@ -13,7 +13,7 @@ HeadNode:
       MountDir: {{ head_ephemeral_mount }}
   Iam:
     AdditionalIamPolicies:
-      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+      - Policy: arn:{{partition}}:iam::aws:policy/AmazonSSMManagedInstanceCore
 Scheduling:
   Scheduler: {{ scheduler }}
   {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -145,7 +145,9 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     job_id = slurm_commands.assert_job_submitted(result.stdout)
 
     # Update cluster with new configuration
-    additional_policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonAppStreamServiceAccess"
+    additional_policy_arn = (
+        f"arn:{utils.get_arn_partition(region)}:iam::aws:policy/service-role/AmazonAppStreamServiceAccess"
+    )
     updated_config_file = pcluster_config_reader(
         config_file="pcluster.config.update.yaml",
         output_file="pcluster.config.update.successful.yaml",


### PR DESCRIPTION
### Description of changes
See commit descriptions for details

### Tests
The following integration tests have been passed
```
{%- import 'common.jinja2' as common -%}
{%- set NEW_REGION = ["us-east-1"] -%}
---
test-suites:
  cli_commands:
    test_cli_commands.py::test_slurm_cli_commands:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  iam:
    test_iam.py::test_iam_policies:
      dimensions:
        - regions: {{ NEW_REGION }}
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_iam.py::test_iam_resource_prefix:
      dimensions:
        - regions: [ "eu-north-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2" ]
          schedulers: [ "slurm" ]
  schedulers:
    test_slurm.py::test_slurm_config_update:
      dimensions:
        - regions: ["ap-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_slurm.py::test_slurm_memory_based_scheduling:
      dimensions:
        - regions: ["ap-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  storage:
    test_ephemeral.py::test_head_node_stop:
      dimensions:
        - regions: ["us-east-1"]
          instances: ["m5d.xlarge", "h1.2xlarge"]
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_efs.py::test_efs_compute_az:
      dimensions:
        - regions: ["eu-west-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
