### PR TITLE
`[requirements/flask]` Pin flask at 2.2.x

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -22,5 +22,5 @@ aws-cdk.aws-sqs~=1.137
 aws-cdk.aws-cloudformation~=1.137
 werkzeug~=2.0
 connexion~=2.13.0
-flask~=2.0
+flask~=2.2.0
 jmespath~=0.10

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -48,7 +48,7 @@ REQUIRES = [
     "aws-cdk.aws-cloudformation~=" + CDK_VERSION,
     "werkzeug~=2.0",
     "connexion~=2.13.0",
-    "flask~=2.0",
+    "flask~=2.2.0",
     "jmespath~=0.10",
 ]
 


### PR DESCRIPTION
### Description of changes
* Pin flask to the `2.2.x` version as the JSONEncoder class is removed in the `2.3.x` series.

### Tests
* Installed with `pip install -e .` in the `cli` directory
* Ran `pcluster version`
* Didn't raise an exception.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
