### PR TITLE
[Multi User] Enable support for Active Directory password in Secrets Manager for region us-isob-east-1.

### DIFF
--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -77,8 +77,9 @@ class PasswordSecretArnValidator(Validator):
         """Validate that PasswordSecretArn contains a valid ARN for the given region.
 
         In particular, the ARN should be one of the following resources:
-         1. a readable secret in AWS Secrets Manager, which is supported in all regions but us-isob-east-1.
-         2. a readable parameter in SSM Parameter Store, which is supported only in us-isob-east-1.
+         1. a readable secret in AWS Secrets Manager, which is supported in all regions.
+         2. a readable parameter in SSM Parameter Store, which is supported only in us-isob-east-1
+            for retro-compatibility.
         """
         try:
             # We only require the secret to exist; we do not validate its content.
@@ -88,7 +89,7 @@ class PasswordSecretArnValidator(Validator):
             if service == "ssm":
                 resource = arn_components[5].split("/")[0]
 
-            if service == "secretsmanager" and resource == "secret" and region != "us-isob-east-1":
+            if service == "secretsmanager" and resource == "secret":
                 AWSApi.instance().secretsmanager.describe_secret(password_secret_arn)
             elif service == "ssm" and resource == "parameter" and region == "us-isob-east-1":
                 parameter_name = arn_components[5].split("/")[1]

--- a/cli/tests/pcluster/validators/test_directory_service_validators.py
+++ b/cli/tests/pcluster/validators/test_directory_service_validators.py
@@ -175,9 +175,8 @@ def test_ldap_tls_reqcert_validator(ldap_tls_reqcert, expected_message):
             "us-isob-east-1",
             "secretsmanager",
             None,
-            "The secret arn:PARTITION:secretsmanager:REGION:ACCOUNT:secret:WHATEVER_SECRET is not supported "
-            "in region us-isob-east-1.",
-            FailureLevel.ERROR,
+            None,
+            None,
             id="PasswordSecretArn as a Secret in Secrets Manager, in us-isob-east-1",
         ),
         pytest.param(


### PR DESCRIPTION
### Description of changes
Enable support for Active Directory password in Secrets Manager for region us-isob-east-1.

### Tests
1. PENDING Cluster creation succeeded in us-isob-east-1 with password stored in Secrets Manager.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
