### PR TITLE
[Bug fix]Avoid creating dangling security groups when external EFS is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ CHANGELOG
 - Fix an issue that was causing misalignment of compute nodes IP on instances with multiple network interfaces.
 - Fix replacement of `StoragePass` in `slurm_parallelcluster_slurmdbd.conf` when a queue parameter update is performed and the Slurm accounting configurations are not updated.
 - Fix issue causing `cfn-hup` daemon to fail when it gets restarted.
+- Fix issue causing dangling security groups to be created when creating a cluster with an existing EFS.
 
 3.5.1
 -----

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -782,7 +782,6 @@ class ClusterCdkStack:
         """Add specific Cfn Resources to map the EFS storage."""
         # EFS FileSystem
         efs_id = shared_efs.file_system_id
-        new_file_system = efs_id is None
         deletion_policy = convert_deletion_policy(shared_efs.deletion_policy)
         if not efs_id and shared_efs.mount_dir:
             efs_resource = efs.CfnFileSystem(
@@ -798,33 +797,32 @@ class ClusterCdkStack:
             efs_resource.cfn_options.deletion_policy = efs_resource.cfn_options.update_replace_policy = deletion_policy
             efs_id = efs_resource.ref
 
-        checked_availability_zones = []
+            # Create Mount Targets
+            checked_availability_zones = []
 
-        # Mount Targets for Compute Fleet
-        compute_subnet_ids = self.config.compute_subnet_ids
-        file_system_security_groups = [self._add_storage_security_group(id, shared_efs)]
+            # Mount Targets for Compute Fleet
+            compute_subnet_ids = self.config.compute_subnet_ids
+            file_system_security_groups = [self._add_storage_security_group(id, shared_efs)]
 
-        for subnet_id in compute_subnet_ids:
+            for subnet_id in compute_subnet_ids:
+                self._add_efs_mount_target(
+                    id,
+                    efs_id,
+                    file_system_security_groups,
+                    subnet_id,
+                    checked_availability_zones,
+                    deletion_policy,
+                )
+
+            # Mount Target for Head Node
             self._add_efs_mount_target(
                 id,
                 efs_id,
                 file_system_security_groups,
-                subnet_id,
+                self.config.head_node.networking.subnet_id,
                 checked_availability_zones,
-                new_file_system,
                 deletion_policy,
             )
-
-        # Mount Target for Head Node
-        self._add_efs_mount_target(
-            id,
-            efs_id,
-            file_system_security_groups,
-            self.config.head_node.networking.subnet_id,
-            checked_availability_zones,
-            new_file_system,
-            deletion_policy,
-        )
 
         self.shared_storage_attributes[SharedStorageType.EFS]["EncryptionInTransits"].append(
             shared_efs.encryption_in_transit
@@ -840,23 +838,19 @@ class ClusterCdkStack:
         security_groups,
         subnet_id,
         checked_availability_zones,
-        new_file_system,
         deletion_policy,
     ):
         """Create a EFS Mount Point for the file system, if not already available on the same AZ."""
         availability_zone = AWSApi.instance().ec2.get_subnet_avail_zone(subnet_id)
         if availability_zone not in checked_availability_zones:
-            if new_file_system:
-                efs_resource = efs.CfnMountTarget(
-                    self.stack,
-                    "{0}MT{1}".format(efs_cfn_resource_id, availability_zone),
-                    file_system_id=file_system_id,
-                    security_groups=[sg.ref for sg in security_groups],
-                    subnet_id=subnet_id,
-                )
-                efs_resource.cfn_options.deletion_policy = (
-                    efs_resource.cfn_options.update_replace_policy
-                ) = deletion_policy
+            efs_resource = efs.CfnMountTarget(
+                self.stack,
+                "{0}MT{1}".format(efs_cfn_resource_id, availability_zone),
+                file_system_id=file_system_id,
+                security_groups=[sg.ref for sg in security_groups],
+                subnet_id=subnet_id,
+            )
+            efs_resource.cfn_options.deletion_policy = efs_resource.cfn_options.update_replace_policy = deletion_policy
             checked_availability_zones.append(availability_zone)
 
     def _add_raid_volume(self, id_prefix: str, shared_ebs: SharedEbs):

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -70,6 +70,25 @@ def test_cluster_builder_from_configuration_file(
     _generate_template(cluster, capsys)
 
 
+def test_no_security_groups_created_from_configuration_file(mocker, capsys, pcluster_config_reader, test_datadir):
+    """Starting from a config with security groups overwritten and external file systems, no sg should be created."""
+    mock_aws_api(mocker)
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+    mock_bucket_object_utils(mocker)
+
+    # Search config file from example_configs folder to test standard configuration
+    _, cluster = load_cluster_model_from_yaml("config.yaml", test_datadir)
+    generated_template, _ = _generate_template(cluster, capsys)
+    assert_that(
+        all(
+            resource["Type"]
+            not in ["AWS::EC2::SecurityGroup", "AWS::EC2::SecurityGroupEgress", "AWS::EC2::SecurityGroupIngress"]
+            for resource in generated_template["Resources"].values()
+        )
+    ).is_true()
+
+
 def _assert_config_snapshot(config, expected_full_config_path):
     """
     Confirm that no new configuration sections were added / removed.

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_no_security_groups_created_from_configuration_file/config.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_no_security_groups_created_from_configuration_file/config.yaml
@@ -1,0 +1,73 @@
+Region: us-east-1
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+    SecurityGroups:
+      - sg-34567890
+  Ssh:
+    KeyName: ec2-key-name
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      CapacityType: ONDEMAND
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+        SecurityGroups:
+          - sg-34567890
+      ComputeResources:
+        - Name: compute-resource-1
+          InstanceType: c5.xlarge
+        - Name: compute-resource-2
+          InstanceType: c4.xlarge
+    - Name: queue2
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+        SecurityGroups:
+          - sg-12345678
+          - sg-12345679
+      ComputeResources:
+        - Name: compute-resource-1
+          InstanceType: c4.2xlarge
+        - Name: compute-resource-2
+          InstanceType: c5.2xlarge
+          MinCount: 1
+          MaxCount: 15
+SharedStorage:
+  - MountDir: /my/mount/point1
+    Name: name1
+    StorageType: Ebs
+    EbsSettings:
+      VolumeType: gp2  # gp2 | gp3 | io1 | io2 | sc1 | st1 | standard
+      Iops: 100
+      Size: 150
+      Encrypted: True
+      KmsKeyId: String
+      SnapshotId: snap-12345678
+      VolumeId: vol-12345678
+      DeletionPolicy: Retain
+  - MountDir: /my/mount/point2
+    Name: name2
+    StorageType: Efs
+    EfsSettings:
+      FileSystemId: fs-12345678
+  - MountDir: /my/mount/point3
+    Name: name3
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      FileSystemId: fs-12345678901234567
+  - MountDir: /my/mount/point4
+    Name: name4
+    StorageType: FsxOpenZfs
+    FsxOpenZfsSettings:
+      VolumeId: fsvol-12345678901234567
+  - MountDir: /my/mount/point5
+    Name: name5
+    StorageType: FsxOntap
+    FsxOntapSettings:
+      VolumeId: fsvol-12345678901234567


### PR DESCRIPTION
This commit also contains a minor code refactor

### Tests
* Created a new unit test to check a CloudFormation template does not contain security groups when proper cluster configuration file is provided.
* Integration test test_efs_compute_az has been passed

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
