### PR TITLE
Explicitly specify `region` key when formatting string

### DIFF
--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -139,5 +139,5 @@ def resource_bucket_shared(request, s3_bucket_factory_shared, lambda_layer_sourc
 @pytest.fixture(scope="class")
 def resource_bucket(request, region, resource_bucket_shared):
     if request.config.getoption("resource_bucket"):
-        return request.config.getoption("resource_bucket").format(region)
+        return request.config.getoption("resource_bucket").format(region=region)
     return resource_bucket_shared[region]


### PR DESCRIPTION
### Description of changes
Explicitly specify `region` key when formatting string

### Tests
```
>>> without_region='mybucket'
>>> without_region.format(region='us-east-1')
'mybucket'

>>> with_region='mybucket-{region}
>>> with_region'.format('us-east-1')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
KeyError: 'region'
>>> with_region.format(region='us-east-1')
'mybucket-us-east-1'
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
