### PR TITLE
[Integ-tests] Fix ARN of a policy in test_update_slurm

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -146,9 +146,7 @@ def test_update_slurm(region, pcluster_config_reader, s3_bucket_factory, cluster
     job_id = slurm_commands.assert_job_submitted(result.stdout)
 
     # Update cluster with new configuration
-    additional_policy_arn = (
-        f"arn:{utils.get_arn_partition(region)}:iam::aws:policy/service-role/AWSCloudFormationReadOnlyAccess"
-    )
+    additional_policy_arn = f"arn:{utils.get_arn_partition(region)}:iam::aws:policy/AWSCloudFormationReadOnlyAccess"
     updated_config_file = pcluster_config_reader(
         config_file="pcluster.config.update.yaml",
         output_file="pcluster.config.update.successful.yaml",


### PR DESCRIPTION
This was a bug from https://github.com/aws/aws-parallelcluster/pull/5339/commits/750fc9e2fd0ced5a6d85aab2a7c71fec944d1ead

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
