### PR TITLE
[Test] Fix IAM policy ParallelClusterClusterPolicy used by integration tests.

### DIFF
--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -498,14 +498,12 @@ Resources:
             Resource: '*'
             Effect: Allow
             Sid: ResourceGroupRead
-          - Action:
-              - !Sub arn:${AWS::Partition}:secretsmanager:${Region}:${AWS::AccountId}:secret:*
-            Resource: '*'
+          - Action: "secretsmanager:GetSecretValue"
+            Resource: !Sub arn:${AWS::Partition}:secretsmanager:${Region}:${AWS::AccountId}:secret:*
             Effect: Allow
             Sid: DirectoryServicePasswordReadFromSecretsManager
-          - Action:
-              - !Sub arn:${AWS::Partition}:ssm:${Region}:${AWS::AccountId}:parameter/
-            Resource: '*'
+          - Action: "ssm:GetParameter"
+            Resource: !Sub arn:${AWS::Partition}:ssm:${Region}:${AWS::AccountId}:parameter/*
             Effect: Allow
             Sid: DirectoryServicePasswordReadFromSsm
 


### PR DESCRIPTION
### Description of changes
Fix IAM policy ParallelClusterClusterPolicy used by integration tests.
In particular, fixed the statements:
1. DirectoryServicePasswordReadFromSecretsManager
2. DirectoryServicePasswordReadFromSsm

### Tests
* Will be tested by authoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

 Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>