### PR TITLE
[develop] Change fixture scope in test_ad_integration

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -142,7 +142,7 @@ def zip_dir(path):
     return file_out
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="class")
 def store_secret_in_secret_manager(request, cfn_stacks_factory):
     secret_arns = {}
 
@@ -356,7 +356,7 @@ def _delete_certificate(certificate_arn, region):
     boto3.client("acm", region_name=region).delete_certificate(CertificateArn=certificate_arn)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="class")
 def directory_factory(request, cfn_stacks_factory, vpc_stack, store_secret_in_secret_manager):  # noqa: C901
     # TODO: use external data file and file locking in order to share directories across processes
     created_directory_stacks = defaultdict(dict)


### PR DESCRIPTION
With AZ Override changes, vpc_stack is created with class scope. To avoid scope mismatch issues we are also changing the scope of the fixture in ad_integration.

### Description of changes
* Change fixture scope in test_ad_integration
With AZ Override changes, vpc_stack is created with class scope. 
To avoid scope mismatch issues we are also changing the scope of the fixture in ad_integration.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
