### PR TITLE
[CFN] Filter out NoneType arguments when calling the CloudFormation client methods

### DIFF
--- a/cli/src/pcluster/aws/cfn.py
+++ b/cli/src/pcluster/aws/cfn.py
@@ -16,6 +16,7 @@ from botocore.exceptions import ClientError
 from pcluster.aws.aws_resources import StackInfo
 from pcluster.aws.common import AWSClientError, AWSExceptionHandler, Boto3Client, StackNotFoundError
 from pcluster.constants import PCLUSTER_IMAGE_ID_TAG, PCLUSTER_VERSION_TAG
+from pcluster.utils import remove_none_values
 
 LOGGER = logging.getLogger(__name__)
 
@@ -31,13 +32,17 @@ class CfnClient(Boto3Client):
         self, stack_name: str, disable_rollback: bool, tags: list, template_body: str, parameters: list = None
     ):
         """Create CFN stack by using the given template."""
+        optional_args = {
+            "Tags": tags,
+            "Parameters": parameters,
+        }
+        optional_args_with_value = remove_none_values(optional_args)
         return self._client.create_stack(
             StackName=stack_name,
             TemplateBody=template_body,
             Capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
             DisableRollback=disable_rollback,
-            Tags=tags,
-            Parameters=parameters,
+            **optional_args_with_value,
         )
 
     @AWSExceptionHandler.handle_client_exception
@@ -51,13 +56,18 @@ class CfnClient(Boto3Client):
         parameters: list = None,
     ):
         """Create CFN stack by using the given template url."""
+        optional_args = {
+            "Tags": tags,
+            "Parameters": parameters,
+        }
+        optional_args_with_value = remove_none_values(optional_args)
+
         return self._client.create_stack(
             StackName=stack_name,
             TemplateURL=template_url,
             Capabilities=[capabilities, "CAPABILITY_NAMED_IAM"],
             DisableRollback=disable_rollback,
-            Tags=tags,
-            Parameters=parameters,
+            **optional_args_with_value,
         )
 
     @AWSExceptionHandler.handle_client_exception
@@ -78,19 +88,17 @@ class CfnClient(Boto3Client):
     @AWSExceptionHandler.handle_client_exception
     def update_stack_from_url(self, stack_name: str, template_url: str, tags: list = None, parameters: list = None):
         """Update CFN stack by using the given template url."""
-        if tags is None:
-            return self._client.update_stack(
-                StackName=stack_name,
-                TemplateURL=template_url,
-                Capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
-                Parameters=parameters,
-            )
+        optional_args = {
+            "Tags": tags,
+            "Parameters": parameters,
+        }
+        optional_args_with_value = remove_none_values(optional_args)
+
         return self._client.update_stack(
             StackName=stack_name,
             TemplateURL=template_url,
             Capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
-            Tags=tags,
-            Parameters=parameters,
+            **optional_args_with_value,
         )
 
     @AWSExceptionHandler.handle_client_exception


### PR DESCRIPTION
### Description of changes
* Some CloudFormation arguments such as `Tags`, `Parameters` do not allow `NoneType` arguments

`Invalid type for parameter Parameters, value: None, type: <class 'NoneType'>, valid types: <class 'list'>, <class 'tuple'>"`

* These changes remove the optional arguments with a `NoneType` value ([remove_none_values](https://github.com/aws/aws-parallelcluster/blob/8868c0c376637dcc3196598c0cc498756181e46e/cli/src/pcluster/utils.py#L402))
* This ensures that the arguments are only included in the CloudFormation client method calls when they have a value

### Tests
* Ran existing unit tests
* Successfully initiated a `pcluster build-image`

### References
* [remove_none_values](https://github.com/aws/aws-parallelcluster/blob/8868c0c376637dcc3196598c0cc498756181e46e/cli/src/pcluster/utils.py#L402)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
