### PR TITLE
Run InSpec controls from AMI build Test phase

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
@@ -283,18 +283,14 @@ phases:
                 fi
               fi
 
-      - name: Log4jPatcher
+      - name: InSpecTestsForPlatform
         action: ExecuteBash
         inputs:
           commands:
             - |
               set -vx
-              OS="{{ test.OperatingSystemName.outputs.stdout }}"
-              if [[ ${OS} =~ ^alinux ]]; then
-                echo "verify log4j-cve-2021-44228-hotpatch service is disabled"
-                systemctl show -p SubState log4j-cve-2021-44228-hotpatch | grep -i -v running
-                [[ $? -ne 0 ]] && echo "log4j-cve-2021-44228-hotpatch service is running" && exit 1
-                systemctl show -p LoadState log4j-cve-2021-44228-hotpatch | grep -i "LoadState=masked"
-                [[ $? -ne 0 ]] && echo "log4j-cve-2021-44228-hotpatch service is not masked" && exit 1
-              fi
-              echo "Log4jPatcher Group test passed"
+              echo "Performing InSpec tests for platform on the AMI..."
+              cd /etc/chef/cookbooks/aws-parallelcluster-platform
+              inspec exec test --profiles-path . --controls /tag:testami/ --no-distinct-exit
+              [[ $? -ne 0 ]] && echo "InSpec tests for platform failed" && exit 1
+              echo "InSpec tests for platform passed"


### PR DESCRIPTION
### Description of changes
Run InSpec controls from AMI build Test phase.

Controls tagged as tag:testami will be run.

### Tests
An AMI built using this code. Checked InSpec controls run from Test phase of the AMI build

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2083

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
