### PR TITLE
[develop] Always call parameters by name while submitting a job for testing

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -280,14 +280,14 @@ class SlurmCommands(SchedulerCommands):
 
         return self._submit_batch_job(
             job_submit_command,
-            nodes,
-            slots,
-            host,
-            after_ok,
-            partition,
-            constraint,
-            prefer,
-            other_options,
+            nodes=nodes,
+            slots=slots,
+            host=host,
+            after_ok=after_ok,
+            partition=partition,
+            constraint=constraint,
+            prefer=prefer,
+            other_options=other_options,
             raise_on_error=raise_on_error,
         )
 
@@ -316,14 +316,14 @@ class SlurmCommands(SchedulerCommands):
 
         return self._submit_batch_job(
             job_submit_command,
-            nodes,
-            slots,
-            host,
-            after_ok,
-            partition,
-            constraint,
-            other_options,
-            additional_files,
+            nodes=nodes,
+            slots=slots,
+            host=host,
+            after_ok=after_ok,
+            partition=partition,
+            constraint=constraint,
+            other_options=other_options,
+            additional_files=additional_files,
             raise_on_error=raise_on_error,
         )
 


### PR DESCRIPTION
### Description of changes
* when submitting a job during a test always calls parameters by name to ensure the they are properly managed and formatted in a valid job submission command 

### Tests
* Tests are failing in develop after merging the fix for Fast Failover that added a parameter and broke the sequence of parameters

### References
* [Fix FFO](https://github.com/aws/aws-parallelcluster/commit/43bb9307c9d0eae1dffdd08df99c7f384f4c1596)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
