### PR TITLE
[develop] Remove custom AMI from fast_failover test

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_fast_capacity_failover/pcluster.config.yaml
@@ -1,6 +1,5 @@
 Image:
   Os: {{ os }}
-  CustomAmi: ami-0b2e93208d0d6c2d8
 HeadNode:
   InstanceType: {{ instance }}
   Networking:


### PR DESCRIPTION
### Description of changes
The AMI was used for testing and debugging a fix 
It was pushed by mistake with the fix.

* Remove custom AMI from fast_failover test

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
