### PR TITLE
Replace aws-parallelcluster::validations with InSpec controls

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -385,5 +385,8 @@ phases:
           commands:
             - |
               set -vx
-
-              cinc-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/parallelcluster/image_dna.json --override-runlist aws-parallelcluster::validations
+              echo "Performing InSpec validation on the AMI..."
+              cd /etc/chef/cookbooks/aws-parallelcluster
+              inspec exec test/resources --profiles-path . --controls /tag:install/ --no-distinct-exit
+              [[ $? -ne 0 ]] && echo "InSpec validation failed" && exit 1
+              echo "InSpec validation passed"


### PR DESCRIPTION
### Description of changes
Replace aws-parallelcluster::validations with InSpec controls

### Tests
* Created an AMI using this code
* Checked AMI logs and verified the step has been executed correctly

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2062

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
