### PR TITLE
Add lower limit to ScaledownIdleTime configuration property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Fix cluster creation failure when using CloudFormation custom resource with `ElastipIp` set to `True`.
+- Add validation to `ScaledownIdletime` value, to prevent setting a value lower than `-1`.
 
 3.6.1
 ------

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1579,7 +1579,10 @@ class DatabaseSchema(BaseSchema):
 class SlurmSettingsSchema(BaseSchema):
     """Represent the schema of the Scheduling Settings."""
 
-    scaledown_idletime = fields.Int(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    scaledown_idletime = fields.Int(
+        validate=validate.Range(min=-1),
+        metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP},
+    )
     dns = fields.Nested(DnsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     queue_update_strategy = fields.Str(
         validate=validate.OneOf([strategy.value for strategy in QueueUpdateStrategy]),

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -43,6 +43,7 @@ from pcluster.schemas.cluster_schema import (
     SlurmComputeResourceSchema,
     SlurmQueueNetworkingSchema,
     SlurmQueueSchema,
+    SlurmSettingsSchema,
 )
 
 
@@ -788,3 +789,18 @@ def test_iam_validator(instance_role, instance_profile, expected_message):
         iam = LoginNodesIamSchema().load(iam_dict)
         assert_that(iam.instance_role).is_equal_to(instance_role)
         assert_that(iam.instance_profile).is_equal_to(instance_profile)
+
+
+@pytest.mark.parametrize(
+    "section_dict, expected_message",
+    [
+        ({"ScaledownIdletime": -100}, "Must be greater than or equal"),
+        ({"ScaledownIdletime": -2}, "Must be greater than or equal"),
+        ({"ScaledownIdletime": -1}, None),
+        ({"ScaledownIdletime": 0}, None),
+        ({"ScaledownIdletime": 1}, None),
+        ({"ScaledownIdletime": 100}, None),
+    ],
+)
+def test_slurm_scaledown_idletime_validator(section_dict, expected_message):
+    _validate_and_assert_error(SlurmSettingsSchema(), section_dict, expected_message)


### PR DESCRIPTION
### Description of changes
According to Slurm doc https://slurm.schedmd.com/slurm.conf.html#OPT_SuspendTime, SuspendTime cannot be lower than -1, thus ScaledownIdletime allowed value must be validated accordingly 


### Tests
n/a

### References
n/a

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
