### PR TITLE
`[integ-tests/custom_resource]` Exercise custom role additional policies

### DIFF
--- a/tests/integration-tests/configs/custom_resource.yaml
+++ b/tests/integration-tests/configs/custom_resource.yaml
@@ -26,3 +26,7 @@ test-suites:
       dimensions:
         - oss: ["alinux2"]
           regions: ["us-east-2"]
+    test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
+      dimensions:
+        - oss: ["alinux2"]
+          regions: ["us-east-2"]

--- a/tests/integration-tests/resources/cluster_custom_resource.yaml
+++ b/tests/integration-tests/resources/cluster_custom_resource.yaml
@@ -26,6 +26,10 @@ Parameters:
     Description: Script to run on HeadNode configured
     Type: String
     Default: ''
+  CustomBucketAccess:
+    Description: Name of a bucket to provide access to on the HeadNode
+    Type: String
+    Default: ''
   DeletionPolicy:
     Type: String
     Default: Delete
@@ -36,6 +40,7 @@ Parameters:
 
 Conditions:
   OnNodeConfiguredCondition: !Not [!Equals [!Ref OnNodeConfigured, '']]
+  CustomBucketCondition: !Not [!Equals [!Ref CustomBucketAccess, '']]
 
 Resources:
   PclusterCluster:
@@ -59,6 +64,13 @@ Resources:
             -
               OnNodeConfigured:
                 Script: !Ref OnNodeConfigured
+            - !Ref AWS::NoValue
+          Iam: !If
+            - CustomBucketCondition
+            -
+              S3Access:
+                - BucketName: !Ref CustomBucketAccess
+                  EnableWriteAccess: false
             - !Ref AWS::NoValue
         Scheduling:
           Scheduler: slurm

--- a/tests/integration-tests/tests/custom_resource/conftest.py
+++ b/tests/integration-tests/tests/custom_resource/conftest.py
@@ -14,9 +14,13 @@
 from pathlib import Path
 
 import boto3
+import cfn_tools
 import pkg_resources
 import pytest
 from cfn_stacks_factory import CfnStack, CfnStacksFactory
+from troposphere import Output, Ref
+from troposphere.iam import ManagedPolicy
+from troposphere.template_generator import TemplateGenerator
 from utils import generate_stack_name
 
 
@@ -42,22 +46,18 @@ def cluster_custom_resource_provider_template_fixture(resources_dir):
     return resources_dir / ".." / ".." / ".." / "cloudformation" / "custom_resource" / "cluster.yaml"
 
 
-@pytest.fixture(scope="class", name="cluster_custom_resource_provider")
-def cluster_custom_resource_provider_fixture(
-    request, region, resource_bucket, cluster_custom_resource_service_token, cluster_custom_resource_provider_template
-):
-    """Create the cluster custom resource stack."""
-    factory = CfnStacksFactory(request.config.getoption("credential"))
-    if cluster_custom_resource_service_token:
-        yield cluster_custom_resource_service_token
-        return
+@pytest.fixture(scope="session", name="policies_template_path")
+def policies_template_path_fixture(resources_dir):
+    return resources_dir / ".." / ".." / ".." / "cloudformation" / "policies" / "parallelcluster-policies.yaml"
 
-    parameters = {"CustomBucket": resource_bucket}
-    with open(cluster_custom_resource_provider_template, encoding="utf-8") as cfn_file:
+
+def cluster_custom_resource_provider_generator(credentials, region, stack_name, parameters, template):
+    factory = CfnStacksFactory(credentials)
+    with open(template, encoding="utf-8") as cfn_file:
         template_data = cfn_file.read()
 
     stack = CfnStack(
-        name=generate_stack_name("custom-resource-provider", request.config.getoption("stackname_suffix")),
+        name=stack_name,
         region=region,
         template=template_data,
         parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items()],
@@ -69,6 +69,25 @@ def cluster_custom_resource_provider_fixture(
         yield stack.cfn_outputs.get("ServiceToken")
     finally:
         factory.delete_all_stacks()
+
+
+@pytest.fixture(scope="class", name="cluster_custom_resource_provider")
+def cluster_custom_resource_provider_fixture(
+    request, region, resource_bucket, cluster_custom_resource_service_token, cluster_custom_resource_provider_template
+):
+    """Create the cluster custom resource stack."""
+    if cluster_custom_resource_service_token:
+        yield cluster_custom_resource_service_token
+        return
+
+    parameters = {"CustomBucket": resource_bucket}
+    yield from cluster_custom_resource_provider_generator(
+        request.config.getoption("credential"),
+        region,
+        generate_stack_name("custom-resource-provider", request.config.getoption("stackname_suffix")),
+        parameters,
+        cluster_custom_resource_provider_template,
+    )
 
 
 @pytest.fixture(scope="class", name="cluster_custom_resource_factory")
@@ -107,3 +126,55 @@ def cluster_custom_resource_factory_fixture(
     yield _produce_cluster_custom_resource_stack
 
     factory.delete_all_stacks()
+
+
+@pytest.fixture(scope="class", name="resource_bucket_cluster_template")
+def resource_bucket_cluster_template_fixture(policies_template_path, resource_bucket):
+    bucket_policy = ManagedPolicy(
+        title="ResourceBucketAccess",
+        Description="Policy to access resource bucket",
+        PolicyDocument={
+            "Statement": [
+                {
+                    "Action": ["s3:GetObject"],
+                    "Effect": "Allow",
+                    "Resource": {"Fn::Sub": f"arn:${{AWS::Partition}}:s3:::{resource_bucket}/*"},
+                },
+                {
+                    "Action": ["events:PutRule", "events:DeleteRule", "events:PutTargets", "events:RemoveTargets"],
+                    "Effect": "Allow",
+                    "Resource": {"Fn::Sub": "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*"},
+                },
+            ],
+            "Version": "2012-10-17",
+        },
+    )
+
+    with open(policies_template_path, "r", encoding="utf-8") as f:
+        policies_template = TemplateGenerator(cfn_tools.load_yaml(f.read()))
+
+    policies_template.add_resource(bucket_policy)
+    policies_template.add_output(Output("ResourceBucketAccess", Value=Ref("ResourceBucketAccess")))
+    managed_policies = policies_template.resources.get("ParallelClusterLambdaRole").properties["ManagedPolicyArns"]
+    managed_policies.append(Ref("ResourceBucketAccess"))
+    return policies_template.to_yaml()
+
+
+@pytest.fixture(scope="class", name="resource_bucket_policies")
+def resource_bucket_policies_fixture(request, region, resource_bucket_cluster_template):
+    factory = CfnStacksFactory(request.config.getoption("credential"))
+
+    parameters = {"EnableIamAdminAccess": "true"}
+    stack = CfnStack(
+        name=generate_stack_name("resource-bucket-policies", request.config.getoption("stackname_suffix")),
+        region=region,
+        template=resource_bucket_cluster_template,
+        capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
+        parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items()],
+    )
+
+    try:
+        factory.create_stack(stack, True)
+        yield stack
+    finally:
+        factory.delete_all_stacks()


### PR DESCRIPTION

### Description of changes
* Add a test that utilizes the `CustomLambdaRole` and `AdditionalIamPolicies` parameters of the custom resource provider stack.
  * Update the cluster yaml that uses the custom resource provider to accept a bucket in the parameters. This config option adds an additional policy that will provide access to the bucket to the HeadNode. In order to provide this additional policy to the HeadNode, the lambda which is creating the cluster must have access to this policy. As this is not a part of our default policies, this will validate that expanded permissions have been provided if the cluster is created.
* Create a modified version of our policies stack which adds a managed policy which provides access to the resource bucket, adds this modified policy to the lambda role as well as returning the managed policy.
* The individual test exercises both the above role for the `CustomLambdaRole` property when creating the custom resource provider as well as the managed policy for the `AdditionalIamPolicies` parameter.
* Use the service token from the modified custom resource provider with each of the parameters defined above to demonstrate that a custom role and an additional policy can be provided to the custom resource provider and that the policy will be propagated to the lambda which creates the cluster (and transitively to the cluster stack when it is created).

### Tests
* A modified version of the `custom_resource.yaml` test suite was utilized which enables the `` as follows:

`tests/integration-tests/configs/custom_resource.yaml`:
```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  custom_resource:
    test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
```

This test suite was run with the following resulting output demonstrating successful tests:


```
Results (2152.39s):
       2 passed
2023-04-05 20:48:52,973 - INFO - 11604 - test_runner - All tests completed!
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
