### PR TITLE
Permit to run system-analyzer.sh on RHEL

### DIFF
--- a/tests/integration-tests/tests/common/data/system-analyzer.sh
+++ b/tests/integration-tests/tests/common/data/system-analyzer.sh
@@ -179,7 +179,7 @@ function main() {
     ubuntu)
       PACKAGE_REPORT_CMD="dpkg-query -l"
       ;;
-    amzn | centos)
+    amzn | centos | rhel)
       PACKAGE_REPORT_CMD="rpm -qa"
       ;;
     *)


### PR DESCRIPTION
Previously it was failing with:
```
Unrecognized system. Found /etc/os-release ID content: rhel
```

After the change the script is executed correctly:
```
[root@ip-10-0-0-33 ec2-user]# bash system-analyzer.sh /tmp/test
Wed Mar  8 14:49:30 UTC 2023 - system-analyzer - INFO - START
Wed Mar  8 14:49:30 UTC 2023 - system-analyzer - INFO - Directory /tmp/test exists.
Wed Mar  8 14:49:30 UTC 2023 - system-analyzer - INFO - Create temporary directory
Wed Mar  8 14:49:30 UTC 2023 - system-analyzer - INFO - Save OS type and version
Wed Mar  8 14:49:30 UTC 2023 - system-analyzer - INFO - Save uname
Wed Mar  8 14:49:30 UTC 2023 - system-analyzer - INFO - Save installed packages on system
Wed Mar  8 14:49:32 UTC 2023 - system-analyzer - INFO - Save installed services and timer
Wed Mar  8 14:49:32 UTC 2023 - system-analyzer - INFO - Save scheduled commands
Wed Mar  8 14:49:32 UTC 2023 - system-analyzer - INFO - Save mpi versions
Wed Mar  8 14:49:33 UTC 2023 - system-analyzer - INFO - Save network information
Wed Mar  8 14:49:33 UTC 2023 - system-analyzer - INFO - Save IMDSv2 information
Wed Mar  8 14:49:33 UTC 2023 - system-analyzer - INFO - Save /etc/passwd content
Wed Mar  8 14:49:33 UTC 2023 - system-analyzer - INFO - Create the archive
Wed Mar  8 14:49:33 UTC 2023 - system-analyzer - INFO - DONE
[root@ip-10-0-0-33 ec2-user]#
```

