### PR TITLE
[Isolated Regions] [Test] Fixes to test logic to support US isolated regions

### DIFF
--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -197,7 +197,7 @@ def assert_aws_identity_access_is_correct(cluster, users_allow_list, remote_comm
 
     for user, allowed in users_allow_list.items():
         logging.info(f"Asserting access to AWS caller identity is {'allowed' if allowed else 'denied'} for user {user}")
-        command = f"sudo -u {user} aws sts get-caller-identity"
+        command = f"sudo -u {user} aws sts get-caller-identity --region {cluster.region}"
         result = remote_command_executor.run_remote_command(command, raise_on_error=False)
         logging.info(f"user={user} and result.failed={result.failed}")
         logging.info(f"user={user} and result.stdout={result.stdout}")

--- a/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_cluster_networking/test_cluster_in_private_subnet/pcluster.config.yaml
@@ -28,12 +28,17 @@ Scheduling:
         SubnetIds:
           - {{ private_subnet_id }}
 SharedStorage:
-  - MountDir: {{ fsx_mount_dir }}
-    Name: privatefsx
+  - MountDir: {{ mount_dir }}
+    Name: privatestorage
+    {% if storage_type == "EFS" %}
+    StorageType: Efs
+    {% endif %}
+    {% if storage_type == "FSX" %}
     StorageType: FsxLustre
     FsxLustreSettings:
       StorageCapacity: 1200
       DeploymentType: SCRATCH_2
+    {% endif %}
 DeploymentSettings:
   LambdaFunctionsVpcConfig:
     SecurityGroupIds:

--- a/tests/integration-tests/tests/networking/test_security_groups.py
+++ b/tests/integration-tests/tests/networking/test_security_groups.py
@@ -61,8 +61,8 @@ def test_overwrite_sg(region, scheduler, custom_security_group, pcluster_config_
     for instance in instances:
         assert_that(instance["SecurityGroups"]).is_length(1)
 
-    if scheduler != "awsbatch":
-        # FSx is not supported when using AWS Batch as a scheduler
+    # FSx is not supported in US isolated regions or when using AWS Batch as a scheduler
+    if "us-iso" not in region and scheduler != "awsbatch":
         logging.info("Collecting security groups of the FSx")
         fsx_id = cluster.cfn_resources[f"FSX{create_hash_suffix(fsx_name)}"]
         fsx_client = boto3.client("fsx", region_name=region)

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.update.yaml
@@ -34,7 +34,7 @@ SharedStorage:
   - MountDir: efs
     Name: {{ efs_name }}
     StorageType: Efs
-  {% if scheduler != "awsbatch" %}
+  {% if "us-iso" not in region and scheduler != "awsbatch" %}
   - MountDir: fsx
     Name: {{ fsx_name }}
     StorageType: FsxLustre

--- a/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_security_groups/test_overwrite_sg/pcluster.config.yaml
@@ -34,7 +34,7 @@ SharedStorage:
   - MountDir: efs
     Name: {{ efs_name }}
     StorageType: Efs
-  {% if scheduler != "awsbatch" %}
+  {% if "us-iso" not in region and scheduler != "awsbatch" %}
   - MountDir: fsx
     Name: {{ fsx_name }}
     StorageType: FsxLustre

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -9,9 +9,13 @@ HeadNode:
   LocalStorage:
     RootVolume:
       Encrypted: false # Test turning off root volume encryption
-      VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
-      Throughput: {% if "-iso" in region %}null{% else %}135{% endif %}
+      {% if "-iso" in region %}
+      VolumeType: gp2
+      {% else %}
+      VolumeType: gp3
+      Throughput: 135
       Iops: 3400
+      {% endif %}
   Imds:
     Secured: {{ imds_secured }}
 Scheduling:
@@ -23,9 +27,13 @@ Scheduling:
         LocalStorage:
           RootVolume:
             Encrypted: false  # Test turning off root volume encryption
-            VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
-            Throughput: {% if "-iso" in region %}null{% else %}130{% endif %}
+            {% if "-iso" in region %}
+            VolumeType: gp2
+            {% else %}
+            VolumeType: gp3
+            Throughput: 130
             Iops: 3200
+            {% endif %}
       {% endif %}
       ComputeResources:
         - Name: compute-resource-0
@@ -48,9 +56,13 @@ Scheduling:
         LocalStorage:
           RootVolume:
             Encrypted: false
-            VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
-            Throughput: {% if "-iso" in region %}null{% else %}130{% endif %}
+            {% if "-iso" in region %}
+            VolumeType: gp2
+            {% else %}
+            VolumeType: gp3
+            Throughput: 130
             Iops: 3200
+            {% endif %}
       ComputeResources:
         - Name: compute-resource-0
           Instances:
@@ -66,11 +78,15 @@ SharedStorage:
     Name: ebs1
     StorageType: Ebs
     EbsSettings:
-      Iops: 3200
       Size: {{ volume_sizes[0] }}
-      VolumeType: {% if "-iso" in region %}gp2{% else %}gp3{% endif %}
-      Throughput: {% if "-iso" in region %}null{% else %}130{% endif %}
       Encrypted: true
+      {% if "-iso" in region %}
+      VolumeType: gp2
+      {% else %}
+      VolumeType: gp3
+      Throughput: 130
+      Iops: 3200
+      {% endif %}
   - MountDir: {{ mount_dirs[1] }}
     Name: ebs2
     StorageType: Ebs
@@ -82,9 +98,13 @@ SharedStorage:
     Name: ebs3
     StorageType: Ebs
     EbsSettings:
-      Iops: 150
       Size: {{ volume_sizes[2] }}
-      VolumeType: {% if "-iso" in region %}gp2{% else %}io2{% endif %}
+      {% if "-iso" in region %}
+      VolumeType: gp2
+      {% else %}
+      VolumeType: io2
+      Iops: 150
+      {% endif %}
   - MountDir: {{ mount_dirs[3] }}
     Name: ebs4
     StorageType: Ebs


### PR DESCRIPTION
### Description of changes
1. Adapt assertion on AWS identity by specifying the region in 'aws sts get-caller-identity' calls, executed to make assertions in 'test_imds_secured'.
2. Make KmsFactory able to support US isolated regions.
3. Adapt 'test_overwrite_sg' so that it does not use FSxLustre file systems in US isolated regions.
4. Adapt 'test_cluster_in_private_subnet'  so that it does not use FSxLustre file systems in US isolated regions.
5. Fix cluster config used in 'test_ebs_multiple' so that it uses the correct EBS settings for US isolated regions.

### Tests
* PENDING Regression test in Commercial
* Will be validated in ADC

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
