### PR TITLE
Pin pytest version to 7.3

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -13,7 +13,7 @@ matplotlib
 pexpect
 pykwalify
 pyOpenSSL
-pytest
+pytest~=7.3.2
 pytest-datadir
 pytest-html
 pytest-rerunfailures


### PR DESCRIPTION
pytest 7.4.0 breaks the possibility to add custom options to pytest. Tests are failing with:

```
ERROR: usage: test_runner.py [options] [file_or_dir] [file_or_dir] [...]

test_runner.py: error: unrecognized arguments: --tests-log-file=...log --output-dir=.../eu-north-1 --key-name=... --key-path=...
```
