### PR TITLE
[Isolated Regions] pcluster configure: fix the filter used to get qualifying subnets when not running in US isolated regions.

### DIFF
--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -104,7 +104,7 @@ def _get_subnets(conn, vpc_id):
     # Subnets in these regions do not have the field "Ipv6Native", so
     # applying the filter ipv6-native=false would make the DescribeSubnets call to always return an empty set.
     if not conn.meta.region_name.startswith("us-iso"):
-        subnet_filters += {"Name": "ipv6-native", "Values": ["false"]}
+        subnet_filters.append({"Name": "ipv6-native", "Values": ["false"]})
     subnet_list = conn.describe_subnets(Filters=subnet_filters).get("Subnets")
     for subnet in subnet_list:
         subnet_options.append(


### PR DESCRIPTION
### Description of changes
Fix regression introduced in pcluster configure. 
In particular, we fixed the filter used to get qualifying subnets when not running in US isolated regions.
The bug was causing the describe_subnets call to fail when executed in non US isolated regions.
Regression was introduced in https://github.com/aws/aws-parallelcluster/pull/5025.

### Tests
* Manually tested pcluster configure in eu-west-1.
* Test `test_pcluster_configure` succeeded in us-east-1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
