### PR TITLE
Modify the failure code in the integration test

### DIFF
--- a/cli/src/pcluster/models/cluster_resources.py
+++ b/cli/src/pcluster/models/cluster_resources.py
@@ -170,7 +170,7 @@ class ClusterStack(StackInfo):
                 "HeadNodeBootstrapFailure", "Cluster creation timed out.", "WaitCondition timed out"
             ),
             ClusterCreationFailure(
-                "StaticNodeBoostrapFailure",
+                "StaticNodeBootstrapFailure",
                 "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning.",
                 "Cluster has been set to PROTECTED mode due to failures detected in static node provisioning",
             ),

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -1054,7 +1054,7 @@ class TestDescribeCluster:
                 ],
                 [
                     {
-                        "failureCode": "StaticNodeBoostrapFailure",
+                        "failureCode": "StaticNodeBootstrapFailure",
                         "failureReason": "Cluster has been set to PROTECTED mode "
                         "due to failures detected in static node provisioning.",
                     }

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1781,7 +1781,7 @@ def _test_compute_fleet_status(command_executor, expected_status):
 
 
 @retry(wait_fixed=seconds(10), stop_max_delay=minutes(5))
-def _test_cluster_creation_failure(cluster, failure_code="StaticNodeBoostrapFailure"):
+def _test_cluster_creation_failure(cluster, failure_code="StaticNodeBootstrapFailure"):
     """Retry describe-cluster until we see {failure_code}."""
     response = cluster.describe_cluster()
     assert_that(response["failures"][0]["failureCode"]).is_equal_to(failure_code)

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1781,7 +1781,7 @@ def _test_compute_fleet_status(command_executor, expected_status):
 
 
 @retry(wait_fixed=seconds(10), stop_max_delay=minutes(5))
-def _test_cluster_creation_failure(cluster, failure_code="HeadNodeBootstrapFailure"):
+def _test_cluster_creation_failure(cluster, failure_code="StaticNodeBoostrapFailure"):
     """Retry describe-cluster until we see {failure_code}."""
     response = cluster.describe_cluster()
     assert_that(response["failures"][0]["failureCode"]).is_equal_to(failure_code)


### PR DESCRIPTION
### Description of changes
* An issue arose with the integration test, test_slurm_protected_mode_on_cluster_create, due to the introduction of a new error code: StaticNodeBootstrapFailure. To address this, the expected error code within the test function has been updated to correspond with the new error code. This adjustment ensures the test accurately reflects the current functionality.

### Tests
* Change the error code in the integration test

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
