### PR TITLE
[Test] Pin pytest version to 7.3

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -13,7 +13,7 @@ matplotlib
 pexpect
 pykwalify
 pyOpenSSL
-pytest
+pytest~=7.3.2
 pytest-datadir
 pytest-html
 pytest-rerunfailures


### PR DESCRIPTION
Porting from https://github.com/aws/aws-parallelcluster/pull/5425

### Description of changes
Pin pytest version to 7.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
