### PR TITLE
[Permissions] Add action 'cloudformation:ListStacks' to ParallelClusterClusterPolicy in parallelcluster-policies.yaml.

### DIFF
--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -419,6 +419,7 @@ Resources:
               - cloudformation:DescribeStackEvents
               - cloudformation:DescribeStackResources
               - cloudformation:GetTemplate
+              - cloudformation:ListStacks
             Resource: !Sub
               - arn:*:cloudformation:${RequestedRegion}:${AWS::AccountId}:stack/*
               - RequestedRegion: !If [IsMultiRegion, '*', !Ref Region]


### PR DESCRIPTION
### Description of changes
Add action 'cloudformation:ListStacks' to ParallelClusterClusterPolicy in parallelcluster-policies.yaml.
This action is required by the Pcluster APIs. The regression has been introduced by a recent policy scope down made to improve the security posture https://github.com/aws/aws-parallelcluster/pull/5176

### Tests
* Will be tested on the authoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
