### PR TITLE
Don't suppress JSII Node EOL warning with `JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION`

### DIFF
--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -27,7 +27,6 @@ from botocore.exceptions import NoCredentialsError  # TODO: remove
 os.environ["JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION"] = "1"
 os.environ["JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION"] = "1"
 os.environ["JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION"] = "1"
-os.environ["JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION"] = "1"
 
 # Controllers
 import pcluster.api.controllers.cluster_compute_fleet_controller  # noqa: E402


### PR DESCRIPTION
### Description of changes
In order to suppress the Node EOL warning it is not sufficient to set `JSII_SILENCE_WARNING_END_OF_LIFE_NODE_VERSION` to `"1"`, it needs to be set to the message indicated in https://github.com/aws/jsii/pull/4077.

This message is bound to change for new Node versions, and in any case we have moved imports of cdk libraries in the context manager.

### Tests
Verified that with Node 14 the warning is still not visible thanks to https://github.com/aws/aws-parallelcluster/pull/5285.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
