### PR TITLE
Fix API Validation by explicitly asking for YAML output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: mikefarah/yq@v4.6.3
+      - uses: mikefarah/yq@v4.32.2
       - run: api/docker/awslambda/docker-build.sh
   shellcheck:
     name: Shellcheck

--- a/api/spec/build-model.sh
+++ b/api/spec/build-model.sh
@@ -10,4 +10,5 @@ fi
 pushd smithy && ../../gradlew build && popd
 GENERATED_JSON_PATH="smithy/build/smithyprojections/smithy/source/openapi/ParallelCluster.openapi.json"
 ./spec_overrides.sh "$GENERATED_JSON_PATH"
-yq eval -P $GENERATED_JSON_PATH > openapi/ParallelCluster.openapi.yaml
+# Convert json into yaml
+yq eval -P $GENERATED_JSON_PATH -o yaml > openapi/ParallelCluster.openapi.yaml

--- a/api/spec/build-model.sh
+++ b/api/spec/build-model.sh
@@ -8,6 +8,6 @@ then
     exit 1
 fi
 pushd smithy && ../../gradlew build && popd
-GENERATED_YAML_PATH="smithy/build/smithyprojections/smithy/source/openapi/ParallelCluster.openapi.json"
-./spec_overrides.sh "$GENERATED_YAML_PATH"
-yq eval -P $GENERATED_YAML_PATH > openapi/ParallelCluster.openapi.yaml
+GENERATED_JSON_PATH="smithy/build/smithyprojections/smithy/source/openapi/ParallelCluster.openapi.json"
+./spec_overrides.sh "$GENERATED_JSON_PATH"
+yq eval -P $GENERATED_JSON_PATH > openapi/ParallelCluster.openapi.yaml


### PR DESCRIPTION
### Description of changes
* API Validation step was failing because the git diff was comparing a yaml with a json. In this way we're sure the produced file is always a yaml.
* Update yq GitHub action version to latest version available
