### PR TITLE
[3.6] Add support for the HealthChecks sections in the cluster configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 - Allow to specify a sequence of multiple custom actions scripts per event.
 - Add support for customizing the cluster Slurm configuration via the ParallelCluster configuration YAML file.
 - Track the longest dynamic node idle time in CloudWatch Dashboard.
+- Add new configuration section `HealthChecks/Gpu` for enabling the GPU Health Check in the compute node before job submission.
 
 **CHANGES**
 - Increase the default `RetentionInDays` of CloudWatch logs from 14 to 180 days.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -764,6 +764,25 @@ class Efa(Resource):
         self.gdr_support = Resource.init_param(gdr_support, default=False)
 
 
+# ---------------------- Health Checks ---------------------- #
+
+
+class GpuHealthCheck(Resource):
+    """Represent the configuration for the GPU Health Check."""
+
+    def __init__(self, enabled: bool = None, **kwargs):
+        super().__init__(**kwargs)
+        self.enabled = enabled
+
+
+class HealthChecks(Resource):
+    """Represent the health checks configuration."""
+
+    def __init__(self, gpu: GpuHealthCheck = None, **kwargs):
+        super().__init__(**kwargs)
+        self.gpu = gpu or GpuHealthCheck(implied=True)
+
+
 # ---------------------- Monitoring ---------------------- #
 
 
@@ -1880,6 +1899,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         schedulable_memory: int = None,
         capacity_reservation_target: CapacityReservationTarget = None,
         networking: SlurmComputeResourceNetworking = None,
+        health_checks: HealthChecks = None,
         custom_slurm_settings: Dict = None,
         **kwargs,
     ):
@@ -1896,6 +1916,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         self._instance_types_with_instance_storage = []
         self._instance_type_info_map = {}
         self.networking = networking or SlurmComputeResourceNetworking(implied=True)
+        self.health_checks = health_checks or HealthChecks(implied=True)
         self.custom_slurm_settings = Resource.init_param(custom_slurm_settings, default={})
 
     @staticmethod
@@ -2194,9 +2215,11 @@ class SlurmQueue(_CommonQueue):
         self,
         allocation_strategy: str = None,
         custom_slurm_settings: Dict = None,
+        health_checks: HealthChecks = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.health_checks = health_checks or HealthChecks(implied=True)
         self.custom_slurm_settings = Resource.init_param(custom_slurm_settings, default={})
         if any(
             isinstance(compute_resource, SlurmFlexibleComputeResource) for compute_resource in self.compute_resources

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -55,9 +55,11 @@ from pcluster.config.cluster_config import (
     ExistingFsxOntap,
     ExistingFsxOpenZfs,
     FlexibleInstanceType,
+    GpuHealthCheck,
     HeadNode,
     HeadNodeImage,
     HeadNodeNetworking,
+    HealthChecks,
     Iam,
     Image,
     Imds,
@@ -1019,6 +1021,31 @@ class ClusterDevSettingsSchema(BaseDevSettingsSchema):
         return ClusterDevSettings(**data)
 
 
+# ---------------------- Health Checks ---------------------- #
+
+
+class GpuHealthCheckSchema(BaseSchema):
+    """Represent the schema of gpu health check."""
+
+    enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return GpuHealthCheck(**data)
+
+
+class HealthChecksSchema(BaseSchema):
+    """Represent the HealthChecks schema."""
+
+    gpu = fields.Nested(GpuHealthCheckSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return HealthChecks(**data)
+
+
 # ---------------------- Node and Cluster Schema ---------------------- #
 
 
@@ -1231,6 +1258,7 @@ class SlurmComputeResourceSchema(_ComputeResourceSchema):
     networking = fields.Nested(
         SlurmComputeResourceNetworkingSchema, metadata={"update_policy": UpdatePolicy.MANAGED_PLACEMENT_GROUP}
     )
+    health_checks = fields.Nested(HealthChecksSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     custom_slurm_settings = fields.Dict(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @validates_schema
@@ -1355,6 +1383,7 @@ class SlurmQueueSchema(_CommonQueueSchema):
     networking = fields.Nested(
         SlurmQueueNetworkingSchema, required=True, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY}
     )
+    health_checks = fields.Nested(HealthChecksSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     custom_slurm_settings = fields.Dict(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -1124,3 +1124,218 @@ def test_timeouts_schema(head_node_bootstrap_timeout, compute_node_bootstrap_tim
         assert_that(timeouts.compute_node_bootstrap_timeout).is_equal_to(
             compute_node_bootstrap_timeout or NODE_BOOTSTRAP_TIMEOUT
         )
+
+
+@pytest.mark.parametrize(
+    "config_dict, failure_message, expected_queue_gpu_hc, expected_cr1_gpu_hc, expected_cr2_gpu_hc",
+    [
+        # HealthChecks dictionary is empty
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {"Name": "compute_resource1", "InstanceType": "c5.2xlarge", "MaxCount": 5},
+                    {"Name": "compute_resource2", "InstanceType": "c4.2xlarge"},
+                ],
+                "HealthChecks": {},
+            },
+            "",
+            None,
+            None,
+            None,
+        ),
+        # Health Checks sections are not defined
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {"Name": "compute_resource1", "InstanceType": "c5.2xlarge", "MaxCount": 5},
+                    {"Name": "compute_resource2", "InstanceType": "c4.2xlarge"},
+                ],
+            },
+            "",
+            None,
+            None,
+            None,
+        ),
+        # Health Checks section is defined at queue level
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {"Name": "compute_resource1", "InstanceType": "c5.2xlarge", "MaxCount": 5},
+                    {"Name": "compute_resource2", "InstanceType": "c4.2xlarge"},
+                ],
+                "HealthChecks": {"Gpu": {"Enabled": True}},
+            },
+            "",
+            True,
+            None,
+            None,
+        ),
+        # Health Checks section is defined in a single compute resource
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {"Name": "compute_resource1", "InstanceType": "c5.2xlarge", "MaxCount": 5},
+                    {
+                        "Name": "compute_resource2",
+                        "InstanceType": "c4.2xlarge",
+                        "HealthChecks": {"Gpu": {"Enabled": True}},
+                    },
+                ],
+            },
+            "",
+            None,
+            None,
+            True,
+        ),
+        # Health Checks sections are defined at queue level and a single compute resource
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {"Name": "compute_resource1", "InstanceType": "c5.2xlarge", "MaxCount": 5},
+                    {
+                        "Name": "compute_resource2",
+                        "InstanceType": "c4.2xlarge",
+                        "HealthChecks": {"Gpu": {"Enabled": True}},
+                    },
+                ],
+                "HealthChecks": {"Gpu": {"Enabled": True}},
+            },
+            "",
+            True,
+            None,
+            True,
+        ),
+        # Health Checks sections are defined at queue level and in both compute resource
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {
+                        "Name": "compute_resource1",
+                        "InstanceType": "c5.2xlarge",
+                        "MaxCount": 5,
+                        "HealthChecks": {"Gpu": {"Enabled": True}},
+                    },
+                    {
+                        "Name": "compute_resource2",
+                        "InstanceType": "c4.2xlarge",
+                        "HealthChecks": {"Gpu": {"Enabled": True}},
+                    },
+                ],
+                "HealthChecks": {"Gpu": {"Enabled": True}},
+            },
+            "",
+            True,
+            True,
+            True,
+        ),
+        # Gpu Health Check enable is defined using the true string value instead of the boolean value
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {"Name": "compute_resource1", "InstanceType": "c5.2xlarge", "MaxCount": 5},
+                    {"Name": "compute_resource2", "InstanceType": "c4.2xlarge"},
+                ],
+                "HealthChecks": {"Gpu": {"Enabled": "true"}},
+            },
+            "",
+            True,
+            None,
+            None,
+        ),
+        # Gpu Health Check enable is defined using the true integer value instead of the boolean value
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {"Name": "compute_resource1", "InstanceType": "c5.2xlarge", "MaxCount": 5},
+                    {"Name": "compute_resource2", "InstanceType": "c4.2xlarge"},
+                ],
+                "HealthChecks": {"Gpu": {"Enabled": 1}},
+            },
+            "",
+            True,
+            None,
+            None,
+        ),
+        # Gpu Health Check enable is defined using a string, and it doesn't represent a boolean
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {"Name": "compute_resource1", "InstanceType": "c5.2xlarge", "MaxCount": 5},
+                    {"Name": "compute_resource2", "InstanceType": "c4.2xlarge"},
+                ],
+                "HealthChecks": {"Gpu": {"Enabled": "vero"}},
+            },
+            "Not a valid boolean",
+            None,
+            None,
+            None,
+        ),
+        # Gpu Health Check enable is defined using an integer, and it doesn't represent a boolean
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {"Name": "compute_resource1", "InstanceType": "c5.2xlarge", "MaxCount": 5},
+                    {"Name": "compute_resource2", "InstanceType": "c4.2xlarge"},
+                ],
+                "HealthChecks": {"Gpu": {"Enabled": -1}},
+            },
+            "Not a valid boolean",
+            None,
+            None,
+            None,
+        ),
+        # Gpu Health Check enable is not defined
+        (
+            {
+                "Name": "Standard-Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [
+                    {"Name": "compute_resource1", "InstanceType": "c5.2xlarge", "MaxCount": 5},
+                    {"Name": "compute_resource2", "InstanceType": "c4.2xlarge"},
+                ],
+                "HealthChecks": {"Gpu"},
+            },
+            "Invalid input type",
+            None,
+            None,
+            None,
+        ),
+    ],
+)
+def test_slurm_gpu_health_checks(
+    mocker,
+    config_dict,
+    failure_message,
+    expected_queue_gpu_hc,
+    expected_cr1_gpu_hc,
+    expected_cr2_gpu_hc,
+):
+    mock_aws_api(mocker)
+    if failure_message:
+        with pytest.raises(ValidationError, match=failure_message):
+            SlurmQueueSchema().load(config_dict)
+    else:
+        queue = SlurmQueueSchema().load(config_dict)
+        assert_that(queue.health_checks.gpu.enabled).is_equal_to(expected_queue_gpu_hc)
+        assert_that(queue.compute_resources[0].health_checks.gpu.enabled).is_equal_to(expected_cr1_gpu_hc)
+        assert_that(queue.compute_resources[1].health_checks.gpu.enabled).is_equal_to(expected_cr2_gpu_hc)

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -108,6 +108,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -125,6 +128,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -142,6 +148,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -159,6 +168,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -176,6 +188,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -206,6 +221,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -239,6 +257,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -256,6 +277,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -273,6 +297,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -290,6 +317,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -307,6 +337,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -337,6 +370,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -370,6 +406,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -387,6 +426,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -404,6 +446,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -421,6 +466,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -438,6 +486,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -468,6 +519,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -501,6 +555,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -518,6 +575,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -535,6 +595,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -552,6 +615,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -569,6 +635,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -599,6 +668,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -632,6 +704,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -649,6 +724,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -666,6 +744,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -683,6 +764,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -700,6 +784,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -730,6 +817,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -763,6 +853,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -780,6 +873,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -797,6 +893,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -814,6 +913,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -831,6 +933,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -861,6 +966,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -894,6 +1002,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -911,6 +1022,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -928,6 +1042,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -945,6 +1062,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -962,6 +1082,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -992,6 +1115,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -1025,6 +1151,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1042,6 +1171,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1059,6 +1191,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1076,6 +1211,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1093,6 +1231,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1123,6 +1264,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -1156,6 +1300,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1173,6 +1320,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1190,6 +1340,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1207,6 +1360,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1224,6 +1380,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1254,6 +1413,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -1287,6 +1449,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1304,6 +1469,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1321,6 +1489,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1338,6 +1509,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1355,6 +1529,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1385,6 +1562,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -1418,6 +1598,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1435,6 +1618,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1452,6 +1638,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1469,6 +1658,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1486,6 +1678,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1516,6 +1711,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -1549,6 +1747,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1566,6 +1767,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1583,6 +1787,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1600,6 +1807,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1617,6 +1827,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1647,6 +1860,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -1680,6 +1896,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1697,6 +1916,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1714,6 +1936,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1731,6 +1956,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1748,6 +1976,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1778,6 +2009,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -1811,6 +2045,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1828,6 +2065,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1845,6 +2085,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1862,6 +2105,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1879,6 +2125,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1909,6 +2158,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -1942,6 +2194,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1959,6 +2214,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1976,6 +2234,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -1993,6 +2254,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2010,6 +2274,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2040,6 +2307,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -2073,6 +2343,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2090,6 +2363,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2107,6 +2383,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2124,6 +2403,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2141,6 +2423,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2171,6 +2456,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -2204,6 +2492,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2221,6 +2512,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2238,6 +2532,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2255,6 +2552,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2272,6 +2572,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2302,6 +2605,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -2335,6 +2641,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2352,6 +2661,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2369,6 +2681,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2386,6 +2701,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2403,6 +2721,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2433,6 +2754,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -2466,6 +2790,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2483,6 +2810,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2500,6 +2830,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2517,6 +2850,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2534,6 +2870,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2564,6 +2903,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -2597,6 +2939,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2614,6 +2959,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2631,6 +2979,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2648,6 +2999,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2665,6 +3019,9 @@ Scheduling:
       Efa:
         Enabled: false
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.xlarge
       MaxCount: 10
       MinCount: 0
@@ -2695,6 +3052,9 @@ Scheduling:
         - arg0
         Script: https://test.tgz
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess
@@ -2728,6 +3088,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -2745,6 +3108,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -2762,6 +3128,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -2785,6 +3154,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -2815,6 +3187,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -2832,6 +3207,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -2849,6 +3227,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -2872,6 +3253,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -2902,6 +3286,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -2919,6 +3306,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -2936,6 +3326,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -2959,6 +3352,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -2989,6 +3385,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3006,6 +3405,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3023,6 +3425,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3046,6 +3451,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3076,6 +3484,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3093,6 +3504,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3110,6 +3524,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3133,6 +3550,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3163,6 +3583,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3180,6 +3603,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3197,6 +3623,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3220,6 +3649,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3250,6 +3682,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3267,6 +3702,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3284,6 +3722,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3307,6 +3748,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3337,6 +3781,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3354,6 +3801,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3371,6 +3821,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3394,6 +3847,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3424,6 +3880,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3441,6 +3900,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3458,6 +3920,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3481,6 +3946,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3511,6 +3979,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3528,6 +3999,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3545,6 +4019,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3568,6 +4045,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3598,6 +4078,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3615,6 +4098,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3632,6 +4118,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3655,6 +4144,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3685,6 +4177,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3702,6 +4197,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3719,6 +4217,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3742,6 +4243,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3772,6 +4276,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3789,6 +4296,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3806,6 +4316,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3829,6 +4342,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3859,6 +4375,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3876,6 +4395,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3893,6 +4415,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3916,6 +4441,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -3946,6 +4474,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3963,6 +4494,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -3980,6 +4514,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4003,6 +4540,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -4033,6 +4573,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4050,6 +4593,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4067,6 +4613,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4090,6 +4639,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -4120,6 +4672,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4137,6 +4692,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4154,6 +4712,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4177,6 +4738,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -4207,6 +4771,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4224,6 +4791,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4241,6 +4811,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4264,6 +4837,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -4294,6 +4870,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4311,6 +4890,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4328,6 +4910,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4351,6 +4936,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile
@@ -4381,6 +4969,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4398,6 +4989,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4415,6 +5009,9 @@ Scheduling:
       Efa:
         Enabled: true
         GdrSupport: false
+      HealthChecks:
+        Gpu:
+          Enabled: null
       InstanceType: c5.2xlarge
       MaxCount: 15
       MinCount: 1
@@ -4438,6 +5035,9 @@ Scheduling:
           VolumeType: gp2
     CustomActions: null
     CustomSlurmSettings: {}
+    HealthChecks:
+      Gpu:
+        Enabled: null
     Iam:
       AdditionalIamPolicies: []
       InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile


### PR DESCRIPTION
### Description of changes
* Add support for the new HealthChecks section in the SlurmQueue and ComputeResource sections in order to enable the GPU Health Check.

### Tests
* Unit tests added for the updated files
* Manually tested the creation and the update of a cluster with several configurations: with/without the new section in the SlurmQueue/ComputeResource/SlurmQueue and ComputeResource sections.
  * If no HealthChecks configurations are added the config file will be generated with `null` values as done for the `PlacementGroup` section:
```
[root@q1-st-compute1-1 bin]# cat /opt/parallelcluster/shared/cluster-config.yaml | grep "HealthChecks" -A 2
      HealthChecks:
        Gpu:
          Enabled: null
--
      HealthChecks:
        Gpu:
          Enabled: null
--
    HealthChecks:
      Gpu:
        Enabled: null
```
  * if the HealthChecks configurations are provided then the config file will reflect the configurations themselves. For example:
```
[root@q1-st-compute1-1 bin]# cat /opt/parallelcluster/shared/cluster-config.yaml | grep "HealthChecks" -A 2
      HealthChecks:
        Gpu:
          Enabled: true
--
      HealthChecks:
        Gpu:
          Enabled: false
--
    HealthChecks:
      Gpu:
        Enabled: null
```


### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
