### PR TITLE
[develop] Upgrade image used by CodeBuild environment for AWS Batch clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ CHANGELOG
 - Set Slurm prolog and epilog configurations to target a directory, /opt/slurm/etc/scripts/prolog.d/ and /opt/slurm/etc/scripts/epilog.d/ respectively.
 - Upgrade Slurm to version 23.02.1.
 - Upgrade munge to version 0.5.15.
+- Upgrade image used by CodeBuild environment when building container images for AWS Batch clusters, from
+  `aws/codebuild/amazonlinux2-x86_64-standard:3.0` to `aws/codebuild/amazonlinux2-x86_64-standard:4.0` and from
+  `aws/codebuild/amazonlinux2-aarch64-standard:1.0` to `aws/codebuild/amazonlinux2-aarch64-standard:2.0`.
 
 **BUG FIXES**
 - Fix EFS, FSx network security groups validators to avoid reporting false errors.
@@ -737,7 +740,7 @@ CHANGELOG
 - Improve retrieval of instance type info by using `DescribeInstanceType` API.
 - Remove `custom_awsbatch_template_url` configuration parameter.
 - Upgrade `pip` to latest version in virtual environments.
-- Upgrade image used by CodeBuild environment when building container images for Batch clusters, from
+- Upgrade image used by CodeBuild environment when building container images for AWS Batch clusters, from
   `aws/codebuild/amazonlinux2-x86_64-standard:1.0` to `aws/codebuild/amazonlinux2-x86_64-standard:3.0`.
 
 **BUG FIXES**

--- a/cli/src/pcluster/templates/awsbatch_builder.py
+++ b/cli/src/pcluster/templates/awsbatch_builder.py
@@ -567,9 +567,9 @@ class AwsBatchConstruct(Construct):
                         value=self._docker_build_wait_condition_handle.ref,
                     ),
                 ],
-                image="aws/codebuild/amazonlinux2-aarch64-standard:1.0"
+                image="aws/codebuild/amazonlinux2-aarch64-standard:2.0"
                 if self._condition_use_arm_code_build_image()
-                else "aws/codebuild/amazonlinux2-x86_64-standard:3.0",
+                else "aws/codebuild/amazonlinux2-x86_64-standard:4.0",
                 type="ARM_CONTAINER" if self._condition_use_arm_code_build_image() else "LINUX_CONTAINER",
                 privileged_mode=True,
             ),


### PR DESCRIPTION
### Description of changes
Upgrade image used by CodeBuild environment when building container images for Batch clusters, from `aws/codebuild/amazonlinux2-x86_64-standard:3.0` to `aws/codebuild/amazonlinux2-x86_64-standard:4.0` and from `aws/codebuild/amazonlinux2-aarch64-standard:1.0` to `aws/codebuild/amazonlinux2-aarch64-standard:2.0`.

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
