### PR TITLE
Add metric for GPU health check failure

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -3094,6 +3094,17 @@ class SlurmClusterConfig(CommonSchedulerClusterConfig):
                     result[instance_type] = instance_type_info.instance_type_data
         return result
 
+    @property
+    def has_gpu_health_checks_enabled(self):
+        """Return True if an queue or compute resources has GPU health checking enabled."""
+        for queue in self.scheduling.queues:
+            if queue.health_checks.gpu.enabled:
+                return True
+            for compute_resource in queue.compute_resources:
+                if compute_resource.health_checks.gpu.enabled:
+                    return True
+        return False
+
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
         self._register_validator(

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -332,13 +332,22 @@ class CWDashboardConstruct(Construct):
                 filter_pattern=_generate_metric_filter_pattern("invalid-backing-instance-count"),
                 metric_value=metric_value,
             ),
-            # Use text matching here because it comes from slurmctld.log
             _CustomMetricFilter(
                 metric_name="SlurmNodeNotRespondingErrors",
                 filter_pattern=_generate_metric_filter_pattern("node-not-responding-down-count"),
                 metric_value=metric_value,
             ),
         ]
+
+        if self.config.has_gpu_health_checks_enabled:
+            compute_node_events.append(
+                _CustomMetricFilter(
+                    metric_name="GpuHealthCheckFailures",
+                    filter_pattern='{ $.event-type = "compute-node-health-check" && $.scheduler = "slurm" && '
+                    '$.detail.health-check-name = "Gpu" && $.detail.health-check-result != 0 }',
+                    metric_value="1",
+                )
+            )
 
         cluster_health_metrics = [
             _HealthMetric(

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -221,6 +221,7 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml):
         "OnNodeConfiguredDownloadErrors",
         "OnNodeConfiguredRunErrors",
     ]
+    health_check_failure_metrics = ["GpuHealthCheckFailures"]
     idle_node_metrics = ["MaxDynamicNodeIdleTime"]
     if scheduler == "slurm":
         # Contains error metric title
@@ -235,7 +236,17 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml):
         else:
             for metric in custom_action_metrics:
                 assert_that(output_yaml).does_not_contain(metric)
+        _verify_health_check_failure_metrics(cluster_config, output_yaml, health_check_failure_metrics)
     else:
         assert_that(output_yaml).does_not_contain("Cluster Health Metrics")
-        for metric in slurm_related_metrics + custom_action_metrics + idle_node_metrics:
+        for metric in slurm_related_metrics + custom_action_metrics + idle_node_metrics + health_check_failure_metrics:
+            assert_that(output_yaml).does_not_contain(metric)
+
+
+def _verify_health_check_failure_metrics(cluster_config, output_yaml, health_check_failure_metrics):
+    if cluster_config.has_gpu_health_checks_enabled:
+        for metric in health_check_failure_metrics:
+            assert_that(output_yaml).contains(metric)
+    else:
+        for metric in health_check_failure_metrics:
             assert_that(output_yaml).does_not_contain(metric)

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.slurm.conditional_vol.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/alinux2.slurm.conditional_vol.yaml
@@ -32,6 +32,9 @@ Scheduling:
           MaxCount: 5
         - Name: compute_resource2
           InstanceType: c4.2xlarge
+      HealthChecks:
+        Gpu:
+          Enabled: true
       CustomActions:
         OnNodeConfigured:
           Script: s3://{{ resource_bucket }}/scripts/postinstall.sh

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos7.slurm.full.yaml
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder/test_cw_dashboard_builder/centos7.slurm.full.yaml
@@ -37,6 +37,9 @@ Scheduling:
           MaxCount: 5
         - Name: compute_resource2
           InstanceType: c4.2xlarge
+          HealthChecks:
+            Gpu:
+              Enabled: true
 SharedStorage:
   - MountDir: /my/mount/ebs1
     Name: name1


### PR DESCRIPTION
### Description of changes
* This change add the GPU health check failure metric to the "Unhealthy Instance Errors" dashboard widget.

### Tests
* Added assertions to verify that the GPU widget is added to the dashboard if GPU health checks are enabled and to verify that the widget is not added if GPU health checks are not enabled.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
