### PR TITLE
Fix bug in ImageBuilder resources tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Fix EFS, FSx network security groups validators to avoid reporting false errors.
+- Fix missing tagging of resources created by ImageBuilder during the `build-image` operation.
 
 3.5.0
 -----

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -577,6 +577,7 @@ class ImageBuilderCdkStack(Stack):
             "InfrastructureConfiguration",
             name=self._build_resource_name(IMAGEBUILDER_RESOURCE_NAME_PREFIX),
             tags=build_tags,
+            resource_tags=build_tags,
             instance_profile_name=instance_profile_name or Fn.ref("InstanceProfile"),
             terminate_instance_on_failure=self.config.dev_settings.terminate_instance_on_failure
             if self.config.dev_settings and self.config.dev_settings.terminate_instance_on_failure is not None

--- a/cli/tests/pcluster/templates/test_imagebuilder_stack.py
+++ b/cli/tests/pcluster/templates/test_imagebuilder_stack.py
@@ -2580,6 +2580,9 @@ def test_imagebuilder_build_tags(mocker, resource, response, expected_imagebuild
         else:
             assert_that(resource.get("Properties").get("Tags")).is_equal_to(expected_imagebuilder_resource_tags)
 
+        if resource_name == "InfrastructureConfiguration":
+            assert_that(resource.get("Properties").get("ResourceTags")).is_equal_to(expected_imagebuilder_resource_tags)
+
 
 @pytest.mark.parametrize(
     "resource, response, expected_imagebuilder_subnet_id",

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -189,6 +189,18 @@ def assert_instance_has_desired_imds_v2_setting(instance, status):
     assert_that(imds_v2_status).is_equal_to(status)
 
 
+def assert_instance_has_desired_tags(instance, tags: List[dict]):
+    instance_id = instance.get("InstanceId")
+    instance_tags = instance.get("Tags")
+    instance_name = [tag["Value"] for tag in instance_tags if tag["Key"] == "Name"]
+    instance_name_part = f" ({instance_name[0]})" if instance_name else ""
+
+    logging.info(f"Instance {instance_id}{instance_name_part} has tags {instance_tags}")
+
+    for tag in tags:
+        assert_that(instance_tags).contains(tag)
+
+
 def assert_aws_identity_access_is_correct(cluster, users_allow_list, remote_command_executor=None):
     logging.info("Asserting access to AWS caller identity is correct")
 


### PR DESCRIPTION
### Description of changes
* Set the build tags also in the resources created by ImageBuilder.

### Tests
* Modified imagebuilder_stack unit tests accordingly
* Added assertion in `test_build_image()` and ran the integration test to verify that the new assertion works as expected.

### References
Fixes known issue: https://github.com/aws/aws-parallelcluster/issues/5089

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
