### PR TITLE
`[update-policy/MAX_COUNT]` Coerce values for numerical validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
 **BUG FIXES**
 - Fix EFS, FSx network security groups validators to avoid reporting false errors.
 - Fix missing tagging of resources created by ImageBuilder during the `build-image` operation.
+- Fix Update policy for MaxCount to always perform numerical comparisons on MaxCount property.
 
 3.5.0
 -----

--- a/cli/src/pcluster/config/update_policy.py
+++ b/cli/src/pcluster/config/update_policy.py
@@ -420,8 +420,8 @@ UpdatePolicy.MAX_COUNT = UpdatePolicy(
     fail_reason=lambda change, patch: "Shrinking a queue requires the compute fleet to be stopped first",
     action_needed=UpdatePolicy.ACTIONS_NEEDED["pcluster_stop"],
     condition_checker=lambda change, patch: not patch.cluster.has_running_capacity()
-    or (change.new_value if change.new_value is not None else DEFAULT_MAX_COUNT)
-    >= (change.old_value if change.old_value is not None else DEFAULT_MAX_COUNT),
+    or (int(change.new_value) if change.new_value is not None else DEFAULT_MAX_COUNT)
+    >= (int(change.old_value) if change.old_value is not None else DEFAULT_MAX_COUNT),
 )
 
 # Update supported only with all compute nodes down or with replacement policy set different from COMPUTE_FLEET_STOP

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -30,6 +30,7 @@ from tests.pcluster.test_utils import dummy_cluster
     "is_fleet_stopped, old_max, new_max, expected_result",
     [
         pytest.param(True, 10, 9, True, id="stopped fleet and new_max < old_max"),
+        pytest.param(False, "10", "9", False, id="running fleet and new_max < old_max"),
         pytest.param(True, 10, 11, True, id="stopped fleet new_max > old_max"),
         pytest.param(False, 10, 9, False, id="running fleet and new_max < old_max"),
         pytest.param(False, 10, 11, True, id="running fleet and new_max > old_max"),


### PR DESCRIPTION
### Description of changes
* This change coerces the input parameters to the `UpdatePolicy.MAX_COUNT` checker to be coerced to integers. They are already checked for reg-exp match, however the checking here happens on the non-coerced inputs which might be strings. In this case the previous code would do a lexicographical comparison (thus `"9" > "10"`).


### Tests

The following test case demonstrates the issue:

```.py
"""Test update setting to lower number of instances."""
import os
import pprint

import urllib3
import yaml

import pcluster.api.errors
import pcluster.lib as pc

config = {
    "Image": {"Os": "alinux2"},
    "HeadNode": {"InstanceType": "t2.large", "Networking": {"SubnetId": os.environ["HEAD_NODE_SUBNET"]}},
    "DevSettings": {"AmiSearchFilters": {"Owner": "self"}},
    "Scheduling": {
        "Scheduler": "slurm",
        "SlurmQueues": [
            {
                "Name": "queue0",
                "ComputeResources": [{"Name": "queue0-i0", "InstanceType": "t2.micro", "MaxCount": "10"}],
                "Networking": {"SubnetIds": [os.environ["HEAD_NODE_SUBNET"]]},
            }
        ],
    },
}

CLUSTER_NAME = "update-less"
pp = pprint.PrettyPrinter().pprint


def cluster_config(cluster_name):
    """Return the configuration for a cluster."""
    cluster = pc.describe_cluster(cluster_name=cluster_name)
    http = urllib3.PoolManager()
    resp = http.request(url=cluster["clusterConfiguration"]["url"], method="GET")
    return yaml.safe_load(resp.data.decode("UTF-8"))


pc.create_cluster(cluster_name=CLUSTER_NAME, cluster_configuration=config, wait=True)
config["Scheduling"]["SlurmQueues"][0]["ComputeResources"][0]["MaxCount"] = "9"
try:
    pp(pc.update_cluster(cluster_name=CLUSTER_NAME, cluster_configuration=config, wait=True))
except Exception as e:
    pp(pcluster.api.errors.exception_message(e))
print("---------------------- After Update ----------------------")
pp(cluster_config(CLUSTER_NAME)["Scheduling"]["SlurmQueues"])
pc.delete_cluster(cluster_name=CLUSTER_NAME)
```

Before the change this is the output which demonstrates that using strings it is possible to update a cluster from a MaxCount of `"10"` to `"9"` on a running cluster:

```
---------------------- Updating ----------------------
{'cloudFormationStackStatus': 'UPDATE_COMPLETE',
 'cloudformationStackArn': 'arn:aws:cloudformation:us-east-2:00000000000:...',
 'clusterConfiguration': {'url': 'REDACTED'},
 'clusterName': 'update-less',
 'clusterStatus': 'UPDATE_COMPLETE',
 'computeFleetStatus': 'RUNNING',
 'creationTime': '2023-03-19T20:13:57.854Z',
 'headNode': {'instanceId': 'i-0d57750dd3938f9b5',
              'instanceType': 't2.large',
              'launchTime': '2023-03-19T20:18:37.000Z',
              'privateIpAddress': '10.0.0.68',
              'publicIpAddress': '13.58.64.130',
              'state': 'running'},
 'lastUpdatedTime': '2023-03-19T20:22:10.292Z',
 'region': 'us-east-2',
 'scheduler': {'type': 'slurm'},
 'tags': [{'key': 'parallelcluster:version', 'value': '3.6.0'},
          {'key': 'parallelcluster:cluster-name', 'value': 'update-less'}],
 'version': '3.6.0'}
---------------------- After Update ----------------------
[{'ComputeResources': [{'InstanceType': 't2.micro',
                        'MaxCount': '9',
                        'Name': 'queue0-i0'}],
  'Name': 'queue0',
  'Networking': {'SubnetIds': ['subnet-0000000.....']}}]
```

After the change we can see that the invalid update is properly caught with the UpdatePolicy:

```
{'change_set': [{'current_value': '10',
                 'parameter': 'Scheduling.SlurmQueues[queue0].ComputeResources[queue0-i0].MaxCount',
                 'requested_value': '9'}],
 'configuration_validation_errors': None,
 'message': 'Update failure',
 'update_validation_errors': [{'current_value': '10',
                               'message': 'Shrinking a queue requires the '
                                          'compute fleet to be stopped first. '
                                          'Stop the compute fleet with the '
                                          'pcluster update-compute-fleet '
                                          'command',
                               'parameter': 'Scheduling.SlurmQueues[queue0].ComputeResources[queue0-i
0].MaxCount',
                               'requested_value': '9'}]}
---------------------- After Update ----------------------
[{'ComputeResources': [{'InstanceType': 't2.micro',
                        'MaxCount': '10',
                        'Name': 'queue0-i0'}],
  'Name': 'queue0',
  'Networking': {'SubnetIds': ['subnet-000000000000']}}]
```

* The unit test is updated to capture this case, before the change to the logic the unit test would fail, after the change to the logic it passes.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
