### PR TITLE
[Integ-test] test slurm with custom partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 
 **CHANGES**
 - Assign Slurm dynamic nodes a priority (weight) of 1000 by default. This allows Slurm to prioritize idle static nodes over idle dynamic ones.
+- Make `aws-parallelcluster-node` daemons handle only ParallelCluster-managed Slurm partitions.
 
 **BUG FIXES**
 - Add validation to `ScaledownIdletime` value, to prevent setting a value lower than `-1`.

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_partitions/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_partitions/pcluster.config.yaml
@@ -1,0 +1,50 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmSettings:
+    CustomSlurmSettings:
+      - NodeSet: nodeset
+        Nodes: "ondemand1-st-ondemand1-i1-[1-2],ondemand2-dy-ondemand2-c5large-[1-10]"
+      - PartitionName: CustomerPartition1
+        Nodes: nodeset
+      - PartitionName: CustomerPartition2
+        Nodes: nodeset
+  SlurmQueues:
+    - Name: ondemand1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: ondemand1-c5large
+          Instances:
+            - InstanceType: c5.large
+        - Name: ondemand1-i1
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 2
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket }}
+      CustomActions:
+        OnNodeStart:
+          # pre-install script to make c5.large instance type instance has bootstrap error
+          Script: s3://{{ bucket }}/scripts/preinstall.sh
+    - Name: ondemand2
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: ondemand2-c5large
+          Instances:
+            - InstanceType: c5.large
+        - Name: ondemand2-i1
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_partitions/preinstall.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_custom_partitions/preinstall.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+function get_instance_type() {
+  token=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
+  instance_type_url="http://169.254.169.254/latest/meta-data/instance-type"
+  instance_type=$(curl --retry 3 --retry-delay 0 --silent --fail -H "X-aws-ec2-metadata-token: ${token}" "${instance_type_url}")
+}
+get_instance_type
+if [ "${instance_type}" == "c5.large" ]; then
+  echo "Test Bootstrap error that causes instance to self terminate."
+  exit 1
+fi
+


### PR DESCRIPTION
### Description of changes
This new test do the following checks:
1. pcluster nodes in custom partition are not brought down when the partition is set to inactive
2. cluster recovers without over-scaling after terminating EC2 instances of static nodes belonging to multiple partition
3. protected mode only manages pcluster partitions
4. pcluster stop/start only manages pcluster partitions

This PR also contains minor refactor to help the new test reuse existing code

### Tests
The following tests have been passed
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  schedulers:
    test_slurm.py::test_slurm:
      dimensions:
        - regions: [ "eu-central-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "ubuntu2004" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_slurm_pmix: # TODO: include in main test_slurm to reduce number of created clusters
      dimensions:
        - regions: [ "ap-south-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "centos7" ]
          schedulers: [ "slurm" ]
        - regions: [ "ap-northeast-1" ]
          instances: {{ common.INSTANCES_DEFAULT_ARM }}
          oss: [ "rhel8" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_slurm_scaling:
      dimensions:
        - regions: [ "use2-az2" ]  # do not move, unless instance type support is moved as well
          instances: [ {{ common.instance("instance_type_1") }} ]
          oss: [ "alinux2" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_error_handling:
      dimensions:
        - regions: [ "ca-central-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_slurm_protected_mode:
      dimensions:
        - regions: [ "ca-central-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "rhel8" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_slurm_protected_mode_on_cluster_create:
      dimensions:
        - regions: [ "ap-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "centos7" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_slurm_memory_based_scheduling:
      dimensions:
        - regions: [ "ap-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "ubuntu2004" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_scontrol_reboot:
      dimensions:
        - regions: [ "us-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "ubuntu2004" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_scontrol_reboot_ec2_health_checks:
      dimensions:
        - regions: [ "us-east-2" ]
          instances: [ "t2.medium" ]
          oss: [ "ubuntu2004" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_slurm_overrides:
      dimensions:
        - regions: [ "me-south-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "ubuntu2004" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_scontrol_update_nodelist_sorting:
      dimensions:
        - regions: [ "ca-central-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2" ]
          schedulers: [ "slurm" ]
    test_slurm_accounting.py::test_slurm_accounting:
      dimensions:
        - regions: [ "ap-south-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "ubuntu2004" ]
          schedulers: [ "slurm" ]
    test_slurm_accounting.py::test_slurm_accounting_disabled_to_enabled_update:
      dimensions:
        - regions: [ "us-west-2" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "centos7" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_slurm_reconfigure_race_condition:
      dimensions:
        - regions: [ "af-south-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2" ]
          schedulers: [ "slurm" ]
    test_slurm.py::test_slurm_custom_partitions:
      dimensions:
        - regions: [ "us-east-1" ]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
          oss: [ "alinux2" ]
          schedulers: [ "slurm" ]
```

### References
This PR depends on https://github.com/aws/aws-parallelcluster-cookbook/pull/2323 and https://github.com/aws/aws-parallelcluster-node/pull/539

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
