### PR TITLE
Revisit list of tests required to validate a new OS

### DIFF
--- a/tests/integration-tests/configs/new_os.yaml
+++ b/tests/integration-tests/configs/new_os.yaml
@@ -129,13 +129,6 @@ test-suites:
           instances: ["c6gn.16xlarge"]
           oss: {{ NEW_OS }}
           schedulers: ["slurm"]
-  intel_hpc:
-    test_intel_hpc.py::test_intel_hpc:
-      dimensions:
-        - regions: ["us-east-2"]
-          instances: ["c5.18xlarge"]
-          oss: {{ NEW_OS }}
-          schedulers: ["slurm"]
   networking:
     test_cluster_networking.py::test_cluster_in_private_subnet:
       dimensions:

--- a/tests/integration-tests/configs/new_os.yaml
+++ b/tests/integration-tests/configs/new_os.yaml
@@ -157,15 +157,15 @@ test-suites:
   scaling:
     test_scaling.py::test_multiple_jobs_submission:
       dimensions:
-        - regions: {{ common.REGIONS_COMMERCIAL }}
+        - regions: ["us-west-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
-        - regions: {{ common.REGIONS_CHINA }}
+        - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]
-        - regions: {{ common.REGIONS_GOVCLOUD }}
+        - regions: ["us-gov-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ NEW_OS }}
           schedulers: [ "slurm" ]

--- a/tests/integration-tests/configs/new_os.yaml
+++ b/tests/integration-tests/configs/new_os.yaml
@@ -303,11 +303,6 @@ test-suites:
         - regions: ["eu-central-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ NEW_OS }}
-    test_update.py::test_update_compute_ami:
-      dimensions:
-        - regions: ["eu-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          oss: {{ NEW_OS }}
     test_update.py::test_update_instance_list:
       dimensions:
         - regions: ["ap-south-1"]

--- a/tests/integration-tests/configs/new_os.yaml
+++ b/tests/integration-tests/configs/new_os.yaml
@@ -75,12 +75,6 @@ test-suites:
         - regions: ["eu-west-3"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: {{ NEW_OS }}
-    test_createami.py::test_kernel4_build_image_run_cluster:
-      dimensions:
-        - regions: ["us-west-1"]
-          instances: {{ common.INSTANCES_DEFAULT_X86 }}
-          schedulers: ["slurm"]
-          oss: {{ NEW_OS }}
   dcv:
     test_dcv.py::test_dcv_configuration:
       dimensions:


### PR DESCRIPTION
### Description of changes
* Remove Intel HPC test from new-os test - It is useless since Intel HPC is supported only on CentOS 7.
* Reduce number of tests for a new OS - We don't need to test in every commercial region to validate an OS.
* Remove test_update_compute_ami from new-os tests. This test is searching for a published 3.x version of the AMI
for the given os, so cannot be used when testing a new OS.
* Remove kernel4 test from new-os tests. This is useful only for Alinux2 only.
