### PR TITLE
[Isolated Regions][Test] Skip SSL enforcement in 'test_slurm_accounting' when running in US isolated regions.

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting.py
@@ -65,7 +65,11 @@ def _require_server_identity(remote_command_executor, test_resources_dir, region
 
 
 def _test_require_server_identity(remote_command_executor, test_resources_dir, region):
-    _require_server_identity(remote_command_executor, test_resources_dir, region)
+    # TODO We must address the extra challenges of configuring SSL in isolated regions.
+    # For the time being we skip this check to unblock the validation of the feature without SSL.
+    # This is reasonable in the short term because the SSL configuration is actually out of scope for ParallelCluster.
+    if "us-iso" not in region:
+        _require_server_identity(remote_command_executor, test_resources_dir, region)
     retry(stop_max_attempt_number=3, wait_fixed=seconds(10))(_is_accounting_enabled)(
         remote_command_executor,
     )


### PR DESCRIPTION
### Description of changes
Skip SSL enforcement in 'test_slurm_accounting' when running in US isolated regions.
We must address the extra challenges of configuring SSL in isolated regions because unblocking the test on this enforcement. For the time being we skip this check to unblock the validation of the feature without SSL.
This is reasonable in the short term because the SSL configuration is actually out of scope for ParallelCluster.

We already tracked a backlog item to re-enable this enforcement in the near future, but for the time being is more valuable to unblock the rest of the feature validations.

### Tests
1. Test succeeded in isolated regions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
