### PR TITLE
Add ubuntu 22 to image builder resources

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -57,7 +57,7 @@ phases:
               [ -n "${CfnParamCincInstaller}" ] && CINC_URL="${CfnParamCincInstaller}"
               echo "${!CINC_URL}"
 
-      # Check input base AMI OS and get OS information, the output should be like centos.7 | amzn.2 | ubuntu.18.04 | ubuntu.20.04 | rhel.8.7
+      # Check input base AMI OS and get OS information, the output should be like centos.7 | amzn.2 | ubuntu.18.04 | ubuntu.20.04 | ubuntu.22.04 | rhel.8.7
       - name: OperatingSystemRelease
         action: ExecuteBash
         inputs:
@@ -90,6 +90,8 @@ phases:
                 OS='ubuntu1804'
               elif [ `echo "${!RELEASE}" | grep '^ubuntu\.20'` ]; then
                 OS='ubuntu2004'
+              elif [ `echo "${!RELEASE}" | grep '^ubuntu\.22'` ]; then
+                OS='ubuntu2204'
               elif [ `echo "${!RELEASE}" | grep '^rhel\.8'` ]; then
                 OS='rhel8'
               else
@@ -151,10 +153,10 @@ phases:
                   exit {{ FailExitCode }}
                 fi
 
-                # This component only supports aarch64 CPUs on Amazon Linux 2, Ubuntu1804, Ubuntu2004, Centos7 and RHEL8
+                # This component only supports aarch64 CPUs on Amazon Linux 2, Ubuntu1804, Ubuntu2004, Ubuntu2204, Centos7 and RHEL8
                 ARCH=$(uname -m)
                 if [[ `echo ${!ARCH}` == 'aarch64' ]]; then
-                  if [ `echo "${!RELEASE}" | grep -Ev '^(amzn\.2|centos\.7|ubuntu\.18\.04|ubuntu\.20\.04|rhel\.8)'` ]; then
+                  if [ `echo "${!RELEASE}" | grep -Ev '^(amzn\.2|centos\.7|ubuntu\.18\.04|ubuntu\.20\.04|ubuntu\.22\.04|rhel\.8)'` ]; then
                     echo "This component does not support '${!RELEASE}' on ARM64 CPUs. Failing build."
                     exit {{ FailExitCode }}
                   fi

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_tag.yaml
@@ -53,6 +53,8 @@ phases:
                 OS='ubuntu1804'
               elif [ $(echo "${RELEASE}" | grep '^ubuntu\.20') ]; then
                 OS='ubuntu2004'
+              elif [ $(echo "${RELEASE}" | grep '^ubuntu\.22') ]; then
+                OS='ubuntu2204'
               elif [ $(echo "${RELEASE}" | grep '^rhel\.8') ]; then
                 OS='rhel8'
               fi

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_test.yaml
@@ -42,6 +42,8 @@ phases:
                 OS='ubuntu1804'
               elif [ `echo "${RELEASE}" | grep '^ubuntu\.20'` ]; then
                 OS='ubuntu2004'
+              elif [ `echo "${RELEASE}" | grep '^ubuntu\.22'` ]; then
+                OS='ubuntu2204'
               elif [ `echo "${RELEASE}" | grep '^rhel\.8'` ]; then
                 OS='rhel8'
               else
@@ -125,7 +127,7 @@ phases:
                 su -l pcluster-scheduler-plugin -c "which python" | grep envs/scheduler_plugin_virtualenv/bin/python
                 [[ $? -ne 0 ]] && echo "Check scheduler plugin virtualenv python path failed" && exit 1
               fi
-              
+
               echo "Virtualenv test passed"
 
       - name: Pip

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -42,6 +42,8 @@ phases:
                 OS='ubuntu1804'
               elif [ `echo "${RELEASE}" | grep '^ubuntu\.20'` ]; then
                 OS='ubuntu2004'
+              elif [ `echo "${RELEASE}" | grep '^ubuntu\.22'` ]; then
+                OS='ubuntu2204'
               elif [ `echo "${RELEASE}" | grep '^rhel\.8'` ]; then
                 OS='rhel8'
               else
@@ -124,7 +126,7 @@ phases:
               set -v
               ARCHITECTURE='{{ validate.OperatingSystemArchitecture.outputs.stdout }}'
               OS='{{ validate.OperatingSystemName.outputs.stdout }}'
-              if [ ${ARCHITECTURE} == 'arm64' ] && [[ ${OS} =~ ^(ubuntu(18|20)04|alinux2|rhel8)$ ]] || [ ${ARCHITECTURE} == 'x86_64' ]; then
+              if [ ${ARCHITECTURE} == 'arm64' ] && [[ ${OS} =~ ^(ubuntu(18|20|22)04|alinux2|rhel8)$ ]] || [ ${ARCHITECTURE} == 'x86_64' ]; then
                 echo "true"
               else
                 echo "false"

--- a/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/update_and_reboot.yaml
@@ -10,7 +10,7 @@ constants:
 phases:
   - name: build
     steps:
-      # Check input base AMI OS and get OS information, the output should be like centos.7 | amzn.2 | ubuntu.18.04 | ubuntu.20.04 | rhel.8.7
+      # Check input base AMI OS and get OS information, the output should be like centos.7 | amzn.2 | ubuntu.18.04 | ubuntu.20.04 | ubuntu.22.04 | rhel.8.7
       - name: OperatingSystemRelease
         action: ExecuteBash
         inputs:
@@ -43,6 +43,8 @@ phases:
                 OS='ubuntu1804'
               elif [ `echo "${!RELEASE}" | grep '^ubuntu\.20'` ]; then
                 OS='ubuntu2004'
+              elif [ `echo "${!RELEASE}" | grep '^ubuntu\.22'` ]; then
+                OS='ubuntu2204'
               elif [ `echo "${!RELEASE}" | grep '^rhel\.8'` ]; then
                 OS='rhel8'
               else
@@ -82,10 +84,10 @@ phases:
                 exit {{ FailExitCode }}
               fi
 
-              # This component only supports aarch64 CPUs on Amazon Linux 2, Ubuntu1804, Ubuntu2004, Centos7 and RHEL 8
+              # This component only supports aarch64 CPUs on Amazon Linux 2, Ubuntu1804, Ubuntu2004, Ubuntu2204, Centos7 and RHEL 8
               ARCH=$(uname -m)
               if [[ `echo ${!ARCH}` == 'aarch64' ]]; then
-                if [ `echo "${!RELEASE}" | grep -Ev '^(amzn\.2|centos\.7|ubuntu\.18\.04|ubuntu\.20\.04|rhel\.8)'` ]; then
+                if [ `echo "${!RELEASE}" | grep -Ev '^(amzn\.2|centos\.7|ubuntu\.18\.04|ubuntu\.20\.04|ubuntu\.22\.04|rhel\.8)'` ]; then
                   echo "This component does not support '${!RELEASE}' on ARM64 CPUs. Failing build."
                   exit {{ FailExitCode }}
                 fi
@@ -129,17 +131,17 @@ phases:
 
               if [[ ${!PLATFORM} == RHEL ]]; then
                 yum -y update
-              
+
                 if [[ ${!OS} != "rhel8" ]]; then
                   package-cleanup -y --oldkernels --count=1
                 else
                   # package-cleanup has changed in RHEL8 and it works differently
                   # RHEL8 keeps at least 2 kernel for fallback reason https://access.redhat.com/solutions/1227
                   # The kernel cleanup should be performed manually
-              
+
                   # get the default kernel for the next boot
                   LAST_KERNEL_VERSION=$(grubby --default-kernel | sed -e "s/.*-\(4.18.0-.*\).$(uname -m)/\1/g")
-                  
+
                   # get all the installed kernel versions except the one for the next boot
                   KERNEL_VERSIONS_CLEANUP=$(rpm -q --qf "%{VERSION}-%{RELEASE}\n" kernel | grep -v "$LAST_KERNEL_VERSION")
                   for VERSION in $KERNEL_VERSIONS_CLEANUP; do


### PR DESCRIPTION
### Description of changes
* Added support for ubuntu 22 to several OS specific clauses in the image builder resources

### Tests
* Ran build-image to start a build with an Ubuntu 22 base image

### References
* https://app.asana.com/0/1204432608861774/1204440046491568/f

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
