### PR TITLE
Fix typo in parameter name

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2317,7 +2317,7 @@ class SlurmScheduling(Resource):
         )
         self._register_validator(
             RootVolumeEncryptionConsistencyValidator,
-            enrcyption_settings=[
+            encryption_settings=[
                 (queue.name, queue.compute_settings.local_storage.root_volume.encrypted) for queue in self.queues
             ],
         )


### PR DESCRIPTION
### Description of changes
Fix typo in parameter name.

----

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
