### PR TITLE
Add rhel8 tests to redhat8.yaml config file

### DIFF
--- a/tests/integration-tests/configs/redhat8.yaml
+++ b/tests/integration-tests/configs/redhat8.yaml
@@ -1,4 +1,8 @@
 {%- import 'common.jinja2' as common with context -%}
+{%- set OSS_COMMERCIAL_X86_RH8 = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
+{%- set OSS_COMMERCIAL_ARM_RH8 = ["alinux2", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
+{%- set OSS_ONE_PER_DISTRO_RH8 = ["centos7", "alinux2", "ubuntu1804", "rhel8"] -%}
+
 ---
 test-suites:
   ad_integration:
@@ -26,7 +30,7 @@ test-suites:
       dimensions:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu1804"]
+          oss: ["ubuntu1804", "rhel8"]
           schedulers: ["slurm"]
   cloudwatch_logging:
     test_cloudwatch_logging.py::test_cloudwatch_logging:
@@ -46,14 +50,14 @@ test-suites:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_ONE_PER_DISTRO }}
+          oss: {{ common.OSS_ONE_PER_DISTRO_RH8 }}
           schedulers: ["slurm"]
   createami:
     test_createami.py::test_build_image:
       dimensions:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2", "ubuntu2004", "centos7"]
+          oss: ["alinux2", "ubuntu2004", "centos7", "rhel8"]
     test_createami.py::test_kernel4_build_image_run_cluster:
       dimensions:
         - regions: ["eu-south-1"]
@@ -78,7 +82,7 @@ test-suites:
       dimensions:
         - regions: ["us-west-1"]
           instances: ["m4.xlarge"]
-          oss: ["alinux2", "centos7"]
+          oss: ["alinux2", "centos7", "rhel8"]
           schedulers: ["slurm"]
           benchmarks:
             - mpi_variants: [ "openmpi", "intelmpi" ]
@@ -91,22 +95,22 @@ test-suites:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
   efa:
     test_efa.py::test_efa:
       dimensions:
         - regions: ["sa-east-1"]
           instances: ["c5n.9xlarge"]
-          oss: ["alinux2"]
+          oss: ["alinux2", "rhel8"]
           schedulers: ["slurm"]
         - regions: ["us-east-1"]
           instances: ["p4d.24xlarge"]
-          oss: ["alinux2"]
+          oss: ["alinux2", "rhel8"]
           schedulers: ["slurm"]
         - regions: ["us-east-1"]
           instances: ["c6gn.16xlarge"]
-          oss: ["ubuntu1804", "ubuntu2004"]
+          oss: ["ubuntu2004", "rhel8"]
           schedulers: ["slurm"]
   intel_hpc:
     test_intel_hpc.py::test_intel_hpc:
@@ -120,7 +124,7 @@ test-suites:
       dimensions:
         - regions: ["me-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["centos7"]
+          oss: ["centos7", "rhel8"]
           schedulers: ["slurm"]
     test_cluster_networking.py::test_cluster_in_no_internet_subnet:
       dimensions:
@@ -128,30 +132,30 @@ test-suites:
           # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: ["rhel8"]
           schedulers: ["slurm"]
     test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
       dimensions:
         - regions: [ "us-west-2" ]
-          oss: [ "alinux2" ]
+          oss: [ "alinux2", "rhel8"]
   scaling:
     test_mpi.py::test_mpi:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM_RH8 }}
           schedulers: ["slurm"]
     test_mpi.py::test_mpi_ssh:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
   schedulers:
     test_awsbatch.py::test_awsbatch:
@@ -164,23 +168,23 @@ test-suites:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_pmix:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
         - regions: ["ap-northeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM_RH8 }}
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_scaling:
       dimensions:
         - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_ONE_PER_DISTRO }}
+          oss: {{ common.OSS_ONE_PER_DISTRO_RH8 }}
           schedulers: ["slurm"]
   storage:
     # Commercial regions that can't test FSx: ap-northeast-1, ap-southeast-1, ap-southeast-2, eu-central-1, eu-north-1, eu-west-1, eu-west-2, us-east-1, us-east-2, us-west-1, us-west-2
@@ -188,11 +192,11 @@ test-suites:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["centos7"]
+          oss: ["centos7", "rhel8"]
           schedulers: ["slurm"]
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["ubuntu2004"]
+          oss: ["ubuntu2004", "rhel8"]
           schedulers: ["slurm"]
     # The checks performed in test_multiple_fsx is the same as test_fsx_lustre.
     # We should consider this when assigning dimensions to each test.
@@ -200,7 +204,7 @@ test-suites:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM_RH8 }}
           schedulers: ["slurm"]
           benchmarks:
             - mpi_variants: [ "openmpi", "intelmpi" ]
@@ -212,13 +216,13 @@ test-suites:
       dimensions:
         - regions: ["us-east-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: ["alinux2", "rhel8"]
           schedulers: ["slurm"]
     test_efs.py::test_multiple_efs:
       dimensions:
         - regions: [ "eu-west-2" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM_RH8 }}
           schedulers: [ "slurm" ]
           benchmarks:
             - mpi_variants: [ "openmpi", "intelmpi" ]
@@ -230,62 +234,62 @@ test-suites:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_multiple:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu1804"]
+          oss: ["ubuntu1804", "rhel8"]
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_existing:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["centos7"]
+          oss: ["centos7", "rhel8"]
           schedulers: ["slurm"]
     # Ephemeral test requires instance type with instance store
     test_ephemeral.py::test_head_node_stop:
       dimensions:
         - regions: ["us-east-1"]
           instances: ["m5d.xlarge", "h1.2xlarge"]
-          oss: ["alinux2"]
+          oss: ["alinux2", "rhel8"]
           schedulers: ["slurm"]
   update:
     test_update.py::test_update_slurm:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["ubuntu2204", "rhel8"]
     test_update.py::test_update_compute_ami:
       dimensions:
         - regions: ["eu-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: ["centos7", "rhel8"]
     test_update.py::test_update_instance_list:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: ["alinux2", "rhel8"]
           schedulers: ["slurm"]
     test_update.py::test_queue_parameters_update:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
+          oss: ["alinux2", "rhel8"]
           schedulers: ["slurm"]
     test_update.py::test_dynamic_file_systems_update:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["ubuntu1804", "rhel8"]
           schedulers: ["slurm"]
         - regions: ["ap-northeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          oss: ["ubuntu1804", "rhel8"]
           schedulers: ["slurm"]
     test_update.py::test_multi_az_create_and_update:
       dimensions:
         - regions: [ "eu-west-2" ]
           schedulers: [ "slurm" ]
-          oss: ["alinux2"]
+          oss: ["alinux2", "rhel8"]


### PR DESCRIPTION
In future we need to enable not yet supported features like:
* test_ad_integration
* test_dcv
* test_cloudwatch_logging
* test_arm_pl

Reduced number of "update" tests.