### PR TITLE
`[cloudformation/custom_resource]` improve output, parametrize, deletion policy

### DIFF
--- a/cloudformation/ad/ad-integration.yaml
+++ b/cloudformation/ad/ad-integration.yaml
@@ -1,3 +1,6 @@
+
+Description: AWS ParallelCluster ActiveDirectory Database
+
 Parameters:
   DomainName:
     Description: AD Domain Name.

--- a/cloudformation/custom_resource/cluster-1-click.yaml
+++ b/cloudformation/custom_resource/cluster-1-click.yaml
@@ -1,0 +1,86 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: AWS ParallelCluster CloudFormation Cluster
+
+Parameters:
+  KeyName:
+    Description: KeyPair to login to the head node
+    Type: AWS::EC2::KeyPair::KeyName
+    AllowedPattern: ".+"  # Required
+
+  AvailabilityZone:
+    Description: Availability zone where instances will be launched
+    Type: AWS::EC2::AvailabilityZone::Name
+    AllowedPattern: ".+"  # Required
+
+Mappings:
+  ParallelCluster:
+    Constants:
+      Version: 3.6.0
+      Bucket: '' # For debug purposes only
+
+Conditions:
+  UseCustomBucket: !Not [!Equals [!FindInMap [ParallelCluster, Constants, Bucket], '']]
+
+Resources:
+  PclusterClusterProvider:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        CustomBucket: !If [ UseCustomBucket, !FindInMap [ParallelCluster, Constants, Bucket], !Ref AWS::NoValue ]
+      TemplateURL: !Sub
+        - https://${Bucket}.s3.${AWS::Region}.amazonaws.com/parallelcluster/${Version}/templates/custom_resource/cluster.yaml
+        - { Version: !FindInMap [ParallelCluster, Constants, Version ],
+            Bucket: !If [ UseCustomBucket, !FindInMap [ParallelCluster, Constants, Bucket], !Sub "${AWS::Region}-aws-parallelcluster" ]
+          }
+
+  PclusterVpc:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        PublicCIDR: 10.0.0.0/24
+        PrivateCIDR: 10.0.16.0/20
+        AvailabilityZone: !Ref AvailabilityZone
+      TemplateURL: !Sub
+        - https://${Bucket}.s3.${AWS::Region}.amazonaws.com/parallelcluster/${Version}/templates/networking/public-private.cfn.json
+        - { Version: !FindInMap [ParallelCluster, Constants, Version],
+            Bucket: !If [ UseCustomBucket, !FindInMap [ParallelCluster, Constants, Bucket], !Sub "${AWS::Region}-aws-parallelcluster" ]
+          }
+
+  PclusterCluster:
+    Type: Custom::PclusterCluster
+    Properties:
+      ServiceToken: !GetAtt [ PclusterClusterProvider, Outputs.ServiceToken ]
+      ClusterName: !Sub 'c-${AWS::StackName}'
+      ClusterConfiguration:
+        DevSettings: !If
+          - UseCustomBucket
+          -
+            AmiSearchFilters:
+              Owner: self
+          - !Ref AWS::NoValue
+        Image:
+          Os: alinux2
+        HeadNode:
+          InstanceType: t2.medium
+          Networking:
+            SubnetId: !GetAtt [ PclusterVpc, Outputs.PublicSubnetId ]
+          Ssh:
+            KeyName: !Ref KeyName
+        Scheduling:
+          Scheduler: slurm
+          SlurmQueues:
+          - Name: queue0
+            ComputeResources:
+            - Name: queue0-cr0
+              InstanceType: t2.micro
+            Networking:
+              SubnetIds:
+              - !GetAtt [ PclusterVpc, Outputs.PrivateSubnetId ]
+
+Outputs:
+  HeadNodeIp:
+    Description: The Public IP address of the HeadNode
+    Value: !GetAtt [ PclusterCluster, headNode.publicIpAddress ]
+  ValidationMessages:
+    Description: Any warnings from cluster create or update operations.
+    Value: !GetAtt PclusterCluster.validationMessages

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: AWS ParallelCluster Cluster Custom Resource
+Description: AWS ParallelCluster Cluster Custom Resource Provider
 
 Parameters:
 

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -180,7 +180,7 @@ Resources:
 
               try:
                   meta_keys = {"ServiceToken", "DeletionPolicy"}
-                  kwargs = {**{pcluster.utils.to_snake_case(k): serialize(v) for k, v in properties.items() if k not in meta_keys}, "wait": False}
+                  kwargs = {**{pcluster.utils.to_snake_case(k): serialize(v) for k, v in drop_keys(properties, meta_keys).items()}, "wait": False}
                   func = {"CREATE": pc.create_cluster, "UPDATE": pc.update_cluster}[request_type]
                   update_response(func(**kwargs))
               except (APIOperationException, ParameterException, TypeError)  as e:

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -105,6 +105,11 @@ Resources:
   PclusterCfnFunction:
     Type: AWS::Lambda::Function
     Properties:
+      Tags:
+        - Key: "parallelcluster:version"
+          Value: !FindInMap [ParallelCluster, Constants, Version]
+        - Key: "parallelcluster:custom_resource"
+          Value: "cluster"
       FunctionName: !Sub
         - pcluster-cfn-${StackIdSuffix}
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -167,6 +167,8 @@ Resources:
               request_type = event["RequestType"].upper()
               helper.Data["validationMessages"] = "[]"  # default value
 
+              if properties.get("DeletionPolicy", "Delete") not in {"Retain", "Delete"}:
+                  raise ValueError("DeletionPolicy must be one of [\"Retain\", \"Delete\"].")
               if request_type == "CREATE" and "ClusterName" not in properties:
                   raise ValueError("Couldn't find a ClusterName in the properties.")
               elif request_type == "UPDATE" and event["PhysicalResourceId"] != properties.get("ClusterName"):
@@ -177,7 +179,7 @@ Resources:
               physical_resource_id = cluster_name
 
               try:
-                  meta_keys = {"ServiceToken"}
+                  meta_keys = {"ServiceToken", "DeletionPolicy"}
                   kwargs = {**{pcluster.utils.to_snake_case(k): serialize(v) for k, v in properties.items() if k not in meta_keys}, "wait": False}
                   func = {"CREATE": pc.create_cluster, "UPDATE": pc.update_cluster}[request_type]
                   update_response(func(**kwargs))
@@ -208,6 +210,13 @@ Resources:
           def delete(event, context):
               properties = event["ResourceProperties"]
               cluster_name = properties.get("ClusterName")
+
+              deletion_policy = properties.get("DeletionPolicy", "Delete")
+              if deletion_policy not in {"Retain", "Delete"}:
+                  raise ValueError("DeleetionPolicy must be one of [\"Retain\", \"Delete\"].")
+              if deletion_policy == "Retain":
+                  return cluster_name
+
               logger.info(f"Deleting: {cluster_name}")
               try:
                   update_response(pc.delete_cluster(cluster_name=cluster_name))

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: AWS ParallelCluster CloudFormation Template
+Description: AWS ParallelCluster Cluster Custom Resource
 
 Parameters:
 

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -146,12 +146,15 @@ Resources:
           def drop_keys(_dict, keys):
               return {k: v for k, v in _dict.items() if k not in keys}
 
-          def flatten(obj, path=""):
-              """Flatten a nested map using dot-notation for keys."""
-              _dict = obj if isinstance(obj, dict) else {str(i): v for i, v in enumerate(obj)}
-              ret = {path + str(k): v for k, v in _dict.items() if not isinstance(v, (dict, list))}
-              for k, v in filter(lambda x: isinstance(x[1], (dict, list)), list(_dict.items())):
-                  ret.update(flatten(v, f"{path}{k}."))
+          def flatten(obj, ret={}, path=""):
+              """flatten a nested map using dot-notation for keys."""
+              if isinstance(obj, list):  # convert list to dictionary for flattening
+                  return flatten({str(i): v for i, v in enumerate(obj)}, ret, path)
+              for k, v in obj.items():
+                  if isinstance(v, (dict, list)):  # recurse on complex objects
+                      flatten(v, ret, f"{path}{k}.")
+                  else:  # otherwise add with prefix
+                      ret[path + str(k)] = v
               return ret
 
           def update_response(data):

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -14,6 +14,12 @@ Parameters:
     Type: CommaDelimitedList
     Default: ''
 
+  CustomBucket:
+    Description: (Debug only) bucket to retrieve S3 artifacts for internal resources.
+    Type: String
+    Default: ''
+
+
 Mappings:
   ParallelCluster:
     Constants:
@@ -23,6 +29,7 @@ Conditions:
   CustomRoleCondition: !Not [!Equals [!Ref CustomLambdaRole, '']]
   UsePCPolicies: !Not [!Condition CustomRoleCondition ]
   UseAdditionalIamPolicies: !Not [!Equals [!Join ['', !Ref AdditionalIamPolicies ], '']]
+  UseCustomBucket: !Not [!Equals [!Ref CustomBucket, '']]
 
 Resources:
   PclusterLayer:
@@ -33,7 +40,7 @@ Resources:
         - { StackIdSuffix: !Select [2, !Split ['/', !Ref 'AWS::StackId']] }
       Description: Library which contains aws-parallelcluster python package and dependencies
       Content:
-        S3Bucket: !Sub ${AWS::Region}-aws-parallelcluster
+        S3Bucket: !If [ UseCustomBucket, !Ref CustomBucket, !Sub "${AWS::Region}-aws-parallelcluster" ]
         S3Key: !Sub
         - parallelcluster/${Version}/layers/aws-parallelcluster/lambda-layer.zip
         - { Version: !FindInMap [ParallelCluster, Constants, Version] }
@@ -45,8 +52,10 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub
-        - https://${Region}-aws-parallelcluster.s3.${Region}.amazonaws.com/parallelcluster/${Version}/templates/policies/policies.yaml
-        - { Version: !FindInMap [ParallelCluster, Constants, Version], Region: !Ref AWS::Region }
+        - https://${Bucket}.s3.${Region}.amazonaws.com/parallelcluster/${Version}/templates/policies/policies.yaml
+        - { Version: !FindInMap [ParallelCluster, Constants, Version ],
+            Bucket: !If [UseCustomBucket, !Ref CustomBucket, !Sub "${AWS::Region}-aws-parallelcluster" ],
+            Region: !Ref AWS::Region }
       TimeoutInMinutes: 10
       Parameters:
         EnableIamAdminAccess: true

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -53,7 +53,9 @@ Resources:
 
   PclusterCfnFunctionLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Retain
     Properties:
+      RetentionInDays: 90
       LogGroupName: !Sub /aws/lambda/${PclusterCfnFunction}
 
   EventsPolicy:
@@ -106,6 +108,7 @@ Resources:
           import datetime
           import json
           import logging
+          import os
           import random
           import re
           import string
@@ -126,19 +129,38 @@ Resources:
           from crhelper import CfnResource
           helper = CfnResource()
 
-          def update_response(response):
-              logger.info(response)
-              helper.Data.update(response)
+          def drop_keys(_dict, keys):
+              return {k: v for k, v in _dict.items() if k not in keys}
+
+          def flatten(obj, path=""):
+              """Flatten a nested map using dot-notation for keys."""
+              _dict = obj if isinstance(obj, dict) else {str(i): v for i, v in enumerate(obj)}
+              ret = {path + str(k): v for k, v in _dict.items() if not isinstance(v, (dict, list))}
+              for k, v in filter(lambda x: isinstance(x[1], (dict, list)), list(_dict.items())):
+                  ret.update(flatten(v, f"{path}{k}."))
+              return ret
+
+          def update_response(data):
+              logger.info(data)
+              # create / delete responses have cluster information nested in "cluster" key,
+              # flatten that portion while keeping other keys to propagate warnings.
+              if "cluster" in data:
+                  helper.Data.update(flatten(data["cluster"]))
+                  helper.Data["validationMessages"] = json.dumps(data.get("validationMessages", []))
+              else:  # without "cluster" in the keys, this is a cluster object.
+                  helper.Data.update(flatten(data))
 
           def serialize(val):
               return utils.to_iso_timestr(val) if isinstance(val, datetime.date) else val
 
           def create_or_update(event):
               properties = event["ResourceProperties"]
+              request_type = event["RequestType"].upper()
+              helper.Data["validationMessages"] = "[]"  # default value
 
-              if event["RequestType"].upper() == "CREATE" and "ClusterName" not in properties:
+              if request_type == "CREATE" and "ClusterName" not in properties:
                   raise ValueError("Couldn't find a ClusterName in the properties.")
-              elif event["RequestType"].upper() == "UPDATE" and event["PhysicalResourceId"] != properties.get("ClusterName"):
+              elif request_type == "UPDATE" and event["PhysicalResourceId"] != properties.get("ClusterName"):
                   raise ValueError("Cannot update the ClusterName in the properties.")
 
               cluster_name = properties["ClusterName"]
@@ -146,17 +168,22 @@ Resources:
               physical_resource_id = cluster_name
 
               try:
-                  kwargs = {**{pcluster.utils.to_snake_case(k): serialize(v) for k, v in properties.items() if k not in {"ServiceToken"}}, "wait": False}
-                  func = {"CREATE": pc.create_cluster, "UPDATE": pc.update_cluster}[event["RequestType"].upper()]
+                  meta_keys = {"ServiceToken"}
+                  kwargs = {**{pcluster.utils.to_snake_case(k): serialize(v) for k, v in properties.items() if k not in meta_keys}, "wait": False}
+                  func = {"CREATE": pc.create_cluster, "UPDATE": pc.update_cluster}[request_type]
                   update_response(func(**kwargs))
               except (APIOperationException, ParameterException, TypeError)  as e:
+                  logger.info(str(e))
                   raise ValueError(str(e))
               except Exception as e:
                   message = pcluster.api.errors.exception_message(e)
-                  str_msg = encoder.JSONEncoder().encode(message)
+                  # StatusReason is truncated, so skip changeset in output, still logged below
+                  block_list = {"change_set"}
+                  str_msg = encoder.JSONEncoder().encode(drop_keys(message.to_dict(), block_list))
                   if not re.search(r"No changes found", str_msg):
-                    logger.info(f"No changes found to update: {cluster_name}")
-                    raise ValueError(str_msg)
+                      logger.info(encoder.JSONEncoder().encode(message))
+                      raise ValueError(str_msg)
+                  logger.info(f"No changes found to update: {cluster_name}")
 
               return physical_resource_id
 
@@ -170,7 +197,8 @@ Resources:
 
           @helper.delete
           def delete(event, context):
-              cluster_name = event["ResourceProperties"].get("ClusterName")
+              properties = event["ResourceProperties"]
+              cluster_name = properties.get("ClusterName")
               logger.info(f"Deleting: {cluster_name}")
               try:
                   update_response(pc.delete_cluster(cluster_name=cluster_name))
@@ -183,6 +211,7 @@ Resources:
           # Polling functionality for async CUD operations
 
           def poll(event):
+              log_group = os.getenv("AWS_LAMBDA_LOG_GROUP_NAME")
               cluster_name = event["ResourceProperties"].get("ClusterName")
               try:
                   cluster = pc.describe_cluster(cluster_name=cluster_name)
@@ -192,7 +221,8 @@ Resources:
                       update_response(cluster)
                       return cluster_name
                   elif status in {"CREATE_FAILED", "UPDATE_FAILED", "DELETE_FAILED"}:
-                      raise ValueError(f"{cluster_name} failed {event['RequestType'].upper()}. See substack for further details.")
+                      reasons = ",".join(f["failureCode"] for f in cluster.get("failures", []))
+                      raise ValueError(f"{cluster_name}: {reasons} (LogGroup: {log_group})")
 
               # If create fails and we try to roll-back (e.g. delete),
               # gracefully handle missing cluster. on the delete pathway, the
@@ -202,7 +232,7 @@ Resources:
                       # Returning a value here signifies that the delete is completed and we can stop polling
                       # not returning a value here causes cfn resource helper to keep polling.
                       return cluster_name
-                  raise ValueError(f"{cluster_name} failed {event['RequestType'].upper()}. See substack for further details.")
+                  raise ValueError(f"{cluster_name} failed {event['RequestType'].upper()}. See LogGroup: {log_group}")
 
           @helper.poll_create
           def poll_create(event, context):
@@ -226,6 +256,12 @@ Resources:
         - !Ref PclusterLayer
 
 Outputs:
-  Function:
+  ServiceToken:
     Description: Lambda for managing PCluster Resources
     Value: !GetAtt PclusterCfnFunction.Arn
+  LogGroupArn:
+    Description: ARN of LogGroup for Lambda logging
+    Value: !GetAtt PclusterCfnFunctionLogGroup.Arn
+  LambaLayerArn:
+    Description: ARN for the ParallelCluster Lambda Layer
+    Value: !Ref PclusterLayer

--- a/cloudformation/database/serverless-database.yaml
+++ b/cloudformation/database/serverless-database.yaml
@@ -1,6 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: >-
-  This template is provided as part of a tutorial on how to enable Slurm Accounting using Parallel Cluster.
+Description: AWS ParallelCluster Slurm Accounting Database
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/cloudformation/networking/public-private.cfn.json
+++ b/cloudformation/networking/public-private.cfn.json
@@ -30,7 +30,7 @@
       ]
     }
   },
-  "Description": "Public/Private Network for AWS ParallelCluster",
+  "Description": "AWS ParallelCluster Public/Private Network",
   "Outputs": {
     "VpcId": {
       "Value": {

--- a/cloudformation/networking/public.cfn.json
+++ b/cloudformation/networking/public.cfn.json
@@ -30,7 +30,7 @@
       ]
     }
   },
-  "Description": "Public Network for AWS ParallelCluster",
+  "Description": "AWS ParallelCluster Public Network",
   "Outputs": {
     "VpcId": {
       "Value": {

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Template for the ParallelCluster Policies'
+Description: 'AWS ParallelCluster Policies'
 
 Parameters:
   Region:

--- a/cloudformation/tests/conftest.py
+++ b/cloudformation/tests/conftest.py
@@ -70,8 +70,8 @@ def service_token(pytestconfig):
     return pytestconfig.getoption("service_token")
 
 
-@pytest.fixture(scope="session")
-def bucket(pytestconfig):
+@pytest.fixture(scope="session", name="bucket")
+def bucket_fixture(pytestconfig):
     """Bucket returned from pytest arguments for retrieving artifacts."""
     return pytestconfig.getoption("bucket")
 

--- a/cloudformation/tests/conftest.py
+++ b/cloudformation/tests/conftest.py
@@ -1,4 +1,5 @@
 """Additional pytest configuration."""
+import os
 import random
 import string
 
@@ -6,6 +7,12 @@ import boto3
 import pytest
 
 PUBPRIV_TEMPLATE = "../networking/public-private.cfn.json"
+
+
+def pytest_addoption(parser):
+    """Add the pytest parameter options with defaults from environment."""
+    for arg in ["bucket", "private_subnet_id", "public_subnet_id", "service_token"]:
+        parser.addoption(f"--{arg}", action="store", default=os.environ.get(arg.upper(), ""))
 
 
 def random_str():
@@ -57,6 +64,30 @@ def random_stack_name_fixture():
     return random_str()
 
 
+@pytest.fixture(scope="session")
+def service_token(pytestconfig):
+    """Bucket returned from pytest arguments for retrieving artifacts."""
+    return pytestconfig.getoption("service_token")
+
+
+@pytest.fixture(scope="session")
+def bucket(pytestconfig):
+    """Bucket returned from pytest arguments for retrieving artifacts."""
+    return pytestconfig.getoption("bucket")
+
+
+@pytest.fixture(scope="session", name="private_subnet_id")
+def private_subnet_id_fixture(pytestconfig):
+    """public_subnet_id returned from pytest arguments for HeadNode."""
+    return pytestconfig.getoption("private_subnet_id")
+
+
+@pytest.fixture(scope="session", name="public_subnet_id")
+def public_subnet_id_fixture(pytestconfig):
+    """private_subnet_id returned from pytest argumenets for Compute Nodes."""
+    return pytestconfig.getoption("public_subnet_id")
+
+
 @pytest.fixture(scope="session", name="cfn")
 def cfn_fixture():
     """Create a CloudFormation Boto3 client."""
@@ -65,8 +96,12 @@ def cfn_fixture():
 
 
 @pytest.fixture(scope="module", name="default_vpc")
-def default_vpc_fixture(cfn):
+def default_vpc_fixture(private_subnet_id, public_subnet_id):
     """Create our default VPC networking and return the stack name."""
+    if private_subnet_id != "" and public_subnet_id != "":
+        yield {"PublicSubnetId": public_subnet_id, "PrivateSubnetId": private_subnet_id}
+        return
+
     ec2 = boto3.client("ec2")
     azs = ec2.describe_availability_zones()["AvailabilityZones"]
     stack_name = random_str()

--- a/cloudformation/tests/test_cluster.yaml
+++ b/cloudformation/tests/test_cluster.yaml
@@ -1,6 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: >
-  AWS ParallelCluster CloudFormation Template
+Description: AWS ParallelCluster CloudFormation Cluster
 
 Parameters:
   ClusterName:

--- a/cloudformation/tests/test_cluster.yaml
+++ b/cloudformation/tests/test_cluster.yaml
@@ -15,7 +15,7 @@ Parameters:
   ComputeInstanceMax:
     Description: Maximum number of compute instances
     Type: Number
-    Default: 10
+    Default: 16
   ServiceToken:
     Description: ARN of Lambda Function backing the Cluster Resource
     Type: String
@@ -34,6 +34,9 @@ Resources:
       ServiceToken: !Ref ServiceToken
       ClusterName: !Ref ClusterName
       ClusterConfiguration:
+        DevSettings:
+          AmiSearchFilters:
+            Owner: self
         Image:
           Os: alinux2
         HeadNode:
@@ -51,10 +54,17 @@ Resources:
           SlurmQueues:
           - Name: queue0
             ComputeResources:
-            - Name: queue0-i0
+            - Name: queue0-cr0
               InstanceType: t2.micro
-              MinCount: 0
               MaxCount: !Ref ComputeInstanceMax
             Networking:
               SubnetIds:
               - !Ref ComputeNodeSubnet
+
+Outputs:
+  HeadNodeIp:
+    Description: The Public IP address of the HeadNode
+    Value: !GetAtt [ PclusterCluster, headNode.publicIpAddress ]
+  ValidationMessages:
+    Description: Any warnings from cluster create or update operations.
+    Value: !GetAtt PclusterCluster.validationMessages

--- a/cloudformation/tests/test_cluster.yaml
+++ b/cloudformation/tests/test_cluster.yaml
@@ -23,6 +23,13 @@ Parameters:
     Description: Script to run on HeadNode configured
     Type: String
     Default: ''
+  DeletionPolicy:
+    Type: String
+    Default: Delete
+    AllowedValues:
+      - Delete
+      - Retain
+    Description: Enter Retain or Delete to define the operation when the stack is deleted. Default is to Delete.
 
 Conditions:
   OnNodeConfiguredCondition: !Not [!Equals [!Ref OnNodeConfigured, '']]
@@ -32,6 +39,7 @@ Resources:
     Type: Custom::PclusterCluster
     Properties:
       ServiceToken: !Ref ServiceToken
+      DeletionPolicy: !Ref DeletionPolicy
       ClusterName: !Ref ClusterName
       ClusterConfiguration:
         DevSettings:

--- a/cloudformation/tests/test_cluster_custom_resource.py
+++ b/cloudformation/tests/test_cluster_custom_resource.py
@@ -13,6 +13,18 @@ CLUSTER_TEMPLATE = "../custom_resource/cluster.yaml"
 TEST_CLUSTER = "test_cluster.yaml"
 
 
+def failure_reason(cfn, stack_name):
+    """Return the StatusReason from the most recent failed stack event."""
+
+    def failed_event_predicate(event):
+        """Predicate used to filter failed stacks to validate output."""
+        failed_states = {"CREATE_FAILED", "UPDATE_FAILED"}
+        return event["LogicalResourceId"] == "PclusterCluster" and event["ResourceStatus"] in failed_states
+
+    events = cfn.describe_stack_events(StackName=stack_name)["StackEvents"]
+    return next(filter(failed_event_predicate, events))["ResourceStatusReason"]
+
+
 # The following functions late-bind the library as it is only used locally
 def _list_clusters(cluster_name):
     """List clusters and filter by name."""
@@ -26,6 +38,13 @@ def _describe_cluster(cluster_name):
     import pcluster.lib as pcluster
 
     return pcluster.describe_cluster(cluster_name=cluster_name)
+
+
+def _update_cluster(cluster_name, config, **kwargs):
+    """Late bind library and describe cluster."""
+    import pcluster.lib as pcluster
+
+    return pcluster.update_cluster(cluster_name=cluster_name, cluster_configuration=config, **kwargs)
 
 
 def _delete_cluster(cluster_name):
@@ -61,7 +80,7 @@ def cluster_fixture(cfn, default_vpc, cluster_custom_resource):
         "ClusterName": cluster_name,
         "HeadNodeSubnet": default_vpc["PublicSubnetId"],
         "ComputeNodeSubnet": default_vpc["PrivateSubnetId"],
-        "ServiceToken": cluster_custom_resource["Function"],
+        "ServiceToken": cluster_custom_resource["ServiceToken"],
     }
 
     with open(TEST_CLUSTER, encoding="utf-8") as templ:
@@ -105,15 +124,34 @@ def cluster_fixture(cfn, default_vpc, cluster_custom_resource):
         raise exc
 
 
+@pytest.mark.local
+def test_cluster_create(cfn, cluster):
+    """Use the fixture to validate creation ."""
+    stack_name, cluster_name, _parameters = cluster
+    error_message = "KeyPairValidator"
+    stack = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]
+    assert_that(stack["StackStatus"]).is_not_none()
+
+    # Validate that PC sees the cluster, state might but updated depending on test order
+    cluster = _list_clusters(cluster_name)
+    assert_that(cluster["clusterStatus"]).is_not_none()
+
+    outputs = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]["Outputs"]
+    head_node_ip = next(filter(lambda x: x["OutputKey"] == "HeadNodeIp", outputs)).get("OutputValue")
+    validation_messages = next(filter(lambda x: x["OutputKey"] == "ValidationMessages", outputs)).get("OutputValue")
+    assert_that(validation_messages).contains(error_message)
+    assert_that(head_node_ip).is_not_none()
+
+
 @pytest.mark.parametrize(
-    "parameters",
+    "parameters, error_message",
     [
-        ({"ClusterName": "0"}),
-        ({"OnNodeConfigured": "s3://invalidbucket/invlidkey"}),
+        ({"ClusterName": "0"}, "Bad Request: '0' does not match"),
+        ({"OnNodeConfigured": "s3://invalidbucket/invlidkey"}, "OnNodeConfiguredDownloadFailure"),
     ],
 )
 @pytest.mark.local
-def test_cluster_create_invalid_syntax(cfn, default_vpc, cluster_custom_resource, parameters):
+def test_cluster_create_invalid(cfn, default_vpc, cluster_custom_resource, parameters, error_message):
     """Try to create a cluster with invalid syntax and ensure that it fails."""
     stack_name = random.choice(string.ascii_lowercase) + random_str()
     cluster_name = f"c-{stack_name}"
@@ -121,7 +159,7 @@ def test_cluster_create_invalid_syntax(cfn, default_vpc, cluster_custom_resource
         "ClusterName": cluster_name,
         "HeadNodeSubnet": default_vpc["PublicSubnetId"],
         "ComputeNodeSubnet": default_vpc["PrivateSubnetId"],
-        "ServiceToken": cluster_custom_resource["Function"],
+        "ServiceToken": cluster_custom_resource["ServiceToken"],
         **parameters,
     }
 
@@ -139,18 +177,42 @@ def test_cluster_create_invalid_syntax(cfn, default_vpc, cluster_custom_resource
     with pytest.raises(botocore.exceptions.WaiterError):
         cfn.get_waiter("stack_create_complete").wait(StackName=stack_name)
 
+    reason = failure_reason(cfn, stack_name)
+    assert_that(reason).contains(error_message)
+
     # Stack will be in a ROLLBACK_COMPLETE state at this point, so delete it
     cfn.delete_stack(StackName=stack_name)
     cfn.get_waiter("stack_delete_complete").wait(StackName=stack_name)
 
 
+@pytest.mark.parametrize(
+    "external_update",
+    [
+        (False),
+        (True),
+    ],
+)
 @pytest.mark.local
-def test_cluster_update(cfn, cluster):
+# pylint: disable=too-many-locals
+def test_cluster_update(cfn, cluster, external_update):
     """Perform crud validation on cluster."""
     stack_name, cluster_name, parameters = cluster
+    validation_message = "KeyPairValidator"
+
+    old_config = cluster_config(cluster_name)
+    old_max = int(old_config["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MaxCount"])
+    update_parameters = {"ComputeInstanceMax": str(int(old_max) + 1)}
+
+    # External updates are not supported due to lack of drift detection,
+    # however testing here ensures we don't catastrophically fail.
+    if external_update:
+        config = cluster_config(cluster_name)
+        max_count = update_parameters["ComputeInstanceMax"]
+        config["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MaxCount"] = max_count
+        cluster = _update_cluster(cluster_name, config, wait=True)
 
     # Update the stack
-    update_params = {"ComputeInstanceMax": "8", **parameters}
+    update_params = parameters | update_parameters
     cfn.update_stack(
         StackName=stack_name,
         UsePreviousTemplate=True,
@@ -158,22 +220,36 @@ def test_cluster_update(cfn, cluster):
     )
     cfn.get_waiter("stack_update_complete").wait(StackName=stack_name)
 
+    outputs = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]["Outputs"]
+    head_node_ip = next(filter(lambda x: x["OutputKey"] == "HeadNodeIp", outputs)).get("OutputValue")
+    assert_that(head_node_ip).is_not_none()
+
+    # The underlying update doesn't happen if it was externally updated, so no
+    # validations messages will be available in this case.
+    if not external_update:
+        validation_messages = next(filter(lambda x: x["OutputKey"] == "ValidationMessages", outputs)).get("OutputValue")
+        assert_that(validation_messages).contains(validation_message)
+
     cluster = _list_clusters(cluster_name)
     assert_that(cluster["clusterStatus"]).is_equal_to("UPDATE_COMPLETE")
+
     config = cluster_config(cluster_name)
-    assert_that(int(config["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MaxCount"])).is_equal_to(8)
+    max_count = int(config["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MaxCount"])
+    assert_that(max_count).is_equal_to(int(update_parameters["ComputeInstanceMax"]))
 
 
 @pytest.mark.parametrize(
-    "update_parameters",
+    "update_parameters, error_message",
     [
-        ({"ClusterName": "j"}),
-        ({"ComputeInstanceMax": "-10"}),
-        ({"OnNodeConfigured": "s3://invalidpath"}),
+        ({"ClusterName": "j", "ComputeInstanceMax": "20"}, "Cannot update the ClusterName"),
+        ({"ComputeInstanceMax": "10"}, "Stop the compute fleet"),
+        ({"ComputeInstanceMax": "-10"}, "Must be greater than or equal to 1."),
+        ({"OnNodeConfigured": "s3://invalid", "ComputeInstanceMax": "20"}, "s3 url 's3://invalid' is invalid."),
     ],
 )
 @pytest.mark.local
-def test_update_invalid(cfn, cluster, update_parameters):
+# pylint: disable=too-many-locals
+def test_cluster_update_invalid(cfn, cluster, update_parameters, error_message):
     """Perform crud validation on cluster."""
     stack_name, cluster_name, parameters = cluster
 
@@ -181,7 +257,7 @@ def test_update_invalid(cfn, cluster, update_parameters):
     old_config = cluster_config(cluster_name)
 
     # Update the stack to change the name
-    update_params = {**parameters, **update_parameters}
+    update_params = parameters | update_parameters
     cfn.update_stack(
         StackName=stack_name,
         UsePreviousTemplate=True,
@@ -189,6 +265,8 @@ def test_update_invalid(cfn, cluster, update_parameters):
     )
     with pytest.raises(botocore.exceptions.WaiterError):
         cfn.get_waiter("stack_update_complete").wait(StackName=stack_name)
+
+    assert_that(failure_reason(cfn, stack_name)).contains(error_message)
 
     cluster = _list_clusters(cluster_name)
     assert_that(cluster["clusterName"]).is_equal_to(cluster_name)
@@ -210,7 +288,7 @@ def test_cluster_delete_out_of_band(cfn, default_vpc, cluster_custom_resource):
         "ClusterName": cluster_name,
         "HeadNodeSubnet": default_vpc["PublicSubnetId"],
         "ComputeNodeSubnet": default_vpc["PrivateSubnetId"],
-        "ServiceToken": cluster_custom_resource["Function"],
+        "ServiceToken": cluster_custom_resource["ServiceToken"],
     }
 
     with open(TEST_CLUSTER, encoding="utf-8") as templ:

--- a/cloudformation/tests/test_cluster_custom_resource.py
+++ b/cloudformation/tests/test_cluster_custom_resource.py
@@ -190,13 +190,7 @@ def test_cluster_create_invalid(cfn, default_vpc, cluster_custom_resource, param
     cfn.get_waiter("stack_delete_complete").wait(StackName=stack_name)
 
 
-@pytest.mark.parametrize(
-    "external_update",
-    [
-        (False),
-        (True),
-    ],
-)
+@pytest.mark.parametrize("external_update", [(False), (True)])
 @pytest.mark.local
 # pylint: disable=too-many-locals
 def test_cluster_update(cfn, cluster, external_update):

--- a/cloudformation/tests/test_cluster_custom_resource.py
+++ b/cloudformation/tests/test_cluster_custom_resource.py
@@ -65,10 +65,15 @@ def cluster_config(cluster_name):
 
 
 @pytest.fixture(scope="module", name="cluster_custom_resource")
-def cluster_custom_resource_fixture():
+def cluster_custom_resource_fixture(bucket, service_token):
     """Create the cluster custom resource stack."""
+    if service_token != "":
+        yield {"ServiceToken": service_token}
+        return
+
     capabilities = ["CAPABILITY_IAM", "CAPABILITY_AUTO_EXPAND"]
-    yield from cfn_stack_generator(CLUSTER_TEMPLATE, random_str(), None, capabilities)
+    params = {"CustomBucket": bucket}
+    yield from cfn_stack_generator(CLUSTER_TEMPLATE, random_str(), params, capabilities)
 
 
 @pytest.fixture(scope="module", name="cluster")

--- a/util/bump-version.sh
+++ b/util/bump-version.sh
@@ -65,6 +65,7 @@ main() {
         sed -i "s| version: $CURRENT_VERSION_SHORT| version: $NEW_VERSION_SHORT|g" api/spec/openapi/ParallelCluster.openapi.yaml
         sed -i "s| version: \"$CURRENT_VERSION_SHORT\"| version: \"$NEW_VERSION_SHORT\"|g" api/spec/smithy/model/parallelcluster.smithy
         sed -i "s| Version: $CURRENT_VERSION| Version: $NEW_VERSION|g" cloudformation/custom_resource/cluster.yaml
+        sed -i "s| Version: $CURRENT_VERSION| Version: $NEW_VERSION|g" cloudformation/custom_resource/cluster-1-click.yaml
         cp "$PC_SUPPORT_DIR/os_$CURRENT_VERSION.json" "$PC_SUPPORT_DIR/os_$NEW_VERSION.json"
         git add "$PC_SUPPORT_DIR/os_$NEW_VERSION.json"
 


### PR DESCRIPTION
### Description of changes
The outputs from custom resources cannot be nested, therefore in order to be able to capture the nested properties of a cluster (e.g. `{"headNode": {"privateIpAddress": "1.2.3.4"}}`) from the custom resource to expose as an output on the CloudFormation stack, we need to flatten the properties.
* Flatten cluster properties, extract the properties from the "cluster" property obtained from the `cluster_create` and `cluster_delete` operations. Propagate relevant information in the stack events on failure.
* Parameterize the bucket, service token and subnet ids to ease in testing and assist in E2E tests in our CI pipeline.
* Capture the head node IP address and validation messages in the outputs of the test stack and validate it in the tests.
* Unify the description on our CloudFormation stacks (see screenshot)
* Add support for a `DeletionPolicy` parameter as well as tests.
* Add a 1-click CFN template for E2E testing and documentation purposes.
* Add tags to lambda function for tracking.

### Tests

The local tests were run against all commits included as of https://github.com/aws/aws-parallelcluster/commit/e8f8bb3c65a5c3b606c4b411df7775d791ae992d

```.sh
$ pytest -m local -s -x ./test_cluster_custom_resource.py
======================================== test session starts =========================================
platform darwin -- Python 3.9.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/cgruenwa/src/cgpc/aws-parallelcluster/cloudformation/tests, configfile: pytest.ini
plugins: xdist-3.1.0, html-3.2.0, mock-3.10.0, typeguard-2.13.3, cov-4.0.0, metadata-2.0.4, datadir-1.
4.1
collected 11 items

test_cluster_custom_resource.py ...........

========================================== warnings summary ==========================================
[...]
============================ 11 passed, 40 warnings in 3870.00s (1:04:29) ============================
```

- Internal docs have been updated to demonstrate this functionality.

- The 1-click CFN has been tested by the following:
  -  Setting the `Bucket` value in the mappings of `cluster-1-click.yaml`
  - Uploading the artifacts to the specified bucket in the appropriate paths
  - Running the script below

```.sh
dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

random-string()
{

if [[ $OSTYPE == 'darwin'* ]]; then
    echo $RANDOM | md5 | head -c 5; echo;
else
    echo $RANDOM | md5sum | head -c 5; echo;
fi
}

cfn_template=${dir}/cluster-1-click.yaml
stack_name=$(echo "pc-1-click"-`random-string`)
echo "Deploying: " ${cfn_template} "->" ${stack_name}


aws cloudformation deploy \
    --stack-name ${stack_name} \
    --parameter-overrides KeyName=${KEYNAME} \
    --template-file ${cfn_template} \
    --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND

aws cloudformation describe-stacks --stack-name ${stack_name}

aws cloudformation delete-stack --stack-name ${stack_name}
```

### Output:
```
$ ./deploy.sh
Deploying:  [...]/aws-parallelcluster/cloudformation/custom_resource/cluster-1-cli
ck.yaml -> pc-1-click-e40bd

Waiting for changeset to be created..
Waiting for stack create/update to complete
Successfully created/updated stack - pc-1-click-e40bd
{
    "Stacks": [
        {
            "StackId": "arn:[...]",
            "StackName": "pc-1-click-e40bd",
            "ChangeSetId": "[...]",
            "Description": "AWS ParallelCluster CloudFormation Template\n",
            "Parameters": [
                {
                    "ParameterKey": "KeyName",
                    "ParameterValue": "REDACTED"
                },
                {
                    "ParameterKey": "AvailabilityZone",
                    "ParameterValue": "us-east-2a"
                }
            ],
            "CreationTime": "2023-03-20T01:00:25.278000+00:00",
            "LastUpdatedTime": "2023-03-20T01:00:30.832000+00:00",
            "RollbackConfiguration": {},
            "StackStatus"
```

----

![image](https://user-images.githubusercontent.com/6087509/226223472-e571c8c7-6f9f-4998-86e6-d9ad88f10442.png)


----

Validating tags:

![image](https://user-images.githubusercontent.com/6087509/226402482-9f81cf60-e393-4c13-8424-2ceacd68f22b.png)


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
