### PR TITLE
[develop] Fix cli dimensions filtering in TestRunner

### DIFF
--- a/tests/integration-tests/conftest_tests_config.py
+++ b/tests/integration-tests/conftest_tests_config.py
@@ -87,7 +87,7 @@ def apply_cli_dimensions_filtering(config, items):
     allowed_values = {}
     for dimension in DIMENSIONS_MARKER_ARGS:
         values = config.getoption(dimension + "s")
-        if dimension == "region":
+        if dimension == "region" and values is not None:
             # values may contain a list of az_id/regions.
             # We have to unmarshal any of them in case one or more overrides were specified
             values = [unmarshal_az_override(v) for v in values]


### PR DESCRIPTION
### Description of changes
With AZ Override changes, region dimension may contain an AZ that has to be unmarshalled, but only if the dimension has a value that is not None.

* checks if the `regions` value is not None before attempting to unmarshall the value

### Tests
* Launched with a local test configuration 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
