### PR TITLE
3.6 Remove cluster health metrics from ADC regions

### DIFF
--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -16,6 +16,7 @@ from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_logs as logs
 from aws_cdk.core import Construct, Duration, Stack
 
+from pcluster.aws.common import get_region
 from pcluster.config.cluster_config import BaseClusterConfig, SharedFsxLustre, SharedStorageType
 
 MAX_WIDTH = 24
@@ -45,6 +46,10 @@ _CWLogWidget = namedtuple(
 _HealthMetric = namedtuple(
     "_ErrorMetric", ["title", "metric_filters", "left_y_axis", "left_annotations"], defaults=(None, None)
 )
+
+
+def is_region_supported(region: str):
+    return not region.startswith("us-iso")
 
 
 def new_pcluster_metric(title=None, metrics=None, supported_vol_types=None, namespace=None, additional_dimensions=None):
@@ -147,7 +152,7 @@ class CWDashboardConstruct(Construct):
 
         # Head Node logs add custom metrics if cw_log and metrics are enabled
         if self.config.is_cw_logging_enabled:
-            if self.config.scheduling.scheduler == "slurm":
+            if self.config.scheduling.scheduler == "slurm" and is_region_supported(get_region()):
                 self._add_custom_health_metrics()
             self._add_cw_log()
 


### PR DESCRIPTION
### Description of changes
* Some CloudWatch CloudFormation resources are not supported in the ADC regions.
* Do not try to create these resources if the cluster is being created in one of the ADC regions.

### Tests
* Added test to validate resources don't get added to the cluster template if the region is an ADC region.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
