### PR TITLE
Fix MultiNetworkInterfacesInstancesValidator failure messages

### DIFF
--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -1448,9 +1448,9 @@ class MultiNetworkInterfacesInstancesValidator(Validator):
         for queue in multi_nic_queues:
             if queue.networking.assign_public_ip:
                 self._add_failure(
-                    f"The queue {queue.name} contains an instance type with multiple network interfaces and "
-                    f"the AssignPublicIp value can not be set to true. AWS public IPs can only be assigned to "
-                    f"instances launched with a single network interface.",
+                    f"The queue {queue.name} contains an instance type with multiple network interfaces however the "
+                    f"AssignPublicIp value is set to true. AWS public IPs can only be assigned to instances launched "
+                    f"with a single network interface.",
                     FailureLevel.ERROR,
                 )
 
@@ -1459,9 +1459,8 @@ class MultiNetworkInterfacesInstancesValidator(Validator):
             )
             if queue_subnets_with_public_ips:
                 self._add_failure(
-                    f"The queue {queue.name} contains an instance type with multiple network interfaces but the "
-                    f"subnets {queue_subnets_with_public_ips} automatically assign public IPs and this can cause "
-                    f"bootstrap issues. AWS public IPs can only be assigned to instances launched with a single "
-                    f"network interface.",
+                    f"The queue {queue.name} contains an instance type with multiple network interfaces however the "
+                    f"subnets {queue_subnets_with_public_ips} is configured to automatically assign public IPs. AWS "
+                    f"public IPs can only be assigned to instances launched with a single network interface.",
                     FailureLevel.ERROR,
                 )

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -2798,9 +2798,9 @@ def test_root_volume_encryption_consistency_validator(
                 {"SubnetId": "subnet_2", "MapPublicIpOnLaunch": False},
             ],
             [
-                "The queue queue_1 contains an instance type with multiple network interfaces and the AssignPublicIp "
-                "value can not be set to true. AWS public IPs can only be assigned to instances launched with a single "
-                "network interface."
+                "The queue queue_1 contains an instance type with multiple network interfaces however the "
+                "AssignPublicIp value is set to true. AWS public IPs can only be assigned to instances "
+                "launched with a single network interface."
             ],
             id="Test with multi nic queue with assigned public ip and no subnet with public ip",
         ),
@@ -2812,9 +2812,9 @@ def test_root_volume_encryption_consistency_validator(
                 {"SubnetId": "subnet_2", "MapPublicIpOnLaunch": False},
             ],
             [
-                "The queue queue_1 contains an instance type with multiple network interfaces but the subnets "
-                "['subnet_1'] automatically assign public IPs and this can cause bootstrap issues. AWS public IPs "
-                "can only be assigned to instances launched with a single network interface."
+                "The queue queue_1 contains an instance type with multiple network interfaces however the subnets "
+                "['subnet_1'] is configured to automatically assign public IPs. AWS public IPs can only be assigned "
+                "to instances launched with a single network interface."
             ],
             id="Test with multi nic queue with no assigned public ip and subnet with public ip",
         ),
@@ -2826,12 +2826,12 @@ def test_root_volume_encryption_consistency_validator(
                 {"SubnetId": "subnet_2", "MapPublicIpOnLaunch": False},
             ],
             [
-                "The queue queue_1 contains an instance type with multiple network interfaces and the AssignPublicIp "
-                "value can not be set to true. AWS public IPs can only be assigned to instances launched with a single "
-                "network interface.",
-                "The queue queue_1 contains an instance type with multiple network interfaces but the subnets "
-                "['subnet_1'] automatically assign public IPs and this can cause bootstrap issues. AWS public IPs "
-                "can only be assigned to instances launched with a single network interface.",
+                "The queue queue_1 contains an instance type with multiple network interfaces however the "
+                "AssignPublicIp value is set to true. AWS public IPs can only be assigned to instances "
+                "launched with a single network interface.",
+                "The queue queue_1 contains an instance type with multiple network interfaces however the subnets "
+                "['subnet_1'] is configured to automatically assign public IPs. AWS public IPs can only be assigned "
+                "to instances launched with a single network interface.",
             ],
             id="Test with multi nic queue with assigned public ip and subnet with public ip",
         ),


### PR DESCRIPTION
### Description of changes
Fix `MultiNetworkInterfacesInstancesValidator` failure messages.

### Tests
Unit tests.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
