### PR TITLE
[Isolated Regions] Mark Slurm Accounting feature as supported in US ISO regions.

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -252,7 +252,7 @@ UNSUPPORTED_FEATURES_MAP = {
     Feature.FSX_LUSTRE: ["us-iso"],
     Feature.FSX_ONTAP: ["us-iso"],
     Feature.FSX_OPENZFS: ["us-iso"],
-    Feature.SLURM_DATABASE: ["us-iso"],
+    Feature.SLURM_DATABASE: [],
     Feature.CLUSTER_HEALTH_METRICS: ["us-iso"],
 }
 

--- a/cli/tests/pcluster/test_utils.py
+++ b/cli/tests/pcluster/test_utils.py
@@ -564,7 +564,7 @@ class TestAsyncUtils(unittest.TestCase):
         (Feature.FSX_OPENZFS, "us-iso-west-1", False),
         (Feature.FSX_OPENZFS, "us-isob-east-1", False),
         (Feature.FSX_OPENZFS, "us-isoWHATEVER", False),
-        (Feature.SLURM_DATABASE, "us-isoWHATEVER", False),
+        (Feature.SLURM_DATABASE, "us-isoWHATEVER", True),
         (Feature.CLUSTER_HEALTH_METRICS, "us-isoWHATEVER", False),
         (Feature.BATCH, "WHATEVER-ELSE", True),
         (Feature.DCV, "WHATEVER-ELSE", True),


### PR DESCRIPTION
### Description of changes
Mark Slurm Accounting feature as supported in US ISO regions.
Previous blockers to feature support are now removed (Secrets Manager is now available in US ISO regions)

### Tests
1. Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
