### PR TITLE
[Test] Fix integration tests: test_update_instance_list and scheduler_plugin_integration.

### DIFF
--- a/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_arm64.yaml
+++ b/tests/integration-tests/tests/scheduler_plugin/test_scheduler_plugin/test_scheduler_plugin_integration/scheduler_queues_arm64.yaml
@@ -91,7 +91,7 @@
         Encrypted: true
         Size: null
         VolumeType: gp3
-        Throughput: 130
+        Throughput: 125
         Iops: 3000
   CustomActions: null
   CustomSettings: null

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -531,7 +531,7 @@ def test_update_instance_list(
         submit_command_args={"command": "sleep 1000", "nodes": 1, "other_options": "--exclusive"}
     )
     # Check instance type is the expected for min count
-    _check_instance_type(ec2, instances, "c5.xlarge")
+    _check_instance_type(ec2, instances, "c5d.xlarge")
 
     # Update cluster with new configuration, adding new instance type with lower price
     updated_config_file = pcluster_config_reader(config_file="pcluster.config.update.yaml")
@@ -548,8 +548,8 @@ def test_update_instance_list(
     new_instances = cluster.get_cluster_instance_ids(node_type="Compute")
     logging.info(new_instances)
     new_instances.remove(instances[0])
-    # Check new instance type is the expected one
-    _check_instance_type(ec2, new_instances, "c5d.xlarge")
+    # Check new instance type is the expected one, i.e. the one with lower price.
+    _check_instance_type(ec2, new_instances, "c5.xlarge")
 
     # Update cluster removing instance type from the list
     updated_config_file = pcluster_config_reader(config_file="pcluster.config.update.remove.yaml")

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.remove.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.remove.yaml
@@ -13,7 +13,7 @@ Scheduling:
       ComputeResources:
         - Name: queue1-i1
           Instances:
-            - InstanceType: c5d.xlarge
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
@@ -13,8 +13,8 @@ Scheduling:
       ComputeResources:
         - Name: queue1-i1
           Instances:
-            - InstanceType: c5.xlarge
             - InstanceType: c5d.xlarge
+            - InstanceType: c5.xlarge
           MinCount: 1
           MaxCount: 2
       Networking:

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
@@ -13,7 +13,7 @@ Scheduling:
       ComputeResources:
         - Name: queue1-i1
           Instances:
-            - InstanceType: c5.xlarge
+            - InstanceType: c5d.xlarge
           MinCount: 1
           MaxCount: 2
       Networking:


### PR DESCRIPTION
### Description of changes
Fix the following integration tests showing regressions caused by recent changes related to US isolated regions.
* `test_update_instance_list`: the test expects to use the instance type with lower price, so the fix consist in going from c5d.xlarge to c5.xlarge
* `scheduler_plugin_integration` (arm64 case only): the test expects root volume throughput to be 125, like in the x86_64 case

### Tests
* Integ Test `test_update_instance_list`
* Integ Test `scheduler_plugin_integration`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
