### PR TITLE
Temporary comment out metric filter policy in PermissionBoundary

### DIFF
--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -1047,12 +1047,12 @@ Resources:
               - cloudwatch:DeleteAlarms
               - cloudwatch:DescribeAlarms
             Resource: "*"
-          - Effect: Allow
-            Action:
-              - logs:DescribeMetricFilters
-              - logs:PutMetricFilter
-              - logs:deleteMetricFilter
-            Resource: "*"
+#          - Effect: Allow # TODO: Refactor it, comment it out now to workaround exceeds quota for PolicySize: 6144
+#            Action:
+#              - logs:DescribeMetricFilters
+#              - logs:PutMetricFilter
+#              - logs:deleteMetricFilter
+#            Resource: "*"
 
 Outputs:
   ParallelClusterUserRole:


### PR DESCRIPTION
PermissionBoundary currently is not used in integration tests. Temporary comment it out to workaround integration test failure on creating UserRole that exceeds quota for PolicySize: 6144. Add a TODO item to recover it after refactoring PermissionBoundary policies


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
