### PR TITLE
Add SuspendExcNodes to SLURM_SETTINGS_DENY_LIST

### DIFF
--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -31,6 +31,7 @@ SLURM_SETTINGS_DENY_LIST = {
             "slurmctldparameters",
             "slurmdlogfile",
             "slurmuser",
+            "suspendexcnodes",
             "suspendprogram",
             "suspendtime",
             "taskplugin",


### PR DESCRIPTION
### Description of changes
* Add SuspendExcNodes to SLURM_SETTINGS_DENY_LIST
  * This parameter was mistakenly not included in the deny list when it was implemented (see https://github.com/aws/aws-parallelcluster/pull/5103)

### Tests
* No need for tests.

### References
* Previous PR with implementation of `CustomSlurmSettings` on the CLI side: https://github.com/aws/aws-parallelcluster/pull/5103

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
