### PR TITLE
Add Tags at compute resource level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ CHANGELOG
 - Add support for customizing the cluster Slurm configuration via the ParallelCluster configuration YAML file.
 - Track the longest dynamic node idle time in CloudWatch Dashboard.
 - Add new configuration section `HealthChecks/Gpu` for enabling the GPU Health Check in the compute node before job execution.
-- Add support for `Tags` in the `SlurmQueues` section.
 - Add support for `DetailedMonitoring` in the `Monitoring` section.
+- Add support for `Tags` in the `SlurmQueues` and `SlurmQueues/ComputeResources` section.
 
 **CHANGES**
 - Increase the default `RetentionInDays` of CloudWatch logs from 14 to 180 days.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1911,6 +1911,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         networking: SlurmComputeResourceNetworking = None,
         health_checks: HealthChecks = None,
         custom_slurm_settings: Dict = None,
+        tags: List[Tag] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -1928,6 +1929,7 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         self.networking = networking or SlurmComputeResourceNetworking(implied=True)
         self.health_checks = health_checks or HealthChecks(implied=True)
         self.custom_slurm_settings = Resource.init_param(custom_slurm_settings, default={})
+        self.tags = tags
 
     @staticmethod
     def fetch_instance_type_info(instance_type) -> InstanceTypeInfo:
@@ -1977,6 +1979,10 @@ class _BaseSlurmComputeResource(BaseComputeResource):
     @abstractmethod
     def instance_types(self) -> List[str]:
         pass
+
+    def get_tags(self):
+        """Return tags configured in the slurm compute resource configuration."""
+        return self.tags
 
 
 class FlexibleInstanceType(Resource):
@@ -3140,6 +3146,7 @@ class SlurmClusterConfig(CommonSchedulerClusterConfig):
                     compute_resource_name=compute_resource.name,
                     cluster_tags=self.get_tags(),
                     queue_tags=queue.get_tags(),
+                    compute_resource_tags=compute_resource.get_tags(),
                 )
 
     @property

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -65,6 +65,18 @@ def validate_no_reserved_tag(tags):
                 raise ValidationError(message=f"The tag key prefix '{PCLUSTER_PREFIX}' is reserved and cannot be used.")
 
 
+def validate_no_duplicate_tag(tags):
+    """Validate there is no duplicate tag keys in the same tag section."""
+    all_tags = set()
+    for tag in tags:
+        tag_key = tag.key
+        if tag_key in all_tags:
+            raise ValidationError(
+                f"Duplicate tag key ({tag_key}) detected. Tags keys should be unique within the Tags section."
+            )
+        all_tags.add(tag_key)
+
+
 def get_field_validator(field_name):
     allowed_values = ALLOWED_VALUES[field_name]
     return validate.OneOf(allowed_values) if isinstance(allowed_values, list) else validate.Regexp(allowed_values)

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -28,6 +28,7 @@ from pcluster.config.cluster_config import (
     HeadNode,
     SharedStorageType,
     SlurmClusterConfig,
+    SlurmComputeResource,
     SlurmQueue,
 )
 from pcluster.constants import (
@@ -145,7 +146,7 @@ def get_cluster_tags(stack_name: str, raw_dict: bool = False):
     return tags if raw_dict else dict_to_cfn_tags(tags)
 
 
-def get_custom_tags(config: Union[BaseClusterConfig, SlurmQueue], raw_dict: bool = False):
+def get_custom_tags(config: Union[BaseClusterConfig, SlurmQueue, SlurmComputeResource], raw_dict: bool = False):
     """Return a list of tags set by the user."""
     custom_tags = config.get_tags()
     tags = {tag.key: tag.value for tag in custom_tags} if custom_tags else {}

--- a/cli/src/pcluster/templates/queue_group_stack.py
+++ b/cli/src/pcluster/templates/queue_group_stack.py
@@ -134,12 +134,12 @@ class QueueGroupStack(NestedStack):
                     self._config.is_detailed_monitoring_enabled,
                 )
 
-    def _get_custom_compute_resource_tags(self, queue_config):
-        """Override Queue Tags value on Cluster level tags if there are duplicated keys."""
+    def _get_custom_compute_resource_tags(self, queue_config, compute_resource_config):
+        """Compute resource tags and Queue Tags value on Cluster level tags if there are duplicated keys."""
         tags = get_custom_tags(self._config, raw_dict=True)
         queue_tags = get_custom_tags(queue_config, raw_dict=True)
-        tags.update(queue_tags)
-        return dict_to_cfn_tags(tags)
+        compute_resource_tags = get_custom_tags(compute_resource_config, raw_dict=True)
+        return dict_to_cfn_tags({**tags, **queue_tags, **compute_resource_tags})
 
     def _add_compute_resource_launch_template(
         self,
@@ -315,14 +315,14 @@ class QueueGroupStack(NestedStack):
                         )
                         + [CfnTag(key=PCLUSTER_QUEUE_NAME_TAG, value=queue.name)]
                         + [CfnTag(key=PCLUSTER_COMPUTE_RESOURCE_NAME_TAG, value=compute_resource.name)]
-                        + self._get_custom_compute_resource_tags(queue),
+                        + self._get_custom_compute_resource_tags(queue, compute_resource),
                     ),
                     ec2.CfnLaunchTemplate.TagSpecificationProperty(
                         resource_type="volume",
                         tags=get_default_volume_tags(self.stack_name, "Compute")
                         + [CfnTag(key=PCLUSTER_QUEUE_NAME_TAG, value=queue.name)]
                         + [CfnTag(key=PCLUSTER_COMPUTE_RESOURCE_NAME_TAG, value=compute_resource.name)]
-                        + self._get_custom_compute_resource_tags(queue),
+                        + self._get_custom_compute_resource_tags(queue, compute_resource),
                     ),
                 ],
                 **conditional_template_properties,

--- a/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.yaml
+++ b/cli/tests/pcluster/config/test_config_patch/test_single_param_change/pcluster.config.yaml
@@ -31,6 +31,11 @@ Scheduling:
           InstanceType: {{compute_instance_type}}
           MinCount: 1
           MaxCount: {{max_count}}
+          {% if compute_tag_value %}
+          Tags:
+            - Key: computetag1
+              Value: {{compute_tag_value}}
+          {% endif %}
       Image:
         CustomAmi: {{queue_custom_ami}}
       {% if queue_tag_value %}

--- a/cli/tests/pcluster/config/test_update_policy.py
+++ b/cli/tests/pcluster/config/test_update_policy.py
@@ -249,6 +249,26 @@ def test_max_count_policy(mocker, is_fleet_stopped, old_max, new_max, expected_r
             True,
             id="Stop fleet and queue tag unset without queue update strategy",
         ),
+        pytest.param(
+            False,
+            "Tags",
+            ["Scheduling", "SlurmQueues[queue1]", "ComputeResources", "Tags[computetag1]"],
+            '{"Key": "compute_tag2","Value": "compute_tag_value_1"}',
+            None,
+            QueueUpdateStrategy.DRAIN.value,
+            True,
+            id="running fleet and compute tag unset with update strategy DRAIN",
+        ),
+        pytest.param(
+            False,
+            "Value",
+            ["Scheduling", "SlurmQueues[queue1]", "ComputeResources[compute-resource1]", "Tags[computetag1]"],
+            "value_1",
+            "value_2",
+            None,
+            False,
+            id="running fleet and change compute tag without update strategy DRAIN",
+        ),
     ],
 )
 def test_queue_update_strategy_condition_checker(

--- a/cli/tests/pcluster/schemas/test_common_schema.py
+++ b/cli/tests/pcluster/schemas/test_common_schema.py
@@ -18,6 +18,7 @@ from pcluster.schemas.common_schema import (
     ImdsSchema,
     LambdaFunctionsVpcConfigSchema,
     validate_json_format,
+    validate_no_duplicate_tag,
     validate_no_reserved_tag,
 )
 
@@ -111,3 +112,21 @@ def test_validate_no_reserved_tag(tags, failure_message):
             validate_no_reserved_tag(tags)
     else:
         validate_no_reserved_tag(tags)
+
+
+@pytest.mark.parametrize(
+    "tags, failure_message",
+    [
+        ([BaseTag(key="test1", value="test"), BaseTag(key="test2", value="test")], None),
+        (
+            [BaseTag(key="test1", value="test"), BaseTag(key="test1", value="test")],
+            "Duplicate tag key \\(test1\\) detected. Tags keys should be unique within the Tags section.",
+        ),
+    ],
+)
+def test_validate_no_duplicate_tag(tags, failure_message):
+    if failure_message:
+        with pytest.raises(ValidationError, match=failure_message):
+            validate_no_duplicate_tag(tags)
+    else:
+        validate_no_duplicate_tag(tags)

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
@@ -78,6 +78,11 @@ Scheduling:
         {% for j in range(max_number_of_ondemand_crs) %}
         - Name: compute-resource-ondemand-{{ i }}{{ j }}
           InstanceType: c5.xlarge
+          Tags:
+            {% for i in range(number_of_tags) %}
+            - Key: computetag{{ i }}
+              Value: computetag{{ i }}
+            {% endfor %}
         {% endfor %}
       CustomActions:
         OnNodeStart:
@@ -148,6 +153,11 @@ Scheduling:
             PlacementGroup:
               Enabled: true
               Id: String
+          Tags:
+            {% for i in range(number_of_tags) %}
+            - Key: computetag{{ i }}
+              Value: computetag{{ i }}
+            {% endfor %}
         {% endfor %}
       Iam:
         InstanceProfile: arn:aws:iam::aws:instance-profile/CustomNodeInstanceProfile

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -122,6 +122,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -142,6 +145,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -162,6 +168,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -182,6 +191,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -202,6 +214,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -274,6 +289,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -294,6 +312,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -314,6 +335,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -334,6 +358,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -354,6 +381,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -426,6 +456,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -446,6 +479,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -466,6 +502,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -486,6 +525,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -506,6 +548,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -578,6 +623,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -598,6 +646,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -618,6 +669,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -638,6 +692,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -658,6 +715,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -730,6 +790,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -750,6 +813,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -770,6 +836,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -790,6 +859,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -810,6 +882,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -882,6 +957,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -902,6 +980,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -922,6 +1003,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -942,6 +1026,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -962,6 +1049,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1034,6 +1124,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1054,6 +1147,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1074,6 +1170,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1094,6 +1193,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1114,6 +1216,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1186,6 +1291,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1206,6 +1314,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1226,6 +1337,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1246,6 +1360,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1266,6 +1383,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1338,6 +1458,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1358,6 +1481,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1378,6 +1504,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1398,6 +1527,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1418,6 +1550,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1490,6 +1625,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1510,6 +1648,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1530,6 +1671,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1550,6 +1694,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1570,6 +1717,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1642,6 +1792,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1662,6 +1815,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1682,6 +1838,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1702,6 +1861,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1722,6 +1884,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1794,6 +1959,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1814,6 +1982,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1834,6 +2005,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1854,6 +2028,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1874,6 +2051,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -1946,6 +2126,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1966,6 +2149,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -1986,6 +2172,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2006,6 +2195,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2026,6 +2218,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -2098,6 +2293,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2118,6 +2316,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2138,6 +2339,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2158,6 +2362,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2178,6 +2385,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -2250,6 +2460,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2270,6 +2483,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2290,6 +2506,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2310,6 +2529,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2330,6 +2552,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -2402,6 +2627,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2422,6 +2650,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2442,6 +2673,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2462,6 +2696,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2482,6 +2719,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -2554,6 +2794,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2574,6 +2817,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2594,6 +2840,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2614,6 +2863,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2634,6 +2886,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -2706,6 +2961,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2726,6 +2984,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2746,6 +3007,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2766,6 +3030,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2786,6 +3053,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -2858,6 +3128,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2878,6 +3151,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2898,6 +3174,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2918,6 +3197,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -2938,6 +3220,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -3010,6 +3295,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -3030,6 +3318,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -3050,6 +3341,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -3070,6 +3364,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: false
@@ -3090,6 +3387,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: null
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume: null
@@ -3162,6 +3462,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3182,6 +3485,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3202,6 +3508,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3264,6 +3573,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3284,6 +3596,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3304,6 +3619,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3366,6 +3684,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3386,6 +3707,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3406,6 +3730,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3468,6 +3795,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3488,6 +3818,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3508,6 +3841,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3570,6 +3906,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3590,6 +3929,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3610,6 +3952,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3672,6 +4017,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3692,6 +4040,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3712,6 +4063,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3774,6 +4128,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3794,6 +4151,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3814,6 +4174,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3876,6 +4239,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3896,6 +4262,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3916,6 +4285,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -3978,6 +4350,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -3998,6 +4373,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4018,6 +4396,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -4080,6 +4461,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4100,6 +4484,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4120,6 +4507,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -4182,6 +4572,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4202,6 +4595,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4222,6 +4618,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -4284,6 +4683,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4304,6 +4706,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4324,6 +4729,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -4386,6 +4794,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4406,6 +4817,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4426,6 +4840,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -4488,6 +4905,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4508,6 +4928,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4528,6 +4951,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -4590,6 +5016,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4610,6 +5039,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4630,6 +5062,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -4692,6 +5127,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4712,6 +5150,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4732,6 +5173,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -4794,6 +5238,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4814,6 +5261,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4834,6 +5284,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -4896,6 +5349,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4916,6 +5372,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -4936,6 +5395,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -4998,6 +5460,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -5018,6 +5483,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -5038,6 +5506,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:
@@ -5100,6 +5571,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -5120,6 +5594,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     - CapacityReservationTarget: null
       CustomSlurmSettings: {}
       DisableSimultaneousMultithreading: true
@@ -5140,6 +5617,9 @@ Scheduling:
           Name: null
       SchedulableMemory: null
       SpotPrice: 1.1
+      Tags:
+      - Key: computetag0
+        Value: computetag0
     ComputeSettings:
       LocalStorage:
         EphemeralVolume:

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -107,6 +107,11 @@ Scheduling:
       ComputeResources:
         - Name: compute_resource_1
           InstanceType: c4.2xlarge
+          Tags:
+            - Key: compute_tag1
+              Value: String
+            - Key: compute_tag2
+              Value: String
         - Name: compute_resource_2
           InstanceType: c5.2xlarge
           MinCount: 1

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_validators_are_called_with_correct_argument/slurm.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_validators_are_called_with_correct_argument/slurm.yaml
@@ -20,6 +20,11 @@ Scheduling:
       ComputeResources:
         - Name: compute_resource1
           InstanceType: t2.large
+          Tags:
+            - Key: compute_tag1
+              Value: String
+            - Key: compute_tag2
+              Value: String
         - Name: compute_resource2
           InstanceType: c4.2xlarge
     - Name: queue2


### PR DESCRIPTION
### Description of changes
Add support for Tags section under compute resource level.
```
  SlurmQueues:
    - Name: compute
      AllocationStrategy: lowest-price
      ComputeResources:
        - Name: defaultcompute
          Instances:
            - InstanceType: c5.xlarge
          MinCount: 0
          MaxCount: 505
          Tags:
            - Key: mytag1
              Value: tagvalue13
```
The tags section under queue level support queue update strategy
* Add validator to make sure no duplicate tags within the same section
* Add warning to warn compute resource tags will override queue tags, queue tags will override cluster level tags when there are duplicated tag keys.

### Tests
* Manually test
  * Test cluster creation with Tags section in compute resources, 
    * verify duplicated tags in the Compute Resource section override Queue level
    * verify duplicated tags in the Compute Resource section override Cluster level
  * Test cluster update with Tags section in compute resources
  * Test cluster creation/update is blocked when there are duplicated Tags within the same section
* Unit test

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
