### PR TITLE
Fix root volume id retrieval in integration tests

### DIFF
--- a/tests/integration-tests/constants.py
+++ b/tests/integration-tests/constants.py
@@ -9,14 +9,6 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-OS_TO_ROOT_VOLUME_DEVICE = {
-    "centos7": "/dev/sda1",
-    "alinux2": "/dev/xvda",
-    "ubuntu1804": "/dev/sda1",
-    "ubuntu2004": "/dev/sda1",
-    "rhel8": "/dev/xvda",
-}
-
 SCHEDULERS_SUPPORTING_IMDS_SECURED = ["slurm", "plugin"]
 
 OSU_BENCHMARK_VERSION = "5.7.1"


### PR DESCRIPTION
### Description of changes
* Fix root volume id retrieval in integration tests

### Tests
* Manual run of integration test `test_ebs.py::test_ebs_multiple` 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
