### PR TITLE
Add ELBv2 boto3 client and some methods

### DIFF
--- a/cli/src/pcluster/aws/elb.py
+++ b/cli/src/pcluster/aws/elb.py
@@ -1,0 +1,60 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import Any, List, Tuple
+
+from pcluster.aws.common import AWSExceptionHandler, Boto3Client
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ElbClient(Boto3Client):
+    """Implement ELB Boto3 client."""
+
+    def __init__(self):
+        super().__init__("elbv2")
+
+    @AWSExceptionHandler.handle_client_exception
+    def list_load_balancers(self):
+        """Retrieve a list of load balancers using pagination."""
+        balancers, next_marker = self._describe_load_balancers()
+        while next_marker is not None:
+            next_balancers, next_marker = self._describe_load_balancers(next_marker)
+            balancers.extend(next_balancers)
+        return balancers
+
+    @AWSExceptionHandler.handle_client_exception
+    def _describe_load_balancers(self, next_marker=None) -> Tuple[List[Any], str]:
+        """Retrieve a list of load balancers."""
+        describe_load_balancers_kwargs = {}
+        if next_marker:
+            describe_load_balancers_kwargs["Marker"] = next_marker
+        response = self._client.describe_load_balancers(**describe_load_balancers_kwargs)
+        return response["LoadBalancers"], response.get("NextMarker")
+
+    @AWSExceptionHandler.handle_client_exception
+    def describe_tags(self, load_balancer_arns: []):
+        """Retrieve a list of tags associated to the load balancer arns provided as parameter."""
+        """You can specify up to 20 load balancer arns in a single call."""
+        tags_response = self._client.describe_tags(ResourceArns=load_balancer_arns)
+        return tags_response.get("TagDescriptions")
+
+    @AWSExceptionHandler.handle_client_exception
+    def describe_target_groups(self, load_balancer_arn: str):
+        """Retrieve a list of target groups associated to the load balancer arn provided as parameter."""
+        target_group = self._client.describe_target_groups(LoadBalancerArn=load_balancer_arn)
+        return target_group.get("TargetGroups")
+
+    @AWSExceptionHandler.handle_client_exception
+    def describe_target_health(self, target_group_arn: str):
+        """Retrieve a list of target health associated to the target group arn provided as parameter."""
+        target_group_health = self._client.describe_target_health(TargetGroupArn=target_group_arn)
+        return target_group_health.get("TargetHealthDescriptions")

--- a/cli/tests/pcluster/aws/test_elb.py
+++ b/cli/tests/pcluster/aws/test_elb.py
@@ -1,0 +1,192 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the 'LICENSE.txt' file accompanying this file. This file is distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from assertpy import assert_that
+
+from pcluster.aws.elb import ElbClient
+from tests.utils import MockedBoto3Request
+
+
+@pytest.fixture()
+def boto3_stubber_path():
+    return "pcluster.aws.common.boto3"
+
+
+@pytest.mark.parametrize("generate_error", [True, False])
+def test_list_load_balancers(boto3_stubber, generate_error):
+    """Verify that list_instance_types behaves as expected."""
+    dummy_message = "dummy error message"
+
+    dummy_load_balancer = {
+        "LoadBalancerArn": "dummy_load_balancer_arn",
+        "DNSName": "dummy_dns_name",
+        "LoadBalancerName": "dummy-load-balancer",
+        "Scheme": "internet-facing",
+        "State": {"Code": "active"},
+    }
+
+    dummy_load_balancer_2 = {
+        "LoadBalancerArn": "dummy_load_balancer_arn_2",
+        "DNSName": "dummy_dns_name",
+        "LoadBalancerName": "dummy-load-balancer-2",
+        "Scheme": "internal",
+        "State": {"Code": "provisioning"},
+    }
+
+    dummy_next_marker = "next_marker"
+
+    mocked_requests = [
+        MockedBoto3Request(
+            method="describe_load_balancers",
+            expected_params={},
+            response={"LoadBalancers": [dummy_load_balancer], "NextMarker": dummy_next_marker, "ResponseMetadata": {}},
+            generate_error=False,
+        ),
+        MockedBoto3Request(
+            method="describe_load_balancers",
+            expected_params={"Marker": dummy_next_marker},
+            response=dummy_message
+            if generate_error
+            else {"LoadBalancers": [dummy_load_balancer_2], "ResponseMetadata": {}},
+            generate_error=generate_error,
+        ),
+    ]
+    boto3_stubber("elbv2", mocked_requests)
+    if generate_error:
+        with pytest.raises(BaseException, match=dummy_message):
+            ElbClient().list_load_balancers()
+    else:
+        return_value = ElbClient().list_load_balancers()
+        assert_that(return_value).is_equal_to([dummy_load_balancer, dummy_load_balancer_2])
+
+
+@pytest.mark.parametrize("generate_error", [True, False])
+def test_describe_tags(boto3_stubber, generate_error):
+    """Verify that list_instance_types behaves as expected."""
+    dummy_load_balancer_arns = ["dummy_load_balancer_arn", "another_dummy_load_balancer_arn"]
+    dummy_message = "dummy error message"
+    dummy_tags_description = [
+        {
+            "ResourceArn": "dummy_load_balancer_arn",
+            "Tags": [
+                {
+                    "Key": "parallelcluster:cluster-name",
+                    "Value": "pcluster-name-1",
+                },
+            ],
+        },
+        {
+            "ResourceArn": "another_dummy_load_balancer_arn",
+            "Tags": [
+                {
+                    "Key": "parallelcluster:cluster-name",
+                    "Value": "pcluster-name-2",
+                },
+            ],
+        },
+    ]
+    mocked_requests = [
+        MockedBoto3Request(
+            method="describe_tags",
+            expected_params={"ResourceArns": dummy_load_balancer_arns},
+            response=dummy_message
+            if generate_error
+            else {"TagDescriptions": dummy_tags_description, "ResponseMetadata": {}},
+            generate_error=generate_error,
+        )
+    ]
+    boto3_stubber("elbv2", mocked_requests)
+    if generate_error:
+        with pytest.raises(BaseException, match=dummy_message):
+            ElbClient().describe_tags(dummy_load_balancer_arns)
+    else:
+        return_value = ElbClient().describe_tags(dummy_load_balancer_arns)
+        assert_that(return_value).is_equal_to(dummy_tags_description)
+
+
+@pytest.mark.parametrize("generate_error", [True, False])
+def test_describe_targets_group(boto3_stubber, generate_error):
+    """Verify that describe_target_groups behaves as expected."""
+    dummy_load_balancer_arn = "dummy_load_balancer_arn"
+    dummy_message = "dummy error message"
+
+    dummy_target_groups = [
+        {
+            "HealthCheckPort": "22",
+            "LoadBalancerArns": [dummy_load_balancer_arn],
+        },
+        {
+            "HealthCheckPort": "22",
+            "LoadBalancerArns": [dummy_load_balancer_arn],
+        },
+    ]
+    mocked_requests = [
+        MockedBoto3Request(
+            method="describe_target_groups",
+            expected_params={"LoadBalancerArn": dummy_load_balancer_arn},
+            response=dummy_message if generate_error else {"TargetGroups": dummy_target_groups, "ResponseMetadata": {}},
+            generate_error=generate_error,
+        )
+    ]
+    boto3_stubber("elbv2", mocked_requests)
+    if generate_error:
+        with pytest.raises(BaseException, match=dummy_message):
+            ElbClient().describe_target_groups(dummy_load_balancer_arn)
+    else:
+        return_value = ElbClient().describe_target_groups(dummy_load_balancer_arn)
+        assert_that(return_value).is_equal_to(dummy_target_groups)
+
+
+@pytest.mark.parametrize("generate_error", [True, False])
+def test_describe_target_health(boto3_stubber, generate_error):
+    """Verify that describe_target_health behaves as expected."""
+    dummy_target_arn = "dummy_target_arn"
+    dummy_message = "dummy error message"
+    dummy_targets_health = [
+        {
+            "HealthCheckPort": "22",
+            "Target": {
+                "Id": "i-123456",
+                "Port": 22,
+            },
+            "TargetHealth": {
+                "State": "healthy",
+            },
+        },
+        {
+            "HealthCheckPort": "22",
+            "Target": {
+                "Id": "i-789101",
+                "Port": 22,
+            },
+            "TargetHealth": {
+                "State": "healthy",
+            },
+        },
+    ]
+    mocked_requests = [
+        MockedBoto3Request(
+            method="describe_target_health",
+            expected_params={"TargetGroupArn": "dummy_target_arn"},
+            response=dummy_message
+            if generate_error
+            else {"TargetHealthDescriptions": dummy_targets_health, "ResponseMetadata": {}},
+            generate_error=generate_error,
+        )
+    ]
+    boto3_stubber("elbv2", mocked_requests)
+    if generate_error:
+        with pytest.raises(BaseException, match=dummy_message):
+            ElbClient().describe_target_health(dummy_target_arn)
+    else:
+        return_value = ElbClient().describe_target_health(dummy_target_arn)
+        assert_that(return_value).is_equal_to(dummy_targets_health)


### PR DESCRIPTION
### Description of changes
* Add ELBv2 boto3 client and some methods useful to define the status of the login nodes pool.

### Tests
* Unit tests
* Manual test retrieving all the load balancers, tags, target groups and targets health available in my personal account. 

### References
* Login Nodes infrastructure: https://github.com/aws/aws-parallelcluster/commit/c732ab5fd0576f00a0b92954571cc1bc95af13c7

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
