### PR TITLE
Fix transient log rotation integtation test

### DIFF
--- a/tests/integration-tests/tests/log_rotation/test_log_rotation.py
+++ b/tests/integration-tests/tests/log_rotation/test_log_rotation.py
@@ -233,6 +233,12 @@ def _test_logs_are_rotated(os, logs, remote_command_executor, before_log_rotatio
                 f"echo '{before_log_rotation_message}' | sudo tee --append {log.get('log_path')}",
                 compute_node_ip,
             )
+    # Flush changes to the disk using sync to ensure file is not detected as empty by mistake and not rotate
+    _run_command_on_node(
+        remote_command_executor,
+        "sync",
+        compute_node_ip,
+    )
     # force log rotate without waiting for logs to reach certain size
     _run_command_on_node(remote_command_executor, "sudo logrotate -f /etc/logrotate.conf", compute_node_ip)
     # check if logs are rotated


### PR DESCRIPTION
### Description of changes
* Sporadic failure on logrotation integration test may caused by we force rotate the log file right after writing entries to it, the changes in the files are not yet flushed to disk, file is detected as empty by mistake and not rotate. This fix is to flush changes to the disk using sync after it is written to log file to ensure file is not detected as empty by mistake during rotation

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
