### PR TITLE
[Isolated Regions] Remove the instance configuration step for Isolated regions from head and compute node user data.

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -35,13 +35,6 @@ export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
 PROXY
 fi
 
-# Configure Amazon Linux 2 instance running in US isolated region.
-. /etc/os-release
-if [[ "${!ID}${!VERSION_ID}" == "amzn2" && "${AWS::Region}" == us-iso* ]]; then
-  configuration_script="/opt/parallelcluster/scripts/patch-iso-instance.sh"
-  [ -f ${!configuration_script} ] && bash ${!configuration_script}
-fi
-
 --==BOUNDARY==
 Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -35,13 +35,6 @@ export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
 PROXY
 fi
 
-# Configure Amazon Linux 2 instance running in US isolated region.
-. /etc/os-release
-if [[ "${!ID}${!VERSION_ID}" == "amzn2" && "${AWS::Region}" == us-iso* ]]; then
-  configuration_script="/opt/parallelcluster/scripts/patch-iso-instance.sh"
-  [ -f ${!configuration_script} ] && bash ${!configuration_script}
-fi
-
 --==BOUNDARY==
 Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0


### PR DESCRIPTION
### Description of changes
Remove the instance configuration step for Isolated regions from head and compute node user data.
In fact, we assume such configuration to be executed at AMI build-time.

### Tests
1. [PENDING] Validation in US ISO regions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
