### PR TITLE
[develop] Add DirectoryService config in login nodes dna.json

### DIFF
--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -60,7 +60,8 @@ write_files:
           "custom_awsbatchcli_package": "${CustomAwsBatchCliPackage}",
           "cw_logging_enabled": "false",
           "directory_service": {
-            "enabled": "${DirectoryServiceEnabled}"
+            "enabled": "${DirectoryServiceEnabled}",
+            "generate_ssh_keys_for_users": "${DirectoryServiceGenerateSshKeys}"
           },
           "ebs_shared_dirs": "${EbsSharedDirs}",
           "efs_fs_ids": "${EFSIds}",

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -96,6 +96,8 @@ class Pool(Construct):
             )
         ]
 
+        ds_config = self._config.directory_service
+        ds_generate_keys = str(ds_config.generate_ssh_keys_for_users).lower() if ds_config else "false"
         return ec2.CfnLaunchTemplate(
             self,
             f"LoginNodeLaunchTemplate{self._pool.name}",
@@ -113,14 +115,16 @@ class Pool(Construct):
                         get_user_data_content("../resources/login_node/user_data.sh"),
                         {
                             **{
-                                "RAIDSharedDir": to_comma_separated_string(
-                                    self._shared_storage_mount_dirs[SharedStorageType.RAID]
-                                ),
-                                "RAIDType": to_comma_separated_string(
-                                    self._shared_storage_attributes[SharedStorageType.RAID]["Type"]
-                                ),
-                                "DisableMultiThreadingManually": "false",
                                 "BaseOS": self._config.image.os,
+                                "ClusterName": self.stack_name,
+                                "CustomNodePackage": self._config.custom_node_package or "",
+                                "CustomAwsBatchCliPackage": self._config.custom_aws_batch_cli_package or "",
+                                "CWLoggingEnabled": "true" if self._config.is_cw_logging_enabled else "false",
+                                "DirectoryServiceEnabled": str(ds_config is not None).lower(),
+                                "DirectoryServiceGenerateSshKeys": ds_generate_keys,
+                                "EbsSharedDirs": to_comma_separated_string(
+                                    self._shared_storage_mount_dirs[SharedStorageType.EBS]
+                                ),
                                 "EFSIds": get_shared_storage_ids_by_type(
                                     self._shared_storage_infos, SharedStorageType.EFS
                                 ),
@@ -135,6 +139,8 @@ class Pool(Construct):
                                     self._shared_storage_attributes[SharedStorageType.EFS]["IamAuthorizations"],
                                     use_lower_case=True,
                                 ),
+                                "EphemeralDir": DEFAULT_EPHEMERAL_DIR,
+                                "ExtraJson": self._config.extra_chef_attributes,
                                 "FSXIds": get_shared_storage_ids_by_type(
                                     self._shared_storage_infos, SharedStorageType.FSX
                                 ),
@@ -153,24 +159,20 @@ class Pool(Construct):
                                 "FSXSharedDirs": to_comma_separated_string(
                                     self._shared_storage_mount_dirs[SharedStorageType.FSX]
                                 ),
-                                "Scheduler": self._config.scheduling.scheduler,
-                                "EphemeralDir": DEFAULT_EPHEMERAL_DIR,
-                                "EbsSharedDirs": to_comma_separated_string(
-                                    self._shared_storage_mount_dirs[SharedStorageType.EBS]
-                                ),
-                                "OSUser": OS_MAPPING[self._config.image.os]["user"],
-                                "ClusterName": self.stack_name,
+                                "HeadNodePrivateIp": self._head_eni.attr_primary_private_ip_address,
                                 "IntelHPCPlatform": "true" if self._config.is_intel_hpc_platform_enabled else "false",
-                                "CWLoggingEnabled": "true" if self._config.is_cw_logging_enabled else "false",
                                 "LogRotationEnabled": "true" if self._config.is_log_rotation_enabled else "false",
-                                "CustomNodePackage": self._config.custom_node_package or "",
-                                "CustomAwsBatchCliPackage": self._config.custom_aws_batch_cli_package or "",
-                                "ExtraJson": self._config.extra_chef_attributes,
+                                "OSUser": OS_MAPPING[self._config.image.os]["user"],
+                                "RAIDSharedDir": to_comma_separated_string(
+                                    self._shared_storage_mount_dirs[SharedStorageType.RAID]
+                                ),
+                                "RAIDType": to_comma_separated_string(
+                                    self._shared_storage_attributes[SharedStorageType.RAID]["Type"]
+                                ),
+                                "Scheduler": self._config.scheduling.scheduler,
                                 "UsePrivateHostname": str(
                                     get_attr(self._config, "scheduling.settings.dns.use_ec2_hostnames", default=False)
                                 ).lower(),
-                                "DirectoryServiceEnabled": str(self._config.directory_service is not None).lower(),
-                                "HeadNodePrivateIp": self._head_eni.attr_primary_private_ip_address,
                                 "Timeout": str(
                                     get_attr(
                                         self._config,


### PR DESCRIPTION
### Description of changes
To properly activate DirectoryService recipes in LoginNodes the configuration details must be injected in the dna.json
* Add Directory Service configuration in the LoginNodes dna.json
* Sort in alphabetical order params definition to make it easier find and update them

### Tests
* See linked PR

### References
* [Recipe changes](https://github.com/aws/aws-parallelcluster-cookbook/pull/2360)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
