### PR TITLE
[develop] Permit tags prefix validators to work if a tag is defined as a boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ CHANGELOG
 - Fix issue causing `cfn-hup` daemon to fail when it gets restarted.
 - Fix issue causing dangling security groups to be created when creating a cluster with an existing EFS.
 - Fix issue causing NVIDIA GPU compute nodes not to resume correctly after executing an `scontrol reboot` command.
+- Fix tags parsing to show a meaningful error message when using a boolean in the `Value` field of `Tags`.
 
 3.5.1
 -----

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -69,7 +69,10 @@ def validate_no_duplicate_tag(tags):
     """Validate there is no duplicate tag keys in the same tag section."""
     all_tags = set()
     for tag in tags:
-        tag_key = tag.key
+        if isinstance(tag, BaseTag):
+            tag_key = tag.key
+        else:
+            tag_key = tag.get("key", "")
         if tag_key in all_tags:
             raise ValidationError(
                 f"Duplicate tag key ({tag_key}) detected. Tags keys should be unique within the Tags section."

--- a/cli/tests/pcluster/schemas/test_common_schema.py
+++ b/cli/tests/pcluster/schemas/test_common_schema.py
@@ -101,6 +101,7 @@ def test_lambda_functions_vpc_config_schema(lambda_functions_vpc_config, failure
         ([BaseTag(key=f"{PCLUSTER_PREFIX}test", value="test")], f"The tag key prefix '{PCLUSTER_PREFIX}' is reserved"),
         ([BaseTag(key=f"test{PCLUSTER_PREFIX}", value="test")], None),
         ([{"key": "test", "value": "test"}], None),
+        ([{"key": "test", "value": True}], None),
         ([{"key": f"{PCLUSTER_PREFIX}test", "value": "test"}], f"The tag key prefix '{PCLUSTER_PREFIX}' is reserved"),
         ([{"key": f"test{PCLUSTER_PREFIX}", "value": "test"}], None),
         ([{"key": "test"}], None),
@@ -122,6 +123,13 @@ def test_validate_no_reserved_tag(tags, failure_message):
             [BaseTag(key="test1", value="test"), BaseTag(key="test1", value="test")],
             "Duplicate tag key \\(test1\\) detected. Tags keys should be unique within the Tags section.",
         ),
+        (
+            [{"key": "test1", "value": "test"}, {"key": "test1", "value": "test2"}],
+            "Duplicate tag key \\(test1\\) detected. Tags keys should be unique within the Tags section.",
+        ),
+        ([{"key": "test1", "value": "test"}], None),
+        ([{"key": "test1", "value": True}], None),
+        ([{"key": "test1"}], None),
     ],
 )
 def test_validate_no_duplicate_tag(tags, failure_message):


### PR DESCRIPTION
### Description of changes

If one tag in the config has a boolean value (e.g. YES), tags variable will be a list of dict. If all of them are strings, tags variable will be a list of BaseTag objects.

This patch improves the `validate_no_duplicate_tag` to be able to work in both the cases.

### Tests

Previously, when using a config like:
```
Tags:
   - Key: WrongTagValue
     Value: YES
```
the cluster creation was failing with an error:
```
"message": "Invalid cluster configuration: 'dict' object has no attribute 'key'"
```

I replicated the issue within the unit tests and then fixed it.

Now, at cluster creation time, the validator is executed correctly and the Schema parsing fails with a meaningful message:
```
    "type": "ConfigSchemaValidator",
    "message": "[('Tags', {1: {'Value': ['Not a valid string.']}})]"
```

