### PR TITLE
`[integration-tests/resource-bucket]` Fix defect in fixture for resource-bucket

### DIFF
--- a/tests/integration-tests/README.md
+++ b/tests/integration-tests/README.md
@@ -136,7 +136,7 @@ CloudFormation / Custom Resource options:
 
 API options:
   --api-definition-s3-uri API_DEFINITION_S3_URI
-                        URI of the Docker image for the Lambda of the ParallelCluster API (default: None)
+                        URI of the OpenAPI spec of the ParallelCluster API (default: None)
   --api-infrastructure-s3-uri API_INFRASTRUCTURE_S3_URI
                         URI of the CloudFormation template for the ParallelCluster API (default: None)
   --api-uri API_URI     URI of an existing ParallelCluster API (default: None)

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -142,13 +142,8 @@ def pytest_addoption(parser):
         "--resource-bucket",
         help="(Optional) Name of bucket to use to look for standard resources like hosted CloudFormation templates.",
     )
-    parser.addoption(
-        "--lambda-layer-source",
-        help="(Optional) S3 URI of lambda layer to copy rather than building.",
-    )
-    parser.addoption(
-        "--api-definition-s3-uri", help="URI of the Docker image for the Lambda of the ParallelCluster API"
-    )
+    parser.addoption("--lambda-layer-source", help="(Optional) S3 URI of lambda layer to copy rather than building.")
+    parser.addoption("--api-definition-s3-uri", help="URI of the OpenAPI spec of the ParallelCluster API")
     parser.addoption(
         "--api-infrastructure-s3-uri", help="URI of the CloudFormation template for the ParallelCluster API"
     )

--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -102,7 +102,7 @@ def get_resource_map():
 def resource_bucket_shared(request, s3_bucket_factory_shared, lambda_layer_source):
     root = Path(pkg_resources.resource_filename(__name__, "/../.."))
     if request.config.getoption("resource_bucket"):
-        return request.config.getoption("resource_bucket")
+        return  # short-circuit this fixture if a resource-bucket is provided
 
     for region, s3_bucket in s3_bucket_factory_shared.items():
         logger.info(f"Uploading artifacts to: {s3_bucket}[{region}]")
@@ -134,5 +134,7 @@ def resource_bucket_shared(request, s3_bucket_factory_shared, lambda_layer_sourc
 
 
 @pytest.fixture(scope="class")
-def resource_bucket(region, resource_bucket_shared):
+def resource_bucket(request, region, resource_bucket_shared):
+    if request.config.getoption("resource_bucket"):
+        return request.config.getoption("resource_bucket")
     return resource_bucket_shared[region]

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -328,7 +328,7 @@ def _init_argparser():
     api_group = parser.add_argument_group("API options")
     api_group.add_argument(
         "--api-definition-s3-uri",
-        help="URI of the Docker image for the Lambda of the ParallelCluster API",
+        help="URI of the OpenAPI spec of the ParallelCluster API",
         default=TEST_DEFAULTS.get("api_definition_s3_uri"),
     )
     api_group.add_argument(


### PR DESCRIPTION
### Description of changes
* Move where we short-circuit the `resource-bucket` parameter to fix a bug
* Fix description of the `api-definition-s3-uri`

### Tests
* Use the following test_runner to run scripts out of an external bucket:

```
#!/bin/bash
python -m test_runner \
    -c configs/custom_resource.yaml \
    --key-name ${KEYNAME} \
    --key-path ${HOME}/keys/${KEYNAME}.pem \
    --resource-bucket pcluster-cfn-us-east-2 \
    --show-output \
    --vpc-stack ${VPC_STACK} \
    --use-default-iam-credentials \
    --sequential
```
During the running of the test, verify that the logs do not show any resource bucket creation.

The `test_cluster_create` test passes:

```
custom_resource/test_cluster_custom_resource.py::test_cluster_create[us-east-2-alinux2-None] ✓ 
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
