### PR TITLE
Create a RootVolumeEncryptionConsistencyValidator

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -98,6 +98,7 @@ from pcluster.validators.cluster_validators import (
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
     RegionValidator,
+    RootVolumeEncryptionConsistencyValidator,
     RootVolumeSizeValidator,
     SchedulableMemoryValidator,
     SchedulerOsValidator,
@@ -2313,6 +2314,12 @@ class SlurmScheduling(Resource):
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(
             DuplicateNameValidator, name_list=[queue.name for queue in self.queues], resource_name="Queue"
+        )
+        self._register_validator(
+            RootVolumeEncryptionConsistencyValidator,
+            enrcyption_settings=[
+                (queue.name, queue.compute_settings.local_storage.root_volume.encrypted) for queue in self.queues
+            ],
         )
         self._register_validator(
             MaxCountValidator,

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -1408,3 +1408,19 @@ class DictLaunchTemplateBuilder(_LaunchTemplateBuilder):
                 }
             )
         }
+
+
+class RootVolumeEncryptionConsistencyValidator(Validator):
+    """Verify consistency on the Encryption parameter of all the specified RootVolumes of the queues."""
+
+    def _validate(self, encryption_settings: list):
+        reference_queue_name, reference_root_volume_encryption = encryption_settings.pop(0)
+        for queue in encryption_settings:
+            queue_name, root_volume_encryption = queue
+            if reference_root_volume_encryption != root_volume_encryption:
+                self._add_failure(
+                    f"The Encryption parameter of the root volume of the queue {queue_name} is not consistent "
+                    f"with the value set for the queue {reference_queue_name}, and may cause a problem in case "
+                    f"of Service Control Policies (SCPs) enforcing encryption.",
+                    FailureLevel.WARNING,
+                )

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -410,6 +410,7 @@ def test_scheduler_plugin_all_validators_are_called(test_datadir, mocker):
                 "CapacityReservationResourceGroupValidator",
                 "DatabaseUriValidator",
                 "InstanceTypePlacementGroupValidator",
+                "RootVolumeEncryptionConsistencyValidator",
             ]
             + flexible_instance_types_validators
         ):


### PR DESCRIPTION
### Description of changes
This patch creates a RootVolumeEncryptionConsistencyValidator that checks that all the queues' root volumes have the same encryption settings.

### Tests
Unit tests.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
