### PR TITLE
[Isolated Regions] [Test] Fix cluster configuration used in 'test_scheduler_plugin_integration'

### DIFF
--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_arm64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_arm64.yaml
@@ -24,9 +24,9 @@
       RootVolume:
         Encrypted: true
         Size: null
-        VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
-        Throughput: {% if "-iso" in region %}null{% else %}125{% endif %}
-        Iops: {% if "-iso" in region %}null{% else %}3000{% endif %}
+        VolumeType: gp3
+        Throughput: 125
+        Iops: 3000
   CustomActions: null
   CustomSettings: null
   Iam:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_x86_64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues.before_update_x86_64.yaml
@@ -24,9 +24,9 @@
       RootVolume:
         Encrypted: true
         Size: null
-        VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
-        Throughput: {% if "-iso" in region %}null{% else %}125{% endif %}
-        Iops: {% if "-iso" in region %}null{% else %}3000{% endif %}
+        VolumeType: gp3
+        Throughput: 125
+        Iops: 3000
   CustomActions: null
   CustomSettings: null
   Iam:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_arm64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_arm64.yaml
@@ -41,9 +41,9 @@
       RootVolume:
         Encrypted: true
         Size: null
-        VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
-        Throughput: {% if "-iso" in region %}null{% else %}125{% endif %}
-        Iops: {% if "-iso" in region %}null{% else %}3000{% endif %}
+        VolumeType: gp3
+        Throughput: 125
+        Iops: 3000
   CustomActions: null
   CustomSettings: null
   Iam:
@@ -89,10 +89,10 @@
       EphemeralVolume: null
       RootVolume:
         Encrypted: true
-        Iops: 3000
         Size: null
-        VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
-        Throughput: {% if "-iso" in region %}null{% else %}130{% endif %}
+        VolumeType: gp3
+        Throughput: 130
+        Iops: 3000
   CustomActions: null
   CustomSettings: null
   Iam:

--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_x86_64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_x86_64.yaml
@@ -41,9 +41,9 @@
       RootVolume:
         Encrypted: true
         Size: null
-        VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
-        Throughput: {% if "-iso" in region %}null{% else %}125{% endif %}
-        Iops: {% if "-iso" in region %}null{% else %}3000{% endif %}
+        VolumeType: gp3
+        Throughput: 125
+        Iops: 3000
   CustomActions: null
   CustomSettings: null
   Iam:
@@ -89,10 +89,10 @@
       EphemeralVolume: null
       RootVolume:
         Encrypted: true
-        Iops: 3000
         Size: null
-        VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
-        Throughput: {% if "-iso" in region %}null{% else %}125{% endif %}
+        VolumeType: gp3
+        Throughput: 125
+        Iops: 3000
   CustomActions: null
   CustomSettings: null
   Iam:


### PR DESCRIPTION
### Description of changes
Fixed cluster configuration used in 'test_scheduler_plugin_integration'.
In particular, we removed the failing Jinja conditions related to US isolated regions.
This is a fair short term solution because scheduler plugin is not supported in US isolated regions.

### Tests
* Test scheduler_plugin_integration in Commercial succeeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
