### PR TITLE
[Isolated Regions] [Policies] Omit AWSXRayDaemonWriteAccess policy of ParallelClusterLambdaRole in US isolated regions as the policy is not supported in these regions.

### DIFF
--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -100,6 +100,9 @@ Conditions:
   EnableIamPolicy: !Or
     - !Equals [!Ref EnableIamAdminAccess, true]
     - !Condition EnablePermissionsBoundary
+  InIsolatedRegion: !Or
+    - !Equals [!Ref AWS::Partition, 'aws-iso']
+    - !Equals [!Ref AWS::Partition, 'aws-iso-b']
 
 Resources:
   ### IAM POLICIES
@@ -184,7 +187,10 @@ Resources:
               Service: lambda.amazonaws.com
       ManagedPolicyArns:
         # Required for Lambda logging and XRay
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSXRayDaemonWriteAccess
+        - !If
+          - InIsolatedRegion
+          - !Ref AWS::NoValue
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSXRayDaemonWriteAccess
         - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         # Required to run ParallelCluster functionalities
         - !Ref ParallelClusterClusterPolicy


### PR DESCRIPTION
### Description of changes
Omit AWSXRayDaemonWriteAccess policy of ParallelClusterLambdaRole in US isolated regions
as the policy is not supported in these regions. Such policy can be safely omitted because it is optional and it does not compromise the functionalities of the feature.

### Tests
Validated in ADC regions that this change unblocks the execution of the tests for custom resources.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
