### PR TITLE
[3.x] Add an higher timeout to the configure spawned process

### DIFF
--- a/tests/integration-tests/tests/configure/test_pcluster_configure.py
+++ b/tests/integration-tests/tests/configure/test_pcluster_configure.py
@@ -311,7 +311,7 @@ def get_unsupported_test_runner_options(request):
 def assert_configure_workflow(request, region, stages, config_path):
     logging.info(f"Using `pcluster configure` to write a configuration to {config_path}")
     environ["AWS_DEFAULT_REGION"] = region
-    configure_process = pexpect.spawn(f"pcluster configure --config {config_path}", encoding="utf-8")
+    configure_process = pexpect.spawn(f"pcluster configure --config {config_path}", encoding="utf-8", timeout=90)
     output_dir = request.config.getoption("output_dir")
     with open(
         f"{output_dir}/spawned-process-log-{datetime.now().strftime('%d-%m-%Y-%H:%M:%S.%f')}", "w", encoding="utf-8"


### PR DESCRIPTION
### Description of changes
* Add an higher timeout to the configure spawned process (default is 30)

### Tests
* Launched locally

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
