### PR TITLE
[Isolated Regions][Test] Make 'test_create_wrong_pcluster_version' executable in us-iso regions + fix regression on Jinja syntax impacting EFS tests

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -93,15 +93,12 @@ test-suites:
 #          instances: {{ INSTANCES }}
 #          oss: {{ OSS }}
 #          schedulers: {{ SCHEDULERS }}
-# This test cannot be executed in US isolated regions
-# because it relies on having AMIs for different pcluster versions in the region
-# and this is not the case in these regions.
-#    test_create.py::test_create_wrong_pcluster_version:
-#      dimensions:
-#        - regions: {{ REGIONS }}
-#          instances: {{ INSTANCES }}
-#          oss: {{ OSS }}
-#          schedulers: {{ SCHEDULERS }}
+    test_create.py::test_create_wrong_pcluster_version:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
     test_create.py::test_create_imds_secured:
       dimensions:
         - regions: {{ REGIONS }}

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -55,7 +55,7 @@ def test_create_wrong_pcluster_version(
 ):
     """Test error message when AMI provided was baked by a pcluster whose version is different from current version"""
     current_version = get_installed_parallelcluster_version()
-    wrong_version = "2.8.1"
+    wrong_version = "3.5.1"
     logging.info("Asserting wrong_version is different from current_version")
     assert_that(current_version != wrong_version).is_true()
     # Retrieve an AMI without 'aws-parallelcluster-<version>' in its name.

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_compute_az/pcluster.config.yaml
@@ -38,7 +38,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {% if len(private_subnet_ids) >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}
+          - {% if private_subnet_ids|length >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}
     {% endif %}
 # This compute subnet would be in a different AZ than head node for regions defined in AVAILABILITY_ZONE_OVERRIDES
 # See conftest for details

--- a/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_multiple_efs/pcluster.config.yaml
@@ -38,7 +38,7 @@ Scheduling:
           MaxCount: 1
       Networking:
         SubnetIds:
-          - {% if len(private_subnet_ids) >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}
+          - {% if private_subnet_ids|length >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}
     {% endif %}
 # This compute subnet would be in a different AZ than head node for regions defined in AVAILABILITY_ZONE_OVERRIDES
 # See conftest for details

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_create.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_create.config.yaml
@@ -31,4 +31,4 @@ Scheduling:
           MaxCount: 4
       Networking:
         SubnetIds:
-          - {% if len(private_subnet_ids) >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}
+          - {% if private_subnet_ids|length >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_1.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_1.config.yaml
@@ -31,5 +31,5 @@ Scheduling:
           MaxCount: 4
       Networking:
         SubnetIds:
-          - {% if len(private_subnet_ids) >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[0] }} {% endif %}
+          - {% if private_subnet_ids|length >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[0] }} {% endif %}
           - {{ public_subnet_ids[1] }}

--- a/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_2.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_multi_az_create_and_update/pcluster_update_2.config.yaml
@@ -31,4 +31,4 @@ Scheduling:
           MaxCount: 4
       Networking:
         SubnetIds:
-          - {% if len(private_subnet_ids) >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}
+          - {% if private_subnet_ids|length >= 3 %} {{ private_subnet_ids[2] }} {% else %} {{ private_subnet_ids[1] }} {% endif %}


### PR DESCRIPTION
### Description of changes
1. Make 'test_create_wrong_pcluster_version' executable in us-iso regions. the test was disabled in US ISO regions because it assumed the AMI for PC 2.8.1 to be available in the region, but this is not the case for these regions because the oldest AMI is 3.5.1 there.
1. Fix regression on 'test_efs_compute_az', 'test_multiple_efs' and 'test_multi_az_create_and_update' caused by Jinja syntax error.

### Tests
Will be validated in US iso regions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
