### PR TITLE
Fix parallelcluster_validate.yaml after cuda variables name change

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -165,7 +165,7 @@ phases:
           commands:
             - |
               set -v
-              PATTERN=$(jq '.default.cluster.nvidia.cuda_version' {{ CookbookDefaultFile }})
+              PATTERN=$(jq '.default.cluster.nvidia.cuda.version' {{ CookbookDefaultFile }})
               VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo ${VERSION}
 


### PR DESCRIPTION
### Description of changes
* Fix parallelcluster_validate.yaml after cuda variables name change

### Tests
* Manually build an alinux2 x86 to check if the image is created
```
Image:
  Name: aws-parallelcluster-3.7.0-amzn2-hvm-x86_64-202304242107
  RootVolume:
    Size: 35
Build:
  Imds:
    ImdsSupport: v2.0
  Iam:
    AdditionalIamPolicies:
      - Policy: arn:aws:iam::xxxxxxxxxxxx:policy/BuildImageInstancePolicy
  InstanceType: g4dn.2xlarge
  ParentImage: ami-0778fc263eb67f4c7
DevSettings:
  Cookbook:
    ChefCookbook: https://github.com/aws/aws-parallelcluster-cookbook/tarball/17f5b44ac05c881ffa2e70eef736eccf0ad62706
    ExtraChefAttributes: |
      {"cluster": {"nvidia": {"enabled": "yes" }, "is_official_ami_build": "true"}}
  NodePackage: https://github.com/aws/aws-parallelcluster-node/tarball/81134c75f85d2a0ffbb78a7df626b04692f5713c
  AwsBatchCliPackage: https://github.com/aws/aws-parallelcluster/tarball/f44a8c589c231555ab977f5db37600e03c3fd312
  DisableValidateAndTest: False
```

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2033

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
