### PR TITLE
`[custom_resource]` Limit response size.

### DIFF
--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -159,13 +159,18 @@ Resources:
 
           def update_response(data):
               logger.info(data)
+              # Avoid limit on response object size, user has provided these, so drop them in the response
+              extra_keys = {"clusterConfiguration", "scheduler", "tags"}
               # create / delete responses have cluster information nested in "cluster" key,
               # flatten that portion while keeping other keys to propagate warnings.
               if "cluster" in data:
-                  helper.Data.update(flatten(data["cluster"]))
-                  helper.Data["validationMessages"] = json.dumps(data.get("validationMessages", []))
+                  helper.Data.update(flatten(drop_keys(data["cluster"], extra_keys)))
+
+                  validation_messages = json.dumps(data.get("validationMessages", []))
+                  validation_messages = "TRUNCATED:" + validation_messages[:2048] if len(validation_messages) > 2048 else validation_messages
+                  helper.Data["validationMessages"] = validation_messages
               else:  # without "cluster" in the keys, this is a cluster object.
-                  helper.Data.update(flatten(data))
+                  helper.Data.update(flatten(drop_keys(data, extra_keys)))
 
           def serialize(val):
               return utils.to_iso_timestr(val) if isinstance(val, datetime.date) else val


### PR DESCRIPTION
### Description of changes
The response size is limited to 4k otherwise it throws an error.

This PR removes `tags.*`, the `clusterConfiguration.url` and the `scheduler.type` keys from the response as well as truncating the validation messages if they are too long (these are also available from the lamba output if they are truncated).

All of this data is provided from the cluster at creation time and is available by describing a cluster (either in the CLI or in a lambda in CFN) so therefore is not needed to be in the response.

### Tests
* An example cluster with custom storage and tags was failing to create before.
* Updating the code allowed the cluster to be created.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
