### PR TITLE
[Integ-tests] Reduce sporadic failures of test_slurm_scaling and subnet creations in different AZs

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -994,10 +994,10 @@ def vpc_stacks(cfn_stacks_factory, request):
         # otherwise, select a subset of all AZs in the region
         else:
             az_list = get_availability_zones(region, credential)
-            # if number of available zones is smaller than 3, list is expanded to 3 and filled with [None, ...]
+            # if number of available zones is smaller than 3, list is expanded to 3 and filled with the last item.
             if len(az_list) < 3:
                 diff = 3 - len(az_list)
-                availability_zones = az_list + [None] * diff
+                availability_zones = az_list + [az_list[-1]] * diff
             else:
                 availability_zones = random.sample(az_list, k=3)
 

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -885,7 +885,7 @@ def _test_keep_or_replace_suspended_nodes(
     )
     job_id = submit_initial_job(
         scheduler_commands,
-        "sleep 500",
+        "sleep 550",
         partition,
         dynamic_instance_type,
         num_dynamic_nodes,


### PR DESCRIPTION
### Description of changes
These sporadic failures are discovered when testing in isolated regions.
The test_slurm_scaling fix applied to both `develop` and `release-3.5` branches.
The subnet creations in different AZs fix only apply to `release-3.5`. The code in `develop` branch is correct.
See commits descriptions for details.

### Tests
The following tests are successful
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  storage:
    test_ebs.py::test_ebs_snapshot:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  schedulers:
    test_slurm.py::test_slurm_scaling:
      dimensions:
        - regions: ["us-isob-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
