### PR TITLE
[Isolated Regions] Set Slurm Database as unsupported in US isolated regions.

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2230,6 +2230,8 @@ class Database(Resource):
         self.password_secret_arn = Resource.init_param(password_secret_arn)
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
+        region = get_region()
+        self._register_validator(FeatureRegionValidator, feature=Feature.SLURM_DATABASE, region=region)
         if self.uri:
             self._register_validator(DatabaseUriValidator, uri=self.uri)
         if self.password_secret_arn:

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -230,6 +230,7 @@ class Feature(Enum):
     FSX_LUSTRE = "FSx Lustre"
     FSX_ONTAP = "FSx ONTAP"
     FSX_OPENZFS = "FSx OpenZfs"
+    SLURM_DATABASE = "SLURM Database"
 
 
 UNSUPPORTED_FEATURES_MAP = {
@@ -238,6 +239,7 @@ UNSUPPORTED_FEATURES_MAP = {
     Feature.FSX_LUSTRE: ["us-iso"],
     Feature.FSX_ONTAP: ["us-iso"],
     Feature.FSX_OPENZFS: ["us-iso"],
+    Feature.SLURM_DATABASE: ["us-iso"],
 }
 
 

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -541,8 +541,13 @@ def test_scheduler_plugin_validators_are_called_with_correct_argument(test_datad
 
     # Assert validators are called
     scheduler_os_validator.assert_has_calls([call(os="centos7", scheduler="plugin")])
+    # The following features are excluded from the verification
+    # because they are not implied by the cluster configuration under test:
+    #   1. Batch
+    #   2. Slurm Database
+    features_to_validate = [feature for feature in Feature if feature not in [Feature.BATCH, Feature.SLURM_DATABASE]]
     feature_region_validator.assert_has_calls(
-        [call(feature=feature, region="us-east-1") for feature in Feature if feature is not Feature.BATCH],
+        [call(feature=feature, region="us-east-1") for feature in features_to_validate],
         any_order=True,
     )
     compute_resource_size_validator.assert_has_calls(

--- a/cli/tests/pcluster/validators/test_feature_validators.py
+++ b/cli/tests/pcluster/validators/test_feature_validators.py
@@ -41,11 +41,13 @@ from .utils import assert_failure_messages
         (Feature.FSX_OPENZFS, "us-iso-west-1", "FSx OpenZfs is not supported in region 'us-iso-west-1'"),
         (Feature.FSX_OPENZFS, "us-isob-east-1", "FSx OpenZfs is not supported in region 'us-isob-east-1'"),
         (Feature.FSX_OPENZFS, "us-isoWHATEVER", "FSx OpenZfs is not supported in region 'us-isoWHATEVER'"),
+        (Feature.SLURM_DATABASE, "us-isoWHATEVER", "SLURM Database is not supported in region 'us-isoWHATEVER'"),
         (Feature.BATCH, "WHATEVER-ELSE", None),
         (Feature.DCV, "WHATEVER-ELSE", None),
         (Feature.FSX_LUSTRE, "WHATEVER-ELSE", None),
         (Feature.FSX_ONTAP, "WHATEVER-ELSE", None),
         (Feature.FSX_OPENZFS, "WHATEVER-ELSE", None),
+        (Feature.SLURM_DATABASE, "WHATEVER-ELSE", None),
     ],
 )
 def test_feature_region_validator(feature, region, expected_message):


### PR DESCRIPTION
### Description of changes
Set Slurm Database as unsupported in US isolated regions.

### Tests
* Unit Tests
* Full regression tests will be executed by the authoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
