### PR TITLE
Fix validation of custom nodes, nodesets and partitions in CustomSlurmSettings

### DIFF
--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -89,6 +89,10 @@ class CustomSlurmSettingsValidator(Validator):
         denied_settings = set()
 
         for custom_settings_dict in custom_settings:
+            if settings_level == CustomSlurmSettingLevel.SLURM_CONF and len(custom_settings_dict) > 1:
+                # This can happen only for custom nodes, nodesets and partitions: we do not validate them against the
+                # deny-list.
+                continue
             for custom_setting in list(custom_settings_dict.keys()):
                 if custom_setting.lower() in deny_list:
                     denied_settings.add(custom_setting)

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -218,6 +218,14 @@ def test_cluster_name_validator_slurm_accounting(cluster_name, scheduling, shoul
             "CommunicationParameters,SlurmctldParameters",
         ),
         (
+            "When defining custom partitions or nodelists with parameters that exist also at global level and are"
+            "deny-listed there (e.g. SuspendTime), the validation should not fail",
+            [{"PartitionName": "external", "Nodes": "external-nodes-[1-10]", "State": "UP", "SuspendTime": "INFINITE"}],
+            SLURM_SETTINGS_DENY_LIST["SlurmConf"]["Global"],  # keep the deny-list lowercase
+            CustomSlurmSettingLevel.SLURM_CONF,
+            "",
+        ),
+        (
             "No error when custom settings are not in the deny_list",
             [{"Allowed1": "Value1", "Allowed2": "Value2"}],
             ["denied1", "denied2"],  # keep the deny-list lowercase


### PR DESCRIPTION
### Description of changes
* Do not validate custom nodes, nodesets and partitions in CustomSlurmSettings against the deny-list of Slurm parameters at global cluster level. Custom nodes, nodesets and partitions are in control of the user and we should not validate their definition unless strictly necessary (as for the node names).
* This fixes a minor issue where SuspendTime defined in a custom partition via CustomSlurmSettings would trigger the corresponding validator.

### Tests
* Added one scenario in the unit tests to cover the previously faulty logic.

### References
* https://github.com/aws/aws-parallelcluster/pull/5389

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
