### PR TITLE
Make test_slurm_memory_based_scheduling more robust

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -529,7 +529,7 @@ def test_slurm_memory_based_scheduling(
         submit_command_args={
             "nodes": 1,
             "slots": 1,
-            "command": "srun ./a.out 3500000000 300",
+            "command": "srun ./a.out 3000000000 300",
             "other_options": "-w queue1-st-ondemand1-i1-1",
             "raise_on_error": False,
         }

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
@@ -24,7 +24,7 @@ Scheduling:
           Instances:
             - InstanceType: c5.large
           MinCount: 1
-          SchedulableMemory: 3000
+          SchedulableMemory: 2500
         - Name: ondemand1-i2
           Instances:
             - InstanceType: {{ instance }}


### PR DESCRIPTION
### Description of changes
* Make test_slurm_memory_based_scheduling more robust
    * The test was failing on Ubuntu 20.04 but not on Amazon Linux 2 due to slight differences in the total available memory in user space between the two OSs.
    * Reduce memory consumption of last job in the integration test to minimize the risk for the job to run out of memory and be killed.
    * Set the new memory consumption of the job to 3 GB (3x10^9 B).
    * Change SchedulableMemory to 2500 MiB in the last phase of the test to make sure the new `RealMemory` parameter is well below the 3 GB used by the job.

### Tests
* Successfully ran the test on both Amazon Linux 2 and Ubuntu 20.04.

### References
* https://github.com/aws/aws-parallelcluster/pull/5239

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
