### PR TITLE
[Login Nodes] Set UpdatePolicy for LoginNodes parameters.

### DIFF
--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -313,3 +313,7 @@ UNSUPPORTED_OPERATIONS_MAP = {
 }
 
 MAX_TAGS_COUNT = 40  # Tags are limited to 50, reserve some tags for parallelcluster specified tags
+
+IAM_ROLE_REGEX = "^arn:.*:role/"
+IAM_INSTANCE_PROFILE_REGEX = "^arn:.*:instance-profile/"
+IAM_POLICY_REGEX = "^arn:.*:policy/"

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -172,6 +172,7 @@ class Cluster:
         self.__official_ami = None
         self.__has_running_capacity = None
         self.__running_capacity = None
+        self.__has_running_login_nodes = None
 
     @property
     def stack(self):
@@ -730,6 +731,14 @@ class Cluster:
                     self.compute_fleet_status_manager.get_status() != ComputeFleetStatus.STOPPED
                 )
         return self.__has_running_capacity
+
+    def has_running_login_nodes(self, updated_value: bool = False) -> bool:
+        """Return True if the cluster has running login nodes. Note: the value will be cached."""
+        if self.__has_running_login_nodes is None or updated_value:
+            self.__has_running_login_nodes = (
+                self.login_nodes_status.get_healthy_nodes() + self.login_nodes_status.get_unhealthy_nodes() != 0
+            )
+        return self.__has_running_login_nodes
 
     def get_running_capacity(self, updated_value: bool = False):
         """Return the number of instances or desired capacity. Note: the value will be cached."""

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -104,6 +104,9 @@ from pcluster.constants import (
     FSX_ONTAP,
     FSX_OPENZFS,
     FSX_VOLUME_ID_REGEX,
+    IAM_INSTANCE_PROFILE_REGEX,
+    IAM_POLICY_REGEX,
+    IAM_ROLE_REGEX,
     LUSTRE,
     MAX_SLURM_NODE_PRIORITY,
     MIN_SLURM_NODE_PRIORITY,
@@ -879,7 +882,7 @@ class ClusterIamSchema(BaseSchema):
 
     roles = fields.Nested(RolesSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     permissions_boundary = fields.Str(
-        metadata={"update_policy": UpdatePolicy.SUPPORTED}, validate=validate.Regexp("^arn:.*:policy/")
+        metadata={"update_policy": UpdatePolicy.SUPPORTED}, validate=validate.Regexp(IAM_POLICY_REGEX)
     )
 
     resource_prefix = fields.Str(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
@@ -894,7 +897,7 @@ class BaseIamSchema(BaseSchema):
     """Represent the schema of common Iam parameters used by head, queue and login nodes."""
 
     instance_role = fields.Str(
-        metadata={"update_policy": UpdatePolicy.SUPPORTED}, validate=validate.Regexp("^arn:.*:role/")
+        metadata={"update_policy": UpdatePolicy.SUPPORTED}, validate=validate.Regexp(IAM_ROLE_REGEX)
     )
     additional_iam_policies = fields.Nested(
         AdditionalIamPolicySchema, many=True, metadata={"update_policy": UpdatePolicy.SUPPORTED, "update_key": "Policy"}
@@ -934,7 +937,7 @@ class HeadNodeIamSchema(IamSchema):
     """Represent the schema of IAM for HeadNode."""
 
     instance_profile = fields.Str(
-        metadata={"update_policy": UpdatePolicy.UNSUPPORTED}, validate=validate.Regexp("^arn:.*:instance-profile/")
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED}, validate=validate.Regexp(IAM_INSTANCE_PROFILE_REGEX)
     )
 
 
@@ -943,7 +946,7 @@ class QueueIamSchema(IamSchema):
 
     instance_profile = fields.Str(
         metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP},
-        validate=validate.Regexp("^arn:.*:instance-profile/"),
+        validate=validate.Regexp(IAM_INSTANCE_PROFILE_REGEX),
     )
 
 
@@ -951,7 +954,7 @@ class LoginNodesIamSchema(BaseIamSchema):
     """Represent the IAM schema of LoginNodes."""
 
     instance_role = fields.Str(
-        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP}, validate=validate.Regexp("^arn:.*:role/")
+        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP}, validate=validate.Regexp(IAM_ROLE_REGEX)
     )
 
     additional_iam_policies = fields.Nested(
@@ -961,7 +964,7 @@ class LoginNodesIamSchema(BaseIamSchema):
     )
 
     instance_profile = fields.Str(
-        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP}, validate=validate.Regexp("^arn:.*:instance-profile/")
+        metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP}, validate=validate.Regexp(IAM_INSTANCE_PROFILE_REGEX)
     )
 
     @post_load
@@ -1331,8 +1334,11 @@ class LoginNodesPoolSchema(BaseSchema):
     )
     count = fields.Int(
         required=True,
-        validate=validate.Range(min=0, validate=validate.Range(min=0, error="The count for LoginNodes Pool must be greater than or equal to 0."),),
-        metadata={"update_policy": UpdatePolicy.SUPPORTED}
+        validate=validate.Range(
+            min=0,
+            validate=validate.Range(min=0, error="The count for LoginNodes Pool must be greater than or equal to 0."),
+        ),
+        metadata={"update_policy": UpdatePolicy.SUPPORTED},
     )
     ssh = fields.Nested(LoginNodesSshSchema, required=True, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
     iam = fields.Nested(LoginNodesIamSchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
@@ -1340,7 +1346,7 @@ class LoginNodesPoolSchema(BaseSchema):
         validate=validate.Range(
             min=1, max=120, error="The gracetime period for LoginNodes Pool must be an interger from 1 to 120."
         ),
-        metadata={"update_policy": UpdatePolicy.SUPPORTED}
+        metadata={"update_policy": UpdatePolicy.SUPPORTED},
     )
 
     @post_load

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1336,7 +1336,7 @@ class LoginNodesPoolSchema(BaseSchema):
         required=True,
         validate=validate.Range(
             min=0,
-            validate=validate.Range(min=0, error="The count for LoginNodes Pool must be greater than or equal to 0."),
+            error="The count for LoginNodes Pool must be greater than or equal to 0.",
         ),
         metadata={"update_policy": UpdatePolicy.SUPPORTED},
     )

--- a/cli/src/pcluster/schemas/common_schema.py
+++ b/cli/src/pcluster/schemas/common_schema.py
@@ -22,7 +22,7 @@ from marshmallow import Schema, ValidationError, fields, post_dump, post_load, p
 from pcluster.config.cluster_config import BaseTag
 from pcluster.config.common import AdditionalIamPolicy, Cookbook, DeploymentSettings, Imds, LambdaFunctionsVpcConfig
 from pcluster.config.update_policy import UpdatePolicy
-from pcluster.constants import PCLUSTER_PREFIX, SUPPORTED_ARCHITECTURES
+from pcluster.constants import IAM_POLICY_REGEX, PCLUSTER_PREFIX, SUPPORTED_ARCHITECTURES
 from pcluster.utils import to_pascal_case
 
 ALLOWED_VALUES = {
@@ -185,7 +185,7 @@ class AdditionalIamPolicySchema(BaseSchema):
     """Represent the schema of Additional IAM policy."""
 
     policy = fields.Str(
-        required=True, metadata={"update_policy": UpdatePolicy.SUPPORTED}, validate=validate.Regexp("^arn:.*:policy/")
+        required=True, metadata={"update_policy": UpdatePolicy.SUPPORTED}, validate=validate.Regexp(IAM_POLICY_REGEX)
     )
 
     @post_load

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -28,7 +28,7 @@ from pcluster.config.imagebuilder_config import (
     UpdateOsPackages,
     Volume,
 )
-from pcluster.constants import PCLUSTER_IMAGE_NAME_REGEX
+from pcluster.constants import IAM_INSTANCE_PROFILE_REGEX, IAM_POLICY_REGEX, IAM_ROLE_REGEX, PCLUSTER_IMAGE_NAME_REGEX
 from pcluster.imagebuilder_utils import AMI_NAME_REQUIRED_SUBSTRING
 from pcluster.schemas.common_schema import (
     ALLOWED_VALUES,
@@ -135,11 +135,11 @@ class DistributionConfigurationSchema(BaseSchema):
 class IamSchema(BaseSchema):
     """Represent the schema of the ImageBuilder IAM."""
 
-    instance_role = fields.Str(validate=validate.Regexp("^arn:.*:role/"))
-    instance_profile = fields.Str(validate=validate.Regexp("^arn:.*:instance-profile/"))
-    cleanup_lambda_role = fields.Str(validate=validate.Regexp("^arn:.*:role/"))
+    instance_role = fields.Str(validate=validate.Regexp(IAM_ROLE_REGEX))
+    instance_profile = fields.Str(validate=validate.Regexp(IAM_INSTANCE_PROFILE_REGEX))
+    cleanup_lambda_role = fields.Str(validate=validate.Regexp(IAM_ROLE_REGEX))
     additional_iam_policies = fields.Nested(AdditionalIamPolicySchema, many=True)
-    permissions_boundary = fields.Str(validate=validate.Regexp("^arn:.*:policy/"))
+    permissions_boundary = fields.Str(validate=validate.Regexp(IAM_POLICY_REGEX))
 
     @validates_schema
     def no_coexist_role_policies(self, data, **kwargs):


### PR DESCRIPTION
### Changes
Set UpdatePolicy for LoginNodes parameters.
In particular, all parameters require login nodes to be stopped, with the only exception for Count and GracetimePeriod.

### Tests
1. Existing unit tests
2. New unit tests
3. Manual verifications

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
