### PR TITLE
[Isolated Regions] Adapt 'pcluster configure' to support US Isolated regions

### DIFF
--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -99,12 +99,13 @@ def _get_vpcs_and_subnets():
 
 def _get_subnets(conn, vpc_id):
     subnet_options = []
-    subnet_list = conn.describe_subnets(
-        Filters=[
-            {"Name": "vpcId", "Values": [vpc_id]},
-            {"Name": "ipv6-native", "Values": ["false"]},
-        ]
-    ).get("Subnets")
+    subnet_filters = [{"Name": "vpcId", "Values": [vpc_id]}]
+    # US isolated regions do not support IPv6.
+    # Subnets in these regions do not have the field "Ipv6Native", so
+    # applying the filter ipv6-native=false would make the DescribeSubnets call to always return an empty set.
+    if not conn.meta.region_name.startswith("us-iso"):
+        subnet_filters += {"Name": "ipv6-native", "Values": ["false"]}
+    subnet_list = conn.describe_subnets(Filters=subnet_filters).get("Subnets")
     for subnet in subnet_list:
         subnet_options.append(
             OrderedDict(

--- a/cli/src/pcluster/cli/commands/dcv_connect.py
+++ b/cli/src/pcluster/cli/commands/dcv_connect.py
@@ -121,7 +121,7 @@ def _retrieve_dcv_session_url(ssh_cmd, cluster_name, head_node_ip):
     )
 
 
-def _retry(func, func_args, attempts=1, wait=0):
+def _retry(func, func_args, attempts=1, wait=0):  # pylint: disable=R1710
     """
     Call function and re-execute it if it raises an Exception.
 


### PR DESCRIPTION
### Description of changes
Adapt 'pcluster configure' to support US Isolated regions by avoiding the filter 'ipv6-native=false' when describing subnets. In fact, subnets in these regions do not expose the field 'Ipv6Native' at all.

Disabled [PyLint rule R1710](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/inconsistent-return-statements.html) on the function _retry() used by dcv_connect(). We want to fix this in a follow up PR, but we want to unblock this PR first, which not even touches the linted line.


### Tests
* Manually tested in Commercial.
* Manually tested in us-isob-east-1 (verified that it should be equivalent also in us-iso-east-1)
* Full regression test will be executed by the authoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
