### PR TITLE
3.x Add metric for idle compute nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
 - Increase the limit on the maximum number of queues per cluster from 10 to 40.
 - Allow to specify a sequence of multiple custom actions scripts per event.
 - Add support for customizing the cluster Slurm configuration via the ParallelCluster configuration YAML file.
+- Track the longest dynamic node idle time in CloudWatch Dashboard.
 
 **CHANGES**
 - Increase the default `RetentionInDays` of CloudWatch logs from 14 to 180 days.

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -149,7 +149,7 @@ class CWDashboardConstruct(Construct):
         # Head Node logs add custom metrics if cw_log and metrics are enabled
         if self.config.is_cw_logging_enabled:
             if self.config.scheduling.scheduler == "slurm":
-                self._add_custom_error_metrics()
+                self._add_custom_health_metrics()
             self._add_cw_log()
 
     def _update_coord(self, d_x, d_y):
@@ -265,8 +265,8 @@ class CWDashboardConstruct(Construct):
         metric_filter.add_dependency(self.cw_log_group)
         return metric_filter
 
-    def _add_custom_error_metrics(self):
-        """Create custom error metric filter and outputs to cloudwatch graph."""
+    def _add_custom_health_metrics(self):
+        """Create custom health metric filters and outputs to cloudwatch graph."""
 
         def _generate_metric_filter_pattern(event_type, failure_type=None):
             if failure_type:
@@ -394,7 +394,7 @@ class CWDashboardConstruct(Construct):
                 "Compute Fleet Idle Time",
                 [
                     _CustomMetricFilter(
-                        metric_name="LongestDynamicNodeIdleTime",
+                        metric_name="MaxDynamicNodeIdleTime",
                         filter_pattern='{ $.event-type = "compute-node-idle-time" && $.scheduler = "slurm" && '
                         '$.detail.node-type = "dynamic"}',
                         metric_value="$.detail.longest-idle-time",

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -9,6 +9,7 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import defaultdict, namedtuple
+from typing import Iterable
 
 from aws_cdk import Duration, Stack
 from aws_cdk import aws_cloudwatch as cloudwatch
@@ -32,13 +33,19 @@ class Coord:
 _PclusterMetric = namedtuple(
     "_PclusterMetric", ["title", "metrics", "supported_vol_types", "namespace", "additional_dimensions"]
 )
-_CustomMetricFilter = namedtuple("_CustomMetricFilter", ["metric_name", "filter_pattern", "metric_value"])
+_CustomMetricFilter = namedtuple(
+    "_CustomMetricFilter",
+    ["metric_name", "filter_pattern", "metric_value", "metric_statistic", "metric_unit"],
+    defaults=("Sum", "Count"),
+)
 _Filter = namedtuple("new_filter", ["pattern", "param"])
 _CWLogWidget = namedtuple(
     "_CWLogWidget",
     ["title", "conditions", "fields", "filters", "sort", "limit"],
 )
-_ErrorMetric = namedtuple("_ErrorMetric", ["title", "metric_filters"])
+_HealthMetric = namedtuple(
+    "_ErrorMetric", ["title", "metric_filters", "left_y_axis", "left_annotations"], defaults=(None, None)
+)
 
 
 def new_pcluster_metric(title=None, metrics=None, supported_vol_types=None, namespace=None, additional_dimensions=None):
@@ -180,7 +187,7 @@ class CWDashboardConstruct(Construct):
         self.cloudwatch_dashboard.add_widgets(text_widget)
         self._update_coord_after_section(d_y=1)
 
-    def _generate_graph_widget(self, title, metric_list):
+    def _generate_graph_widget(self, title, metric_list, **widget_kwargs):
         """Generate a graph widget and update the coordinates."""
         widget = cloudwatch.GraphWidget(
             title=title,
@@ -188,6 +195,7 @@ class CWDashboardConstruct(Construct):
             region=self._stack_region,
             width=self.graph_width,
             height=self.graph_height,
+            **widget_kwargs,
         )
         widget.position(x=self.coord.x_value, y=self.coord.y_value)
         self._update_coord(self.graph_width, self.graph_height)
@@ -230,7 +238,9 @@ class CWDashboardConstruct(Construct):
                 widgets_list.append(graph_widget)
         return widgets_list
 
-    def _add_custom_pcluster_metric_filter(self, metric_name, filter_pattern, custom_namespace, metric_value):
+    def _add_custom_pcluster_metric_filter(
+        self, metric_name, filter_pattern, custom_namespace, metric_value, metric_unit=None
+    ):
         """Adding custom metric filter from named tuple."""
         metric_filter = logs.CfnMetricFilter(
             scope=self.stack_scope,
@@ -242,6 +252,7 @@ class CWDashboardConstruct(Construct):
                     metric_namespace=custom_namespace,
                     metric_name=metric_name,
                     metric_value=metric_value,
+                    unit=metric_unit,
                     dimensions=[
                         logs.CfnMetricFilter.DimensionProperty(
                             key="ClusterName",
@@ -329,14 +340,17 @@ class CWDashboardConstruct(Construct):
                 metric_value=metric_value,
             ),
         ]
-        cluster_common_errors = [
-            _ErrorMetric(
+
+        cluster_health_metrics = [
+            _HealthMetric(
                 "Instance Provisioning Errors",
                 jobs_not_starting_errors,
+                left_y_axis=cloudwatch.YAxisProps(min=0.0),
             ),
-            _ErrorMetric(
+            _HealthMetric(
                 "Unhealthy Instance Errors",
                 compute_node_events,
+                left_y_axis=cloudwatch.YAxisProps(min=0.0),
             ),
         ]
         if self.config.has_custom_actions_in_queue:
@@ -367,14 +381,48 @@ class CWDashboardConstruct(Construct):
                 ),
             ]
 
-            cluster_common_errors.append(
-                _ErrorMetric(
+            cluster_health_metrics.append(
+                _HealthMetric(
                     "Custom Action Errors",
                     custom_action_errors,
+                    left_y_axis=cloudwatch.YAxisProps(min=0.0),
                 )
             )
+
+        cluster_health_metrics.append(
+            _HealthMetric(
+                "Compute Fleet Idle Time",
+                [
+                    _CustomMetricFilter(
+                        metric_name="LongestDynamicNodeIdleTime",
+                        filter_pattern='{ $.event-type = "compute-node-idle-time" && $.scheduler = "slurm" && '
+                        '$.detail.node-type = "dynamic"}',
+                        metric_value="$.detail.longest-idle-time",
+                        metric_statistic="max",
+                        metric_unit="Seconds",
+                    ),
+                ],
+                left_y_axis=cloudwatch.YAxisProps(min=0.0),
+                left_annotations=[
+                    cloudwatch.HorizontalAnnotation(
+                        value=self.config.scheduling.settings.scaledown_idletime * 60,
+                        color=cloudwatch.Color.GREEN,
+                        fill=cloudwatch.Shading.BELOW,
+                        visible=True,
+                    ),
+                    cloudwatch.HorizontalAnnotation(
+                        value=self.config.scheduling.settings.scaledown_idletime * 60,
+                        label="Idle Time Scaledown",
+                        color=cloudwatch.Color.BLUE,
+                        fill=cloudwatch.Shading.ABOVE,
+                        visible=True,
+                    ),
+                ],
+            )
+        )
+
         self._add_text_widget("# Cluster Health Metrics")
-        self._add_error_metrics_graph_widgets(cluster_common_errors)
+        self._add_health_metrics_graph_widgets(cluster_health_metrics)
         self._add_text_widget(
             "General [Troubleshooting Resources]"
             "(https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting.html)"
@@ -715,28 +763,34 @@ class CWDashboardConstruct(Construct):
             param = "@logStream"
         return _Filter(pattern, param)
 
-    def _add_error_metrics_graph_widgets(self, cluster_common_errors):
-        """Add cluster error metrics graph widgets."""
+    def _add_health_metrics_graph_widgets(self, cluster_health_metrics: Iterable[_HealthMetric]):
+        """Add cluster health metrics graph widgets."""
         custom_namespace = "ParallelCluster"
         widgets_list = []
-        for error in cluster_common_errors:
+        for health_metric in cluster_health_metrics:
             metric_list = []
-            for new_filter in error.metric_filters:
+            for new_filter in health_metric.metric_filters:
                 self._add_custom_pcluster_metric_filter(
                     metric_name=new_filter.metric_name,
                     filter_pattern=new_filter.filter_pattern,
                     custom_namespace=custom_namespace,
                     metric_value=new_filter.metric_value,
+                    metric_unit=new_filter.metric_unit,
                 )
                 cloudwatch_metric = cloudwatch.Metric(
                     namespace=custom_namespace,
                     metric_name=new_filter.metric_name,
                     period=Duration.minutes(1),
-                    statistic="Sum",
+                    statistic=new_filter.metric_statistic,
                     dimensions_map={"ClusterName": self.config.cluster_name},
                 )
                 metric_list.append(cloudwatch_metric)
-            graph_widget = self._generate_graph_widget(error.title, metric_list)
+            graph_widget = self._generate_graph_widget(
+                health_metric.title,
+                metric_list,
+                left_y_axis=health_metric.left_y_axis,
+                left_annotations=health_metric.left_annotations,
+            )
             widgets_list.append(graph_widget)
 
         self.cloudwatch_dashboard.add_widgets(*widgets_list)

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -221,7 +221,7 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml):
         "OnNodeConfiguredDownloadErrors",
         "OnNodeConfiguredRunErrors",
     ]
-    idle_node_metrics = ["LongestDynamicNodeIdleTime"]
+    idle_node_metrics = ["MaxDynamicNodeIdleTime"]
     if scheduler == "slurm":
         # Contains error metric title
         assert_that(output_yaml).contains("Cluster Health Metrics")

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -221,10 +221,13 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml):
         "OnNodeConfiguredDownloadErrors",
         "OnNodeConfiguredRunErrors",
     ]
+    idle_node_metrics = ["LongestDynamicNodeIdleTime"]
     if scheduler == "slurm":
         # Contains error metric title
         assert_that(output_yaml).contains("Cluster Health Metrics")
         for metric in slurm_related_metrics:
+            assert_that(output_yaml).contains(metric)
+        for metric in idle_node_metrics:
             assert_that(output_yaml).contains(metric)
         if cluster_config.has_custom_actions_in_queue:
             for metric in custom_action_metrics:
@@ -234,5 +237,5 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml):
                 assert_that(output_yaml).does_not_contain(metric)
     else:
         assert_that(output_yaml).does_not_contain("Cluster Health Metrics")
-        for metric in slurm_related_metrics + custom_action_metrics:
+        for metric in slurm_related_metrics + custom_action_metrics + idle_node_metrics:
             assert_that(output_yaml).does_not_contain(metric)

--- a/tests/integration-tests/tests/dashboard_and_alarms/test_structured_log_events.py
+++ b/tests/integration-tests/tests/dashboard_and_alarms/test_structured_log_events.py
@@ -32,19 +32,22 @@ def test_custom_compute_action_failure(
 
     bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
     bad_script = "on_compute_configured_error.sh"
-    bad_script_path = f"test_metric_logging/{bad_script}"
+    bad_script_path = f"test_structured_logging/{bad_script}"
     bucket.upload_file(str(test_datadir / bad_script), bad_script_path)
 
-    # Create S3 bucket for pre-install scripts
     cluster_config = pcluster_config_reader(bucket=bucket_name, bad_script_path=bad_script_path)
     cluster = clusters_factory(cluster_config)
 
     remote_command_executor = RemoteCommandExecutor(cluster)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
 
-    scheduler_commands.submit_command("hostname", nodes=1)
+    scheduler_commands.submit_command("hostname", nodes=1, partition="queue-1")
+    scheduler_commands.submit_command("hostname", nodes=1, partition="queue-2")
+
     assert_that_event_exists(cluster, r".+\.clustermgtd_events", "invalid-backing-instance-count")
     assert_that_event_exists(cluster, r".+\.clustermgtd_events", "protected-mode-error-count")
     assert_that_event_exists(cluster, r".+\.bootstrap_error_msg", "custom-action-error")
+    assert_that_event_exists(cluster, r".+\.clustermgtd_events", "compute-node-idle-time")
 
     test_cluster_health_metric(["OnNodeConfiguredRunErrors"], cluster.name, region)
+    test_cluster_health_metric(["MaxDynamicNodeIdleTime"], cluster.name, region)

--- a/tests/integration-tests/tests/dashboard_and_alarms/test_structured_log_events/test_custom_compute_action_failure/pcluster.config.yaml
+++ b/tests/integration-tests/tests/dashboard_and_alarms/test_structured_log_events/test_custom_compute_action_failure/pcluster.config.yaml
@@ -21,6 +21,16 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+    - Name: queue-2
+      ComputeResources:
+        - Name: compute-b
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 0
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
       Iam:
         S3Access:
           - BucketName: {{ bucket }}


### PR DESCRIPTION
### Description of changes
* This change adds a CloudWatch log filter metric and corresponding dashboard widget to display the maximum amount of time a dynamic compute node has been idle.

![Screen Shot 2023-04-04 at 5 57 53 PM](https://user-images.githubusercontent.com/110434140/229954697-b2dd5de3-aff2-4220-a9a8-16bdc309a004.png)

### Tests
* Updated metric unit tests to verify the new metric is added to the cluster template when the scheduler is "Slurm" and CloudWatch logging is enabled, and that it is not in the cluster template if these conditions are not met.
* Added check for idle node metric to structured logging event integration test.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
