### PR TITLE
Force the remote command executor to use only the key provided and add ubuntu2204 to integ test utils

### DIFF
--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -46,7 +46,10 @@ class RemoteCommandExecutor:
             "host": node_ip,
             "user": username,
             "forward_agent": False,
-            "connect_kwargs": {"key_filename": [alternate_ssh_key if alternate_ssh_key else cluster.ssh_key]},
+            "connect_kwargs": {
+                "key_filename": [alternate_ssh_key if alternate_ssh_key else cluster.ssh_key],
+                "look_for_keys": False,
+            },
         }
         if bastion:
             # Need to execute simple ssh command before using Connection to avoid Paramiko _check_banner error
@@ -55,6 +58,10 @@ class RemoteCommandExecutor:
             )
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
+        logging.info(
+            f"Connecting to {connection_kwargs['host']} as {connection_kwargs['user']} with "
+            f"{connection_kwargs['connect_kwargs']['key_filename']}"
+        )
         self.__connection = Connection(**connection_kwargs)
         self.__user_at_hostname = "{0}@{1}".format(username, node_ip)
 

--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -37,6 +37,10 @@ OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP = {
         "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-*-server-*",
         "owners": ["099720109477"],
     },
+    "ubuntu2204": {
+        "name": "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-*-server-*",
+        "owners": ["099720109477"],
+    },
     # We need to specify the minor because the most recently created RHEL8 AMI is currently 8.4
     "rhel8": {"name": "RHEL-8.7*_HVM*", "owners": ["309956199498", "841258680906", "219670896067"]},
 }

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -505,6 +505,7 @@ def get_username_for_os(os):
         "alinux2": "ec2-user",
         "centos7": "centos",
         "ubuntu2004": "ubuntu",
+        "ubuntu2204": "ubuntu",
         "rhel8": "ec2-user",
     }
     return usernames.get(os)


### PR DESCRIPTION
Added an additional log line to make it clear to the user what the parameters are for the integ test connection via SSH.

Forcing the use of only the key provided will prevent paramiko from trying to use another key that might be found on the system via the `look_for_keys` parameter.  https://docs.paramiko.org/en/latest/api/client.html#paramiko.client.SSHClient.connect

The integration test framework needs a user defined for each OS and an entry in the `OS_TO_OFFICIAL_AMI_NAME_OWNER_MAP` dictionary

### Tests
* Local integ tests and a full new os test suite on jenkins

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
