### PR TITLE
[Test] Add us-iso-east-1 to isolated regions in integ test config.

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -1,5 +1,5 @@
 {%- import 'common.jinja2' as common with context -%}
-{%- set REGIONS = ["us-isob-east-1"] -%}
+{%- set REGIONS = ["us-isob-east-1","us-iso-east-1"] -%}
 {%- set INSTANCES = ["c5.xlarge"] -%}
 {%- set OSS = ["alinux2"] -%}
 {%- set SCHEDULERS = ["slurm"] -%}


### PR DESCRIPTION
### Description of changes
Add us-iso-east-1 to isolated regions in integ test config.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
