### PR TITLE
Run schedulers workstream integ tests only on alinux2

### DIFF
--- a/tests/integration-tests/configs/schedulers.yaml
+++ b/tests/integration-tests/configs/schedulers.yaml
@@ -29,10 +29,6 @@ test-suites:
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
-        - regions: ["eu-north-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
     test_mpi.py::test_mpi_ssh:
       dimensions:
         - regions: ["eu-north-1"]
@@ -44,10 +40,6 @@ test-suites:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["awsbatch"]
-        - regions: ["ap-northeast-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
     test_awsbatch.py::test_awsbatch_defaults:
@@ -66,10 +58,6 @@ test-suites:
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
-        - regions: ["ap-northeast-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_scaling:
@@ -198,10 +186,6 @@ test-suites:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2"]
-          schedulers: ["slurm"]
-        - regions: ["ap-northeast-1"]
-          instances: {{ common.INSTANCES_DEFAULT_ARM }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
     test_update.py::test_multi_az_create_and_update:

--- a/tests/integration-tests/configs/schedulers.yaml
+++ b/tests/integration-tests/configs/schedulers.yaml
@@ -6,7 +6,7 @@ test-suites:
       dimensions:
         - regions: ["ap-northeast-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu1804"]
+          oss: ["alinux2"]
           schedulers: ["slurm"]
   efa:
     test_efa.py::test_efa:
@@ -20,24 +20,24 @@ test-suites:
       dimensions:
         - regions: ["us-east-2"]
           instances: ["c5.18xlarge"]
-          oss: ["centos7"]
+          oss: ["alinux2"]
           schedulers: ["slurm"]
   scaling:
     test_mpi.py::test_mpi:  # TODO: move outside of the scaling dir
       dimensions:
         - regions: ["ap-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_mpi.py::test_mpi_ssh:
       dimensions:
         - regions: ["eu-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
   schedulers:
     test_awsbatch.py::test_awsbatch:
@@ -60,27 +60,27 @@ test-suites:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
       dimensions:
         - regions: ["ap-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
         - regions: ["ap-northeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_scaling:
       dimensions:
         - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_ONE_PER_DISTRO }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
         - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
           instances: [{{ common.instance("instance_type_1") }}]
-          oss: [ "alinux2" ]
+          oss: ["alinux2"]
           schedulers: [ "slurm" ]
     test_slurm.py::test_error_handling:
       dimensions:
@@ -122,19 +122,19 @@ test-suites:
       dimensions:
         - regions: ["us-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_slurm.py::test_scontrol_reboot_ec2_health_checks:
       dimensions:
         - regions: ["us-east-2"]
           instances: ["t2.medium"]
-          oss: ["ubuntu2004"]
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_overrides:
       dimensions:
         - regions: ["me-south-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["ubuntu2004"]
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_slurm.py::test_scontrol_update_nodelist_sorting:
       dimensions:
@@ -146,13 +146,13 @@ test-suites:
       dimensions:
         - regions: ["us-east-1", "ap-south-1"]
           instances:  {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["alinux2", "ubuntu2004"]
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_slurm_accounting.py::test_slurm_accounting_disabled_to_enabled_update:
       dimensions:
         - regions: ["us-west-2"]
           instances:  {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: ["centos7", "ubuntu1804"]
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_reconfigure_race_condition:
        dimensions:
@@ -176,7 +176,7 @@ test-suites:
       dimensions:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["alinux2"]
     test_update.py::test_update_compute_ami:
       dimensions:
         - regions: ["eu-west-1"]
@@ -198,15 +198,14 @@ test-suites:
       dimensions:
         - regions: ["eu-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ common.OSS_COMMERCIAL_X86 }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
         - regions: ["ap-northeast-1"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: {{ common.OSS_COMMERCIAL_ARM }}
+          oss: ["alinux2"]
           schedulers: ["slurm"]
     test_update.py::test_multi_az_create_and_update:
       dimensions:
         - regions: [ "eu-west-2" ]
           schedulers: [ "slurm" ]
           oss: ["alinux2"]
-


### PR DESCRIPTION
### Description of changes
* Change the integration tests setup for schedulers.yaml (only used for internal testing purposes).

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
