### PR TITLE
[Test] Add check in test 'test_trainium' to verify that the primary IP is set correctly on multi NICs instances.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG
 - Fix EFS, FSx network security groups validators to avoid reporting false errors.
 - Fix missing tagging of resources created by ImageBuilder during the `build-image` operation.
 - Fix Update policy for MaxCount to always perform numerical comparisons on MaxCount property.
+- Fix IP association on instances with multiple network cards.
 
 3.5.1
 -----

--- a/tests/integration-tests/tests/trainium/test_trainium.py
+++ b/tests/integration-tests/tests/trainium/test_trainium.py
@@ -38,6 +38,8 @@ def test_trainium(
     # _test_allreduce_single_node(test_datadir, remote_command_executor, scheduler_commands)
     _test_ccl_two_nodes(test_datadir, remote_command_executor, scheduler_commands)
 
+    _test_primary_ip(test_datadir, remote_command_executor, scheduler_commands)
+
 
 def _test_allreduce_single_node(test_datadir, remote_command_executor, scheduler_commands):
     result = scheduler_commands.submit_script(str(test_datadir / "neuron-allreduce.sh"), partition="queue-trn2")
@@ -64,3 +66,14 @@ def _test_ccl_two_nodes(test_datadir, remote_command_executor, scheduler_command
 
     print(result.stdout)
     assert_that(result.stdout).contains("CCL(1)", "CCL(50)", "CCL(99)", "CCL(100)")
+
+
+def _test_primary_ip(test_datadir, remote_command_executor, scheduler_commands):
+    result = scheduler_commands.submit_script(str(test_datadir / "test-primary-ip.sh"), partition="queue-trn32")
+    job_id = scheduler_commands.assert_job_submitted(result.stdout)
+    scheduler_commands.wait_job_completed(job_id)
+    scheduler_commands.assert_job_succeeded(job_id)
+    result = remote_command_executor.run_remote_command("cat output-primary-ip.txt")
+
+    print(result.stdout)
+    assert_that(result.stdout).contains("PASSED")

--- a/tests/integration-tests/tests/trainium/test_trainium/test_trainium/test-primary-ip.sh
+++ b/tests/integration-tests/tests/trainium/test_trainium/test_trainium/test-primary-ip.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Test the alignment of the Route 53 IP and the the host IP.
+
+OUTPUT_FILE="output-primary-ip.txt"
+
+# Get DNS Server
+DNS_SERVER=""
+grep Ubuntu /etc/issue &>/dev/null && DNS_SERVER=$(systemd-resolve --status | grep "DNS Servers" | awk '{print $3}' | sort -r | head -1)
+
+# Determine expected entry in /etc/hosts
+IP="$(host $HOSTNAME $DNS_SERVER | tail -1 | awk '{print $4}')"
+DOMAIN=$(jq .cluster.dns_domain /etc/chef/dna.json | tr -d \")
+EXPECTED="$IP $HOSTNAME.${DOMAIN::-1} $HOSTNAME"
+echo "Expected entry in /etc/hosts: $EXPECTED" | tee $OUTPUT_FILE
+
+# Retrieve actual entry in /etc/hosts
+ACTUAL="$(grep "$HOSTNAME" /etc/hosts)"
+echo "Actual entry in /etc/hosts: $ACTUAL" | tee -a $OUTPUT_FILE
+
+# Check
+if [[ "$ACTUAL" == "$EXPECTED" ]]; then
+  echo "PASSED" | tee -a $OUTPUT_FILE
+else
+  echo "ERROR: Route53 IP does not match host IP" | tee -a $OUTPUT_FILE
+fi


### PR DESCRIPTION
### Description of changes
1. Add check in test 'test_trainium' to verify that the primary IP is set correctly on multi NICs instances.
2. Add changelog entry for 3.6.0 about multi NICs bug fix.

### Tests
1. Regression tests: `test_trainium`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Giacomo Marciani <mgiacomo@amazon.com>
