### PR TITLE
Revert removal of wait variable in clusters_factory.py

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -483,7 +483,8 @@ class ClustersFactory:
 
         # This changes the default behavior of the create-cluster command and makes it wait for the cluster creation to
         # finish before returning.
-        if kwargs.pop("wait", True):
+        wait = kwargs.pop("wait", True)
+        if wait:
             command.append("--wait")
 
         # TODO Remove the validator suppression below once the plugin scheduler is officially supported
@@ -508,8 +509,8 @@ class ClustersFactory:
         logging.info("Destroying cluster {0}".format(name))
         if name in self.__created_clusters:
             delete_logs = test_passed and self._delete_logs_on_success and self.__created_clusters[name].create_complete
+            cluster = self.__created_clusters[name]
             try:
-                cluster = self.__created_clusters[name]
                 cluster.delete(delete_logs=delete_logs)
             except Exception as e:
                 logging.error(


### PR DESCRIPTION
### Description of changes
* Revert removal of wait variable in clusters_factory.py
* Move statement to avoid potential access to uninitialized variable.

### References
* Bug introduced in https://github.com/aws/aws-parallelcluster/pull/5196

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
