### PR TITLE
`[custom_resource]` Sort configuration errors.

### DIFF
--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -203,7 +203,15 @@ Resources:
                   message = pcluster.api.errors.exception_message(e)
                   # StatusReason is truncated, so skip changeset in output, still logged below
                   block_list = {"change_set"}
-                  str_msg = encoder.JSONEncoder().encode(drop_keys(message.to_dict(), block_list))
+                  message_data = drop_keys(message.to_dict(), block_list)
+                  logger.info(message_data)
+
+                  # sort more critical errors last
+                  if "configuration_validation_errors" in message_data and message_data["configuration_validation_errors"]:
+                      order = {k: i for i, k in enumerate(["INFO", "WARNING", "ERROR"])}
+                      message_data["configuration_validation_errors"].sort(key=lambda e: order[e["level"]])
+
+                  str_msg = encoder.JSONEncoder().encode(message_data)
                   if not re.search(r"No changes found", str_msg):
                       logger.info(encoder.JSONEncoder().encode(message))
                       raise ValueError(str_msg)

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -244,7 +244,7 @@ class CfnStacksFactory:
                     final_status = self.__wait_for_stack_update(stack.cfn_stack_id, cfn_client)
                     self.__assert_stack_status(
                         final_status,
-                        "UPDATE_COMPLETE",
+                        {"UPDATE_COMPLETE", "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS"},
                         stack_name=stack.cfn_stack_id,
                         region=region,
                         stack_is_under_test=stack_is_under_test,
@@ -256,7 +256,6 @@ class CfnStacksFactory:
                         "Update of stack {0} in region {1} failed with exception: {2}".format(name, region, e)
                     )
                     raise
-                del self.__created_stacks[internal_id]
                 logging.info("Stack {0} updated successfully in region {1}".format(name, region))
             else:
                 logging.warning(
@@ -306,7 +305,8 @@ class CfnStacksFactory:
 
     @staticmethod
     def __assert_stack_status(status, expected_status, region, stack_name=None, stack_is_under_test=False):
-        if status != expected_status:
+        expected_status = {expected_status} if not isinstance(expected_status, set) else expected_status
+        if status not in expected_status:
             message = (
                 f"Stack status {status} for {stack_name} differs "
                 f"from the expected status of {expected_status} in region {region}"

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
@@ -77,7 +77,7 @@ def test_cluster_create_invalid(region, cluster_custom_resource_factory, paramet
     """Try to create a cluster with invalid syntax and ensure that it fails."""
     with pytest.raises(StackError) as stack_error:
         cluster_custom_resource_factory(parameters)
-    reason = failure_reason(stack_error.stack_events)
+    reason = failure_reason(stack_error.value.stack_events)
     assert_that(reason).contains(error_message)
 
 
@@ -147,7 +147,7 @@ def test_cluster_update_invalid(region, cluster_custom_resource_factory, update_
     with pytest.raises(StackError) as stack_error:
         stack.factory.update_stack(stack.name, stack.region, parameters, stack_is_under_test=True)
 
-    reason = failure_reason(stack_error.stack_events)
+    reason = failure_reason(stack_error.value.stack_events)
     assert_that(reason).contains(error_message)
 
     cluster = pc().list_clusters(query=f"clusters[?clusterName=='{cluster_name}']|[0]")


### PR DESCRIPTION
### Description of changes
* Sort configuration errors (if they exist) so that if they are truncated in the CloudFormation reason, errors are more likely to be displayed.
* Fix bug in integ-tests for checking the response reason.

### Tests
* Due to an unforeseen issue in the integration tests, all tests for custom resource were run as follows:

- An image was built (using `develop`) for `alinux2` to get the latest AMI.
- Integration tests were run using the following test_runner:
```
python -m test_runner \
    -c configs/custom_resource.yaml \
    --key-name ${KEYNAME} \
    --key-path ${HOME}/keys/${KEYNAME}.pem \
    --show-output \
    --vpc-stack [REDACTED] \
    --use-default-iam-credentials \
    --sequential
```

- The `configs/custom_resource.yaml` was left unmodified to run all tests.

Results:

```
Results (10542.66s):
      13 passed
2023-04-13 15:14:07,688 - INFO - 318306 - test_runner - All tests completed!
```


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
