### PR TITLE
support get_instance_types_data on all config classes

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1737,6 +1737,10 @@ class BaseClusterConfig(Resource):
         """Return tags configured in the cluster configuration."""
         return self.tags
 
+    def get_instance_types_data(self) -> dict:
+        """Get instance type infos for all instance types used in the configuration file."""
+        return {}
+
 
 class AwsBatchComputeResource(BaseComputeResource):
     """Represent the AwsBatch Compute Resource."""

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -32,7 +32,7 @@ from marshmallow import ValidationError
 from pcluster.api.models import Metadata
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError, BadRequestError, LimitExceededError, StackNotFoundError, get_region
-from pcluster.config.cluster_config import BaseClusterConfig, SchedulerPluginScheduling, SlurmScheduling, Tag
+from pcluster.config.cluster_config import BaseClusterConfig, SchedulerPluginScheduling, Tag
 from pcluster.config.common import ValidatorSuppressor
 from pcluster.config.config_patch import ConfigPatch
 from pcluster.constants import (
@@ -533,13 +533,12 @@ class Cluster:
             if self.template_body:
                 self.bucket.upload_cfn_template(self.template_body, PCLUSTER_S3_ARTIFACTS_DICT.get("template_name"))
 
-            if isinstance(self.config.scheduling, (SlurmScheduling, SchedulerPluginScheduling)):
-                # upload instance types data
-                self.bucket.upload_config(
-                    self.config.get_instance_types_data(),
-                    PCLUSTER_S3_ARTIFACTS_DICT.get("instance_types_data_name"),
-                    format=S3FileFormat.JSON,
-                )
+            # upload instance types data
+            self.bucket.upload_config(
+                self.config.get_instance_types_data(),
+                PCLUSTER_S3_ARTIFACTS_DICT.get("instance_types_data_name"),
+                format=S3FileFormat.JSON,
+            )
 
             if isinstance(self.config.scheduling, SchedulerPluginScheduling):
                 self._render_and_upload_scheduler_plugin_template()

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -377,3 +377,6 @@ class TestBaseClusterConfig:
     def test_get_managed_placement_group_keys(self, queue, expected_result):
         actual = queue.get_managed_placement_group_keys()
         assert_that(actual).is_equal_to(expected_result)
+
+    def test_get_instance_types_data(self, base_cluster_config):
+        assert_that(base_cluster_config.get_instance_types_data()).is_equal_to({})


### PR DESCRIPTION
### Description of changes
get_instance_types_data added to the BaseClusterConfig guarantees that instance-types-data.json is uploaded to S3 for every scheduler and the chef resource "fetch_config" to work for every scheduler configuration, while currently it was failing for clusters with awsbatch schedulers

### Tests
* Manual test of awsbatch cluster creation
* Unit tested get_instance_types_data in BaseClusterConfig returning empty dict

### References
* This would solve the issues caused by https://github.com/aws/aws-parallelcluster-cookbook/pull/1829

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
