### PR TITLE
GPU Health Check End-to-End tests

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -731,3 +731,10 @@ log_rotation:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004"]
         schedulers: ["slurm"]
+health_checks:
+  test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
+    dimensions:
+      - regions: ["eu-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -230,13 +230,12 @@ class SlurmCommands(SchedulerCommands):
         """Waits until the job queue is empty."""
 
         @retry(
-            retry_on_result=lambda result: bool(result),  # Retry internally works with only boolean values
+            retry_on_result=lambda result: bool(result.stdout.strip()),  # Retry works with only boolean values
             wait_fixed=seconds(10),
             stop_max_delay=minutes(timeout),
         )
         def _job_queue_empty():
-            result = self._remote_command_executor.run_remote_command("squeue -h")
-            return result.stdout
+            return self._remote_command_executor.run_remote_command("squeue -h")
 
         return _job_queue_empty()
 

--- a/tests/integration-tests/tests/health_checks/test_gpu_health_checks.py
+++ b/tests/integration-tests/tests/health_checks/test_gpu_health_checks.py
@@ -1,0 +1,193 @@
+from dataclasses import dataclass
+from typing import Union
+
+import pytest
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+
+from tests.common.assertions import assert_head_node_is_running
+
+HEALTH_CHECK_LOG_FILE = "/var/log/parallelcluster/slurm_health_check.log"
+
+
+@dataclass
+class NodeHealthStatus:
+    """Class to keep track of expected health status of a node"""
+
+    node_name: str
+    health_check_executed: bool
+    latest_job: Union[int, None]
+
+
+@pytest.mark.usefixtures("instance", "os", "scheduler")
+def test_cluster_with_gpu_health_checks(
+    region,
+    pcluster_config_reader,
+    s3_bucket_factory,
+    clusters_factory,
+    test_datadir,
+    scheduler_commands_factory,
+):
+    """Test cluster with GPU Checks."""
+
+    expected_nodes_health_statuses = {
+        "queue-1": {
+            "compute-resource-1": NodeHealthStatus(
+                node_name="queue-1-dy-compute-resource-1-1",
+                health_check_executed=False,
+                latest_job=None,
+            ),
+            "compute-resource-2": NodeHealthStatus(
+                node_name="queue-1-dy-compute-resource-2-1",
+                health_check_executed=True,
+                latest_job=None,
+            ),
+            "compute-resource-3": NodeHealthStatus(
+                node_name="queue-1-st-compute-resource-3-1",
+                health_check_executed=True,
+                latest_job=None,
+            ),
+            "compute-resource-4": NodeHealthStatus(
+                node_name="queue-1-dy-compute-resource-4-1",
+                health_check_executed=False,
+                latest_job=None,
+            ),
+            "compute-resource-5": NodeHealthStatus(
+                node_name="queue-1-dy-compute-resource-5-1",
+                health_check_executed=False,
+                latest_job=None,
+            ),
+            "compute-resource-6": NodeHealthStatus(
+                node_name="queue-1-dy-compute-resource-6-1",
+                health_check_executed=False,
+                latest_job=None,
+            ),
+        },
+        "queue-2": {
+            "compute-resource-1": NodeHealthStatus(
+                node_name="queue-2-dy-compute-resource-1-1",
+                health_check_executed=True,
+                latest_job=None,
+            ),
+            "compute-resource-2": NodeHealthStatus(
+                node_name="queue-2-dy-compute-resource-2-1",
+                health_check_executed=False,
+                latest_job=None,
+            ),
+        },
+    }
+    cluster_config = pcluster_config_reader()
+    cluster = clusters_factory(cluster_config)
+    assert_head_node_is_running(region, cluster)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    slurm_commands = scheduler_commands_factory(remote_command_executor)
+
+    # Submit job to the test nodes
+    queue_cr_expected_nodes_health_statuses = expected_nodes_health_statuses.items()
+    for queue, cr_expected_nodes_health_statuses in queue_cr_expected_nodes_health_statuses:
+        no_of_nodes = len(cr_expected_nodes_health_statuses.keys())
+        job_id = slurm_commands.submit_command_and_assert_job_accepted(
+            submit_command_args={
+                "command": "srun sleep 1",
+                "host": ",".join(
+                    node_health_status.node_name for cr, node_health_status in cr_expected_nodes_health_statuses.items()
+                ),
+                "partition": queue,
+                "slots": no_of_nodes,
+                "nodes": no_of_nodes,
+            }
+        )
+        for node_health_status in cr_expected_nodes_health_statuses.values():
+            node_health_status.latest_job = job_id
+
+    # Wait for all jobs to be completed
+    slurm_commands.wait_job_queue_empty()
+
+    # Check if GPU Health Checks Manager was started on all nodes and actual Health Checks executed for nodes where
+    # its enabled and the instance type is GPU-enabled.
+    for _, cr_expected_nodes_health_statuses in queue_cr_expected_nodes_health_statuses:
+        for node_health_status in cr_expected_nodes_health_statuses.values():
+            node_address = slurm_commands.get_node_addr(node_name=node_health_status.node_name)
+            _assert_file_content_in_compute_node(
+                HEALTH_CHECK_LOG_FILE,
+                node_address,
+                cluster,
+                [rf".*JobID {node_health_status.latest_job}.*Running GPU Health Check with DCGMI.*"],
+                should_exist=node_health_status.health_check_executed,
+            )
+
+    # Simulate failing GPU Health Check and assert the node is set to DRAIN
+    _test_failing_gpu_health_checks(
+        slurm_commands=slurm_commands,
+        cluster=cluster,
+        target_node=expected_nodes_health_statuses["queue-1"]["compute-resource-3"],
+        target_queue="queue-1",
+        failure_script_path=test_datadir / "mock_failing_gpu_health_check.sh",
+        successful_script_path=test_datadir / "mock_successful_gpu_health_check.sh",
+        rollback_script_path=test_datadir / "restore_gpu_health_check.sh",
+    )
+
+
+def _test_failing_gpu_health_checks(
+    slurm_commands,
+    cluster,
+    target_node,
+    target_queue,
+    failure_script_path,
+    successful_script_path,
+    rollback_script_path,
+):
+    node_address = slurm_commands.get_node_addr(node_name=target_node.node_name)
+    compute_node_remote_command_executor = RemoteCommandExecutor(cluster, compute_node_ip=node_address)
+
+    # Mock failing GPU Health Checks
+    results_from_compute_node = compute_node_remote_command_executor.run_remote_script(failure_script_path).stdout
+    assert_that(results_from_compute_node).contains("Mocked failing GPU Health Check")
+
+    # Run job on the node
+    job_id = slurm_commands.submit_command_and_assert_job_accepted(
+        submit_command_args={
+            "command": "srun sleep 1",
+            "host": target_node.node_name,
+            "partition": target_queue,
+        }
+    )
+
+    # Assert that node is set to drain due to failing prologue/health check script
+    slurm_commands.wait_nodes_status("drained", filter_by_nodes=[target_node.node_name])
+
+    # Mock successful health check
+    results_from_compute_node = compute_node_remote_command_executor.run_remote_script(successful_script_path).stdout
+    assert_that(results_from_compute_node).contains("Mocked successful GPU Health Check")
+
+    # Assert that the node is replaced and job is executed
+    slurm_commands.wait_nodes_status("idle", filter_by_nodes=[target_node.node_name])
+    slurm_commands.wait_job_queue_empty()
+
+    # Confirm health check was successful
+    _assert_file_content_in_compute_node(
+        HEALTH_CHECK_LOG_FILE,
+        target_node.node_name,
+        cluster,
+        [rf".*JobID {job_id}.*HealthCheckManager finished with exit code '0'*"],
+        should_exist=True,
+    )
+
+    # Restore correct health check configuration
+    node_address = slurm_commands.get_node_addr(node_name=target_node.node_name)
+    compute_node_remote_command_executor = RemoteCommandExecutor(cluster, compute_node_ip=node_address)
+    results_from_compute_node = compute_node_remote_command_executor.run_remote_script(rollback_script_path).stdout
+    assert_that(results_from_compute_node).contains("Health check configuration restored")
+
+
+def _assert_file_content_in_compute_node(file_path, compute_node_ip, cluster, patterns, should_exist=True):
+    compute_node_remote_command_executor = RemoteCommandExecutor(cluster, compute_node_ip=compute_node_ip)
+    results_from_compute_node = compute_node_remote_command_executor.run_remote_command(
+        command=f"cat {file_path}"
+    ).stdout
+
+    for pattern in patterns:
+        if should_exist:
+            assert_that(results_from_compute_node).matches(pattern)
+        else:
+            assert_that(results_from_compute_node).does_not_match(pattern)

--- a/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/mock_failing_gpu_health_check.sh
+++ b/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/mock_failing_gpu_health_check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir -p $HOME/mock_health_checks
+sudo tee $HOME/mock_health_checks/gpu_health_check.sh > /dev/null <<EOT
+#!/bin/bash
+exit 1
+EOT
+sudo chmod +x $HOME/mock_health_checks/gpu_health_check.sh
+
+sudo sed -i '/managed_health_check_dir =/ s|\/opt\/slurm\/etc\/pcluster\/\.slurm_plugin\/scripts\/health_checks|'$HOME'\/mock_health_checks|' /opt/slurm/etc/pcluster/.slurm_plugin/scripts/conf/health_check_manager.conf
+echo "Mocked failing GPU Health Check"
+cat /opt/slurm/etc/pcluster/.slurm_plugin/scripts/conf/health_check_manager.conf

--- a/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/mock_successful_gpu_health_check.sh
+++ b/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/mock_successful_gpu_health_check.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir -p $HOME/mock_health_checks
+sudo tee $HOME/mock_health_checks/gpu_health_check.sh > /dev/null <<EOT
+#!/bin/bash
+exit 0
+EOT
+sudo chmod +x $HOME/mock_health_checks/gpu_health_check.sh
+
+sudo sed -i '/managed_health_check_dir =/ s|\/opt\/slurm\/etc\/pcluster\/\.slurm_plugin\/scripts\/health_checks|'$HOME'\/mock_health_checks|' /opt/slurm/etc/pcluster/.slurm_plugin/scripts/conf/health_check_manager.conf
+echo "Mocked successful GPU Health Check"
+cat /opt/slurm/etc/pcluster/.slurm_plugin/scripts/conf/health_check_manager.conf

--- a/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/pcluster.config.yaml
+++ b/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/pcluster.config.yaml
@@ -1,0 +1,69 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue-1
+    HealthChecks:
+      Gpu:
+        Enabled: true
+    ComputeResources:
+    - Name: compute-resource-1
+      Instances:
+        - InstanceType: g4dn.xlarge
+      HealthChecks:
+        Gpu:
+          Enabled: false
+    - Name: compute-resource-2
+      Instances:
+        - InstanceType: g4dn.xlarge
+      HealthChecks:
+        Gpu:
+          Enabled: true
+    - Name: compute-resource-3
+      Instances:
+        - InstanceType: g4dn.xlarge
+      MinCount: 1
+    - Name: compute-resource-4
+      Instances:
+        - InstanceType: c5.xlarge
+      HealthChecks:
+        Gpu:
+          Enabled: false
+    - Name: compute-resource-5
+      Instances:
+        - InstanceType: c5.xlarge
+      HealthChecks:
+        Gpu:
+          Enabled: true
+    - Name: compute-resource-6
+      Instances:
+        - InstanceType: c5.xlarge
+    Networking:
+      SubnetIds:
+        - {{ private_subnet_id }}
+  - Name: queue-2
+    ComputeResources:
+    - Name: compute-resource-1
+      Instances:
+        - InstanceType: g4dn.xlarge
+      HealthChecks:
+        Gpu:
+          Enabled: true
+    - Name: compute-resource-2
+      Instances:
+        - InstanceType: c5.xlarge
+      HealthChecks:
+        Gpu:
+          Enabled: true
+    Networking:
+      SubnetIds:
+        - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/restore_gpu_health_check.sh
+++ b/tests/integration-tests/tests/health_checks/test_gpu_health_checks/test_cluster_with_gpu_health_checks/restore_gpu_health_check.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sudo sed -i '/managed_health_check_dir =/ s|'$HOME'\/mock_health_checks|\/opt\/slurm\/etc\/pcluster\/\.slurm_plugin\/scripts\/health_checks|' /opt/slurm/etc/pcluster/.slurm_plugin/scripts/conf/health_check_manager.conf
+
+echo "Health check configuration restored"
+cat /opt/slurm/etc/pcluster/.slurm_plugin/scripts/conf/health_check_manager.conf


### PR DESCRIPTION
### Description of changes
* End to End tests for GPU Health Checks
  * Enable Health Checks at Queue Level AND only some compute resources that have a GPU-Enabled instance type
  * Simulate a GPU Health Check failure by pointing the health check manager to a different script that returns the exit code as needed (Exit 0 to simulate successful health checks, Exit 1 otherwise)

### Tests
```
* Queue 1 (HealthChecks Enabled)
    * CR-1 (Has GPU-Enabled InstanceTypes AND Health Check Disabled)
    * CR-2 (Has GPU-Enabled InstanceTypes AND Health Check Enabled)
    * CR-3 (Has GPU-Enabled InstanceTypes AND Health Check Section NOT explicitly added)
    * CR-4 (Has NO GPU-Enabled InstanceTypes AND Health Check Disabled)
    * CR-5 (Has NO GPU-Enabled InstanceTypes AND Health Check Enabled)
    * CR-6 (Has NO GPU-Enabled InstanceTypes AND Health Check Section NOT explicitly added)
* Queue 2 (HealthChecks Not Explicitly Enabled in Config)
    * CR-1 (Has GPU-Enabled InstanceTypes AND HealthChecks Enabled)
    * CR-2 (Has NO GPU-Enabled InstanceTypes AND Health Check Enabled)
```

### References
* N/A

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
