### PR TITLE
Execute LaunchTemplateValidator only for the first queue

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2704,16 +2704,18 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
         checked_images = []
-        for queue in self.scheduling.queues:
+        for index, queue in enumerate(self.scheduling.queues):
             queue_image = self.image_dict[queue.name]
-            self._register_validator(
-                ComputeResourceLaunchTemplateValidator,
-                queue=queue,
-                ami_id=queue_image,
-                os=self.image.os,
-                tags=self.get_cluster_tags(),
-                imds_support=self.imds.imds_support,
-            )
+            if index == 0:
+                # Execute LaunchTemplateValidator only for the first queue
+                self._register_validator(
+                    ComputeResourceLaunchTemplateValidator,
+                    queue=queue,
+                    ami_id=queue_image,
+                    os=self.image.os,
+                    tags=self.get_cluster_tags(),
+                    imds_support=self.imds.imds_support,
+                )
             ami_volume_size = AWSApi.instance().ec2.describe_image(queue_image).volume_size
             root_volume = queue.compute_settings.local_storage.root_volume
             root_volume_size = root_volume.size

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -428,6 +428,12 @@ def test_scheduler_plugin_validators_are_called_with_correct_argument(test_datad
     validators_path = "pcluster.validators"
 
     cluster_validators = validators_path + ".cluster_validators"
+    head_node_lt_validator = mocker.patch(
+        cluster_validators + ".HeadNodeLaunchTemplateValidator._validate", return_value=[]
+    )
+    compute_resources_lt_validator = mocker.patch(
+        cluster_validators + ".ComputeResourceLaunchTemplateValidator._validate", return_value=[]
+    )
     scheduler_os_validator = mocker.patch(cluster_validators + ".SchedulerOsValidator._validate", return_value=[])
     feature_validators = validators_path + ".feature_validators"
     feature_region_validator = mocker.patch(feature_validators + ".FeatureRegionValidator._validate", return_value=[])
@@ -673,6 +679,8 @@ def test_scheduler_plugin_validators_are_called_with_correct_argument(test_datad
     user_name_validator.assert_has_calls([call(user_name="user1"), call(user_name="user2")])
 
     # No assertion on the argument for minor validators
+    head_node_lt_validator.assert_called_once()
+    compute_resources_lt_validator.assert_called_once()
     name_validator.assert_called()
     fsx_s3_validator.assert_called()
     fsx_backup_options_validator.assert_called()


### PR DESCRIPTION
### Description of changes
* To speed up config validation we are now executing the run-instances dryrun with the queue LaunchTemplate only for the first queue.

### Tests
* Tested cluster-creation with a policy requesting encryption of the root volume and explicitly setting false to the second queue. Without the patch the creation was failing, with the patch the creation can proceed.
