### PR TITLE
[Isolated Regions] [Test] Remove test case 'test_cluster_in_private_subnet' from isolated regions config

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -221,12 +221,14 @@ test-suites:
 #          oss: {{ OSS }}
 #          schedulers: {{ SCHEDULERS }}
   networking:
-    test_cluster_networking.py::test_cluster_in_private_subnet:
-      dimensions:
-        - regions: {{ REGIONS }}
-          instances: {{ INSTANCES }}
-          oss: {{ OSS }}
-          schedulers: {{ SCHEDULERS }}
+# This test is considered out of scope for isolated regions
+# We will evaluate to re-include it after release 3.5.1
+#    test_cluster_networking.py::test_cluster_in_private_subnet:
+#      dimensions:
+#        - regions: {{ REGIONS }}
+#          instances: {{ INSTANCES }}
+#          oss: {{ OSS }}
+#          schedulers: {{ SCHEDULERS }}
     test_cluster_networking.py::test_existing_eip:
       dimensions:
         - regions: {{ REGIONS }}


### PR DESCRIPTION
### Description of changes
Remove test case 'test_cluster_in_private_subnet' from isolated regions config because it has been considered out of scope given the air-gaped nature of these regions.

We will re-evaluate to include this test case after the release.

### Tests
Not needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
