### PR TITLE
Add custom scripts error metric filters to cloudwatch dashboard

### DIFF
--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -293,18 +293,32 @@ class CWDashboardConstruct(Construct):
             ),
         ]
 
-        # custom_script_errors = [  # TODO: Change Me
-        #     _CustomMetricFilter(
-        #         metric_name="CannotRetrieveCustomScript",
-        #         filter_pattern=custom_scripts_failure_event_pattern,
-        #         metric_value="1",
-        #     ),
-        #     _CustomMetricFilter(
-        #         metric_name="ErrorWithCustomScript",
-        #         filter_pattern=custom_scripts_failure_event_pattern,
-        #         metric_value="1",
-        #     ),
-        # ]
+        custom_script_errors = [
+            _CustomMetricFilter(
+                metric_name="OnNodeStartDownloadError",
+                filter_pattern='{ $.event-type = "custom-action-error" && $.scheduler = "slurm" && '
+                '$.detail.action = "OnNodeStart" && $.detail.stage = "downloading"}',
+                metric_value="1",
+            ),
+            _CustomMetricFilter(
+                metric_name="OnNodeStartExecutionError",
+                filter_pattern='{ $.event-type = "custom-action-error" && $.scheduler = "slurm" && '
+                '$.detail.action = "OnNodeStart" && $.detail.stage = "executing"}',
+                metric_value="1",
+            ),
+            _CustomMetricFilter(
+                metric_name="OnNodeConfiguredDownloadError",
+                filter_pattern='{ $.event-type = "custom-action-error" && $.scheduler = "slurm" && '
+                '$.detail.action = "OnNodeConfigured" && $.detail.stage = "downloading"}',
+                metric_value="1",
+            ),
+            _CustomMetricFilter(
+                metric_name="OnNodeConfiguredExecutionError",
+                filter_pattern='{ $.event-type = "custom-action-error" && $.scheduler = "slurm" && '
+                '$.detail.action = "OnNodeConfigured" && $.detail.stage = "executing"}',
+                metric_value="1",
+            ),
+        ]
 
         compute_node_events = [
             _CustomMetricFilter(
@@ -355,13 +369,13 @@ class CWDashboardConstruct(Construct):
                 compute_node_events,
             ),
         ]
-        # if self.config.has_custom_actions_in_queue: # TODO: Uncomment here when custom script is implemented
-        #     cluster_common_errors.append(
-        #         _ErrorMetric(
-        #             "Custom Script Errors",
-        #             custom_script_errors,
-        #         )
-        #     )
+        if self.config.has_custom_actions_in_queue:
+            cluster_common_errors.append(
+                _ErrorMetric(
+                    "Custom Script Errors",
+                    custom_script_errors,
+                )
+            )
         self._add_text_widget("# Cluster Health Metrics")
         self._add_error_metrics_graph_widgets(cluster_common_errors)
         self._add_text_widget(

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -272,48 +272,48 @@ class CWDashboardConstruct(Construct):
                 metric_value=metric_value,
             ),
             _CustomMetricFilter(
-                metric_name="VcpuLimit",
+                metric_name="VcpuLimitErrors",
                 filter_pattern=_generate_metric_filter_pattern(launch_failure_event_type, "vcpu-limit-failures"),
                 metric_value=metric_value,
             ),
             _CustomMetricFilter(
-                metric_name="VolumeLimit",
+                metric_name="VolumeLimitErrors",
                 filter_pattern=_generate_metric_filter_pattern(launch_failure_event_type, "volume-limit-failures"),
                 metric_value=metric_value,
             ),
             _CustomMetricFilter(
-                metric_name="NodeCapacityInsufficient",
+                metric_name="InsufficientCapacityErrors",
                 filter_pattern=_generate_metric_filter_pattern(launch_failure_event_type, "ice-failures"),
                 metric_value=metric_value,
             ),
             _CustomMetricFilter(
-                metric_name="OtherLaunchedInstanceFailures",
+                metric_name="OtherLaunchedInstanceErrors",
                 filter_pattern=_generate_metric_filter_pattern(launch_failure_event_type, "other-failures"),
                 metric_value=metric_value,
             ),
         ]
 
-        custom_script_errors = [
+        custom_action_errors = [
             _CustomMetricFilter(
-                metric_name="OnNodeStartDownloadError",
+                metric_name="OnNodeStartDownloadErrors",
                 filter_pattern='{ $.event-type = "custom-action-error" && $.scheduler = "slurm" && '
                 '$.detail.action = "OnNodeStart" && $.detail.stage = "downloading"}',
                 metric_value="1",
             ),
             _CustomMetricFilter(
-                metric_name="OnNodeStartExecutionError",
+                metric_name="OnNodeStartExecutionErrors",
                 filter_pattern='{ $.event-type = "custom-action-error" && $.scheduler = "slurm" && '
                 '$.detail.action = "OnNodeStart" && $.detail.stage = "executing"}',
                 metric_value="1",
             ),
             _CustomMetricFilter(
-                metric_name="OnNodeConfiguredDownloadError",
+                metric_name="OnNodeConfiguredDownloadErrors",
                 filter_pattern='{ $.event-type = "custom-action-error" && $.scheduler = "slurm" && '
                 '$.detail.action = "OnNodeConfigured" && $.detail.stage = "downloading"}',
                 metric_value="1",
             ),
             _CustomMetricFilter(
-                metric_name="OnNodeConfiguredExecutionError",
+                metric_name="OnNodeConfiguredExecutionErrors",
                 filter_pattern='{ $.event-type = "custom-action-error" && $.scheduler = "slurm" && '
                 '$.detail.action = "OnNodeConfigured" && $.detail.stage = "executing"}',
                 metric_value="1",
@@ -322,39 +322,39 @@ class CWDashboardConstruct(Construct):
 
         compute_node_events = [
             _CustomMetricFilter(
-                metric_name="ReplacementTimeoutExpires",
+                metric_name="ReplacementTimeoutExpiredErrors",
                 filter_pattern=_generate_metric_filter_pattern(
                     "protected-mode-error-count", "static-replacement-timeout-error"
                 ),
                 metric_value=metric_value,
             ),
             _CustomMetricFilter(
-                metric_name="ResumeTimeoutExpires",
+                metric_name="ResumeTimeoutExpiredErrors",
                 filter_pattern=_generate_metric_filter_pattern(
                     "protected-mode-error-count", "dynamic-resume-timeout-error"
                 ),
                 metric_value=metric_value,
             ),
             _CustomMetricFilter(
-                metric_name="EC2MaintenanceEvent",
+                metric_name="EC2HealthCheckErrors",
                 filter_pattern=_generate_metric_filter_pattern("nodes-failing-health-check-count", "ec2_health_check"),
                 metric_value=metric_value,
             ),
             _CustomMetricFilter(
-                metric_name="EC2ScheduledMaintenanceEvent",
+                metric_name="ScheduledEventHealthCheckErrors",
                 filter_pattern=_generate_metric_filter_pattern(
                     "nodes-failing-health-check-count", "scheduled_event_health_check"
                 ),
                 metric_value=metric_value,
             ),
             _CustomMetricFilter(
-                metric_name="NoCorrespondingInstanceForNode",
+                metric_name="NoCorrespondingInstanceErrors",
                 filter_pattern=_generate_metric_filter_pattern("invalid-backing-instance-count"),
                 metric_value=metric_value,
             ),
             # Use text matching here because it comes from slurmctld.log
             _CustomMetricFilter(
-                metric_name="SlurmNodeNotResponding",
+                metric_name="SlurmNodeNotRespondingErrors",
                 filter_pattern=_generate_metric_filter_pattern("node-not-responding-down-count"),
                 metric_value=metric_value,
             ),
@@ -372,8 +372,8 @@ class CWDashboardConstruct(Construct):
         if self.config.has_custom_actions_in_queue:
             cluster_common_errors.append(
                 _ErrorMetric(
-                    "Custom Script Errors",
-                    custom_script_errors,
+                    "Custom Action Errors",
+                    custom_action_errors,
                 )
             )
         self._add_text_widget("# Cluster Health Metrics")

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -179,18 +179,18 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml):
     scheduler = cluster_config.scheduling.scheduler
     slurm_related_metrics = [
         "IamPolicyErrors",
-        "VcpuLimit",
-        "VolumeLimit",
-        "NodeCapacityInsufficient",
-        "OtherLaunchedInstanceFailures",
-        "ReplacementTimeoutExpires",
-        "ResumeTimeoutExpires",
-        "EC2MaintenanceEvent",
-        "EC2ScheduledMaintenanceEvent",
-        "NoCorrespondingInstanceForNode",
-        "SlurmNodeNotResponding",
+        "VcpuLimitErrors",
+        "VolumeLimitErrors",
+        "InsufficientCapacityErrors",
+        "OtherLaunchedInstanceErrors",
+        "ReplacementTimeoutExpiredErrors",
+        "ResumeTimeoutExpiredErrors",
+        "EC2HealthCheckErrors",
+        "ScheduledEventHealthCheckErrors",
+        "NoCorrespondingInstanceErrors",
+        "SlurmNodeNotRespondingErrors",
     ]
-    custom_script_metrics = [
+    custom_action_metrics = [
         "OnNodeStartDownloadError",
         "OnNodeStartExecutionError",
         "OnNodeConfiguredDownloadError",
@@ -202,12 +202,12 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml):
         for metric in slurm_related_metrics:
             assert_that(output_yaml).contains(metric)
         if cluster_config.has_custom_actions_in_queue:
-            for metric in custom_script_metrics:
+            for metric in custom_action_metrics:
                 assert_that(output_yaml).contains(metric)
         else:
-            for metric in custom_script_metrics:
+            for metric in custom_action_metrics:
                 assert_that(output_yaml).does_not_contain(metric)
     else:
         assert_that(output_yaml).does_not_contain("Cluster Health Metrics")
-        for metric in slurm_related_metrics + custom_script_metrics:
+        for metric in slurm_related_metrics + custom_action_metrics:
             assert_that(output_yaml).does_not_contain(metric)

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -190,20 +190,24 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml):
         "NoCorrespondingInstanceForNode",
         "SlurmNodeNotResponding",
     ]
+    custom_script_metrics = [
+        "OnNodeStartDownloadError",
+        "OnNodeStartExecutionError",
+        "OnNodeConfiguredDownloadError",
+        "OnNodeConfiguredExecutionError",
+    ]
     if scheduler == "slurm":
         # Contains error metric title
         assert_that(output_yaml).contains("Cluster Health Metrics")
         for metric in slurm_related_metrics:
             assert_that(output_yaml).contains(metric)
         if cluster_config.has_custom_actions_in_queue:
-            assert_that(output_yaml).contains("CannotRetrieveCustomScript")
-            assert_that(output_yaml).contains("ErrorWithCustomScript")
+            for metric in custom_script_metrics:
+                assert_that(output_yaml).contains(metric)
         else:
-            assert_that(output_yaml).does_not_contain("CannotRetrieveCustomScript")
-            assert_that(output_yaml).does_not_contain("ErrorWithCustomScript")
+            for metric in custom_script_metrics:
+                assert_that(output_yaml).does_not_contain(metric)
     else:
-        for metric in slurm_related_metrics:
+        assert_that(output_yaml).does_not_contain("Cluster Health Metrics")
+        for metric in slurm_related_metrics + custom_script_metrics:
             assert_that(output_yaml).does_not_contain(metric)
-            assert_that(output_yaml).does_not_contain("Cluster Health Metrics")
-            assert_that(output_yaml).does_not_contain("CannotRetrieveCustomScript")
-            assert_that(output_yaml).does_not_contain("ErrorWithCustomScript")

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.slurm.conditional_vol.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.slurm.conditional_vol.yaml
@@ -32,6 +32,9 @@ Scheduling:
           MaxCount: 5
         - Name: compute_resource2
           InstanceType: c4.2xlarge
+      CustomActions:
+        OnNodeConfigured:
+          Script: s3://{{ resource_bucket }}/scripts/postinstall.sh
 SharedStorage:
   - MountDir: /my/mount/ebs1
     Name: name1

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos7.slurm.full.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos7.slurm.full.yaml
@@ -22,6 +22,11 @@ Scheduling:
           InstanceType: c5.2xlarge
         - Name: compute_resource2
           InstanceType: c4.2xlarge
+      CustomActions:
+        OnNodeStart:
+          Script: s3://{{ resource_bucket }}/scripts/preinstall.sh
+          Args:
+            - arg1
     - Name: queue2
       Networking:
         SubnetIds:


### PR DESCRIPTION
### Description of changes
* Add Custom script error metric filters for "OnNodeStartDownloadError", "OnNodeStartExecutionError", "OnNodeConfiguredDownloadError", "OnNodeConfiguredExecutionError"
* 
<img width="1471" alt="image" src="https://user-images.githubusercontent.com/68676935/227009241-a18c830b-b1d4-4401-9815-774fbee9f6d3.png">


### Tests
* Unit test
* Manually test

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
