### PR TITLE
integ-test: Increase the wait time for checking log file is empty

### DIFF
--- a/tests/integration-tests/tests/log_rotation/test_log_rotation.py
+++ b/tests/integration-tests/tests/log_rotation/test_log_rotation.py
@@ -138,7 +138,7 @@ def test_log_rotation(
     )
 
 
-@retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(9))
 def _wait_file_not_empty(remote_command_executor, file_path, compute_node_ip=None):
     if compute_node_ip:
         size = _run_command_on_node(remote_command_executor, f"stat --format=%s {file_path}", compute_node_ip)


### PR DESCRIPTION
### Description of changes
* Fix transient integration test failure for waiting new log entries in slurm_suspend log. The test checks that the suspend log is not empty within 5 minutes after submitting the job to a dynamic node, SuspendTimeout=120 seconds. Sometimes the dynamic node startup time may be longer, increase the wait time to 9 minutes, allow 5 minutes for launch nodes, 2 minutes for suspend, 1 minute for job to finish.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
