### PR TITLE
Optimize integration tests for both develop and released

### DIFF
--- a/tests/integration-tests/configs/common.jinja2
+++ b/tests/integration-tests/configs/common.jinja2
@@ -25,11 +25,3 @@
         "{{ instance_key }}"
     {%- endif -%}
 {%- endmacro -%}
-
-{%- set OSS_COMMERCIAL_X86_NO_RHEL8 = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004"] -%}
-{%- set OSS_COMMERCIAL_ARM_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
-{%- set OSS_CHINA_X86_NO_RHEL8  = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
-{%- set OSS_CHINA_ARM_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
-{%- set OSS_GOVCLOUD_X86_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
-{%- set OSS_GOVCLOUD_ARM_NO_RHEL8 = ["alinux2", "ubuntu1804", "ubuntu2004"] -%}
-{%- set OSS_ONE_PER_DISTRO_NO_RHEL8 = ["centos7", "alinux2", "ubuntu2004"] -%}

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -68,12 +68,8 @@ cloudwatch_logging:
   test_compute_console_output_logging.py::test_custom_action_error:
     dimensions:
       - regions: ["ap-east-1"]
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
+        oss: ["rhel8"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        schedulers: ["slurm"]
-      - regions: ["us-west-2"]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
         schedulers: ["slurm"]
 configure:
   test_pcluster_configure.py::test_pcluster_configure:
@@ -196,7 +192,7 @@ monitoring:
     dimensions:
       - regions: ["af-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2", "ubuntu2004"]
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
 dcv:
   test_dcv.py::test_dcv_configuration:

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -3,17 +3,13 @@ ad_integration:
     dimensions:
       - regions: [ "ap-southeast-1" ]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["alinux2", "rhel8"]
         schedulers: ["slurm"]
         benchmarks:
           - mpi_variants: ["openmpi"]
             num_instances: [5]
             osu_benchmarks:
               collective: ["osu_alltoall"]
-      - regions: ["ap-southeast-2"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu1804"]
-        schedulers: ["slurm"]
       - regions: ["eu-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004", "centos7"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -171,13 +171,15 @@ createami:
         schedulers: ["slurm"]
         oss: ["alinux2"]
   test_createami.py::test_build_image_custom_components:
+    # Test arn custom component with combination (eu-west-1, m6g.xlarge, alinux2)
+    # Test script custom component with combination (ap-southeast-2, c5.xlarge, ubuntu2004)
     dimensions:
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["rhel8"]
+        oss: ["ubuntu2004"]
       - regions: ["eu-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["centos7"]
+        oss: ["alinux2"]
   test_createami.py::test_build_image_wrong_pcluster_version:
     dimensions:
       - regions: ["ca-central-1"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -573,13 +573,9 @@ storage:
         schedulers: ["slurm"]
   test_fsx_lustre.py::test_fsx_lustre_backup:
     dimensions:
-      - regions: ["eu-south-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["rhel8"]
-        schedulers: ["slurm"]
       - regions: ["ap-southeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu1804"]
         schedulers: ["slurm"]
   # EFS tests can be done in any region.
   test_efs.py::test_efs_compute_az:

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -168,7 +168,7 @@ createami:
     dimensions:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2004", "alinux2", "ubuntu1804"]
   test_createami.py::test_kernel4_build_image_run_cluster:
     dimensions:
       - regions: ["eu-south-1"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -141,7 +141,7 @@ create:
     dimensions:
       - regions: ["ap-northeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        schedulers: ["slurm", "awsbatch"]
+        schedulers: ["slurm"]
         oss: ["alinux2"]
   test_create.py::test_cluster_creation_with_invalid_ebs:
     dimensions:

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -45,7 +45,7 @@ cli_commands:
 cloudwatch_logging:
   test_cloudwatch_logging.py::test_cloudwatch_logging:
     dimensions:
-      # 1) run the test for all of the schedulers with alinux2
+      # 1) run the test for all the schedulers with alinux2
       - regions: ["cn-northwest-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
@@ -54,15 +54,10 @@ cloudwatch_logging:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["awsbatch"]
-      # 2) run the test for all x86 OSes with slurm
-      - regions: ["ap-east-1"]
-        instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.OSS_COMMERCIAL_X86 }}
-        schedulers: ["slurm"]
-      # 3) run the test for all ARM OSes on an ARM instance
+      # 2) run the test for all OSes with slurm
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.OSS_COMMERCIAL_ARM }}
+        oss: ["ubuntu2004", "rhel8", "centos7"]
         schedulers: ["slurm"]
   test_compute_console_output_logging.py::test_console_output_with_monitoring_disabled:
     dimensions:

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -744,8 +744,3 @@ log_rotation:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004"]
         schedulers: ["slurm"]
-      - regions: ["ap-northeast-1"]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["alinux2"]
-        schedulers: ["slurm"]
-

--- a/tests/integration-tests/configs/new_os.yaml
+++ b/tests/integration-tests/configs/new_os.yaml
@@ -1,131 +1,344 @@
-{%- import 'common.jinja2' as common -%}
-{%- set REGION = ["##PLACEHOLDER##"] -%}
+{%- import 'common.jinja2' as common with context -%}
 {%- set NEW_OS = ["##PLACEHOLDER##"] -%}
 ---
 test-suites:
-  scaling:
-    test_mpi.py::test_mpi:
+  pcluster_api:
+    test_api.py::test_cluster_slurm:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: [ "sa-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-  schedulers:
-    test_slurm.py::test_slurm:
+  ad_integration:
+    test_ad_integration.py::test_ad_integration:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: ["ap-southeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-    test_awsbatch.py::test_awsbatch:
+          schedulers: ["slurm"]
+          benchmarks:
+            - mpi_variants: [ "openmpi", "intelmpi" ]
+              num_instances: [ 4 ]
+              slots_per_instance: 2
+              osu_benchmarks:
+                collective: [ "osu_alltoall" ]
+  arm_pl:
+    test_arm_pl.py::test_arm_pl:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: ["ap-southeast-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["ubuntu2004"]
+          schedulers: ["slurm"]
+  cfn-init:
+    test_cfn_init.py::test_replace_compute_on_failure:
+      dimensions:
+        - regions: ["af-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["rhel8"]
+          schedulers: [ "slurm" ]
+  cli_commands:
+    test_cli_commands.py::test_slurm_cli_commands:
+      dimensions:
+        - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-  storage:
-    test_fsx_lustre.py::test_fsx_lustre:
+          schedulers: ["slurm"]
+  cloudwatch_logging:
+    test_cloudwatch_logging.py::test_cloudwatch_logging:
       dimensions:
-        - regions: {{ REGION }}
+        # 2) run the test for all x86 OSes with slurm
+        - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-        - regions: {{ REGION }}
+          oss:  ["ubuntu2004"]
+          schedulers: ["slurm"]
+        # 3) run the test for all ARM OSes on an ARM instance
+        - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-    test_efs.py::test_efs_compute_az:
+          oss:  ["alinux2"]
+          schedulers: ["slurm"]
+    test_compute_console_output_logging.py::test_custom_action_error:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: [ "ap-east-1" ]
+          oss: ["rhel8"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-    test_ebs.py::test_ebs_single:
-      dimensions:
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-    test_ephemeral.py::test_head_node_stop:
-      dimensions:
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-  dcv:
-    test_dcv.py::test_dcv_configuration:
-      dimensions:
-        # DCV on GPU enabled instance
-        - regions: {{ REGION }}
-          instances: ["g3.8xlarge"]
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-        # DCV on non GPU enabled instance
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-  efa:
-    test_efa.py::test_efa:
-      dimensions:
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
   configure:
     test_pcluster_configure.py::test_pcluster_configure:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-        - regions: {{ REGION }}
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
+          oss: {{ OSS_ONE_PER_DISTRO }}
+          schedulers: ["slurm"]
+  createami:
+    test_createami.py::test_build_image:
+      dimensions:
+        - regions: ["eu-west-3"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2", "ubuntu2004", "centos7", "rhel8"]
+    test_createami.py::test_kernel4_build_image_run_cluster:
+      dimensions:
+        - regions: ["eu-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          schedulers: ["awsbatch", "slurm"]
+          oss: ["alinux2"]
+  dcv:
+    test_dcv.py::test_dcv_configuration:
+      dimensions:
+        # DCV on GPU enabled instance
+        - regions: ["us-east-1"]
+          instances: ["g4dn.2xlarge"]
+          oss: ["ubuntu1804"]
+          schedulers: ["slurm"]
+        # DCV on ARM + GPU
+        - regions: ["us-east-1"]
+          instances: ["g5g.2xlarge"]
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
+  disable_hyperthreading:
+    test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
+      dimensions:
+        - regions: ["us-west-1"]
+          instances: ["m4.xlarge"]
+          oss: ["alinux2", "centos7", "rhel8"]
+          schedulers: ["slurm"]
+          benchmarks:
+            - mpi_variants: [ "openmpi", "intelmpi" ]
+              num_instances: [ 4 ]
+              slots_per_instance: 2
+              osu_benchmarks:
+                collective: [ "osu_alltoall" ]
+  dns:
+    test_dns.py::test_hit_no_cluster_dns_mpi:
+      dimensions:
+        - regions: ["af-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+  efa:
+    test_efa.py::test_efa:
+      dimensions:
+        - regions: ["sa-east-1"]
+          instances: ["c5n.9xlarge"]
+          oss: ["alinux2", "rhel8"]
+          schedulers: ["slurm"]
+        - regions: ["use1-az6"]   # do not move, unless capacity reservation is moved as well
+          instances: ["p4d.24xlarge"]
+          oss: ["rhel8"]
+          schedulers: ["slurm"]
+        - regions: ["us-east-1"]
+          instances: ["c6gn.16xlarge"]
+          oss: ["ubuntu2004", "rhel8"]
+          schedulers: ["slurm"]
+  intel_hpc:
+    test_intel_hpc.py::test_intel_hpc:
+      dimensions:
+        - regions: ["us-east-2"]
+          instances: ["c5.18xlarge"]
+          oss: ["centos7"]
+          schedulers: ["slurm"]
   networking:
     test_cluster_networking.py::test_cluster_in_private_subnet:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: ["me-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ NEW_OS }}
-          schedulers: [ "slurm" ]
-    # Useful for instances with multiple network interfaces
+          oss: ["centos7", "rhel8"]
+          schedulers: ["slurm"]
+    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
+      dimensions:
+        # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an
+        # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
+        - regions: ["us-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
-        - regions: {{ REGION }}
-          instances: [ "p4d.24xlarge" ]
-          oss: {{ NEW_OS }}
+        - regions: ["ap-northeast-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["rhel8"]
+          schedulers: ["slurm"]
+    test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
+      dimensions:
+        - regions: [ "us-west-2" ]
+          oss: [ "rhel8" ]
+  scaling:
+    test_scaling.py::test_multiple_jobs_submission:
+      dimensions:
+        - regions: {{ common.REGIONS_COMMERCIAL }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["rhel8"]
           schedulers: [ "slurm" ]
+        - regions: {{ common.REGIONS_CHINA }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["rhel8"]
+          schedulers: [ "slurm" ]
+        - regions: {{ common.REGIONS_GOVCLOUD }}
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["rhel8"]
+          schedulers: [ "slurm" ]
+        - regions: [ "us-west-2" ]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["rhel8"]
+          schedulers: {{ common.SCHEDULERS_TRAD }}
+        - regions: [ "cn-north-1" ]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["rhel8"]
+          schedulers: [ "slurm" ]
+        - regions: [ "us-gov-east-1" ]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["rhel8"]
+          schedulers: [ "slurm" ]
+    test_mpi.py::test_mpi:
+      dimensions:
+        - regions: ["eu-north-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ OSS_COMMERCIAL_ARM }}
+          schedulers: ["slurm"]
+    test_mpi.py::test_mpi_ssh:
+      dimensions:
+        - regions: ["eu-north-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+  schedulers:
+    test_awsbatch.py::test_awsbatch:
+      dimensions:
+        - regions: ["eu-north-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["awsbatch"]
+    test_slurm.py::test_slurm:
+      dimensions:
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+    test_slurm.py::test_slurm_pmix:
+      dimensions:
+        - regions: ["ap-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+        - regions: ["ap-southeast-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ OSS_COMMERCIAL_ARM }}
+          schedulers: ["slurm"]
+    test_slurm.py::test_slurm_scaling:
+      dimensions:
+        - regions: ["us-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ OSS_ONE_PER_DISTRO }}
+          schedulers: ["slurm"]
+  storage:
+    # Commercial regions that can't test FSx: ap-northeast-1, ap-southeast-1, ap-southeast-2, eu-central-1, eu-north-1, eu-west-1, eu-west-2, us-east-1, us-east-2, us-west-1, us-west-2
+    test_fsx_lustre.py::test_fsx_lustre:
+      dimensions:
+        - regions: ["eu-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7", "rhel8"]
+          schedulers: ["slurm"]
+        - regions: ["eu-north-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["ubuntu2004", "rhel8"]
+          schedulers: ["slurm"]
+    # The checks performed in test_multiple_fsx is the same as test_fsx_lustre.
+    # We should consider this when assigning dimensions to each test.
+    test_fsx_lustre.py::test_multiple_fsx:
+      dimensions:
+        - regions: ["eu-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ OSS_COMMERCIAL_ARM }}
+          schedulers: ["slurm"]
+          benchmarks:
+            - mpi_variants: [ "openmpi", "intelmpi" ]
+              num_instances: [ 4 ]
+              slots_per_instance: 2
+              osu_benchmarks:
+                collective: [ "osu_alltoall" ]
+    test_fsx_lustre.py::test_fsx_lustre_configuration_options:
+      dimensions:
+        - regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2", "rhel8"]
+          schedulers: ["slurm"]
+    test_fsx_lustre.py::test_fsx_lustre_backup:
+      dimensions:
+        - regions: [ "eu-south-1" ]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["rhel8"]
+          schedulers: [ "slurm" ]
+    test_efs.py::test_multiple_efs:
+      dimensions:
+        - regions: [ "ca-central-1" ]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: {{ OSS_COMMERCIAL_ARM }}
+          schedulers: [ "slurm" ]
+          benchmarks:
+            - mpi_variants: [ "openmpi", "intelmpi" ]
+              num_instances: [ 4 ]
+              slots_per_instance: 2
+              osu_benchmarks:
+                collective: [ "osu_alltoall" ]
+    test_raid.py::test_raid_performance_mode:
+      dimensions:
+        - regions: ["ap-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
+          schedulers: ["slurm"]
+    test_ebs.py::test_ebs_multiple:
+      dimensions:
+        - regions: ["me-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1804", "rhel8"]
+          schedulers: ["slurm"]
+    test_ebs.py::test_ebs_existing:
+      dimensions:
+        - regions: ["eu-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7", "rhel8"]
+          schedulers: ["slurm"]
+    # Ephemeral test requires instance type with instance store
+    test_ephemeral.py::test_head_node_stop:
+      dimensions:
+        - regions: ["use1-az4"]
+          instances: ["m5d.xlarge", "h1.2xlarge"]
+          oss: ["alinux2", "rhel8"]
+          schedulers: ["slurm"]
+  update:
+    test_update.py::test_update_slurm:
+      dimensions:
+        - regions: ["eu-central-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu2004", "rhel8"]
+    test_update.py::test_update_compute_ami:
+      dimensions:
+        - regions: ["eu-west-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["centos7", "rhel8"]
+    test_update.py::test_update_instance_list:
+      dimensions:
+        - regions: ["ap-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2", "rhel8"]
+          schedulers: ["slurm"]
+    test_update.py::test_queue_parameters_update:
+      dimensions:
+        - regions: ["ap-south-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2", "rhel8"]
+          schedulers: ["slurm"]
+    test_update.py::test_dynamic_file_systems_update:
+      dimensions:
+        - regions: ["eu-west-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["ubuntu1804", "rhel8"]
+          schedulers: ["slurm"]
+        - regions: ["ap-northeast-1"]
+          instances: {{ common.INSTANCES_DEFAULT_ARM }}
+          oss: ["ubuntu1804", "rhel8"]
+          schedulers: ["slurm"]
+    test_update.py::test_multi_az_create_and_update:
+      dimensions:
+        - regions: [ "eu-west-2" ]
+          schedulers: [ "slurm" ]
+          oss: ["alinux2", "rhel8"]

--- a/tests/integration-tests/configs/redhat8.yaml
+++ b/tests/integration-tests/configs/redhat8.yaml
@@ -1,7 +1,4 @@
 {%- import 'common.jinja2' as common with context -%}
-{%- set OSS_COMMERCIAL_X86_RH8 = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
-{%- set OSS_COMMERCIAL_ARM_RH8 = ["alinux2", "ubuntu1804", "ubuntu2004", "rhel8"] -%}
-{%- set OSS_ONE_PER_DISTRO_RH8 = ["centos7", "alinux2", "ubuntu1804", "rhel8"] -%}
 
 ---
 test-suites:
@@ -17,7 +14,7 @@ test-suites:
       dimensions:
         - regions: ["ap-southeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
           benchmarks:
             - mpi_variants: [ "openmpi", "intelmpi" ]
@@ -70,7 +67,7 @@ test-suites:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ OSS_ONE_PER_DISTRO_RH8 }}
+          oss: {{ OSS_ONE_PER_DISTRO }}
           schedulers: ["slurm"]
   createami:
     test_createami.py::test_build_image:
@@ -115,7 +112,7 @@ test-suites:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
   efa:
     test_efa.py::test_efa:
@@ -152,7 +149,7 @@ test-suites:
           # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
@@ -195,13 +192,13 @@ test-suites:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ OSS_COMMERCIAL_ARM_RH8 }}
+          oss: {{ OSS_COMMERCIAL_ARM }}
           schedulers: ["slurm"]
     test_mpi.py::test_mpi_ssh:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
   schedulers:
     test_awsbatch.py::test_awsbatch:
@@ -220,17 +217,17 @@ test-suites:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
         - regions: ["ap-southeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ OSS_COMMERCIAL_ARM_RH8 }}
+          oss: {{ OSS_COMMERCIAL_ARM }}
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_scaling:
       dimensions:
         - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ OSS_ONE_PER_DISTRO_RH8 }}
+          oss: {{ OSS_ONE_PER_DISTRO }}
           schedulers: ["slurm"]
   storage:
     # Commercial regions that can't test FSx: ap-northeast-1, ap-southeast-1, ap-southeast-2, eu-central-1, eu-north-1, eu-west-1, eu-west-2, us-east-1, us-east-2, us-west-1, us-west-2
@@ -250,7 +247,7 @@ test-suites:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ OSS_COMMERCIAL_ARM_RH8 }}
+          oss: {{ OSS_COMMERCIAL_ARM }}
           schedulers: ["slurm"]
           benchmarks:
             - mpi_variants: [ "openmpi", "intelmpi" ]
@@ -274,7 +271,7 @@ test-suites:
       dimensions:
         - regions: [ "ca-central-1" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ OSS_COMMERCIAL_ARM_RH8 }}
+          oss: {{ OSS_COMMERCIAL_ARM }}
           schedulers: [ "slurm" ]
           benchmarks:
             - mpi_variants: [ "openmpi", "intelmpi" ]
@@ -286,7 +283,7 @@ test-suites:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ OSS_COMMERCIAL_X86_RH8 }}
+          oss: {{ OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_multiple:
       dimensions:

--- a/tests/integration-tests/configs/redhat8.yaml
+++ b/tests/integration-tests/configs/redhat8.yaml
@@ -7,7 +7,7 @@ test-suites:
       dimensions:
         - regions: [ "sa-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: [ "rhel8" ]
+          oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
   ad_integration:
     test_ad_integration.py::test_ad_integration:
@@ -27,21 +27,21 @@ test-suites:
       dimensions:
         - regions: ["ap-southeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["ubuntu2004"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
   cfn-init:
     test_cfn_init.py::test_replace_compute_on_failure:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
   cli_commands:
     test_cli_commands.py::test_slurm_cli_commands:
       dimensions:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu1804", "rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
   cloudwatch_logging:
     test_cloudwatch_logging.py::test_cloudwatch_logging:
@@ -59,7 +59,7 @@ test-suites:
     test_compute_console_output_logging.py::test_custom_action_error:
       dimensions:
         - regions: [ "ap-east-1" ]
-          oss: ["rhel8"]
+          oss: {{ NEW_OS }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: [ "slurm" ]
   configure:
@@ -74,32 +74,32 @@ test-suites:
       dimensions:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2", "ubuntu2004", "centos7", "rhel8"]
+          oss: {{ NEW_OS }}
     test_createami.py::test_kernel4_build_image_run_cluster:
       dimensions:
         - regions: ["eu-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           schedulers: ["awsbatch", "slurm"]
-          oss: ["alinux2"]
+          oss: {{ NEW_OS }}
   dcv:
     test_dcv.py::test_dcv_configuration:
       dimensions:
         # DCV on GPU enabled instance
         - regions: ["us-east-1"]
           instances: ["g4dn.2xlarge"]
-          oss: ["ubuntu1804"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
         # DCV on ARM + GPU
         - regions: ["us-east-1"]
           instances: ["g5g.2xlarge"]
-          oss: ["alinux2"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
   disable_hyperthreading:
     test_disable_hyperthreading.py::test_hit_disable_hyperthreading:
       dimensions:
         - regions: ["us-west-1"]
           instances: ["m4.xlarge"]
-          oss: ["alinux2", "centos7", "rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
           benchmarks:
             - mpi_variants: [ "openmpi", "intelmpi" ]
@@ -112,36 +112,36 @@ test-suites:
       dimensions:
         - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ OSS_COMMERCIAL_X86 }}
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
   efa:
     test_efa.py::test_efa:
       dimensions:
         - regions: ["sa-east-1"]
           instances: ["c5n.9xlarge"]
-          oss: ["alinux2", "rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
         - regions: ["use1-az6"]   # do not move, unless capacity reservation is moved as well
           instances: ["p4d.24xlarge"]
-          oss: ["rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
         - regions: ["us-east-1"]
           instances: ["c6gn.16xlarge"]
-          oss: ["ubuntu2004", "rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
   intel_hpc:
     test_intel_hpc.py::test_intel_hpc:
       dimensions:
         - regions: ["us-east-2"]
           instances: ["c5.18xlarge"]
-          oss: ["centos7"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
   networking:
     test_cluster_networking.py::test_cluster_in_private_subnet:
       dimensions:
         - regions: ["me-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["centos7", "rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
     test_cluster_networking.py::test_cluster_in_no_internet_subnet:
       dimensions:
@@ -149,50 +149,50 @@ test-suites:
           # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ OSS_COMMERCIAL_X86 }}
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
     test_on_demand_capacity_reservation.py::test_on_demand_capacity_reservation:
       dimensions:
         - regions: [ "us-west-2" ]
-          oss: [ "rhel8" ]
+          oss: {{ NEW_OS }}
   scaling:
     test_scaling.py::test_multiple_jobs_submission:
       dimensions:
         - regions: {{ common.REGIONS_COMMERCIAL }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
         - regions: {{ common.REGIONS_CHINA }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
         - regions: {{ common.REGIONS_GOVCLOUD }}
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
         - regions: [ "us-west-2" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: {{ common.SCHEDULERS_TRAD }}
         - regions: [ "cn-north-1" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
         - regions: [ "us-gov-east-1" ]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["rhel8"]
+          oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
     test_mpi.py::test_mpi:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ OSS_COMMERCIAL_ARM }}
+          oss: {{ NEW_OS }}
           schedulers: ["slurm"]
     test_mpi.py::test_mpi_ssh:
       dimensions:

--- a/tests/integration-tests/configs/schedulers.yaml
+++ b/tests/integration-tests/configs/schedulers.yaml
@@ -27,7 +27,7 @@ test-suites:
       dimensions:
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
@@ -60,23 +60,23 @@ test-suites:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
         - regions: ["ap-northeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM_NO_RHEL8 }}
+          oss: {{ common.OSS_COMMERCIAL_ARM }}
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_scaling:
       dimensions:
         - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_ONE_PER_DISTRO_NO_RHEL8 }}
+          oss: {{ common.OSS_ONE_PER_DISTRO }}
           schedulers: ["slurm"]
         - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
           instances: [{{ common.instance("instance_type_1") }}]
@@ -176,7 +176,7 @@ test-suites:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86_NO_RHEL8 }}
+          oss: {{ common.OSS_COMMERCIAL_X86 }}
     test_update.py::test_update_compute_ami:
       dimensions:
         - regions: ["eu-west-1"]


### PR DESCRIPTION
### Description of changes

These changes removed 16 tests from develop and 14 tests from released.

- Add AD test for rhel8 in place of ubuntu18
- Remove NO_RHEL8 and RHEL8 variables from test config 
- Remove architecture dimension from log_rotation test 
- Remove architecture dimension from lustre_backup test 
- Restore test_createami for all remarkable OSes 
- Optimize cloudwatch_logging tests 
- Optimize test_build_image_custom_components tests 
- Remove OS dimension from test_custom_compute_action_failure and test_custom_action_error
- Remove awsbatch from cluster creation timeout test

### Tests
Executed test_runner.py in dry-run mode.
* develop - before: 263 - after: 249 tests
* released - before:  240 - after: 224 tests

### References
Second optimization step after: https://github.com/aws/aws-parallelcluster/pull/5198
