### PR TITLE
[Isolated Regions] [Test] Make EBS settings in cluster configurations compatible with US isolated regions.

### DIFF
--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_arm64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_arm64.yaml
@@ -23,10 +23,10 @@
       EphemeralVolume: null
       RootVolume:
         Encrypted: true
-        Iops: 3000
         Size: null
-        Throughput: 125
-        VolumeType: gp3
+        VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
+        Throughput: { % if "-iso" in region % }null{ % else % }125{ % endif % }
+        Iops: { % if "-iso" in region % }null{ % else % }3000{ % endif % }
   CustomActions: null
   CustomSettings: null
   Iam:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_x86_64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_x86_64.yaml
@@ -23,10 +23,10 @@
       EphemeralVolume: null
       RootVolume:
         Encrypted: true
-        Iops: 3000
         Size: null
-        Throughput: 125
-        VolumeType: gp3
+        VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
+        Throughput: { % if "-iso" in region % }null{ % else % }125{ % endif % }
+        Iops: { % if "-iso" in region % }null{ % else % }3000{ % endif % }
   CustomActions: null
   CustomSettings: null
   Iam:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_arm64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_arm64.yaml
@@ -40,10 +40,10 @@
       EphemeralVolume: null
       RootVolume:
         Encrypted: true
-        Iops: 3000
         Size: null
-        Throughput: 125
-        VolumeType: gp3
+        VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
+        Throughput: { % if "-iso" in region % }null{ % else % }125{ % endif % }
+        Iops: { % if "-iso" in region % }null{ % else % }3000{ % endif % }
   CustomActions: null
   CustomSettings: null
   Iam:
@@ -91,8 +91,8 @@
         Encrypted: true
         Iops: 3000
         Size: null
-        Throughput: 125
-        VolumeType: gp3
+        VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
+        Throughput: { % if "-iso" in region % }null{ % else % }130{ % endif % }
   CustomActions: null
   CustomSettings: null
   Iam:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_x86_64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_x86_64.yaml
@@ -40,10 +40,10 @@
       EphemeralVolume: null
       RootVolume:
         Encrypted: true
-        Iops: 3000
         Size: null
-        Throughput: 125
-        VolumeType: gp3
+        VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
+        Throughput: { % if "-iso" in region % }null{ % else % }125{ % endif % }
+        Iops: { % if "-iso" in region % }null{ % else % }3000{ % endif % }
   CustomActions: null
   CustomSettings: null
   Iam:
@@ -91,8 +91,8 @@
         Encrypted: true
         Iops: 3000
         Size: null
-        Throughput: 125
-        VolumeType: gp3
+        VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
+        Throughput: { % if "-iso" in region % }null{ % else % }125{ % endif % }
   CustomActions: null
   CustomSettings: null
   Iam:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -9,9 +9,9 @@ HeadNode:
   LocalStorage:
     RootVolume:
       Encrypted: false # Test turning off root volume encryption
-      VolumeType: gp3
-      Iops: 3400
-      Throughput: 135
+      VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
+      Throughput: { % if "-iso" in region % }null{ % else % }135{ % endif % }
+      Iops: { % if "-iso" in region % }null{ % else % }3400{ % endif % }
   Imds:
     Secured: {{ imds_secured }}
 Scheduling:
@@ -23,9 +23,9 @@ Scheduling:
         LocalStorage:
           RootVolume:
             Encrypted: false  # Test turning off root volume encryption
-            VolumeType: gp3
-            Iops: 3200
-            Throughput: 130
+            VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
+            Throughput: { % if "-iso" in region % }null{ % else % }130{ % endif % }
+            Iops: { % if "-iso" in region % }null{ % else % }3200{ % endif % }
       {% endif %}
       ComputeResources:
         - Name: compute-resource-0
@@ -48,9 +48,9 @@ Scheduling:
         LocalStorage:
           RootVolume:
             Encrypted: false
-            VolumeType: gp3
-            Iops: 3200
-            Throughput: 130
+            VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
+            Throughput: { % if "-iso" in region % }null{ % else % }130{ % endif % }
+            Iops: { % if "-iso" in region % }null{ % else % }3200{ % endif % }
       ComputeResources:
         - Name: compute-resource-0
           Instances:
@@ -68,9 +68,9 @@ SharedStorage:
     EbsSettings:
       Iops: 3200
       Size: {{ volume_sizes[0] }}
-      VolumeType: gp3
+      VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
+      Throughput: { % if "-iso" in region % }null{ % else % }130{ % endif % }
       Encrypted: true
-      Throughput: 130
   - MountDir: {{ mount_dirs[1] }}
     Name: ebs2
     StorageType: Ebs

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_drain.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_drain.yaml
@@ -57,7 +57,7 @@ SharedStorage:
     Name: /manage-ebs
     StorageType: Ebs
     EbsSettings:
-      VolumeType: gp3
+      VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
       DeletionPolicy: {{ new_ebs_deletion_policy }}
   - MountDir: {{ existing_ebs_mount_dir }}
     Name: existing_ebs

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_rollback.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_rollback.yaml
@@ -45,7 +45,7 @@ SharedStorage:
     Name: {{ new_ebs_mount_dir }}
     StorageType: Ebs
     EbsSettings:
-      VolumeType: gp3
+      VolumeType: { % if "-iso" in region % }gp2{ % else % }gp3{ % endif % }
       DeletionPolicy: Delete
   - MountDir: {{ problematic_ebs_mount_dir }}
     Name: {{ problematic_ebs_mount_dir }}


### PR DESCRIPTION
### Description of changes
Make EBS settings in cluster configurations compatible with US isolated regions.
In particular, US isolated regions do not support VolumeType gp3 with Throughput and Iops specifications.

### Tests
* Verified EBS settings compatibility in us-isob-east-1.
* Full regression tests will be proven by authoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
