### PR TITLE
[integ-tests] Add missing tests to isolated_regions.yaml

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -12,6 +12,11 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
+          benchmarks:
+            - mpi_variants: ["openmpi"]
+              num_instances: [5]
+              osu_benchmarks:
+                collective: ["osu_alltoall"]
   cfn-init:
     test_cfn_init.py::test_replace_compute_on_failure:
       dimensions:
@@ -217,14 +222,12 @@ test-suites:
 #          oss: {{ OSS }}
 #          schedulers: {{ SCHEDULERS }}
   networking:
-# This test is considered out of scope for isolated regions
-# We will evaluate to re-include it after release 3.5.1
-#    test_cluster_networking.py::test_cluster_in_private_subnet:
-#      dimensions:
-#        - regions: {{ REGIONS }}
-#          instances: {{ INSTANCES }}
-#          oss: {{ OSS }}
-#          schedulers: {{ SCHEDULERS }}
+    test_cluster_networking.py::test_cluster_in_private_subnet:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
     test_cluster_networking.py::test_existing_eip:
       dimensions:
         - regions: {{ REGIONS }}
@@ -237,12 +240,13 @@ test-suites:
     test_networking.py::test_public_private_network_topology:
       dimensions:
         - regions: {{ REGIONS }}
-    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
-      dimensions:
-        - regions: {{ REGIONS }}
-          instances: {{ INSTANCES }}
-          oss: {{ OSS }}
-          schedulers: {{ SCHEDULERS }}
+# Isolated regions do not have VPC endpoints.
+#    test_cluster_networking.py::test_cluster_in_no_internet_subnet:
+#      dimensions:
+#        - regions: {{ REGIONS }}
+#          instances: {{ INSTANCES }}
+#          oss: {{ OSS }}
+#          schedulers: {{ SCHEDULERS }}
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
         - regions: {{ REGIONS }}
@@ -540,3 +544,17 @@ test-suites:
 #        - regions: {{ REGIONS }}
 #          oss: {{ OSS }}
 #          schedulers: {{ SCHEDULERS }}
+log_rotation:
+  test_log_rotation.py::test_log_rotation:
+    dimensions:
+      - regions: ["ap-south-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["ubuntu2004"]
+        schedulers: ["slurm"]
+health_checks:
+  test_gpu_health_checks.py::test_cluster_with_gpu_health_checks:
+    dimensions:
+      - regions: ["eu-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]


### PR DESCRIPTION
There were new tests added for 3.6.0 release. This commit adds those tests. Moreover, this commit adds `benchmarks` section of ad integration. The section is required even if the benchmark is not run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
