### PR TITLE
[3.x] Enforcing Serial execution for Multi-nics tests and add them in release config

### DIFF
--- a/tests/integration-tests/configs/released.yaml
+++ b/tests/integration-tests/configs/released.yaml
@@ -30,3 +30,10 @@ test-suites:
     test_api.py::test_official_images:
       dimensions:
         - regions: ["sa-east-1"]
+  multiple_nics:
+    test_multiple_nics.py::test_multiple_nics:
+      dimensions:
+        - regions: ["use1-az6"] # do not move, unless capacity reservation is moved as well
+          instances: ["p4d.24xlarge"]
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          schedulers: [ "slurm" ]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -81,6 +81,7 @@ from utils import (
     scheduler_plugin_definition_uploader,
     set_logger_formatter,
 )
+from xdist import get_xdist_worker_id
 
 from tests.common.osu_common import run_osu_benchmarks
 from tests.common.schedulers_common import get_scheduler_commands
@@ -1301,9 +1302,10 @@ def serial_execution_by_instance(request, instance):
         lock_file = f"{outdir}/{instance}.lock"
         lock = FileLock(lock_file=lock_file)
         logging.info("Acquiring lock file %s", lock.lock_file)
-        with lock.acquire(poll_interval=15, timeout=7200):
+        with lock.acquire(poll_interval=15, timeout=12000):
+            logging.info(f"The lock is acquired by worker ID {get_xdist_worker_id(request)}: {os.getpid()}")
             yield
-        logging.info("Releasing lock file %s", lock.lock_file)
+        logging.info(f"Releasing lock file {lock.lock_file} by {get_xdist_worker_id(request)}: {os.getpid()}")
         lock.release()
     else:
         logging.info("Ignoring serial execution for instance %s", instance)

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics.py
@@ -15,7 +15,7 @@ from remote_command_executor import RemoteCommandExecutor
 from utils import get_compute_nodes_instance_ids
 
 
-@pytest.mark.usefixtures("os", "instance", "scheduler")
+@pytest.mark.usefixtures("os", "instance", "scheduler", "serial_execution_by_instance")
 def test_multiple_nics(
     region,
     pcluster_config_reader,

--- a/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
+++ b/tests/integration-tests/tests/multiple_nics/test_multiple_nics/test_multiple_nics/pcluster.config.yaml
@@ -1,7 +1,8 @@
 Image:
   Os: {{ os }}
 HeadNode:
-  InstanceType: {{ instance }}
+# Add multi-NIC instance type from https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html  
+  InstanceType: r6in.metal
   Networking:
     SubnetId: {{ public_subnet_id }}
     ElasticIp: true


### PR DESCRIPTION
### Description of changes
* Adding Multple Nics integration tests in released.yaml
* Enforcing sequential execution for Multiple-nics tests
* Changing the headNode from p4d.24xlarge to r6in.metal, which is [Multi-nic instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#network-cards:~:text=User%20Guide.-,Network%20cards,-Instances%20with%20multiple) to avoid ICE in HN.

### Tests
* Tested the changes in pipeline.


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
