### PR TITLE
add a cluster bootstrap failure and a test case

### DIFF
--- a/cli/src/pcluster/models/cluster_resources.py
+++ b/cli/src/pcluster/models/cluster_resources.py
@@ -102,7 +102,6 @@ class ClusterStack(StackInfo):
         @dataclass
         class ClusterCreationFailure:
             """Represent the object holding the data of ClusterCreationFailure."""
-
             failure_code: str
             api_failure_reason: str
             cfn_failure_reason: str
@@ -168,6 +167,11 @@ class ClusterStack(StackInfo):
             ),
             ClusterCreationFailure(
                 "HeadNodeBootstrapFailure", "Cluster creation timed out.", "WaitCondition timed out"
+            ),
+            ClusterCreationFailure(
+                "ClusterBoostrapFailure",
+                "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning.",
+                "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning"
             ),
         ]
 

--- a/cli/src/pcluster/models/cluster_resources.py
+++ b/cli/src/pcluster/models/cluster_resources.py
@@ -169,7 +169,7 @@ class ClusterStack(StackInfo):
                 "HeadNodeBootstrapFailure", "Cluster creation timed out.", "WaitCondition timed out"
             ),
             ClusterCreationFailure(
-                "ClusterBoostrapFailure",
+                "StaticNodeBoostrapFailure",
                 "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning.",
                 "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning"
             ),

--- a/cli/src/pcluster/models/cluster_resources.py
+++ b/cli/src/pcluster/models/cluster_resources.py
@@ -102,6 +102,7 @@ class ClusterStack(StackInfo):
         @dataclass
         class ClusterCreationFailure:
             """Represent the object holding the data of ClusterCreationFailure."""
+
             failure_code: str
             api_failure_reason: str
             cfn_failure_reason: str

--- a/cli/src/pcluster/models/cluster_resources.py
+++ b/cli/src/pcluster/models/cluster_resources.py
@@ -171,7 +171,7 @@ class ClusterStack(StackInfo):
             ClusterCreationFailure(
                 "StaticNodeBoostrapFailure",
                 "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning.",
-                "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning"
+                "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning",
             ),
         ]
 

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -1042,12 +1042,13 @@ class TestDescribeCluster:
                             "StackName": "fake-name",
                             "ResourceType": "AWS::CloudFormation::WaitCondition",
                             "ResourceStatus": "CREATE_FAILED",
-                            "ResourceStatusReason": "Cluster has been set to PROTECTED mode "
+                            "ResourceStatusReason": "WaitCondition received failed message: '"
+                            "Cluster has been set to PROTECTED mode "
                             "due to failures detected in static node provisioning. "
                             "Please check /var/log/chef-client.log in the head node, "
                             "or check the chef-client.log in CloudWatch logs. "
                             "Please refer to https://docs.aws.amazon.com/parallelcluster/"
-                            "latest/ug/troubleshooting-v3.html for more details.",
+                            "latest/ug/troubleshooting-v3.html for more details.'",
                         },
                     ]
                 ],

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -1043,11 +1043,11 @@ class TestDescribeCluster:
                             "ResourceType": "AWS::CloudFormation::WaitCondition",
                             "ResourceStatus": "CREATE_FAILED",
                             "ResourceStatusReason": "Cluster has been set to PROTECTED mode "
-                                                    "due to failures detected in static node provisioning. "
-                                                    "Please check /var/log/chef-client.log in the head node, "
-                                                    "or check the chef-client.log in CloudWatch logs. "
-                                                    "Please refer to https://docs.aws.amazon.com/parallelcluster/"
-                                                    "latest/ug/troubleshooting-v3.html for more details.",
+                            "due to failures detected in static node provisioning. "
+                            "Please check /var/log/chef-client.log in the head node, "
+                            "or check the chef-client.log in CloudWatch logs. "
+                            "Please refer to https://docs.aws.amazon.com/parallelcluster/"
+                            "latest/ug/troubleshooting-v3.html for more details.",
                         },
                     ]
                 ],

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -1043,17 +1043,21 @@ class TestDescribeCluster:
                             "ResourceType": "AWS::CloudFormation::WaitCondition",
                             "ResourceStatus": "CREATE_FAILED",
                             "ResourceStatusReason": "Cluster has been set to PROTECTED mode "
-                                                    "due to failures detected in static node provisioning.",
+                                                    "due to failures detected in static node provisioning. "
+                                                    "Please check /var/log/chef-client.log in the head node, "
+                                                    "or check the chef-client.log in CloudWatch logs. "
+                                                    "Please refer to https://docs.aws.amazon.com/parallelcluster/"
+                                                    "latest/ug/troubleshooting-v3.html for more details.",
                         },
                     ]
                 ],
                 [
                     {
-                        "failureCode": "ClusterBoostrapFailure",
+                        "failureCode": "StaticNodeBoostrapFailure",
                         "failureReason": "Cluster has been set to PROTECTED mode "
-                                         "due to failures detected in static node provisioning.",
+                        "due to failures detected in static node provisioning.",
                     }
-                ]
+                ],
             ),
         ],
         ids=[
@@ -1063,7 +1067,7 @@ class TestDescribeCluster:
             "cluster_creation_timeout",
             "cluster_resource_creation_failure",
             "no_stack_event",
-            "cluster_protected_mode"
+            "cluster_protected_mode",
         ],
     )
     def test_cluster_creation_failed(

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -1033,6 +1033,28 @@ class TestDescribeCluster:
                 [],
                 [{"failureCode": "ClusterCreationFailure", "failureReason": "Failed to create the cluster."}],
             ),
+            (
+                "CREATE_FAILED",
+                [
+                    [
+                        {
+                            "StackId": "fake-id",
+                            "StackName": "fake-name",
+                            "ResourceType": "AWS::CloudFormation::WaitCondition",
+                            "ResourceStatus": "CREATE_FAILED",
+                            "ResourceStatusReason": "Cluster has been set to PROTECTED mode "
+                                                    "due to failures detected in static node provisioning.",
+                        },
+                    ]
+                ],
+                [
+                    {
+                        "failureCode": "ClusterBoostrapFailure",
+                        "failureReason": "Cluster has been set to PROTECTED mode "
+                                         "due to failures detected in static node provisioning.",
+                    }
+                ]
+            ),
         ],
         ids=[
             "get_stack_events_without_next_token",
@@ -1041,6 +1063,7 @@ class TestDescribeCluster:
             "cluster_creation_timeout",
             "cluster_resource_creation_failure",
             "no_stack_event",
+            "cluster_protected_mode"
         ],
     )
     def test_cluster_creation_failed(


### PR DESCRIPTION
### Description of changes
* Add a new cluster creation failure to reflect the failure reason that "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning."
* Add a test case in the test file to check the output failure reason message

### Tests
* Run the cluster_protected_mode test case in pytest and see the expected failure 
![Image](https://github.com/aws/aws-parallelcluster/assets/48724314/ce660a30-91f7-48fb-bc09-85d1ce7d0b3a)
* Manually test the code in the local machine by running the describe-cluster command 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
