### PR TITLE
Fix liter error R1710

### DIFF
--- a/cli/src/pcluster/cli/commands/dcv_connect.py
+++ b/cli/src/pcluster/cli/commands/dcv_connect.py
@@ -141,6 +141,7 @@ def _retry(func, func_args, attempts=1, wait=0):
 
             LOGGER.debug("%s, retrying in %s seconds..", e, wait)
             time.sleep(wait)
+    return None
 
 
 class DcvConnectCommand(CliCommand):


### PR DESCRIPTION
R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
