### PR TITLE
Add ubuntu 2204 to integration test configs develop and common

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -12,7 +12,7 @@ ad_integration:
               collective: ["osu_alltoall"]
       - regions: ["eu-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004", "centos7"]
+        oss: ["ubuntu2204", "centos7"]
         schedulers: ["slurm"]
 arm_pl:
   test_arm_pl.py::test_arm_pl:
@@ -39,7 +39,7 @@ cli_commands:
     dimensions:
       - regions: ["ap-northeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
 cloudwatch_logging:
   test_cloudwatch_logging.py::test_cloudwatch_logging:
@@ -56,7 +56,7 @@ cloudwatch_logging:
       # 2) run the test for all OSes with slurm
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["ubuntu2004", "rhel8"]
+        oss: ["ubuntu2204", "rhel8"]
         schedulers: ["slurm"]
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -79,7 +79,7 @@ configure:
     dimensions:
       - regions: ["af-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
       - regions: ["ap-southeast-2"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
@@ -139,7 +139,7 @@ create:
       - regions: ["ap-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         schedulers: ["slurm"]
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
   test_create.py::test_cluster_creation_timeout:
     dimensions:
       - regions: ["ap-northeast-2"]
@@ -162,7 +162,7 @@ createami:
     dimensions:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004", "alinux2", "rhel8"]
+        oss: ["ubuntu2204", "alinux2", "rhel8"]
   test_createami.py::test_kernel4_build_image_run_cluster:
     dimensions:
       - regions: ["eu-south-1"]
@@ -195,7 +195,7 @@ monitoring:
     dimensions:
       - regions: ["af-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
 dcv:
   test_dcv.py::test_dcv_configuration:
@@ -231,7 +231,7 @@ disable_hyperthreading:
     dimensions:
       - regions: ["us-west-1"]
         instances: ["c5.xlarge"]
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
         benchmarks:
           - mpi_variants: ["openmpi", "intelmpi"]
@@ -266,7 +266,7 @@ efa:
         schedulers: ["slurm"]
       - regions: ["use1-az6"]  # do not move, unless capacity reservation is moved as well
         instances: ["c6gn.16xlarge"]
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
       - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
         instances: [{{ common.instance("instance_type_1") }}]
@@ -385,7 +385,7 @@ scaling:
         schedulers: ["slurm"]
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
   test_mpi.py::test_mpi_ssh:
     dimensions:
@@ -414,7 +414,7 @@ schedulers:
     dimensions:
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
   test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
     dimensions:
@@ -466,7 +466,7 @@ schedulers:
     dimensions:
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
   test_slurm.py::test_scontrol_reboot:
     dimensions:
@@ -478,7 +478,7 @@ schedulers:
     dimensions:
       - regions: ["us-east-2"]
         instances: ["t2.medium"]
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
   test_slurm.py::test_slurm_overrides:
     dimensions:
@@ -496,7 +496,7 @@ schedulers:
     dimensions:
       - regions: ["ap-south-1"]
         instances:  {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
   test_slurm_accounting.py::test_slurm_accounting_disabled_to_enabled_update:
     dimensions:
@@ -532,7 +532,7 @@ storage:
         schedulers: ["slurm"]
       - regions: ["eu-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
   test_fsx_lustre.py::test_fsx_file_cache:
     dimensions:
@@ -542,7 +542,7 @@ storage:
         schedulers: [ "slurm" ]
       - regions: [ "eu-north-1" ]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: [ "ubuntu2004" ]
+        oss: [ "ubuntu2204" ]
         schedulers: [ "slurm" ]
   # The checks performed in test_multiple_fsx is the same as test_fsx_lustre.
   # We should consider this when assigning dimensions to each test.
@@ -611,7 +611,7 @@ storage:
         schedulers: ["awsbatch"]
       - regions: [ "ca-central-1" ]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: [ "slurm" ]
         benchmarks:
           - mpi_variants: ["intelmpi"]
@@ -643,7 +643,7 @@ storage:
     dimensions:
       - regions: ["us-east-2"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
   test_ebs.py::test_ebs_single:
     dimensions:
@@ -723,7 +723,7 @@ update:
         schedulers: ["slurm"]
       - regions: ["ap-northeast-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
   test_update.py::test_multi_az_create_and_update:
     dimensions:

--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -26,7 +26,7 @@ test-suites:
           schedulers: [ "slurm" ]
         - regions: ["use2-az2"]  # do not move, unless instance type support is moved as well
           instances: [{{ common.instance("instance_type_1") }}]
-          oss: ["ubuntu2004"]
+          oss: ["ubuntu2204"]
           schedulers: [ "slurm" ]
     test_fabric.py::test_fabric:
       dimensions:
@@ -85,7 +85,7 @@ test-suites:
       dimensions:
         - regions: ["us-west-2"]
           instances: {{ common.INSTANCES_DEFAULT_ARM }}
-          oss: ["ubuntu2004"]
+          oss: ["ubuntu2204"]
           schedulers: ["slurm"]
         - regions: ["cn-north-1"]
           instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -100,7 +100,7 @@ test-suites:
       dimensions:
         - regions: ["usw2-az4"]  # do not move, unless instance type support is moved as well
           schedulers: ["slurm"]
-          oss: ["ubuntu2004"]
+          oss: ["ubuntu2204"]
   custom_resource:
     test_cluster_custom_resource.py::test_cluster_create:
       dimensions:


### PR DESCRIPTION
Sprinkled ubuntu2204 across the integration tests for develop.yaml and common.yaml, replacing every other instance or so of ubuntu2004. 

### Tests
* Ran local integration tests to verify the refactor works

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
