### PR TITLE
[develop] Add proxy attribute to LoginNodes Networking Schema

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1227,9 +1227,10 @@ class LoginNodesSsh(_BaseSsh):
 class LoginNodesNetworking(_BaseNetworking, SubnetsMixin):
     """Represent the networking configuration for LoginNodes."""
 
-    def __init__(self, subnet_ids: List[str], **kwargs):
+    def __init__(self, subnet_ids: List[str], proxy: Proxy = None, **kwargs):
         _BaseNetworking.__init__(self, **kwargs)
         SubnetsMixin.__init__(self, subnet_ids, **kwargs)
+        self.proxy = proxy
 
     @property
     def is_subnet_public(self):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -622,6 +622,17 @@ class QueueProxySchema(BaseSchema):
         return Proxy(**data)
 
 
+class LoginNodeProxySchema(BaseSchema):
+    """Represent the schema of proxy for a Login Node."""
+
+    http_proxy_address = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return Proxy(**data)
+
+
 class BaseNetworkingSchema(BaseSchema):
     """Represent the schema of common networking parameters used by head, compute and login nodes."""
 
@@ -1274,6 +1285,8 @@ class LoginNodesNetworkingSchema(BaseNetworkingSchema):
         required=True,
         validate=validate.Length(equal=1, error="Only one subnet can be associated with a login node pool"),
     )
+
+    proxy = fields.Nested(LoginNodeProxySchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
@@ -16,6 +16,8 @@ LoginNodes:
         {% for i in range(10) %}
         - sg-3456789{{ i }}
         {% endfor %}
+      Proxy:
+        HttpProxyAddress: https://proxy-address:port
     Ssh:
       KeyName: validate_key_name
     Iam:

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -97,6 +97,8 @@ LoginNodes:
     Name: test
     Networking:
       AdditionalSecurityGroups: null
+      Proxy:
+        HttpProxyAddress: https://proxy-address:port
       SecurityGroups:
       - sg-34567890
       - sg-34567891


### PR DESCRIPTION
### Description of changes
Customers that have restricted networking may need to set a Proxy to allow network traffic to external networks (i.e. internet).

* Add a new LoginNodesProxySchema class
* Add proxy attribute in LoginNodesNetworkingSchema class
* Add proxy attribute in LoginNodesNetworking class
* Fix tests

### Tests
* Unit tests successfully executed locally

### References
* [LoginNodes PR](https://github.com/aws/aws-parallelcluster/pull/5384)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
