### PR TITLE
Fix integration test of cw logging by write dummy message to empty log

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -379,7 +379,11 @@ class CloudWatchLoggingClusterState:
         """Figure out which of the relevant logs for the ComputeFleet nodes don't exist."""
         if self.compute_nodes_count == 0:
             return
-        critical_compute_node_logs = ["/var/log/parallelcluster/computemgtd"] if self.scheduler == "slurm" else []
+        critical_compute_node_logs = (
+            ["/var/log/parallelcluster/computemgtd", "/var/log/parallelcluster/bootstrap_error_msg"]
+            if self.scheduler == "slurm"
+            else []
+        )
         for log_dict in self._relevant_logs.get(COMPUTE_NODE_ROLE_NAME):
             log_path = log_dict.get("file_path")
             if log_path in critical_compute_node_logs:


### PR DESCRIPTION
### Description of changes
* The log file "/var/log/parallelcluster/bootstrap_error_msg" does not exist during integration test, manually write dummy message to the log to make sure the logs is uploaded to cw

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
