### PR TITLE
[Isolated Regions][Test] Replace custom SSM document used to add AD users with the AWS-managed document AWS-RunShellScript.

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -30,7 +30,13 @@ from paramiko import RSAKey
 from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
 from time_utils import seconds
-from utils import generate_stack_name, is_fsx_supported, random_alphanumeric, render_jinja_template
+from utils import (
+    generate_stack_name,
+    is_directory_supported,
+    is_fsx_supported,
+    random_alphanumeric,
+    render_jinja_template,
+)
 
 from tests.ad_integration.cluster_user import ClusterUser
 from tests.common.osu_common import compile_osu
@@ -692,6 +698,9 @@ def test_ad_integration(
 
     Optionally, it executes performance tests using OSU benchmarks.
     """
+    if not is_directory_supported(region, directory_type):
+        pytest.skip(f"Skipping the test because directory type {directory_type} is not supported in region {region}")
+
     head_node_instance_type = "c5n.18xlarge" if request.config.getoption("benchmarks") else "c5.xlarge"
     compute_instance_type_info = {"name": "c5.xlarge", "num_cores": 4}
     fsx_supported = is_fsx_supported(region)

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -253,15 +253,14 @@ def _check_ssm_success(ssm_client, command_id, instance_id):
 def _populate_directory_with_users(directory_stack, num_users_to_create, region):
     logging.info("Creating %s users in directory service", str(num_users_to_create))
     ssm_client = boto3.client("ssm", region_name=region)
-    document_name = directory_stack.cfn_resources["UserAddingDocument"]
     admin_node_instance_id = directory_stack.cfn_resources["AdDomainAdminNode"]
     directory_id = directory_stack.cfn_resources["Directory"]
     command_id = ssm_client.send_command(
-        DocumentName=document_name,
+        DocumentName="AWS-RunShellScript",
         InstanceIds=[directory_stack.cfn_resources["AdDomainAdminNode"]],
         MaxErrors="0",
         TimeoutSeconds=num_users_to_create * 4 + 300,
-        Parameters={"DirectoryId": [directory_id], "NumUsersToCreate": [str(num_users_to_create)]},
+        Parameters={"commands": [f"bash /usr/local/bin/add_a_number_of_users.sh {directory_id} {num_users_to_create}"]},
     )["Command"]["CommandId"]
     _check_ssm_success(ssm_client, command_id, admin_node_instance_id)
     logging.info("Creation of %s users in directory service completed", str(num_users_to_create))

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration/ad_stack.yaml
@@ -249,27 +249,6 @@ Resources:
     DependsOn:
       - Directory
       - JoinProfile
-  UserAddingDocument:
-    Type: AWS::SSM::Document
-    Properties:
-      Content:
-        schemaVersion: "2.2"
-        description: Add user to AD domain
-        parameters:
-          DirectoryId:
-            type: String
-            description: ID of the direc
-          NumUsersToCreate:
-            type: String
-            description: Number of users to be created
-        mainSteps:
-          - action: aws:runShellScript
-            name: addAdUser
-            inputs:
-              runCommand:
-                - "bash /usr/local/bin/add_a_number_of_users.sh {% raw %}{{ DirectoryId }} {{ NumUsersToCreate }}{% endraw %} "
-      DocumentType: Command
-      TargetType: /AWS::EC2::Instance
 Outputs:
   VpcId:
     Value:

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -802,3 +802,7 @@ def is_dcv_supported(region: str):
 
 def is_fsx_supported(region: str):
     return "us-iso" not in region
+
+
+def is_directory_supported(region: str, directory_type: str):
+    return False if "us-iso" in region and directory_type == "SimpleAD" else True


### PR DESCRIPTION
### Description of changes
Replace custom SSM document used to add AD users with the AWS-managed document AWS-RunShellScript.
this change has two advantages:
1. it avoids the use of SSM:Document resource that does not support some properties such as TargetType in us-iso-east-1.
2. it simplifies the AD infrastructure deployed by the test, regardless iso regions.
3. it makes the Ad infra deployed by the test one step closer to the AD infra deployed by our public 1-click template, that is our next goal for this test.
Furthermore: skipping test case on SimpleAD in regions where it is not supported, i.e. US iso regions.

### Tests
1. [SUCCEEDED] Validation in Commercial.
2. [PENDING] Validation in us-iso-east-1.
3. [PENDING] Validation in us-isob-east-1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
