### PR TITLE
Fix cluster creation failure when using Custom Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Remove hardcoding of root volume device name (`/dev/sda1` and `/dev/xvda`) and retrieve it from the AMI(s) used during `create-cluster`.
+- Fix cluster creation failure when using CloudFormation custom resource with `ElastipIp` set to `True`.
 
 3.6.0
 ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Remove hardcoding of root volume device name (`/dev/sda1` and `/dev/xvda`) and retrieve it from the AMI(s) used during `create-cluster`.
-- Fix cluster creation failure when using CloudFormation custom resource with `ElastipIp` set to `True`.
+- Fix cluster creation failure when using CloudFormation custom resource with `ElasticIp` set to `True`.
 
 3.6.0
 ----

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -656,6 +656,16 @@ class HeadNodeNetworking(_BaseNetworking):
         """Compute availability zone from subnet id."""
         return AWSApi.instance().ec2.get_subnet_avail_zone(self.subnet_id)
 
+    @property
+    def headnode_elastic_ip(self):
+        """Headnode Elastic Ip."""
+        if isinstance(self.elastic_ip, bool):
+            return self.elastic_ip
+        if isinstance(self.elastic_ip, str):
+            if self.elastic_ip.lower() in ["true", "false"]:
+                return self.elastic_ip.lower() == "true"
+        return self.elastic_ip
+
 
 class PlacementGroup(Resource):
     """Represent the placement group for networking."""

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -480,7 +480,7 @@ class ClusterCdkStack:
             group_set=head_eni_group_set,
         )
 
-        elastic_ip = self.config.head_node.networking.elastic_ip
+        elastic_ip = self.config.head_node.networking.headnode_elastic_ip
         if elastic_ip:
             # Create and associate EIP to Head Node
             if elastic_ip is True:

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -115,6 +115,8 @@ class ElasticIpValidator(Validator):
 
     def _validate(self, elastic_ip: Union[str, bool]):
         if isinstance(elastic_ip, str):
+            if elastic_ip.lower() in ["true", "false"]:
+                return
             try:
                 AWSApi.instance().ec2.get_eip_allocation_id(elastic_ip)
             except AWSClientError as e:


### PR DESCRIPTION
### Description of changes
* Backport of [fix](https://github.com/aws/aws-parallelcluster/pull/5368) to 3.6 release branch
> Fix cluster creation failure when using CloudFormation custom resource with `ElastipIp` set to `True` due to CloudFormation converts all boolean values specified in the template into strings


### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Source [develop PR](https://github.com/aws/aws-parallelcluster/pull/5368)
 
### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
