### PR TITLE
[Isolated Regions][Test] Fixes to test_slurm_accounting and test_cluster_in_private_subnet

### DIFF
--- a/tests/integration-tests/tests/networking/test_cluster_networking.py
+++ b/tests/integration-tests/tests/networking/test_cluster_networking.py
@@ -35,7 +35,6 @@ from tests.common.storage.constants import StorageType
 from tests.common.utils import get_default_vpc_security_group
 from tests.storage.storage_common import (
     assert_fsx_lustre_correctly_mounted,
-    get_efs_ids,
     get_fsx_ids,
     test_efs_correctly_mounted,
     verify_directory_correctly_shared,
@@ -106,8 +105,7 @@ def _test_shared_storage_in_private_subnet(
 ):
     """Test FSx can be mounted in private subnet."""
     if storage_type == StorageType.STORAGE_EFS:
-        fs_id = get_efs_ids(cluster, region)[0]
-        test_efs_correctly_mounted(remote_command_executor, mount_dir, region, fs_id)
+        test_efs_correctly_mounted(remote_command_executor, mount_dir)
     elif storage_type == StorageType.STORAGE_FSX:
         fs_id = get_fsx_ids(cluster, region)[0]
         assert_fsx_lustre_correctly_mounted(remote_command_executor, mount_dir, region, fs_id)

--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
@@ -10,6 +10,7 @@ from retrying import retry
 from time_utils import seconds
 
 from tests.cloudwatch_logging import cloudwatch_logging_boto3_utils as cw_utils
+from tests.common.utils import get_aws_domain
 
 STARTED_PATTERN = re.compile(r".*slurmdbd version [\d.]+ started")
 
@@ -44,8 +45,15 @@ def _is_accounting_enabled(remote_command_executor):
     return remote_command_executor.run_remote_command("sacct", raise_on_error=False).ok
 
 
+def _rds_ca_bundle_url(region):
+    if "us-iso" in region:
+        return f"https://s3.{region}.{get_aws_domain(region)}/rds-downloads/rds-combined-ca-bundle.pem"
+    else:
+        return f"https://truststore.pki.rds.amazonaws.com/{region}/{region}-bundle.pem"
+
+
 def _require_server_identity(remote_command_executor, test_resources_dir, region):
-    ca_url = f"https://truststore.pki.rds.amazonaws.com/{region}/{region}-bundle.pem"
+    ca_url = _rds_ca_bundle_url(region)
     remote_command_executor.run_remote_script(
         os.path.join(str(test_resources_dir), "require_server_identity.sh"),
         args=[


### PR DESCRIPTION
### Description of changes
Fixed the following tests to unblock them in US isolated regions:
1. `test_slurm_accounting`: using the dedicated RDS CA bundle US ISO regions.
2. `test_cluster_in_private_subnet`: fixed wrong parameters passed to a function called only in US ISO that was causing the execution of undesired assertions related to EFS TLS.

### Tests
Validated in US ISO regions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
