### PR TITLE
Remove Ubuntu 22 from the remarkable AMI list until Deep Engine provides an AMI

### DIFF
--- a/tests/integration-tests/tests/common/utils.py
+++ b/tests/integration-tests/tests/common/utils.py
@@ -50,7 +50,6 @@ OS_TO_REMARKABLE_AMI_NAME_OWNER_MAP = {
     "alinux2": {"name": "Deep Learning Base AMI (Amazon Linux 2)*", "owners": ["amazon"]},
     "centos7": {"name": "FPGA Developer AMI*", "owners": ["679593333241"]},
     "ubuntu2004": {"name": "Deep Learning AMI GPU CUDA * (Ubuntu 20.04)*", "owners": ["amazon"]},
-    "ubuntu2204": {"name": "Deep Learning AMI GPU CUDA * (Ubuntu 22.04)*", "owners": ["amazon"]},
     # Simple redhat8 to be able to build in remarkable test
     "rhel8": {"name": "RHEL-8.7*_HVM*", "owners": ["309956199498", "841258680906", "219670896067"]},
 }

--- a/tests/integration-tests/tests/createami/test_createami.py
+++ b/tests/integration-tests/tests/createami/test_createami.py
@@ -73,8 +73,8 @@ def test_invalid_config(
 
     # Test Suppression of a validator
 
-    # Get base AMI -- remarkable AMIs are not available for ARM and ubuntu2004, centos7 yet
-    if os not in ["ubuntu2004", "centos7"]:
+    # Get base AMI -- remarkable AMIs are not available for ARM and ubuntu2204, centos7 yet
+    if os not in ["ubuntu2204", "centos7"]:
         base_ami = retrieve_latest_ami(region, os, ami_type="remarkable", architecture=architecture)
     else:
         base_ami = retrieve_latest_ami(region, os, architecture=architecture)


### PR DESCRIPTION
Removing the AMI from the list and disabling the test for remarkable AMIs on Ubuntu 22 until the upstream AMI is available.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
