### PR TITLE
[develop] Add integ-test for Custom Slurm Settings

### DIFF
--- a/tests/integration-tests/configs/schedulers.yaml
+++ b/tests/integration-tests/configs/schedulers.yaml
@@ -160,6 +160,12 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: [ "slurm" ]
+    test_slurm.py::test_slurm_custom_config_parameters:
+      dimensions:
+        - regions: ["euw1-az1"]
+          instances: ["c5.xlarge"]
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
   update:
     test_update.py::test_update_awsbatch:
       dimensions:

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -214,24 +214,16 @@ class SlurmCommands(SchedulerCommands):
         return _job_status_retryer()
 
     def get_job_exit_status(self, job_id):  # noqa: D102
-        result = self._remote_command_executor.run_remote_command("scontrol show jobs -o {0}".format(job_id))
-        match = re.search(r"ExitCode=(.+?) ", result.stdout)
-        return match.group(1)
+        return self.get_job_info(job_id, field="ExitCode")
 
     def get_job_start_time(self, job_id):  # noqa: D102
-        result = self._remote_command_executor.run_remote_command("scontrol show jobs -o {0}".format(job_id))
-        match = re.search(r"StartTime=(.+?) ", result.stdout)
-        return match.group(1)
+        return self.get_job_info(job_id, field="StartTime")
 
     def get_job_submit_time(self, job_id):  # noqa: D102
-        result = self._remote_command_executor.run_remote_command("scontrol show jobs -o {0}".format(job_id))
-        match = re.search(r"SubmitTime=(.+?) ", result.stdout)
-        return match.group(1)
+        return self.get_job_info(job_id, field="SubmitTime")
 
     def get_job_eligible_time(self, job_id):  # noqa: D102
-        result = self._remote_command_executor.run_remote_command("scontrol show jobs -o {0}".format(job_id))
-        match = re.search(r"EligibleTime=(.+?) ", result.stdout)
-        return match.group(1)
+        return self.get_job_info(job_id, field="EligibleTime")
 
     def assert_job_submitted(self, sbatch_output):  # noqa: D102
         __tracebackhide__ = True

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -404,6 +404,16 @@ class SlurmCommands(SchedulerCommands):
         result = self._remote_command_executor.run_remote_command(check_partitions_cmd)
         return result.stdout.splitlines()
 
+    def get_partition_info(self, partition, field=None):
+        """Return partitions details. If field is provided, only the fieed is returned."""
+        result = self._remote_command_executor.run_remote_command(
+            "scontrol show partition {0}".format(partition)
+        ).stdout
+        if field is not None:
+            match = re.search(rf"(\s{field})=(\S*)", result)
+            return match.group(2)
+        return result
+
     def get_job_info(self, job_id, field=None):
         """Return job details from slurm. If field is provided, only the field is returned"""
         result = self._remote_command_executor.run_remote_command("scontrol show jobs -o {0}".format(job_id)).stdout

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -397,15 +397,16 @@ def test_slurm_config_update(
         config_file="pcluster.config.update_scheduling.yaml",
     )
 
+
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
 @pytest.mark.slurm_custom_config_parameters
 def test_slurm_custom_config_parameters(
-        region,
-        pcluster_config_reader,
-        clusters_factory,
-        test_datadir,
-        s3_bucket_factory,
-        scheduler_commands_factory,
+    region,
+    pcluster_config_reader,
+    clusters_factory,
+    test_datadir,
+    s3_bucket_factory,
+    scheduler_commands_factory,
 ):
     """Test slurm custom settings."""
     # When launching a cluster with a Yaml with custom config parameters
@@ -425,29 +426,32 @@ def test_slurm_custom_config_parameters(
     # Bulk Settings
     debug_flags = slurm_commands.get_conf_param("DebugFlags")
     # must check them individually because they can be reordered
-    assert("Steps" in debug_flags)
-    assert("Power" in debug_flags)
-    assert("CpuFrequency" in debug_flags)
-    assert("medium" == slurm_commands.get_conf_param("GpuFreqDef"))
-    assert("5000" == slurm_commands.get_conf_param("MaxStepCount"))
+    assert "Steps" in debug_flags
+    assert "Power" in debug_flags
+    assert "CpuFrequency" in debug_flags
+    assert "medium" == slurm_commands.get_conf_param("GpuFreqDef")
+    assert "5000" == slurm_commands.get_conf_param("MaxStepCount")
+
+    # Partition
+    assert "5" == slurm_commands.get_partition_info("q1", "GraceTime")
+    assert "500" == slurm_commands.get_partition_info("q1", "MaxMemPerNode")
 
     # ComputeResource 1
-    assert("50" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Weight"))
-    assert("10000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Port"))
-    assert("2000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Memory"))
+    assert "50" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Weight")
+    assert "10000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Port")
+    assert "2000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Memory")
 
     # ComputeResource 2
-    assert("150" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Weight"))
-    assert("10010" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Port"))
-    assert("2500" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Memory"))
+    assert "150" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Weight")
+    assert "10010" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Port")
+    assert "2500" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Memory")
 
     # Update the cluster changing Queue and Compute resources settings in the yaml
     # and Bulk settings with a config file in S3
 
     updated_config_file = pcluster_config_reader(
-        config_file="pcluster.config.update.yaml",
-        custom_settings_file=slurm_settings_file,
-        bucket=bucket_name)
+        config_file="pcluster.config.update.yaml", custom_settings_file=slurm_settings_file, bucket=bucket_name
+    )
 
     # apply the changes on the cluster
     logging.info("Updating the cluster to remove all the shared storage (managed storage will be retained)")
@@ -457,28 +461,31 @@ def test_slurm_custom_config_parameters(
     cluster.start()
     wait_for_computefleet_changed(cluster, "RUNNING")
 
-
     # then we expect updated custom values to be set in slurm config
     # Bulk Settings
     debug_flags = slurm_commands.get_conf_param("DebugFlags")
     # must check them individually because they can be reordered
-    assert("Steps" in debug_flags)
-    assert("Power" in debug_flags)
-    assert("CpuFrequency" in debug_flags)
-    assert("BurstBuffer" in debug_flags)
-    assert("Network" in debug_flags)
-    assert("high" == slurm_commands.get_conf_param("GpuFreqDef"))
-    assert("10000" == slurm_commands.get_conf_param("MaxStepCount"))
+    assert "Steps" in debug_flags
+    assert "Power" in debug_flags
+    assert "CpuFrequency" in debug_flags
+    assert "BurstBuffer" in debug_flags
+    assert "Network" in debug_flags
+    assert "high" == slurm_commands.get_conf_param("GpuFreqDef")
+    assert "10000" == slurm_commands.get_conf_param("MaxStepCount")
+
+    # Partition
+    assert "15" == slurm_commands.get_partition_info("q1", "GraceTime")
+    assert "1500" == slurm_commands.get_partition_info("q1", "MaxMemPerNode")
 
     # ComputeResource 1
-    assert("75" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Weight"))
-    assert("20000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Port"))
-    assert("4000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Memory"))
+    assert "75" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Weight")
+    assert "20000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Port")
+    assert "4000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Memory")
 
     # ComputeResource 2
-    assert("250" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Weight"))
-    assert("25000" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Port"))
-    assert("4100" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Memory"))
+    assert "250" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Weight")
+    assert "25000" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Port")
+    assert "4100" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Memory")
 
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -53,7 +53,7 @@ from tests.common.hit_common import (
     wait_for_num_nodes_in_scheduler,
 )
 from tests.common.mpi_common import compile_mpi_ring
-from tests.common.schedulers_common import TorqueCommands
+from tests.common.schedulers_common import SlurmCommands, TorqueCommands
 from tests.monitoring import structured_log_event_utils
 
 
@@ -396,6 +396,89 @@ def test_slurm_config_update(
         remote_command_executor,
         config_file="pcluster.config.update_scheduling.yaml",
     )
+
+@pytest.mark.usefixtures("region", "os", "instance", "scheduler")
+@pytest.mark.slurm_custom_config_parameters
+def test_slurm_custom_config_parameters(
+        region,
+        pcluster_config_reader,
+        clusters_factory,
+        test_datadir,
+        s3_bucket_factory,
+        scheduler_commands_factory,
+):
+    """Test slurm custom settings."""
+    # When launching a cluster with a Yaml with custom config parameters
+
+    # Prepare bucket
+    bucket_name = s3_bucket_factory()
+    bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+    bucket.upload_file(str(test_datadir / "custom_slurm_settings.txt"), "custom_slurm_settings.conf")
+    slurm_settings_file = f" s3://{bucket_name}/custom_slurm_settings.conf"
+
+    cluster_config = pcluster_config_reader(bucket=bucket_name)
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    slurm_commands = SlurmCommands(remote_command_executor)
+
+    # then we expect custom values to be set in slurm config
+    # Bulk Settings
+    debug_flags = slurm_commands.get_conf_param("DebugFlags")
+    # must check them individually because they can be reordered
+    assert("Steps" in debug_flags)
+    assert("Power" in debug_flags)
+    assert("CpuFrequency" in debug_flags)
+    assert("medium" == slurm_commands.get_conf_param("GpuFreqDef"))
+    assert("5000" == slurm_commands.get_conf_param("MaxStepCount"))
+
+    # ComputeResource 1
+    assert("50" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Weight"))
+    assert("10000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Port"))
+    assert("2000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Memory"))
+
+    # ComputeResource 2
+    assert("150" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Weight"))
+    assert("10010" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Port"))
+    assert("2500" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Memory"))
+
+    # Update the cluster changing Queue and Compute resources settings in the yaml
+    # and Bulk settings with a config file in S3
+
+    updated_config_file = pcluster_config_reader(
+        config_file="pcluster.config.update.yaml",
+        custom_settings_file=slurm_settings_file,
+        bucket=bucket_name)
+
+    # apply the changes on the cluster
+    logging.info("Updating the cluster to remove all the shared storage (managed storage will be retained)")
+    cluster.stop()
+    wait_for_computefleet_changed(cluster, "STOPPED")
+    cluster.update(str(updated_config_file))
+    cluster.start()
+    wait_for_computefleet_changed(cluster, "RUNNING")
+
+
+    # then we expect updated custom values to be set in slurm config
+    # Bulk Settings
+    debug_flags = slurm_commands.get_conf_param("DebugFlags")
+    # must check them individually because they can be reordered
+    assert("Steps" in debug_flags)
+    assert("Power" in debug_flags)
+    assert("CpuFrequency" in debug_flags)
+    assert("BurstBuffer" in debug_flags)
+    assert("Network" in debug_flags)
+    assert("high" == slurm_commands.get_conf_param("GpuFreqDef"))
+    assert("10000" == slurm_commands.get_conf_param("MaxStepCount"))
+
+    # ComputeResource 1
+    assert("75" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Weight"))
+    assert("20000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Port"))
+    assert("4000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Memory"))
+
+    # ComputeResource 2
+    assert("250" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Weight"))
+    assert("25000" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Port"))
+    assert("4100" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Memory"))
 
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_config_parameters/custom_slurm_settings.txt
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_config_parameters/custom_slurm_settings.txt
@@ -1,0 +1,9 @@
+#
+# Example slurm.conf file with custom settings
+#
+# Put this file on all nodes of your cluster.
+# See the slurm.conf man page for more information.
+#
+DebugFlags=Steps,Power,CpuFrequency,BurstBuffer,Network
+GpuFreqDef=high
+MaxStepCount=10000

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_config_parameters/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_config_parameters/pcluster.config.update.yaml
@@ -1,0 +1,42 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket }}
+        EnableWriteAccess: true
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    CustomSlurmSettingsIncludeFile: {{ custom_settings_file }}
+  SlurmQueues:
+    - Name: q1
+      CustomSlurmSettings:
+        GraceTime: 15
+        MaxMemPerNode: 1500
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: cr1
+          CustomSlurmSettings:
+            Port: 20000
+            RealMemory: 4000
+            Weight: 75
+          Instances:
+            - InstanceType: t2.large
+          MinCount: 0
+        - Name: cr2
+          CustomSlurmSettings:
+            Port: 25000
+            RealMemory: 4100
+            Weight: 250
+          Instances:
+            - InstanceType: t2.large
+          MinCount: 0
+

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_config_parameters/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_config_parameters/pcluster.config.yaml
@@ -1,0 +1,44 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket }}
+        EnableWriteAccess: true
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    CustomSlurmSettings:
+      - DebugFlags: Steps,Power,CpuFrequency
+      - GpuFreqDef: medium
+      - MaxStepCount: 5000
+  SlurmQueues:
+    - Name: q1
+      CustomSlurmSettings:
+        GraceTime: 5
+        MaxMemPerNode: 500
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: cr1
+          CustomSlurmSettings:
+            Port: 10000
+            RealMemory: 2000
+            Weight: 50
+          Instances:
+            - InstanceType: t2.large
+          MinCount: 0
+        - Name: cr2
+          CustomSlurmSettings:
+            Port: 10010
+            RealMemory: 2500
+            Weight: 150
+          Instances:
+            - InstanceType: t2.large
+          MinCount: 0


### PR DESCRIPTION
### Description of changes
* Add integ test that
  * launches a cluster with custom slurm settings in the yaml
  * updates cluster with custom slurm settings retrieved from S3 and changes in the yaml

### Tests
* Successfully executed the test in my personal account.

### References
* [Cookbook fix on update recipe](https://github.com/aws/aws-parallelcluster-cookbook/pull/2005)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
