### PR TITLE
Propagate cluster s3 bucket information to the compute nodes

### DIFF
--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -92,6 +92,7 @@ write_files:
           "hosted_zone": "${ClusterHostedZone}",
           "node_type": "ComputeFleet",
           "cluster_user": "${OSUser}",
+          "cluster_s3_bucket": "${ClusterS3Bucket}",
           "enable_intel_hpc_platform": "${IntelHPCPlatform}",
           "cw_logging_enabled": "${CWLoggingEnabled}",
           "log_rotation_enabled": "${LogRotationEnabled}",

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -402,6 +402,7 @@ class ClusterCdkStack:
                 cluster_hosted_zone=self.scheduler_resources.cluster_hosted_zone if self.scheduler_resources else None,
                 dynamodb_table=self.scheduler_resources.dynamodb_table if self.scheduler_resources else None,
                 head_eni=self._head_eni,
+                bucket=self.bucket,
                 slurm_construct=self.scheduler_resources,
             )
         self._add_scheduler_plugin_substack()

--- a/cli/src/pcluster/templates/compute_fleet_stack.py
+++ b/cli/src/pcluster/templates/compute_fleet_stack.py
@@ -46,6 +46,7 @@ class ComputeFleetConstruct(Construct):
         cluster_hosted_zone,
         dynamodb_table,
         head_eni,
+        bucket,
         slurm_construct: SlurmConstruct,
     ):
         super().__init__(scope, id)
@@ -60,6 +61,7 @@ class ComputeFleetConstruct(Construct):
         self._cluster_hosted_zone = cluster_hosted_zone
         self._dynamodb_table = dynamodb_table
         self._head_eni = head_eni
+        self._bucket = bucket
         self._slurm_construct = slurm_construct
 
         self.launch_templates = {}
@@ -95,6 +97,7 @@ class ComputeFleetConstruct(Construct):
             head_eni=self._head_eni,
             slurm_construct=self._slurm_construct,
             compute_security_group=self._compute_security_group,
+            bucket=self._bucket,
         )
 
         self.managed_compute_fleet_instance_roles.update(queues_stack.managed_compute_instance_roles)

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -57,6 +57,7 @@ class QueuesStack(NestedStack):
         cluster_hosted_zone,
         dynamodb_table,
         head_eni,
+        bucket,
     ):
         super().__init__(scope, id)
         self._queues = queues
@@ -70,6 +71,7 @@ class QueuesStack(NestedStack):
         self._cluster_hosted_zone = cluster_hosted_zone
         self._dynamodb_table = dynamodb_table
         self._head_eni = head_eni
+        self._bucket = bucket
         self._launch_template_builder = CdkLaunchTemplateBuilder()
         self._add_resources()
 
@@ -275,6 +277,7 @@ class QueuesStack(NestedStack):
                                 if self._cluster_hosted_zone
                                 else "",
                                 "OSUser": OS_MAPPING[self._config.image.os]["user"],
+                                "ClusterS3Bucket": self._bucket.name,
                                 "ClusterName": self.stack_name,
                                 "SlurmDynamoDBTable": self._dynamodb_table.ref if self._dynamodb_table else "NONE",
                                 "LogGroupName": self._log_group.log_group_name


### PR DESCRIPTION
This is required to fetch config from S3 if for some reason the config file is no longer available in the shared storage.

As part of cookbook refactoring I wrongly moved the fetch_config.rb before the mount of the shared storage. Since the config was not available from the shared storage, the compute node was trying to download it from s3 but the cluster/cluster_s3_bucket node attribute was unavailable.

I'm going to restore the order to avoid fetching from s3 every time but in any case it's useful to add robustness to the compute nodes fetch_config logic.

