### PR TITLE
Removes Weight parameter from CustomSlurmSettings integ-test

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -437,12 +437,10 @@ def test_slurm_custom_config_parameters(
     assert "500" == slurm_commands.get_partition_info("q1", "MaxMemPerNode")
 
     # ComputeResource 1
-    assert "50" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Weight")
     assert "10000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Port")
     assert "2000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Memory")
 
     # ComputeResource 2
-    assert "150" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Weight")
     assert "10010" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Port")
     assert "2500" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Memory")
 
@@ -478,12 +476,10 @@ def test_slurm_custom_config_parameters(
     assert "1500" == slurm_commands.get_partition_info("q1", "MaxMemPerNode")
 
     # ComputeResource 1
-    assert "75" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Weight")
     assert "20000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Port")
     assert "4000" == slurm_commands.get_node_attribute("q1-dy-cr1-1", "Memory")
 
     # ComputeResource 2
-    assert "250" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Weight")
     assert "25000" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Port")
     assert "4100" == slurm_commands.get_node_attribute("q1-dy-cr2-1", "Memory")
 

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_config_parameters/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_config_parameters/pcluster.config.update.yaml
@@ -27,7 +27,6 @@ Scheduling:
           CustomSlurmSettings:
             Port: 20000
             RealMemory: 4000
-            Weight: 75
           Instances:
             - InstanceType: t2.large
           MinCount: 0
@@ -35,7 +34,6 @@ Scheduling:
           CustomSlurmSettings:
             Port: 25000
             RealMemory: 4100
-            Weight: 250
           Instances:
             - InstanceType: t2.large
           MinCount: 0

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_config_parameters/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_config_parameters/pcluster.config.yaml
@@ -30,7 +30,6 @@ Scheduling:
           CustomSlurmSettings:
             Port: 10000
             RealMemory: 2000
-            Weight: 50
           Instances:
             - InstanceType: t2.large
           MinCount: 0
@@ -38,7 +37,6 @@ Scheduling:
           CustomSlurmSettings:
             Port: 10010
             RealMemory: 2500
-            Weight: 150
           Instances:
             - InstanceType: t2.large
           MinCount: 0


### PR DESCRIPTION
### Description of changes
* Removes Weight parameter from CustomSlurmSettings integ-test

The PR below made the `weight` parameter "managed", as such is not allowed anymore as CustomSlurmSetting.

This PR remove this settings from the integration test.
Note: We may want to add a different parameter in the integ-test, but I considered this out-of-scope for this fix.

### Tests
* Launched the Integration test in my personal account

### References
* [Introduce Slurm compute node priority customization](https://github.com/aws/aws-parallelcluster/pull/5314)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
