### PR TITLE
[3.x] Add an assertion to verify config tags have precedence over stack ones

### DIFF
--- a/tests/integration-tests/resources/cluster_custom_resource.yaml
+++ b/tests/integration-tests/resources/cluster_custom_resource.yaml
@@ -50,6 +50,9 @@ Resources:
       DeletionPolicy: !Ref DeletionPolicy
       ClusterName: !Ref ClusterName
       ClusterConfiguration:
+        Tags:
+          - Key: inside_configuration_key
+            Value: overridden
         DevSettings:
           AmiSearchFilters:
             Owner: self

--- a/tests/integration-tests/tests/custom_resource/conftest.py
+++ b/tests/integration-tests/tests/custom_resource/conftest.py
@@ -146,7 +146,10 @@ def cluster_custom_resource_factory_fixture(
             template=template_data,
             parameters=[{"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items()],
             capabilities=["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"],
-            tags=[{"Key": "cluster_name", "Value": cluster_name}],  # For testing, add a tag to the stack
+            tags=[
+                {"Key": "cluster_name", "Value": cluster_name},
+                {"Key": "inside_configuration_key", "Value": "stack_level_value"},
+            ],  # For testing, add tags to the stack
         )
 
         cfn_stacks_factory.create_stack(stack, True)

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource.py
@@ -67,6 +67,7 @@ def test_cluster_create(region, cluster_custom_resource_factory):
     cluster = pc().describe_cluster(cluster_name=cluster_name)
     assert_that(cluster["clusterStatus"]).is_not_none()
     assert_that(_cluster_tag(cluster, "cluster_name")).is_equal_to(cluster_name)
+    assert_that(_cluster_tag(cluster, "inside_configuration_key")).is_equal_to("overridden")
     assert_that(_cluster_tag(cluster, "parallelcluster:custom_resource")).is_equal_to("cluster")
     assert_that(stack.cfn_outputs.get("ValidationMessages", "")).contains(error_message)
     assert_that(stack.cfn_outputs.get("HeadNodeIp")).is_not_none()


### PR DESCRIPTION
### Description of changes
* Add an assertion to verify config tags have precedence over stack ones.

Will move to 3.6 branch after merge

### Tests
* Run the create integ test

```
2023-05-15 14:39:18,538 - INFO - 7440 - test_cluster_create[eu-west-1-alinux2-None] - fixture_utils - Deleting shared fixture initialize_cli_creds.
 custom_resource/test_cluster_custom_resource.py::test_cluster_create[eu-west-1-alinux2-None] ✓                                                                                                                                                                                                          100% ██████████2023-05-15 14:39:18,545 - INFO - 7440 - test_cluster_create[eu-west-1-alinux2-None] - conftest - Completed test test_cluster_create[eu-west-1-alinux2-None]

Results (1099.01s (0:18:19)):
       1 passed
2023-05-15 14:39:19,280 - INFO - test_runner - All tests completed!

```
### References
* Follow up of https://github.com/aws/aws-parallelcluster/pull/5306

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
