### PR TITLE
[release-3.6]Move CDK imports under the redirect_stdouterr_to_logger contextmanager

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -18,7 +18,6 @@ import tempfile
 from pcluster.config.cluster_config import BaseClusterConfig
 from pcluster.config.imagebuilder_config import ImageBuilderConfig
 from pcluster.models.s3_bucket import S3Bucket
-from pcluster.templates.cdk_artifacts_manager import CDKArtifactsManager
 from pcluster.utils import load_yaml_dict
 
 LOGGER = logging.getLogger(__name__)
@@ -35,6 +34,8 @@ class CDKTemplateBuilder:
         LOGGER.info("Importing CDK...")
         from aws_cdk.core import App  # pylint: disable=C0415
 
+        # CDK import must be inside the redirect_stdouterr_to_logger contextmanager
+        from pcluster.templates.cdk_artifacts_manager import CDKArtifactsManager  # pylint: disable=C0415
         from pcluster.templates.cluster_stack import ClusterCdkStack  # pylint: disable=C0415
 
         LOGGER.info("CDK import completed successfully")

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -12,8 +12,6 @@
 import re
 from urllib.parse import urlparse
 
-from aws_cdk.core import Arn, ArnFormat
-
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError
 from pcluster.constants import DIRECTORY_SERVICE_RESERVED_SETTINGS
@@ -83,6 +81,9 @@ class PasswordSecretArnValidator(Validator):
          2. a readable parameter in SSM Parameter Store, which is supported only in us-isob-east-1.
         """
         try:
+            # CDK import must be inside the redirect_stdouterr_to_logger contextmanager
+            from aws_cdk.core import Arn, ArnFormat  # pylint: disable=C0415
+
             # We only require the secret to exist; we do not validate its content.
             arn_components = Arn.split(password_secret_arn, ArnFormat.COLON_RESOURCE_NAME)
             service, resource = arn_components.service, arn_components.resource


### PR DESCRIPTION
### Description of changes
All CDK imports must be inside the `redirect_stdouterr_to_logger` contextmanager, so that warning messages coming from CDK are redirected to the CLI log instead of stdout

### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
