### PR TITLE
[Integ-tests] Fix _delete_volumes to use the right boto3 call

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -401,7 +401,7 @@ class Cluster:
         ec2_client = boto3.client("ec2", region_name=self.region)
         volumes = ec2_client.describe_volumes(Filters=[get_stack_id_tag_filter(self.cfn_stack_arn)])["Volumes"]
         for volume in volumes:
-            ec2_client.delete_snapshot(VolumeId=volume["VolumeId"])
+            ec2_client.delete_volume(VolumeId=volume["VolumeId"])
 
 
 class ClustersFactory:

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -488,7 +488,7 @@ test-suites:
     test_ephemeral.py::test_head_node_stop:
       dimensions:
         - regions: {{ REGIONS }}
-          instances: {{ INSTANCES }}
+          instances: ["m5d.xlarge", "h1.2xlarge"]
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
   tags:


### PR DESCRIPTION
There are two commits:

1. The first commit fixes a 1.5-year-old bug :)
2. The second commit fixes isolated_regions.yaml to use the right instance type for head node stop. Because this test requires instance types with instance store

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
