### PR TITLE
[Test] Fix dynamic file system mounting test by making the external storage stack retrieve the VPC stack output properly.

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -889,15 +889,11 @@ def external_shared_storage_stack(request, test_datadir, region, vpc_stack: CfnV
 
             vpc = vpc_stack.cfn_outputs["VpcId"]
             public_subnet_id = vpc_stack.get_public_subnet()
-            subnet_id0 = vpc_stack.cfn_outputs["PrivateSubnetId"]
-            subnet_id1 = vpc_stack.cfn_outputs["PrivateAz2SubnetId"]
             import_path = "s3://{0}".format(bucket_name)
             export_path = "s3://{0}/export_dir".format(bucket_name)
             params = [
                 {"ParameterKey": "vpc", "ParameterValue": vpc},
                 {"ParameterKey": "PublicSubnetId", "ParameterValue": public_subnet_id},
-                {"ParameterKey": "SubnetId0", "ParameterValue": subnet_id0},
-                {"ParameterKey": "SubnetId1", "ParameterValue": subnet_id1},
                 {"ParameterKey": "ImportPathParam", "ParameterValue": import_path},
                 {"ParameterKey": "ExportPathParam", "ParameterValue": export_path},
             ]


### PR DESCRIPTION
### Description of changes
Fix dynamic file system mounting test by making the external storage stack retrieve the VPC stack output properly.

### Tests
* Regression tests: `test_dynamic_file_systems_update`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
