### PR TITLE
[Slurm] Add CustomSlurmSettings parameter for queue and compute resource

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1935,9 +1935,14 @@ class FlexibleInstanceType(Resource):
 class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
     """Represents a Slurm Compute Resource with Multiple Instance Types."""
 
-    def __init__(self, instances: List[FlexibleInstanceType], **kwargs):
+    def __init__(self,
+                 instances: List[FlexibleInstanceType],
+                 custom_slurm_settings: Dict = None,
+                 **kwargs,
+    ):
         super().__init__(**kwargs)
         self.instances = Resource.init_param(instances)
+        self.custom_slurm_settings = Resource.init_param(custom_slurm_settings, default={})
 
     @property
     def instance_types(self) -> List[str]:
@@ -1972,10 +1977,15 @@ class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
 class SlurmComputeResource(_BaseSlurmComputeResource):
     """Represents a Slurm Compute Resource with a Single Instance Type."""
 
-    def __init__(self, instance_type, **kwargs):
+    def __init__(self,
+                 instance_type,
+                 custom_slurm_settings: Dict = None,
+                 **kwargs,
+    ):
         super().__init__(**kwargs)
         self.instance_type = Resource.init_param(instance_type)
         self.__instance_type_info = None
+        self.custom_slurm_settings = Resource.init_param(custom_slurm_settings, default={})
 
     @property
     def instance_types(self) -> List[str]:
@@ -2161,9 +2171,11 @@ class SlurmQueue(_CommonQueue):
     def __init__(
         self,
         allocation_strategy: str = None,
+        custom_slurm_settings: Dict = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.custom_slurm_settings = Resource.init_param(custom_slurm_settings, default={})
         if any(
             isinstance(compute_resource, SlurmFlexibleComputeResource) for compute_resource in self.compute_resources
         ):

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -192,8 +192,7 @@ from pcluster.validators.scheduler_plugin_validators import (
     UserNameValidator,
 )
 from pcluster.validators.slurm_settings_validator import (
-    SLURM_SETTINGS_COMPUTE_RESOURCE_DENY_LIST,
-    SLURM_SETTINGS_QUEUE_DENY_LIST,
+    SLURM_SETTINGS_DENY_LIST,
     SlurmCustomSettingLevel,
     SlurmCustomSettingsValidator,
     SlurmCustomSettingsWarning,
@@ -2237,7 +2236,7 @@ class SlurmQueue(_CommonQueue):
             self._register_validator(
                 SlurmCustomSettingsValidator,
                 custom_settings=self.custom_slurm_settings,
-                deny_list=SLURM_SETTINGS_QUEUE_DENY_LIST,
+                deny_list=SLURM_SETTINGS_DENY_LIST["Queue"],
                 settings_level=SlurmCustomSettingLevel.QUEUE,
             )
             self._register_validator(SlurmCustomSettingsWarning)
@@ -2262,7 +2261,7 @@ class SlurmQueue(_CommonQueue):
                 self._register_validator(
                     SlurmCustomSettingsValidator,
                     custom_settings=compute_resource.custom_slurm_settings,
-                    deny_list=SLURM_SETTINGS_COMPUTE_RESOURCE_DENY_LIST,
+                    deny_list=SLURM_SETTINGS_DENY_LIST["ComputeResource"],
                     settings_level=SlurmCustomSettingLevel.COMPUTE_RESOURCE,
                 )
                 self._register_validator(SlurmCustomSettingsWarning)

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1209,6 +1209,7 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
     networking = fields.Nested(
         SlurmComputeResourceNetworkingSchema, metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP}
     )
+    custom_slurm_settings = fields.Dict(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @validates_schema
     def no_coexist_instance_type_flexibility(self, data, **kwargs):
@@ -1332,6 +1333,7 @@ class SlurmQueueSchema(_CommonQueueSchema):
     networking = fields.Nested(
         SlurmQueueNetworkingSchema, required=True, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
     )
+    custom_slurm_settings = fields.Dict(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -1,0 +1,69 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+from pcluster.validators.common import FailureLevel, Validator
+
+# SLURM SETTINGS are case-insensitive - keep them lowercase since they are compared with setting.lower()
+SLURM_SETTINGS_QUEUE_DENY_LIST = ["nodes", "state", "partitionname", "resumetimeout", "suspendtime"]
+SLURM_SETTINGS_COMPUTE_RESOURCE_DENY_LIST = ["nodename", "nodehostname", "nodeaddr", "state", "gres"]
+
+
+class SlurmCustomSettingLevel(str, Enum):
+    """
+    Slurm Custom Settings level.
+
+    This enum defines the scope where the custom settings are defined.
+    """
+
+    QUEUE = "Queue"
+    COMPUTE_RESOURCE = "ComputeResource"
+
+
+class SlurmCustomSettingsValidator(Validator):
+    """
+    Slurm Custom Settings validator.
+
+    Validate custom settings in Slurm ComputeResource and Queue.
+    """
+
+    def _validate(self, custom_settings, deny_list, settings_level: SlurmCustomSettingLevel):
+        denied_settings = set()
+
+        for custom_setting in list(custom_settings.keys()):
+            if custom_setting.lower() in deny_list:
+                denied_settings.add(custom_setting)
+        if len(denied_settings) > 0:
+            settings = ",".join(sorted(denied_settings))
+            self._add_failure(
+                f"Using the following custom Slurm settings at {settings_level} level is not allowed: {settings}",
+                FailureLevel.ERROR,
+            )
+
+
+class SlurmCustomSettingsWarning(Validator):
+    """
+    Slurm Custom Settings Warning.
+
+    This validator emits a warning message if custom settings are enabled.
+    The message is displayed only once no matter how many times instances of the validator are created.
+    """
+
+    signaled = False
+
+    def _validate(self):
+        if not SlurmCustomSettingsWarning.signaled:
+            self._add_failure(
+                "Custom Slurm settings are in use: please monitor the cluster carefully.",
+                FailureLevel.WARNING,
+            )
+            SlurmCustomSettingsWarning.signaled = True

--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -14,8 +14,10 @@ from enum import Enum
 from pcluster.validators.common import FailureLevel, Validator
 
 # SLURM SETTINGS are case-insensitive - keep them lowercase since they are compared with setting.lower()
-SLURM_SETTINGS_QUEUE_DENY_LIST = ["nodes", "state", "partitionname", "resumetimeout", "suspendtime"]
-SLURM_SETTINGS_COMPUTE_RESOURCE_DENY_LIST = ["nodename", "nodehostname", "nodeaddr", "state", "gres"]
+SLURM_SETTINGS_DENY_LIST = {
+    "Queue": ["nodes", "partitionname", "resumetimeout", "state", "suspendtime"],
+    "ComputeResource": ["cpus", "features", "gres", "nodeaddr", "nodehostname", "nodename", "state"],
+}
 
 
 class SlurmCustomSettingLevel(str, Enum):


### PR DESCRIPTION
### Description of changes
* Add optional parameter `CustomSlurmSettings` for queue and compute resource
* Add update policy for `CustomSlurmSettings` parameter
* Add validator for CustomSlurmSettings
* Add Unit Tests for CustomSlurmSettings

### Tests
* local dryrun with config 
```
  SlurmQueues:
  - Name: queue1
    CustomSlurmSettings:
      Nodes: Node1
      PartitionName: CustomPartition
    ComputeResources:
    - Name: t2micro
      CustomSlurmSettings:
        NodeName: CustomNodeName
        State: CustomState
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~~Check if documentation is impacted by this change.~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
