### PR TITLE
Suppress JSII warnings for Node version

### DIFF
--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -23,21 +23,27 @@ from functools import partial
 import argparse
 from botocore.exceptions import NoCredentialsError  # TODO: remove
 
+# Suppress JSII warnings for Node version
+os.environ["JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION"] = "1"
+os.environ["JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION"] = "1"
+os.environ["JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION"] = "1"
+os.environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = "1"
+
 # Controllers
-import pcluster.api.controllers.cluster_compute_fleet_controller
-import pcluster.api.controllers.cluster_instances_controller
-import pcluster.api.controllers.cluster_operations_controller
-import pcluster.api.controllers.image_operations_controller
-import pcluster.api.errors
-import pcluster.cli.commands.commands as cli_commands
-import pcluster.cli.logger as pcluster_logging
-import pcluster.cli.model
-from pcluster.api import encoder
-from pcluster.cli.commands.common import CliCommand, exit_msg, to_bool, to_int, to_number
-from pcluster.cli.exceptions import APIOperationException, ParameterException
-from pcluster.cli.logger import redirect_stdouterr_to_logger
-from pcluster.cli.middleware import add_additional_args, middleware_hooks
-from pcluster.utils import to_camel_case, to_snake_case
+import pcluster.api.controllers.cluster_compute_fleet_controller  # noqa: E402
+import pcluster.api.controllers.cluster_instances_controller  # noqa: E402
+import pcluster.api.controllers.cluster_operations_controller  # noqa: E402
+import pcluster.api.controllers.image_operations_controller  # noqa: E402
+import pcluster.api.errors  # noqa: E402
+import pcluster.cli.commands.commands as cli_commands  # noqa: E402
+import pcluster.cli.logger as pcluster_logging  # noqa: E402
+import pcluster.cli.model  # noqa: E402
+from pcluster.api import encoder  # noqa: E402
+from pcluster.cli.commands.common import CliCommand, exit_msg, to_bool, to_int, to_number  # noqa: E402
+from pcluster.cli.exceptions import APIOperationException, ParameterException  # noqa: E402
+from pcluster.cli.logger import redirect_stdouterr_to_logger  # noqa: E402
+from pcluster.cli.middleware import add_additional_args, middleware_hooks  # noqa: E402
+from pcluster.utils import to_camel_case, to_snake_case  # noqa: E402
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Description of changes
This patch suppressess the JSII warnings for Node version in the same way that JSII does in their tests. Reference:

https://github.com/aws/jsii/blob/main/packages/%40jsii/python-runtime/tests/test_invoke_bin.py#L15-L18

### Tests
```
(venv) ➜  aws-parallelcluster git:(release-3.6) ✗ nvm use 19.5
Now using node v19.5.0 (npm v9.3.1)
(venv) ➜  aws-parallelcluster git:(release-3.6) ✗ node --version
v19.5.0
(venv) ➜  aws-parallelcluster git:(release-3.6) ✗ pcluster version
{
  "version": "3.6.0"
}
(venv) ➜  aws-parallelcluster git:(release-3.6) ✗ nvm use 20.0
Now using node v20.0.0 (npm v9.6.4)
(venv) ➜  aws-parallelcluster git:(release-3.6) ✗ node --version
v20.0.0
(venv) ➜  aws-parallelcluster git:(release-3.6) ✗ pcluster version
{
  "version": "3.6.0"
}
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
