### PR TITLE
Export SLURM_TASKS_PER_NODE on NCCL test to avoid Slurm 23.02 bug

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/nccl_benchmarks/nccl_tests_submit_openmpi.sh
@@ -3,6 +3,8 @@
 #SBATCH --exclusive
 #SBATCH --ntasks-per-node=8
 
+# Temporary workaround to solve a bug in Slurm 23.02: https://bugs.schedmd.com/show_bug.cgi?id=16426
+export SLURM_TASKS_PER_NODE="8(x2)"
 
 module load openmpi
 NCCL_VERSION='2.7.8-1'


### PR DESCRIPTION
Temporary workaround to solve a bug in Slurm 23.02: https://bugs.schedmd.com/show_bug.cgi?id=16426

