### PR TITLE
[integ-tests] Fix test_build_image intermittent failures

### DIFF
--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -289,10 +289,10 @@ def _test_get_image_log_events(image):
             assert_that(events).is_length(expect_count)
 
         if expect_first is True:
-            assert_that(events[0]["message"]).matches(first_event["message"])
+            assert_that(events[0]["message"]).contains(first_event["message"])
 
         if expect_first is False:
-            assert_that(events[0]["message"]).does_not_match(first_event["message"])
+            assert_that(events[0]["message"]).does_not_contain(first_event["message"])
 
 
 def _test_export_logs(s3_bucket_factory, image, region):


### PR DESCRIPTION
The failing point is where the code checks the output of `pcluster get_log_events`. It asserts the output same/different from the command with different input flags.

The use of Regex is both unnecessary and wrong. It is unnecessary because there are no Regex in logs. It is wrong because it mistakes some symbols (e.g. `()`) as Regex operator, cause failures like:
```
AssertionError: Expected <Launched instance (instance id: i-0fc16a5f4611601a5)> to match pattern <Launched instance (instance id: i-0fc16a5f4611601a5)>, but did not.
```

This commit fixes bug from https://github.com/aws/aws-parallelcluster/pull/3677

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
