### PR TITLE
`[custom_resource]` Tag cluster created with custom resource.

### DIFF
--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -61,7 +61,7 @@ def validate_no_reserved_tag(tags):
                 tag_key = tag.key
             else:
                 tag_key = tag.get("key", "")
-            if tag_key.startswith(PCLUSTER_PREFIX):
+            if tag_key.startswith(PCLUSTER_PREFIX) and not tag_key == "parallelcluster:custom_resource":
                 raise ValidationError(message=f"The tag key prefix '{PCLUSTER_PREFIX}' is reserved and cannot be used.")
 
 

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -607,6 +607,7 @@ def test_subnet_id_validator_slurm_and_scheduler_plugin(subnet_ids, expected_mes
     "key, expected_message",
     [
         ("key1", None),
+        ("parallelcluster:custom_resource", None),
         ("parallelcluster:version", "The tag key prefix 'parallelcluster:' is reserved and cannot be used."),
     ],
 )

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -200,10 +200,10 @@ Resources:
               try:
                   meta_keys = {"ServiceToken", "DeletionPolicy"}
                   kwargs = {**{pcluster.utils.to_snake_case(k): serialize(v) for k, v in drop_keys(properties, meta_keys).items()}, "wait": False}
+                  resource_tags = [{"Key": "parallelcluster:custom_resource", "Value": "cluster"}]
                   config_tags = properties["ClusterConfiguration"].get("Tags", [])
                   stack_tags = get_stack_tags(event['StackId'], {t["Key"] for t in config_tags})
-                  if len(stack_tags) > 0:
-                      kwargs["cluster_configuration"]["Tags"] = stack_tags + config_tags
+                  kwargs["cluster_configuration"]["Tags"] = stack_tags + config_tags + resource_tags
                   func = {"CREATE": pc.create_cluster, "UPDATE": pc.update_cluster}[request_type]
                   update_response(func(**kwargs))
               except (APIOperationException, ParameterException, TypeError)  as e:

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
@@ -56,14 +56,18 @@ def _stack_parameter(stack, parameter_key):
     return next(filter(lambda x: x["ParameterKey"] == parameter_key, stack.parameters)).get("ParameterValue")
 
 
+def _cluster_tag(cluster, tag_key):
+    return next(filter(lambda t: t["key"] == tag_key, cluster["tags"]))["value"]
+
+
 def test_cluster_create(region, cluster_custom_resource_factory):
     stack = cluster_custom_resource_factory()
     error_message = "KeyPairValidator"
     cluster_name = _stack_parameter(stack, "ClusterName")
     cluster = pc().describe_cluster(cluster_name=cluster_name)
     assert_that(cluster["clusterStatus"]).is_not_none()
-    tags = cluster["tags"]
-    assert_that(next(filter(lambda t: t["key"] == "cluster_name", tags))["value"]).is_equal_to(cluster_name)
+    assert_that(_cluster_tag(cluster, "cluster_name")).is_equal_to(cluster_name)
+    assert_that(_cluster_tag(cluster, "parallelcluster:custom_resource")).is_equal_to("cluster")
     assert_that(stack.cfn_outputs.get("ValidationMessages", "")).contains(error_message)
     assert_that(stack.cfn_outputs.get("HeadNodeIp")).is_not_none()
 


### PR DESCRIPTION
### Description of changes
* Cherry pick c49bdfc5aeb863066bf9a7ab95f9a318872c4fc8 -> `release-3.6`
