### PR TITLE
Add Ubuntu 22 support for pcluster create-cluster and configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 **ENHANCEMENTS**
 - Allow configuration of static and dynamic node priorities in compute resources via the ParallelCluster configuration YAML file.
+- Add support for Ubuntu 22.
 
 **CHANGES**
 

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -24,7 +24,7 @@ CIDR_ALL_IPS = "0.0.0.0/0"
 
 SUPPORTED_SCHEDULERS = ["slurm", "awsbatch"]
 SCHEDULERS_SUPPORTING_IMDS_SECURED = ["slurm", "plugin"]
-SUPPORTED_OSES = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"]
+SUPPORTED_OSES = ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "ubuntu2204", "rhel8"]
 SUPPORTED_OSES_FOR_SCHEDULER = {"slurm": SUPPORTED_OSES, "plugin": SUPPORTED_OSES, "awsbatch": ["alinux2"]}
 DELETE_POLICY = "Delete"
 RETAIN_POLICY = "Retain"
@@ -40,6 +40,7 @@ OS_MAPPING = {
     "alinux2": {"user": "ec2-user", "root-device": "/dev/xvda"},
     "ubuntu1804": {"user": "ubuntu", "root-device": "/dev/sda1"},
     "ubuntu2004": {"user": "ubuntu", "root-device": "/dev/sda1"},
+    "ubuntu2204": {"user": "ubuntu", "root-device": "/dev/sda1"},
     "rhel8": {"user": "ec2-user", "root-device": "/dev/sda1"},
 }
 
@@ -48,6 +49,7 @@ OS_TO_IMAGE_NAME_PART_MAP = {
     "centos7": "centos7-hvm",
     "ubuntu1804": "ubuntu-1804-lts-hvm",
     "ubuntu2004": "ubuntu-2004-lts-hvm",
+    "ubuntu2204": "ubuntu-2204-lts-hvm",
     "rhel8": "rhel8-hvm",
 }
 

--- a/cli/src/pcluster/templates/cw_dashboard_builder.py
+++ b/cli/src/pcluster/templates/cw_dashboard_builder.py
@@ -713,7 +713,7 @@ class CWDashboardConstruct(Construct):
                     ),
                     self._new_cw_log_widget(
                         title="syslog",
-                        conditions=[Condition(["ubuntu1804", "ubuntu2004"], base_os)],
+                        conditions=[Condition(["ubuntu1804", "ubuntu2004", "ubuntu2204"], base_os)],
                         filters=[self._new_filter(pattern=f"{head_private_ip}.*syslog")],
                     ),
                     self._new_cw_log_widget(

--- a/cli/tests/pcluster/aws/test_ec2.py
+++ b/cli/tests/pcluster/aws/test_ec2.py
@@ -115,6 +115,7 @@ def test_get_supported_architectures(mocker, instance_type, supported_architectu
         ("amzn2-hvm", "alinux2"),
         ("centos7-hvm", "centos7"),
         ("ubuntu-2004-lts-hvm", "ubuntu2004"),
+        ("ubuntu-2204-lts-hvm", "ubuntu2204"),
         ("nonexistant-hvm", "linux"),
         ("nonexistant", "linux"),
     ],

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_disabled_efa_no_placement_group/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_efa_not_supported/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_efa_not_supported/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_default_placement_group/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 Allowed values for VPC ID:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_existing_placement_group/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 Allowed values for VPC ID:

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_enabled_efa_non_existent_placement_group/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 The EC2 instance selected supports enhanced networking capabilities using Elastic Fabric Adapter (EFA). EFA enables you to run applications requiring high levels of inter-node communications at scale on AWS at no additional charge (https://docs.aws.amazon.com/parallelcluster/latest/ug/efa-v3.html).
 Enabling EFA requires compute instances to be placed within a Placement Group. Please specify an existing Placement Group name or leave it blank for ParallelCluster to create one.
 ERROR: non-existent-test-pg is not an acceptable value for Placement Group name

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_filtered_subnets_by_az/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_automation_no_awsbatch_no_errors/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_no_input_no_automation_no_errors/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_subnet_automation_no_awsbatch_no_errors_empty_vpc/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_awsbatch_no_errors/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 Allowed values for Availability Zone:
 1. eu-west-1a
 2. eu-west-1b

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 There are no VPC for the given region. Starting automatic creation of VPC and subnets...
 Allowed values for Availability Zone:
 1. eu-west-1a

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_vpc_automation_no_vpc_in_region_public/output.txt
@@ -34,7 +34,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 There are no VPC for the given region. Starting automatic creation of VPC and subnets...
 Allowed values for Availability Zone:
 1. eu-west-1a

--- a/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/output.txt
+++ b/cli/tests/pcluster/cli/configure/test_pcluster_configure/test_with_region_arg/output.txt
@@ -17,7 +17,8 @@ Allowed values for Operating System:
 2. centos7
 3. ubuntu1804
 4. ubuntu2004
-5. rhel8
+5. ubuntu2204
+6. rhel8
 Allowed values for VPC ID:
   #  id            name                                 number_of_subnets
 ---  ------------  ---------------------------------  -------------------

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -85,8 +85,8 @@ def test_generate_random_prefix():
 @pytest.mark.parametrize(
     "architecture, supported_oses",
     [
-        ("x86_64", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"]),
-        ("arm64", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"]),
+        ("x86_64", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "ubuntu2204", "rhel8"]),
+        ("arm64", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "ubuntu2204", "rhel8"]),
     ],
 )
 def test_get_supported_os_for_architecture(architecture, supported_oses):
@@ -99,7 +99,7 @@ def test_get_supported_os_for_architecture(architecture, supported_oses):
 @pytest.mark.parametrize(
     "scheduler, supported_oses",
     [
-        ("slurm", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "rhel8"]),
+        ("slurm", ["alinux2", "centos7", "ubuntu1804", "ubuntu2004", "ubuntu2204", "rhel8"]),
         ("awsbatch", ["alinux2"]),
     ],
 )


### PR DESCRIPTION
Add Ubuntu 22 support for pcluster create-cluster and configure by following the example for RHEL8.

Added ubuntu2204 to the SUPPORTED_OSES list.

Searched the CLI code for OS dependent clauses mentioning 'ubuntu' and added ubuntu2204 where necessary, including in unit tests.

### Tests
* Ran unit tests for pcluster configure
* Ran `pcluster create-cluster` with a vanilla ubuntu 22 AMI to start creation

### References
* https://github.com/aws/aws-parallelcluster/pull/2869

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
