### PR TITLE
`[integ-tests/custom_resource_bucket]` Update where we store the netw…

### DIFF
--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -86,13 +86,16 @@ def policies_uri_fixture(request, region, resource_bucket):
 
 
 def get_resource_map():
-    prefix = f"parallelcluster/{get_installed_parallelcluster_version()}"
+    version = get_installed_parallelcluster_version()
+    prefix = f"parallelcluster/{version}"
     resources = {
         "api/infrastructure/parallelcluster-api.yaml": f"{prefix}/api/parallelcluster-api.yaml",
         "api/spec/openapi/ParallelCluster.openapi.yaml": f"{prefix}/api/ParallelCluster.openapi.yaml",
         "cloudformation/custom_resource/cluster.yaml": f"{prefix}/templates/custom_resource/cluster.yaml",
-        "cloudformation/networking/public.cfn.json": f"{prefix}/templates/networking/public.cfn.json",
-        "cloudformation/networking/public-private.cfn.json": f"{prefix}/templates/networking/public-private.cfn.json",
+        "cloudformation/networking/public.cfn.json": f"{prefix}/templates/networking/public-{version}.cfn.json",
+        "cloudformation/networking/public-private.cfn.json": (
+            f"{prefix}/templates/networking/public-private-{version}.cfn.json"
+        ),
         "cloudformation/policies/parallelcluster-policies.yaml": f"{prefix}/templates/policies/policies.yaml",
     }
     return resources


### PR DESCRIPTION
…orking stack to match prod.


### Description of changes
* We are storing artifacts in an ephemeral bucket (called `resource_bucket`) to mirror the organization in prod. This updates where we store the networking stack artifacts to match the prod location.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
