### PR TITLE
Adds AWS Budgets support to the configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
 - Increase the limit on the maximum number of queues per cluster from 10 to 40.
 - Allow to specify a sequence of multiple custom actions scripts per event.
 - Add support for customizing the cluster Slurm configuration via the ParallelCluster configuration YAML file.
+- Add support for creatiing AWS Budgets via the ParallelCluster configuration YAML file.
 
 **CHANGES**
 - Increase the default `RetentionInDays` of CloudWatch logs from 14 to 180 days.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1052,6 +1052,61 @@ class ClusterDevSettings(BaseDevSettings):
             self._register_validator(UrlValidator, url=self.cluster_template)
 
 
+# ---------------------- Budgets ---------------------- #
+
+
+class BudgetNotification(Resource):
+    """Represent the configuration of each notification under the NotificationsWithSubscribers field of a budget."""
+
+    def __init__(
+        self,
+        threshold: float,
+        notification_type: str = None,
+    ):
+        super().__init__()
+        self.notification_type = Resource.init_param(notification_type, default="ACTUAL")
+        self.threshold = Resource.init_param(threshold)
+
+
+class BudgetSubscriber(Resource):
+    """Represent the configuration of an individual subscriber of a budget notification."""
+
+    def __init__(self, address: str, subscription_type: str = None):
+        super().__init__()
+        self.subscription_type = Resource.init_param(subscription_type, default="EMAIL")
+        self.address = Resource.init_param(address)
+
+
+class BudgetNotificationWithSubscribers(Resource):
+    """Represent the configuration of the NotificationWithSubscribers field of a budget."""
+
+    def __init__(self, notification: BudgetNotification, subscribers: List[BudgetSubscriber] = None):
+        super().__init__()
+        self.notification = notification
+        self.subscribers = subscribers
+
+
+class Budget(Resource):
+    """Represent the configuration of a Budget."""
+
+    def __init__(
+        self,
+        name: str,
+        budget_limit_amount: float,
+        time_unit: str = None,
+        time_period_start: str = None,
+        tags: List[Tag] = None,
+        notifications_with_subscribers: List[BudgetNotificationWithSubscribers] = None,
+    ):
+        super().__init__()
+        self.name = Resource.init_param(name)
+        self.budget_limit_amount = Resource.init_param(budget_limit_amount)
+        self.time_unit = Resource.init_param(time_unit, default="MONTHLY")
+        self.time_period_start = Resource.init_param(time_period_start)
+        self.tags = tags
+        self.notifications_with_subscribers = notifications_with_subscribers
+
+
 # ---------------------- Nodes and Cluster ---------------------- #
 
 
@@ -1256,6 +1311,7 @@ class BaseClusterConfig(Resource):
         additional_resources: str = None,
         dev_settings: ClusterDevSettings = None,
         deployment_settings: DeploymentSettings = None,
+        budgets: List[Budget] = None,
     ):
         super().__init__()
         self.__region = None
@@ -1288,6 +1344,7 @@ class BaseClusterConfig(Resource):
         self.deployment_settings = deployment_settings
         self.managed_head_node_security_group = None
         self.managed_compute_security_group = None
+        self.budgets = Resource.init_param(budgets)
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(RegionValidator, region=self.region)

--- a/cli/src/pcluster/templates/budget_builder.py
+++ b/cli/src/pcluster/templates/budget_builder.py
@@ -1,0 +1,79 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+from aws_cdk import aws_budgets as budgets
+from constructs import Construct
+
+from pcluster.config.cluster_config import BaseClusterConfig
+
+
+class CostBudgets:
+    """Create the budgets based on the configuration file."""
+
+    def __init__(self, scope: Construct, cluster_config: BaseClusterConfig):
+        self.cluster_config = cluster_config
+        self.scope = scope
+        self._create_budgets()
+
+    def _create_budgets(self):
+        """Create the Cfn templates for the list of budgets."""
+        budget_list = self.cluster_config.budgets
+        cfn_budget_list = []
+
+        for budget in budget_list:
+            cfn_budget = self._add_parameters(budget)
+            cfn_budget_list.append(cfn_budget)
+
+        return cfn_budget_list
+
+    def _add_parameters(self, budget):
+        """Add each budget's parameters."""
+        cost_filters = {"TagKeyValue": [f"{tag.key}${tag.value}" for tag in budget.tags]}
+        unit = "CNY" if self.cluster_config.region.startswith("cn") else "USD"
+        budget_data = budgets.CfnBudget.BudgetDataProperty(
+            budget_type="COST",
+            time_unit=budget.time_unit,
+            time_period=budgets.CfnBudget.TimePeriodProperty(start=budget.time_period_start),
+            budget_limit=budgets.CfnBudget.SpendProperty(amount=budget.budget_limit_amount, unit=unit),
+            cost_filters=cost_filters,
+        )
+        notifications_with_subscribers = (
+            add_budget_notifications(budget) if budget.notifications_with_subscribers else None
+        )
+        budget_id = budget.name
+        cfn_budget = budgets.CfnBudget(
+            self.scope, budget_id, budget=budget_data, notifications_with_subscribers=notifications_with_subscribers
+        )
+        return cfn_budget
+
+
+def add_budget_notifications(budget):
+    """Create the notifications with subscribers for each budget."""
+    notifications_with_subscribers = []
+    for single_notification in budget.notifications_with_subscribers:
+        notifications_with_subscribers.append(
+            budgets.CfnBudget.NotificationWithSubscribersProperty(
+                notification=budgets.CfnBudget.NotificationProperty(
+                    comparison_operator="GREATER_THAN",
+                    notification_type=single_notification.notification.notification_type,
+                    threshold_type="PERCENTAGE",
+                    threshold=single_notification.notification.threshold,
+                ),
+                subscribers=[
+                    budgets.CfnBudget.SubscriberProperty(
+                        address=subscriber.address,
+                        subscription_type=subscriber.subscription_type,
+                    )
+                    for subscriber in single_notification.subscribers
+                ],
+            )
+        )
+
+    return notifications_with_subscribers

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -59,6 +59,7 @@ from pcluster.constants import (
 )
 from pcluster.models.s3_bucket import S3Bucket
 from pcluster.templates.awsbatch_builder import AwsBatchConstruct
+from pcluster.templates.budget_builder import CostBudgets
 from pcluster.templates.cdk_builder_utils import (
     CdkLaunchTemplateBuilder,
     HeadNodeIamResources,
@@ -287,6 +288,10 @@ class ClusterCdkStack:
             )
 
             self._add_alarms()
+
+        # Budgets
+        if self.config.budgets:
+            self.budgets = CostBudgets(self.stack, self.config)
 
     def _add_alarms(self):
         self.alarms = []

--- a/cli/tests/pcluster/example_configs/awsbatch.full.yaml
+++ b/cli/tests/pcluster/example_configs/awsbatch.full.yaml
@@ -102,6 +102,28 @@ Monitoring:
     CloudWatch:
       Enabled: true
 CustomS3Bucket: String
+Budgets:
+  - Name: budget1
+    BudgetLimitAmount: 30.0
+    TimeUnit: MONTHLY
+    Tags:
+      - Key: user:parallelcluster:cluster-name
+        Value: budget3
+      - Key: user:parallelcluster:node-type
+        Value: HeadNode
+      - Key: user:parallelcluster:queue-name
+        Value: my_queue_name
+      - Key: user:parallelcluster:compute-resource-name
+        Value: my_compute-resource-name
+    NotificationsWithSubscribers:
+      - Notification:
+          Threshold: 40.0
+          NotificationType: ACTUAL
+        Subscribers:
+          - SubscriptionType: EMAIL
+            Address: example1@email.com
+          - SubscriptionType: SNS
+            Address: example@email.com
 Tags:
   - Key: String
     Value: String

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -210,6 +210,33 @@ Monitoring:
 AdditionalPackages:
   IntelSoftware:
     IntelHpcPlatform: false
+Budgets:
+  - Name: budget1
+    BudgetLimitAmount: 30.0
+    TimeUnit: MONTHLY
+    Tags:
+      - Key: user:parallelcluster:cluster-name
+        Value: budget3
+      - Key: user:parallelcluster:node-type
+        Value: HeadNode
+      - Key: user:parallelcluster:queue-name
+        Value: my_queue_name
+      - Key: user:parallelcluster:compute-resource-name
+        Value: my_compute-resource-name
+    NotificationsWithSubscribers:
+      - Notification:
+          Threshold: 40.0
+          NotificationType: ACTUAL
+        Subscribers:
+          - SubscriptionType: EMAIL
+            Address: example1@email.com
+          - SubscriptionType: SNS
+            Address: example@email.com
+  - Name: budget2
+    BudgetLimitAmount: 30.0
+    Tags:
+      - Key: user:parallelcluster:cluster-name
+        Value: budget3
 Tags:
   - Key: String
     Value: String

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -17,6 +17,8 @@ from pcluster.schemas.cluster_schema import (
     AwsBatchComputeResourceSchema,
     AwsBatchQueueNetworkingSchema,
     AwsBatchQueueSchema,
+    BudgetNotificationSchema,
+    BudgetSubscriberSchema,
     CloudWatchLogsSchema,
     ClusterSchema,
     DcvSchema,
@@ -658,3 +660,45 @@ def test_instance_role_validator(instance_role, expected_message):
 )
 def test_password_secret_arn_validator(password_secret_arn, expected_message):
     _validate_and_assert_error(DirectoryServiceSchema(), {"PasswordSecretArn": password_secret_arn}, expected_message)
+
+
+@pytest.mark.parametrize(
+    "notification_type, threshold, expected_message",
+    [
+        (None, 50, None),
+        ("Actual", 30.0, "Must be one of"),
+        ("FORECASTED", -20, "Must be greater than or equal to 0."),
+        (None, 5.2, None),
+        (None, 3, None),
+    ],
+)
+def test_budget_notification_schema_validators(
+    notification_type,
+    threshold,
+    expected_message,
+):
+    section_dict = {}
+    if notification_type:
+        section_dict["NotificationType"] = notification_type
+    if threshold:
+        section_dict["Threshold"] = threshold
+
+    _validate_and_assert_error(BudgetNotificationSchema(), section_dict, expected_message)
+
+
+@pytest.mark.parametrize(
+    "subscription_type, address, expected_message",
+    [
+        (None, "alias@amazon.com", None),
+        ("EMAIL", "alias@amazon.com", None),
+        ("SNS", "arn:aws:sns:us-east-1:444455556666:MyTopic", None),
+        ("GMAIL", "email@gmail.com", "Must be one of"),
+    ],
+)
+def test_budget_subscriber_schema_validators(subscription_type, address, expected_message):
+    section_dict = {}
+    if address:
+        section_dict["Address"] = address
+    if subscription_type:
+        section_dict["SubscriptionType"] = subscription_type
+    _validate_and_assert_error(BudgetSubscriberSchema(), section_dict, expected_message)


### PR DESCRIPTION
Enables the creation of AWS Budgets using the cluster configuration file

Creates schema and configuration for the necessary fields when creating a list of AWS Cost Budgets. Generates the CloudFormation template for the list of budgets in the configuration. Some field validation also added, to ensure proper functionality.

Unit tests added for the validation of the budget schema.


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.
* Link to impacted open issues.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
