### PR TITLE
Make CW Dashboard Builder use the shared is_feature_supported as source of truth to check the support for cluster health metrics.

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -243,6 +243,7 @@ class Feature(Enum):
     FSX_ONTAP = "FSx ONTAP"
     FSX_OPENZFS = "FSx OpenZfs"
     SLURM_DATABASE = "SLURM Database"
+    CLUSTER_HEALTH_METRICS = "Cluster Health Metrics"
 
 
 UNSUPPORTED_FEATURES_MAP = {
@@ -252,6 +253,7 @@ UNSUPPORTED_FEATURES_MAP = {
     Feature.FSX_ONTAP: ["us-iso"],
     Feature.FSX_OPENZFS: ["us-iso"],
     Feature.SLURM_DATABASE: ["us-iso"],
+    Feature.CLUSTER_HEALTH_METRICS: ["us-iso"],
 }
 
 

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -16,8 +16,9 @@ from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_logs as logs
 from aws_cdk.core import Construct, Duration, Stack
 
-from pcluster.aws.common import get_region
 from pcluster.config.cluster_config import BaseClusterConfig, SharedFsxLustre, SharedStorageType
+from pcluster.constants import Feature
+from pcluster.utils import is_feature_supported
 
 MAX_WIDTH = 24
 
@@ -46,10 +47,6 @@ _CWLogWidget = namedtuple(
 _HealthMetric = namedtuple(
     "_ErrorMetric", ["title", "metric_filters", "left_y_axis", "left_annotations"], defaults=(None, None)
 )
-
-
-def is_region_supported(region: str):
-    return not region.startswith("us-iso")
 
 
 def new_pcluster_metric(title=None, metrics=None, supported_vol_types=None, namespace=None, additional_dimensions=None):
@@ -152,7 +149,7 @@ class CWDashboardConstruct(Construct):
 
         # Head Node logs add custom metrics if cw_log and metrics are enabled
         if self.config.is_cw_logging_enabled:
-            if self.config.scheduling.scheduler == "slurm" and is_region_supported(get_region()):
+            if self.config.scheduling.scheduler == "slurm" and is_feature_supported(Feature.CLUSTER_HEALTH_METRICS):
                 self._add_custom_health_metrics()
             self._add_cw_log()
 

--- a/cli/src/pcluster/utils.py
+++ b/cli/src/pcluster/utils.py
@@ -35,7 +35,12 @@ from yaml.constructor import ConstructorError
 from yaml.resolver import BaseResolver
 
 from pcluster.aws.common import get_region
-from pcluster.constants import SUPPORTED_OSES_FOR_ARCHITECTURE, SUPPORTED_OSES_FOR_SCHEDULER
+from pcluster.constants import (
+    SUPPORTED_OSES_FOR_ARCHITECTURE,
+    SUPPORTED_OSES_FOR_SCHEDULER,
+    UNSUPPORTED_FEATURES_MAP,
+    Feature,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -165,6 +170,17 @@ def get_supported_os_for_scheduler(scheduler):
 def get_supported_os_for_architecture(architecture):
     """Return list of supported OSes for the specified architecture."""
     return SUPPORTED_OSES_FOR_ARCHITECTURE.get(architecture, [])
+
+
+def is_feature_supported(feature: Feature, region: str = None):
+    """
+    Check if a feature is supported for the given region.
+
+    If region is None, consider the region set in the environment.
+    """
+    _region = get_region() if region is None else region
+    prefixes_of_unsupported_regions = UNSUPPORTED_FEATURES_MAP.get(feature, [])
+    return all(not _region.startswith(region_prefix) for region_prefix in prefixes_of_unsupported_regions)
 
 
 def to_utc_datetime(time_in, default_timezone=datetime.timezone.utc) -> datetime.datetime:

--- a/cli/src/pcluster/validators/feature_validators.py
+++ b/cli/src/pcluster/validators/feature_validators.py
@@ -11,8 +11,8 @@
 #
 # This module contains all the classes representing the Resources objects.
 # These objects are obtained from the configuration file through a conversion based on the Schema classes.
-from pcluster.aws.common import get_region
-from pcluster.constants import UNSUPPORTED_FEATURES_MAP, Feature
+from pcluster import utils
+from pcluster.constants import Feature
 from pcluster.validators.common import FailureLevel, Validator
 
 
@@ -20,16 +20,5 @@ class FeatureRegionValidator(Validator):
     """Validate if a feature is supported in the given region."""
 
     def _validate(self, feature: Feature, region: str):
-        if not self._is_feature_supported(feature, region):
+        if not utils.is_feature_supported(feature, region):
             self._add_failure(f"{feature.value} is not supported in region '{region}'.", FailureLevel.ERROR)
-
-    @staticmethod
-    def _is_feature_supported(feature: Feature, region: str):
-        """
-        Check if a feature is supported for the given region.
-
-        If region is None, consider the region set in the environment.
-        """
-        _region = get_region() if region is None else region
-        prefixes_of_unsupported_regions = UNSUPPORTED_FEATURES_MAP.get(feature, [])
-        return all(not _region.startswith(region_prefix) for region_prefix in prefixes_of_unsupported_regions)

--- a/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
+++ b/cli/tests/pcluster/templates/test_cw_dashboard_builder.py
@@ -16,10 +16,10 @@ import yaml
 from assertpy import assert_that
 
 from pcluster.config.cluster_config import SharedStorageType
+from pcluster.constants import Feature
 from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
-from pcluster.templates.cw_dashboard_builder import is_region_supported
-from pcluster.utils import load_yaml_dict
+from pcluster.utils import is_feature_supported, load_yaml_dict
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket, mock_bucket, mock_bucket_object_utils
 
@@ -225,7 +225,7 @@ def _verify_common_error_metrics_graphs(cluster_config, output_yaml, region):
     ]
     health_check_failure_metrics = ["GpuHealthCheckFailures"]
     idle_node_metrics = ["MaxDynamicNodeIdleTime"]
-    if scheduler == "slurm" and is_region_supported(region):
+    if scheduler == "slurm" and is_feature_supported(Feature.CLUSTER_HEALTH_METRICS, region):
         # Contains error metric title
         assert_that(output_yaml).contains("Cluster Health Metrics")
         for metric in slurm_related_metrics:

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -24,6 +24,7 @@ import pcluster.utils as utils
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.aws_resources import InstanceTypeInfo
 from pcluster.aws.common import Cache
+from pcluster.constants import Feature
 from pcluster.models.cluster import Cluster, ClusterStack
 from pcluster.utils import batch_by_property_callback, yaml_load
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
@@ -537,3 +538,43 @@ class TestAsyncUtils(unittest.TestCase):
 
         assert_that(expected_results).contains_sequence(*results)
         assert_that(unique_calls).is_equal_to(total_calls)
+
+
+@pytest.mark.parametrize(
+    "feature, region, expected_result",
+    [
+        (Feature.BATCH, "ap-northeast-3", False),
+        (Feature.BATCH, "us-iso-east-1", False),
+        (Feature.BATCH, "us-iso-west-1", False),
+        (Feature.BATCH, "us-isob-east-1", False),
+        (Feature.BATCH, "us-isoWHATEVER", False),
+        (Feature.DCV, "us-iso-east-1", False),
+        (Feature.DCV, "us-iso-west-1", False),
+        (Feature.DCV, "us-isob-east-1", False),
+        (Feature.DCV, "us-isoWHATEVER", False),
+        (Feature.FSX_LUSTRE, "us-iso-east-1", False),
+        (Feature.FSX_LUSTRE, "us-iso-west-1", False),
+        (Feature.FSX_LUSTRE, "us-isob-east-1", False),
+        (Feature.FSX_LUSTRE, "us-isoWHATEVER", False),
+        (Feature.FSX_ONTAP, "us-iso-east-1", False),
+        (Feature.FSX_ONTAP, "us-iso-west-1", False),
+        (Feature.FSX_ONTAP, "us-isob-east-1", False),
+        (Feature.FSX_ONTAP, "us-isoWHATEVER", False),
+        (Feature.FSX_OPENZFS, "us-iso-east-1", False),
+        (Feature.FSX_OPENZFS, "us-iso-west-1", False),
+        (Feature.FSX_OPENZFS, "us-isob-east-1", False),
+        (Feature.FSX_OPENZFS, "us-isoWHATEVER", False),
+        (Feature.SLURM_DATABASE, "us-isoWHATEVER", False),
+        (Feature.CLUSTER_HEALTH_METRICS, "us-isoWHATEVER", False),
+        (Feature.BATCH, "WHATEVER-ELSE", True),
+        (Feature.DCV, "WHATEVER-ELSE", True),
+        (Feature.FSX_LUSTRE, "WHATEVER-ELSE", True),
+        (Feature.FSX_ONTAP, "WHATEVER-ELSE", True),
+        (Feature.FSX_OPENZFS, "WHATEVER-ELSE", True),
+        (Feature.SLURM_DATABASE, "WHATEVER-ELSE", True),
+        (Feature.CLUSTER_HEALTH_METRICS, "WHATEVER-ELSE", True),
+    ],
+)
+def test_is_feature_supported(feature, region, expected_result):
+    actual_result = utils.is_feature_supported(feature=feature, region=region)
+    assert_that(actual_result).is_equal_to(expected_result)

--- a/cli/tests/pcluster/validators/test_feature_validators.py
+++ b/cli/tests/pcluster/validators/test_feature_validators.py
@@ -10,6 +10,7 @@
 # limitations under the License.
 
 import pytest
+from assertpy import assert_that
 
 from pcluster.constants import Feature
 from pcluster.validators.feature_validators import FeatureRegionValidator
@@ -18,38 +19,27 @@ from .utils import assert_failure_messages
 
 
 @pytest.mark.parametrize(
-    "feature, region, expected_message",
+    "feature, supported, expected_message",
     [
-        (Feature.BATCH, "ap-northeast-3", "AWS Batch scheduler is not supported in region 'ap-northeast-3'"),
-        (Feature.BATCH, "us-iso-east-1", "AWS Batch scheduler is not supported in region 'us-iso-east-1'"),
-        (Feature.BATCH, "us-iso-west-1", "AWS Batch scheduler is not supported in region 'us-iso-west-1'"),
-        (Feature.BATCH, "us-isob-east-1", "AWS Batch scheduler is not supported in region 'us-isob-east-1'"),
-        (Feature.BATCH, "us-isoWHATEVER", "AWS Batch scheduler is not supported in region 'us-isoWHATEVER'"),
-        (Feature.DCV, "us-iso-east-1", "NICE DCV is not supported in region 'us-iso-east-1'"),
-        (Feature.DCV, "us-iso-west-1", "NICE DCV is not supported in region 'us-iso-west-1'"),
-        (Feature.DCV, "us-isob-east-1", "NICE DCV is not supported in region 'us-isob-east-1'"),
-        (Feature.DCV, "us-isoWHATEVER", "NICE DCV is not supported in region 'us-isoWHATEVER'"),
-        (Feature.FSX_LUSTRE, "us-iso-east-1", "FSx Lustre is not supported in region 'us-iso-east-1'"),
-        (Feature.FSX_LUSTRE, "us-iso-west-1", "FSx Lustre is not supported in region 'us-iso-west-1'"),
-        (Feature.FSX_LUSTRE, "us-isob-east-1", "FSx Lustre is not supported in region 'us-isob-east-1'"),
-        (Feature.FSX_LUSTRE, "us-isoWHATEVER", "FSx Lustre is not supported in region 'us-isoWHATEVER'"),
-        (Feature.FSX_ONTAP, "us-iso-east-1", "FSx ONTAP is not supported in region 'us-iso-east-1'"),
-        (Feature.FSX_ONTAP, "us-iso-west-1", "FSx ONTAP is not supported in region 'us-iso-west-1'"),
-        (Feature.FSX_ONTAP, "us-isob-east-1", "FSx ONTAP is not supported in region 'us-isob-east-1'"),
-        (Feature.FSX_ONTAP, "us-isoWHATEVER", "FSx ONTAP is not supported in region 'us-isoWHATEVER'"),
-        (Feature.FSX_OPENZFS, "us-iso-east-1", "FSx OpenZfs is not supported in region 'us-iso-east-1'"),
-        (Feature.FSX_OPENZFS, "us-iso-west-1", "FSx OpenZfs is not supported in region 'us-iso-west-1'"),
-        (Feature.FSX_OPENZFS, "us-isob-east-1", "FSx OpenZfs is not supported in region 'us-isob-east-1'"),
-        (Feature.FSX_OPENZFS, "us-isoWHATEVER", "FSx OpenZfs is not supported in region 'us-isoWHATEVER'"),
-        (Feature.SLURM_DATABASE, "us-isoWHATEVER", "SLURM Database is not supported in region 'us-isoWHATEVER'"),
-        (Feature.BATCH, "WHATEVER-ELSE", None),
-        (Feature.DCV, "WHATEVER-ELSE", None),
-        (Feature.FSX_LUSTRE, "WHATEVER-ELSE", None),
-        (Feature.FSX_ONTAP, "WHATEVER-ELSE", None),
-        (Feature.FSX_OPENZFS, "WHATEVER-ELSE", None),
-        (Feature.SLURM_DATABASE, "WHATEVER-ELSE", None),
+        (Feature.BATCH, True, None),
+        (Feature.BATCH, False, "AWS Batch scheduler is not supported in region 'WHATEVER-REGION'"),
+        (Feature.DCV, True, None),
+        (Feature.DCV, False, "NICE DCV is not supported in region 'WHATEVER-REGION'"),
+        (Feature.FSX_LUSTRE, True, None),
+        (Feature.FSX_LUSTRE, False, "FSx Lustre is not supported in region 'WHATEVER-REGION'"),
+        (Feature.FSX_ONTAP, True, None),
+        (Feature.FSX_ONTAP, False, "FSx ONTAP is not supported in region 'WHATEVER-REGION'"),
+        (Feature.FSX_OPENZFS, True, None),
+        (Feature.FSX_OPENZFS, False, "FSx OpenZfs is not supported in region 'WHATEVER-REGION'"),
+        (Feature.SLURM_DATABASE, True, None),
+        (Feature.SLURM_DATABASE, False, "SLURM Database is not supported in region 'WHATEVER-REGION'"),
     ],
 )
-def test_feature_region_validator(feature, region, expected_message):
-    actual_failures = FeatureRegionValidator().execute(feature=feature, region=region)
-    assert_failure_messages(actual_failures, expected_message)
+def test_feature_region_validator(mocker, feature, supported, expected_message):
+    is_feature_supported = mocker.patch("pcluster.utils.is_feature_supported", return_value=supported)
+    actual_failures = FeatureRegionValidator().execute(feature=feature, region="WHATEVER-REGION")
+    is_feature_supported.assert_called_once()
+    if supported:
+        assert_that(actual_failures).is_empty()
+    else:
+        assert_failure_messages(actual_failures, expected_message)

--- a/cli/tests/pcluster/validators/test_feature_validators.py
+++ b/cli/tests/pcluster/validators/test_feature_validators.py
@@ -33,6 +33,8 @@ from .utils import assert_failure_messages
         (Feature.FSX_OPENZFS, False, "FSx OpenZfs is not supported in region 'WHATEVER-REGION'"),
         (Feature.SLURM_DATABASE, True, None),
         (Feature.SLURM_DATABASE, False, "SLURM Database is not supported in region 'WHATEVER-REGION'"),
+        (Feature.CLUSTER_HEALTH_METRICS, True, None),
+        (Feature.CLUSTER_HEALTH_METRICS, False, "Cluster Health Metrics is not supported in region 'WHATEVER-REGION'"),
     ],
 )
 def test_feature_region_validator(mocker, feature, supported, expected_message):


### PR DESCRIPTION
### Description of changes
1. Moved the logic to validate feature support for regions from validator to shared utilities. 
2. Added feature flagging for CLUSTER_HEALTH_METRICS.
3. Made CW Dashboard Builder use the shared is_feature_supported as source of truth to check the support for cluster health metrics.

### Tests
1. Unit Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
