### PR TITLE
Add rhel8 to supported OSs for ARM (it was already in supported OSs for x86_64)

### DIFF
--- a/cli/src/pcluster/cli/commands/dcv_util.py
+++ b/cli/src/pcluster/cli/commands/dcv_util.py
@@ -16,6 +16,6 @@ def get_supported_dcv_os(architecture):
     """Return a list of all the operating system supported by DCV."""
     architectures_dict = {
         "x86_64": SUPPORTED_OSES,
-        "arm64": ["ubuntu1804", "alinux2", "centos7"],
+        "arm64": ["ubuntu1804", "alinux2", "centos7", "rhel8"],
     }
     return architectures_dict.get(architecture, [])

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -1305,7 +1305,7 @@ def test_shared_storage_mount_dir_validator(mount_dir, expected_message):
         (False, "alinux2", "t2.micro", None, None, None),  # doesn't fail because DCV is disabled
         (True, "ubuntu1804", "m6g.xlarge", None, None, None),
         (True, "alinux2", "m6g.xlarge", None, None, None),
-        (True, "rhel8", "m6g.xlarge", None, None, "Please double check the os configuration"),
+        (True, "rhel8", "m6g.xlarge", None, None, None),
         (True, "ubuntu2004", "m6g.xlarge", None, None, "Please double check the os configuration"),
     ],
 )


### PR DESCRIPTION
### Description of changes
Add rhel8 to supported OSs for ARM (it was already in supported OSs for x86_64)

### Tests
- Unit tests.
- `pcluster dcv-connect` to rhel8 cluster (custom build with these and the unmerged dcv config changes in [this patch](https://github.com/aws/aws-parallelcluster-cookbook/pull/2016)).

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
