### PR TITLE
Introduce CustomSlurmSettings in SlurmSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 - Add log rotation support for ParallelCluster managed logs.
 - Track common errors of compute nodes on Cloudwatch Dashboard.
 - Increase the limit on the maximum number of queues per cluster from 10 to 40.
+- Add support for customizing the cluster Slurm configuration via the ParallelCluster configuration YAML file.
 
 **CHANGES**
 - Increase the default `RetentionInDays` of CloudWatch logs from 14 to 180 days.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -193,9 +193,9 @@ from pcluster.validators.scheduler_plugin_validators import (
 )
 from pcluster.validators.slurm_settings_validator import (
     SLURM_SETTINGS_DENY_LIST,
-    SlurmCustomSettingLevel,
-    SlurmCustomSettingsValidator,
-    SlurmCustomSettingsWarning,
+    CustomSlurmSettingLevel,
+    CustomSlurmSettingsValidator,
+    CustomSlurmSettingsWarning,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -2234,12 +2234,12 @@ class SlurmQueue(_CommonQueue):
             )
         if self.custom_slurm_settings:
             self._register_validator(
-                SlurmCustomSettingsValidator,
-                custom_settings=self.custom_slurm_settings,
-                deny_list=SLURM_SETTINGS_DENY_LIST["Queue"],
-                settings_level=SlurmCustomSettingLevel.QUEUE,
+                CustomSlurmSettingsValidator,
+                custom_settings=[self.custom_slurm_settings],
+                deny_list=SLURM_SETTINGS_DENY_LIST["Queue"]["Global"],
+                settings_level=CustomSlurmSettingLevel.QUEUE,
             )
-            self._register_validator(SlurmCustomSettingsWarning)
+            self._register_validator(CustomSlurmSettingsWarning)
         for compute_resource in self.compute_resources:
             self._register_validator(
                 EfaSecurityGroupValidator,
@@ -2259,12 +2259,12 @@ class SlurmQueue(_CommonQueue):
             )
             if compute_resource.custom_slurm_settings:
                 self._register_validator(
-                    SlurmCustomSettingsValidator,
-                    custom_settings=compute_resource.custom_slurm_settings,
-                    deny_list=SLURM_SETTINGS_DENY_LIST["ComputeResource"],
-                    settings_level=SlurmCustomSettingLevel.COMPUTE_RESOURCE,
+                    CustomSlurmSettingsValidator,
+                    custom_settings=[compute_resource.custom_slurm_settings],
+                    deny_list=SLURM_SETTINGS_DENY_LIST["ComputeResource"]["Global"],
+                    settings_level=CustomSlurmSettingLevel.COMPUTE_RESOURCE,
                 )
-                self._register_validator(SlurmCustomSettingsWarning)
+                self._register_validator(CustomSlurmSettingsWarning)
             for instance_type in compute_resource.instance_types:
                 self._register_validator(
                     CapacityTypeValidator,
@@ -2317,6 +2317,7 @@ class SlurmSettings(Resource):
         queue_update_strategy: str = None,
         enable_memory_based_scheduling: bool = None,
         database: Database = None,
+        custom_slurm_settings: List[Dict] = None,
         **kwargs,
     ):
         super().__init__()
@@ -2327,6 +2328,25 @@ class SlurmSettings(Resource):
         )
         self.enable_memory_based_scheduling = Resource.init_param(enable_memory_based_scheduling, default=False)
         self.database = database
+        self.custom_slurm_settings = Resource.init_param(custom_slurm_settings)
+
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
+        if self.custom_slurm_settings:  # if not empty register validator
+            self._register_validator(
+                CustomSlurmSettingsValidator,
+                custom_settings=self.custom_slurm_settings,
+                deny_list=SLURM_SETTINGS_DENY_LIST["SlurmConf"]["Global"],
+                settings_level=CustomSlurmSettingLevel.SLURM_CONF,
+            )
+            self._register_validator(CustomSlurmSettingsWarning)
+            if self.database:
+                self._register_validator(
+                    CustomSlurmSettingsValidator,
+                    custom_settings=self.custom_slurm_settings,
+                    deny_list=SLURM_SETTINGS_DENY_LIST["SlurmConf"]["Accounting"],
+                    settings_level=CustomSlurmSettingLevel.SLURM_CONF,
+                )
 
 
 class QueueUpdateStrategy(Enum):

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -193,6 +193,7 @@ from pcluster.validators.scheduler_plugin_validators import (
 )
 from pcluster.validators.slurm_settings_validator import (
     SLURM_SETTINGS_DENY_LIST,
+    CustomSlurmNodeNamesValidator,
     CustomSlurmSettingLevel,
     CustomSlurmSettingsIncludeFileOnlyValidator,
     CustomSlurmSettingsValidator,
@@ -2343,6 +2344,7 @@ class SlurmSettings(Resource):
                 settings_level=CustomSlurmSettingLevel.SLURM_CONF,
             )
             self._register_validator(CustomSlurmSettingsWarning)
+            self._register_validator(CustomSlurmNodeNamesValidator, custom_settings=self.custom_slurm_settings)
             if self.database:
                 self._register_validator(
                     CustomSlurmSettingsValidator,

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -194,6 +194,7 @@ from pcluster.validators.scheduler_plugin_validators import (
 from pcluster.validators.slurm_settings_validator import (
     SLURM_SETTINGS_DENY_LIST,
     CustomSlurmSettingLevel,
+    CustomSlurmSettingsIncludeFileOnlyValidator,
     CustomSlurmSettingsValidator,
     CustomSlurmSettingsWarning,
 )
@@ -2318,6 +2319,7 @@ class SlurmSettings(Resource):
         enable_memory_based_scheduling: bool = None,
         database: Database = None,
         custom_slurm_settings: List[Dict] = None,
+        custom_slurm_settings_include_file: str = None,
         **kwargs,
     ):
         super().__init__()
@@ -2329,6 +2331,7 @@ class SlurmSettings(Resource):
         self.enable_memory_based_scheduling = Resource.init_param(enable_memory_based_scheduling, default=False)
         self.database = database
         self.custom_slurm_settings = Resource.init_param(custom_slurm_settings)
+        self.custom_slurm_settings_include_file = Resource.init_param(custom_slurm_settings_include_file)
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
@@ -2347,6 +2350,13 @@ class SlurmSettings(Resource):
                     deny_list=SLURM_SETTINGS_DENY_LIST["SlurmConf"]["Accounting"],
                     settings_level=CustomSlurmSettingLevel.SLURM_CONF,
                 )
+        if self.custom_slurm_settings_include_file:
+            self._register_validator(UrlValidator, url=self.custom_slurm_settings_include_file)
+            self._register_validator(
+                CustomSlurmSettingsIncludeFileOnlyValidator,
+                custom_settings=self.custom_slurm_settings,
+                include_file_url=self.custom_slurm_settings_include_file,
+            )
 
 
 class QueueUpdateStrategy(Enum):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1420,6 +1420,7 @@ class SlurmSettingsSchema(BaseSchema):
     )
     enable_memory_based_scheduling = fields.Bool(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
     database = fields.Nested(DatabaseSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    custom_slurm_settings = fields.List(fields.Dict, metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1421,6 +1421,7 @@ class SlurmSettingsSchema(BaseSchema):
     enable_memory_based_scheduling = fields.Bool(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
     database = fields.Nested(DatabaseSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
     custom_slurm_settings = fields.List(fields.Dict, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    custom_slurm_settings_include_file = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 from enum import Enum
+from typing import Dict, List
 
 from pcluster.validators.common import FailureLevel, Validator
 
@@ -114,3 +115,20 @@ class CustomSlurmSettingsWarning(Validator):
                 FailureLevel.WARNING,
             )
             CustomSlurmSettingsWarning.signaled = True
+
+
+class CustomSlurmSettingsIncludeFileOnlyValidator(Validator):
+    """
+    Custom Slurm Settings Include File Only validator.
+
+    This validator returns an error if the CustomSlurmSettingsIncludeFile configuration parameter
+    is used together with the CustomSlurmSettings under SlurmSettings.
+    """
+
+    def _validate(self, custom_settings: List[Dict], include_file_url: str):
+        if custom_settings and include_file_url:
+            self._add_failure(
+                "CustomSlurmsettings and CustomSlurmSettingsIncludeFile cannot be used together "
+                "under SlurmSettings.",
+                FailureLevel.ERROR,
+            )

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -26,6 +26,7 @@ from pcluster.validators import (
     kms_validators,
     networking_validators,
     s3_validators,
+    slurm_settings_validator,
 )
 from pcluster.validators.common import Validator, ValidatorContext
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
@@ -43,6 +44,7 @@ def _mock_all_validators(mocker, mockers, additional_modules=None):
         instances_validators,
         networking_validators,
         s3_validators,
+        slurm_settings_validator,
     ]
     if additional_modules:
         modules += additional_modules

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -45,15 +45,22 @@ Scheduling:
     Dns:
       DisableManagedDns: false
       HostedZoneId: 12345ABC
+    CustomSlurmSettingsIncludeFile: https://test.conf
   SlurmQueues:
     - Name: queue1
       CapacityType: ONDEMAND
       Networking:
         SubnetIds:
           - subnet-12345678
+      CustomSlurmSettings:
+        Param1: Value1
+        Param2: Value2
       ComputeResources:
         - Name: compute_resource1
           InstanceType: c5.xlarge
+          CustomSlurmSettings:
+            Param1: Value1
+            Param2: Value2
         - Name: compute_resource2
           InstanceType: c4.xlarge
       CustomActions:

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_2.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_2.yaml
@@ -11,6 +11,11 @@ Scheduling:
   Scheduler: slurm
   SlurmSettings:
     EnableMemoryBasedScheduling: true
+    CustomSlurmSettings:
+      - Param1: Value1
+      - Param2: Value2
+      - NodeName: test-node[1-100]
+        CPUs: 100
     Database:
       Uri: test.databaseserver.com
       UserName: test_admin

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -82,6 +82,7 @@ from pcluster.validators.ebs_validators import (
 from pcluster.validators.slurm_settings_validator import (
     SLURM_SETTINGS_DENY_LIST,
     CustomSlurmSettingLevel,
+    CustomSlurmSettingsIncludeFileOnlyValidator,
     CustomSlurmSettingsValidator,
     CustomSlurmSettingsWarning,
 )
@@ -260,6 +261,28 @@ def test_custom_slurm_settings_warning():
 
     actual_failures = CustomSlurmSettingsWarning().execute()
     assert_failure_messages(actual_failures, None)
+
+
+@pytest.mark.parametrize(
+    "custom_slurm_settings, custom_slurm_settings_include_file, expected_message",
+    [
+        ([{"Param1": "Value1"}, {"Param2": "Value2"}], "", ""),
+        ([], "s3://test", ""),
+        (
+            [{"Param1": "Value1"}, {"Param2": "Value2"}],
+            "s3://test",
+            "CustomSlurmsettings and CustomSlurmSettingsIncludeFile cannot be used together under SlurmSettings.",
+        ),
+    ],
+)
+def test_custom_slurm_settings_include_file_only_validator(
+    custom_slurm_settings, custom_slurm_settings_include_file, expected_message
+):
+    actual_failures = CustomSlurmSettingsIncludeFileOnlyValidator().execute(
+        custom_slurm_settings,
+        custom_slurm_settings_include_file,
+    )
+    assert_failure_messages(actual_failures, expected_message)
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -80,9 +80,10 @@ from pcluster.validators.ebs_validators import (
     SharedEbsVolumeIdValidator,
 )
 from pcluster.validators.slurm_settings_validator import (
-    SlurmCustomSettingLevel,
-    SlurmCustomSettingsValidator,
-    SlurmCustomSettingsWarning,
+    SLURM_SETTINGS_DENY_LIST,
+    CustomSlurmSettingLevel,
+    CustomSlurmSettingsValidator,
+    CustomSlurmSettingsWarning,
 )
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.validators.utils import assert_failure_level, assert_failure_messages
@@ -197,52 +198,67 @@ def test_cluster_name_validator_slurm_accounting(cluster_name, scheduling, shoul
     [
         (
             "No error when custom settings are not in the deny_list",
-            {"Allowed1": "Value1", "Allowed2": "Value2"},
+            [{"Allowed1": "Value1"}, {"Allowed2": "Value2"}],
+            SLURM_SETTINGS_DENY_LIST["SlurmConf"],  # keep the deny-list lowercase
+            CustomSlurmSettingLevel.SLURM_CONF,
+            "",
+        ),
+        (
+            "Fails when custom settings at SlurmConf level are in the deny_list, invalid parameters are reported",
+            [{"SlurmctldParameters": "SubPar1,Subpar2=1"}, {"CommunicationParameters": "SubPar1"}],
+            SLURM_SETTINGS_DENY_LIST["SlurmConf"]["Global"],  # keep the deny-list lowercase
+            CustomSlurmSettingLevel.SLURM_CONF,
+            "Using the following custom Slurm settings at SlurmConf level is not allowed: "
+            "CommunicationParameters,SlurmctldParameters",
+        ),
+        (
+            "No error when custom settings are not in the deny_list",
+            [{"Allowed1": "Value1", "Allowed2": "Value2"}],
             ["denied1", "denied2"],  # keep the deny-list lowercase
-            SlurmCustomSettingLevel.QUEUE,
+            CustomSlurmSettingLevel.QUEUE,
             "",
         ),
         (
             "Fails when custom settings are in the deny_list, invalid parameters are reported",
-            {"Denied1": "Value1", "Denied2": "Value2"},
+            [{"Denied1": "Value1", "Denied2": "Value2"}],
             ["denied1", "denied2"],
-            SlurmCustomSettingLevel.QUEUE,
+            CustomSlurmSettingLevel.QUEUE,
             "Using the following custom Slurm settings at Queue level is not allowed: Denied1,Denied2",
         ),
         (
             "No error when custom settings are not in the deny_list",
-            {"Allowed1": "Value1", "Allowed2": "Value2"},
+            [{"Allowed1": "Value1", "Allowed2": "Value2"}],
             ["denied1", "denied2"],
-            SlurmCustomSettingLevel.COMPUTE_RESOURCE,
+            CustomSlurmSettingLevel.COMPUTE_RESOURCE,
             "",
         ),
         (
             "Fails when custom settings are in the deny_list, invalid parameters are reported",
-            {"Denied1": "Value1", "Denied2": "Value2"},
+            [{"Denied1": "Value1", "Denied2": "Value2"}],
             ["denied1", "denied2"],
-            SlurmCustomSettingLevel.COMPUTE_RESOURCE,
+            CustomSlurmSettingLevel.COMPUTE_RESOURCE,
             "Using the following custom Slurm settings at ComputeResource level is not allowed: Denied1,Denied2",
         ),
         (
             "Case doesn't affect the result and duplicates are avoided, but only the first occurrence is reported",
-            {"Denied1": "Value1", "Denied2": "Value2", "dEnIeD1": "Value1", "deNIeD2": "Value2"},
+            [{"Denied1": "Value1", "Denied2": "Value2", "dEnIeD1": "Value1", "deNIeD2": "Value2"}],
             ["denied1", "denied2"],
-            SlurmCustomSettingLevel.COMPUTE_RESOURCE,
+            CustomSlurmSettingLevel.COMPUTE_RESOURCE,
             "Using the following custom Slurm settings at ComputeResource level is not allowed: Denied1,Denied2",
         ),
     ],
 )
 def test_custom_slurm_settings_validator(description, custom_settings, deny_list, settings_level, expected_message):
-    actual_failures = SlurmCustomSettingsValidator().execute(custom_settings, deny_list, settings_level)
+    actual_failures = CustomSlurmSettingsValidator().execute(custom_settings, deny_list, settings_level)
     assert_failure_messages(actual_failures, expected_message)
 
 
 def test_custom_slurm_settings_warning():
     # when multiple instances are invoked it should show the warning only once
-    actual_failures = SlurmCustomSettingsWarning().execute()
+    actual_failures = CustomSlurmSettingsWarning().execute()
     assert_failure_messages(actual_failures, "Custom Slurm settings are in use: please monitor the cluster carefully.")
 
-    actual_failures = SlurmCustomSettingsWarning().execute()
+    actual_failures = CustomSlurmSettingsWarning().execute()
     assert_failure_messages(actual_failures, None)
 
 


### PR DESCRIPTION
### Description of changes
* Introduce `CustomSlurmSettings` and `CustomSlurmSettingsIncludeFile` under `SlurmSettings`.
* Add validation for `CustomSlurmSettings` at bulk slurm.conf level.
* Validate that `CustomSlurmSettingsIncludeFile` is a valid URL and that it is not used together with `CustomSlurmSettings`.
* Introduce context in `SLURM_SETTINGS_DENY_LIST` dictionary to differentiate groups of denied parameters based on when they are used.
* Reformat `SLURM_SETTINGS_DENY_LIST` for better readability of the structure of the dictionary.
* Refactor `SlurmCustomSettings*` objects to `CustomSlurmSettings*`.

### Tests
* Add unit test cases for the `CustomSlurmSettings` at `SlurmConf` level.
* Add unit tests for `CustomSlurmSettingsIncludeFileOnlyValidator`.
* Successfully performed manual test with new configuration parameter formatted this way:
  ```
  Scheduling:
  Scheduler: slurm
  SlurmSettings:
    CustomSlurmSettings:
      - Param1: Value1
      - Param2: Value2
      - Nodename: node-bla-[001-100]
        CPUs: 16
  ```

### References
* https://github.com/aws/aws-parallelcluster/pull/5079

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~Check if documentation is impacted by this change.~   Documentation coming at a second time.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
