### PR TITLE
[integ-tests] Improve ParallelCluster cfn custom resource integration tests

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -105,31 +105,39 @@ test-suites:
       dimensions:
         - oss: ["alinux2"]
           regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_create_invalid:
       dimensions:
         - oss: ["alinux2"]
           regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_update:
       dimensions:
         - oss: ["alinux2"]
           regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_update_invalid:
       dimensions:
         - oss: ["alinux2"]
           regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_update_tag_propagation:
       dimensions:
         - oss: [ "alinux2" ]
           regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_delete_out_of_band:
       dimensions:
         - oss: ["alinux2"]
           regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_delete_retain:
       dimensions:
         - oss: ["alinux2"]
           regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
     test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
       dimensions:
         - oss: ["alinux2"]
           regions: ["us-east-2"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}

--- a/tests/integration-tests/resources/cluster_custom_resource.yaml
+++ b/tests/integration-tests/resources/cluster_custom_resource.yaml
@@ -5,89 +5,16 @@ Parameters:
   ClusterName:
     Description: Name of cluster. Note this must be different than the stack name.
     Type: String
-  HeadNodeSubnet:
-    Description: Subnet for the HeadNode
-    Type: String
-  ComputeNodeSubnet:
-    Description: Subnet for the ComputeNode
-    Type: String
-  ComputeInstanceMax:
-    Description: Maximum number of compute instances
-    Type: Number
-    Default: 16
   ServiceToken:
     Description: ARN of Lambda Function backing the Cluster Resource
     Type: String
-  Os:
-    Description: Operating system for nodes
-    Type: String
-    Default: 'alinux2'
-  OnNodeConfigured:
-    Description: Script to run on HeadNode configured
-    Type: String
-    Default: ''
-  CustomBucketAccess:
-    Description: Name of a bucket to provide access to on the HeadNode
-    Type: String
-    Default: ''
-  DeletionPolicy:
-    Type: String
-    Default: Delete
-    AllowedValues:
-      - Delete
-      - Retain
-    Description: Enter Retain or Delete to define the operation when the stack is deleted. Default is to Delete.
-
-Conditions:
-  OnNodeConfiguredCondition: !Not [!Equals [!Ref OnNodeConfigured, '']]
-  CustomBucketCondition: !Not [!Equals [!Ref CustomBucketAccess, '']]
 
 Resources:
   PclusterCluster:
     Type: Custom::PclusterCluster
     Properties:
       ServiceToken: !Ref ServiceToken
-      DeletionPolicy: !Ref DeletionPolicy
       ClusterName: !Ref ClusterName
-      ClusterConfiguration:
-        Imds:
-          ImdsSupport: v2.0
-        Tags:
-          - Key: inside_configuration_key
-            Value: overridden
-        DevSettings:
-          AmiSearchFilters:
-            Owner: self
-        Image:
-          Os: !Ref Os
-        HeadNode:
-          InstanceType: t2.small
-          Networking:
-            SubnetId: !Ref HeadNodeSubnet
-          CustomActions: !If
-            - OnNodeConfiguredCondition
-            -
-              OnNodeConfigured:
-                Script: !Ref OnNodeConfigured
-            - !Ref AWS::NoValue
-          Iam: !If
-            - CustomBucketCondition
-            -
-              S3Access:
-                - BucketName: !Ref CustomBucketAccess
-                  EnableWriteAccess: false
-            - !Ref AWS::NoValue
-        Scheduling:
-          Scheduler: slurm
-          SlurmQueues:
-          - Name: queue0
-            ComputeResources:
-            - Name: queue0-cr0
-              InstanceType: t2.micro
-              MaxCount: !Ref ComputeInstanceMax
-            Networking:
-              SubnetIds:
-              - !Ref ComputeNodeSubnet
 
 Outputs:
   HeadNodeIp:

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_create/pcluster.config.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_create/pcluster.config.yaml
@@ -1,0 +1,30 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+{% for q in range(no_of_queues) %}
+  - Name: queue-{{q}}
+    ComputeSettings:
+      LocalStorage:
+        RootVolume:
+          Encrypted: true
+    ComputeResources:
+    - Name: queue-{{q}}-cr
+      Instances:
+        - InstanceType: {{ instance }}
+      MinCount: 0
+      MaxCount: 16
+    Networking:
+      SubnetIds:
+        - {{ private_subnet_id }}
+{% endfor %}

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_create_invalid/pcluster.config.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_create_invalid/pcluster.config.yaml
@@ -1,0 +1,25 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  CustomActions:
+    OnNodeConfigured:
+      Script: s3://invalidbucket/invalidkey
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue0
+    ComputeResources:
+    - Name: queue0-cr0
+      InstanceType: {{ instance }}
+      MaxCount: 16
+    Networking:
+      SubnetIds:
+      - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_create_with_custom_policies/pcluster.config.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_create_with_custom_policies/pcluster.config.yaml
@@ -1,0 +1,22 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue0
+    ComputeResources:
+    - Name: queue0-cr0
+      InstanceType: {{ instance }}
+      MaxCount: 16
+    Networking:
+      SubnetIds:
+      - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_delete_out_of_band/pcluster.config.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_delete_out_of_band/pcluster.config.yaml
@@ -1,0 +1,22 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue0
+    ComputeResources:
+    - Name: queue0-cr0
+      InstanceType: {{ instance }}
+      MaxCount: 16
+    Networking:
+      SubnetIds:
+      - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_delete_retain/pcluster.config.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_delete_retain/pcluster.config.yaml
@@ -1,0 +1,22 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue0
+    ComputeResources:
+    - Name: queue0-cr0
+      InstanceType: {{ instance }}
+      MaxCount: 16
+    Networking:
+      SubnetIds:
+      - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update/pcluster.config.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update/pcluster.config.yaml
@@ -1,0 +1,30 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+{% for q in range(no_of_queues) %}
+  - Name: queue-{{q}}
+    ComputeSettings:
+      LocalStorage:
+        RootVolume:
+          Encrypted: true
+    ComputeResources:
+    - Name: queue-{{q}}-cr
+      Instances:
+        - InstanceType: {{ instance }}
+      MinCount: 0
+      MaxCount: 3
+    Networking:
+      SubnetIds:
+        - {{ private_subnet_id }}
+{% endfor %}

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update_invalid/pcluster.config.negativemaxcount.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update_invalid/pcluster.config.negativemaxcount.yaml
@@ -1,0 +1,22 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue0
+    ComputeResources:
+    - Name: queue0-cr0
+      InstanceType: {{ instance }}
+      MaxCount: -10
+    Networking:
+      SubnetIds:
+      - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update_invalid/pcluster.config.reducemaxcount.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update_invalid/pcluster.config.reducemaxcount.yaml
@@ -1,0 +1,22 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue0
+    ComputeResources:
+    - Name: queue0-cr0
+      InstanceType: {{ instance }}
+      MaxCount: 10
+    Networking:
+      SubnetIds:
+      - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update_invalid/pcluster.config.wrongscripturi.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update_invalid/pcluster.config.wrongscripturi.yaml
@@ -1,0 +1,25 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  CustomActions:
+    OnNodeConfigured:
+      Script: s3://invalid
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue0
+    ComputeResources:
+    - Name: queue0-cr0
+      InstanceType: {{ instance }}
+      MaxCount: 16
+    Networking:
+      SubnetIds:
+      - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update_invalid/pcluster.config.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update_invalid/pcluster.config.yaml
@@ -1,0 +1,22 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue0
+    ComputeResources:
+    - Name: queue0-cr0
+      InstanceType: {{ instance }}
+      MaxCount: 16
+    Networking:
+      SubnetIds:
+      - {{ private_subnet_id }}

--- a/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update_tag_propagation/pcluster.config.yaml
+++ b/tests/integration-tests/tests/custom_resource/test_cluster_custom_resource/test_cluster_update_tag_propagation/pcluster.config.yaml
@@ -1,0 +1,22 @@
+Imds:
+  ImdsSupport: v2.0
+Tags:
+  - Key: inside_configuration_key
+    Value: overridden
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue0
+    ComputeResources:
+    - Name: queue0-cr0
+      InstanceType: {{ instance }}
+      MaxCount: {{ max_count }}
+    Networking:
+      SubnetIds:
+      - {{ private_subnet_id }}


### PR DESCRIPTION
1. Extract cluster configuration file from `cluster_custom_resource` to individual pcluster.config.yaml files. Therefore, the tests are more similar/extensible to other integration tests and the cluster configuration can be easily modified for each test.
2. Let test_cluster_create and test_cluster_update use 50 queues. This will test most potential limits (e.g. Eventbridge size limit)
3. Simplify test_cluster_create_invalid and test_cluster_update_invalid. This will save the cost and time of integration tests
4. Reorder some fixtures, add a wait_for_rollback, add resource cleanup to fix sporadic failures and resource leftovers

### Tests
the following integration tests have been passed
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  custom_resource:
    test_cluster_custom_resource.py::test_cluster_create:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_create_invalid:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_update:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_update_invalid:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_update_tag_propagation:
      dimensions:
        - oss: [ "alinux2" ]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_delete_out_of_band:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_delete_retain:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
```

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
