### PR TITLE
Add Test option for using run-instance API rather than create-fleet API for compute Fleet

### DIFF
--- a/tests/integration-tests/configs/new_instance_types.yaml
+++ b/tests/integration-tests/configs/new_instance_types.yaml
@@ -1,100 +1,98 @@
 {%- import 'common.jinja2' as common -%}
-{%- set REGION = ["##PLACEHOLDER##"] -%}
-{%- set NEW_INSTANCE_TYPES = ["##PLACEHOLDER##"] -%}
 ---
 test-suites:
   scaling:
     test_mpi.py::test_mpi:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
   schedulers:
     test_slurm.py::test_slurm:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_pmix:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: ["ubuntu2004"]
           schedulers: ["slurm"]
     test_awsbatch.py::test_awsbatch:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
   storage:
     test_fsx_lustre.py::test_fsx_lustre:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: [ "slurm" ]
     test_efs.py::test_efs_compute_az:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: ["alinux2"]
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_single:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: ["centos7"]
           schedulers: ["slurm"]
     # Ephemeral test requires instance type with instance store
     test_ephemeral.py::test_head_node_stop:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: ["alinux2"]
           schedulers: ["slurm"]
   dcv:
     # Useful on GPU enabled instances
     test_dcv.py::test_dcv_configuration:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: ["alinux2"]
           schedulers: ["slurm"]
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
           schedulers: ["slurm"]
   configure:
     test_pcluster_configure.py::test_pcluster_configure:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: {{ common.OSS_ONE_PER_DISTRO }}
           schedulers: ["slurm"]
   networking:
     test_cluster_networking.py::test_cluster_in_private_subnet:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: ["ubuntu1804"]
           schedulers: ["slurm"]
-    # Useful for instances with multiple network interfaces
+#     Useful for instances with multiple network interfaces
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: ["alinux2"]
           schedulers: ["slurm"]
   spot:
     test_spot.py::test_spot_default:
       dimensions:
-        - regions: {{ REGION }}
-          instances: {{ NEW_INSTANCE_TYPES }}
+        - regions: [{{ REGIONS }}]
+          instances: [{{ INSTANCES }}]
           oss: ["centos7"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -179,6 +179,11 @@ def pytest_addoption(parser):
         help="Name of CFN stack providing database stack to be used for testing Slurm accounting feature.",
     )
     parser.addoption("--external-shared-storage-stack-name", help="Name of existing external shared storage stack.")
+    parser.addoption(
+        "--force-run-instance-fleet-manager",
+        help="Force usage of Run-instance-api instead of creat-fleet api for compute fleet",
+        action="store_true",
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -712,6 +717,20 @@ def inject_additional_config_settings(cluster_config, request, region, benchmark
                 if not compute_resource.get("MaxCount"):
                     # Use larger max count to support performance tests if not specified explicitly.
                     compute_resource["MaxCount"] = 150
+
+    # Forcing the usage of Run-instance API for creation of fleet when we use InstanceType instead of Instances/InstanceType
+    if (
+        scheduler != "awsbatch"
+        and dict_has_nested_key(config_content, ("Scheduling", "SlurmQueues"))
+        and request.config.getoption("force_run_instance_fleet_manager")
+    ):
+        for queues in config_content["Scheduling"]["SlurmQueues"]:
+            if dict_has_nested_key(queues, ["ComputeResources"]):
+                for compute_resources in queues["ComputeResources"]:
+                    if dict_has_nested_key(compute_resources, ["Instances"]):
+                        instance_type = compute_resources["Instances"][0]["InstanceType"]
+                    compute_resources.pop("Instances")
+                    compute_resources["InstanceType"] = instance_type
 
     with open(cluster_config, "w", encoding="utf-8") as conf_file:
         yaml.dump(config_content, conf_file)

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -19,7 +19,7 @@ from jinja2.sandbox import SandboxedEnvironment
 from utils import InstanceTypesData
 
 
-def read_config_file(config_file, print_rendered=False):
+def read_config_file(config_file, print_rendered=False, **kwargs):
     """
     Read the test config file and apply Jinja rendering.
     Multiple invocations of the same function within the same process produce the same rendering output. This is done
@@ -30,7 +30,7 @@ def read_config_file(config_file, print_rendered=False):
     :return: a dict containig the parsed config file
     """
     logging.info("Parsing config file: %s", config_file)
-    rendered_config = _render_config_file(config_file)
+    rendered_config = _render_config_file(config_file, **kwargs)
     try:
         return yaml.safe_load(rendered_config)
     except Exception:
@@ -48,7 +48,7 @@ def dump_rendered_config_file(config):
 
 
 @lru_cache(maxsize=None)
-def _render_config_file(config_file):
+def _render_config_file(config_file, **kwargs):
     """
     Apply Jinja rendering to the specified config file.
 
@@ -61,7 +61,7 @@ def _render_config_file(config_file):
         return (
             SandboxedEnvironment(loader=file_loader)
             .get_template(config_name)
-            .render(additional_instance_types_map=InstanceTypesData.additional_instance_types_map)
+            .render(additional_instance_types_map=InstanceTypesData.additional_instance_types_map, **kwargs)
         )
     except Exception as e:
         logging.error("Failed when rendering config file %s with error: %s", config_file, e)

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/pcluster.config.yaml
@@ -18,10 +18,12 @@ Scheduling:
       ComputeResources:
         - Name: ondemand-i1
           Instances:
-            - InstanceType: c4.xlarge
+#TODO revert to c4.xlarge
+            - InstanceType: {{ instance_type_1 }}
         - Name: same-name-diff-queue
           Instances:
-            - InstanceType: c5.xlarge
+#TODO revert to c5.xlarge
+            - InstanceType: {{ instance_type_2 }}
           MaxCount: 5
     - Name: gpu
       Networking:


### PR DESCRIPTION
### Description of changes
* Making changes for using instances, region and OS dimensions for TEST_CONFIG Yaml file.
* Added `--force-run-instance-fleet-manager` testing option for using run-instance API rather than create-fleet API for compute Fleet

### Tests
* Tested the changes Locally


### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
