### PR TITLE
Add  integ-testing option to force usage of run-instance API over Create-fleet api

### DIFF
--- a/tests/integration-tests/configs/new_instance_types.yaml
+++ b/tests/integration-tests/configs/new_instance_types.yaml
@@ -1,57 +1,66 @@
 {%- import 'common.jinja2' as common -%}
-{%- set REGION = ["##PLACEHOLDER##"] -%}
+{% if REGIONS  %}
+{%- set NEW_REGIONS = [ REGIONS ] -%}
+{% else %}
+{%- set NEW_REGIONS = ["##PLACEHOLDER##"] -%}
+{% endif %}
+{% if INSTANCES  %}
+{%- set NEW_INSTANCE_TYPES = [ INSTANCES ] -%}
+{% else %}
 {%- set NEW_INSTANCE_TYPES = ["##PLACEHOLDER##"] -%}
+{% endif %}
+
 ---
 test-suites:
   scaling:
     test_mpi.py::test_mpi:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
   schedulers:
     test_slurm.py::test_slurm:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: ["slurm"]
     test_slurm.py::test_slurm_pmix:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: ["ubuntu2004"]
           schedulers: ["slurm"]
     test_awsbatch.py::test_awsbatch:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: ["alinux2"]
           schedulers: ["awsbatch"]
   storage:
     test_fsx_lustre.py::test_fsx_lustre:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: {{ common.OSS_COMMERCIAL_X86 }}
           schedulers: [ "slurm" ]
     test_efs.py::test_efs_compute_az:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
     test_ebs.py::test_ebs_single:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: ["centos7"]
           schedulers: ["slurm"]
     # Ephemeral test requires instance type with instance store
     test_ephemeral.py::test_head_node_stop:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
@@ -59,42 +68,42 @@ test-suites:
     # Useful on GPU enabled instances
     test_dcv.py::test_dcv_configuration:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
   efa:
     test_efa.py::test_efa:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: ["alinux2", "ubuntu1804", "ubuntu2004"]
           schedulers: ["slurm"]
   configure:
     test_pcluster_configure.py::test_pcluster_configure:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: {{ common.OSS_ONE_PER_DISTRO }}
           schedulers: ["slurm"]
   networking:
     test_cluster_networking.py::test_cluster_in_private_subnet:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: ["ubuntu1804"]
           schedulers: ["slurm"]
-    # Useful for instances with multiple network interfaces
+#     Useful for instances with multiple network interfaces
     test_multi_cidr.py::test_multi_cidr:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: ["alinux2"]
           schedulers: ["slurm"]
   spot:
     test_spot.py::test_spot_default:
       dimensions:
-        - regions: {{ REGION }}
+        - regions: {{ NEW_REGIONS }}
           instances: {{ NEW_INSTANCE_TYPES }}
           oss: ["centos7"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -179,6 +179,12 @@ def pytest_addoption(parser):
         help="Name of CFN stack providing database stack to be used for testing Slurm accounting feature.",
     )
     parser.addoption("--external-shared-storage-stack-name", help="Name of existing external shared storage stack.")
+    parser.addoption(
+        "--force-run-instances",
+        help="Force the usage of EC2 run-instances boto3 API instead of create-fleet for compute fleet scaling up."
+        " Note: If there are multiple instances in the list, only the first will be used.",
+        action="store_true",
+    )
 
 
 def pytest_generate_tests(metafunc):
@@ -712,6 +718,21 @@ def inject_additional_config_settings(cluster_config, request, region, benchmark
                 if not compute_resource.get("MaxCount"):
                     # Use larger max count to support performance tests if not specified explicitly.
                     compute_resource["MaxCount"] = 150
+
+    # Forcing the usage of Run-instance API for creation of fleet
+    # when we use InstanceType instead of Instances/InstanceType
+    if (
+        scheduler == "slurm"
+        and dict_has_nested_key(config_content, ("Scheduling", "SlurmQueues"))
+        and request.config.getoption("force_run_instances")
+    ):
+        for queues in config_content["Scheduling"]["SlurmQueues"]:
+            if dict_has_nested_key(queues, ["ComputeResources"]):
+                for compute_resources in queues["ComputeResources"]:
+                    if dict_has_nested_key(compute_resources, ["Instances"]):
+                        instance_type = compute_resources["Instances"][0]["InstanceType"]
+                    compute_resources.pop("Instances")
+                    compute_resources["InstanceType"] = instance_type
 
     with open(cluster_config, "w", encoding="utf-8") as conf_file:
         yaml.dump(config_content, conf_file)

--- a/tests/integration-tests/framework/tests_configuration/config_renderer.py
+++ b/tests/integration-tests/framework/tests_configuration/config_renderer.py
@@ -19,7 +19,7 @@ from jinja2.sandbox import SandboxedEnvironment
 from utils import InstanceTypesData
 
 
-def read_config_file(config_file, print_rendered=False):
+def read_config_file(config_file, print_rendered=False, **kwargs):
     """
     Read the test config file and apply Jinja rendering.
     Multiple invocations of the same function within the same process produce the same rendering output. This is done
@@ -30,7 +30,7 @@ def read_config_file(config_file, print_rendered=False):
     :return: a dict containig the parsed config file
     """
     logging.info("Parsing config file: %s", config_file)
-    rendered_config = _render_config_file(config_file)
+    rendered_config = _render_config_file(config_file, **kwargs)
     try:
         return yaml.safe_load(rendered_config)
     except Exception:
@@ -48,7 +48,7 @@ def dump_rendered_config_file(config):
 
 
 @lru_cache(maxsize=None)
-def _render_config_file(config_file):
+def _render_config_file(config_file, **kwargs):
     """
     Apply Jinja rendering to the specified config file.
 
@@ -61,7 +61,7 @@ def _render_config_file(config_file):
         return (
             SandboxedEnvironment(loader=file_loader)
             .get_template(config_name)
-            .render(additional_instance_types_map=InstanceTypesData.additional_instance_types_map)
+            .render(additional_instance_types_map=InstanceTypesData.additional_instance_types_map, **kwargs)
         )
     except Exception as e:
         logging.error("Failed when rendering config file %s with error: %s", config_file, e)

--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -89,6 +89,7 @@ TEST_DEFAULTS = {
     "cluster_custom_resource_service_token": None,
     "resource_bucket": None,
     "lambda_layer_source": None,
+    "force_run_instances": False,
 }
 
 
@@ -402,6 +403,14 @@ def _init_argparser():
         default=TEST_DEFAULTS.get("external_shared_storage_stack_name"),
     )
 
+    debug_group.add_argument(
+        "--force-run-instances",
+        help="Force the usage of EC2 run-instances boto3 API instead of create-fleet for compute fleet scaling up."
+        "Note: If there are multiple instances in the list, only the first will be used.",
+        default=TEST_DEFAULTS.get("force_run_instances"),
+        action="store_true",
+    )
+
     return parser
 
 
@@ -432,13 +441,16 @@ def _is_url(value):
         raise argparse.ArgumentTypeError("'{0}' is not a valid url".format(value))
 
 
-def _test_config_file(value):
-    _is_file(value)
+def _test_config_file(config_file_path, config_args=None):
+    _is_file(config_file_path)
     try:
-        config = read_config_file(value)
+        if config_args:
+            config = read_config_file(config_file_path, **config_args)
+        else:
+            config = read_config_file(config_file_path)
         return config
     except Exception:
-        raise argparse.ArgumentTypeError("'{0}' is not a valid test config".format(value))
+        raise argparse.ArgumentTypeError("'{0}' is not a valid test config".format(config_file_path))
 
 
 def _join_with_not(args):
@@ -583,6 +595,9 @@ def _set_custom_stack_args(args, pytest_args):
     if args.no_delete:
         pytest_args.append("--no-delete")
 
+    if args.force_run_instances:
+        pytest_args.append("--force-run-instances")
+
     if args.iam_user_role_stack_name:
         pytest_args.extend(["--iam-user-role-stack-name", args.iam_user_role_stack_name])
 
@@ -688,6 +703,17 @@ def _run_parallel(args):
         job.join()
 
 
+def _get_config_arguments(args):
+    test_config_args = {}
+    if args.instances:
+        test_config_args["INSTANCES"] = args.instances[0]
+    if args.regions:
+        test_config_args["REGIONS"] = args.regions[0]
+    if args.oss:
+        test_config_args["OSS"] = args.oss[0]
+    return test_config_args
+
+
 def _check_args(args):
     # If --cluster is set only one os, scheduler, instance type and region can be provided
     if args.cluster:
@@ -705,7 +731,8 @@ def _check_args(args):
         assert_that(args.schedulers).described_as("--schedulers cannot be empty").is_not_empty()
     else:
         try:
-            args.tests_config = _test_config_file(args.tests_config)
+            test_config_args = _get_config_arguments(args)
+            args.tests_config = _test_config_file(args.tests_config, test_config_args)
             assert_valid_config(args.tests_config, args.tests_root_dir)
             logger.info("Found valid config file:\n%s", dump_rendered_config_file(args.tests_config))
         except Exception:

--- a/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
+++ b/tests/integration-tests/tests/networking/test_multi_cidr/test_multi_cidr/pcluster.config.yaml
@@ -3,7 +3,7 @@ Image:
 HeadNode:
   InstanceType: {{ instance }}
   Networking:
-    SubnetId: {{ public_subnet_ids[0] }}
+    SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
   Imds:
@@ -27,4 +27,4 @@ Scheduling:
           {% endif %}
       Networking:
         SubnetIds:
-          - {{ private_subnet_ids[1] }}
+          - {{ private_subnet_id }}


### PR DESCRIPTION
### Description of changes
* Adding `--force-run-instance-fleet-manager` integration testing option to force the usage of run-instance API over Create-fleet api for cluster creation
* Change usage of random subnets over different AZ for `test_multi_cidr`

### Tests
* Tests using `new_instance_types.yaml`



### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
