### PR TITLE
Fix cluster creation failure when using cfn resource with Elastic Ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 - Assign Slurm dynamic nodes a priority (weight) of 1000 by default. This allows Slurm to prioritize idle static nodes over idle dynamic ones.
 
 **BUG FIXES**
+- Fix cluster creation failure when using CloudFormation custom resource with `ElastipIp` set to `True`.
 
 3.6.0
 ----

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -678,6 +678,16 @@ class HeadNodeNetworking(_BaseNetworking):
         """Compute availability zone from subnet id."""
         return AWSApi.instance().ec2.get_subnet_avail_zone(self.subnet_id)
 
+    @property
+    def headnode_elastic_ip(self):
+        """Headnode Elastic Ip."""
+        if isinstance(self.elastic_ip, bool):
+            return self.elastic_ip
+        if isinstance(self.elastic_ip, str):
+            if self.elastic_ip.lower() in ["true", "false"]:
+                return self.elastic_ip.lower() == "true"
+        return self.elastic_ip
+
 
 class PlacementGroup(Resource):
     """Represent the placement group for networking."""

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -481,7 +481,7 @@ class ClusterCdkStack:
             group_set=head_eni_group_set,
         )
 
-        elastic_ip = self.config.head_node.networking.elastic_ip
+        elastic_ip = self.config.head_node.networking.headnode_elastic_ip
         if elastic_ip:
             # Create and associate EIP to Head Node
             if elastic_ip is True:

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -115,6 +115,8 @@ class ElasticIpValidator(Validator):
 
     def _validate(self, elastic_ip: Union[str, bool]):
         if isinstance(elastic_ip, str):
+            if elastic_ip.lower() in ["true", "false"]:
+                return
             try:
                 AWSApi.instance().ec2.get_eip_allocation_id(elastic_ip)
             except AWSClientError as e:


### PR DESCRIPTION
### Description of changes
* Fix cluster creation failure when using CloudFormation custom resource with `ElastipIp` set to `True`. 
* This is due to CloudFormation converts all boolean values specified in the template into strings


### Tests
* Unit test
* Manually create a cluster with ElasticIp set to "True" string. ParallelCluster is able to create the elastic ip

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
