### PR TITLE
[Isolated Regions] [Test] Adapt the volume size check in test_ebs_existing to the us-isob-east-1 case.

### DIFF
--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -182,7 +182,11 @@ def test_ebs_existing(
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
     existing_mount_dir = "/" + existing_mount_dir
-    test_ebs_correctly_mounted(remote_command_executor, existing_mount_dir, volume_size="9.8")
+    # The expected volume size has been experimentally defined.
+    # Such value is slightly different in us-isob-east-1.
+    # TODO We should retrieve the expected volume size from the SnapshotsFactory.
+    expected_volume_size = 9.7 if region == "us-isob-east-1" else 9.8
+    test_ebs_correctly_mounted(remote_command_executor, existing_mount_dir, volume_size=expected_volume_size)
     _test_ebs_correctly_shared(remote_command_executor, existing_mount_dir, scheduler_commands)
     # Checks for test data
     result = remote_command_executor.run_remote_command("cat {}/test.txt".format(existing_mount_dir))


### PR DESCRIPTION
### Description of changes
Adapt the volume size check in test_ebs_existing to the us-isob-east-1 case.

Note: we should improve this test by retrieving the expected volume size directly form the SnapshotsFactory rather than relying on magic number. Nevertheless, we want to merge this change because:
1. we have always used static value for this check in commercial regions
2. we need to quickly unblock in us-isob-east-1.

### Tests
When executed in us-isob-east-1, we keep observing that the EBS volume size returned is always 9.7G.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
