### PR TITLE
Dynamically retrieve root volume device name from the AMI during cluster creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 CHANGELOG
 =========
 
+3.6.1
+------
+
+**ENHANCEMENTS**
+
+**CHANGES**
+
+**BUG FIXES**
+- Remove hardcoding of root volume device name (`/dev/sda1` and `/dev/xvda`) and retrieve it from the AMI(s) used during `create-cluster`.
+
 3.6.0
 ----
 **ENHANCEMENTS**

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1358,7 +1358,7 @@ class BaseClusterConfig(Resource):
         self._register_validator(
             HeadNodeLaunchTemplateValidator,
             head_node=self.head_node,
-            os=self.image.os,
+            root_volume_device_name=AWSApi.instance().ec2.describe_image(self.head_node_ami).device_name,
             ami_id=self.head_node_ami,
             tags=self.get_tags(),
             imds_support=self.imds.imds_support,
@@ -2867,7 +2867,7 @@ class CommonSchedulerClusterConfig(BaseClusterConfig):
                     ComputeResourceLaunchTemplateValidator,
                     queue=queue,
                     ami_id=queue_image,
-                    os=self.image.os,
+                    root_volume_device_name=AWSApi.instance().ec2.describe_image(queue_image).device_name,
                     tags=self.get_tags(),
                     imds_support=self.imds.imds_support,
                 )

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -36,11 +36,11 @@ SLURM = "slurm"
 AWSBATCH = "awsbatch"
 
 OS_MAPPING = {
-    "centos7": {"user": "centos", "root-device": "/dev/sda1"},
-    "alinux2": {"user": "ec2-user", "root-device": "/dev/xvda"},
-    "ubuntu1804": {"user": "ubuntu", "root-device": "/dev/sda1"},
-    "ubuntu2004": {"user": "ubuntu", "root-device": "/dev/sda1"},
-    "rhel8": {"user": "ec2-user", "root-device": "/dev/sda1"},
+    "centos7": {"user": "centos"},
+    "alinux2": {"user": "ec2-user"},
+    "ubuntu1804": {"user": "ubuntu"},
+    "ubuntu2004": {"user": "ubuntu"},
+    "rhel8": {"user": "ec2-user"},
 }
 
 OS_TO_IMAGE_NAME_PART_MAP = {

--- a/cli/src/pcluster/launch_template_utils.py
+++ b/cli/src/pcluster/launch_template_utils.py
@@ -1,12 +1,10 @@
 from abc import ABC, abstractmethod
 
-from pcluster.constants import OS_MAPPING
-
 
 class _LaunchTemplateBuilder(ABC):
     """Abstract class with methods with the common logic for launch template builders."""
 
-    def get_block_device_mappings(self, root_volume, image_os):
+    def get_block_device_mappings(self, root_volume, root_volume_device_name):
         """Return a list of block device mappings."""
         block_device_mappings = []
         for _, (device_name_index, virtual_name_index) in enumerate(zip(list(map(chr, range(97, 121))), range(0, 24))):
@@ -14,9 +12,7 @@ class _LaunchTemplateBuilder(ABC):
             virtual_name = "ephemeral{0}".format(virtual_name_index)
             block_device_mappings.append(self._block_device_mapping_for_virt(device_name, virtual_name))
 
-        block_device_mappings.append(
-            self._block_device_mapping_for_ebs(OS_MAPPING[image_os]["root-device"], root_volume)
-        )
+        block_device_mappings.append(self._block_device_mapping_for_ebs(root_volume_device_name, root_volume))
         return block_device_mappings
 
     def get_instance_market_options(self, queue, compute_resource):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -936,7 +936,8 @@ class ClusterCdkStack:
             launch_template_data=ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
                 instance_type=head_node.instance_type,
                 block_device_mappings=self._launch_template_builder.get_block_device_mappings(
-                    head_node.local_storage.root_volume, self.config.image.os
+                    head_node.local_storage.root_volume,
+                    AWSApi.instance().ec2.describe_image(self.config.head_node_ami).device_name,
                 ),
                 key_name=head_node.ssh.key_name,
                 network_interfaces=head_lt_nw_interfaces,

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -5,6 +5,7 @@ from aws_cdk import aws_logs as logs
 from aws_cdk.core import CfnTag, Fn, NestedStack, Stack
 from constructs import Construct
 
+from pcluster.aws.aws_api import AWSApi
 from pcluster.config.cluster_config import (
     SchedulerPluginQueue,
     SharedStorageType,
@@ -190,7 +191,8 @@ class QueuesStack(NestedStack):
             launch_template_name=f"{self.stack_name}-{queue.name}-{compute_resource.name}",
             launch_template_data=ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(
                 block_device_mappings=self._launch_template_builder.get_block_device_mappings(
-                    queue.compute_settings.local_storage.root_volume, self._config.image.os
+                    queue.compute_settings.local_storage.root_volume,
+                    AWSApi.instance().ec2.describe_image(self._config.image_dict[queue.name]).device_name,
                 ),
                 # key_name=,
                 network_interfaces=compute_lt_nw_interfaces,

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -1162,7 +1162,7 @@ class _LaunchTemplateValidator(Validator):
 class HeadNodeLaunchTemplateValidator(_LaunchTemplateValidator):
     """Try to launch the requested instance (in dry-run mode) to verify configuration parameters."""
 
-    def _validate(self, head_node, os, ami_id, tags, imds_support):
+    def _validate(self, head_node, root_volume_device_name, ami_id, tags, imds_support):
         try:
             head_node_security_groups = []
             if head_node.networking.security_groups:
@@ -1189,7 +1189,9 @@ class HeadNodeLaunchTemplateValidator(_LaunchTemplateValidator):
                 TagSpecifications=self._generate_tag_specifications(tags),
                 KeyName=head_node.ssh.key_name,
                 BlockDeviceMappings=(
-                    self._launch_template_builder.get_block_device_mappings(head_node.local_storage.root_volume, os)
+                    self._launch_template_builder.get_block_device_mappings(
+                        head_node.local_storage.root_volume, root_volume_device_name
+                    )
                 ),
                 MetadataOptions={
                     "HttpTokens": "required" if imds_support == "v2.0" else "optional",
@@ -1224,7 +1226,7 @@ class HeadNodeImdsValidator(Validator):
 class ComputeResourceLaunchTemplateValidator(_LaunchTemplateValidator):
     """Try to launch the requested instances (in dry-run mode) to verify configuration parameters."""
 
-    def _validate(self, queue, os, ami_id, tags, imds_support):
+    def _validate(self, queue, root_volume_device_name, ami_id, tags, imds_support):
         try:
             # Retrieve network parameters
             queue_subnet_id = queue.networking.subnet_ids[0]
@@ -1249,7 +1251,7 @@ class ComputeResourceLaunchTemplateValidator(_LaunchTemplateValidator):
             # For SlurmFlexibleComputeResource test only the first InstanceType through a RunInstances
             self._test_compute_resource(
                 queue=queue,
-                os=os,
+                root_volume_device_name=root_volume_device_name,
                 compute_resource=dry_run_compute_resource,
                 use_public_ips=bool(queue.networking.assign_public_ip),
                 ami_id=ami_id,
@@ -1267,7 +1269,7 @@ class ComputeResourceLaunchTemplateValidator(_LaunchTemplateValidator):
     def _test_compute_resource(
         self,
         queue,
-        os,
+        root_volume_device_name,
         compute_resource,
         use_public_ips,
         ami_id,
@@ -1300,7 +1302,7 @@ class ComputeResourceLaunchTemplateValidator(_LaunchTemplateValidator):
                 queue, compute_resource
             ),
             BlockDeviceMappings=self._launch_template_builder.get_block_device_mappings(
-                queue.compute_settings.local_storage.root_volume, os
+                queue.compute_settings.local_storage.root_volume, root_volume_device_name
             ),
             MetadataOptions={
                 "HttpTokens": "required" if imds_support == "v2.0" else "optional",

--- a/cli/tests/pcluster/aws/dummy_aws_api.py
+++ b/cli/tests/pcluster/aws/dummy_aws_api.py
@@ -13,7 +13,7 @@ import os
 from datetime import datetime
 
 from pcluster.aws.aws_api import AWSApi
-from pcluster.aws.aws_resources import FsxFileSystemInfo, InstanceTypeInfo
+from pcluster.aws.aws_resources import FsxFileSystemInfo, ImageInfo, InstanceTypeInfo
 from pcluster.aws.cfn import CfnClient
 from pcluster.aws.dynamo import DynamoResource
 from pcluster.aws.ec2 import Ec2Client
@@ -380,5 +380,9 @@ class _DummySsmClient(SsmClient):
 def mock_aws_api(mocker, mock_instance_type_info=True):
     """Mock AWS Api."""
     mocker.patch("pcluster.aws.aws_api.AWSApi.instance", return_value=_DummyAWSApi())
+    mocker.patch(
+        "pcluster.aws.ec2.Ec2Client.describe_image",
+        return_value=ImageInfo({"BlockDeviceMappings": [{"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 35}}]}),
+    )
     if mock_instance_type_info:
         mocker.patch("pcluster.aws.ec2.Ec2Client.get_instance_type_info", side_effect=_DummyInstanceTypeInfo)

--- a/cli/tests/pcluster/templates/test_cdk_builder_utils.py
+++ b/cli/tests/pcluster/templates/test_cdk_builder_utils.py
@@ -103,7 +103,7 @@ def test_get_default_volume_tags(stack_name, node_type, raw_dict, expected_resul
 @pytest.mark.usefixtures("get_region")
 class TestCdkLaunchTemplateBuilder:
     @pytest.mark.parametrize(
-        "root_volume_parameters, image_os, expected_response",
+        "root_volume_parameters, root_volume_device_name, expected_response",
         [
             pytest.param(
                 dict(
@@ -114,7 +114,7 @@ class TestCdkLaunchTemplateBuilder:
                     throughput=30,
                     delete_on_termination=False,
                 ),
-                "centos7",
+                "/dev/sda1",
                 [
                     ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
                         device_name="/dev/xvdba", virtual_name="ephemeral0"
@@ -210,7 +210,7 @@ class TestCdkLaunchTemplateBuilder:
                     throughput=20,
                     delete_on_termination=True,
                 ),
-                "alinux2",
+                "/dev/xvda",
                 [
                     ec2.CfnLaunchTemplate.BlockDeviceMappingProperty(
                         device_name="/dev/xvdba", virtual_name="ephemeral0"
@@ -300,11 +300,11 @@ class TestCdkLaunchTemplateBuilder:
             ),
         ],
     )
-    def test_get_block_device_mappings(self, root_volume_parameters, image_os, expected_response):
+    def test_get_block_device_mappings(self, root_volume_parameters, root_volume_device_name, expected_response):
         root_volume = RootVolume(**root_volume_parameters)
-        assert_that(CdkLaunchTemplateBuilder().get_block_device_mappings(root_volume, image_os)).is_equal_to(
-            expected_response
-        )
+        assert_that(
+            CdkLaunchTemplateBuilder().get_block_device_mappings(root_volume, root_volume_device_name)
+        ).is_equal_to(expected_response)
 
     @pytest.mark.parametrize(
         "queue, compute_resource, expected_response",

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -2658,7 +2658,7 @@ def test_are_subnets_covered_by_cidrs(mocker, ip_ranges, subnet_cidrs, covered):
 @pytest.mark.usefixtures("get_region")
 class TestDictLaunchTemplateBuilder:
     @pytest.mark.parametrize(
-        "root_volume_parameters, image_os, region, expected_response",
+        "root_volume_parameters, root_volume_device_name, region, expected_response",
         [
             pytest.param(
                 dict(
@@ -2669,7 +2669,7 @@ class TestDictLaunchTemplateBuilder:
                     throughput=30,
                     delete_on_termination=False,
                 ),
-                "centos7",
+                "/dev/sda1",
                 "WHATEVER-NON-US-ISO-REGION",
                 [
                     {"DeviceName": "/dev/xvdba", "VirtualName": "ephemeral0"},
@@ -2718,7 +2718,7 @@ class TestDictLaunchTemplateBuilder:
                     throughput=20,
                     delete_on_termination=True,
                 ),
-                "alinux2",
+                "/dev/xvda",
                 "WHATEVER-NON-US-ISO-REGION",
                 [
                     {"DeviceName": "/dev/xvdba", "VirtualName": "ephemeral0"},
@@ -2766,7 +2766,7 @@ class TestDictLaunchTemplateBuilder:
                     throughput=20,
                     delete_on_termination=True,
                 ),
-                "alinux2",
+                "/dev/xvda",
                 "us-isoWHATEVER",
                 [
                     {"DeviceName": "/dev/xvdba", "VirtualName": "ephemeral0"},
@@ -2809,12 +2809,14 @@ class TestDictLaunchTemplateBuilder:
             ),
         ],
     )
-    def test_get_block_device_mappings(self, mocker, root_volume_parameters, image_os, region, expected_response):
+    def test_get_block_device_mappings(
+        self, mocker, root_volume_parameters, root_volume_device_name, region, expected_response
+    ):
         mocker.patch("pcluster.config.cluster_config.get_region", return_value=region)
         root_volume = RootVolume(**root_volume_parameters)
-        assert_that(DictLaunchTemplateBuilder().get_block_device_mappings(root_volume, image_os)).is_equal_to(
-            expected_response
-        )
+        assert_that(
+            DictLaunchTemplateBuilder().get_block_device_mappings(root_volume, root_volume_device_name)
+        ).is_equal_to(expected_response)
 
     @pytest.mark.parametrize(
         "queue, compute_resource, expected_response",


### PR DESCRIPTION
Side note: we already retrieve root volume device name from the AMI dynamically during integration tests and image creation


### Description of changes
The symptom is: If an AMI with a root device name different from the hard-coding is used, every cluster node has an additional EBS volume besides the root volume, even if no additional volume is specified in the cluster configuration file. And the [RootVolume](https://docs.aws.amazon.com/parallelcluster/latest/ug/HeadNode-v3.html#yaml-HeadNode-LocalStorage-RootVolume) configuration takes effect on the additional volume instead of the root volume.

### Tests
The following tests have been passed
```
{%- import 'common.jinja2' as common with context -%}
{%- set INSTANCES = ["c5.xlarge"] -%}
{%- set OSS = ["alinux2"] -%}
{%- set SCHEDULERS = ["slurm"] -%}
---
test-suites:
  cfn-init:
    test_cfn_init.py::test_replace_compute_on_failure:
      dimensions:
        - regions: ["af-south-1"]
          instances: {{ INSTANCES }}
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
    test_cfn_init.py::test_install_args_quotes:
      dimensions:
        - regions: ["us-west-1"]
          instances: {{ INSTANCES }}
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
  cli_commands:
    test_cli_commands.py::test_slurm_cli_commands:
      dimensions:
        - regions: ["ap-northeast-2"]
          instances: {{ INSTANCES }}
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
  cloudwatch_logging:
    test_cloudwatch_logging.py::test_cloudwatch_logging:
      dimensions:
        - regions: ["ap-east-1"]
          instances: {{ INSTANCES }}
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
  configure:
    test_pcluster_configure.py::test_pcluster_configure:
      dimensions:
        - regions: ["ap-southeast-2"]
          instances: {{ INSTANCES }}
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
  create:
    test_create.py::test_create_imds_secured:
      dimensions:
        - regions: ["eu-south-1"]
          instances: {{ INSTANCES }}
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
    test_create.py::test_cluster_creation_with_invalid_ebs:
      dimensions:
        - regions: ["ap-south-1"]
          instances: {{ INSTANCES }}
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
  storage:
    test_ebs.py::test_ebs_single:
      dimensions:
        - regions: ["us-east-2"]
          instances: {{ INSTANCES }}
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
    test_deletion_policy.py::test_retain_on_deletion:
      dimensions:
        - regions: ["ap-east-1" ]
          instances: {{ INSTANCES }}
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
    test_ephemeral.py::test_head_node_stop:
      dimensions:
        - regions: ["use1-az4"]
          instances: ["m5d.xlarge"]
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
  update:
    test_update.py::test_queue_parameters_update:
      dimensions:
        - regions: ["ap-south-1"]
          instances: {{ INSTANCES }}
          oss: {{ OSS }}
          schedulers: {{ SCHEDULERS }}
```


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
