### PR TITLE
[Integ-tests] Fix isolated_regions.yaml to include expected benchmark…

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -141,6 +141,13 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
+          benchmarks:
+            - mpi_variants: ["openmpi", "intelmpi"]
+              num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+              slots_per_instance: 2
+              partition: "ht-disabled"
+              osu_benchmarks:
+                collective: ["osu_allreduce", "osu_alltoall"]
   dns:
     test_dns.py::test_hit_no_cluster_dns_mpi:
       dimensions:
@@ -426,6 +433,12 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
+          benchmarks:
+            - mpi_variants: ["openmpi", "intelmpi"]
+              num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+              slots_per_instance: 2
+              osu_benchmarks:
+                collective: ["osu_allreduce", "osu_alltoall"]
     test_raid.py::test_raid_fault_tolerance_mode:
       dimensions:
         - regions: {{ REGIONS }}


### PR DESCRIPTION
… specifications

Even though the benchmarks are not actually run, the tests expect the benchmark specifications. Otherwise, the tests fail at the beginning.

A further action item is to improve the testing framework to not expect benchmark specifications if benchmark is not enabled

Signed-off-bFy: Hanwen <hanwenli@amazon.com>cli-patch-v9.txt


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
