### PR TITLE
[Integ-tests] Extend timeout to wait for node state update

### DIFF
--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -489,7 +489,7 @@ class SlurmCommands(SchedulerCommands):
             else current_node_states
         )
 
-    @retry(wait_fixed=seconds(15), stop_max_delay=minutes(6))
+    @retry(wait_fixed=seconds(15), stop_max_delay=minutes(8))
     def wait_nodes_status(self, status, filter_by_nodes=None):
         """Wait nodes to reach the status specified"""
         nodes_status = self.get_nodes_status(filter_by_nodes)


### PR DESCRIPTION
In our integration tests we have sporadic failures due to the fact that sometimes 6 minutes are not enough to reboot the compute nodes.

This is happening for example on test_multiple_efs.

