### PR TITLE
3.x Fix expected to match custom action changes

### DIFF
--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -134,13 +134,13 @@ def test_cluster_creation_with_problematic_preinstall_script(
     assert_lines_in_logs(
         remote_command_executor,
         ["/var/log/cfn-init.log"],
-        [f"Failed to execute OnNodeStart script s3://{ bucket_name }/scripts/{script_name}"],
+        [f"Failed to execute OnNodeStart script 1 s3://{ bucket_name }/scripts/{script_name}"],
     )
     logging.info("Verifying error in cloudformation failure reason")
     stack_events = cluster.get_stack_events().get("events")
     cfn_failure_reason = _get_failure_reason(stack_events)
     expected_cfn_failure_reason = (
-        "Failed to execute OnNodeStart script, "
+        "Failed to execute OnNodeStart script 1, "
         "return code: 1. Please check /var/log/cfn-init.log in the head node, or check the "
         "cfn-init.log in CloudWatch logs. Please refer to https://docs.aws.amazon.com/"
         "parallelcluster/latest/ug/troubleshooting-v3.html#troubleshooting-v3-get-logs for "


### PR DESCRIPTION
### Description of changes
* This change should fix an integration test that started failing due to changes in the custom action executor message formatting.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
