### PR TITLE
Removing alinux2 from `test_on_demand_capacity_reservation`

### DIFF
--- a/tests/integration-tests/configs/redhat8.yaml
+++ b/tests/integration-tests/configs/redhat8.yaml
@@ -163,7 +163,7 @@ test-suites:
     test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
       dimensions:
         - regions: [ "us-west-2" ]
-          oss: [ "alinux2", "rhel8"]
+          oss: [ "rhel8" ]
   scaling:
     test_scaling.py::test_multiple_jobs_submission:
       dimensions:


### PR DESCRIPTION
### Description of changes
Removing alinux2 from `test_on_demand_capacity_reservation`

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
