### PR TITLE
[Isolated Regions] [Test] Fix cluster configuration used by test_ebs_multiple in US Isolated regions.

### DIFF
--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -11,7 +11,7 @@ HeadNode:
       Encrypted: false # Test turning off root volume encryption
       VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
       Throughput: {% if "-iso" in region %}null{% else %}135{% endif %}
-      Iops: {% if "-iso" in region %}null{% else %}3400{% endif %}
+      Iops: 3400
   Imds:
     Secured: {{ imds_secured }}
 Scheduling:
@@ -25,7 +25,7 @@ Scheduling:
             Encrypted: false  # Test turning off root volume encryption
             VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
             Throughput: {% if "-iso" in region %}null{% else %}130{% endif %}
-            Iops: {% if "-iso" in region %}null{% else %}3200{% endif %}
+            Iops: 3200
       {% endif %}
       ComputeResources:
         - Name: compute-resource-0
@@ -50,7 +50,7 @@ Scheduling:
             Encrypted: false
             VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
             Throughput: {% if "-iso" in region %}null{% else %}130{% endif %}
-            Iops: {% if "-iso" in region %}null{% else %}3200{% endif %}
+            Iops: 3200
       ComputeResources:
         - Name: compute-resource-0
           Instances:
@@ -84,7 +84,7 @@ SharedStorage:
     EbsSettings:
       Iops: 150
       Size: {{ volume_sizes[2] }}
-      VolumeType: io2
+      VolumeType: {% if "-iso" in region %}gp2{% else %}io2{% endif %}
   - MountDir: {{ mount_dirs[3] }}
     Name: ebs4
     StorageType: Ebs


### PR DESCRIPTION
### Description of changes
Fix cluster configuration used by `test_ebs_multiple` in US Isolated regions.
In particular:
1. enable the Iops configuration also in Isolated regions.
2. use VolumeType gp2 instead of io2 in US isolated regions because io2 is not supported.

### Tests
* Will be tested by authoritative pipeline in Commercial
* Will be manually tested in us-isob-east-1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
