### PR TITLE
Test if resources remain undeleted on cluster updates involving changes order/number of queues

### DIFF
--- a/cli/tests/pcluster/cli/test_update_cluster/TestUpdateClusterCommand/test_resource_unchanged_due_to_queue_reorder/pcluster_1_queue.config.yaml
+++ b/cli/tests/pcluster/cli/test_update_cluster/TestUpdateClusterCommand/test_resource_unchanged_due_to_queue_reorder/pcluster_1_queue.config.yaml
@@ -1,0 +1,21 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue-a
+      ComputeResources:
+        - Name: queue-a-cr-static
+          Instances:
+            - InstanceType: t2.micro
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - subnet-12345678

--- a/cli/tests/pcluster/cli/test_update_cluster/TestUpdateClusterCommand/test_resource_unchanged_due_to_queue_reorder/pcluster_max_queue.config.yaml
+++ b/cli/tests/pcluster/cli/test_update_cluster/TestUpdateClusterCommand/test_resource_unchanged_due_to_queue_reorder/pcluster_max_queue.config.yaml
@@ -1,0 +1,33 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+{% for q in range(49) %}
+    - Name: queue-{{q}}
+      ComputeResources:
+        - Name: queue1-i1
+          Instances:
+            - InstanceType: t2.micro
+          MinCount: 0
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+{% endfor %}
+    - Name: queue-a
+      ComputeResources:
+        - Name: queue-a-cr-static
+          Instances:
+            - InstanceType: t2.micro
+          MinCount: 1
+          MaxCount: 2
+      Networking:
+        SubnetIds:
+          - subnet-12345678

--- a/cli/tests/pcluster/utils.py
+++ b/cli/tests/pcluster/utils.py
@@ -16,7 +16,9 @@ from assertpy import assert_that
 
 from pcluster.constants import LAMBDA_VPC_ACCESS_MANAGED_POLICY
 from pcluster.schemas.cluster_schema import ClusterSchema
+from pcluster.templates.cdk_builder import CDKTemplateBuilder
 from pcluster.utils import load_yaml_dict
+from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket
 
 
 def load_cluster_model_from_yaml(config_file_name, test_datadir=None):
@@ -111,3 +113,11 @@ def _get_lambda_functions(resources):
 
 def _get_managed_policy_arns(role):
     return {arn.get("Fn::Sub") for arn in role.get("Properties").get("ManagedPolicyArns", [])}
+
+
+def load_cfn_templates_from_config(config_file_path, pcluster_config_reader):
+    rendered_config_file = pcluster_config_reader(config_file_path)
+    cluster_config = ClusterSchema(cluster_name="clustername").load(load_yaml_dict(rendered_config_file))
+    return CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster_config, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )


### PR DESCRIPTION
### Description of changes
* This test checks if the resources associated with a queue (e.g the launch templates, instance profiles) remain unchanged during cluster update operations

### Tests
* It loads the template of a 50 queue cluster with the last queue being the same across updates
* Loads a different template reduces to 1 queue (the last queue unchanged)
* Confirms that the launch templates and IAM roles/profiles of the unchanged queue are not removed from the template
* Loads the initial template to increase to 50 queues (last one remaining unchanged)
* Confirms that the launch templates and IAM roles/profiles of the unchanged queue are not removed from the template

### References
* https://github.com/aws/aws-parallelcluster/pull/5297

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
