### PR TITLE
Remove dryrun argument from validate_create_request

### DIFF
--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -120,7 +120,7 @@ def create_cluster(
 
         if dryrun:
             ignored_validation_failures = cluster.validate_create_request(
-                get_validator_suppressors(suppress_validators), FailureLevel[validation_failure_level], dry_run=dryrun
+                get_validator_suppressors(suppress_validators), FailureLevel[validation_failure_level]
             )
             validation_messages = validation_results_to_config_validation_errors(ignored_validation_failures)
             raise DryrunOperationException(validation_messages=validation_messages or None)


### PR DESCRIPTION
* This argument has been removed as part of BYOS code removal.
* The IDE shows a warning "Remove unused argument".

### References
* https://github.com/aws/aws-parallelcluster/pull/5407


