### PR TITLE
[3.x] Remove NewLine characters in THIRD-PARTY-LICENSES.txt created through create-attribution-doc.sh 

### DIFF
--- a/util/create-attribution-doc.sh
+++ b/util/create-attribution-doc.sh
@@ -7,7 +7,7 @@ append_package_details_to_final_license_file(){
   # Function to Append Package Details to the THIRD-PARTY-LICENSES file
   #Arguments ->  1- Package Name, 2- Package Version, 3- License Type , 4- URL for package, 5,6,7- URL for License
   # Adding a header to final License file with Package Name, Package Version, License Type , URL for package
-  echo "\n\n\n$1 \n$2 \n$3 \n$4" >> $final_license_file
+  echo -e "\n\n\n$1 \n$2 \n$3 \n$4" >> $final_license_file
   # Appending License
   curl $5 >> $final_license_file
   # Adding Dual Licenses if they exist 


### PR DESCRIPTION

### Description of changes
* Removing unwanted NewLine Characters in THIRD-PARTY-LICENSES.txt created through create-attribution-doc.sh
* Link to impacted open issues.

### Tests
* Locally tested the changes
* Tested for Installer Build pipelines



### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
