### PR TITLE
Remove the test for new entry in DCV server log

### DIFF
--- a/tests/integration-tests/tests/log_rotation/test_log_rotation.py
+++ b/tests/integration-tests/tests/log_rotation/test_log_rotation.py
@@ -61,7 +61,7 @@ def test_log_rotation(
             "log_name": "dcv-server",
             "log_path": "/var/log/dcv/server.log",
             "existence": True,
-            "trigger_new_entries": True,
+            "trigger_new_entries": False,
         },
         {"log_name": "dcv-xsession", "log_path": "/var/log/dcv/dcv-xsession.*.log"},
         {"log_name": "slurmdbd", "log_path": "/var/log/slurmdbd.log"},


### PR DESCRIPTION
### Description of changes
* After upgrade to DCV 2022.2, the following log is not genereted each minutes: 2023-04-04 20:21:49,406394 [  2215:2215  ] INFO  certificate-loader - is certificate self signed: 'YES' - time validity check result: 'Ok(Ok)'

  Remove the check to wait for the dcv server log to be not empty after logrotation

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
