### PR TITLE
Remove tests on awscli from Test phase

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
@@ -110,33 +110,6 @@ phases:
               RESERVED_BASE_UID=$(echo ${PATTERN} | tr -d '\n' | cut -d = -f 2 | xargs)
               echo "${RESERVED_BASE_UID}"
 
-      ### tests ###
-      - name: AWSCli
-        action: ExecuteBash
-        inputs:
-          commands:
-            - |
-              set -vx
-              OS="{{ test.OperatingSystemName.outputs.stdout }}"
-              if [[ ${OS} =~ ^alinux ]]; then
-                username="ec2-user"
-              elif [[ ${OS} =~ ^rhel ]]; then
-                username="ec2-user"
-              elif [[ ${OS} =~ ^centos ]]; then
-                username="centos"
-              elif [[ ${OS} =~ ^ubuntu ]]; then
-                username="ubuntu"
-              fi
-              export PATH="/usr/local/bin:/usr/bin/:${PATH}"
-
-              echo "Executing awscli as user..."
-              su - ${username} -c "aws --version"
-
-              echo "Executing awscli as root..."
-              aws --version
-              [[ $? -ne 0 ]] && echo "fail to execute awscli as root" && exit 1
-              echo "AWSCli test passed"
-
       - name: Virtualenv
         action: ExecuteBash
         inputs:


### PR DESCRIPTION
### Description of changes
Remove tests verifying awscli can be run from Test phase of AMI build, since they have been implemented as InSpec tests.

Link to the change: https://github.com/aws/aws-parallelcluster-cookbook/commit/42437f8dd24acf822726d0d2e1b5ca4622324a26#diff-d46c494ddde5654c685e1404915e54a90187aaacdb4d8ab4fb82cf7732f05a28R27-R45

### Tests
* Successful AMI build 

### References
* https://github.com/aws/aws-parallelcluster-cookbook/commit/42437f8dd24acf822726d0d2e1b5ca4622324a26#diff-d46c494ddde5654c685e1404915e54a90187aaacdb4d8ab4fb82cf7732f05a28R27-R45

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
