### PR TITLE
[develop] Avoid Node.js warnings using same approach used in 3.6.0 branch

### DIFF
--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -27,7 +27,6 @@ from botocore.exceptions import NoCredentialsError  # TODO: remove
 os.environ["JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION"] = "1"
 os.environ["JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION"] = "1"
 os.environ["JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION"] = "1"
-os.environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = "1"
 
 # Controllers
 import pcluster.api.controllers.cluster_compute_fleet_controller  # noqa: E402

--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -23,21 +23,27 @@ from functools import partial
 import argparse
 from botocore.exceptions import NoCredentialsError  # TODO: remove
 
+# Suppress JSII warnings for Node version
+os.environ["JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION"] = "1"
+os.environ["JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION"] = "1"
+os.environ["JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION"] = "1"
+os.environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = "1"
+
 # Controllers
-import pcluster.api.controllers.cluster_compute_fleet_controller
-import pcluster.api.controllers.cluster_instances_controller
-import pcluster.api.controllers.cluster_operations_controller
-import pcluster.api.controllers.image_operations_controller
-import pcluster.api.errors
-import pcluster.cli.commands.commands as cli_commands
-import pcluster.cli.logger as pcluster_logging
-import pcluster.cli.model
-from pcluster.api import encoder
-from pcluster.cli.commands.common import CliCommand, exit_msg, to_bool, to_int, to_number
-from pcluster.cli.exceptions import APIOperationException, ParameterException
-from pcluster.cli.logger import redirect_stdouterr_to_logger
-from pcluster.cli.middleware import add_additional_args, middleware_hooks
-from pcluster.utils import to_camel_case, to_snake_case
+import pcluster.api.controllers.cluster_compute_fleet_controller  # noqa: E402
+import pcluster.api.controllers.cluster_instances_controller  # noqa: E402
+import pcluster.api.controllers.cluster_operations_controller  # noqa: E402
+import pcluster.api.controllers.image_operations_controller  # noqa: E402
+import pcluster.api.errors  # noqa: E402
+import pcluster.cli.commands.commands as cli_commands  # noqa: E402
+import pcluster.cli.logger as pcluster_logging  # noqa: E402
+import pcluster.cli.model  # noqa: E402
+from pcluster.api import encoder  # noqa: E402
+from pcluster.cli.commands.common import CliCommand, exit_msg, to_bool, to_int, to_number  # noqa: E402
+from pcluster.cli.exceptions import APIOperationException, ParameterException  # noqa: E402
+from pcluster.cli.logger import redirect_stdouterr_to_logger  # noqa: E402
+from pcluster.cli.middleware import add_additional_args, middleware_hooks  # noqa: E402
+from pcluster.utils import to_camel_case, to_snake_case  # noqa: E402
 
 LOGGER = logging.getLogger(__name__)
 

--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -23,26 +23,21 @@ from functools import partial
 import argparse
 from botocore.exceptions import NoCredentialsError  # TODO: remove
 
+# Controllers
+import pcluster.api.controllers.cluster_compute_fleet_controller
+import pcluster.api.controllers.cluster_instances_controller
+import pcluster.api.controllers.cluster_operations_controller
+import pcluster.api.controllers.image_operations_controller
+import pcluster.api.errors
+import pcluster.cli.commands.commands as cli_commands
 import pcluster.cli.logger as pcluster_logging
+import pcluster.cli.model
+from pcluster.api import encoder
+from pcluster.cli.commands.common import CliCommand, exit_msg, to_bool, to_int, to_number
+from pcluster.cli.exceptions import APIOperationException, ParameterException
 from pcluster.cli.logger import redirect_stdouterr_to_logger
-
-pcluster_logging.config_logger()
-
-# Redirect console output from imports to log file (https://github.com/aws/jsii/issues/4065)
-with redirect_stdouterr_to_logger():
-    # Controllers
-    import pcluster.api.controllers.cluster_compute_fleet_controller
-    import pcluster.api.controllers.cluster_instances_controller
-    import pcluster.api.controllers.cluster_operations_controller
-    import pcluster.api.controllers.image_operations_controller
-    import pcluster.api.errors
-    import pcluster.cli.commands.commands as cli_commands
-    import pcluster.cli.model
-    from pcluster.api import encoder
-    from pcluster.cli.commands.common import CliCommand, exit_msg, to_bool, to_int, to_number
-    from pcluster.cli.exceptions import APIOperationException, ParameterException
-    from pcluster.cli.middleware import add_additional_args, middleware_hooks
-    from pcluster.utils import to_camel_case, to_snake_case
+from pcluster.cli.middleware import add_additional_args, middleware_hooks
+from pcluster.utils import to_camel_case, to_snake_case
 
 LOGGER = logging.getLogger(__name__)
 
@@ -263,6 +258,7 @@ def run(sys_args, model=None):
 
 
 def main():
+    pcluster_logging.config_logger()
     try:
         ret = run(sys.argv[1:])
         if ret:

--- a/cli/src/pcluster/templates/cdk_builder.py
+++ b/cli/src/pcluster/templates/cdk_builder.py
@@ -18,7 +18,6 @@ import tempfile
 from pcluster.config.cluster_config import BaseClusterConfig
 from pcluster.config.imagebuilder_config import ImageBuilderConfig
 from pcluster.models.s3_bucket import S3Bucket
-from pcluster.templates.cdk_artifacts_manager import CDKArtifactsManager
 from pcluster.utils import load_yaml_dict
 
 LOGGER = logging.getLogger(__name__)
@@ -35,6 +34,8 @@ class CDKTemplateBuilder:
         LOGGER.info("Importing CDK...")
         from aws_cdk.core import App  # pylint: disable=C0415
 
+        # CDK import must be inside the redirect_stdouterr_to_logger contextmanager
+        from pcluster.templates.cdk_artifacts_manager import CDKArtifactsManager  # pylint: disable=C0415
         from pcluster.templates.cluster_stack import ClusterCdkStack  # pylint: disable=C0415
 
         LOGGER.info("CDK import completed successfully")

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -81,9 +81,6 @@ class PasswordSecretArnValidator(Validator):
          2. a readable parameter in SSM Parameter Store, which is supported only in us-isob-east-1.
         """
         try:
-            # CDK import must be inside the redirect_stdouterr_to_logger contextmanager
-            from aws_cdk.core import Arn, ArnFormat  # pylint: disable=C0415
-
             # We only require the secret to exist; we do not validate its content.
             arn_components = password_secret_arn.split(":")
             service = arn_components[2]

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -81,6 +81,9 @@ class PasswordSecretArnValidator(Validator):
          2. a readable parameter in SSM Parameter Store, which is supported only in us-isob-east-1.
         """
         try:
+            # CDK import must be inside the redirect_stdouterr_to_logger contextmanager
+            from aws_cdk.core import Arn, ArnFormat  # pylint: disable=C0415
+
             # We only require the secret to exist; we do not validate its content.
             arn_components = password_secret_arn.split(":")
             service = arn_components[2]


### PR DESCRIPTION
### Description of changes
* We're reverting the  `[CLI] Redirect console output from third-party imports in the CLI entrypoint to the logfile` because it is causing issues with custom resources, then fixing the warning message by suppressing JSII warnings and moving only CDK imports under the redircet_stdouterr_to_logger contextmanager.

### References
* https://github.com/aws/aws-parallelcluster/pull/5284
* https://github.com/aws/aws-parallelcluster/pull/5285
* https://github.com/aws/aws-parallelcluster/pull/5274