### PR TITLE
[Test] Move utility functions from 'performance_tests/common' to 'common/utils'

### DIFF
--- a/tests/integration-tests/tests/efa/test_fabric.py
+++ b/tests/integration-tests/tests/efa/test_fabric.py
@@ -17,8 +17,7 @@ from assertpy import assert_that
 from remote_command_executor import RemoteCommandExecutor
 
 from tests.common.assertions import assert_no_errors_in_logs
-from tests.common.utils import run_system_analyzer
-from tests.performance_tests.common import read_remote_file, wait_process_completion
+from tests.common.utils import read_remote_file, run_system_analyzer, wait_process_completion
 
 FABTESTS_BASIC_TESTS = ["rdm_tagged_bw", "rdm_tagged_pingpong"]
 


### PR DESCRIPTION
### Description of changes
Move utility functions from 'performance_tests/common' to 'common/utils', so that 'test_fabric' does not depend on 'performance_tests' code.

**Note** This PR introduces a code duplication of the two utility functions 'read_remote_file' and 'wait_process_completion', but we will address it in a follow up PR. because the current change is just to unblock tersting in US Isolated regions.

### Tests
* Will be tested by authoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
