### PR TITLE
Reenable validations for functionalities previously not supported in rhel8

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -106,7 +106,7 @@ phases:
           commands:
             - |
               set -v
-              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} != 'arm64' && {{ validate.OperatingSystemName.outputs.stdout }} != 'rhel8' ]] && echo "true" || echo "false"
+              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} != 'arm64' ]] && echo "true" || echo "false"
 
       - name: ArmPLSupported
         action: ExecuteBash
@@ -114,7 +114,7 @@ phases:
           commands:
             - |
               set -v
-              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} == 'arm64' && {{ validate.OperatingSystemName.outputs.stdout }} != 'rhel8' ]] && echo "true" || echo "false"
+              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} == 'arm64' ]] && echo "true" || echo "false"
 
       - name: FabricManagerSupported
         action: ExecuteBash
@@ -122,7 +122,7 @@ phases:
           commands:
             - |
               set -v
-              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} == 'arm64' || {{ validate.OperatingSystemName.outputs.stdout }} == 'rhel8' ]] && echo "false" || echo "true"
+              [[ {{ validate.OperatingSystemArchitecture.outputs.stdout }} == 'arm64' ]] && echo "false" || echo "true"
 
       - name: LustreSupported
         action: ExecuteBash
@@ -270,7 +270,7 @@ phases:
                   echo "Checking Intel MPI 20xx installed and module available..."
                   unset MODULEPATH
                   source /etc/profile.d/modules.sh
-                  (module avail intelmpi)2>&1 | grep "/opt/intel/mpi/20.*/modulefiles/"
+                  (module avail intelmpi)2>&1 | grep "/opt/intel/mpi/20.*/modulefiles"
                   [[ $? -ne 0 ]] && echo "Check Intel MPI failed" && exit 1
                 else
                   dpkg -l | grep libfabric && modinfo efa | grep efa && [ -d /opt/amazon/efa ]
@@ -287,7 +287,7 @@ phases:
               set -vx
               PLATFORM='{{ validate.PlatformName.outputs.stdout }}'
 
-              if [[ {{ validate.NvidiaEnabled.outputs.stdout }} == 'no' || {{ validate.OperatingSystemName.outputs.stdout }} == 'rhel8' ]]; then
+              if [[ {{ validate.NvidiaEnabled.outputs.stdout }} == 'no' ]]; then
                 echo "Nvidia recipe not enabled, skipping." && exit 0
               fi
               if [ {{ validate.HasGPU.outputs.stdout }} == "false" ]; then


### PR DESCRIPTION
### Description of changes
Previously, intel mpi, arm pl and fabric manager were not supported in rhel8, but we have added all these functionalities, therefore in this patch we reenable the validation.

Note that in `parallelcluster_test.yaml` we skip some checks for scheduler plugin in the case where the os is rhel8, because with rhel8 in the cookbook we directly skip the installation of the scheduler plugin, therefore in the AMI we don't have, i.e., the scheduler plugin python virtual environment.

Furthermore, we change the modulefiles regexp because in rhel8 it does not appear in the `module avail` output.

### Tests
Tested in personal pipeline with build image dev setting to enable validations.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
