### PR TITLE
3.x Add cluster_name to compute fleet dna.json

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -71,6 +71,7 @@ write_files:
     content: |
       {
         "cluster": {
+          "cluster_name": "${ClusterName}",
           "stack_name": "${AWS::StackName}",
           "stack_arn": "${AWS::StackId}",
           "enable_efa": "${EnableEfa}",

--- a/cli/src/pcluster/templates/queue_group_stack.py
+++ b/cli/src/pcluster/templates/queue_group_stack.py
@@ -263,6 +263,7 @@ class QueueGroupStack(NestedStack):
                                 if self._cluster_hosted_zone
                                 else "",
                                 "OSUser": OS_MAPPING[self._config.image.os]["user"],
+                                "ClusterName": self.stack_name,
                                 "SlurmDynamoDBTable": self._dynamodb_table.ref if self._dynamodb_table else "NONE",
                                 "LogGroupName": self._log_group.log_group_name
                                 if self._config.monitoring.logs.cloud_watch.enabled


### PR DESCRIPTION
### Description of changes
* This change explicitly sets the value for the cluster name in the compute fleet dna.json since the cluster name and stack name no longer coincide.

### Tests
* Manually deployed a cluster with the updated template and confirmed value for 'cluster': {'cluster_name'} had the cluster name for a value in the compute fleet launch template.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
