### PR TITLE
Remove rhel8 from failing tests and use ubuntu2004 in OSS_ONE_PER_DISTRO 

### DIFF
--- a/tests/integration-tests/configs/common.jinja2
+++ b/tests/integration-tests/configs/common.jinja2
@@ -6,12 +6,9 @@
 {%- set SCHEDULERS_TRAD = ["slurm"] -%}
 {%- set OSS_BATCH = ["alinux2"] -%}
 {%- set OSS_COMMERCIAL_X86 = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
-{%- set OSS_COMMERCIAL_X86_NO_RHEL8 = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004"] -%}
 {%- set OSS_CHINA_X86 = ["alinux2", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
 {%- set OSS_GOVCLOUD_X86 = ["alinux2", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
-{%- set OSS_GOVCLOUD_X86_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
 {%- set OSS_COMMERCIAL_ARM = ["alinux2", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
-{%- set OSS_COMMERCIAL_ARM_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
 {%- set OSS_CHINA_ARM = ["alinux2", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
 {%- set OSS_GOVCLOUD_ARM = ["alinux2", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
 {%- set OSS_ONE_PER_DISTRO = ["centos7", "alinux2", "ubuntu2004", "rhel8"] -%}
@@ -28,3 +25,11 @@
         "{{ instance_key }}"
     {%- endif -%}
 {%- endmacro -%}
+
+{%- set OSS_COMMERCIAL_X86_NO_RHEL8 = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004"] -%}
+{%- set OSS_COMMERCIAL_ARM_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
+{%- set OSS_CHINA_X86_NO_RHEL8  = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
+{%- set OSS_CHINA_ARM_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
+{%- set OSS_GOVCLOUD_X86_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
+{%- set OSS_GOVCLOUD_ARM_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
+{%- set OSS_ONE_PER_DISTRO_NO_RHEL8 = ["centos7", "alinux2", "ubuntu2004"] -%}

--- a/tests/integration-tests/configs/common.jinja2
+++ b/tests/integration-tests/configs/common.jinja2
@@ -14,7 +14,7 @@
 {%- set OSS_COMMERCIAL_ARM_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
 {%- set OSS_CHINA_ARM = ["alinux2", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
 {%- set OSS_GOVCLOUD_ARM = ["alinux2", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
-{%- set OSS_ONE_PER_DISTRO = ["centos7", "alinux2", "ubuntu1804", "rhel8"] -%}
+{%- set OSS_ONE_PER_DISTRO = ["centos7", "alinux2", "ubuntu2004", "rhel8"] -%}
 {%- set INSTANCES_DEFAULT_X86 = ["c5.xlarge"] -%}
 {%- set INSTANCES_DEFAULT_ARM = ["m6g.xlarge"] -%} # m6g.xlarge is not supported in af-south-1, eu-south-1, eu-west-3, me-south-1
 {%- set INSTANCES_DEFAULT = ["c5.xlarge", "m6g.xlarge"] -%}

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -44,7 +44,7 @@ cfn-init:
     dimensions:
       - regions: ["af-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_ONE_PER_DISTRO }}
+        oss: {{ common.OSS_ONE_PER_DISTRO_NO_RHEL8 }}
         schedulers: ["slurm"]
   test_cfn_init.py::test_install_args_quotes:
     dimensions:
@@ -57,7 +57,7 @@ cli_commands:
     dimensions:
       - regions: ["ap-northeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["rhel8"]
+        oss: ["ubuntu1804"]
         schedulers: ["slurm"]
 cloudwatch_logging:
   test_cloudwatch_logging.py::test_cloudwatch_logging:
@@ -74,12 +74,12 @@ cloudwatch_logging:
       # 2) run the test for all x86 OSes with slurm
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
         schedulers: ["slurm"]
       # 3) run the test for all ARM OSes on an ARM instance
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: {{ common.OSS_COMMERCIAL_ARM_NO_RHEL8 }}
         schedulers: ["slurm"]
   test_compute_console_output_logging.py::test_console_output_with_monitoring_disabled:
     dimensions:
@@ -90,12 +90,12 @@ cloudwatch_logging:
   test_compute_console_output_logging.py::test_custom_action_error:
     dimensions:
       - regions: ["ap-east-1"]
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         schedulers: ["slurm"]
       - regions: ["us-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: {{ common.OSS_COMMERCIAL_ARM_NO_RHEL8 }}
         schedulers: ["slurm"]
 configure:
   test_pcluster_configure.py::test_pcluster_configure:
@@ -185,7 +185,7 @@ createami:
     dimensions:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2", "ubuntu2004", "centos7", "rhel8"]
+        oss: {{ common.OSS_ONE_PER_DISTRO_NO_RHEL8 }}
   test_createami.py::test_kernel4_build_image_run_cluster:
     dimensions:
       - regions: ["eu-south-1"]
@@ -218,7 +218,7 @@ dcv:
       # DCV on GPU enabled instance
       - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
         instances: ["g4dn.2xlarge"]
-        oss: {{common.OSS_COMMERCIAL_X86}}
+        oss: {{common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
         schedulers: ["slurm"]
       # DCV on ARM
       - regions: ["sa-east-1"]
@@ -279,7 +279,7 @@ dns:
     dimensions:
       - regions: ["af-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
         schedulers: ["slurm"]
   test_dns.py::test_existing_hosted_zone:
     dimensions:
@@ -348,7 +348,7 @@ networking:
     dimensions:
       - regions: ["me-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2", "rhel8"]
+        oss: ["alinux2"]
         schedulers: ["slurm"]
   test_cluster_networking.py::test_existing_eip:
     dimensions:
@@ -423,7 +423,7 @@ scaling:
     dimensions:
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
         schedulers: ["slurm"]
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
@@ -461,24 +461,24 @@ schedulers:
 {%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_ONE_PER_DISTRO }}
+        oss: {{ common.OSS_ONE_PER_DISTRO_NO_RHEL8 }}
         schedulers: ["slurm_plugin"]
 {%- endif %}
   test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
     dimensions:
       - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
         schedulers: ["slurm"]
       - regions: ["ap-northeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: {{ common.OSS_COMMERCIAL_ARM_NO_RHEL8 }}
         schedulers: ["slurm"]
   test_slurm.py::test_slurm_scaling:
     dimensions:
       - regions: ["us-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_ONE_PER_DISTRO }}
+        oss: {{ common.OSS_ONE_PER_DISTRO_NO_RHEL8 }}
         schedulers: ["slurm"]
 {%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
       - regions: ["me-south-1"]
@@ -606,7 +606,7 @@ storage:
     dimensions:
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
         schedulers: ["slurm"]
         benchmarks:
           - mpi_variants: ["openmpi", "intelmpi"]
@@ -616,11 +616,11 @@ storage:
               collective: ["osu_allreduce", "osu_alltoall"]
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: {{ common.OSS_COMMERCIAL_ARM_NO_RHEL8 }}
         schedulers: ["slurm"]
       - regions: ["cn-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["rhel8"]
+        oss: ["alinux2"]
         schedulers: ["slurm"]
       - regions: ["us-gov-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -630,7 +630,7 @@ storage:
     dimensions:
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
         schedulers: ["slurm"]
   test_fsx_lustre.py::test_fsx_lustre_configuration_options:
     dimensions:
@@ -642,11 +642,11 @@ storage:
     dimensions:
       - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_ONE_PER_DISTRO }}
+        oss: {{ common.OSS_ONE_PER_DISTRO_NO_RHEL8 }}
         schedulers: ["slurm"]
       - regions: ["ap-southeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: {{ common.OSS_COMMERCIAL_ARM_NO_RHEL8 }}
         schedulers: ["slurm"]
   # EFS tests can be done in any region.
   test_efs.py::test_efs_compute_az:
@@ -671,7 +671,7 @@ storage:
         schedulers: ["awsbatch"]
       - regions: [ "ca-central-1" ]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: {{ common.OSS_COMMERCIAL_ARM_NO_RHEL8 }}
         schedulers: [ "slurm" ]
         benchmarks:
           - mpi_variants: ["openmpi", "intelmpi"]
@@ -681,7 +681,7 @@ storage:
               collective: ["osu_allreduce", "osu_alltoall"]
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_GOVCLOUD_X86 }}
+        oss: {{ common.OSS_GOVCLOUD_X86_NO_RHEL8 }}
         schedulers: ["slurm"]
   test_raid.py::test_raid_fault_tolerance_mode:
     dimensions:
@@ -715,7 +715,7 @@ storage:
         schedulers: ["slurm"]
   test_ebs.py::test_ebs_single:
     dimensions:
-      {%- for region, oss in [("us-east-2", common.OSS_COMMERCIAL_X86), ("cn-northwest-1", common.OSS_CHINA_X86), ("us-gov-west-1", common.OSS_GOVCLOUD_X86)] %}
+      {%- for region, oss in [("us-east-2", common.OSS_COMMERCIAL_X86_NO_RHEL8), ("cn-northwest-1", common.OSS_CHINA_X86_NO_RHEL8), ("us-gov-west-1", common.OSS_GOVCLOUD_X86_NO_RHEL8)] %}
       - regions: ["{{ region }}"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ oss }}

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -48,7 +48,7 @@ test-suites:
       dimensions:
         - regions: ["sa-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2", "rhel8"]
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_api.py::test_cluster_awsbatch:
       dimensions:
@@ -84,27 +84,27 @@ test-suites:
       dimensions:
         - regions: {{ common.REGIONS_COMMERCIAL }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
           schedulers: ["slurm"]
         - regions: {{ common.REGIONS_CHINA }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_CHINA_X86 }}
+          oss: {{ common.OSS_CHINA_X86_NO_RHEL8 }}
           schedulers: ["slurm"]
         - regions: {{ common.REGIONS_GOVCLOUD }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_GOVCLOUD_X86 }}
+          oss: {{ common.OSS_GOVCLOUD_X86_NO_RHEL8 }}
           schedulers: ["slurm"]
         - regions: ["us-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          oss: {{ common.OSS_COMMERCIAL_ARM_NO_RHEL8 }}
           schedulers: {{ common.SCHEDULERS_TRAD }}
         - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_CHINA_ARM }}
+          oss: {{ common.OSS_CHINA_ARM_NO_RHEL8 }}
           schedulers: ["slurm"]
         - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_GOVCLOUD_ARM }}
+          oss: {{ common.OSS_GOVCLOUD_ARM_NO_RHEL8 }}
           schedulers: ["slurm"]
   trainium:
     test_trainium.py::test_trainium:


### PR DESCRIPTION
Some features are not yet supported or there are known issues to be fixed.
Temporary removing of rhel8 tests by defining *_NO_RHEL8 variables.

Failing tests to investigate are:
* test_multiple_jobs_submission
* test_cfn_init.py::test_replace_compute_on_failure
* test_compute_console_output_logging.py::test_custom_action_error
* test_slurm
* test_ebs_multiple
* test_api.py::test_cluster_slurm
* test_fsx_lustre_backup

Failing tests that should pass but are failing because develop is not rebased on top of redhat8 branch are:
* test_slurm_scaling
* test_slurm_cli_commands
* test_mpi
* test_slurm_pmix
* Networking
  * test_hit_no_cluster_dns_mpi
  * test_cluster_in_private_subnet
* Storage:
  * test_multiple_fsx
  * test_multiple_efs

Failing tests because of not yet supported features are:
* test_cloudwatch_logging
* test_dcv_configuration
* test_createami.py::test_build_image (missing remarkable ami)