### PR TITLE
[integ-tests-3.6] Remove `h1.2xlarge` instance type from the test_ephemeral integration…

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -661,7 +661,7 @@ storage:
   test_ephemeral.py::test_head_node_stop:
     dimensions:
       - regions: ["use1-az4"]
-        instances: ["m5d.xlarge", "h1.2xlarge"]
+        instances: ["m5d.xlarge"]  # SSD based instance
         oss: ["alinux2"]
         schedulers: ["slurm"]
 tags:


### PR DESCRIPTION
### Description of changes
- Cherry-picked from [5473](https://github.com/aws/aws-parallelcluster/pull/5473)
- `h1.2xlarge` has reduced availability in `us-east-1d` and is an old instance type based on HDD.
- This commit removes it from the `test_ephemeral` integration tests.

### Tests
* Ran the tests locally

### References
* https://github.com/aws/aws-parallelcluster/pull/2901

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
