### PR TITLE
[3.6] Extend test for fast failover to validate multiple instance type behavior

### DIFF
--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -191,3 +191,23 @@ class RemoteCommandExecutor:
         :returns: A `.Result` object.
         """
         return self.__connection.get(*args, **kwargs)
+
+    def clear_log_file(self, path: str):
+        """Clear a log file in a specific path."""
+
+        self.run_remote_command(f"sudo truncate -s 0 {path}")
+
+    def clear_clustermgtd_log(self):
+        """Clear clustermgtd log file."""
+
+        self.clear_log_file("/var/log/parallelcluster/clustermgtd")
+
+    def clear_slurm_resume_log(self):
+        """Clear slurm_resume log file."""
+
+        self.clear_log_file("/var/log/parallelcluster/slurm_resume.log")
+
+    def clear_slurmctld_log(self):
+        """Clear slurmctld log file."""
+
+        self.clear_log_file("/var/log/slurmctld.log")

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -280,14 +280,14 @@ class SlurmCommands(SchedulerCommands):
 
         return self._submit_batch_job(
             job_submit_command,
-            nodes,
-            slots,
-            host,
-            after_ok,
-            partition,
-            constraint,
-            prefer,
-            other_options,
+            nodes=nodes,
+            slots=slots,
+            host=host,
+            after_ok=after_ok,
+            partition=partition,
+            constraint=constraint,
+            prefer=prefer,
+            other_options=other_options,
             raise_on_error=raise_on_error,
         )
 
@@ -316,14 +316,14 @@ class SlurmCommands(SchedulerCommands):
 
         return self._submit_batch_job(
             job_submit_command,
-            nodes,
-            slots,
-            host,
-            after_ok,
-            partition,
-            constraint,
-            other_options,
-            additional_files,
+            nodes=nodes,
+            slots=slots,
+            host=host,
+            after_ok=after_ok,
+            partition=partition,
+            constraint=constraint,
+            other_options=other_options,
+            additional_files=additional_files,
             raise_on_error=raise_on_error,
         )
 

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -271,6 +271,7 @@ class SlurmCommands(SchedulerCommands):
         after_ok=None,
         partition=None,
         constraint=None,
+        prefer=None,
         other_options=None,
         raise_on_error=True,
     ):
@@ -285,6 +286,7 @@ class SlurmCommands(SchedulerCommands):
             after_ok,
             partition,
             constraint,
+            prefer,
             other_options,
             raise_on_error=raise_on_error,
         )
@@ -334,6 +336,7 @@ class SlurmCommands(SchedulerCommands):
         after_ok=None,
         partition=None,
         constraint=None,
+        prefer=None,
         other_options=None,
         additional_files=None,
         raise_on_error=True,
@@ -351,6 +354,8 @@ class SlurmCommands(SchedulerCommands):
             submission_command += " -p {0}".format(partition)
         if constraint:
             submission_command += " -C '{0}'".format(constraint)
+        if prefer:
+            submission_command += " --prefer='{0}'".format(prefer)
         if other_options:
             submission_command += " {0}".format(other_options)
         submission_command += " {0}".format(job_submit_command)

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -601,7 +601,7 @@ def test_scontrol_reboot(
     slurm_commands = scheduler_commands_factory(remote_command_executor)
 
     # Clear clustermgtd logs before starting the tests
-    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
+    remote_command_executor.clear_clustermgtd_log()
 
     # Run first job to wake up dynamic nodes from power_down state
     slurm_commands.submit_command(
@@ -647,7 +647,7 @@ def test_scontrol_reboot(
     )
 
     # Clear clustermgtd logs produced in previous tests
-    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
+    remote_command_executor.clear_clustermgtd_log()
 
     # Check that node in REBOOT_ISSUED state can be powered down
     _test_scontrol_reboot_powerdown_reboot_issued_node(
@@ -723,8 +723,8 @@ def test_scontrol_reboot_ec2_health_checks(
     remote_command_executor.run_remote_command(f'ssh {str(compute_nodes[0])} "./{script}"')
 
     # Clear clustermgtd and slurmctld logs before starting the tests
-    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/slurmctld.log")
-    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
+    remote_command_executor.clear_slurmctld_log
+    remote_command_executor.clear_clustermgtd_log()
 
     # 2 iterations to cover the two scenarios described in the test description
     for scenario in range(1, 3):
@@ -758,8 +758,8 @@ def test_scontrol_reboot_ec2_health_checks(
         assert_compute_node_states(slurm_commands, compute_nodes, "idle")
 
         # Reset the slurmctld and clustermgtd logs
-        remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/slurmctld.log")
-        remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
+        remote_command_executor.clear_slurmctld_log()
+        remote_command_executor.clear_clustermgtd_log()
 
 
 @pytest.mark.usefixtures("region", "os", "instance", "scheduler")
@@ -1942,8 +1942,8 @@ def _test_disable_fast_capacity_failover(
     _set_insufficient_capacity_timeout(remote_command_executor, 0, clustermgtd_conf_path)
 
     # clear slurm_resume and clustermgtd logs in order to start from a clean state
-    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/slurm_resume.log")
-    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
+    remote_command_executor.clear_slurm_resume_log()
+    remote_command_executor.clear_clustermgtd_log()
 
     # submit a job to trigger insufficient capacity
     job_id = scheduler_commands.submit_command_and_assert_job_accepted(
@@ -2008,8 +2008,8 @@ def _test_enable_fast_capacity_failover(
     _set_insufficient_capacity_timeout(remote_command_executor, 180, clustermgtd_conf_path)
 
     # clear slurm_resume and clustermgtd logs in order to start from a clean state
-    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/slurm_resume.log")
-    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
+    remote_command_executor.clear_slurm_resume_log()
+    remote_command_executor.clear_clustermgtd_log()
 
     # trigger insufficient capacity: we are using `prefer` to allow requeuing the job on a different CR
     job_id = scheduler_commands.submit_command_and_assert_job_accepted(

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -345,34 +345,68 @@ def test_fast_capacity_failover(
     remote_command_executor = RemoteCommandExecutor(cluster)
     clustermgtd_conf_path = _retrieve_clustermgtd_conf_path(remote_command_executor)
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
-    # after the cluster is launched, apply the override patch to launch ice nodes
+
+    # after the cluster is launched, apply the override patch to launch ice for nodes in
+    # "ice-compute-resource" and "ice-cr-multiple" compute resources
     remote_command_executor.run_remote_script(str(test_datadir / "overrides.sh"), run_as_root=True)
+
+    # All nodes
     nodes_in_scheduler = scheduler_commands.get_compute_nodes("queue1", all_nodes=True)
     static_nodes, dynamic_nodes = get_partition_nodes(nodes_in_scheduler)
-    ice_dynamic_nodes = [node for node in dynamic_nodes if "ice-compute-resource" in node]
-    static_nodes_in_ice_compute_resource = [node for node in static_nodes if "ice-compute-resource" in node]
-    # test enable fast instance capacity failover
+
+    # Nodes in Single Instance Type CR
+    ice_single_dynamic_nodes = [node for node in dynamic_nodes if "ice-compute-resource" in node]
+    ice_single_static_nodes = [node for node in static_nodes if "ice-compute-resource" in node]
+
+    # Nodes in Multiple Instance Type CR
+    ice_multi_dynamic_nodes = [node for node in dynamic_nodes if "ice-cr-multiple" in node]
+    ice_multi_static_nodes = [node for node in static_nodes if "ice-cr-multiple" in node]
+
+    # Checks Fast Failover in case of Single Instance Type - using RunInstances API
     _test_enable_fast_capacity_failover(
         scheduler_commands,
         remote_command_executor,
         clustermgtd_conf_path,
-        static_nodes_in_ice_compute_resource,
-        ice_dynamic_nodes,
+        ice_single_static_nodes,
+        ice_single_dynamic_nodes,
+        target_compute_resource="ice-compute-resource",
     )
+
+    # Check observability logic
     structured_log_event_utils.assert_that_event_exists(
         cluster, r".+\.slurm_resume_events", "node-launch-failure-count"
     )
     test_cluster_health_metric(["InsufficientCapacityErrors"], cluster.cfn_name, region)
-    # remove logs from slurm_resume log and clustermgtd log in order to check logs after disable fast capacity fail-over
-    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/slurm_resume.log")
-    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
-    # test disable ice logic
+
+    # test behavior when Fast Failover is disabled
     _test_disable_fast_capacity_failover(
         scheduler_commands,
         remote_command_executor,
         clustermgtd_conf_path,
-        static_nodes_in_ice_compute_resource,
-        ice_dynamic_nodes,
+        ice_single_static_nodes,
+        ice_single_dynamic_nodes,
+        target_compute_resource="ice-compute-resource",
+    )
+
+    # Checks Fast Failover in case of Multiple Instance Types - using CreateFleet API
+    # test enable fast instance capacity failover for "ice-cr-multiple" cr
+    _test_enable_fast_capacity_failover(
+        scheduler_commands,
+        remote_command_executor,
+        clustermgtd_conf_path,
+        ice_multi_static_nodes,
+        ice_multi_dynamic_nodes,
+        target_compute_resource="ice-cr-multiple",
+    )
+
+    # test disable ffo logic
+    _test_disable_fast_capacity_failover(
+        scheduler_commands,
+        remote_command_executor,
+        clustermgtd_conf_path,
+        ice_multi_static_nodes,
+        ice_multi_dynamic_nodes,
+        target_compute_resource="ice-cr-multiple",
     )
 
 
@@ -1901,17 +1935,23 @@ def _test_disable_fast_capacity_failover(
     clustermgtd_conf_path,
     static_nodes_in_ice_compute_resource,
     ice_dynamic_nodes,
+    target_compute_resource,
 ):
     """Test fast capacity failover has no effect on cluster when it is disabled."""
-    # set insufficient_capacity_timeout to 0 to disable fast instance capacity failover logic
+    # disable Fast Failover by setting insufficient_capacity_timeout to 0
     _set_insufficient_capacity_timeout(remote_command_executor, 0, clustermgtd_conf_path)
+
+    # clear slurm_resume and clustermgtd logs in order to start from a clean state
+    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/slurm_resume.log")
+    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
+
     # submit a job to trigger insufficient capacity
     job_id = scheduler_commands.submit_command_and_assert_job_accepted(
         submit_command_args={
             "command": "sleep 30",
             "nodes": 2,
             "other_options": "--no-requeue",
-            "constraint": "c5.large",
+            "constraint": target_compute_resource,
         }
     )
     # wait till the node failed to launch
@@ -1962,12 +2002,18 @@ def _test_enable_fast_capacity_failover(
     clustermgtd_conf_path,
     static_nodes_in_ice_compute_resource,
     ice_dynamic_nodes,
+    target_compute_resource,
 ):
     # set insufficient_capacity_timeout to 180 seconds to quicker reset compute resources
     _set_insufficient_capacity_timeout(remote_command_executor, 180, clustermgtd_conf_path)
-    # trigger insufficient capacity
+
+    # clear slurm_resume and clustermgtd logs in order to start from a clean state
+    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/slurm_resume.log")
+    remote_command_executor.run_remote_command("sudo truncate -s 0 /var/log/parallelcluster/clustermgtd")
+
+    # trigger insufficient capacity: we are using `prefer` to allow requeuing the job on a different CR
     job_id = scheduler_commands.submit_command_and_assert_job_accepted(
-        submit_command_args={"command": "sleep 30", "nodes": 2}
+        submit_command_args={"command": "sleep 30", "nodes": 2, "prefer": target_compute_resource}
     )
     retry(wait_fixed=seconds(20), stop_max_delay=minutes(3))(assert_lines_in_logs)(
         remote_command_executor,

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/overrides.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/overrides.sh
@@ -14,45 +14,56 @@ slurm_plugin_path=$(sudo find / -iname slurm_plugin -print0|grep -FzZ 'node_virt
 cat > $slurm_plugin_path/overrides.py << EOF
 from botocore.exceptions import ClientError
 import boto3
+import logging
 
+logger = logging.getLogger(__name__)
 
 def run_instances(region, boto3_config, **run_instances_kwargs):
     if "ice-compute-resource" in run_instances_kwargs.get("LaunchTemplate", {}).get("LaunchTemplateName"):
+        # Forcing the Placement/tenancy override to host will trigger an InsufficientHostCapacity since we do not
+        # have a fleet of reserved hosts
+        run_instances_kwargs['Placement']= {'Tenancy': 'host'}
+        logger.info("Updated parameters for EC2 run_instances: %s", run_instances_kwargs)
+    ec2_client = boto3.client("ec2", region_name=region, config=boto3_config)
+    return ec2_client.run_instances(**run_instances_kwargs)
 
-        raise ClientError(
-            {
-                "Error": {
-                    "Code": "InsufficientInstanceCapacity",
-                    "Message": "Test InsufficientInstanceCapacity when calling the RunInstances operation.",
-                },
-                "ResponseMetadata": {"RequestId": "testid-123"},
-            },
-            "RunInstances",
-        )
-    else:
-        ec2_client = boto3.client("ec2", region_name=region, config=boto3_config)
-        return ec2_client.run_instances(**run_instances_kwargs)
+def update_lt_instance_overrides(overrides):
+    updated_overrides = []
+    for ov in overrides:
+        if 'InstanceType' in ov:
+            # mutate t2.large into t2-large to force an Error in CreateFleet request
+            mispelled_instance_type = ov['InstanceType'].replace(".", "-")
+            ov['InstanceType'] = mispelled_instance_type
+            updated_overrides.append(ov)
+        else:
+            updated_overrides.append(ov)
 
+    return updated_overrides
 
 def create_fleet(region, boto3_config, **create_fleet_kwargs):
     configs = create_fleet_kwargs.get("LaunchTemplateConfigs", [])
     if len(configs) >= 1 and configs[0]:
-        lt_spec = configs.get("LaunchTemplateConfigs", [])[0].get("LaunchTemplateSpecification")
-        if "ice-cr-multiple" in lt_spec.get("LaunchTemplateName"):
-            response = {
-                "Instances": [],
-                "Errors": [
-                    {"ErrorCode": "InsufficientInstanceCapacity", "ErrorMessage": "Insufficient capacity."},
-                    {"ErrorCode": "InvalidParameterValue", "ErrorMessage": "We couldn't find any instance pools"
-                     " that match your instance requirements. Change your instance requirements, and try again."}
-                ],
-                "ResponseMetadata": {"RequestId": "1234-abcde"},
-            }
+        lt_config = configs[0]
 
-            return response
-        else:
-            ec2_client = boto3.client("ec2", region_name=region, config=boto3_config)
-            return ec2_client.create_fleet(**create_fleet_kwargs)
+        if "ice-cr-multiple" in lt_config.get('LaunchTemplateSpecification').get("LaunchTemplateName"):
+            # CreateFleet will return an Error and an empty list of instances
+            lt_config['Overrides'] = update_lt_instance_overrides(lt_config['Overrides'])
+            logger.info("Updated Instance Overrides for CreateFleet args: %s", create_fleet_kwargs)
+        elif "exception-cr-multiple" in lt_config.get('LaunchTemplateSpecification').get("LaunchTemplateName"):
+            # force CreateFleet to raise an exception since `inf*` instance types have Inferentia accelerators
+            # that are manufactured by AWS, and we are also requesting Manufacturer=nvidia
+            lt_config['Overrides'] = [{
+                        "InstanceRequirements": {
+                            "VCpuCount": { "Min": 2 },
+                            "MemoryMiB": { "Min": 2048 },
+                            "AllowedInstanceTypes": [  "inf*" ],
+                            "AcceleratorManufacturers": [ "nvidia" ]
+                        }
+                    }]
+            logger.info("Updated Instance Overrides for CreateFleet args: %s", create_fleet_kwargs)
+
+        ec2_client = boto3.client("ec2", region_name=region, config=boto3_config)
+        return ec2_client.create_fleet(**create_fleet_kwargs)
     else:
         raise Exception("Missing LaunchTemplateSpecification parameter in create_fleet request.")
 EOF

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/overrides.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/overrides.sh
@@ -32,4 +32,24 @@ def run_instances(region, boto3_config, **run_instances_kwargs):
     else:
         ec2_client = boto3.client("ec2", region_name=region, config=boto3_config)
         return ec2_client.run_instances(**run_instances_kwargs)
+
+
+def create_fleet(region, boto3_config, **create_fleet_kwargs):
+    lt_spec = create_fleet_kwargs.get("LaunchTemplateConfigs", [])[0].get("LaunchTemplateSpecification")
+    if "ice-cr-multiple" in lt_spec.get("LaunchTemplateName"):
+        response = {
+            "Instances": [],
+            "Errors": [
+                {"ErrorCode": "InsufficientInstanceCapacity", "ErrorMessage": "Insufficient capacity."},
+                {"ErrorCode": "InvalidParameterValue", "ErrorMessage": "We couldn't find any instance pools"
+                           " that match your instance requirements. Change your instance requirements, and try again."}
+            ],
+            "ResponseMetadata": {"RequestId": "1234-abcde"},
+        }
+
+        return response
+
+    else:
+        ec2_client = boto3.client("ec2", region_name=region, config=boto3_config)
+        return ec2_client.create_fleet(**create_fleet_kwargs)
 EOF

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
@@ -17,6 +17,11 @@ Scheduling:
         - Name: ice-compute-resource
           InstanceType: c5.large
           MinCount: 1
+        - Name: ice-cr-multiple
+          Instances:
+            - InstanceType: t2.large
+            - InstanceType: t3.large
+          MinCount: 1
         - Name: ondemand1-i1
           InstanceType: {{ instance }}
 SharedStorage:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
@@ -1,5 +1,6 @@
 Image:
   Os: {{ os }}
+  CustomAmi: ami-0b2e93208d0d6c2d8
 HeadNode:
   InstanceType: {{ instance }}
   Networking:
@@ -18,6 +19,11 @@ Scheduling:
           InstanceType: c5.large
           MinCount: 1
         - Name: ice-cr-multiple
+          Instances:
+            - InstanceType: t2.large
+            - InstanceType: t3.large
+          MinCount: 1
+        - Name: exception-cr-multiple
           Instances:
             - InstanceType: t2.large
             - InstanceType: t3.large


### PR DESCRIPTION
### Description of changes
Fast Failover test wasn't taking into account the different behavior derived from create-fleet, used in case of Multiple Instance Types.
This PR 
* Remove mocked responses and make direct calls to EC2 APIs. Expected behaviors are triggered by properly overriding the configuration at runtime
* Add support for slurm sbatch `prefer` option (useful to target a CR while allowing requeueing)
* Add create_fleet override for fast-failover and multiple instance types
* Add multiple-instance-type CR for fast-failover test
* Extends test_fast_failover to validate create_fleet behavior 

This MUST be merged only after merging the PR with the changes in the node package.

### Tests
* End to End test launched successfully in my dev account.
  * This depends on the changes made in the PR linked below and for testing I used a custom AMI with those changes.

 - waiting for test to pass in develop pipeline before merging

### References
* Cherry pick of [PR for develop branch](https://github.com/aws/aws-parallelcluster/pull/5381)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
