### PR TITLE
[Isolated Regions] Fix resolution of CloudFormation endpoint, that is injected into the head node user data.

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -914,7 +914,7 @@ class ClusterCdkStack:
                 )
             )
 
-        cloudformation_url = get_service_endpoint("cloudformation", self.stack.region)
+        cloudformation_url = get_service_endpoint("cloudformation", self.config.region)
 
         # Head node Launch Template
         head_node_launch_template = ec2.CfnLaunchTemplate(


### PR DESCRIPTION
### Description of changes
Fix resolution of CloudFormation endpoint, that is injected into the head node user data.

This fix prevents the wrong resolution of CloudFormation endpoint in regions other than Commercial.
In particular, the bug that we want to fix was making every endpoint to be in the `amazonaws.com` domain even for not Commercial regions. 

Example of this bug behaviour:

```
https://cloudformation.us-isob-east-1.amazonaws.com
```

Example of the correct resolution after the fix:

```
https://cloudformation.us-isob-east-1.sc2s.sgov.gov
```

The root cause is that when the CDK template is built, every variable in `self.stack` is actually a CDK Token and not a concrete value. So every region is resolved as a string like `${Token[AWS.Region.N]}` that makes our endpoint resolver to fallback to the default domain, that is the one for Commercial.

The fix consists in using the concrete value for the region. In fact `self.config.region` a string containing the conrete region value, e.g. eu-west-1, thus making the resolve behave as expected.

### Tests
* Cluster creation (also with the debugger to spot the bug)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
