### PR TITLE
Remove metric filter for AmiLargerThanRootVolume 

### DIFF
--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -272,11 +272,6 @@ class CWDashboardConstruct(Construct):
                 metric_value=metric_value,
             ),
             _CustomMetricFilter(
-                metric_name="AmiLargerThanRootVolume",
-                filter_pattern=_generate_metric_filter_pattern(launch_failure_event_type, "custom-ami-errors"),
-                metric_value=metric_value,
-            ),
-            _CustomMetricFilter(
                 metric_name="VcpuLimit",
                 filter_pattern=_generate_metric_filter_pattern(launch_failure_event_type, "vcpu-limit-failures"),
                 metric_value=metric_value,
@@ -352,7 +347,7 @@ class CWDashboardConstruct(Construct):
         ]
         cluster_common_errors = [
             _ErrorMetric(
-                "JobsNot Starting Errors",
+                "Jobs Not Starting Errors",
                 jobs_not_starting_errors,
             ),
             _ErrorMetric(

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -179,7 +179,6 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml):
     scheduler = cluster_config.scheduling.scheduler
     slurm_related_metrics = [
         "IamPolicyErrors",
-        "AmiLargerThanRootVolume",
         "VcpuLimit",
         "VolumeLimit",
         "NodeCapacityInsufficient",


### PR DESCRIPTION
### Description of changes
* Remove metric filter for AmiLargerThanRootVolume since it can't happen for compute nodes anymore with https://github.com/aws/aws-parallelcluster/commit/fbb995d4221b56b62cb8d7edd5ffa91ee643f002
    


### Tests
* Unit tests

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
