### PR TITLE
Add warning about VPC usage charges in automation

### DIFF
--- a/cli/src/pcluster/cli/commands/configure/easyconfig.py
+++ b/cli/src/pcluster/cli/commands/configure/easyconfig.py
@@ -341,7 +341,18 @@ def _create_vpc_parameters(scheduler, head_node_instance_type, compute_instance_
     vpc_list = vpc_and_subnets["vpc_list"]
     if not vpc_list:
         print("There are no VPC for the given region. Starting automatic creation of VPC and subnets...")
-    if not vpc_list or prompt("Automate VPC creation? (y/n)", lambda x: x in ("y", "n"), default_value="n") == "y":
+    if (
+        not vpc_list
+        or prompt(
+            "The creation of the VPC will result in minimal charges for NAT gateway \n"
+            "creation using a public subnet that are not covered under the free tier.\n"
+            "Please refer to https://aws.amazon.com/vpc/pricing/ for more details.\n"
+            "Automate VPC creation? (y/n)",
+            lambda x: x in ("y", "n"),
+            default_value="n",
+        )
+        == "y"
+    ):
         vpc_parameters.update(
             automate_vpc_with_subnet_creation(
                 _choose_network_configuration(scheduler, head_node_instance_type, compute_instance_types),


### PR DESCRIPTION
### Description of changes
* Adding a message to inform users that NAT Gateways incur charges outside of the free tier.

### Tests
* Tested the CLI locally to print the message during configure

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
