### PR TITLE
Fix logging order of CDK template generation

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -45,12 +45,11 @@ class CDKTemplateBuilder:
             ClusterCdkStack(app, output_file, stack_name, cluster_config, bucket, log_group_name)
 
             cloud_assembly = app.synth()
+            LOGGER.info("CDK template generation completed successfully")
 
             cdk_artifacts_manager = CDKArtifactsManager(cloud_assembly)
             assets_metadata = cdk_artifacts_manager.upload_assets(bucket=bucket)
             generated_template = cdk_artifacts_manager.get_template_body()
-
-        LOGGER.info("CDK template generation completed successfully")
 
         return generated_template, assets_metadata
 

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -877,7 +877,6 @@ def test_cluster_resource_distribution_in_stacks(
     raises_error: bool,
 ):
     mock_aws_api(mocker)
-    "ValueError"
     mock_bucket_object_utils(mocker)
     rendered_config_file = pcluster_config_reader(
         "variable_queue_compute_resources.yaml", no_of_compute_resources_per_queue=no_of_compute_resources_per_queue


### PR DESCRIPTION
### Description of changes
* The CDK generation completion info log is logged after uploading the nested stack template assets. This commit simply moves it to the step after doing the CDK synthesis.
* This commit also removes an unnecessary expression statement added in a previous PR.

### Tests
* Ran existing unit tests

### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
