### PR TITLE
Reduce number of tests executed in develop and released

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -31,7 +31,7 @@ cfn-init:
     dimensions:
       - regions: ["af-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_ONE_PER_DISTRO }}
+        oss: ["rhel8"]
         schedulers: ["slurm"]
   test_cfn_init.py::test_install_args_quotes:
     dimensions:
@@ -89,7 +89,7 @@ configure:
     dimensions:
       - regions: ["af-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_ONE_PER_DISTRO }}
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
       - regions: ["ap-southeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
@@ -122,7 +122,7 @@ configure:
     dimensions:
       - regions: ["us-east-1"]
         instances: {{ common.INSTANCES_EFA_UNSUPPORTED_X86 }}
-        oss: ["alinux2"]
+        oss: ["rhel8"]
         schedulers: ["slurm"]
 
 create:
@@ -161,7 +161,7 @@ create:
       - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         schedulers: ["slurm"]
-        oss: ["ubuntu1804", "ubuntu2004"]
+        oss: ["ubuntu2004"]
 createami:
   test_createami.py::test_invalid_config:
     dimensions:
@@ -172,12 +172,12 @@ createami:
     dimensions:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_ONE_PER_DISTRO }}
+        oss: ["ubuntu2004"]
   test_createami.py::test_kernel4_build_image_run_cluster:
     dimensions:
       - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        schedulers: ["awsbatch", "slurm"]
+        schedulers: ["slurm"]
         oss: ["alinux2"]
   test_createami.py::test_build_image_custom_components:
     dimensions:
@@ -186,7 +186,7 @@ createami:
         oss: ["rhel8"]
       - regions: ["eu-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["alinux2"]
+        oss: ["centos7"]
   test_createami.py::test_build_image_wrong_pcluster_version:
     dimensions:
       - regions: ["ca-central-1"]
@@ -211,28 +211,13 @@ dcv:
       # DCV on GPU enabled instance
       - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
         instances: ["g4dn.2xlarge"]
-        oss: {{common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
-        schedulers: ["slurm"]
-      # DCV on ARM
-      - regions: ["sa-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["alinux2", "ubuntu1804"]
+        oss: ["centos7"]
         schedulers: ["slurm"]
       # DCV on ARM + GPU
       - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
         instances: ["g5g.2xlarge"]
-        oss: ["alinux2", "ubuntu1804"]
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
-      # DCV on Batch
-      - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
-        instances: ["g4dn.2xlarge"]
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
-      # DCV on Batch + ARM
-      - regions: ["us-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
       # DCV in cn regions and non GPU enabled instance
       - regions: ["cn-northwest-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -253,16 +238,12 @@ disable_hyperthreading:
   test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
     dimensions:
       - regions: ["us-west-1"]
-        instances: ["m4.xlarge"]
-        oss: ["alinux2", "centos7"]
-        schedulers: ["slurm"]
-      - regions: ["us-west-1"]
         instances: ["c5.xlarge"]
-        oss: ["ubuntu1804", "ubuntu2004"]
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
         benchmarks:
           - mpi_variants: ["openmpi", "intelmpi"]
-            num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+            num_instances: [5] # Change the head node instance type if you'd test more than 30 instances
             slots_per_instance: 2
             partition: "ht-disabled"
             osu_benchmarks:
@@ -285,7 +266,7 @@ efa:
     dimensions:
       - regions: ["sa-east-1"]
         instances: ["c5n.9xlarge"]
-        oss: ["alinux2"]
+        oss: ["rhel8"]
         schedulers: ["slurm"]
       - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
         instances: ["p4d.24xlarge"]
@@ -293,11 +274,11 @@ efa:
         schedulers: ["slurm"]
       - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
         instances: ["c6gn.16xlarge"]
-        oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
+        oss: ["centos7"]
         schedulers: ["slurm"]
       - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
         instances: [{{ common.instance("instance_type_1") }}]
-        oss: [ "alinux2", "centos7", "ubuntu2004" ]
+        oss: ["ubuntu2004"]
         schedulers: [ "slurm" ]
 iam:
   test_iam.py::test_iam_policies:
@@ -321,8 +302,8 @@ iam:
     dimensions:
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["slurm", "awsbatch"]
+        oss: ["rhel8"]
+        schedulers: ["slurm"]
   test_iam.py::test_iam_resource_prefix:
     dimensions:
       - regions: [ "eu-north-1" ]
@@ -347,8 +328,8 @@ networking:
     dimensions:
       - regions: ["me-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["slurm", "awsbatch"]
+        oss: ["rhel8"]
+        schedulers: ["slurm"]
   test_networking.py::test_public_network_topology:
     dimensions:
       - regions: ["af-south-1", "us-gov-east-1", "cn-northwest-1"]
@@ -361,11 +342,11 @@ networking:
         # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
       - regions: ["us-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["centos7"]
         schedulers: ["slurm"]
       - regions: ["us-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: ["rhel8"]
         schedulers: ["slurm"]
       - regions: ["cn-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -380,27 +361,19 @@ networking:
       - regions: ["ap-northeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "awsbatch"]
+        schedulers: ["slurm"]
   test_security_groups.py::test_additional_sg_and_ssh_from:
     dimensions:
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
-      - regions: ["eu-north-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
   test_security_groups.py::test_overwrite_sg:
     dimensions:
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["centos7"]
         schedulers: ["slurm"]
-      - regions: ["eu-north-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
   test_placement_group.py::test_placement_group:
     dimensions:
       - regions: ["eu-central-1"]
@@ -416,17 +389,17 @@ scaling:
     dimensions:
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["rhel8"]
         schedulers: ["slurm"]
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
   test_mpi.py::test_mpi_ssh:
     dimensions:
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["centos7"]
         schedulers: ["slurm"]
 schedulers:
   test_awsbatch.py::test_awsbatch:
@@ -449,24 +422,20 @@ schedulers:
     dimensions:
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
   test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
     dimensions:
       - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["centos7"]
         schedulers: ["slurm"]
       - regions: ["ap-northeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: ["rhel8"]
         schedulers: ["slurm"]
   test_slurm.py::test_slurm_scaling:
     dimensions:
-      - regions: ["us-west-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_ONE_PER_DISTRO }}
-        schedulers: ["slurm"]
       - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
         instances: [{{ common.instance("instance_type_1") }}]
         oss: [ "alinux2" ]
@@ -481,13 +450,13 @@ schedulers:
     dimensions:
       - regions: ["ca-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["rhel8"]
         schedulers: ["slurm"]
   test_slurm.py::test_slurm_protected_mode_on_cluster_create:
     dimensions:
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["centos7"]
         schedulers: ["slurm"]
   test_slurm.py::test_fast_capacity_failover:
     dimensions:
@@ -499,13 +468,13 @@ schedulers:
     dimensions:
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["ubuntu1804"]
         schedulers: ["slurm"]
   test_slurm.py::test_slurm_memory_based_scheduling:
     dimensions:
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
   test_slurm.py::test_scontrol_reboot:
     dimensions:
@@ -535,13 +504,13 @@ schedulers:
     dimensions:
       - regions: ["us-east-1", "ap-south-1"]
         instances:  {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2", "ubuntu2004"]
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
   test_slurm_accounting.py::test_slurm_accounting_disabled_to_enabled_update:
     dimensions:
       - regions: ["us-west-2"]
         instances:  {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["centos7", "ubuntu1804"]
+        oss: ["centos7"]
         schedulers: ["slurm"]
   test_slurm.py::test_slurm_reconfigure_race_condition:
      dimensions:
@@ -574,7 +543,7 @@ storage:
     dimensions:
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["rhel8"]
         schedulers: ["slurm"]
         benchmarks:
           - mpi_variants: ["openmpi", "intelmpi"]
@@ -584,7 +553,7 @@ storage:
               collective: ["osu_allreduce", "osu_alltoall"]
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
       - regions: ["cn-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -598,7 +567,7 @@ storage:
     dimensions:
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["centos7"]
         schedulers: ["slurm"]
   test_fsx_lustre.py::test_fsx_lustre_configuration_options:
     dimensions:
@@ -610,11 +579,11 @@ storage:
     dimensions:
       - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_ONE_PER_DISTRO }}
+        oss: ["rhel8"]
         schedulers: ["slurm"]
       - regions: ["ap-southeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
   # EFS tests can be done in any region.
   test_efs.py::test_efs_compute_az:
@@ -622,7 +591,7 @@ storage:
       - regions: ["ca-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
-        schedulers: ["slurm", "awsbatch"]
+        schedulers: ["slurm"]
   test_efs.py::test_efs_same_az:
     dimensions:
       - regions: ["ca-central-1"]
@@ -633,13 +602,13 @@ storage:
   # We should consider this when assigning dimensions to each test.
   test_efs.py::test_multiple_efs:
     dimensions:
-      - regions: ["ca-central-1", "cn-northwest-1"]
+      - regions: ["cn-northwest-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_BATCH }}
+        oss: ["alinux2"]
         schedulers: ["awsbatch"]
       - regions: [ "ca-central-1" ]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: ["ubuntu2004"]
         schedulers: [ "slurm" ]
         benchmarks:
           - mpi_variants: ["openmpi", "intelmpi"]
@@ -649,7 +618,7 @@ storage:
               collective: ["osu_allreduce", "osu_alltoall"]
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_GOVCLOUD_X86 }}
+        oss: ["rhel8"]
         schedulers: ["slurm"]
   test_raid.py::test_raid_fault_tolerance_mode:
     dimensions:
@@ -661,39 +630,29 @@ storage:
     dimensions:
       - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["ubuntu2004", "centos7"]
         schedulers: ["slurm"]
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_GOVCLOUD_X86 }}
+        oss: ["rhel8"]
         schedulers: ["slurm"]
-      - regions: ["ap-south-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_BATCH }}
-        schedulers: ["awsbatch"]
   test_ebs.py::test_ebs_multiple:
     dimensions:
-      - regions: ["us-east-2"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["awsbatch"]
       - regions: ["us-east-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"]
         schedulers: ["slurm"]
   test_ebs.py::test_ebs_single:
     dimensions:
-      {%- for region, oss in [("us-east-2", common.OSS_COMMERCIAL_X86), ("cn-northwest-1", common.OSS_CHINA_X86), ("us-gov-west-1", common.OSS_GOVCLOUD_X86)] %}
-      - regions: ["{{ region }}"]
+      - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ oss }}
+        oss: ["alinux2"]
         schedulers: ["slurm"]
-      {%- endfor %}
   test_ebs.py::test_ebs_snapshot:
     dimensions:
       - regions: ["us-east-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["rhel8"]
         schedulers: ["slurm"]
       - regions: ["cn-northwest-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -735,7 +694,7 @@ update:
     dimensions:
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["ubuntu2004"]
   test_update.py::test_update_compute_ami:
     dimensions:
       - regions: ["eu-west-1"]
@@ -757,11 +716,11 @@ update:
     dimensions:
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
       - regions: ["ap-northeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: ["centos7"]
         schedulers: ["slurm"]
   test_update.py::test_multi_az_create_and_update:
     dimensions:
@@ -788,9 +747,9 @@ log_rotation:
     dimensions:
       - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
       - regions: ["ap-northeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["alinux2", "ubuntu1804"]
+        oss: ["alinux2"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -1,4 +1,3 @@
-{%- set SCHEDULER_PLUGIN_TESTS = false -%}
 ad_integration:
   test_ad_integration.py::test_ad_integration:
     dimensions:
@@ -27,19 +26,6 @@ arm_pl:
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: {{ common.OSS_COMMERCIAL_ARM }}
         schedulers: ["slurm"]
-{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
-scheduler_plugin:
-  test_scheduler_plugin.py::test_scheduler_plugin_integration:
-    dimensions:
-      - regions: ["ca-central-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
-        schedulers: ["plugin"]
-      - regions: ["ap-northeast-1"]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM_NO_RHEL8 }}
-        schedulers: ["plugin"]
-{%- endif %}
 cfn-init:
   test_cfn_init.py::test_replace_compute_on_failure:
     dimensions:
@@ -465,12 +451,6 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
-{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
-      - regions: ["eu-central-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_ONE_PER_DISTRO_NO_RHEL8 }}
-        schedulers: ["slurm_plugin"]
-{%- endif %}
   test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
     dimensions:
       - regions: ["ap-south-1"]
@@ -487,12 +467,6 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: {{ common.OSS_ONE_PER_DISTRO }}
         schedulers: ["slurm"]
-{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
-      - regions: ["me-south-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["slurm_plugin"]
-{%- endif %}
       - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
         instances: [{{ common.instance("instance_type_1") }}]
         oss: [ "alinux2" ]
@@ -503,25 +477,12 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm"]
-{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
-      - regions: ["ca-central-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
-        schedulers: ["slurm_plugin"]
-{%- endif %}
   test_slurm.py::test_slurm_protected_mode:
     dimensions:
       - regions: ["ca-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm"]
-# Temporarily disable test_protected_mode for the Slurm scheduler plugin
-#{%- if SCHEDULER_PLUGIN_TESTS is not defined or SCHEDULER_PLUGIN_TESTS == true %}
-#      - regions: ["ca-central-1"]
-#        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-#        oss: ["alinux2"]
-#        schedulers: ["slurm_plugin"]
-#{%- endif %}
   test_slurm.py::test_slurm_protected_mode_on_cluster_create:
     dimensions:
       - regions: ["ap-east-1"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -404,7 +404,7 @@ scaling:
 schedulers:
   test_awsbatch.py::test_awsbatch:
     dimensions:
-      - regions: ["eu-north-1", "us-gov-west-1", "cn-north-1"]
+      - regions: ["us-gov-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
@@ -414,7 +414,7 @@ schedulers:
         schedulers: ["awsbatch"]
   test_awsbatch.py::test_awsbatch_defaults:
     dimensions:
-      - regions: ["eu-north-1", "us-gov-west-1", "cn-north-1"]
+      - regions: ["cn-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
@@ -502,7 +502,7 @@ schedulers:
         schedulers: ["slurm"]
   test_slurm_accounting.py::test_slurm_accounting:
     dimensions:
-      - regions: ["us-east-1", "ap-south-1"]
+      - regions: ["ap-south-1"]
         instances:  {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004"]
         schedulers: ["slurm"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -7,9 +7,9 @@ ad_integration:
         schedulers: ["slurm"]
         benchmarks:
           - mpi_variants: ["openmpi"]
-            num_instances: [100]
+            num_instances: [5]
             osu_benchmarks:
-              collective: ["osu_allreduce", "osu_alltoall"]
+              collective: ["osu_alltoall"]
       - regions: ["ap-southeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu1804"]
@@ -546,11 +546,11 @@ storage:
         oss: ["rhel8"]
         schedulers: ["slurm"]
         benchmarks:
-          - mpi_variants: ["openmpi", "intelmpi"]
-            num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+          - mpi_variants: ["openmpi"]
+            num_instances: [5] # Change the head node instance type if you'd test more than 30 instances
             slots_per_instance: 2
             osu_benchmarks:
-              collective: ["osu_allreduce", "osu_alltoall"]
+              collective: ["osu_alltoall"]
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: ["ubuntu2004"]
@@ -611,11 +611,11 @@ storage:
         oss: ["ubuntu2004"]
         schedulers: [ "slurm" ]
         benchmarks:
-          - mpi_variants: ["openmpi", "intelmpi"]
-            num_instances: [20] # Change the head node instance type if you'd test more than 30 instances
+          - mpi_variants: ["intelmpi"]
+            num_instances: [5] # Change the head node instance type if you'd test more than 30 instances
             slots_per_instance: 2
             osu_benchmarks:
-              collective: ["osu_allreduce", "osu_alltoall"]
+              collective: ["osu_alltoall"]
       - regions: ["us-gov-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["rhel8"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -23,15 +23,15 @@ test-suites:
           schedulers: ["slurm"]
         - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
           instances: ["c6gn.16xlarge"]
-          oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
+          oss: ["rhel8"]
           schedulers: ["slurm"]
         - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
           instances: ["hpc6id.32xlarge"]
-          oss: ["alinux2"]
+          oss: ["centos7"]
           schedulers: [ "slurm" ]
         - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
           instances: [{{ common.instance("instance_type_1") }}]
-          oss: [ "alinux2", "centos7", "ubuntu2004" ]
+          oss: ["ubuntu2004"]
           schedulers: [ "slurm" ]
     test_fabric.py::test_fabric:
       dimensions:
@@ -64,51 +64,39 @@ test-suites:
   scaling:
     # FixMe: MPI tests configs are duplications of the test in common.yaml.
     # The duplications are necessary because the scaling section here overwrites the scaling section in common.yaml.
-    test_mpi.py::test_mpi:
+    test_mpi.py::test_mpi:  # TODO: move outside of the scaling dir
       dimensions:
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["rhel8"]
           schedulers: ["slurm"]
         - regions: ["ca-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          oss: ["ubuntu2004"]
           schedulers: ["slurm"]
     test_mpi.py::test_mpi_ssh:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["centos7"]
           schedulers: ["slurm"]
     test_scaling.py::test_multiple_jobs_submission:
       dimensions:
         - regions: {{ common.REGIONS_COMMERCIAL }}
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["ubuntu2004"]
           schedulers: ["slurm"]
         - regions: {{ common.REGIONS_CHINA }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_CHINA_X86 }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
         - regions: {{ common.REGIONS_GOVCLOUD }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_GOVCLOUD_X86 }}
-          schedulers: ["slurm"]
-        - regions: ["us-west-2"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
-          schedulers: {{ common.SCHEDULERS_TRAD }}
-        - regions: ["cn-north-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_CHINA_ARM }}
-          schedulers: ["slurm"]
-        - regions: ["us-gov-east-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_GOVCLOUD_ARM }}
+          oss: ["rhel8"]
           schedulers: ["slurm"]
   trainium:
     test_trainium.py::test_trainium:
       dimensions:
         - regions: ["usw2-az4"]  # do not move, unless instance type support is moved as well
           schedulers: ["slurm"]
-          oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
+          oss: ["ubuntu2004"]


### PR DESCRIPTION
### Description of changes

This change removes about *247* tests in develop and *133* in released (for 3.6.0 that contains rhel8 too).

#### 1. Remove scheduler plugin tests from common.yaml
#### 2. Remove or reduce useless benchmark execution

#### 3. Reduce tests by redistributing region dimension - This change removes *5* tests.

* test_awsbatch.py redistributed regions between awsbatch tests: 7 -> 3
* test_slurm_accounting.py::test_slurm_accounting: 2 -> 1

#### 4. Remove OS dimension from no OS specific tests - This change removes about *157* tests.

* test_cfn_init.py::test_replace_compute_on_failure: 4 -> 1
* test_pcluster_configure.py::test_pcluster_configure: 4 -> 1
* test_create.py::test_cluster_creation_with_invalid_ebs: 2 -> 1
* test_createami.py OSes redistributed between different createami tests:
    * test_createami.py::test_build_image: 5 -> 1
    * test_createami.py::test_kernel4_build_image_run_cluster: removed batch case 2 -> 1
* test_dcv.py::test_dcv_configuration OSes redistributed between different dcv tests:
    * ARM without GPU case removed because it is a subset of ARM + GPU: 2 -> 0
    * ARM + GPU: 2 -> 1
    * DCV on Batch removed: 2 -> 0
* test_disable_hyperthreading.py::test_hit_disable_hyperthreading: 4 -> 1
* test_iam.py::test_s3_read_write_resource: removed batch: 2 -> 1
* test_cluster_networking.py::test_existing_eip: removed batch: 2 -> 1
* test_cluster_networking.py::test_cluster_in_no_internet_subnet redistributed: 12 -> 4
* test_multi_cidr.py::test_multi_cidr: removed batch: 2 -> 1
* test_security_groups.py::test_additional_sg_and_ssh_from removed batch: 2 -> 1
* test_security_groups.py::test_overwrite_sg removed batch: 2 -> 1
* test_mpi.py::test_mpi most important OSes redistributed between different mpi tests: 15 -> 3
* test_slurm.py redistributed:
    * test_slurm.py::test_slurm: 5 -> 1
    * test_slurm.py::test_slurm_pmix: 10 -> 2
    * test_slurm.py::test_slurm_scaling: 4 -> 1
    * test_slurm.py::test_slurm_protected_mode: mixed OSes
    * test_slurm_accounting.py::test_slurm_accounting: 2 -> 1
    * test_slurm_accounting.py::test_slurm_accounting_disabled_to_enabled_update: 2 -> 1
* test_fsx_lustre.py::test_multiple_fsx: 10 -> 2
* test_fsx_lustre.py::test_multi_az_fsx: 5 -> 1
* test_fsx_lustre.py::test_fsx_lustre_backup: 9 -> 2
* test_efs.py::test_efs_compute_az: removed batch: 2 -> 1
* test_efs.py::test_multiple_efs: 11 -> 3
* test_raid.py::test_raid_performance_mode: 10 -> 3
* test_ebs.py::test_ebs_multiple: removed batch 2 -> 1
* test_ebs.py::test_ebs_single: redistributed between ebs tests 13 -> 1
* test_update.py::test_update_slurm: 5 -> 1
* test_update.py::test_dynamic_file_systems_update: 10 -> 2
* test_log_rotation.py::test_log_rotation: 7 -> 2
* test_efa.py::test_efa redistributed between different efa tests: 9 -> 5
* test_scaling.py::test_multiple_jobs_submission: 26 -> 3
* test_trainium.py::test_trainium: 3 -> 1

### Tests
Tested cluster configuration by running test_runner.py in dry-run mode
* develop.yaml - before:`510 tests collected` - after: `263 tests collected`
* released.yaml - before: `373 tests collected` - after: `240 tests collected`

