### PR TITLE
`[cloudformation/custom_resource]` Add CFN custom resource for cluster.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.6.0
 ----
 **ENHANCEMENTS**
+- Add a CloudFormation custom resource for creating and managing clusters from CloudFormation.
 - Add `mem_used_percent` and `disk_used_percent` metrics for head node memory and root volume disk utilization tracking on the ParallelCluster CloudWatch dashboard, and set up alarms for monitoring these metrics.
 
 **ENHANCEMENTS**

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -99,7 +99,7 @@ Resources:
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       TracingConfig:
         Mode: Active
-      MemorySize: 1024
+      MemorySize: 2048
       Timeout: 60
       Code:
         ZipFile: |

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -33,7 +33,7 @@ Resources:
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       Description: Library which contains aws-parallelcluster python package and dependencies
       Content:
-        S3Bucket: !Sub ${Region}-aws-parallelcluster
+        S3Bucket: !Sub ${AWS::Region}-aws-parallelcluster
         S3Key: !Sub
         - parallelcluster/${Version}/layers/aws-parallelcluster/lambda-layer.zip
         - { Version: !FindInMap [ParallelCluster, Constants, Version] }
@@ -121,14 +121,14 @@ Resources:
           from pcluster.api.errors import exception_message, NotFoundException
           import pcluster.lib as pc
 
-          crhelper_path = "/opt/python//pcluster/resources/custom_resources/custom_resources_code"
+          crhelper_path = "/opt/python/pcluster/resources/custom_resources/custom_resources_code"
           sys.path.insert(0, crhelper_path)
           from crhelper import CfnResource
           helper = CfnResource()
 
           def update_response(response):
-              keep_keys = {"version", "creattionTime", "clusterName", "clusterStatus", "cloudformationStackArn", "lastUpdatedTime", "region"}
-              helper.Data.update({k: v for k, v in response.items() if k in keep_keys})
+              logger.info(response)
+              helper.Data.update(response)
 
           def serialize(val):
               return utils.to_iso_timestr(val) if isinstance(val, datetime.date) else val
@@ -141,7 +141,9 @@ Resources:
               elif event["RequestType"].upper() == "UPDATE" and event["PhysicalResourceId"] != properties.get("ClusterName"):
                   raise ValueError("Cannot update the ClusterName in the properties.")
 
-              physical_resource_id = properties["ClusterName"]
+              cluster_name = properties["ClusterName"]
+              logger.info(f"{event['RequestType'].upper()}: {cluster_name}")
+              physical_resource_id = cluster_name
 
               try:
                   kwargs = {**{pcluster.utils.to_snake_case(k): serialize(v) for k, v in properties.items() if k not in {"ServiceToken"}}, "wait": False}
@@ -153,6 +155,7 @@ Resources:
                   message = pcluster.api.errors.exception_message(e)
                   str_msg = encoder.JSONEncoder().encode(message)
                   if not re.search(r"No changes found", str_msg):
+                    logger.info(f"No changes found to update: {cluster_name}")
                     raise ValueError(str_msg)
 
               return physical_resource_id
@@ -168,6 +171,7 @@ Resources:
           @helper.delete
           def delete(event, context):
               cluster_name = event["ResourceProperties"].get("ClusterName")
+              logger.info(f"Deleting: {cluster_name}")
               try:
                   update_response(pc.delete_cluster(cluster_name=cluster_name))
               except (ParameterException, NotFoundException): # cluster deleted or invalid name -- ignore here.
@@ -195,7 +199,9 @@ Resources:
               # only invalid parameter can be the name
               except (ParameterException, NotFoundException):
                   if event["RequestType"].upper() == "DELETE":
-                      return True
+                      # Returning a value here signifies that the delete is completed and we can stop polling
+                      # not returning a value here causes cfn resource helper to keep polling.
+                      return cluster_name
                   raise ValueError(f"{cluster_name} failed {event['RequestType'].upper()}. See substack for further details.")
 
           @helper.poll_create

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -1,0 +1,225 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: AWS ParallelCluster CloudFormation Template
+
+Parameters:
+
+  CustomLambdaRole:
+    Description: Custom role to use for PC Lambda
+    Type: String
+    Default: ''
+
+  AdditionalIamPolicies:
+    Description: Comma-delimited list of additional IAM Policies to add to the cluster (only used if CustomLambdaRole isn't provided).
+    Type: CommaDelimitedList
+    Default: ''
+
+Mappings:
+  ParallelCluster:
+    Constants:
+      Version: 3.6.0  # major.minor.patch+alpha/beta_identifier
+
+Conditions:
+  CustomRoleCondition: !Not [!Equals [!Ref CustomLambdaRole, '']]
+  UsePCPolicies: !Not [!Condition CustomRoleCondition ]
+  UseAdditionalIamPolicies: !Not [!Equals [!Join ['', !Ref AdditionalIamPolicies ], '']]
+
+Resources:
+  PclusterLayer:
+    Type: AWS::Lambda::LayerVersion
+    Properties:
+      LayerName: !Sub
+        - PCLayer-${StackIdSuffix}
+        - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
+      Description: Library which contains aws-parallelcluster python package and dependencies
+      Content:
+        S3Bucket: !Sub ${Region}-aws-parallelcluster
+        S3Key: !Sub
+        - parallelcluster/${Version}/layers/aws-parallelcluster/lambda-layer.zip
+        - { Version: !FindInMap [ParallelCluster, Constants, Version] }
+      CompatibleRuntimes:
+        - python3.9
+
+  PclusterPolicies:
+    Condition: UsePCPolicies
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${Region}-aws-parallelcluster.s3.${Region}.amazonaws.com/parallelcluster/${Version}/templates/policies/policies.yaml
+        - { Version: !FindInMap [ParallelCluster, Constants, Version], Region: !Ref AWS::Region }
+      TimeoutInMinutes: 10
+      Parameters:
+        EnableIamAdminAccess: true
+
+  PclusterCfnFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${PclusterCfnFunction}
+
+  EventsPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: EventsPolicy
+            Effect: Allow
+            Action:
+              - events:PutRule
+              - events:DeleteRule
+              - events:PutTargets
+              - events:RemoveTargets
+            Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*
+
+  PclusterLambdaRole:
+    Condition: UsePCPolicies
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service: lambda.amazonaws.com
+      ManagedPolicyArns: !Split
+        - ","
+        - !Sub
+          - ${LambdaExecutionPolicy},${ClusterPolicy},${DefaultAdminPolicy},${EventsPolicy}${AdditionalIamPolicies}
+          - { LambdaExecutionPolicy: !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ClusterPolicy: !GetAtt [ PclusterPolicies, Outputs.ParallelClusterClusterPolicy ],
+              DefaultAdminPolicy: !GetAtt [ PclusterPolicies, Outputs.DefaultParallelClusterIamAdminPolicy ],
+              EventsPolicy: !Ref EventsPolicy,
+              AdditionalIamPolicies: !If [UseAdditionalIamPolicies, !Sub [",${AdditionalPolicies}", AdditionalPolicies: !Join [',', !Ref AdditionalIamPolicies ]], ''] }
+
+  PclusterCfnFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub
+        - pcluster-cfn-${StackIdSuffix}
+        - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
+      TracingConfig:
+        Mode: Active
+      MemorySize: 1024
+      Timeout: 60
+      Code:
+        ZipFile: |
+          import datetime
+          import json
+          import logging
+          import random
+          import re
+          import string
+          import sys
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+          import pcluster.api.controllers.cluster_operations_controller
+          import pcluster.api.errors
+          import pcluster.utils
+          from pcluster.api import encoder
+          from pcluster.cli.exceptions import APIOperationException, ParameterException
+          from pcluster.api.errors import exception_message, NotFoundException
+          import pcluster.lib as pc
+
+          crhelper_path = "/opt/python//pcluster/resources/custom_resources/custom_resources_code"
+          sys.path.insert(0, crhelper_path)
+          from crhelper import CfnResource
+          helper = CfnResource()
+
+          def update_response(response):
+              keep_keys = {"version", "creattionTime", "clusterName", "clusterStatus", "cloudformationStackArn", "lastUpdatedTime", "region"}
+              helper.Data.update({k: v for k, v in response.items() if k in keep_keys})
+
+          def serialize(val):
+              return utils.to_iso_timestr(val) if isinstance(val, datetime.date) else val
+
+          def create_or_update(event):
+              properties = event["ResourceProperties"]
+
+              if event["RequestType"].upper() == "CREATE" and "ClusterName" not in properties:
+                  raise ValueError("Couldn't find a ClusterName in the properties.")
+              elif event["RequestType"].upper() == "UPDATE" and event["PhysicalResourceId"] != properties.get("ClusterName"):
+                  raise ValueError("Cannot update the ClusterName in the properties.")
+
+              physical_resource_id = properties["ClusterName"]
+
+              try:
+                  kwargs = {**{pcluster.utils.to_snake_case(k): serialize(v) for k, v in properties.items() if k not in {"ServiceToken"}}, "wait": False}
+                  func = {"CREATE": pc.create_cluster, "UPDATE": pc.update_cluster}[event["RequestType"].upper()]
+                  update_response(func(**kwargs))
+              except (APIOperationException, ParameterException, TypeError)  as e:
+                  raise ValueError(str(e))
+              except Exception as e:
+                  message = pcluster.api.errors.exception_message(e)
+                  str_msg = encoder.JSONEncoder().encode(message)
+                  if not re.search(r"No changes found", str_msg):
+                    raise ValueError(str_msg)
+
+              return physical_resource_id
+
+          @helper.create
+          def create(event, context):
+              return create_or_update(event)
+
+          @helper.update
+          def update(event, context):
+              return create_or_update(event)
+
+          @helper.delete
+          def delete(event, context):
+              cluster_name = event["ResourceProperties"].get("ClusterName")
+              try:
+                  update_response(pc.delete_cluster(cluster_name=cluster_name))
+              except (ParameterException, NotFoundException): # cluster deleted or invalid name -- ignore here.
+                  pass
+              except Exception as e:
+                  message = exception_message(e)
+                  raise ValueError(encoder.JSONEncoder().encode(message))
+
+          # Polling functionality for async CUD operations
+
+          def poll(event):
+              cluster_name = event["ResourceProperties"].get("ClusterName")
+              try:
+                  cluster = pc.describe_cluster(cluster_name=cluster_name)
+                  status = cluster.get("clusterStatus")
+
+                  if status in {"CREATE_COMPLETE", "UPDATE_COMPLETE"}:
+                      update_response(cluster)
+                      return cluster_name
+                  elif status in {"CREATE_FAILED", "UPDATE_FAILED", "DELETE_FAILED"}:
+                      raise ValueError(f"{cluster_name} failed {event['RequestType'].upper()}. See substack for further details.")
+
+              # If create fails and we try to roll-back (e.g. delete),
+              # gracefully handle missing cluster. on the delete pathway, the
+              # only invalid parameter can be the name
+              except (ParameterException, NotFoundException):
+                  if event["RequestType"].upper() == "DELETE":
+                      return True
+                  raise ValueError(f"{cluster_name} failed {event['RequestType'].upper()}. See substack for further details.")
+
+          @helper.poll_create
+          def poll_create(event, context):
+              return poll(event)
+
+          @helper.poll_update
+          def poll_update(event, context):
+              return poll(event)
+
+          @helper.poll_delete
+          def poll_delete(event, context):
+              return poll(event)
+
+          def handler(event, context):
+              helper(event, context)
+
+      Handler: index.handler
+      Runtime: python3.9
+      Role: !If [CustomRoleCondition, !Ref CustomLambdaRole, !GetAtt PclusterLambdaRole.Arn]
+      Layers:
+        - !Ref PclusterLayer
+
+Outputs:
+  Function:
+    Description: Lambda for managing PCluster Resources
+    Value: !GetAtt PclusterCfnFunction.Arn

--- a/cloudformation/tests/conftest.py
+++ b/cloudformation/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 PUBPRIV_TEMPLATE = "../networking/public-private.cfn.json"
 
 
-def _random_str():
+def random_str():
     """Generate a random string."""
     alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
     start = random.choice(string.ascii_uppercase + string.ascii_lowercase)
@@ -54,7 +54,7 @@ def pytest_collection_modifyitems(items, config):
 @pytest.fixture(name="random_stack_name")
 def random_stack_name_fixture():
     """Provide a short random id that can be used in a aack name."""
-    return _random_str()
+    return random_str()
 
 
 @pytest.fixture(scope="session", name="cfn")
@@ -69,7 +69,7 @@ def default_vpc_fixture(cfn):
     """Create our default VPC networking and return the stack name."""
     ec2 = boto3.client("ec2")
     azs = ec2.describe_availability_zones()["AvailabilityZones"]
-    stack_name = _random_str()
+    stack_name = random_str()
     parameters = {"AvailabilityZone": azs[0]["ZoneName"]}
 
     yield from cfn_stack_generator(PUBPRIV_TEMPLATE, stack_name, parameters)

--- a/cloudformation/tests/conftest.py
+++ b/cloudformation/tests/conftest.py
@@ -5,6 +5,44 @@ import string
 import boto3
 import pytest
 
+PUBPRIV_TEMPLATE = "../networking/public-private.cfn.json"
+
+
+def _random_str():
+    """Generate a random string."""
+    alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
+    start = random.choice(string.ascii_uppercase + string.ascii_lowercase)
+    return start + "".join(random.choice(alnum) for _ in range(8))
+
+
+def cfn_stack_generator(path, name, parameters=None, capabilities=None):
+    """Create a stack, wait for completion and yield it."""
+    cfn = boto3.client("cloudformation")
+    with open(path, encoding="utf-8") as templ:
+        template = templ.read()
+
+    parameters = parameters or {}
+
+    # Create networking using CloudFormation, block on completion
+    cfn.create_stack(
+        StackName=name,
+        TemplateBody=template,
+        Capabilities=capabilities or ["CAPABILITY_IAM"],
+        Parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items()],
+    )
+    cfn.get_waiter("stack_create_complete").wait(StackName=name)
+
+    try:
+        outputs = cfn.describe_stacks(StackName=name)["Stacks"][0]["Outputs"]
+        yield {o["OutputKey"]: o["OutputValue"] for o in outputs}
+
+        # Delete the stack through CFN and wait for delete to complete
+        cfn.delete_stack(StackName=name)
+        cfn.get_waiter("stack_delete_complete").wait(StackName=name)
+    except Exception as exc:
+        cfn.delete_stack(StackName=name)
+        raise exc
+
 
 def pytest_collection_modifyitems(items, config):
     """Augment the tests to add unmarked marker to tests that aren't marked."""
@@ -16,8 +54,7 @@ def pytest_collection_modifyitems(items, config):
 @pytest.fixture(name="random_stack_name")
 def random_stack_name_fixture():
     """Provide a short random id that can be used in a aack name."""
-    alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
-    return "".join(random.choice(alnum) for _ in range(8))
+    return _random_str()
 
 
 @pytest.fixture(scope="session", name="cfn")
@@ -25,3 +62,14 @@ def cfn_fixture():
     """Create a CloudFormation Boto3 client."""
     client = boto3.client("cloudformation")
     return client
+
+
+@pytest.fixture(scope="module", name="default_vpc")
+def default_vpc_fixture(cfn):
+    """Create our default VPC networking and return the stack name."""
+    ec2 = boto3.client("ec2")
+    azs = ec2.describe_availability_zones()["AvailabilityZones"]
+    stack_name = _random_str()
+    parameters = {"AvailabilityZone": azs[0]["ZoneName"]}
+
+    yield from cfn_stack_generator(PUBPRIV_TEMPLATE, stack_name, parameters)

--- a/cloudformation/tests/test_cluster.yaml
+++ b/cloudformation/tests/test_cluster.yaml
@@ -1,0 +1,60 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  AWS ParallelCluster CloudFormation Template
+
+Parameters:
+  ClusterName:
+    Description: Name of cluster. Note this must be different than the stack name.
+    Type: String
+  HeadNodeSubnet:
+    Description: Subnet for the HeadNode
+    Type: String
+  ComputeNodeSubnet:
+    Description: Subnet for the ComputeNode
+    Type: String
+  ComputeInstanceMax:
+    Description: Maximum number of compute instances
+    Type: Number
+    Default: 10
+  ServiceToken:
+    Description: ARN of Lambda Function backing the Cluster Resource
+    Type: String
+  OnNodeConfigured:
+    Description: Script to run on HeadNode configured
+    Type: String
+    Default: ''
+
+Conditions:
+  OnNodeConfiguredCondition: !Not [!Equals [!Ref OnNodeConfigured, '']]
+
+Resources:
+  PclusterCluster:
+    Type: Custom::PclusterCluster
+    Properties:
+      ServiceToken: !Ref ServiceToken
+      ClusterName: !Ref ClusterName
+      ClusterConfiguration:
+        Image:
+          Os: alinux2
+        HeadNode:
+          InstanceType: t2.small
+          Networking:
+            SubnetId: !Ref HeadNodeSubnet
+          CustomActions: !If
+            - OnNodeConfiguredCondition
+            -
+              OnNodeConfigured:
+                Script: !Ref OnNodeConfigured
+            - !Ref AWS::NoValue
+        Scheduling:
+          Scheduler: slurm
+          SlurmQueues:
+          - Name: queue0
+            ComputeResources:
+            - Name: queue0-i0
+              InstanceType: t2.micro
+              MinCount: 0
+              MaxCount: !Ref ComputeInstanceMax
+            Networking:
+              SubnetIds:
+              - !Ref ComputeNodeSubnet

--- a/cloudformation/tests/test_cluster_custom_resource.py
+++ b/cloudformation/tests/test_cluster_custom_resource.py
@@ -1,0 +1,245 @@
+"""Test cases for Cluster CloudFormation Custom Resource."""
+import random
+import string
+
+import botocore
+import pytest
+import urllib3
+import yaml
+from assertpy import assert_that
+from conftest import cfn_stack_generator
+
+CLUSTER_TEMPLATE = "../custom_resource/cluster.yaml"
+TEST_CLUSTER = "test_cluster.yaml"
+
+
+# The following functions late-bind the library as it is only used locally
+def _list_clusters(cluster_name):
+    """List clusters and filter by name."""
+    import pcluster.lib as pcluster
+
+    return pcluster.list_clusters(query=f"clusters[?clusterName=='{cluster_name}']|[0]")
+
+
+def _describe_cluster(cluster_name):
+    """Late bind library and describe cluster."""
+    import pcluster.lib as pcluster
+
+    return pcluster.describe_cluster(cluster_name=cluster_name)
+
+
+def _delete_cluster(cluster_name):
+    """Late bind library and delete cluster."""
+    import pcluster.lib as pcluster
+
+    return pcluster.delete_cluster(cluster_name=cluster_name)
+
+
+def _random_id():
+    """Generate a random string."""
+    alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
+    return "".join(random.choice(alnum) for _ in range(8))
+
+
+def cluster_config(cluster_name):
+    """Return the configuration for a cluster."""
+    cluster = _describe_cluster(cluster_name)
+    config_url = cluster["clusterConfiguration"]["url"]
+    http = urllib3.PoolManager()
+    resp = http.request(url=config_url, method="GET")
+    config = yaml.safe_load(resp.data.decode("UTF-8"))
+    return config
+
+
+@pytest.fixture(scope="module", name="cluster_custom_resource")
+def cluster_custom_resource_fixture():
+    """Create the cluster custom resource stack."""
+    capabilities = ["CAPABILITY_IAM", "CAPABILITY_AUTO_EXPAND"]
+    yield from cfn_stack_generator(CLUSTER_TEMPLATE, _random_id(), None, capabilities)
+
+
+@pytest.fixture(scope="module", name="cluster")
+def cluster_fixture(cfn, default_vpc, cluster_custom_resource):
+    """Create a basic cluster through CFN, wait for it to start and return it."""
+    stack_name = random.choice(string.ascii_lowercase) + _random_id()
+    cluster_name = f"c-{stack_name}"
+    parameters = {
+        "ClusterName": cluster_name,
+        "HeadNodeSubnet": default_vpc["PublicSubnetId"],
+        "ComputeNodeSubnet": default_vpc["PrivateSubnetId"],
+        "ServiceToken": cluster_custom_resource["Function"],
+    }
+
+    with open(TEST_CLUSTER, encoding="utf-8") as templ:
+        template = templ.read()
+
+    # Create the cluster using CloudFormation directly
+    cfn.create_stack(
+        StackName=stack_name,
+        TemplateBody=template,
+        Capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
+        Parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items()],
+    )
+
+    # Wait for it to create
+    cfn.get_waiter("stack_create_complete").wait(StackName=stack_name)
+
+    # Validate that CFN sees the stack creation as "CREATE_COMPLETE"
+    stack = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]
+    status = stack["StackStatus"]
+    stack_id = stack["StackId"]
+    assert_that(status).is_equal_to("CREATE_COMPLETE")
+
+    # Validate that PC sees the cluster as "CREATE_COMPLETE"
+    cluster = _list_clusters(cluster_name)
+    assert_that(cluster["clusterStatus"]).is_equal_to("CREATE_COMPLETE")
+
+    try:
+        yield stack_name, cluster_name, parameters
+
+        # Delete the stack through CFN and wait for delete to complete
+        cfn.delete_stack(StackName=stack_name)
+        cfn.get_waiter("stack_delete_complete").wait(StackName=stack_name)
+        status = cfn.describe_stacks(StackName=stack_id)["Stacks"][0]["StackStatus"]
+        assert_that(status).is_equal_to("DELETE_COMPLETE")
+
+        # Validate that PC sees the cluster as deleted
+        cluster = _list_clusters(cluster_name)
+        assert_that(cluster).is_none()
+    except Exception as exc:
+        cfn.delete_stack(StackName=stack_id)
+        raise exc
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        ({"ClusterName": "0"}),
+        ({"OnNodeConfigured": "s3://invalidbucket/invlidkey"}),
+    ],
+)
+@pytest.mark.local
+def test_cluster_create_invalid_syntax(cfn, default_vpc, cluster_custom_resource, parameters):
+    """Try to create a cluster with invalid syntax and ensure that it fails."""
+    stack_name = random.choice(string.ascii_lowercase) + _random_id()
+    cluster_name = f"c-{stack_name}"
+    parameters = {
+        "ClusterName": cluster_name,
+        "HeadNodeSubnet": default_vpc["PublicSubnetId"],
+        "ComputeNodeSubnet": default_vpc["PrivateSubnetId"],
+        "ServiceToken": cluster_custom_resource["Function"],
+        **parameters,
+    }
+
+    with open(TEST_CLUSTER, encoding="utf-8") as templ:
+        template = templ.read()
+
+    # Create the cluster using CloudFormation directly
+    cfn.create_stack(
+        StackName=stack_name,
+        TemplateBody=template,
+        Capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
+        Parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items()],
+    )
+
+    with pytest.raises(botocore.exceptions.WaiterError):
+        cfn.get_waiter("stack_create_complete").wait(StackName=stack_name)
+
+    # Stack will be in a ROLLBACK_COMPLETE state at this point, so delete it
+    cfn.delete_stack(StackName=stack_name)
+    cfn.get_waiter("stack_delete_complete").wait(StackName=stack_name)
+
+
+@pytest.mark.local
+def test_cluster_update(cfn, cluster):
+    """Perform crud validation on cluster."""
+    stack_name, cluster_name, parameters = cluster
+
+    # Update the stack
+    update_params = {"ComputeInstanceMax": "8", **parameters}
+    cfn.update_stack(
+        StackName=stack_name,
+        UsePreviousTemplate=True,
+        Parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in update_params.items()],
+    )
+    cfn.get_waiter("stack_update_complete").wait(StackName=stack_name)
+
+    cluster = _list_clusters(cluster_name)
+    assert_that(cluster["clusterStatus"]).is_equal_to("UPDATE_COMPLETE")
+    config = cluster_config(cluster_name)
+    assert_that(int(config["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MaxCount"])).is_equal_to(8)
+
+
+@pytest.mark.parametrize(
+    "update_parameters",
+    [
+        ({"ClusterName": "j"}),
+        ({"ComputeInstanceMax": "-10"}),
+        ({"OnNodeConfigured": "s3://invalidpath"}),
+    ],
+)
+@pytest.mark.local
+def test_update_invalid(cfn, cluster, update_parameters):
+    """Perform crud validation on cluster."""
+    stack_name, cluster_name, parameters = cluster
+
+    old_cluster_status = _describe_cluster(cluster_name)
+    old_config = cluster_config(cluster_name)
+
+    # Update the stack to change the name
+    update_params = {**parameters, **update_parameters}
+    cfn.update_stack(
+        StackName=stack_name,
+        UsePreviousTemplate=True,
+        Parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in update_params.items()],
+    )
+    with pytest.raises(botocore.exceptions.WaiterError):
+        cfn.get_waiter("stack_update_complete").wait(StackName=stack_name)
+
+    cluster = _list_clusters(cluster_name)
+    assert_that(cluster["clusterName"]).is_equal_to(cluster_name)
+    config = cluster_config(cluster_name)
+    new_max = int(config["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MaxCount"])
+    old_max = int(old_config["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MaxCount"])
+    assert_that(new_max).is_equal_to(old_max)
+
+    cluster_status = _describe_cluster(cluster_name)
+    assert_that(old_cluster_status["lastUpdatedTime"]).is_equal_to(cluster_status["lastUpdatedTime"])
+
+
+@pytest.mark.local
+def test_cluster_delete_out_of_band(cfn, default_vpc, cluster_custom_resource):
+    """Perform crud validation on cluster."""
+    stack_name = random.choice(string.ascii_lowercase) + _random_id()
+    cluster_name = f"c-{stack_name}"
+    parameters = {
+        "ClusterName": cluster_name,
+        "HeadNodeSubnet": default_vpc["PublicSubnetId"],
+        "ComputeNodeSubnet": default_vpc["PrivateSubnetId"],
+        "ServiceToken": cluster_custom_resource["Function"],
+    }
+
+    with open(TEST_CLUSTER, encoding="utf-8") as templ:
+        template = templ.read()
+
+    # Create the cluster using CloudFormation directly
+    cfn.create_stack(
+        StackName=stack_name,
+        TemplateBody=template,
+        Capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
+        Parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items()],
+    )
+
+    stack = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]
+    stack_id = stack["StackId"]
+
+    # Wait for it to create
+    cfn.get_waiter("stack_create_complete").wait(StackName=stack_name)
+
+    _delete_cluster(cluster_name)
+
+    # Delete the stack through CFN and wait for delete to complete
+    cfn.delete_stack(StackName=stack_name)
+    cfn.get_waiter("stack_delete_complete").wait(StackName=stack_name)
+    status = cfn.describe_stacks(StackName=stack_id)["Stacks"][0]["StackStatus"]
+    assert_that(status).is_equal_to("DELETE_COMPLETE")

--- a/cloudformation/tests/test_cluster_custom_resource.py
+++ b/cloudformation/tests/test_cluster_custom_resource.py
@@ -7,7 +7,7 @@ import pytest
 import urllib3
 import yaml
 from assertpy import assert_that
-from conftest import cfn_stack_generator
+from conftest import cfn_stack_generator, random_str
 
 CLUSTER_TEMPLATE = "../custom_resource/cluster.yaml"
 TEST_CLUSTER = "test_cluster.yaml"
@@ -35,13 +35,6 @@ def _delete_cluster(cluster_name):
     return pcluster.delete_cluster(cluster_name=cluster_name)
 
 
-def _random_id():
-    """Generate a random string."""
-    alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
-    start = random.choice(string.ascii_uppercase + string.ascii_lowercase)
-    return start + "".join(random.choice(alnum) for _ in range(8))
-
-
 def cluster_config(cluster_name):
     """Return the configuration for a cluster."""
     cluster = _describe_cluster(cluster_name)
@@ -56,13 +49,13 @@ def cluster_config(cluster_name):
 def cluster_custom_resource_fixture():
     """Create the cluster custom resource stack."""
     capabilities = ["CAPABILITY_IAM", "CAPABILITY_AUTO_EXPAND"]
-    yield from cfn_stack_generator(CLUSTER_TEMPLATE, _random_id(), None, capabilities)
+    yield from cfn_stack_generator(CLUSTER_TEMPLATE, random_str(), None, capabilities)
 
 
 @pytest.fixture(scope="module", name="cluster")
 def cluster_fixture(cfn, default_vpc, cluster_custom_resource):
     """Create a basic cluster through CFN, wait for it to start and return it."""
-    stack_name = random.choice(string.ascii_lowercase) + _random_id()
+    stack_name = random.choice(string.ascii_lowercase) + random_str()
     cluster_name = f"c-{stack_name}"
     parameters = {
         "ClusterName": cluster_name,
@@ -122,7 +115,7 @@ def cluster_fixture(cfn, default_vpc, cluster_custom_resource):
 @pytest.mark.local
 def test_cluster_create_invalid_syntax(cfn, default_vpc, cluster_custom_resource, parameters):
     """Try to create a cluster with invalid syntax and ensure that it fails."""
-    stack_name = random.choice(string.ascii_lowercase) + _random_id()
+    stack_name = random.choice(string.ascii_lowercase) + random_str()
     cluster_name = f"c-{stack_name}"
     parameters = {
         "ClusterName": cluster_name,
@@ -211,7 +204,7 @@ def test_update_invalid(cfn, cluster, update_parameters):
 @pytest.mark.local
 def test_cluster_delete_out_of_band(cfn, default_vpc, cluster_custom_resource):
     """Perform crud validation on cluster."""
-    stack_name = random.choice(string.ascii_lowercase) + _random_id()
+    stack_name = random.choice(string.ascii_lowercase) + random_str()
     cluster_name = f"c-{stack_name}"
     parameters = {
         "ClusterName": cluster_name,

--- a/cloudformation/tests/test_cluster_custom_resource.py
+++ b/cloudformation/tests/test_cluster_custom_resource.py
@@ -38,7 +38,8 @@ def _delete_cluster(cluster_name):
 def _random_id():
     """Generate a random string."""
     alnum = string.ascii_uppercase + string.ascii_lowercase + string.digits
-    return "".join(random.choice(alnum) for _ in range(8))
+    start = random.choice(string.ascii_uppercase + string.ascii_lowercase)
+    return start + "".join(random.choice(alnum) for _ in range(8))
 
 
 def cluster_config(cluster_name):

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -24,7 +24,7 @@ arm_pl:
     dimensions:
       - regions: ["ap-northeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: {{ common.OSS_COMMERCIAL_ARM_NO_RHEL8 }}
         schedulers: ["slurm"]
 {%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
 scheduler_plugin:

--- a/util/bump-version.sh
+++ b/util/bump-version.sh
@@ -64,6 +64,7 @@ main() {
         sed -i "s| ShortVersion: $CURRENT_VERSION_SHORT| ShortVersion: $NEW_VERSION_SHORT|g" api/infrastructure/parallelcluster-api.yaml
         sed -i "s| version: $CURRENT_VERSION_SHORT| version: $NEW_VERSION_SHORT|g" api/spec/openapi/ParallelCluster.openapi.yaml
         sed -i "s| version: \"$CURRENT_VERSION_SHORT\"| version: \"$NEW_VERSION_SHORT\"|g" api/spec/smithy/model/parallelcluster.smithy
+        sed -i "s| Version: $CURRENT_VERSION| Version: $NEW_VERSION|g" cloudformation/custom_resource/cluster.yaml
         cp "$PC_SUPPORT_DIR/os_$CURRENT_VERSION.json" "$PC_SUPPORT_DIR/os_$NEW_VERSION.json"
         git add "$PC_SUPPORT_DIR/os_$NEW_VERSION.json"
 


### PR DESCRIPTION
### Description of changes
* Add a CloudFormation stack for a Cluster CloudFormation Custom Resource

### Tests
* Tests added in the `cloudformation` directory which exercise the new stack. The tests were run locally against an uploaded python layer with the version manually set to `3.5.0`.

Results:

```.sh
tests $ pytest ./test_cluster_custom_resource.py -m local
======================================== test session starts ========================================
platform darwin -- Python 3.9.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/cgruenwa/src/cgpc/aws-parallelcluster/cloudformation/tests, configfile: pytest.ini
plugins: xdist-3.1.0, html-3.2.0, mock-3.10.0, typeguard-2.13.3, cov-4.0.0, metadata-2.0.4, datadir-1
.4.1
collected 7 items

test_cluster_custom_resource.py .......                                                       [100%]

========================================= warnings summary ==========================================
test_cluster_custom_resource.py::test_cluster_update
test_cluster_custom_resource.py::test_cluster_update
  /Users/cgruenwa/Library/Python/3.9/lib/python/site-packages/connexion/decorators/validation.py:16:
DeprecationWarning: Accessing jsonschema.draft4_format_checker is deprecated and will be removed in a
 future release. Instead, use the FORMAT_CHECKER attribute on the corresponding Validator.
    from jsonschema import Draft4Validator, ValidationError, draft4_format_checker

test_cluster_custom_resource.py: 19 warnings
  /Users/cgruenwa/Library/Python/3.9/lib/python/site-packages/pcluster/cli/entrypoint.py:113: Depreca
tionWarning: 'JSONEncoder' is deprecated and will be removed in Flask 2.3. Use 'Flask.json' to provid
e an alternate JSON implementation instead.
    return dispatch_func(**kwargs)

test_cluster_custom_resource.py::test_cluster_delete_out_of_band
  /Users/cgruenwa/Library/Python/3.9/lib/python/site-packages/pcluster/cli/middleware.py:109: Depreca
tionWarning: 'JSONEncoder' is deprecated and will be removed in Flask 2.3. Use 'Flask.json' to provid
e an alternate JSON implementation instead.
    ret = func(**kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================ 7 passed, 22 warnings in 2720.18s (0:45:20) ============================
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
