### PR TITLE
Remove JobCompPass from SLURM_SETTINGS_DENY_LIST

### DIFF
--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -21,7 +21,6 @@ SLURM_SETTINGS_DENY_LIST = {
             "communicationparameters",
             "epilog",
             "grestypes",
-            "jobcomppass",
             "launchparameters",
             "prolog",
             "reconfigflags",


### PR DESCRIPTION
### Description of changes
* Remove JobCompPass from SLURM_SETTINGS_DENY_LIST
  * The rendering of the custom Slurm settings include file is not logged, so it is not necessary to preventively deny the usage of that parameter in CustomSlurmSettings.

### References
* Related to #5103 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
