### PR TITLE
Add redhat8 to test_cloudwatch_logging integ-test

### DIFF
--- a/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
+++ b/tests/integration-tests/tests/cloudwatch_logging/test_cloudwatch_logging.py
@@ -145,10 +145,14 @@ class CloudWatchLoggingClusterState:
     @staticmethod
     def _base_os_to_platform(base_os):
         """Turn the name of a base OS into the platform."""
-        # Special case: alinux2 is how the config file refers to amazon linux 2, but in the chef cookbook
-        # (and the cloudwatch log config produced by it) the platform is "amazon".
+        # Special case: in the files of the cookbook regarding the cloudwatch agent under
+        # cookbooks/aws-parallelcluster-config/files/default/cloudwatch the configurations refers to:
+        # * "alinux2" as platform "amazon"
+        # * "rhel8" as platform "redhat"
         if base_os == "alinux2":
             return "amazon"
+        elif base_os == "rhel8":
+            return "redhat"
         else:
             return base_os.rstrip(string.digits)
 


### PR DESCRIPTION
### Description of changes
* Add redhat8 to test_cloudwatch_logging integ-test

### Tests
* Manual tested in local environment with config
  ```
  {%- import 'common.jinja2' as common with context -%}
  ---
  test-suites:
    cloudwatch_logging:
      test_cloudwatch_logging.py::test_cloudwatch_logging:
        dimensions:
          - regions: ["eu-west-1"]
            instances: {{ common.INSTANCES_DEFAULT_X86 }}
            oss:  ["rhel8"]
            schedulers: ["slurm"]
  ```
  Result:
  ```
  1433.29s call     cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[eu-west-1-c5.xlarge-rhel8-slurm-None]
  5.30s setup    cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[eu-west-1-c5.xlarge-rhel8-slurm-None]
  0.03s teardown cloudwatch_logging/test_cloudwatch_logging.py::test_cloudwatch_logging[eu-west-1-c5.xlarge-rhel8-slurm-None]
  
  Results (1442.05s (0:24:02)):
         1 passed
  ```
Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
