### PR TITLE
[integ-tests] Redistribute tests between regions

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -564,7 +564,7 @@ storage:
         schedulers: ["slurm"]
   test_fsx_lustre.py::test_fsx_lustre_backup:
     dimensions:
-      - regions: ["ap-southeast-1"]
+      - regions: ["us-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: ["ubuntu1804"]
         schedulers: ["slurm"]
@@ -663,7 +663,7 @@ storage:
 tags:
   test_tag_propagation.py::test_tag_propagation:
     dimensions:
-      - regions: ["ap-southeast-1"]
+      - regions: ["us-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm", "awsbatch"]
@@ -720,7 +720,7 @@ multiple_nics:
 resource_bucket:
   test_resource_bucket.py::test_resource_bucket:
     dimensions:
-      - regions: ["ap-southeast-1"]
+      - regions: ["us-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["alinux2"]
         schedulers: ["slurm", "awsbatch"]

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -14,7 +14,6 @@ ad_integration:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004", "centos7"]
         schedulers: ["slurm"]
-# m6g.xlarge is available in the following region: ap-south-1, eu-north-1, eu-west-3, eu-south-1, eu-west-2, eu-west-1, ap-northeast-2, me-south-1, ap-northeast-1, ca-central-1, sa-east-1, ap-east-1, ap-southeast-1, ap-southeast-2, eu-central-1, ap-southeast-3, us-east-1, us-east-2, us-west-1, us-west-2
 arm_pl:
   test_arm_pl.py::test_arm_pl:
     dimensions:
@@ -515,7 +514,6 @@ spot:
         oss: ["centos7"]
         schedulers: ["slurm"]
 storage:
-  # Commercial regions that can't test FSx: ap-northeast-1, ap-southeast-1, ap-southeast-2, eu-central-1, eu-north-1, eu-west-1, eu-west-2, us-east-1, us-east-2, us-west-1, us-west-2
   test_fsx_lustre.py::test_fsx_lustre:
     dimensions:
       - regions: ["eu-west-2"]

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -82,7 +82,7 @@ test-suites:
           schedulers: ["slurm"]
     test_scaling.py::test_multiple_jobs_submission:
       dimensions:
-        - regions: ["af-south-1"]
+        - regions: ["us-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["ubuntu2004"]
           schedulers: ["slurm"]


### PR DESCRIPTION
### Description of changes
* Remove no longer valid comments
* Move test with ARM instance away from af-south-1
* Redistribute tests from ap-southeast-1 to other regions since ap-southeast-1 is the region on which we're testing AD
