### PR TITLE
Add support for LoginNodes in describe_cluster_instances

### DIFF
--- a/api/client/src/docs/NodeType.md
+++ b/api/client/src/docs/NodeType.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**value** | **str** |  |  must be one of ["HeadNode", "ComputeNode", ]
+**value** | **str** |  |  must be one of ["HeadNode", "ComputeNode", "LoginNode", ]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api/client/src/pcluster_client/model/node_type.py
+++ b/api/client/src/pcluster_client/model/node_type.py
@@ -54,6 +54,7 @@ class NodeType(ModelSimple):
         ('value',): {
             'HEADNODE': "HeadNode",
             'COMPUTENODE': "ComputeNode",
+            'LOGINNODE': "LoginNode",
         },
     }
 
@@ -105,10 +106,10 @@ class NodeType(ModelSimple):
         Note that value can be passed either in args or in kwargs, but not in both.
 
         Args:
-            args[0] (str):, must be one of ["HeadNode", "ComputeNode", ]  # noqa: E501
+            args[0] (str):, must be one of ["HeadNode", "ComputeNode", "LoginNode", ]  # noqa: E501
 
         Keyword Args:
-            value (str):, must be one of ["HeadNode", "ComputeNode", ]  # noqa: E501
+            value (str):, must be one of ["HeadNode", "ComputeNode", "LoginNode", ]  # noqa: E501
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.
@@ -199,10 +200,10 @@ class NodeType(ModelSimple):
         Note that value can be passed either in args or in kwargs, but not in both.
 
         Args:
-            args[0] (str):, must be one of ["HeadNode", "ComputeNode", ]  # noqa: E501
+            args[0] (str):, must be one of ["HeadNode", "ComputeNode", "LoginNode", ]  # noqa: E501
 
         Keyword Args:
-            value (str):, must be one of ["HeadNode", "ComputeNode", ]  # noqa: E501
+            value (str):, must be one of ["HeadNode", "ComputeNode", "LoginNode", ]  # noqa: E501
             _check_type (bool): if True, values for parameters in openapi_types
                                 will be type checked and a TypeError will be
                                 raised if the wrong type is input.

--- a/api/spec/openapi/ParallelCluster.openapi.yaml
+++ b/api/spec/openapi/ParallelCluster.openapi.yaml
@@ -2319,6 +2319,7 @@ components:
       enum:
         - HeadNode
         - ComputeNode
+        - LoginNode
     NotFoundExceptionResponseContent:
       type: object
       description: This exception is thrown when the requested entity is not found.

--- a/api/spec/smithy/model/types/Instance.smithy
+++ b/api/spec/smithy/model/types/Instance.smithy
@@ -13,6 +13,7 @@ string InstanceState
 @enum([
     {name: "HEADNODE", value: "HeadNode"},
     {name: "COMPUTENODE", value: "ComputeNode"},
+    {name: "LOGINNODE", value: "LoginNode"},
 ])
 string NodeType
 

--- a/cli/src/pcluster/api/controllers/cluster_instances_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_instances_controller.py
@@ -82,6 +82,11 @@ def describe_cluster_instances(cluster_name, region=None, next_token=None, node_
     )
     ec2_instances = []
     for instance in instances:
+        node_type = ApiNodeType.COMPUTENODE
+        if instance.node_type == NodeType.HEAD_NODE.value:
+            node_type = ApiNodeType.HEADNODE
+        elif instance.node_type == NodeType.LOGIN_NODE.value:
+            node_type = ApiNodeType.LOGINNODE
         ec2_instances.append(
             ClusterInstance(
                 instance_id=instance.id,
@@ -90,9 +95,7 @@ def describe_cluster_instances(cluster_name, region=None, next_token=None, node_
                 instance_type=instance.instance_type,
                 state=instance.state,
                 private_ip_address=instance.private_ip,
-                node_type=ApiNodeType.HEADNODE
-                if instance.node_type == NodeType.HEAD_NODE.value
-                else ApiNodeType.COMPUTENODE,
+                node_type=node_type,
                 queue_name=instance.queue_name,
             )
         )

--- a/cli/src/pcluster/api/converters.py
+++ b/cli/src/pcluster/api/converters.py
@@ -67,5 +67,9 @@ def validation_results_to_config_validation_errors(
 
 
 def api_node_type_to_cluster_node_type(node_type: ApiNodeType):
-    mapping = {ApiNodeType.HEADNODE: NodeType.HEAD_NODE, ApiNodeType.COMPUTENODE: NodeType.COMPUTE}
+    mapping = {
+        ApiNodeType.HEADNODE: NodeType.HEAD_NODE,
+        ApiNodeType.COMPUTENODE: NodeType.COMPUTE,
+        ApiNodeType.LOGINNODE: NodeType.LOGIN_NODE,
+    }
     return mapping.get(node_type)

--- a/cli/src/pcluster/api/models/node_type.py
+++ b/cli/src/pcluster/api/models/node_type.py
@@ -9,6 +9,7 @@
 # pylint: disable=R0801
 
 
+from pcluster.api import util
 from pcluster.api.models.base_model_ import Model
 
 

--- a/cli/src/pcluster/api/models/node_type.py
+++ b/cli/src/pcluster/api/models/node_type.py
@@ -9,7 +9,6 @@
 # pylint: disable=R0801
 
 
-from pcluster.api import util
 from pcluster.api.models.base_model_ import Model
 
 
@@ -24,6 +23,7 @@ class NodeType(Model):
     """
     HEADNODE = "HeadNode"
     COMPUTENODE = "ComputeNode"
+    LOGINNODE = "LoginNode"
 
     def __init__(self):
         """NodeType - a model defined in OpenAPI"""

--- a/cli/src/pcluster/api/openapi/openapi.yaml
+++ b/cli/src/pcluster/api/openapi/openapi.yaml
@@ -3160,6 +3160,7 @@ components:
       enum:
       - HeadNode
       - ComputeNode
+      - LoginNode
       title: NodeType
       type: string
     NotFoundExceptionResponseContent:

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -83,6 +83,7 @@ class NodeType(Enum):
 
     HEAD_NODE = "HeadNode"
     COMPUTE = "Compute"
+    LOGIN_NODE = "LoginNode"
 
     def __str__(self):
         return str(self.value)

--- a/cli/tests/pcluster/api/controllers/test_cluster_instances_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_instances_controller.py
@@ -124,10 +124,11 @@ class TestDescribeClusterInstances:
         [
             ("clustername", None, None),
             ("clustername", NodeType.HEADNODE, None),
+            ("clustername", NodeType.LOGINNODE, None),
             ("clustername", NodeType.COMPUTENODE, None),
             ("clustername", None, "queuename"),
         ],
-        ids=["all instances", "head only", "compute only", "queuename only"],
+        ids=["all instances", "head only", "login only", "compute only", "queuename only"],
     )
     def test_filters(self, mocker, client, cluster_name, node_type, queue_name):
         describe_instances_mock = mocker.patch(
@@ -147,6 +148,8 @@ class TestDescribeClusterInstances:
             if node_type:
                 if node_type == NodeType.HEADNODE:
                     expected_value = "HeadNode"
+                elif node_type == NodeType.LOGINNODE:
+                    expected_value = "LoginNode"
                 else:
                     expected_value = "Compute"
             else:
@@ -159,7 +162,7 @@ class TestDescribeClusterInstances:
         [
             (
                 {"node_type": "wrong_node_type"},
-                {"message": "Bad Request: 'wrong_node_type' is not one of ['HeadNode', 'ComputeNode']"},
+                {"message": "Bad Request: 'wrong_node_type' is not one of ['HeadNode', 'ComputeNode', 'LoginNode']"},
             ),
             (
                 {"region": "eu-west-"},

--- a/cli/tests/pcluster/cli/test_describe_cluster_instances.py
+++ b/cli/tests/pcluster/cli/test_describe_cluster_instances.py
@@ -24,7 +24,8 @@ class TestDescribeClusterInstancesCommand:
             (["--cluster-name", "cluster", "--invalid"], "Invalid arguments ['--invalid']"),
             (
                 ["--cluster-name", "cluster", "--node-type", "invalid"],
-                "error: argument --node-type: invalid choice: 'invalid' (choose from 'HeadNode', 'ComputeNode')",
+                "error: argument --node-type: invalid choice: 'invalid' (choose from 'HeadNode', 'ComputeNode', "
+                "'LoginNode')",
             ),
             (
                 ["--cluster-name", "cluster", "--region", "eu-west-"],

--- a/cli/tests/pcluster/cli/test_describe_cluster_instances/TestDescribeClusterInstancesCommand/test_helper/pcluster-help.txt
+++ b/cli/tests/pcluster/cli/test_describe_cluster_instances/TestDescribeClusterInstancesCommand/test_helper/pcluster-help.txt
@@ -1,6 +1,6 @@
 usage: pcluster describe-cluster-instances [-h] -n CLUSTER_NAME [-r REGION]
                                            [--next-token NEXT_TOKEN]
-                                           [--node-type {HeadNode,ComputeNode}]
+                                           [--node-type {HeadNode,ComputeNode,LoginNode}]
                                            [--queue-name QUEUE_NAME] [--debug]
                                            [--query QUERY]
 
@@ -14,7 +14,7 @@ options:
                         AWS Region that the operation corresponds to.
   --next-token NEXT_TOKEN
                         Token to use for paginated requests.
-  --node-type {HeadNode,ComputeNode}
+  --node-type {HeadNode,ComputeNode,LoginNode}
                         Filter the instances by node type.
   --queue-name QUEUE_NAME
                         Filter the instances by queue name.

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -67,6 +67,9 @@ class TestCluster:
             (NodeType.COMPUTE, [{}, {}, {}], 3),
             (NodeType.COMPUTE, [{}, {}], 2),
             (NodeType.COMPUTE, [], 0),
+            (NodeType.LOGIN_NODE, [{}, {}, {}], 3),
+            (NodeType.LOGIN_NODE, [{}, {}], 2),
+            (NodeType.LOGIN_NODE, [], 0),
         ],
     )
     def test_describe_instances(self, cluster, mocker, node_type, expected_response, expected_instances):

--- a/cloudformation/policies/parallelcluster-policies.yaml
+++ b/cloudformation/policies/parallelcluster-policies.yaml
@@ -564,6 +564,26 @@ Resources:
             Resource: '*'
             Effect: Allow
             Sid: ResourceGroupRead
+          - Action:
+              - autoscaling:CreateAutoScalingGroup
+              - autoscaling:DeleteAutoScalingGroup
+              - autoscaling:DescribeAutoScalingGroups
+              - autoscaling:DescribeScalingActivities
+              - autoscaling:UpdateAutoScalingGroup
+              - elasticloadbalancing:AddTags
+              - elasticloadbalancing:CreateListener
+              - elasticloadbalancing:CreateLoadBalancer
+              - elasticloadbalancing:CreateTargetGroup
+              - elasticloadbalancing:DeleteListener
+              - elasticloadbalancing:DeleteLoadBalancer
+              - elasticloadbalancing:DeleteTargetGroup
+              - elasticloadbalancing:DescribeListeners
+              - elasticloadbalancing:DescribeLoadBalancers
+              - elasticloadbalancing:DescribeTargetGroups
+              - elasticloadbalancing:ModifyLoadBalancerAttributes
+            Resource: '*'
+            Effect: Allow
+            Sid: LoginNodesFunctionalities
 
 
   # ### IMAGE ACTIONS POLICIES

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -56,6 +56,12 @@ test-suites:
         - regions: ["sa-east-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
           oss: ["alinux2"]
+    test_api.py::test_login_nodes:
+      dimensions:
+        - regions: ["sa-east-1"]
+          instances: {{ common.INSTANCES_DEFAULT_X86 }}
+          oss: ["alinux2"]
+          schedulers: ["slurm"]
   scaling:
     # FixMe: MPI tests configs are duplications of the test in common.yaml.
     # The duplications are necessary because the scaling section here overwrites the scaling section in common.yaml.

--- a/tests/integration-tests/tests/pcluster_api/test_api/test_login_nodes/pcluster.config.yaml
+++ b/tests/integration-tests/tests/pcluster_api/test_api/test_login_nodes/pcluster.config.yaml
@@ -1,0 +1,31 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: ondemand1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: compute-resource-1
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          MaxCount: 1
+LoginNodes:
+  Pools:
+    - Name: pool-1
+      InstanceType: {{ instance }}
+      Count: 1
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      Ssh:
+        KeyName: {{ key_name }}


### PR DESCRIPTION
### Description of changes
* Add functionalities to support LoginNodes in the describe_cluster_instances call.
* In order to achieve this result I update the smithy models to support the new type.
* Add more policies in the ParallelClusterClusterPolicy since it is needed to execute the API calls.

### Tests
* Update existing unit tests
* Add a dedicated integration test
* Manually tested the CLI

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

### References
- Login Nodes infrastructure: https://github.com/aws/aws-parallelcluster/commit/c732ab5fd0576f00a0b92954571cc1bc95af13c7

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
