### PR TITLE
[Isolated Regions] [Test] Allow private ParallelCluster AMIs  in isolated regions to facilitate testing for test case test_queue_parameters_update

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -73,7 +73,15 @@ AMI_TYPE_DICT = {
 }
 
 
-def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64", additional_filters=None, request=None):
+def retrieve_latest_ami(
+    region,
+    os,
+    ami_type="official",
+    architecture="x86_64",
+    additional_filters=None,
+    request=None,
+    allow_private_ami=False,
+):
     if additional_filters is None:
         additional_filters = []
     try:
@@ -87,6 +95,7 @@ def retrieve_latest_ami(region, os, ami_type="official", architecture="x86_64", 
                 and not request.config.getoption("pcluster_git_ref")
                 and not request.config.getoption("cookbook_git_ref")
                 and not request.config.getoption("node_git_ref")
+                and not allow_private_ami
             ):  # If none of Git refs is provided, the test is running against released version.
                 # Then retrieve public pcluster AMIs
                 additional_filters.append({"Name": "is-public", "Values": ["true"]})

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -659,7 +659,14 @@ def test_queue_parameters_update(
     # Create cluster with initial configuration
     initial_compute_root_volume_size = 35
     updated_compute_root_volume_size = 40
-    pcluster_ami_id = retrieve_latest_ami(region, os, ami_type="pcluster", request=request)
+    # If you are running this test in your personal account, then you must have
+    # ParallelCluster AMIs following the official naming convention
+    # and set allow_private_ami to True.
+    # We allow private AMIs also in US isolated regions to facilitate testing.
+    allow_private_ami = True if "us-iso" in region else False
+    pcluster_ami_id = retrieve_latest_ami(
+        region, os, ami_type="pcluster", request=request, allow_private_ami=allow_private_ami
+    )
     pcluster_copy_ami_id = ami_copy(
         pcluster_ami_id, "-".join(["test", "update", "computenode", generate_random_string()])
     )


### PR DESCRIPTION
### Description of changes
Allow private ParallelCluster AMIs in isolated regions to facilitate testing for test case: `test_queue_parameters_update`.

### Tests
* [ONGOING] Integ test `test_queue_parameters_update` in Commercial
* [PENDING] Integ test `test_queue_parameters_update` in US ISO. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
