### PR TITLE
Wip/queue nested

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1933,9 +1933,14 @@ class FlexibleInstanceType(Resource):
 class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
     """Represents a Slurm Compute Resource with Multiple Instance Types."""
 
-    def __init__(self, instances: List[FlexibleInstanceType], **kwargs):
+    def __init__(self,
+                 instances: List[FlexibleInstanceType],
+                 custom_slurm_settings: Dict = None,
+                 **kwargs,
+    ):
         super().__init__(**kwargs)
         self.instances = Resource.init_param(instances)
+        self.custom_slurm_settings = Resource.init_param(custom_slurm_settings, default={})
 
     @property
     def instance_types(self) -> List[str]:
@@ -1970,10 +1975,15 @@ class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
 class SlurmComputeResource(_BaseSlurmComputeResource):
     """Represents a Slurm Compute Resource with a Single Instance Type."""
 
-    def __init__(self, instance_type, **kwargs):
+    def __init__(self,
+                 instance_type,
+                 custom_slurm_settings: Dict = None,
+                 **kwargs,
+    ):
         super().__init__(**kwargs)
         self.instance_type = Resource.init_param(instance_type)
         self.__instance_type_info = None
+        self.custom_slurm_settings = Resource.init_param(custom_slurm_settings, default={})
 
     @property
     def instance_types(self) -> List[str]:
@@ -2159,9 +2169,11 @@ class SlurmQueue(_CommonQueue):
     def __init__(
         self,
         allocation_strategy: str = None,
+        custom_slurm_settings: Dict = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.custom_slurm_settings = Resource.init_param(custom_slurm_settings, default={})
         if any(
             isinstance(compute_resource, SlurmFlexibleComputeResource) for compute_resource in self.compute_resources
         ):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1209,6 +1209,7 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
     networking = fields.Nested(
         SlurmComputeResourceNetworkingSchema, metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP}
     )
+    custom_slurm_settings = fields.Dict(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @validates_schema
     def no_coexist_instance_type_flexibility(self, data, **kwargs):
@@ -1332,6 +1333,7 @@ class SlurmQueueSchema(_CommonQueueSchema):
     networking = fields.Nested(
         SlurmQueueNetworkingSchema, required=True, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
     )
+    custom_slurm_settings = fields.Dict(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -1369,7 +1371,6 @@ class SchedulerPluginQueueSchema(_CommonQueueSchema):
     networking = fields.Nested(
         SchedulerPluginQueueNetworkingSchema, required=True, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP}
     )
-    custom_settings = fields.Dict(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1408,6 +1408,30 @@ class DatabaseSchema(BaseSchema):
         return Database(**data)
 
 
+
+
+class BaseNodeSchema(BaseSchema):
+    name = fields.Str()
+    params = fields.Dict()
+
+class NodeSchema(BaseSchema):
+    name = fields.Str()
+    params = fields.Dict()
+
+class NodeSetSchema(BaseSchema):
+    name = fields.Str()
+    nodes = fields.List(fields.Str)
+class PartitionSchema(BaseSchema):
+    name = fields.Str()
+    nodes = fields.List(fields.Str)
+
+class CustomSlurmSchedulingSettingsSchema(BaseSchema):
+    """Represent the schema of the Custom Scheduling Settings."""
+    values = fields.Dict()
+    node_names = fields.List(NodeSchema)
+    node_sets = fields.List(NodeSetSchema)
+    partitions = fields.List(PartitionSchema)
+
 class SlurmSettingsSchema(BaseSchema):
     """Represent the schema of the Scheduling Settings."""
 
@@ -1419,6 +1443,7 @@ class SlurmSettingsSchema(BaseSchema):
     )
     enable_memory_based_scheduling = fields.Bool(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
     database = fields.Nested(DatabaseSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    custom_slurm_settings = fields.Nested(CustomSlurmSchedulingSettingsSchema)
 
     @post_load
     def make_resource(self, data, **kwargs):


### PR DESCRIPTION
### Description of changes
* Quick tests for nested structures for Custom Slurm settings

### Tests
* DryRun with config like 

```
Scheduling:
  Scheduler: slurm
  SlurmSettings:
    CustomSlurmSettings:
      values:
        Param1: Value1
        Param2: Value2
      NodeNames:
        - Name: "node-01"
          params:
            p1: v1
            p2: v2
        - Name: "node-02"
          params:
            p1: v1
            p2: v2
      NodeSets:
        - Name: "node-set-01"
          nodes:
            - "node-01"
            - "node-02"
        - Name: "node-set-02"
          nodes:
            - "node-04"
            - "node-05"
      Partitions:
        - Name: "part-01"
          nodes: "node-set-01"
        - Name: "part-02"
          nodes: "node-set-02"
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
