### PR TITLE
Add MultiNetworkInterfacesInstancesValidator

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -94,6 +94,7 @@ from pcluster.validators.cluster_validators import (
     ManagedFsxMultiAzValidator,
     MaxCountValidator,
     MixedSecurityGroupOverwriteValidator,
+    MultiNetworkInterfacesInstancesValidator,
     NameValidator,
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
@@ -2954,6 +2955,7 @@ class SlurmClusterConfig(CommonSchedulerClusterConfig):
             )
 
         instance_types_data = self.get_instance_types_data()
+        self._register_validator(MultiNetworkInterfacesInstancesValidator, queues=self.scheduling.queues)
         for queue in self.scheduling.queues:
             for compute_resource in queue.compute_resources:
                 if self.scheduling.settings.enable_memory_based_scheduling:

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -417,6 +417,7 @@ def test_scheduler_plugin_all_validators_are_called(test_datadir, mocker):
                 "DatabaseUriValidator",
                 "InstanceTypePlacementGroupValidator",
                 "RootVolumeEncryptionConsistencyValidator",
+                "MultiNetworkInterfacesInstancesValidator",
             ]
             + flexible_instance_types_validators
         ):

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -58,6 +58,7 @@ from pcluster.validators.cluster_validators import (
     ManagedFsxMultiAzValidator,
     MaxCountValidator,
     MixedSecurityGroupOverwriteValidator,
+    MultiNetworkInterfacesInstancesValidator,
     NameValidator,
     NumberOfStorageValidator,
     OverlappingMountDirValidator,
@@ -2762,5 +2763,100 @@ def test_root_volume_encryption_consistency_validator(
     if expected_error_message:
         assert_failure_messages(actual_failures, [expected_error_message])
         assert_failure_level(actual_failures, FailureLevel.WARNING)
+    else:
+        assert_that(actual_failures).is_empty()
+
+
+@pytest.mark.parametrize(
+    "num_cards, assign_public_ip, public_ip_subnets, expected_error_messages",
+    [
+        pytest.param(
+            1,
+            True,
+            [
+                {"SubnetId": "subnet_1", "MapPublicIpOnLaunch": True},
+                {"SubnetId": "subnet_2", "MapPublicIpOnLaunch": False},
+            ],
+            None,
+            id="Test with single nic queue with assigned public ip and subnet with public ip",
+        ),
+        pytest.param(
+            2,
+            False,
+            [
+                {"SubnetId": "subnet_1", "MapPublicIpOnLaunch": False},
+                {"SubnetId": "subnet_2", "MapPublicIpOnLaunch": False},
+            ],
+            None,
+            id="Test with multi nic queue with neither assigned public ip nor subnet with public ip",
+        ),
+        pytest.param(
+            2,
+            True,
+            [
+                {"SubnetId": "subnet_1", "MapPublicIpOnLaunch": False},
+                {"SubnetId": "subnet_2", "MapPublicIpOnLaunch": False},
+            ],
+            [
+                "The queue queue_1 contains an instance type with multiple network interfaces and the AssignPublicIp "
+                "value can not be set to true. AWS public IPs can only be assigned to instances launched with a single "
+                "network interface."
+            ],
+            id="Test with multi nic queue with assigned public ip and no subnet with public ip",
+        ),
+        pytest.param(
+            2,
+            False,
+            [
+                {"SubnetId": "subnet_1", "MapPublicIpOnLaunch": True},
+                {"SubnetId": "subnet_2", "MapPublicIpOnLaunch": False},
+            ],
+            [
+                "The queue queue_1 contains an instance type with multiple network interfaces but the subnets "
+                "['subnet_1'] automatically assign public IPs and this can cause bootstrap issues. AWS public IPs "
+                "can only be assigned to instances launched with a single network interface."
+            ],
+            id="Test with multi nic queue with no assigned public ip and subnet with public ip",
+        ),
+        pytest.param(
+            2,
+            True,
+            [
+                {"SubnetId": "subnet_1", "MapPublicIpOnLaunch": True},
+                {"SubnetId": "subnet_2", "MapPublicIpOnLaunch": False},
+            ],
+            [
+                "The queue queue_1 contains an instance type with multiple network interfaces and the AssignPublicIp "
+                "value can not be set to true. AWS public IPs can only be assigned to instances launched with a single "
+                "network interface.",
+                "The queue queue_1 contains an instance type with multiple network interfaces but the subnets "
+                "['subnet_1'] automatically assign public IPs and this can cause bootstrap issues. AWS public IPs "
+                "can only be assigned to instances launched with a single network interface.",
+            ],
+            id="Test with multi nic queue with assigned public ip and subnet with public ip",
+        ),
+    ],
+)
+def test_multi_network_interfaces_instances_validator(
+    aws_api_mock, num_cards, assign_public_ip, public_ip_subnets, expected_error_messages
+):
+    aws_api_mock.ec2.get_instance_type_info.return_value = InstanceTypeInfo(
+        {"NetworkInfo": {"MaximumNetworkCards": num_cards}}
+    )
+    aws_api_mock.ec2.describe_subnets.return_value = public_ip_subnets
+
+    queues = [
+        SlurmQueue(
+            name="queue_1",
+            compute_resources=[SlurmComputeResource(name="compute_resource_1", instance_type="instance_type")],
+            networking=SlurmQueueNetworking(subnet_ids=["subnet_1", "subnet_2"], assign_public_ip=assign_public_ip),
+        ),
+    ]
+
+    actual_failures = MultiNetworkInterfacesInstancesValidator().execute(queues)
+
+    if expected_error_messages:
+        assert_failure_messages(actual_failures, expected_error_messages)
+        assert_failure_level(actual_failures, FailureLevel.ERROR)
     else:
         assert_that(actual_failures).is_empty()


### PR DESCRIPTION
### Description of changes
This patch add a `MultiNetworkInterfacesInstancesValidator` that for all queues with multi nic compute resources, checks whether the queue assigns a public IP or has any subnet that has a maps a public IP on launch.

### Tests
Unit tests.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
