### PR TITLE
[integ-tests-3.6.0] Pin pytest version to 7.3

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -13,7 +13,7 @@ matplotlib
 pexpect
 pykwalify
 pyOpenSSL
-pytest
+pytest~=7.3.2
 pytest-datadir
 pytest-html
 pytest-rerunfailures


### PR DESCRIPTION
### Description of changes
pytest 7.4.0 breaks the possibility to add custom options to pytest. Tests are failing with:

```
ERROR: usage: test_runner.py [options] [file_or_dir] [file_or_dir] [...]

test_runner.py: error: unrecognized arguments: --tests-log-file=...log --output-dir=.../eu-north-1 --key-name=... --key-path=...
```

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
