### PR TITLE
Create a bucket  in the policies_uri_fixture when testing the API

### DIFF
--- a/tests/integration-tests/tests/pcluster_api/test_api.py
+++ b/tests/integration-tests/tests/pcluster_api/test_api.py
@@ -158,12 +158,13 @@ def policies_template_with_custom_actions_bucket_access_fixture(policies_templat
 
 
 @pytest.fixture(scope="class", name="policies_uri")
-def policies_uri_fixture(policies_template_with_custom_actions_bucket_access, resource_bucket, region):
-    bucket = boto3.resource("s3", region_name=region).Bucket(resource_bucket)
+def policies_uri_fixture(policies_template_with_custom_actions_bucket_access, s3_bucket_factory, region):
+    bucket_name = s3_bucket_factory()
+    bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
     path = f"parallelcluster/{get_installed_parallelcluster_version()}/templates/policies/custom-policies.yaml"
     bucket.put_object(Key=path, Body=policies_template_with_custom_actions_bucket_access)
 
-    yield (f"https://{resource_bucket}.s3.{region}.amazonaws.com{'.cn' if region.startswith('cn') else ''}/{path}")
+    yield (f"https://{bucket_name}.s3.{region}.amazonaws.com{'.cn' if region.startswith('cn') else ''}/{path}")
 
 
 @pytest.mark.usefixtures("os", "instance")


### PR DESCRIPTION
### Description of changes
Since the resource bucket could in some cases be the official resource bucket where we don't have write permissions, we create a dedicated bucket when testing the APIs because we need to publish a policy template with custom actions.

### Tests
Integration test with configuration:

```
{%- import 'common.jinja2' as common -%}
---
test-suites:
  pcluster_api:
    test_api.py::test_cluster_slurm:
      dimensions:
        - regions: ["sa-east-1"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: ["ubuntu2004"]
          schedulers: ["slurm"]
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
