### PR TITLE
Test creation and scaling limits in a cluster with maximum no of queues

### DIFF
--- a/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/pcluster.config.yaml
+++ b/tests/integration-tests/tests/scaling/test_scaling/test_multiple_jobs_submission/pcluster.config.yaml
@@ -18,7 +18,8 @@ Scheduling:
     ScaledownIdletime: {{ scaledown_idletime }}
     {% endif %}
   {{ scheduler_prefix }}Queues:
-    - Name: queue-0
+  {% for q in range(no_of_queues) %}
+    - Name: queue-{{q}}
       ComputeResources:
         - Name: compute-resource-0
           Instances:
@@ -26,3 +27,4 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
+  {% endfor %}


### PR DESCRIPTION
### Description of changes
* A cluster can now have a maximum of 100 queues
* These changes test
    * Creation of a cluster with 100 queues
    * Scaling operations are within expected time despite the overhead of having multiple queues

### Tests
* Assert that the scheduler/slurm creates the 100 partitions as expected
* Assert that scaling time is within the existing expectation

### References
* #5169 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
