### PR TITLE
[IntegTests] Fix Multi-AZ create/update integration test failures

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -1180,20 +1180,20 @@ def odcr_stack(request, region, placement_group_stack, cfn_stacks_factory, vpc_s
     odcr_template.set_version()
     odcr_template.set_description("ODCR stack to test open, targeted, and PG ODCRs")
     public_subnet = vpc_stack.get_public_subnet()
-    public_subnets = vpc_stack.get_all_public_subnets().copy()
-    public_subnets.remove(public_subnet)
-    availability_zone = boto3.resource("ec2").Subnet(public_subnet).availability_zone
-    availability_zone_2 = boto3.resource("ec2").Subnet(public_subnets[0]).availability_zone
+    public_subnets = vpc_stack.get_all_public_subnets()
+    default_public_az = boto3.resource("ec2").Subnet(public_subnet).availability_zone
+    availability_zone_1 = boto3.resource("ec2").Subnet(public_subnets[0]).availability_zone
+    availability_zone_2 = boto3.resource("ec2").Subnet(public_subnets[1]).availability_zone
     open_odcr = ec2.CapacityReservation(
         "integTestsOpenOdcr",
-        AvailabilityZone=availability_zone,
+        AvailabilityZone=default_public_az,
         InstanceCount=4,
         InstancePlatform="Linux/UNIX",
         InstanceType="m5.2xlarge",
     )
     target_odcr = ec2.CapacityReservation(
         "integTestsTargetOdcr",
-        AvailabilityZone=availability_zone,
+        AvailabilityZone=default_public_az,
         InstanceCount=4,
         InstancePlatform="Linux/UNIX",
         InstanceType="r5.xlarge",
@@ -1202,7 +1202,7 @@ def odcr_stack(request, region, placement_group_stack, cfn_stacks_factory, vpc_s
     pg_name = placement_group_stack.cfn_resources["PlacementGroup"]
     pg_odcr = ec2.CapacityReservation(
         "integTestsPgOdcr",
-        AvailabilityZone=availability_zone,
+        AvailabilityZone=default_public_az,
         InstanceCount=2,
         InstancePlatform="Linux/UNIX",
         InstanceType="m5.xlarge",
@@ -1250,7 +1250,7 @@ def odcr_stack(request, region, placement_group_stack, cfn_stacks_factory, vpc_s
     # odcr resources for MultiAZ integ-tests
     az1_odcr = ec2.CapacityReservation(
         "az1Odcr",
-        AvailabilityZone=availability_zone,
+        AvailabilityZone=availability_zone_1,
         InstanceCount=2,
         InstancePlatform="Linux/UNIX",
         InstanceType="t3.micro",


### PR DESCRIPTION
### Description of changes
* The MultiAZ create/update tests rely on creation of capacity reservations in different AZs to ensure instances are launched in different subnets/AZs. One of public AZs created by the `vpc_stack` fixture may be chosen randomly, making it unstable for use in these tests.

* These changes ensure the MultiAZ tests use AZs chosen from a consistent/deterministic list of subnets/AZs.


### Tests
* Ran test locally after reproducing the issue

```
test-suites:
  update:
    test_update.py::test_multi_az_create_and_update:
      dimensions:
      - oss:
        - alinux2
        regions:
        - eu-west-2
        schedulers:
        - slurm
```

```
{
    "all": {
        "total": 1,
        "skipped": 0,
        "failures": 0,
        "errors": 0,
        "succeeded": 1
    },
```

### References
* N/A

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
