### PR TITLE
[Test] Remove hard wired custom AMI from 'test_fast_capacity_failover'.

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
@@ -1,6 +1,5 @@
 Image:
   Os: {{ os }}
-  CustomAmi: ami-0b2e93208d0d6c2d8
 HeadNode:
   InstanceType: {{ instance }}
   Networking:


### PR DESCRIPTION
### Description of changes
Remove hard wired custom AMI from 'test_fast_capacity_failover'.
The AMI has been probably hard wired by mistake.

### Tests
Will be validated on the authoritative pipeline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
