### PR TITLE
Improve loading time of nested stack templates

### DIFF
--- a/cli/src/pcluster/templates/cdk_artifacts_manager.py
+++ b/cli/src/pcluster/templates/cdk_artifacts_manager.py
@@ -19,7 +19,7 @@ from typing import List
 from aws_cdk.cx_api import CloudAssembly, CloudFormationStackArtifact
 
 from pcluster.models.s3_bucket import S3Bucket, S3FileFormat, S3FileType
-from pcluster.utils import LOGGER, load_yaml_dict
+from pcluster.utils import LOGGER, load_json_dict
 
 
 @dataclass
@@ -111,7 +111,7 @@ class CDKArtifactsManager:
 
         for cdk_asset in cdk_assets:
             asset_file_path = os.path.join(self.cluster_cdk_assembly.get_cloud_assembly_directory(), cdk_asset.path)
-            asset_file_content = load_yaml_dict(asset_file_path)
+            asset_file_content = load_json_dict(asset_file_path)
             asset_id = cdk_asset.id
             assets_metadata.append(
                 {

--- a/cli/tests/pcluster/templates/test_cdk_artifacts_manager.py
+++ b/cli/tests/pcluster/templates/test_cdk_artifacts_manager.py
@@ -36,7 +36,7 @@ def test_upload_assets(mocker, mock_cloud_assembly, file_assets, asset_content):
     cloud_assembly = mock_cloud_assembly(assets=file_assets)
     mock_bucket(mocker)
     mock_dict = mock_bucket_object_utils(mocker)
-    mocker.patch("pcluster.templates.cdk_artifacts_manager.load_yaml_dict", return_value=asset_content)
+    mocker.patch("pcluster.templates.cdk_artifacts_manager.load_json_dict", return_value=asset_content)
     bucket = dummy_cluster_bucket()
 
     cdk_assets_manager = CDKArtifactsManager(cloud_assembly)


### PR DESCRIPTION
### Description of changes
- PyYAML builds a graph when loading files. This is time consuming, especially if there is no strong need to use the YAML format for the output. In this case, the nested templates can be loaded as JSON using the standard python library). Since the main template is loaded as YAML, the complete CFN template on CLoudFormation Console will be rendered as YAML (the nested stack templates will be automatically converted to YAML when viewing the main stack).
- This reduces loading time by an average of 5-6 seconds.

### Tests
* Ran existing unit tests

### References
* [PyYAML](https://pyyaml.org/)
* [JSON Load](https://docs.python.org/3/library/json.html#json.load)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
