### PR TITLE
[Isolated Regions][Test] Omit the cluster property DCV.Enabled in test_log_rotation when DCV is not supported.

### DIFF
--- a/tests/integration-tests/tests/log_rotation/test_log_rotation/test_log_rotation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/log_rotation/test_log_rotation/test_log_rotation/pcluster.config.yaml
@@ -8,8 +8,10 @@ HeadNode:
     KeyName: {{ key_name }}
   Imds:
     Secured: {{ imds_secured }}
+  {% if dcv_enabled %}
   Dcv:
-    Enabled: {{ dcv_enabled }}
+    Enabled: True
+  {% endif %}
 Scheduling:
   Scheduler: {{ scheduler }}
   SlurmQueues:


### PR DESCRIPTION
### Description of changes
Omit the cluster property DCV.Enabled in test_log_rotation when DCV is not supported.
This is actually a workaround. The long term goal os to fix our CLI code to accept DCV.Enabled=False when DCV is not supported. Not doing now because we prefer not to change the CLI code in this phase.

### Tests
1. Will be validated in ADC

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
