### PR TITLE
[Integ-tests] Simplify the initial command of RemoteCommandExecutor with a bastion

### DIFF
--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -51,13 +51,7 @@ class RemoteCommandExecutor:
         if bastion:
             # Need to execute simple ssh command before using Connection to avoid Paramiko _check_banner error
             run_command(
-                "ssh -tt -i {key_path} -o StrictHostKeyChecking=no "
-                '-o ProxyCommand="ssh -tt -o StrictHostKeyChecking=no -W %h:%p -A {bastion}" '
-                "-A {user}@{head_node} hostname".format(
-                    key_path=cluster.ssh_key, bastion=bastion, user=username, head_node=node_ip
-                ),
-                timeout=30,
-                shell=True,
+                f"ssh -i {cluster.ssh_key} -o StrictHostKeyChecking=no {bastion} hostname", timeout=30, shell=True
             )
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True


### PR DESCRIPTION
The old complex command led to a `255` failure when running integration tests on an environment other than Jenkins. I tried to figure out why the complex command was there and couldn't get any clue.

The following integration tests, which rely on that part of the logic, have passed:
```
test-suites:
  log_rotation:
    test_log_rotation.py::test_log_rotation:
      dimensions:
        - regions: ["ap-south-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
  health_checks:
    test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
      dimensions:
        - regions: ["eu-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
  networking:
    test_security_groups.py::test_overwrite_sg:
      dimensions:
        - regions: ["eu-west-1"]
          instances: ["c5.xlarge"]
          oss: ["alinux2", "centos7"]
          schedulers: ["slurm"]
    test_cluster_networking.py::test_cluster_in_private_subnet:
      dimensions:
        - regions: ["me-south-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["alinux2"]
          schedulers: ["slurm"]
    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
      dimensions:
        # The region needs to be the same of the Jenkins server since default pre/post install scripts are hosted in an
        # S3 bucket belonging to the same region and S3 VPC Endpoints only work within the region.
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["centos7"]
          schedulers: ["slurm"]
        - regions: ["us-west-1"]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: ["rhel8"]
          schedulers: ["slurm"]
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
