### PR TITLE
Add redhat8 update cluster integration tests in develop

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -774,23 +774,23 @@ update:
     dimensions:
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
+        oss: {{ common.OSS_COMMERCIAL_X86 }}
   test_update.py::test_update_compute_ami:
     dimensions:
       - regions: ["eu-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["rhel8"]
   test_update.py::test_update_instance_list:
     dimensions:
       - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["rhel8"]
         schedulers: ["slurm"]
   test_update.py::test_queue_parameters_update:
     dimensions:
       - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["rhel8"]
         schedulers: ["slurm"]
   test_update.py::test_dynamic_file_systems_update:
     dimensions:


### PR DESCRIPTION
### Description of changes
This patch adds rhel8 to the common cluster update integration tests in develop, except for the awsbatch one, since awsbatch is not supported in rhel8, and the multi-az one, since our ocr_stack class-scoped fixture has hardcoded 'Linux/UNIX' as platform, while rhel8 required 'Red Hat Enterprise Linux'.

If in a follow up patch we decide to set the platform value conditionally based on the operating system, we ought to pay attention to what happens when running this tests for, i.e., alinux2 and rhel8, since this fixture is shared (class level scope) and the two OSs require different platform values.

### Tests
Run tests in personal pipeline.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
