### PR TITLE
Do not check RAID File System at boot

### DIFF
--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -152,7 +152,7 @@ def test_raid_correctly_mounted(remote_command_executor, mount_dir, volume_size)
 
     result = remote_command_executor.run_remote_command("cat /etc/fstab")
     assert_that(result.stdout).matches(
-        r"/dev/md0 {mount_dir} ext4 defaults,nofail,_netdev 0 2".format(mount_dir=mount_dir)
+        r"/dev/md0 {mount_dir} ext4 defaults,nofail,_netdev 0 0".format(mount_dir=mount_dir)
     )
 
 


### PR DESCRIPTION
We recently refactored `manage_raid` cookbook resource to use the common `volume` resource and discovered that in past implementation we were setting `2` as File System Check Order.

0 means that fsck will not check the filesystem.
The root filesystem should be set to 1 and any others you want to be checked assigned after that.

We're changing the test logic to ensure the value is 0 rather than 2 because we do not want to check mounted file system at boot. This can cause cluster timeout issues if the file system is too big (e.g. TiB) and this is aligned to what we are doing with root volume, shared EBS, EFS and FSx.

### References

* https://www.redhat.com/sysadmin/etc-fstab

