### PR TITLE
`[custom_resource]` Propagate tags from stack.

### DIFF
--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -119,6 +119,7 @@ Resources:
       Timeout: 60
       Code:
         ZipFile: |
+          import boto3
           import datetime
           import json
           import logging
@@ -175,6 +176,11 @@ Resources:
           def serialize(val):
               return utils.to_iso_timestr(val) if isinstance(val, datetime.date) else val
 
+          def get_stack_tags(stack_name, overrides):
+              cfn = boto3.client('cloudformation')
+              stack_tags = cfn.describe_stacks(StackName=stack_name)["Stacks"][0].get("Tags", [])
+              return list(filter(lambda t: not (t["Key"].startswith("aws:") or t["Key"] in overrides), stack_tags))
+
           def create_or_update(event):
               properties = event["ResourceProperties"]
               request_type = event["RequestType"].upper()
@@ -194,6 +200,10 @@ Resources:
               try:
                   meta_keys = {"ServiceToken", "DeletionPolicy"}
                   kwargs = {**{pcluster.utils.to_snake_case(k): serialize(v) for k, v in drop_keys(properties, meta_keys).items()}, "wait": False}
+                  config_tags = properties["ClusterConfiguration"].get("Tags", [])
+                  stack_tags = get_stack_tags(event['StackId'], {t["Key"] for t in config_tags})
+                  if len(stack_tags) > 0:
+                      kwargs["cluster_configuration"]["Tags"] = stack_tags + config_tags
                   func = {"CREATE": pc.create_cluster, "UPDATE": pc.update_cluster}[request_type]
                   update_response(func(**kwargs))
               except (APIOperationException, ParameterException, TypeError)  as e:

--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -30,12 +30,13 @@ from utils import (
 class CfnStack:
     """Identify a CloudFormation stack."""
 
-    def __init__(self, name, region, template, parameters=None, capabilities=None):
+    def __init__(self, name, region, template, parameters=None, capabilities=None, tags=None):
         self.name = name
         self.region = region
         self.template = template
         self.parameters = parameters or []
         self.capabilities = capabilities or []
+        self.tags = tags or []
         self.cfn_stack_id = None
         self.__cfn_outputs = None
         self.__cfn_resources = None
@@ -169,6 +170,7 @@ class CfnStacksFactory:
                         TemplateURL=stack.template,
                         Parameters=stack.parameters,
                         Capabilities=stack.capabilities,
+                        Tags=stack.tags,
                     )
                 else:
                     result = cfn_client.create_stack(
@@ -176,6 +178,7 @@ class CfnStacksFactory:
                         TemplateBody=stack.template,
                         Parameters=stack.parameters,
                         Capabilities=stack.capabilities,
+                        Tags=stack.tags,
                     )
                 stack.cfn_stack_id = result["StackId"]
                 self.__created_stacks[id] = stack

--- a/tests/integration-tests/tests/custom_resource/conftest.py
+++ b/tests/integration-tests/tests/custom_resource/conftest.py
@@ -146,6 +146,7 @@ def cluster_custom_resource_factory_fixture(
             template=template_data,
             parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items()],
             capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
+            tags=[{"Key": "cluster_name", "Value": cluster_name}],  # For testing, add a tag to the stack
         )
 
         cfn_stacks_factory.create_stack(stack, True)

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
@@ -60,8 +60,10 @@ def test_cluster_create(region, cluster_custom_resource_factory):
     stack = cluster_custom_resource_factory()
     error_message = "KeyPairValidator"
     cluster_name = _stack_parameter(stack, "ClusterName")
-    cluster = pc().list_clusters(query=f"clusters[?clusterName=='{cluster_name}']|[0]")
+    cluster = pc().describe_cluster(cluster_name=cluster_name)
     assert_that(cluster["clusterStatus"]).is_not_none()
+    tags = cluster["tags"]
+    assert_that(next(filter(lambda t: t["key"] == "cluster_name", tags))["value"]).is_equal_to(cluster_name)
     assert_that(stack.cfn_outputs.get("ValidationMessages", "")).contains(error_message)
     assert_that(stack.cfn_outputs.get("HeadNodeIp")).is_not_none()
 


### PR DESCRIPTION
### Description of changes

#### What: 
* Check the cloudformation stack of the custom resource for tags and if they exist add them to the cluster

#### Why
* Tag propagation from the enclosing stack to the resources it creates is common behavior.
* Customers use tags for permissions boundaries and cost tracking and this provides a convenient mechanism to group them without having to duplicate them in the cluster configuration of the custom resource.

#### Details
* Tags provided directly in the cluster will take precedence over tags provided in the stack (hence the use of `overrides`) and tags with `aws:` are removed as they are not allowed (see below):

![image](https://github.com/aws/aws-parallelcluster/assets/6087509/93bdcf9d-a553-4464-85f6-ec5eb5b575e9)


### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* The custom resource cloudformation stack in the integration tests has a tag added to it and we check the parallelcluster interface directly to see that this tag is propagated.
* The `test_cluster_custom_resource.py::test_cluster_create` was run to validate the updated funtionality:

```
Results (973.07s):
       1 passed
2023-05-11 21:34:38,341 - INFO - 94846 - test_runner - All tests completed!
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
