### PR TITLE
[Isolated Regions] Support Slurm Accounting in ISO regions

### DIFF
--- a/cloudformation/database/serverless-database.yaml
+++ b/cloudformation/database/serverless-database.yaml
@@ -114,6 +114,7 @@ Parameters:
 Transform: AWS::Serverless-2016-10-31
 Conditions:
   CreateSubnets: !Or [!Equals [!Ref DatabaseClusterSubnetOne, ''], !Equals [!Ref DatabaseClusterSubnetTwo, '']]
+  InUsIsobEast1: !Equals [ !Ref AWS::Region, 'us-isob-east-1' ]
 Rules:
   BadSubnetsCidrsAssertion:
     RuleCondition: !Or
@@ -143,7 +144,9 @@ Resources:
     Condition: CreateSubnets
     Properties:
       VpcId: !Ref Vpc
-      AvailabilityZone: !Sub '${AWS::Region}a'
+      AvailabilityZone: !Sub
+        - "${AWS::Region}${AzLetter}"
+        - { AzLetter: !If [ InUsIsobEast1, 'c', 'a'] }
       CidrBlock: !Ref Subnet1CidrBlock
       MapPublicIpOnLaunch: false
       Tags:

--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -393,21 +393,18 @@ test-suites:
           instances: {{ INSTANCES }}
           oss: {{ OSS }}
           schedulers: {{ SCHEDULERS }}
-# These tests cannot be executed in US isolated regions
-# because Slurm Accounting requires Secrets Manager,
-# which is not supported in these regions.
-#    test_slurm_accounting.py::test_slurm_accounting:
-#      dimensions:
-#        - regions: {{ REGIONS }}
-#          instances: {{ INSTANCES }}
-#          oss: {{ OSS }}
-#          schedulers: {{ SCHEDULERS }}
-#    test_slurm_accounting.py::test_slurm_accounting_disabled_to_enabled_update:
-#      dimensions:
-#        - regions: {{ REGIONS }}
-#          instances: {{ INSTANCES }}
-#          oss: {{ OSS }}
-#          schedulers: {{ SCHEDULERS }}
+    test_slurm_accounting.py::test_slurm_accounting:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
+    test_slurm_accounting.py::test_slurm_accounting_disabled_to_enabled_update:
+      dimensions:
+        - regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
+          oss: {{ OSS }}
+          schedulers: {{ SCHEDULERS }}
     test_slurm.py::test_slurm_reconfigure_race_condition:
       dimensions:
         - regions: {{ REGIONS }}


### PR DESCRIPTION
### Description of changes
1. Make template serverless-database deployable in us-isob-east-1.
2. Enable test_slurm_accounting in US ISO regions.

### Tests
1. [SUCCEEDED] Deployed in us-east-1 to verify no regression
3. [PENDING] Deployed in us-isob-east-1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
