### PR TITLE
Trainium with neuron is not yet supported for Ubuntu 22.  Fix test_create expected message

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -100,7 +100,7 @@ test-suites:
       dimensions:
         - regions: ["usw2-az4"]  # do not move, unless instance type support is moved as well
           schedulers: ["slurm"]
-          oss: ["ubuntu2204"]
+          oss: ["ubuntu2004"]
   custom_resource:
     test_cluster_custom_resource.py::test_cluster_create:
       dimensions:

--- a/tests/integration-tests/tests/create/test_create.py
+++ b/tests/integration-tests/tests/create/test_create.py
@@ -207,8 +207,7 @@ def test_cluster_creation_with_invalid_ebs(
     expected_cfn_failure_reason = (
         "Failed to mount EBS volume. Please check /var/log/chef-client.log in the head "
         "node, or check the chef-client.log in CloudWatch logs. Please refer to "
-        "https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html#"
-        "troubleshooting-v3-get-logs for more details on ParallelCluster logs."
+        "https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html for more details."
     )
 
     assert_that(cfn_failure_reason).contains(expected_cfn_failure_reason)


### PR DESCRIPTION
### References
https://github.com/aws/aws-parallelcluster-cookbook/pull/2234

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
