### PR TITLE
Fix code coverage upload to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: cd ${{ matrix.toxdir }} && tox -e ${{ matrix.toxenv }}
+      - name: Upload code coverage report to Codecov
+        uses: codecov/codecov-action@v3
+        if: ${{ endsWith(matrix.toxenv, '-cov') }}
+        with:
+          files: cli/coverage.xml
+          flags: unittests
+          verbose: true
   awsbatch-cli-tests:
     name: AWS Batch CLI Tests
     runs-on: ${{ matrix.os }}

--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -15,13 +15,10 @@ usedevelop =
 deps =
     -rtests/requirements.txt
     pytest-travis-fold
-    cov: codecov
 commands =
     nocov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --ignore=src tests/
     cov: python setup.py clean --all build_ext --force --inplace
     cov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --cov=src --cov-report=xml --cov-append tests/
-    # Disabling coverage report for awsbatch-cli because it's currently conflicting with pcluster cli report
-    # cov: codecov -e TOXENV
 
 # Section used to define common variables used by multiple testenvs.
 [vars]

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -18,7 +18,6 @@ allowlist_externals =
 deps =
     -rtests/requirements.txt
     pytest-travis-fold
-    cov: codecov
 extras =
     awslambda
 commands =
@@ -26,7 +25,6 @@ commands =
     nocov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --ignore=src tests/
     cov: python setup.py clean --all build_ext --force --inplace
     cov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --cov=src --cov-report=xml --cov-append tests/
-    cov: codecov -e TOXENV
 
 # Section used to define common variables used by multiple testenvs.
 [vars]


### PR DESCRIPTION
### Description of changes
* Remove the upload of the code coverage report to Codecov from Tox steps.
* Add to CI workflow: upload of the code coverage report to Codecov.

### References
* [Link to PRs.](https://github.com/aws/aws-parallelcluster/pull/5184)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
