### PR TITLE
[Isolated Regions] Move logic to configure an instance for US isolated regions     from CloudInit x-shellscript phase to CloudInit cloud-boothook phase.

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -35,6 +35,13 @@ export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
 PROXY
 fi
 
+# Configure Amazon Linux 2 instance running in US isolated region.
+. /etc/os-release
+if [[ "${!ID}${!VERSION_ID}" == "amzn2" && "${AWS::Region}" == us-iso* ]]; then
+  configuration_script="/opt/parallelcluster/scripts/patch-iso-instance.sh"
+  [ -f ${!configuration_script} ] && bash ${!configuration_script}
+fi
+
 --==BOUNDARY==
 Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0
@@ -148,12 +155,8 @@ write_files:
       }
       [ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh
 
-      # Configure Amazon Linux 2 instance running in US isolated region.
-      . /etc/os-release
-      if [[ "${!ID}${!VERSION_ID}" == "amzn2" && "${AWS::Region}" == us-iso* ]]; then
-        configuration_script="/opt/parallelcluster/scripts/patch-iso-instance.sh"
-        [[ -f ${!configuration_script} ]] && bash ${!configuration_script} "${AWS::Region}" && . ~/.bash_profile
-      fi
+      # Configure AWS CLI using the expected overrides, if any.
+      [ -f /etc/profile.d/aws-cli-default-config.sh ] && . /etc/profile.d/aws-cli-default-config.sh
 
       custom_cookbook=${CustomChefCookbook}
       export _region=${AWS::Region}

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -35,6 +35,13 @@ export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
 PROXY
 fi
 
+# Configure Amazon Linux 2 instance running in US isolated region.
+. /etc/os-release
+if [[ "${!ID}${!VERSION_ID}" == "amzn2" && "${AWS::Region}" == us-iso* ]]; then
+  configuration_script="/opt/parallelcluster/scripts/patch-iso-instance.sh"
+  [ -f ${!configuration_script} ] && bash ${!configuration_script}
+fi
+
 --==BOUNDARY==
 Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0
@@ -88,12 +95,8 @@ function vendor_cookbook
 }
 [ -f /etc/profile.d/proxy.sh ] && . /etc/profile.d/proxy.sh
 
-# Configure Amazon Linux 2 instance running in US isolated region.
-. /etc/os-release
-if [[ "${!ID}${!VERSION_ID}" == "amzn2" && "${AWS::Region}" == us-iso* ]]; then
-  configuration_script="/opt/parallelcluster/scripts/patch-iso-instance.sh"
-  [[ -f ${!configuration_script} ]] && bash ${!configuration_script} "${AWS::Region}" && . ~/.bash_profile
-fi
+# Configure AWS CLI using the expected overrides, if any.
+[ -f /etc/profile.d/aws-cli-default-config.sh ] && . /etc/profile.d/aws-cli-default-config.sh
 
 # deploy config files
 export PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/aws/bin


### PR DESCRIPTION
### Description of changes
Move logic to configure an instance for US isolated regions from **CloudInit x-shellscript phase** to **CloudInit cloud-boothook phase**.

This change is critical for ParallelCluster to work in US Isolated regions because the actions executed by the script `patch-iso-instance.sh` must be executed as soon as possible, i.e. before services using AWS endpoints gets started.

Furthermore, the file `/etc/profile.d/aws-cli-default-config.sh`, which is generated as part of the instance patching must be sourced in the CloudInit x-shellscript phase to make the cookbook execution inherit the correct environment.

### Tests
* Cluster creation (Commercial and US ISO)
* Cluster update (Commercial and US ISO)
* Job submission with job script interacting with AWS endpoints (Commercial and US ISO)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
