### PR TITLE
Avoid to call describe login nodes if they are not in the cluster config

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -285,7 +285,8 @@ class Cluster:
     def login_nodes_status(self):
         """Status of the login nodes pool."""
         login_nodes_status = LoginNodesStatus(self.stack_name)
-        login_nodes_status.retrieve_data()
+        if self.config.login_nodes:
+            login_nodes_status.retrieve_data()
         return login_nodes_status
 
     @property

--- a/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_cluster_operations_controller.py
@@ -836,8 +836,10 @@ class TestDescribeCluster:
                 "pcluster.models.cluster.Cluster.config_presigned_url", new_callable=mocker.PropertyMock
             ).side_effect = ClusterActionError("failed")
             mocker.patch(
-                "pcluster.models.cluster.Cluster.config", new_callable=mocker.PropertyMock
-            ).side_effect = ClusterActionError("failed")
+                "pcluster.models.cluster.Cluster.config",
+                new_callable=mocker.PropertyMock,
+                side_effect=[DummyLoginNodesConfig(False), ClusterActionError("failed")],
+            )
 
         response = self._send_test_request(client)
 
@@ -1132,8 +1134,11 @@ class TestDescribeCluster:
             "pcluster.models.cluster.Cluster.config_presigned_url", new_callable=mocker.PropertyMock
         ).side_effect = ClusterActionError("failed")
         mocker.patch(
-            "pcluster.models.cluster.Cluster.config", new_callable=mocker.PropertyMock
-        ).side_effect = ClusterActionError("failed")
+            "pcluster.models.cluster.Cluster.config",
+            new_callable=mocker.PropertyMock,
+            side_effect=[DummyLoginNodesConfig(False), ClusterActionError("failed")],
+        )
+
         response = self._send_test_request(client)
         with soft_assertions():
             assert_that(response.status_code).is_equal_to(200)
@@ -2435,3 +2440,8 @@ def test_analyze_changes(changes, expected_current_value, expected_requested_val
     change_set, errors = _analyze_changes(changes)
     assert_that(change_set[0].current_value).is_equal_to(expected_current_value)
     assert_that(change_set[0].requested_value).is_equal_to(expected_requested_value)
+
+
+class DummyLoginNodesConfig:
+    def __init__(self, is_available):
+        self.login_nodes = True if is_available else None

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -779,6 +779,7 @@ class TestCluster:
     @pytest.mark.parametrize("login_nodes_available", [True, False])
     def test_login_nodes_status(self, mocker, cluster, login_nodes_available):
         mock_aws_api(mocker)
+        cluster.config = dummy_slurm_cluster_config(mocker)
         mocker.patch("pcluster.models.login_nodes_status.LoginNodesStatus.retrieve_data")
         mocker.patch(
             "pcluster.models.login_nodes_status.LoginNodesStatus.get_login_nodes_pool_available",


### PR DESCRIPTION
### Description of changes
* Avoid to call describe login nodes if they are not in the cluster config

### Tests
* Manual test with a cluster with and without login nodes pool. Verified with the debugger the sequence of the internal calls.

### References
* Fix to the commit https://github.com/aws/aws-parallelcluster/commit/d9f40324303c0b62c02f68ca40eaa19d1f40c660

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
