### PR TITLE
[Isolated Regions] [Test] Adapt integration test 'test_iam_policies' so that  it can be executed also in US isolated regions.

### DIFF
--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -307,7 +307,7 @@ def test_iam_policies(region, scheduler, pcluster_config_reader, clusters_factor
 
 def _test_s3_access(remote_command_executor, region):
     logging.info("Testing S3 Access")
-    result = remote_command_executor.run_remote_command(f"AWS_DEFAULT_REGION={region} sudo aws s3 ls").stdout
+    result = remote_command_executor.run_remote_command(f"sudo aws s3 ls --region {region}").stdout
     # An error occurred (AccessDenied) when calling the ListBuckets operation: Access Denied
     assert_that(result).does_not_contain("AccessDenied")
 
@@ -315,7 +315,7 @@ def _test_s3_access(remote_command_executor, region):
 def _test_batch_access(remote_command_executor, region):
     logging.info("Testing AWS Batch Access")
     result = remote_command_executor.run_remote_command(
-        f"AWS_DEFAULT_REGION={region} aws batch describe-compute-environments"
+        f"aws batch describe-compute-environments --region {region}"
     ).stdout
     # An error occurred (AccessDeniedException) when calling the DescribeComputeEnvironments operation: ...
     assert_that(result).does_not_contain("AccessDeniedException")


### PR DESCRIPTION
### Description of changes
Adapt integration test `test_iam_policies` so that  it can be executed also in US isolated regions. 
In particular, the region is passed as an explicit option to the AWS CLI remote execution.
This fix is required because the environment variable `AWS_DEFAULT_REGION` is lost when the remote command executor  switches the user.

### Tests
* Executed integration test `test_iam_policies` with scheduler `slurm` in Commercial.
* Executed integration test `test_iam_policies` with scheduler `awsbatch` in Commercial.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
