### PR TITLE
[Test] Add permission dynamodb:BatchGetItem to cluster-roles.cfn.yaml

### DIFF
--- a/tests/iam_policies/cluster-roles.cfn.yaml
+++ b/tests/iam_policies/cluster-roles.cfn.yaml
@@ -79,6 +79,7 @@ Resources:
                   - dynamodb:GetItem
                   - dynamodb:UpdateItem
                   - dynamodb:BatchWriteItem
+                  - dynamodb:BatchGetItem
                 Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/parallelcluster-*
                 Effect: Allow
               - Action: ec2:TerminateInstances


### PR DESCRIPTION
### Description of changes
Add permission `dynamodb:BatchGetItem` to `cluster-roles.cfn.yaml`, which is required to retrieve compute node console output. (#4552 )


