### PR TITLE
[Integ-test] Add `instances` dimension to custom_resource tests in isolated_regions.yaml

### DIFF
--- a/tests/integration-tests/configs/isolated_regions.yaml
+++ b/tests/integration-tests/configs/isolated_regions.yaml
@@ -562,31 +562,39 @@ test-suites:
       dimensions:
         - oss: {{ OSS }}
           regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
     test_cluster_custom_resource.py::test_cluster_create_invalid:
       dimensions:
         - oss: {{ OSS }}
           regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
     test_cluster_custom_resource.py::test_cluster_update:
       dimensions:
         - oss: {{ OSS }}
           regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
     test_cluster_custom_resource.py::test_cluster_update_invalid:
       dimensions:
         - oss: {{ OSS }}
           regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
     test_cluster_custom_resource.py::test_cluster_update_tag_propagation:
       dimensions:
         - oss: {{ OSS }}
           regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
     test_cluster_custom_resource.py::test_cluster_delete_out_of_band:
       dimensions:
         - oss: {{ OSS }}
           regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
     test_cluster_custom_resource.py::test_cluster_delete_retain:
       dimensions:
         - oss: {{ OSS }}
           regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}
     test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
       dimensions:
         - oss: {{ OSS }}
           regions: {{ REGIONS }}
+          instances: {{ INSTANCES }}


### PR DESCRIPTION
The `instances` dimension is required after https://github.com/aws/aws-parallelcluster/pull/5409

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
