### PR TITLE
Permit redhat8 integration tests to run

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -48,6 +48,7 @@ OS_TO_IMAGE_NAME_PART_MAP = {
     "centos7": "centos7-hvm",
     "ubuntu1804": "ubuntu-1804-lts-hvm",
     "ubuntu2004": "ubuntu-2004-lts-hvm",
+    "rhel8": "rhel8-hvm",
 }
 
 IMAGE_NAME_PART_TO_OS_MAP = {value: key for key, value in OS_TO_IMAGE_NAME_PART_MAP.items()}

--- a/tests/integration-tests/configs/redhat8.yaml
+++ b/tests/integration-tests/configs/redhat8.yaml
@@ -21,7 +21,7 @@ test-suites:
   arm_pl:
     test_arm_pl.py::test_arm_pl:
       dimensions:
-        - regions: ["ap-northeast-1"]
+        - regions: ["ap-southeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: {{ common.OSS_COMMERCIAL_ARM }}
           schedulers: ["slurm"]
@@ -176,7 +176,7 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
-        - regions: ["ap-northeast-1"]
+        - regions: ["ap-southeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: {{ OSS_COMMERCIAL_ARM_RH8 }}
           schedulers: ["slurm"]
@@ -238,13 +238,13 @@ test-suites:
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_multiple:
       dimensions:
-        - regions: ["eu-west-2"]
+        - regions: ["me-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["ubuntu1804", "rhel8"]
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_existing:
       dimensions:
-        - regions: ["eu-west-2"]
+        - regions: ["me-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["centos7", "rhel8"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/configs/redhat8.yaml
+++ b/tests/integration-tests/configs/redhat8.yaml
@@ -50,7 +50,7 @@ test-suites:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_ONE_PER_DISTRO_RH8 }}
+          oss: {{ OSS_ONE_PER_DISTRO_RH8 }}
           schedulers: ["slurm"]
   createami:
     test_createami.py::test_build_image:
@@ -95,7 +95,7 @@ test-suites:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
   efa:
     test_efa.py::test_efa:
@@ -132,7 +132,7 @@ test-suites:
           # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
@@ -149,13 +149,13 @@ test-suites:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM_RH8 }}
+          oss: {{ OSS_COMMERCIAL_ARM_RH8 }}
           schedulers: ["slurm"]
     test_mpi.py::test_mpi_ssh:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
   schedulers:
     test_awsbatch.py::test_awsbatch:
@@ -168,23 +168,23 @@ test-suites:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_pmix:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
         - regions: ["ap-northeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM_RH8 }}
+          oss: {{ OSS_COMMERCIAL_ARM_RH8 }}
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_scaling:
       dimensions:
         - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_ONE_PER_DISTRO_RH8 }}
+          oss: {{ OSS_ONE_PER_DISTRO_RH8 }}
           schedulers: ["slurm"]
   storage:
     # Commercial regions that can't test FSx: ap-northeast-1, ap-southeast-1, ap-southeast-2, eu-central-1, eu-north-1, eu-west-1, eu-west-2, us-east-1, us-east-2, us-west-1, us-west-2
@@ -204,7 +204,7 @@ test-suites:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM_RH8 }}
+          oss: {{ OSS_COMMERCIAL_ARM_RH8 }}
           schedulers: ["slurm"]
           benchmarks:
             - mpi_variants: [ "openmpi", "intelmpi" ]
@@ -222,7 +222,7 @@ test-suites:
       dimensions:
         - regions: [ "eu-west-2" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM_RH8 }}
+          oss: {{ OSS_COMMERCIAL_ARM_RH8 }}
           schedulers: [ "slurm" ]
           benchmarks:
             - mpi_variants: [ "openmpi", "intelmpi" ]
@@ -234,7 +234,7 @@ test-suites:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_multiple:
       dimensions:

--- a/tests/integration-tests/configs/redhat8.yaml
+++ b/tests/integration-tests/configs/redhat8.yaml
@@ -104,7 +104,7 @@ test-suites:
           instances: ["c5n.9xlarge"]
           oss: ["alinux2", "rhel8"]
           schedulers: ["slurm"]
-        - regions: ["us-east-1"]
+        - regions: ["use1-az6"]   # do not move, unless capacity reservation is moved as well
           instances: ["p4d.24xlarge"]
           oss: ["alinux2", "rhel8"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/constants.py
+++ b/tests/integration-tests/constants.py
@@ -14,6 +14,7 @@ OS_TO_ROOT_VOLUME_DEVICE = {
     "alinux2": "/dev/xvda",
     "ubuntu1804": "/dev/sda1",
     "ubuntu2004": "/dev/sda1",
+    "rhel8": "/dev/xvda",
 }
 
 SCHEDULERS_SUPPORTING_IMDS_SECURED = ["slurm", "plugin"]

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -83,7 +83,7 @@ def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64", 
         if ami_type == "pcluster":
             ami_name = "aws-parallelcluster-{version}-{ami_name}".format(
                 version=get_installed_parallelcluster_version(),
-                ami_name=AMI_TYPE_DICT.get(ami_type).get(os).get("name"),
+                ami_name=_get_ami_for_os(ami_type, os).get("name"),
             )
             if (
                 request
@@ -94,13 +94,13 @@ def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64", 
                 # Then retrieve public pcluster AMIs
                 additional_filters.append({"Name": "is-public", "Values": ["true"]})
         else:
-            ami_name = AMI_TYPE_DICT.get(ami_type).get(os).get("name")
+            ami_name = _get_ami_for_os(ami_type, os).get("name")
         logging.info("Parent image name %s" % ami_name)
         response = boto3.client("ec2", region_name=region).describe_images(
             Filters=[{"Name": "name", "Values": [ami_name]}, {"Name": "architecture", "Values": [architecture]}]
             + additional_filters,
-            Owners=AMI_TYPE_DICT.get(ami_type).get(os).get("owners"),
-            IncludeDeprecated=AMI_TYPE_DICT.get(ami_type).get(os).get("includeDeprecated", False),
+            Owners=_get_ami_for_os(ami_type, os).get("owners"),
+            IncludeDeprecated=_get_ami_for_os(ami_type, os).get("includeDeprecated", False),
         )
         # Sort on Creation date Desc
         amis = sorted(response.get("Images", []), key=lambda x: x["CreationDate"], reverse=True)
@@ -114,6 +114,16 @@ def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64", 
     except IndexError as e:
         LOGGER.critical("Error no ami retrieved: {0}".format(e))
         raise
+
+
+def _get_ami_for_os(ami_type, os):
+    ami_dict = AMI_TYPE_DICT.get(ami_type)
+    if not ami_dict:
+        raise Exception(f"'{ami_type}' not found in the dict 'AMI_TYPE_DICT'")
+    os_ami = ami_dict.get(os)
+    if not os_ami:
+        raise Exception(f"'{os}' not found in the '{ami_type}' mapping referenced in the 'AMI_TYPE_DICT'")
+    return os_ami
 
 
 def retrieve_pcluster_ami_without_standard_naming(region, os, version, architecture):

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -41,6 +41,8 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
         "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*-server-*",
         "owners": ["099720109477"],
     },
+    # We need to specify the minor because the most recently created RHEL8 AMI is currently 8.4
+    "rhel8": {"name": "RHEL-8.7*_HVM*", "owners": ["309956199498", "841258680906", "219670896067"]},
 }
 
 # Remarkable AMIs are latest deep learning base AMI and FPGA developer AMI without pcluster infrastructure
@@ -63,6 +65,7 @@ OS_TO_PCLUSTER_AMI_NAME_OWNER_MAP = {
     "centos7": {"name": "centos7-hvm-x86_64-*", "owners": PCLUSTER_AMI_OWNERS},
     "ubuntu1804": {"name": "ubuntu-1804-lts-hvm-*-*", "owners": PCLUSTER_AMI_OWNERS},
     "ubuntu2004": {"name": "ubuntu-2004-lts-hvm-*-*", "owners": PCLUSTER_AMI_OWNERS},
+    "rhel8": {"name": "rhel8-hvm-*-*", "owners": PCLUSTER_AMI_OWNERS},
 }
 
 AMI_TYPE_DICT = {

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -483,7 +483,13 @@ def get_vpc_snakecase_value(vpc_stack):
 
 def get_username_for_os(os):
     """Return username for a given os."""
-    usernames = {"alinux2": "ec2-user", "centos7": "centos", "ubuntu1804": "ubuntu", "ubuntu2004": "ubuntu"}
+    usernames = {
+        "alinux2": "ec2-user",
+        "centos7": "centos",
+        "ubuntu1804": "ubuntu",
+        "ubuntu2004": "ubuntu",
+        "rhel8": "ec2-user",
+    }
     return usernames.get(os)
 
 


### PR DESCRIPTION
### Description of changes
* Add image name part to be able to get rhel8 images (OS_TO_IMAGE_NAME_PART_MAP is required to be able to retrieve official images)

### Tests changes
* Add missing username mapping
* Add missing os to root volume mapping for rhel8
* Add rhel8 AMI filters in test runner utilities
* Move p4d tests in the right avail zone
* Fix usage of RHEL8 test variable in redhat8.yaml
* Redistribuite integration tests