### PR TITLE
Use the compute node's IP Address instead of nodename to reduce SSH timeout errors.

### DIFF
--- a/tests/integration-tests/tests/health_checks/test_gpu_health_checks.py
+++ b/tests/integration-tests/tests/health_checks/test_gpu_health_checks.py
@@ -168,7 +168,7 @@ def _test_failing_gpu_health_checks(
     # Confirm health check was successful
     _assert_file_content_in_compute_node(
         HEALTH_CHECK_LOG_FILE,
-        target_node.node_name,
+        slurm_commands.get_node_addr(node_name=target_node.node_name),
         cluster,
         [rf".*JobID {job_id}.*HealthCheckManager finished with exit code '0'*"],
         should_exist=True,


### PR DESCRIPTION
### Description of changes
* Remote execution of commands in compute nodes times out sporadically when using the compute node's nodename in the SSH Proxy command. It's likely latency/failure looking up the nodename IP
* Other remote execution attempts succeed when using the compute node's IP Address
* These changes replace the use of the nodename with the compute node's IP address instead

### Tests
* Ran tests locally

### References
* N/A

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
