### PR TITLE
[Isolated Regions] [Test] Excluding the test 'test_iam_image.py::test_iam_roles'  from test config for US isolated regions

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -190,11 +190,13 @@ test-suites:
         - regions: {{ REGIONS }}
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
-    test_iam_image.py::test_iam_roles:
-      dimensions:
-        - regions: {{ REGIONS }}
-          instances: {{ INSTANCES }}
-          oss: {{ OSS }}
+# This test cannot be executed in US isolated regions
+# because it makes use of build-image, which is not supported in these regions.
+#    test_iam_image.py::test_iam_roles:
+#      dimensions:
+#        - regions: {{ REGIONS }}
+#          instances: {{ INSTANCES }}
+#          oss: {{ OSS }}
     test_iam.py::test_s3_read_write_resource:
       dimensions:
         - regions: {{ REGIONS }}


### PR DESCRIPTION
### Description of changes
[Isolated Regions] [Test] Excluding the test 'test_iam_image.py::test_iam_roles'  from test config for US isolated regions, because we do not support build-image in these regions.

### Tests
Not needed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
