### PR TITLE
Add integration test for MemoryBased Scheduling with Multiple Instance Types

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.mem-based-scheduling.yaml
@@ -26,7 +26,10 @@ Scheduling:
           MinCount: 1
         - Name: ondemand1-i2
           Instances:
-            - InstanceType: {{ instance }}
+            - InstanceType: c5.xlarge
+            - InstanceType: c5a.xlarge
+            - InstanceType: c5d.xlarge
+          MinCount: 1
         - Name: ondemand1-i3
           Instances:
             - InstanceType: c5.4xlarge

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.update-schedulable-memory.yaml
@@ -27,7 +27,10 @@ Scheduling:
           SchedulableMemory: 2500
         - Name: ondemand1-i2
           Instances:
-            - InstanceType: {{ instance }}
+            - InstanceType: c5.xlarge
+            - InstanceType: c5a.xlarge
+            - InstanceType: c5d.xlarge
+          MinCount: 1
         - Name: ondemand1-i3
           Instances:
             - InstanceType: c5.4xlarge

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_memory_based_scheduling/pcluster.config.yaml
@@ -23,7 +23,10 @@ Scheduling:
           MinCount: 1
         - Name: ondemand1-i2
           Instances:
-            - InstanceType: {{ instance }}
+            - InstanceType: c5.xlarge
+            - InstanceType: c5a.xlarge
+            - InstanceType: c5d.xlarge
+          MinCount: 1
         - Name: ondemand1-i3
           Instances:
             - InstanceType: c5.4xlarge


### PR DESCRIPTION
### Description of changes
* Add integration test for MemoryBased Scheduling with Multiple Instance Types
* Add SchedulableMemoryValidator also to FlexibleSlurmComputeResource

### Tests
* Successfully launched integ-test on my account
* Tested the validator for Flexible resources adding an invalid amount of Schedulable memory returned

```
    {
      "level": "ERROR",
      "type": "SchedulableMemoryValidator",
      "message": "SchedulableMemory cannot be larger than EC2 Memory for selected instance type c5.xlarge (8192 MiB)."
    },
```

### References
* [Allow Memory Based Scheduling and FIT](https://github.com/aws/aws-parallelcluster/pull/5344)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
