### PR TITLE
[release-3.6] Redirect console output from third-party imports in the CLI entrypoint to the logfile

### DIFF
--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -23,21 +23,26 @@ from functools import partial
 import argparse
 from botocore.exceptions import NoCredentialsError  # TODO: remove
 
-# Controllers
-import pcluster.api.controllers.cluster_compute_fleet_controller
-import pcluster.api.controllers.cluster_instances_controller
-import pcluster.api.controllers.cluster_operations_controller
-import pcluster.api.controllers.image_operations_controller
-import pcluster.api.errors
-import pcluster.cli.commands.commands as cli_commands
 import pcluster.cli.logger as pcluster_logging
-import pcluster.cli.model
-from pcluster.api import encoder
-from pcluster.cli.commands.common import CliCommand, exit_msg, to_bool, to_int, to_number
-from pcluster.cli.exceptions import APIOperationException, ParameterException
 from pcluster.cli.logger import redirect_stdouterr_to_logger
-from pcluster.cli.middleware import add_additional_args, middleware_hooks
-from pcluster.utils import to_camel_case, to_snake_case
+
+pcluster_logging.config_logger()
+
+# Redirect console output from imports to log file (https://github.com/aws/jsii/issues/4065)
+with redirect_stdouterr_to_logger():
+    # Controllers
+    import pcluster.api.controllers.cluster_compute_fleet_controller
+    import pcluster.api.controllers.cluster_instances_controller
+    import pcluster.api.controllers.cluster_operations_controller
+    import pcluster.api.controllers.image_operations_controller
+    import pcluster.api.errors
+    import pcluster.cli.commands.commands as cli_commands
+    import pcluster.cli.model
+    from pcluster.api import encoder
+    from pcluster.cli.commands.common import CliCommand, exit_msg, to_bool, to_int, to_number
+    from pcluster.cli.exceptions import APIOperationException, ParameterException
+    from pcluster.cli.middleware import add_additional_args, middleware_hooks
+    from pcluster.utils import to_camel_case, to_snake_case
 
 LOGGER = logging.getLogger(__name__)
 
@@ -258,7 +263,6 @@ def run(sys_args, model=None):
 
 
 def main():
-    pcluster_logging.config_logger()
     try:
         ret = run(sys.argv[1:])
         if ret:


### PR DESCRIPTION
### Description of changes
* Cherry picked from https://github.com/aws/aws-parallelcluster/commit/ee436635bfb8b960a68bf29fda758eae34e793dd
* This commit (https://github.com/aws/aws-parallelcluster/pull/5035) imports components of CDK that seem to be untested on Node `v20.0.0`
* When running `pcluster` cli commands in a node `v20.0.0` environment, the following warning message is shown:

```
b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
b'!!                                                                                                                      !!\n'
b'!!  This software has not been tested with node v20.0.0.                                                                !!\n'
b'!!  Should you encounter odd runtime issues, please try using one of the supported release before filing a bug report.  !!\n'
b'!!                                                                                                                      !!\n'
b'!!  This software is currently running on node v20.0.0.                                                                 !!\n'
b'!!  As of the current release of this software, supported node releases are:                                            !!\n'
b'!!  - ^18.0.0 (Planned end-of-life: 2025-04-30)                                                                         !!\n'
b'!!  - ^16.3.0 (Planned end-of-life: 2023-09-11)                                                                         !!\n'
b'!!  - ^19.0.0 (Planned end-of-life: 2023-06-01)                                                                         !!\n'
b'!!  - ^14.6.0 (Planned end-of-life: 2023-04-30) [DEPRECATED]                                                            !!\n'
b'!!                                                                                                                      !!\n'
b'!!  This warning can be silenced by setting the JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION environment variable.        !!\n'
b'!!                                                                                                                      !!\n'
b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
```

* Such warnings should be redirected to the CLI log file, not the console/terminal
* This commit wraps the import section in the entrypoint to ensure any messages printed in third-party imports is redirected to the log file

### Tests
* Manually tested and checked the message appears in the log file.

```
» node --version
v20.0.0

» pcluster version
{
  "version": "3.6.0"
}
```

_pcluster-cli.log_
```
2023-04-21 17:29:48,153 - ERROR - logger.py:74:write() - b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
2023-04-21 17:29:48,153 - ERROR - logger.py:74:write() - b'!!                                                                                                                      !!\n'
2023-04-21 17:29:48,154 - ERROR - logger.py:74:write() - b'!!  This software has not been tested with node v20.0.0.                                                                !!\n'
2023-04-21 17:29:48,154 - ERROR - logger.py:74:write() - b'!!  Should you encounter odd runtime issues, please try using one of the supported release before filing a bug report.  !!\n'
2023-04-21 17:29:48,154 - ERROR - logger.py:74:write() - b'!!                                                                                                                      !!\n'
2023-04-21 17:29:48,154 - ERROR - logger.py:74:write() - b'!!  This software is currently running on node v20.0.0.                                                                 !!\n'
2023-04-21 17:29:48,154 - ERROR - logger.py:74:write() - b'!!  As of the current release of this software, supported node releases are:                                            !!\n'
2023-04-21 17:29:48,154 - ERROR - logger.py:74:write() - b'!!  - ^18.0.0 (Planned end-of-life: 2025-04-30)                                                                         !!\n'
2023-04-21 17:29:48,155 - ERROR - logger.py:74:write() - b'!!  - ^16.3.0 (Planned end-of-life: 2023-09-11)                                                                         !!\n'
2023-04-21 17:29:48,155 - ERROR - logger.py:74:write() - b'!!  - ^19.0.0 (Planned end-of-life: 2023-06-01)                                                                         !!\n'
2023-04-21 17:29:48,155 - ERROR - logger.py:74:write() - b'!!  - ^14.6.0 (Planned end-of-life: 2023-04-30) [DEPRECATED]                                                            !!\n'
2023-04-21 17:29:48,155 - ERROR - logger.py:74:write() - b'!!                                                                                                                      !!\n'
2023-04-21 17:29:48,155 - ERROR - logger.py:74:write() - b'!!  This warning can be silenced by setting the JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION environment variable.        !!\n'
2023-04-21 17:29:48,155 - ERROR - logger.py:74:write() - b'!!                                                                                                                      !!\n'
2023-04-21 17:29:48,155 - ERROR - logger.py:74:write() - b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
2023-04-21 17:29:49,554 - INFO - entrypoint.py:260:run() - Handling CLI command version
```
* Ran existing unit tests.

### References
* https://github.com/aws/jsii/issues/4065
* https://github.com/aws/aws-parallelcluster/pull/5035

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
