### PR TITLE
[Test] Adaptations of integ tests for US isolated regions + minor fixes

### DIFF
--- a/tests/integration-tests/benchmarks/common/metrics_reporter.py
+++ b/tests/integration-tests/benchmarks/common/metrics_reporter.py
@@ -17,7 +17,7 @@ from time import sleep
 import boto3
 from retrying import RetryError, retry
 from time_utils import seconds
-from utils import _describe_cluster_instances
+from utils import describe_cluster_instances
 
 METRIC_WIDGET_TEMPLATE = """
     {{
@@ -93,7 +93,7 @@ def publish_compute_nodes_metric(scheduler_commands, max_monitoring_time, region
                 Namespace="ParallelCluster/benchmarking/{cluster_name}".format(cluster_name=cluster_name),
                 MetricData=[{"MetricName": "ComputeNodesCount", "Value": compute_nodes, "Unit": "Count"}],
             )
-            ec2_instances_count = len(_describe_cluster_instances(cluster_name, region, filter_by_node_type="Compute"))
+            ec2_instances_count = len(describe_cluster_instances(cluster_name, region, filter_by_node_type="Compute"))
             logging.info("Publishing EC2 compute metric: count={0}".format(ec2_instances_count))
             cw_client.put_metric_data(
                 Namespace="ParallelCluster/benchmarking/{cluster_name}".format(cluster_name=cluster_name),

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -491,7 +491,7 @@ test-suites:
     test_ephemeral.py::test_head_node_stop:
       dimensions:
         - regions: {{ REGIONS }}
-          instances: {{ INSTANCES }}
+          instances: ["m5d.xlarge"]
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
   tags:

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -239,7 +239,9 @@ def reboot_head_node(cluster, remote_command_executor=None):
     logging.info(f"result.failed={result.failed}")
     logging.info(f"result.stdout={result.stdout}")
     wait_head_node_running(cluster)
-    time.sleep(120)  # Wait time is required for the head node to complete the reboot
+    # Wait time is required for the head node to complete the reboot.
+    # We observed that headnode in US isolated regions may take more time to reboot.
+    time.sleep(240 if "us-iso" in cluster.region else 120)
     logging.info(f"Rebooted head node for cluster: {cluster.name}")
 
 

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -104,12 +104,14 @@ def test_create_imds_secured(
     cluster = clusters_factory(cluster_config, raise_on_error=True)
     status = "required" if imds_support == "v2.0" else "optional"
 
+    logging.info("Checking cluster access after cluster creation")
     assert_head_node_is_running(region, cluster)
     assert_aws_identity_access_is_correct(cluster, users_allow_list)
     assert_cluster_imds_v2_requirement_status(region, cluster, status)
 
     reboot_head_node(cluster)
 
+    logging.info("Checking cluster access after head node reboot")
     assert_head_node_is_running(region, cluster)
     assert_aws_identity_access_is_correct(cluster, users_allow_list)
     assert_cluster_imds_v2_requirement_status(region, cluster, status)

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/pcluster.config.yaml
@@ -20,8 +20,12 @@ Scheduling:
           - {{ private_subnet_id }}
       ComputeResources:
         - Name: efa-enabled-i1
+          {% if "us-iso" in region %}
+          InstanceType: {{ instance }}
+          {% else %}
           Instances:
             - InstanceType: {{ instance }}
+          {% endif %}
           MaxCount: {{ max_queue_size }}
           MinCount: {{ max_queue_size }}
           DisableSimultaneousMultithreading: true

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -207,7 +207,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
                     "enable_efa": False,
                 },
             },
-            "compute_type": "spot",
+            "compute_type": "ondemand" if "us-iso" in region else "spot",
         },
         "queue2": {
             "compute_resources": {

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -667,9 +667,14 @@ def test_queue_parameters_update(
     pcluster_ami_id = retrieve_latest_ami(
         region, os, ami_type="pcluster", request=request, allow_private_ami=allow_private_ami
     )
+
+    logging.info(f"Latest AMI retrieved: {pcluster_ami_id}")
+
     pcluster_copy_ami_id = ami_copy(
         pcluster_ami_id, "-".join(["test", "update", "computenode", generate_random_string()])
     )
+
+    logging.info(f"Copy of the latest AMI {pcluster_ami_id}: {pcluster_copy_ami_id}")
 
     init_config_file = pcluster_config_reader(
         global_custom_ami=pcluster_ami_id, initial_compute_root_volume_size=initial_compute_root_volume_size
@@ -736,6 +741,7 @@ def _test_update_without_queue_strategy(
 
 def _check_queue_ami(cluster, ec2, ami, queue_name):
     """Check if the ami of the queue instances are expected"""
+    logging.info(f"Checking that queue {queue_name} is using the expected AMI {ami}")
     instances = cluster.get_cluster_instance_ids(node_type="Compute", queue_name=queue_name)
     _check_instance_ami_id(ec2, instances, ami)
 
@@ -837,7 +843,10 @@ def _test_update_queue_strategy_with_running_job(
     _check_queue_ami(cluster, ec2, pcluster_ami_id, "queue1")
 
     queue2_nodes = scheduler_commands.get_compute_nodes("queue2", all_nodes=True)
-    # assert queue2 node state are in expected status corresponding to the queue strategy
+
+    logging.info(
+        f"Checking queue2 node state are in expected status corresponding to the queue strategy {queue_update_strategy}"
+    )
     if queue_update_strategy == "DRAIN":
         scheduler_commands.assert_job_state(queue2_job_id, "RUNNING")
         _check_queue_ami(cluster, ec2, pcluster_ami_id, "queue2")
@@ -851,7 +860,8 @@ def _test_update_queue_strategy_with_running_job(
     scheduler_commands.wait_job_running(queue2_job_id)
     # cancel job in queue1
     scheduler_commands.cancel_job(queue1_job_id)
-    # check the new launching instances are using new amis
+
+    logging.info("Checking that new compute nodes are using the new AMI")
     _check_queue_ami(cluster, ec2, pcluster_ami_id, "queue1")
     _check_queue_ami(cluster, ec2, pcluster_copy_ami_id, "queue2")
     assert_compute_node_states(scheduler_commands, queue1_nodes, "idle")

--- a/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_slurm/pcluster.config.update.yaml
@@ -42,7 +42,7 @@ Scheduling:
           Script: s3://{{ resource_bucket }}/scripts/updated_postinstall.sh # Updated parameter value
           Args:
             - DEF # Updated parameter value
-      CapacityType: SPOT # Updated parameter value
+      CapacityType: {% if "us-iso" in region %}ONDEMAND{% else %}SPOT{% endif %} # Updated parameter value
       ComputeResources:
         - Name: queue1-i1
           Instances:


### PR DESCRIPTION
### Description of changes
1. Add log lines to have more info during test execution in tests: test_queue_parameters_update and test_create_imds_secured.
1. Fix import in metrics_reporter.
1. Update test config to use m5d.xlarge in 'test_head_node_stop'.
1. Increase sleep time waiting for head node reboot from 120 to 240 seconds when running in US isolated regions.
1. Avoid using flexible instance type in test_efa when running in US isolated regions as the instance types used by this test are not supported by ec2:CreateFleet API.
1. Use ONDEMAND capacity instead of SPOT when in US isolated regions in test 'test_update_slurm'.


### Tests
* Changes have been validated in us-isob-east-1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
