### PR TITLE
[Test] Replace t2.large with m5.large in 'test_fast_capacity_failover'

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
@@ -20,12 +20,12 @@ Scheduling:
           MinCount: 1
         - Name: ice-cr-multiple
           Instances:
-            - InstanceType: t2.large
+            - InstanceType: m5.large
             - InstanceType: t3.large
           MinCount: 1
         - Name: exception-cr-multiple
           Instances:
-            - InstanceType: t2.large
+            - InstanceType: m5.large
             - InstanceType: t3.large
           MinCount: 1
         - Name: ondemand1-i1


### PR DESCRIPTION
### Description of changes
Replace t2.large with m5.large in 'test_fast_capacity_failover'.
The test is failing with the instance type t2.large in the last 4 days.
Probably this is a transient issue.
In any case, m5.large is equivalent and it has even higher availability than t2.large.

### Tests
Will be tested on pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
