### PR TITLE
Add queue-level JobExclusiveAllocation cluster configuration parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 - Allow configuration of static and dynamic node priorities in Slurm compute resources via the ParallelCluster configuration YAML file.
 - Add support for Ubuntu 22.
 - Allow memory-based scheduling when multiple instance types are specified for a Slurm Compute Resource.
+- Add a queue-level parameter (`JobExclusiveAllocation`) to ensure nodes in the partition are exclusively allocated to a single job at any given time.
 
 **CHANGES**
 - Assign Slurm dynamic nodes a priority (weight) of 1000 by default. This allows Slurm to prioritize idle static nodes over idle dynamic ones.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2355,12 +2355,14 @@ class SlurmQueue(_CommonQueue):
         allocation_strategy: str = None,
         custom_slurm_settings: Dict = None,
         health_checks: HealthChecks = None,
+        job_exclusive_allocation: bool = None,
         tags: List[Tag] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.health_checks = health_checks or HealthChecks(implied=True)
         self.custom_slurm_settings = Resource.init_param(custom_slurm_settings, default={})
+        self.job_exclusive_allocation = Resource.init_param(job_exclusive_allocation, default=False)
         self.tags = tags
         if any(
             isinstance(compute_resource, SlurmFlexibleComputeResource) for compute_resource in self.compute_resources

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1509,6 +1509,7 @@ class SlurmQueueSchema(_CommonQueueSchema):
     tags = fields.Nested(
         QueueTagSchema, many=True, metadata={"update_policy": UpdatePolicy.QUEUE_UPDATE_STRATEGY, "update_key": "Key"}
     )
+    job_exclusive_allocation = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/validators/slurm_settings_validator.py
+++ b/cli/src/pcluster/validators/slurm_settings_validator.py
@@ -48,7 +48,7 @@ SLURM_SETTINGS_DENY_LIST = {
         ],
     },
     "Queue": {
-        "Global": ["nodes", "partitionname", "resumetimeout", "state", "suspendtime"],
+        "Global": ["nodes", "partitionname", "resumetimeout", "state", "suspendtime", "oversubscribe"],
     },
     "ComputeResource": {
         "Global": ["cpus", "features", "gres", "nodeaddr", "nodehostname", "nodename", "state", "weight"],

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -511,6 +511,42 @@ class TestBaseClusterConfig:
         login_nodes = LoginNodes(pools=[login_node_pool])
         assert_that(login_nodes.pools[0].count).is_equal_to(1)
 
+    @pytest.mark.parametrize(
+        "queue, expected_value",
+        [
+            # JobExclusiveAllocation should be disabled by default
+            (
+                dict(
+                    name="queue",
+                    networking=SlurmQueueNetworking(subnet_ids=[], placement_group=PlacementGroup(enabled=False)),
+                    compute_resources=mock_compute_resources,
+                ),
+                False,
+            ),
+            (
+                dict(
+                    name="queue",
+                    networking=SlurmQueueNetworking(subnet_ids=[], placement_group=PlacementGroup(enabled=False)),
+                    job_exclusive_allocation=True,
+                    compute_resources=mock_compute_resources,
+                ),
+                True,
+            ),
+            (
+                dict(
+                    name="queue",
+                    networking=SlurmQueueNetworking(subnet_ids=[], placement_group=PlacementGroup(enabled=False)),
+                    job_exclusive_allocation=False,
+                    compute_resources=mock_compute_resources,
+                ),
+                False,
+            ),
+        ],
+    )
+    def test_job_exclusive_allocation_defaults(self, queue, expected_value):
+        queue = SlurmQueue(**queue)
+        assert_that(queue.job_exclusive_allocation).is_equal_to(expected_value)
+
 
 class TestSharedEbs:
     @pytest.mark.parametrize(

--- a/cli/tests/pcluster/schemas/test_cluster_schema.py
+++ b/cli/tests/pcluster/schemas/test_cluster_schema.py
@@ -984,3 +984,113 @@ def test_queue_tag_schema(mocker, config_dict, failure_message):
     else:
         conf = QueueTagSchema().load(config_dict)
         QueueTagSchema().dump(conf)
+
+
+@pytest.mark.parametrize(
+    "config_dict, failure_message, expected_job_exc_inst_alloc",
+    [
+        (
+            {
+                "Name": "Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [{"Name": "compute_resource", "InstanceType": "t2.micro"}],
+                "JobExclusiveAllocation": True,
+            },
+            None,
+            True,
+        ),
+        (
+            {
+                "Name": "Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [{"Name": "compute_resource", "InstanceType": "t2.micro"}],
+                "JobExclusiveAllocation": False,
+            },
+            None,
+            False,
+        ),
+        (
+            {
+                "Name": "Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [{"Name": "compute_resource", "InstanceType": "t2.micro"}],
+                "JobExclusiveAllocation": "WRONG",
+            },
+            "Not a valid boolean",
+            False,
+        ),
+        (
+            {
+                "Name": "Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [{"Name": "compute_resource", "InstanceType": "t2.micro"}],
+                "JobExclusiveAllocation": "",
+            },
+            "Not a valid boolean",
+            False,
+        ),
+        (
+            {
+                "Name": "Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [{"Name": "compute_resource", "InstanceType": "t2.micro"}],
+                "JobExclusiveAllocation": None,
+            },
+            "Field may not be null.",
+            False,
+        ),
+        (
+            {
+                "Name": "Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [{"Name": "compute_resource", "InstanceType": "t2.micro"}],
+                "JobExclusiveAllocation": 0,
+            },
+            None,
+            False,
+        ),
+        (
+            {
+                "Name": "Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [{"Name": "compute_resource", "InstanceType": "t2.micro"}],
+                "JobExclusiveAllocation": 1,
+            },
+            None,
+            True,
+        ),
+        (
+            {
+                "Name": "Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [{"Name": "compute_resource", "InstanceType": "t2.micro"}],
+                "JobExclusiveAllocation": "true",
+            },
+            None,
+            True,
+        ),
+        (
+            {
+                "Name": "Queue",
+                "Networking": {"SubnetIds": ["subnet-12345678"]},
+                "ComputeResources": [{"Name": "compute_resource", "InstanceType": "t2.micro"}],
+                "JobExclusiveAllocation": "false",
+            },
+            None,
+            False,
+        ),
+    ],
+)
+def test_job_exclusive_allocation(
+    mocker,
+    config_dict,
+    failure_message,
+    expected_job_exc_inst_alloc,
+):
+    mock_aws_api(mocker)
+    if failure_message:
+        with pytest.raises(ValidationError, match=failure_message):
+            SlurmQueueSchema().load(config_dict)
+    else:
+        queue = SlurmQueueSchema().load(config_dict)
+        assert_that(queue.job_exclusive_allocation).is_equal_to(expected_job_exc_inst_alloc)

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -188,6 +188,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-0
     Networking:
       AdditionalSecurityGroups: null
@@ -265,6 +266,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-1
     Networking:
       AdditionalSecurityGroups: null
@@ -342,6 +344,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-2
     Networking:
       AdditionalSecurityGroups: null
@@ -419,6 +422,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-3
     Networking:
       AdditionalSecurityGroups: null
@@ -496,6 +500,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-4
     Networking:
       AdditionalSecurityGroups: null
@@ -573,6 +578,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-5
     Networking:
       AdditionalSecurityGroups: null
@@ -650,6 +656,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-6
     Networking:
       AdditionalSecurityGroups: null
@@ -727,6 +734,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-7
     Networking:
       AdditionalSecurityGroups: null
@@ -804,6 +812,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-8
     Networking:
       AdditionalSecurityGroups: null
@@ -881,6 +890,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-9
     Networking:
       AdditionalSecurityGroups: null
@@ -958,6 +968,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-10
     Networking:
       AdditionalSecurityGroups: null
@@ -1035,6 +1046,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-11
     Networking:
       AdditionalSecurityGroups: null
@@ -1112,6 +1124,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-12
     Networking:
       AdditionalSecurityGroups: null
@@ -1189,6 +1202,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-13
     Networking:
       AdditionalSecurityGroups: null
@@ -1266,6 +1280,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-14
     Networking:
       AdditionalSecurityGroups: null
@@ -1343,6 +1358,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-15
     Networking:
       AdditionalSecurityGroups: null
@@ -1420,6 +1436,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-16
     Networking:
       AdditionalSecurityGroups: null
@@ -1497,6 +1514,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-17
     Networking:
       AdditionalSecurityGroups: null
@@ -1574,6 +1592,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-18
     Networking:
       AdditionalSecurityGroups: null
@@ -1651,6 +1670,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-19
     Networking:
       AdditionalSecurityGroups: null
@@ -1728,6 +1748,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-20
     Networking:
       AdditionalSecurityGroups: null
@@ -1805,6 +1826,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-21
     Networking:
       AdditionalSecurityGroups: null
@@ -1882,6 +1904,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-22
     Networking:
       AdditionalSecurityGroups: null
@@ -1959,6 +1982,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-23
     Networking:
       AdditionalSecurityGroups: null
@@ -2036,6 +2060,7 @@ Scheduling:
         KeyName: null
     Image:
       CustomAmi: ami-12345678
+    JobExclusiveAllocation: false
     Name: queue-ondemand-24
     Networking:
       AdditionalSecurityGroups: null
@@ -2102,6 +2127,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-0
     Networking:
       AdditionalSecurityGroups: null
@@ -2169,6 +2195,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-1
     Networking:
       AdditionalSecurityGroups: null
@@ -2236,6 +2263,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-2
     Networking:
       AdditionalSecurityGroups: null
@@ -2303,6 +2331,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-3
     Networking:
       AdditionalSecurityGroups: null
@@ -2370,6 +2399,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-4
     Networking:
       AdditionalSecurityGroups: null
@@ -2437,6 +2467,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-5
     Networking:
       AdditionalSecurityGroups: null
@@ -2504,6 +2535,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-6
     Networking:
       AdditionalSecurityGroups: null
@@ -2571,6 +2603,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-7
     Networking:
       AdditionalSecurityGroups: null
@@ -2638,6 +2671,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-8
     Networking:
       AdditionalSecurityGroups: null
@@ -2705,6 +2739,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-9
     Networking:
       AdditionalSecurityGroups: null
@@ -2772,6 +2807,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-10
     Networking:
       AdditionalSecurityGroups: null
@@ -2839,6 +2875,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-11
     Networking:
       AdditionalSecurityGroups: null
@@ -2906,6 +2943,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-12
     Networking:
       AdditionalSecurityGroups: null
@@ -2973,6 +3011,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-13
     Networking:
       AdditionalSecurityGroups: null
@@ -3040,6 +3079,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-14
     Networking:
       AdditionalSecurityGroups: null
@@ -3107,6 +3147,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-15
     Networking:
       AdditionalSecurityGroups: null
@@ -3174,6 +3215,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-16
     Networking:
       AdditionalSecurityGroups: null
@@ -3241,6 +3283,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-17
     Networking:
       AdditionalSecurityGroups: null
@@ -3308,6 +3351,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-18
     Networking:
       AdditionalSecurityGroups: null
@@ -3375,6 +3419,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-19
     Networking:
       AdditionalSecurityGroups: null
@@ -3442,6 +3487,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-20
     Networking:
       AdditionalSecurityGroups: null
@@ -3509,6 +3555,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-21
     Networking:
       AdditionalSecurityGroups: null
@@ -3576,6 +3623,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-22
     Networking:
       AdditionalSecurityGroups: null
@@ -3643,6 +3691,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-23
     Networking:
       AdditionalSecurityGroups: null
@@ -3710,6 +3759,7 @@ Scheduling:
       S3Access: null
     Image:
       CustomAmi: ami-23456789
+    JobExclusiveAllocation: false
     Name: queue-spot-24
     Networking:
       AdditionalSecurityGroups: null


### PR DESCRIPTION
### Description of changes
* This parameter will be used to optionally configure Slurm Partitions to run jobs on exclusively allocated nodes (OverSubscribe=NO)

```
Scheduling:
  Scheduler: ...
  SlurmQueues:
  - Name: ...
    JobExclusiveAllocation: true | false (default: false)
    ...
```

### Tests
* Unit tests to confirm the parameter is parsed and included in the cluster config model (including the default).
* Manually tested against https://github.com/aws/aws-parallelcluster-cookbook/pull/2294


```
» pcluster create-cluster -c jls-config.yaml --debug -n Cluster-JLS
{
  "configurationValidationErrors": [
    {
      "level": "ERROR",
      "type": "CustomSlurmSettingsValidator",
      "message": "Using the following custom Slurm settings at Queue level is not allowed: OverSubscribe"
    }
  ],
  "message": "Invalid cluster configuration."
}
```

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2294

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
