### PR TITLE
Rename error metric OnNodeStart/ConfiguredExecutionErrors to OnNodeStart/ConfiguredRunErrors

### DIFF
--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -348,7 +348,7 @@ class CWDashboardConstruct(Construct):
                     metric_value="1",
                 ),
                 _CustomMetricFilter(
-                    metric_name="OnNodeStartExecutionErrors",
+                    metric_name="OnNodeStartRunErrors",
                     filter_pattern='{ $.event-type = "custom-action-error" && $.scheduler = "slurm" && '
                     '$.detail.action = "OnNodeStart" && $.detail.stage = "executing"}',
                     metric_value="1",
@@ -360,7 +360,7 @@ class CWDashboardConstruct(Construct):
                     metric_value="1",
                 ),
                 _CustomMetricFilter(
-                    metric_name="OnNodeConfiguredExecutionErrors",
+                    metric_name="OnNodeConfiguredRunErrors",
                     filter_pattern='{ $.event-type = "custom-action-error" && $.scheduler = "slurm" && '
                     '$.detail.action = "OnNodeConfigured" && $.detail.stage = "executing"}',
                     metric_value="1",

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -217,9 +217,9 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml):
     ]
     custom_action_metrics = [
         "OnNodeStartDownloadErrors",
-        "OnNodeStartExecutionErrors",
+        "OnNodeStartRunErrors",
         "OnNodeConfiguredDownloadErrors",
-        "OnNodeConfiguredExecutionErrors",
+        "OnNodeConfiguredRunErrors",
     ]
     if scheduler == "slurm":
         # Contains error metric title

--- a/tests/integration-tests/tests/dashboard_and_alarms/test_structured_log_events.py
+++ b/tests/integration-tests/tests/dashboard_and_alarms/test_structured_log_events.py
@@ -47,4 +47,4 @@ def test_custom_compute_action_failure(
     assert_that_event_exists(cluster, r".+\.clustermgtd_events", "protected-mode-error-count")
     assert_that_event_exists(cluster, r".+\.bootstrap_error_msg", "custom-action-error")
 
-    test_cluster_health_metric(["OnNodeConfiguredExecutionErrors"], cluster.name, region)
+    test_cluster_health_metric(["OnNodeConfiguredRunErrors"], cluster.name, region)

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -296,9 +296,7 @@ def test_slurm_protected_mode(
     )
     pending_job_id = _test_active_job_running(scheduler_commands, remote_command_executor, clustermgtd_conf_path)
     _test_protected_mode(scheduler_commands, remote_command_executor, cluster)
-    test_cluster_health_metric(
-        ["NoCorrespondingInstanceErrors", "OnNodeStartExecutionErrors"], cluster.cfn_name, region
-    )
+    test_cluster_health_metric(["NoCorrespondingInstanceErrors", "OnNodeStartRunErrors"], cluster.cfn_name, region)
     _test_job_run_in_working_queue(scheduler_commands)
     _test_recover_from_protected_mode(pending_job_id, pcluster_config_reader, bucket_name, cluster, scheduler_commands)
 


### PR DESCRIPTION
### Description of changes
* Rename error metric OnNodeStart/ConfiguredExecutionErrors to OnNodeStart/ConfiguredRunErrors. Rename the error metric name to make it more user friendly

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
