### PR TITLE
Remove CustomSlurmSettingsWarning

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -198,7 +198,6 @@ from pcluster.validators.slurm_settings_validator import (
     CustomSlurmSettingLevel,
     CustomSlurmSettingsIncludeFileOnlyValidator,
     CustomSlurmSettingsValidator,
-    CustomSlurmSettingsWarning,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -2256,7 +2255,6 @@ class SlurmQueue(_CommonQueue):
                 deny_list=SLURM_SETTINGS_DENY_LIST["Queue"]["Global"],
                 settings_level=CustomSlurmSettingLevel.QUEUE,
             )
-            self._register_validator(CustomSlurmSettingsWarning)
         for compute_resource in self.compute_resources:
             self._register_validator(
                 EfaSecurityGroupValidator,
@@ -2281,7 +2279,6 @@ class SlurmQueue(_CommonQueue):
                     deny_list=SLURM_SETTINGS_DENY_LIST["ComputeResource"]["Global"],
                     settings_level=CustomSlurmSettingLevel.COMPUTE_RESOURCE,
                 )
-                self._register_validator(CustomSlurmSettingsWarning)
             for instance_type in compute_resource.instance_types:
                 self._register_validator(
                     CapacityTypeValidator,
@@ -2364,7 +2361,6 @@ class SlurmSettings(Resource):
                 deny_list=SLURM_SETTINGS_DENY_LIST["SlurmConf"]["Global"],
                 settings_level=CustomSlurmSettingLevel.SLURM_CONF,
             )
-            self._register_validator(CustomSlurmSettingsWarning)
             self._register_validator(CustomSlurmNodeNamesValidator, custom_settings=self.custom_slurm_settings)
             if self.database:
                 self._register_validator(

--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -101,25 +101,6 @@ class CustomSlurmSettingsValidator(Validator):
             )
 
 
-class CustomSlurmSettingsWarning(Validator):
-    """
-    Custom Slurm Settings Warning.
-
-    This validator emits a warning message if custom settings are enabled.
-    The message is displayed only once no matter how many times instances of the validator are created.
-    """
-
-    signaled = False
-
-    def _validate(self):
-        if not CustomSlurmSettingsWarning.signaled:
-            self._add_failure(
-                "Custom Slurm settings are in use: please monitor the cluster carefully.",
-                FailureLevel.WARNING,
-            )
-            CustomSlurmSettingsWarning.signaled = True
-
-
 class CustomSlurmNodeNamesValidator(Validator):
     """
     Custom Slurm Nodelists Names validator.

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -85,7 +85,6 @@ from pcluster.validators.slurm_settings_validator import (
     CustomSlurmSettingLevel,
     CustomSlurmSettingsIncludeFileOnlyValidator,
     CustomSlurmSettingsValidator,
-    CustomSlurmSettingsWarning,
 )
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.validators.utils import assert_failure_level, assert_failure_messages
@@ -258,15 +257,6 @@ def test_cluster_name_validator_slurm_accounting(cluster_name, scheduling, shoul
 def test_custom_slurm_settings_validator(description, custom_settings, deny_list, settings_level, expected_message):
     actual_failures = CustomSlurmSettingsValidator().execute(custom_settings, deny_list, settings_level)
     assert_failure_messages(actual_failures, expected_message)
-
-
-def test_custom_slurm_settings_warning():
-    # when multiple instances are invoked it should show the warning only once
-    actual_failures = CustomSlurmSettingsWarning().execute()
-    assert_failure_messages(actual_failures, "Custom Slurm settings are in use: please monitor the cluster carefully.")
-
-    actual_failures = CustomSlurmSettingsWarning().execute()
-    assert_failure_messages(actual_failures, None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of changes
* Remove generic warning thrown whenever custom Slurm settings are being used.

### References
* Warning originally implemented in the context of https://github.com/aws/aws-parallelcluster/pull/5079

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
