### PR TITLE
Add check on the metadata server availability to speed up the discovery of the public-ipv4

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -746,7 +746,7 @@ storage:
   # Ephemeral test requires instance type with instance store
   test_ephemeral.py::test_head_node_stop:
     dimensions:
-      - regions: ["us-east-1"]
+      - regions: ["use1-az4"]
         instances: ["m5d.xlarge", "h1.2xlarge"]
         oss: ["alinux2"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/redhat8.yaml
+++ b/tests/integration-tests/configs/redhat8.yaml
@@ -303,7 +303,7 @@ test-suites:
     # Ephemeral test requires instance type with instance store
     test_ephemeral.py::test_head_node_stop:
       dimensions:
-        - regions: ["us-east-1"]
+        - regions: ["use1-az4"]
           instances: ["m5d.xlarge", "h1.2xlarge"]
           oss: ["alinux2", "rhel8"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -588,11 +588,15 @@ def get_metadata(metadata_path, raise_error=True):
     metadata_value = None
     try:
         metadata_base_url = "http://169.254.169.254/latest"
-        token = requests.put(f"{metadata_base_url}/api/token", headers={"X-aws-ec2-metadata-token-ttl-seconds": "300"})
+        token = requests.put(
+            f"{metadata_base_url}/api/token", headers={"X-aws-ec2-metadata-token-ttl-seconds": "300"}, timeout=3
+        )
 
         headers = {}
         if token.status_code == requests.codes.ok:
             headers["X-aws-ec2-metadata-token"] = token.content
+        elif token.status_code >= 300:
+            raise Exception("Imds not reachable")
         metadata_value = requests.get(f"{metadata_base_url}/meta-data/{metadata_path}", headers=headers).text
     except Exception as e:
         error_msg = f"Unable to get {metadata_path} metadata. Failed with exception: {e}"


### PR DESCRIPTION
### Description of changes
* Add check on the metadata server availability to speed up the discovery of the public-ipv4

### Tests
* Tested on personal Jenkins and on personal computer
```
2023-03-10 16:33:00,559 - INFO - 734 - test_efa[us-east-1-c5n.9xlarge-alinux2-slurm-None] - conftest - Limiting AllowedIps rule to IP: 54.76.223.48
```

```
2023-03-09 19:29:27,114 - CRITICAL - 4878 - test_head_node_stop[us-east-1-h1.2xlarge-rhel8-slurm-use1-az2] - utils - Unable to get public-ipv4 metadata. Failed with exception: timed out
```

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
