### PR TITLE
Use https Url for PoliciesTemplateUri in API Stack - develop

### DIFF
--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -166,7 +166,7 @@ Resources:
         - UseCustomPoliciesTemplateUri
         - !Ref PoliciesTemplateUri
         - !Sub
-          - "s3://${AWS::Region}-aws-parallelcluster/parallelcluster/${Version}/templates/policies/policies.yaml"
+          - "https://${AWS::Region}-aws-parallelcluster.s3.amazonaws.com/parallelcluster/${Version}/templates/policies/policies.yaml"
           - { Version: !FindInMap [ParallelCluster, Constants, Version] }
       TimeoutInMinutes: 10
       Parameters:

--- a/api/infrastructure/parallelcluster-api.yaml
+++ b/api/infrastructure/parallelcluster-api.yaml
@@ -166,7 +166,7 @@ Resources:
         - UseCustomPoliciesTemplateUri
         - !Ref PoliciesTemplateUri
         - !Sub
-          - "https://${AWS::Region}-aws-parallelcluster.s3.amazonaws.com/parallelcluster/${Version}/templates/policies/policies.yaml"
+          - "https://${AWS::Region}-aws-parallelcluster.s3.${AWS::Region}.${AWS::URLSuffix}/parallelcluster/${Version}/templates/policies/policies.yaml"
           - { Version: !FindInMap [ParallelCluster, Constants, Version] }
       TimeoutInMinutes: 10
       Parameters:


### PR DESCRIPTION
### Description of changes
* Set default URL for the policies stack template as a https URL instead of a s3 URL (apparently not supported by the CFN CreateStack API).

### Tests
* Successfully deployed the API stack by overriding the `PoliciesTemplateUri` using the https URL of the same S3 object currently specified via a s3 URL.

### References
* https://github.com/aws/aws-parallelcluster/pull/5250

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
