### PR TITLE
`[integ-tests/lambda-layer]` Parameterize lambda layer to copy.

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -42,7 +42,7 @@ usage: test_runner.py [-h] --key-name KEY_NAME --key-path KEY_PATH [-n PARALLELI
                       [--custom-cookbook-url CUSTOM_COOKBOOK_URL] [--createami-custom-cookbook-url CREATEAMI_CUSTOM_COOKBOOK_URL] [--createami-custom-node-url CREATEAMI_CUSTOM_NODE_URL] [--custom-awsbatchcli-url CUSTOM_AWSBATCHCLI_URL]
                       [--pre-install PRE_INSTALL] [--post-install POST_INSTALL] [--instance-types-data INSTANCE_TYPES_DATA] [--custom-ami CUSTOM_AMI] [--pcluster-git-ref PCLUSTER_GIT_REF] [--cookbook-git-ref COOKBOOK_GIT_REF]
                       [--node-git-ref NODE_GIT_REF] [--ami-owner AMI_OWNER] [--benchmarks] [--benchmarks-target-capacity BENCHMARKS_TARGET_CAPACITY] [--benchmarks-max-time BENCHMARKS_MAX_TIME]
-                      [--api-definition-s3-uri API_DEFINITION_S3_URI] [--api-infrastructure-s3-uri API_INFRASTRUCTURE_S3_URI] [--api-uri API_URI] [--policies-uri POLICIES_URI] [--vpc-stack VPC_STACK] [--cluster CLUSTER]
+                      [--api-definition-s3-uri API_DEFINITION_S3_URI] [--api-infrastructure-s3-uri API_INFRASTRUCTURE_S3_URI] [--api-uri API_URI] [--policies-uri POLICIES_URI] [--vpc-stack VPC_STACK] [--cluster CLUSTER] [--lambda-layer-source LAMBDA_LAYER_SOURCE]
                       [--no-delete] [--delete-logs-on-success] [--stackname-suffix STACKNAME_SUFFIX] [--dry-run] [--directory-stack-name DIRECTORY_STACK_NAME] [--ldaps-nlb-stack-name LDAPS_NLB_STACK_NAME] [--external-shared-storage-stack-name SHARED_STORAGE_STACK_NAME]
 
 Run integration tests suite.
@@ -131,6 +131,8 @@ CloudFormation / Custom Resource options:
                         ServiceToken (ARN) Cluster CloudFormation custom resource provider (default: None)
   --resource-bucket RESOURCE_BUCKET
                         Name of bucket to use to to retrieve standard hosted resources like CloudFormation templates. (default: None)
+  --lambda-layer-source LAMBDA_LAYER_SOURCE
+                        S3 URI of lambda layer to copy instead of building. (default: None)
 
 API options:
   --api-definition-s3-uri API_DEFINITION_S3_URI

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -143,6 +143,10 @@ def pytest_addoption(parser):
         help="(Optional) Name of bucket to use to look for standard resources like hosted CloudFormation templates.",
     )
     parser.addoption(
+        "--lambda-layer-source",
+        help="(Optional) S3 URI of lambda layer to copy rather than building.",
+    )
+    parser.addoption(
         "--api-definition-s3-uri", help="URI of the Docker image for the Lambda of the ParallelCluster API"
     )
     parser.addoption(
@@ -950,6 +954,11 @@ def api_infrastructure_s3_uri(request):
 @pytest.fixture(scope="session")
 def cluster_custom_resource_service_token(request):
     return request.config.getoption("cluster_custom_resource_service_token")
+
+
+@pytest.fixture(scope="session")
+def lambda_layer_source(request):
+    return request.config.getoption("lambda_layer_source")
 
 
 @pytest.fixture(scope="class")

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -88,6 +88,7 @@ TEST_DEFAULTS = {
     "external_shared_storage_stack_name": None,
     "cluster_custom_resource_service_token": None,
     "resource_bucket": None,
+    "lambda_layer_source": None,
 }
 
 
@@ -317,6 +318,11 @@ def _init_argparser():
         "--resource-bucket",
         help="Name of bucket to use to to retrieve standard hosted resources like CloudFormation templates.",
         default=TEST_DEFAULTS.get("resource_bucket"),
+    )
+    custom_resource_group.add_argument(
+        "--lambda-layer-source",
+        help="S3 URI of lambda layer to copy instead of building.",
+        default=TEST_DEFAULTS.get("lambda_layer_source"),
     )
 
     api_group = parser.add_argument_group("API options")
@@ -598,6 +604,8 @@ def _set_custom_resource_args(args, pytest_args):
         pytest_args.extend(["--cluster-custom-resource-service-token", args.cluster_custom_resource_service_token])
     if args.resource_bucket:
         pytest_args.extend(["--resource-bucket", args.resource_bucket])
+    if args.lambda_layer_source:
+        pytest_args.extend(["--lambda-layer-source", args.lambda_layer_source])
 
 
 def _set_api_args(args, pytest_args):


### PR DESCRIPTION
### Description of changes
* Add a parameter (`--lambda-layer-source`) that allows the user to specify an S3 URI to use to copy the lambda layer (rather than building it) when creating a resource bucket. If the parameter is specified and the integration tests will create a resource bucket (e.g. a resource bucket is _not_ specified) then it does an S3 copy rather than creating the lambda layer.

### Tests
* The `test_api_infrastructure.py::test_api_infrastructure_with_default_parameters` test was run with the following config:

```
{%- import 'common.jinja2' as common with context -%}
test-suites:
  pcluster_api:
    test_api_infrastructure.py::test_api_infrastructure_with_default_parameters:
      dimensions:
        - regions: ["us-east-2"]
```

The test-runner was run both with and without the `--lambda-layer-source` parameter, e.g.:

```.sh
#!/bin/bash
python3 -m test_runner \
    -c configs/api.yaml \
    --key-name ${KEYNAME} \
    --key-path ${HOME}/keys/${KEYNAME}.pem \
    --lambda-layer-source s3://[personal-bucket]/parallelcluster/3.6.0/layers/aws-parallelcluster/lambda-layer.zip \
    --show-output \
    --vpc-stack "[redacted]" \
    --use-default-iam-credentials \
    --sequential
```

and

```.sh
#!/bin/bash
python3 -m test_runner \
    -c configs/api.yaml \
    --key-name ${KEYNAME} \
    --key-path ${HOME}/keys/${KEYNAME}.pem \
    --show-output \
    --vpc-stack "[redacted]" \
    --use-default-iam-credentials \
    --sequential
```

Both tests passed.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
