### PR TITLE
Permit tags prefix validators to work if a tag is defined as a boolean

### DIFF
--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -49,10 +49,19 @@ def validate_json_format(data):
 
 
 def validate_no_reserved_tag(tags):
-    """Validate there is no tag with reserved prefix."""
+    """
+    Validate there is no tag with reserved prefix.
+
+    If one tag in the config has a boolean value, tags will be a list of dict.
+    If all of them are strings, we'll have a list of BaseTag objects.
+    """
     if tags:
         for tag in tags:
-            if tag.key.startswith(PCLUSTER_PREFIX):
+            if isinstance(tag, BaseTag):
+                tag_key = tag.key
+            else:
+                tag_key = tag.get("key", "")
+            if tag_key.startswith(PCLUSTER_PREFIX):
                 raise ValidationError(message=f"The tag key prefix '{PCLUSTER_PREFIX}' is reserved and cannot be used.")
 
 


### PR DESCRIPTION
If one tag in the config has a boolean value, tags variable will be a list of dict. If all of them are strings, tags variable will be a list of BaseTag objects.

This patch improves the `validate_no_reserved_tag` to be able to work in both the cases.

Previously, when using a config like:
```
Tags:
  - Key: WrongTagValue
    Value: true
```
the cluster creation was failing with an error:
```
"message": "Invalid cluster configuration: 'dict' object has no attribute 'key'"
```

I replicated the issue within the unit tests and then fixed it.

Now, at cluster creation time, the validator is executed correctly and the Schema parsing fails with a meaningful message:
```
      "type": "ConfigSchemaValidator",
      "message": "[('Tags', {1: {'Value': ['Not a valid string.']}})]"
```

