### PR TITLE
Replace bash script with InSpec execution for ArmPL validation during AMI build

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -199,31 +199,17 @@ phases:
                 echo cuda-${cuda_ver}/samples/bin
               fi
 
-      - name: ArmPLVersion
-        action: ExecuteBash
-        inputs:
-          commands:
-            - |
-              set -v
-              PATTERN=$(jq '.default.cluster.armpl.major_minor_version' {{ CookbookDefaultFile }})
-              MAJOR_MINOR_VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
-              VERSION+="${MAJOR_MINOR_VERSION}."
-              PATTERN=$(jq '.default.cluster.armpl.patch_version' {{ CookbookDefaultFile }})
-              PATCH_VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
-              VERSION+="${PATCH_VERSION}"
-              echo ${VERSION}
-
-      - name: ArmPLGCCVersion
-        action: ExecuteBash
-        inputs:
-          commands:
-            - |
-              set -v
-              PATTERN=$(jq '.default.cluster.armpl.gcc.major_minor_version' {{ CookbookDefaultFile }})
-              VERSION=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
-              echo ${VERSION}
-
       ### utils ###
+      - name: PatchInSpecProfiles
+        action: ExecuteBash
+        inputs:
+          commands:
+            - |
+              set -v
+              sudo sed -i "s#path: cookbooks#path: /etc/chef/cookbooks#g" /etc/chef/cookbooks/aws-parallelcluster/test/recipes/inspec.yml
+              sudo sed -i "s#path: cookbooks#path: /etc/chef/cookbooks#g" /etc/chef/cookbooks/aws-parallelcluster/test/resources/inspec.yml
+              echo "InSpec profiles patched"
+
       - name: NvidiaEnabled
         action: ExecuteBash
         inputs:
@@ -362,17 +348,9 @@ phases:
               set -vx
               if [ {{ validate.ArmPLSupported.outputs.stdout }} == true ]; then
                 echo "Checking gcc version and module loaded..."
-                unset MODULEPATH
-                source /etc/profile.d/modules.sh
-                (module avail)2>&1 | grep armpl/{{ validate.ArmPLVersion.outputs.stdout }}
-                [[ $? -ne 0 ]] && echo "Check armpl version failed" && exit 1
-                module load armpl/{{ validate.ArmPLVersion.outputs.stdout }}
-                gcc --version | grep {{ validate.ArmPLGCCVersion.outputs.stdout }}
-                [[ $? -ne 0 ]] && echo "Check gcc version for armpl failed" && exit 1
-                (module list)2>&1 | grep armpl/{{ validate.ArmPLVersion.outputs.stdout }}_gcc-{{ validate.ArmPLGCCVersion.outputs.stdout }}
-                [[ $? -ne 0 ]] && echo "Check armpl module failed" && exit 1
-                (module list)2>&1 | grep armpl/gcc-{{ validate.ArmPLGCCVersion.outputs.stdout }}
-                [[ $? -ne 0 ]] && echo "Check gcc module failed" && exit 1
+                cd /etc/chef/cookbooks/aws-parallelcluster
+                inspec exec test/resources --profiles-path . --controls /^arm_pl/ --no-distinct-exit
+                [[ $? -ne 0 ]] && echo "ArmPL test failed" && exit 1
                 echo "ArmPL test passed"
               fi
 


### PR DESCRIPTION
### Description of changes
Replace bash script with InSpec execution for ArmPL validation during AMI build

By reusing the same controls we use in Kitchen tests, we avoid code duplication and coupling between `aws-parallelcluster` and `aws-parallelcluster-cookbooks`.

This is the first step towards reusing InSpec controls for AMI validation and testing. We want all the validation and test checks to be replaced.

PatchInSpecProfiles is temporarily required because of a different cookbooks location in `aws-parallelcluster-cookbooks` and on the AMI.

### Tests
* AMI built using this code

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
