### PR TITLE
[Test] Add permission ec2:GetConsoleOutput to cluster-roles.cfn.yaml

### DIFF
--- a/tests/iam_policies/cluster-roles.cfn.yaml
+++ b/tests/iam_policies/cluster-roles.cfn.yaml
@@ -119,6 +119,11 @@ Resources:
                   - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
                   - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:volume/*
               - Action:
+                  - ec2:GetConsoleOutput
+                Effect: Allow
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/*
+              - Action:
                   - cloudformation:DescribeStackResource
                   - cloudformation:SignalResource
                   - cloudformation:DescribeStacks


### PR DESCRIPTION
### Description of changes
Add permission `ec2:GetConsoleOutput` to `cluster-roles.cfn.yaml`, which is required to retrieve compute node console output. (#4552 )


