### PR TITLE
[integ-test] Test if resources remain undeleted on cluster updates involving large changes in number of queues

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -710,6 +710,11 @@ update:
       - regions: [ "eu-west-2" ]
         schedulers: [ "slurm" ]
         oss: ["alinux2"]
+  test_update.py::test_resource_changes_in_cluster_with_multiple_queues:
+    dimensions:
+      - regions: [ "eu-west-2" ]
+        schedulers: [ "slurm" ]
+        oss: ["alinux2"]
 multiple_nics:
   test_multiple_nics.py::test_multiple_nics:
     dimensions:

--- a/tests/integration-tests/tests/update/test_update/test_resource_changes_in_cluster_with_multiple_queues/pcluster_1_queue.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_resource_changes_in_cluster_with_multiple_queues/pcluster_1_queue.config.yaml
@@ -1,0 +1,21 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue-a
+      ComputeResources:
+        - Name: queue-a-cr-static
+          Instances:
+            - InstanceType: t2.micro
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/update/test_update/test_resource_changes_in_cluster_with_multiple_queues/pcluster_max_queue.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_resource_changes_in_cluster_with_multiple_queues/pcluster_max_queue.config.yaml
@@ -1,0 +1,33 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+{% for q in range(49) %}
+    - Name: queue-{{q}}
+      ComputeResources:
+        - Name: queue1-i1
+          Instances:
+            - InstanceType: t2.micro
+          MinCount: 0
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+{% endfor %}
+    - Name: queue-a
+      ComputeResources:
+        - Name: queue-a-cr-static
+          Instances:
+            - InstanceType: t2.micro
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -673,6 +673,14 @@ def get_stack_name_from_stack_arn(arn):
     return arn.rsplit("/", 2)[-2] if arn else ""
 
 
+def get_instance_profile_from_arn(arn):
+    """
+    Return the instance profile name from the ARN
+    E.g. Stack ARN: "arn:aws:iam::<ACCOUNT_ID>:instance-profile/.../<INSTANCE_PROFILE_NAME>"
+    """
+    return arn.rsplit("/", 1)[-1] if arn else ""
+
+
 def check_pcluster_list_cluster_log_streams(cluster, os, expected_log_streams=None):
     """Test pcluster list-cluster-logs functionality and return cfn-init log stream name."""
     logging.info("Testing that pcluster list-cluster-log-streams is working as expected")


### PR DESCRIPTION
### Description of changes
* This test checks if the resources associated with a node (e.g the instance profile) are not deleted during cluster update operations

### Tests
* It creates a 50 queue cluster with the last queue running a static node
* Gets the instance profile of the static node
* Performs a cluster update to reduce to 1 queue (running the static node)
* Confirms that the instance profile is NOT deleted (still exists) by making a get-instance-profile request
* Performs another cluster update to increase to 50 queues (last one running running the static node)
* Confirms that the instance profile is NOT deleted (still exists) by making a get-instance-profile request
* Confirms jobs are executed successfully

### References
* https://github.com/aws/aws-parallelcluster/pull/5297

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
