### PR TITLE
[Isolated Regions] [Test] Making EFS, Monitoring, AD and DFSM integ tests executable in us-iso regions

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -5,14 +5,13 @@
 {%- set SCHEDULERS = ["slurm"] -%}
 ---
 test-suites:
-#  We must fix the integ test logic to make this integration test to work in us-isob-east-1
-#  ad_integration:
-#    test_ad_integration.py::test_ad_integration:
-#      dimensions:
-#        - regions: {{ REGIONS }}
-#          instances: {{ INSTANCES }}
-#          oss: {{ OSS }}
-#          schedulers: {{ SCHEDULERS }}
+  ad_integration:
+    test_ad_integration.py::test_ad_integration:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
   cfn-init:
     test_cfn_init.py::test_replace_compute_on_failure:
       dimensions:

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -528,13 +528,12 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
-#    We must fix the integ test logic to make this integration test to work in us-isob-east-1
-#    test_update.py::test_dynamic_file_systems_update:
-#      dimensions:
-#        - regions: {{ REGIONS }}
-#          instances: {{ INSTANCES }}
-#          oss: {{ OSS }}
-#          schedulers: {{ SCHEDULERS }}
+    test_update.py::test_dynamic_file_systems_update:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
 # This test cannot be executed in US isolated regions
 # because it relies on a CloudFormation stack using resources
 # that are not supported by CloudFormation in ADC,

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/NLB_SimpleAD.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/NLB_SimpleAD.yaml
@@ -3,8 +3,8 @@ Description: |-
   LDAPS NLB Stack from https://aws.amazon.com/blogs/security/how-to-configure-ldaps-endpoint-for-simple-ad/
 Parameters:
   LDAPSCertificateARN:
-    Description: ARN of SSL Certificate
-    AllowedPattern: "arn:aws:acm:.*"
+    Description: ARN of SSL Certificate provided as ACM Certificate or IAM Server Certificate
+    AllowedPattern: "arn:aws.*:(acm|iam):.*:.*:(certificate|server-certificate)/.*"
     Type: String
   VPCId:
     Description: Please provide a VPC to deploy the solution into.

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update.yaml
@@ -28,16 +28,17 @@ Monitoring:
       RetentionInDays: 14
 SharedStorage:
   - MountDir: /shared
-    Name: fsx
-    StorageType: FsxLustre
-    FsxLustreSettings:
-      StorageCapacity: 2400
-  - MountDir: /ebs
     Name: ebs
     StorageType: Ebs
   - MountDir: /efs
     Name: efs
     StorageType: Efs
+  {% if fsx_supported %}
+  - MountDir: /fsxlustre
+    Name: fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 2400
   - MountDir: /fsxopenzfs
     Name: existingopenzfs
     StorageType: FsxOpenZfs
@@ -48,6 +49,7 @@ SharedStorage:
     StorageType: FsxOntap
     FsxOntapSettings:
       VolumeId: {{ fsx_ontap_volume_id }}
+  {% endif %}
 DirectoryService:
   DomainName: {{ ldap_search_base }}
   DomainAddr: {{ ldap_uri }}

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.update2.yaml
@@ -28,16 +28,17 @@ Monitoring:
       RetentionInDays: 14
 SharedStorage:
   - MountDir: /shared
-    Name: fsx
-    StorageType: FsxLustre
-    FsxLustreSettings:
-      StorageCapacity: 2400
-  - MountDir: /ebs
     Name: ebs
     StorageType: Ebs
   - MountDir: /efs
     Name: efs
     StorageType: Efs
+  {% if fsx_supported %}
+  - MountDir: /fsxlustre
+    Name: fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 2400
   - MountDir: /fsxopenzfs
     Name: existingopenzfs
     StorageType: FsxOpenZfs
@@ -48,6 +49,7 @@ SharedStorage:
     StorageType: FsxOntap
     FsxOntapSettings:
       VolumeId: {{ fsx_ontap_volume_id }}
+  {% endif %}
 DirectoryService:
   DomainName: {{ ldap_search_base }}
   DomainAddr: {{ ldap_uri }}

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/pcluster.config.yaml
@@ -28,16 +28,17 @@ Monitoring:
       RetentionInDays: 14
 SharedStorage:
   - MountDir: /shared
-    Name: fsx
-    StorageType: FsxLustre
-    FsxLustreSettings:
-      StorageCapacity: 2400
-  - MountDir: /ebs
     Name: ebs
     StorageType: Ebs
   - MountDir: /efs
     Name: efs
     StorageType: Efs
+  {% if fsx_supported %}
+  - MountDir: /fsxlustre
+    Name: fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 2400
   - MountDir: /fsxopenzfs
     Name: existingopenzfs
     StorageType: FsxOpenZfs
@@ -48,6 +49,7 @@ SharedStorage:
     StorageType: FsxOntap
     FsxOntapSettings:
       VolumeId: {{ fsx_ontap_volume_id }}
+  {% endif %}
 DirectoryService:
   DomainName: {{ ldap_search_base }}
   DomainAddr: {{ ldap_uri }}

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/workload.sh
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/workload.sh
@@ -2,7 +2,7 @@
 set -ex
 
 # TODO: add efs
-for fspath in shared ebs; do
+for fspath in shared efs; do
     # srun has to be used for whoami because slurm_nss plugin only send user information through srun
     date '+%Y%m%d%H%M%S' > "/$fspath/$(srun whoami)"
 done
@@ -16,4 +16,4 @@ module load openmpi
 # -np total number of processes to run (all CPUs * 4 nodes)
 mpirun \
     > /shared/"$(date '+%Y%m%d%H%M%S')-$(srun whoami)-${BENCHMARK_NAME}".out \
-    /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME}  
+    /shared/openmpi/osu-micro-benchmarks-${OSU_BENCHMARK_VERSION}/mpi/collective/${BENCHMARK_NAME}

--- a/tests/integration-tests/tests/monitoring/test_monitoring.py
+++ b/tests/integration-tests/tests/monitoring/test_monitoring.py
@@ -86,7 +86,10 @@ def _test_dashboard(cw_client, cluster_name, region, dashboard_enabled, cw_log_e
         assert_that(dashboard_response["DashboardName"]).is_equal_to(dashboard_name)
         if cw_log_enabled:
             assert_that(dashboard_response["DashboardBody"]).contains("Head Node Logs")
-            assert_that(dashboard_response["DashboardBody"]).contains("Cluster Health Metrics")
+            if "us-iso" in region:
+                assert_that(dashboard_response["DashboardBody"]).does_not_contain("Cluster Health Metrics")
+            else:
+                assert_that(dashboard_response["DashboardBody"]).contains("Cluster Health Metrics")
         else:
             assert_that(dashboard_response["DashboardBody"]).does_not_contain("Head Node Logs")
             assert_that(dashboard_response["DashboardBody"]).does_not_contain("Cluster Health Metrics")

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
@@ -38,7 +38,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_subnet_ids[2] }}
+          - {% if len(private_subnet_ids) >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}
     {% endif %}
 # This compute subnet would be in a different AZ than head node for regions defined in AVAILABILITY_ZONE_OVERRIDES
 # See conftest for details

--- a/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
@@ -38,7 +38,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {{ private_subnet_ids[2] }}
+          - {% if len(private_subnet_ids) >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}
     {% endif %}
 # This compute subnet would be in a different AZ than head node for regions defined in AVAILABILITY_ZONE_OVERRIDES
 # See conftest for details

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -26,7 +26,7 @@ from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
 from s3_common_utils import check_s3_read_resource, check_s3_read_write_resource, get_policy_resources
 from time_utils import minutes, seconds
-from utils import describe_cluster_instances, retrieve_cfn_resources, wait_for_computefleet_changed
+from utils import describe_cluster_instances, is_fsx_supported, retrieve_cfn_resources, wait_for_computefleet_changed
 
 from tests.common.assertions import assert_lines_in_logs, assert_no_msg_in_logs
 from tests.common.hit_common import assert_compute_node_states, assert_initial_conditions, wait_for_compute_nodes_states
@@ -891,11 +891,14 @@ def external_shared_storage_stack(request, test_datadir, region, vpc_stack: CfnV
             public_subnet_id = vpc_stack.get_public_subnet()
             import_path = "s3://{0}".format(bucket_name)
             export_path = "s3://{0}/export_dir".format(bucket_name)
+            fsx_supported = is_fsx_supported(region)
             params = [
                 {"ParameterKey": "vpc", "ParameterValue": vpc},
                 {"ParameterKey": "PublicSubnetId", "ParameterValue": public_subnet_id},
                 {"ParameterKey": "ImportPathParam", "ParameterValue": import_path},
                 {"ParameterKey": "ExportPathParam", "ParameterValue": export_path},
+                {"ParameterKey": "CreateEfs", "ParameterValue": "true"},
+                {"ParameterKey": "CreateFsx", "ParameterValue": str(fsx_supported).lower()},
             ]
             with open(template_path, encoding="utf-8") as template_file:
                 template = template_file.read()
@@ -932,6 +935,7 @@ def test_dynamic_file_systems_update(
     external_shared_storage_stack,
 ):
     """Test update shared storages."""
+    fsx_supported = is_fsx_supported(region)
     existing_ebs_mount_dir = "/existing_ebs_mount_dir"
     existing_efs_mount_dir = "/existing_efs_mount_dir"
     fsx_lustre_mount_dir = "/existing_fsx_lustre_mount_dir"
@@ -943,7 +947,11 @@ def test_dynamic_file_systems_update(
     new_lustre_mount_dir = "/new_lustre_mount_dir"
     ebs_mount_dirs = [new_ebs_mount_dir, existing_ebs_mount_dir]
     efs_mount_dirs = [existing_efs_mount_dir, new_efs_mount_dir]
-    fsx_mount_dirs = [new_lustre_mount_dir, fsx_lustre_mount_dir, fsx_open_zfs_mount_dir, fsx_ontap_mount_dir]
+    fsx_mount_dirs = (
+        [new_lustre_mount_dir, fsx_lustre_mount_dir, fsx_open_zfs_mount_dir, fsx_ontap_mount_dir]
+        if fsx_supported
+        else []
+    )
     all_mount_dirs = ebs_mount_dirs + [new_raid_mount_dir] + efs_mount_dirs + fsx_mount_dirs
 
     bucket_name = s3_bucket_factory()
@@ -1005,6 +1013,7 @@ def test_dynamic_file_systems_update(
         new_lustre_deletion_policy="Delete",
         new_efs_mount_dir=new_efs_mount_dir,
         new_efs_deletion_policy="Delete",
+        fsx_supported=fsx_supported,
     )
 
     cluster.update(update_cluster_config)
@@ -1069,13 +1078,18 @@ def test_dynamic_file_systems_update(
         new_lustre_deletion_policy="Retain",
         new_efs_mount_dir=new_efs_mount_dir,
         new_efs_deletion_policy="Retain",
+        fsx_supported=fsx_supported,
     )
 
     cluster.update(update_cluster_config)
 
     existing_ebs_ids = [existing_ebs_volume_id]
     existing_efs_ids = [existing_efs_id]
-    existing_fsx_ids = [existing_fsx_lustre_fs_id, existing_fsx_ontap_volume_id, existing_fsx_open_zfs_volume_id]
+    existing_fsx_ids = (
+        [existing_fsx_lustre_fs_id, existing_fsx_ontap_volume_id, existing_fsx_open_zfs_volume_id]
+        if fsx_supported
+        else []
+    )
 
     retained_ebs_noraid_volume_ids = [
         id for id in cluster.cfn_outputs["EBSIds"].split(",") if id not in existing_ebs_ids
@@ -1085,7 +1099,9 @@ def test_dynamic_file_systems_update(
     ]
     retained_ebs_volume_ids = retained_ebs_noraid_volume_ids + retained_ebs_raid_volume_ids
     retained_efs_filesystem_ids = [id for id in cluster.cfn_outputs["EFSIds"].split(",") if id not in existing_efs_ids]
-    retained_fsx_filesystem_ids = [id for id in cluster.cfn_outputs["FSXIds"].split(",") if id not in existing_fsx_ids]
+    retained_fsx_filesystem_ids = (
+        [id for id in cluster.cfn_outputs["FSXIds"].split(",") if id not in existing_fsx_ids] if fsx_supported else []
+    )
 
     # update cluster to remove ebs, raid, efs and fsx with compute fleet stop
     logging.info("Updating the cluster to remove all the shared storage (managed storage will be retained)")
@@ -1146,6 +1162,7 @@ def test_dynamic_file_systems_update(
         pcluster_config_reader,
         scheduler_commands,
         region,
+        fsx_supported,
     )
 
 
@@ -1235,14 +1252,15 @@ def _test_shared_storages_mount_on_headnode(
         test_efs_correctly_mounted(remote_command_executor, efs)
         test_efs_correctly_mounted(remote_command_executor, efs)
     # check fsx
-    check_fsx(
-        cluster,
-        region,
-        scheduler_commands_factory,
-        fsx_mount_dirs,
-        bucket_name,
-        headnode_only=True,
-    )
+    if fsx_mount_dirs:
+        check_fsx(
+            cluster,
+            region,
+            scheduler_commands_factory,
+            fsx_mount_dirs,
+            bucket_name,
+            headnode_only=True,
+        )
 
 
 def _test_shared_storage_rollback(
@@ -1257,6 +1275,7 @@ def _test_shared_storage_rollback(
     pcluster_config_reader,
     scheduler_commands,
     region,
+    fsx_supported,
 ):
     # update cluster with adding non-existing ebs and skip validator
     problematic_volume_id = "vol-00000000000000000"
@@ -1271,6 +1290,7 @@ def _test_shared_storage_rollback(
         new_ebs_mount_dir=new_ebs_mount_dir,
         new_lustre_mount_dir=new_lustre_mount_dir,
         new_efs_mount_dir=new_efs_mount_dir,
+        fsx_supported=fsx_supported,
     )
     # remove logs from chef-client log in order to test cluster rollback behavior
     remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/chef-client.log")
@@ -1290,7 +1310,7 @@ def _test_shared_storage_rollback(
 
     # Check shared storages are not on headnode
     ebs_mount_dirs = [existing_ebs_mount_dir, new_ebs_mount_dir, problematic_ebs_mount_dir]
-    fs_mount_dirs = [new_lustre_mount_dir, new_efs_mount_dir]
+    fs_mount_dirs = [new_lustre_mount_dir, new_efs_mount_dir] if fsx_supported else [new_efs_mount_dir]
     _test_ebs_not_mounted(remote_command_executor, ebs_mount_dirs)
     _test_directory_not_mounted(remote_command_executor, fs_mount_dirs)
 
@@ -1314,9 +1334,11 @@ def _test_shared_storage_rollback(
     managed_efs = [
         fs.get("efs_fs_id") for fs in failed_share_storages.get("efs") if fs.get("mount_dir") == new_efs_mount_dir
     ]
-    managed_fsx = [
-        fs.get("fsx_fs_id") for fs in failed_share_storages.get("fsx") if fs.get("mount_dir") == new_lustre_mount_dir
-    ]
+    managed_fsx = (
+        [fs.get("fsx_fs_id") for fs in failed_share_storages.get("fsx") if fs.get("mount_dir") == new_lustre_mount_dir]
+        if fsx_supported
+        else []
+    )
 
     # assert the managed EBS is clean up
     logging.info("Checking managed EBS is deleted after stack rollback")
@@ -1327,9 +1349,10 @@ def _test_shared_storage_rollback(
     with pytest.raises(ClientError, match="FileSystemNotFound"):
         boto3.client("efs", region).describe_file_systems(FileSystemId=managed_efs[0])
     # assert the managed FSX is clean up
-    logging.info("Checking managed FSX is deleted after stack rollback")
-    with pytest.raises(ClientError, match="FileSystemNotFound"):
-        boto3.client("fsx", region).describe_file_systems(FileSystemIds=managed_fsx)
+    if fsx_supported:
+        logging.info("Checking managed FSX is deleted after stack rollback")
+        with pytest.raises(ClientError, match="FileSystemNotFound"):
+            boto3.client("fsx", region).describe_file_systems(FileSystemIds=managed_fsx)
 
 
 @pytest.mark.usefixtures("os")

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_drain.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_drain.yaml
@@ -79,6 +79,7 @@ SharedStorage:
     StorageType: Efs
     EfsSettings:
       FileSystemId: {{ existing_efs_id }}
+  {% if fsx_supported %}
   - MountDir: {{ new_lustre_mount_dir }}
     Name: manage-fsx
     StorageType: FsxLustre
@@ -104,3 +105,4 @@ SharedStorage:
     StorageType: FsxOntap
     FsxOntapSettings:
       VolumeId: {{ fsx_ontap_volume_id }}
+  {% endif %}

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_rollback.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/pcluster.config.update_rollback.yaml
@@ -67,6 +67,7 @@ SharedStorage:
       PerformanceMode: maxIO
       ThroughputMode: provisioned
       ProvisionedThroughput: 200
+  {% if fsx_supported %}
   - MountDir: {{ new_lustre_mount_dir }}
     Name: {{ new_lustre_mount_dir }}
     StorageType: FsxLustre
@@ -76,3 +77,4 @@ SharedStorage:
       ExportPath: s3://{{ bucket_name }}/export_dir
       DeploymentType: PERSISTENT_1
       PerUnitStorageThroughput: 200
+  {% endif %}

--- a/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/storage-stack.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_dynamic_file_systems_update/storage-stack.yaml
@@ -14,11 +14,24 @@ Parameters:
   vpc:
     Type: String
     Default: ''
+  CreateEfs:
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
+  CreateFsx:
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
+Conditions:
+  CreateEfs: !Equals [!Ref CreateEfs, 'true']
+  CreateFsx: !Equals [!Ref CreateFsx, 'true']
 Resources:
   FileSystemResource0:
     Type: 'AWS::EFS::FileSystem'
+    Condition: CreateEfs
 {% for subnet in one_subnet_per_az %}
   MountTargetResourceEfs0Subnet{{loop.index}}:
+    Condition: CreateEfs
     Properties:
       FileSystemId: !Ref FileSystemResource0
       SecurityGroups:
@@ -27,6 +40,7 @@ Resources:
     Type: 'AWS::EFS::MountTarget'
 {% endfor %}
   SecurityGroupIngressResource0:
+    Condition: CreateEfs
     Properties:
       CidrIp: 192.168.0.0/17
       FromPort: 2049
@@ -35,6 +49,7 @@ Resources:
       ToPort: 2049
     Type: 'AWS::EC2::SecurityGroupIngress'
   SecurityGroupIngressResource1:
+    Condition: CreateEfs
     Properties:
       CidrIp: 192.168.128.0/17
       FromPort: 2049
@@ -43,11 +58,13 @@ Resources:
       ToPort: 2049
     Type: 'AWS::EC2::SecurityGroupIngress'
   SecurityGroupResource:
+    Condition: CreateEfs
     Properties:
       GroupDescription: custom security group for EFS mount targets
       VpcId: !Ref vpc
     Type: 'AWS::EC2::SecurityGroup'
   FSxSecurityGroup:
+    Condition: CreateFsx
     Properties:
       GroupDescription: SecurityGroup for testing existing FSx
       SecurityGroupIngress:
@@ -58,6 +75,7 @@ Resources:
       VpcId: !Ref vpc
     Type: 'AWS::EC2::SecurityGroup'
   FileSystemResource1:
+    Condition: CreateFsx
     Properties:
       FileSystemType: LUSTRE
       LustreConfiguration:
@@ -72,6 +90,7 @@ Resources:
         - !Ref PublicSubnetId
     Type: 'AWS::FSx::FileSystem'
   FSxSecurityGroup1:
+    Condition: CreateFsx
     Properties:
       GroupDescription: SecurityGroup for testing existing FSx
       SecurityGroupIngress:
@@ -110,6 +129,7 @@ Resources:
       VpcId: !Ref vpc
     Type: 'AWS::EC2::SecurityGroup'
   FileSystemResource2:
+    Condition: CreateFsx
     Properties:
       FileSystemType: ONTAP
       OntapConfiguration:
@@ -122,6 +142,7 @@ Resources:
         - !Ref PublicSubnetId
     Type: 'AWS::FSx::FileSystem'
   SVMVolume0:
+    Condition: CreateFsx
     Properties:
       Name: vol0
       OntapConfiguration:
@@ -132,11 +153,13 @@ Resources:
       VolumeType: ONTAP
     Type: 'AWS::FSx::Volume'
   StorageVirtualMachineFileSystemResource:
+    Condition: CreateFsx
     Properties:
       FileSystemId: !Ref FileSystemResource2
       Name: fsx
     Type: 'AWS::FSx::StorageVirtualMachine'
   FSxSecurityGroup2:
+    Condition: CreateFsx
     Properties:
       GroupDescription: SecurityGroup for testing existing FSx
       SecurityGroupIngress:
@@ -183,6 +206,7 @@ Resources:
       VpcId: !Ref vpc
     Type: 'AWS::EC2::SecurityGroup'
   FileSystemResource3:
+    Condition: CreateFsx
     Properties:
       FileSystemType: OPENZFS
       OpenZFSConfiguration:
@@ -202,6 +226,7 @@ Resources:
         - !Ref PublicSubnetId
     Type: 'AWS::FSx::FileSystem'
   OpenZFSVolume0:
+    Condition: CreateFsx
     Properties:
       Name: vol0
       OpenZFSConfiguration:
@@ -216,12 +241,14 @@ Resources:
           - RootVolumeId
       VolumeType: OPENZFS
     Type: 'AWS::FSx::Volume'
+  DummyResource:
+    Type: AWS::CloudFormation::WaitConditionHandle
 Outputs:
   EfsId:
-    Value: !Ref FileSystemResource0
+    Value: !If [ CreateEfs, !Ref FileSystemResource0, '' ]
   FsxLustreFsId:
-    Value: !Ref FileSystemResource1
+    Value: !If [ CreateFsx, !Ref FileSystemResource1, '']
   FsxOntapVolumeId:
-    Value: !Ref SVMVolume0
+    Value: !If [ CreateFsx, !Ref SVMVolume0, '']
   FsxOpenZfsVolumeId:
-    Value: !Ref OpenZFSVolume0
+    Value: !If [ CreateFsx, !Ref OpenZFSVolume0, '']

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_create.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_create.config.yaml
@@ -31,4 +31,4 @@ Scheduling:
           MaxCount: 4
       Networking:
         SubnetIds:
-          - {{ public_subnet_ids[2] }}
+          - {% if len(private_subnet_ids) >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_1.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_1.config.yaml
@@ -31,5 +31,5 @@ Scheduling:
           MaxCount: 4
       Networking:
         SubnetIds:
-          - {{ public_subnet_ids[2] }}
+          - {% if len(private_subnet_ids) >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[0] }} {% endif %}
           - {{ public_subnet_ids[1] }}

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_2.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_2.config.yaml
@@ -31,4 +31,4 @@ Scheduling:
           MaxCount: 4
       Networking:
         SubnetIds:
-          - {{ public_subnet_ids[2] }}
+          - {% if len(private_subnet_ids) >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -794,3 +794,7 @@ def test_cluster_health_metric(metric_names, cluster_name, region):
     logging.info(f"Testing that {metric_names} have data.")
     response = retrieve_metric_data(cluster_name, metric_names, region)
     assert_metrics_has_data(response)
+
+
+def is_fsx_supported(region: str):
+    return "us-iso" not in region


### PR DESCRIPTION
### Description of changes
Make the following integration tests executable in us-iso regions:
1. 'test_multi_az_create_and_update'
1. 'test_multiple_efs'
1. 'test_efs_compute_az'
1. 'test_monitoring'
1. 'test_ad_integration' 
1. 'test_dynamic_file_systems_update'

### Tests
1. PASSED: 'test_multi_az_create_and_update'
1. PASSED: 'test_multiple_efs'
1. PASSED: 'test_efs_compute_az'
1. PASSED: 'test_monitoring'
1. PASSED: 'test_ad_integration'
1. PASSED: 'test_dynamic_file_systems_update'

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
