### PR TITLE
Use aws-parallelcluster-entrypoints:install during AMI build

### DIFF
--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster.yaml
@@ -263,7 +263,7 @@ phases:
               set -v
               echo "Calling chef-client with /etc/parallelcluster/image_dna.json"
               cat /etc/parallelcluster/image_dna.json
-              cinc-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/parallelcluster/image_dna.json --override-runlist aws-parallelcluster::default
+              cinc-client --local-mode --config /etc/chef/client.rb --log_level info --force-formatter --no-color --chef-zero-port 8889 --json-attributes /etc/parallelcluster/image_dna.json --override-runlist aws-parallelcluster-entrypoints::install
 
       - name: CreateBootstrapFile
         action: CreateFile

--- a/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
+++ b/cli/src/pcluster/resources/imagebuilder/parallelcluster_validate.yaml
@@ -202,6 +202,7 @@ phases:
               set -v
               sudo sed -i "s#path: cookbooks#path: /etc/chef/cookbooks#g" /etc/chef/cookbooks/aws-parallelcluster/test/recipes/inspec.yml
               sed -Ei "s#path: .+/aws-parallelcluster#path: /etc/chef/cookbooks/aws-parallelcluster#g" /etc/chef/cookbooks/aws-parallelcluster-*/test/inspec.yml
+              sed -Ei "s#path: cookbooks/aws-parallelcluster#path: /etc/chef/cookbooks/aws-parallelcluster#g" /etc/chef/cookbooks/aws-parallelcluster-*/test/inspec.yml
               echo "InSpec profiles patched"
 
       - name: NvidiaEnabled


### PR DESCRIPTION
### Description of changes
* [Use aws-parallelcluster-entrypoints:install during AMI build](https://github.com/aws/aws-parallelcluster/commit/7bbd00256967cf330389aabfcd6c18b42c5c779f)
* [Patch new inspec.yml paths](https://github.com/aws/aws-parallelcluster/commit/1c10a1e32204c0fe3130cf93c56597c8bcac46ac)

### Tests
* AMI built on this code 

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2230

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
