### PR TITLE
[Isolated Regions] Make test_log_rotation executable in isolated regions

### DIFF
--- a/tests/integration-tests/tests/log_rotation/test_log_rotation/test_log_rotation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/log_rotation/test_log_rotation/test_log_rotation/pcluster.config.yaml
@@ -9,7 +9,7 @@ HeadNode:
   Imds:
     Secured: {{ imds_secured }}
   Dcv:
-    Enabled: true
+    Enabled: {{ dcv_enabled }}
 Scheduling:
   Scheduler: {{ scheduler }}
   SlurmQueues:

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -796,5 +796,9 @@ def test_cluster_health_metric(metric_names, cluster_name, region):
     assert_metrics_has_data(response)
 
 
+def is_dcv_supported(region: str):
+    return "us-iso" not in region
+
+
 def is_fsx_supported(region: str):
     return "us-iso" not in region


### PR DESCRIPTION
### Description of changes
Make test_log_rotation executable in isolated regions by disabling DCV and the checks on the respective logs.
In fact, DDV is not supported in US ISO regions.

### Tests
1. [PASSED] Executed test_log_rotation in us-east-1.
1. [PLANNED POST MERGE] Will be validated in iso regions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
