### PR TITLE
[Templates] Scope down CloudFormation permissions in 'parallelcluster-policies.yaml' template.

### DIFF
--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -394,16 +394,36 @@ Resources:
             Effect: Allow
             Sid: Route53HostedZones
           - Action:
-              - cloudformation:*
-            Resource: '*'
+              - cloudformation:CreateStack
+            Resource: !Sub
+              - arn:*:cloudformation:${RequestedRegion}:${AWS::AccountId}:stack/*
+              - RequestedRegion: !If [IsMultiRegion, '*', !Ref Region]
             Effect: Allow
-            Condition: !If
-              - IsMultiRegion
-              - !Ref AWS::NoValue
-              - StringEquals:
-                  aws:RequestedRegion:
-                    - !Ref Region
-            Sid: CloudFormation
+            Condition:
+              ForAnyValue:StringEquals:
+                aws:TagKeys: ["parallelcluster:cluster-name"]
+            Sid: CloudFormationCreate
+          - Action:
+              - cloudformation:UpdateStack
+            Resource: !Sub
+              - arn:*:cloudformation:${RequestedRegion}:${AWS::AccountId}:stack/*
+              - RequestedRegion: !If [IsMultiRegion, '*', !Ref Region]
+            Effect: Allow
+            Condition:
+              ForAnyValue:StringLike:
+                aws:ResourceTag/parallelcluster:cluster-name: "*"
+            Sid: CloudFormationUpdate
+          - Action:
+              - cloudformation:DeleteStack
+              - cloudformation:DescribeStacks
+              - cloudformation:DescribeStackEvents
+              - cloudformation:DescribeStackResources
+              - cloudformation:GetTemplate
+            Resource: !Sub
+              - arn:*:cloudformation:${RequestedRegion}:${AWS::AccountId}:stack/*
+              - RequestedRegion: !If [IsMultiRegion, '*', !Ref Region]
+            Effect: Allow
+            Sid: CloudFormationReadAndDelete
           - Action:
               - cloudwatch:PutDashboard
               - cloudwatch:ListDashboards


### PR DESCRIPTION
### Description of changes
Scope down CloudFormation permissions in `parallelcluster-policies.yaml` template.

### Tests
* Manually created policies stack created with permissions restricted to only one region (eu-west-1)
* Manually created policies stack created with permissions for all regions (*)
* Integration tests: `test_cluster_create`, `test_cluster_update`, `test_cluster_create_with_custom_policies`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
