### PR TITLE
Allow Memory Based Scheduling and FIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 **ENHANCEMENTS**
 - Allow configuration of static and dynamic node priorities in compute resources via the ParallelCluster configuration YAML file.
 - Add support for Ubuntu 22.
+- Allow memory-based scheduling when multiple instance types are specified for a Slurm Compute Resource.
 
 **CHANGES**
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -169,7 +169,7 @@ from pcluster.validators.instances_validators import (
     InstancesAllocationStrategyValidator,
     InstancesCPUValidator,
     InstancesEFAValidator,
-    InstancesMemorySchedulingValidator,
+    InstancesMemorySchedulingWarningValidator,
     InstancesNetworkingValidator,
 )
 from pcluster.validators.kms_validators import KmsKeyIdEncryptedValidator, KmsKeyValidator
@@ -3198,7 +3198,7 @@ class SlurmClusterConfig(CommonSchedulerClusterConfig):
                         InstancesEFAValidator,
                         InstancesNetworkingValidator,
                         InstancesAllocationStrategyValidator,
-                        InstancesMemorySchedulingValidator,
+                        InstancesMemorySchedulingWarningValidator,
                     ]
                     for validator in flexible_instance_types_validators:
                         self._register_validator(validator, **validator_args)

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -110,6 +110,10 @@ MAX_NUMBER_OF_COMPUTE_RESOURCES_PER_CLUSTER = MAX_COMPUTE_RESOURCES_PER_QUEUE = 
 MIN_SLURM_NODE_PRIORITY = 1
 MAX_SLURM_NODE_PRIORITY = 2**32 - 1  # max value of uint32_t
 
+# Thresholds used to trigger a warning if Memory Based Scheduling and Flexible Instance Types are used together
+MIN_MEMORY_ABSOLUTE_DIFFERENCE = 4096
+MIN_MEMORY_PRECENTAGE_DIFFERENCE = 0.20
+
 MAX_EBS_COUNT = 5
 MAX_NEW_STORAGE_COUNT = {"efs": 1, "fsx": 1, "raid": 1}
 MAX_EXISTING_STORAGE_COUNT = {"efs": 20, "fsx": 20, "raid": 0}


### PR DESCRIPTION
Change the Validator to allow Memory Based Scheduling and Flexible Instance Types to be used at the same time.

A warning is triggered if the Memory difference between the smallest and biggest instances is greater than an absolute threshold and a percentage threshold.


### Tests
* Unit test run locally

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
