### PR TITLE
Add default cluster tags and user's tags to LaunchTemplate CFN resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ CHANGELOG
 **ENHANCEMENTS**
 - Add a CloudFormation custom resource for creating and managing clusters from CloudFormation.
 - Add `mem_used_percent` and `disk_used_percent` metrics for head node memory and root volume disk utilization tracking on the ParallelCluster CloudWatch dashboard, and set up alarms for monitoring these metrics.
-
-**ENHANCEMENTS**
+- Add ParallelCluster and user's tags in the Launch Templates created by CloudFormation at cluster creation time.
 - Add log rotation support for ParallelCluster managed logs.
 
 **CHANGES**

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -91,6 +91,7 @@ from pcluster.templates.cdk_builder_utils import (
     generate_launch_template_version_cfn_parameter_hash,
     get_cloud_watch_logs_policy_statement,
     get_cloud_watch_logs_retention_days,
+    get_cluster_tags,
     get_common_user_data_env,
     get_custom_tags,
     get_default_instance_tags,
@@ -981,6 +982,10 @@ class ClusterCdkStack:
                         resource_type="volume",
                         tags=get_default_volume_tags(self._stack_name, "HeadNode") + get_custom_tags(self.config),
                     ),
+                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
+                        resource_type="launch-template",
+                        tags=get_cluster_tags(self._stack_name) + get_custom_tags(self.config),
+                    ),
                 ],
             ),
         )
@@ -1730,6 +1735,10 @@ class ComputeFleetStack(NestedStack):
                         + [CfnTag(key=PCLUSTER_QUEUE_NAME_TAG, value=queue.name)]
                         + [CfnTag(key=PCLUSTER_COMPUTE_RESOURCE_NAME_TAG, value=compute_resource.name)]
                         + get_custom_tags(self._config),
+                    ),
+                    ec2.CfnLaunchTemplate.TagSpecificationProperty(
+                        resource_type="launch-template",
+                        tags=get_cluster_tags(self.stack_name) + get_custom_tags(self._config),
                     ),
                 ],
                 **conditional_template_properties,


### PR DESCRIPTION
### Description of changes
* TagSpecificationProperty specifies the tags to apply to the launch template during creation. To tag the launch template, ResourceType must be launch-template.
* This is useful for users where there are strict policies requiring all the resources to be tagged or to limit resource creations to specific tags

### Tests
* Tested manual creation of a cluster with a modified CLI.
* Verified the tags are present in both head node and compute launch templates.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
