### PR TITLE
[Integ-tests] Fix isolated_regions.yaml to include expected benchmark specifications

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -141,6 +141,13 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
+          benchmarks:
+            - mpi_variants: ["openmpi", "intelmpi"]
+              num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+              slots_per_instance: 2
+              partition: "ht-disabled"
+              osu_benchmarks:
+                collective: ["osu_allreduce", "osu_alltoall"]
   dns:
     test_dns.py::test_hit_no_cluster_dns_mpi:
       dimensions:
@@ -426,6 +433,12 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
+          benchmarks:
+            - mpi_variants: ["openmpi", "intelmpi"]
+              num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+              slots_per_instance: 2
+              osu_benchmarks:
+                collective: ["osu_allreduce", "osu_alltoall"]
     test_raid.py::test_raid_fault_tolerance_mode:
       dimensions:
         - regions: {{ REGIONS }}


### PR DESCRIPTION
Even though the benchmarks are not actually run, the tests expect the benchmark specifications. Otherwise, the tests fail at the beginning.

A further action item is to improve the testing framework to not expect benchmark specifications if benchmark is not enabled

Signed-off-bFy: Hanwen <hanwenli@amazon.com>cli-patch-v9.txt

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
