### PR TITLE
[Test] Remove dependency to matplotlib.

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -9,8 +9,8 @@ fabric==2.6.0
 filelock
 jinja2
 junitparser
-matplotlib
 pexpect
+psutil
 pykwalify
 pyOpenSSL
 pytest
@@ -24,5 +24,4 @@ requests
 retrying
 troposphere
 untangle
-psutil
 xmltodict


### PR DESCRIPTION
### Description of changes
Remove dependency to matplotlib.
This is needed because the dependency to matplotlib is blocking execution of integration tests in Us isolated regions due to versions incompatibilities.
This is a fair change because this dependency is only used by performance tests that are experimental tests currently unused.

### Tests
* Not needed, matplotlib is only used by unused performance tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
