### PR TITLE
Fix DCV integ tests and execute one scaling test per partition

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -200,12 +200,12 @@ dcv:
       # DCV on GPU enabled instance
       - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
         instances: ["g4dn.2xlarge"]
-        oss: ["centos7"]
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
       # DCV on ARM + GPU
       - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
         instances: ["g5g.2xlarge"]
-        oss: ["ubuntu2004"]
+        oss: ["centos7"]
         schedulers: ["slurm"]
       # DCV in cn regions and non GPU enabled instance
       - regions: ["cn-northwest-1"]
@@ -331,11 +331,11 @@ networking:
         # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
       - regions: ["us-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["centos7"]
+        oss: ["rhel8"]
         schedulers: ["slurm"]
       - regions: ["us-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["rhel8"]
+        oss: ["centos7"]
         schedulers: ["slurm"]
       - regions: ["cn-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -82,15 +82,15 @@ test-suites:
           schedulers: ["slurm"]
     test_scaling.py::test_multiple_jobs_submission:
       dimensions:
-        - regions: {{ common.REGIONS_COMMERCIAL }}
+        - regions: ["af-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["ubuntu2004"]
           schedulers: ["slurm"]
-        - regions: {{ common.REGIONS_CHINA }}
+        - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
-        - regions: {{ common.REGIONS_GOVCLOUD }}
+        - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["rhel8"]
           schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
* Change OS for tests using DCV.  DCV does not work on ubuntu20 and rhel8 on ARM. Validator was failing with:
```
NICE DCV can be used with one of the following operating systems
when using arm64 architecture: ['ubuntu1804', 'alinux2', 'centos7']
```
* Execute 1 test per partition for multiple_Jobs_submission test. Reduced the number of tests:
    * commercial: 19 -> 1
    * china: 2 -> 1
    * commercial: 2 -> 1

### Tests
* Executed test_runner.py in dryrun mode:
     * develop - before: 249 tests, after: 228 tests
     * released - 224 tests, no changes

### References
* Follow up patch after: https://github.com/aws/aws-parallelcluster/pull/5201