### PR TITLE
Give LoginNodes' ssh keyname a default value as HeadNode's keyname

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2789,6 +2789,12 @@ class SlurmClusterConfig(CommonSchedulerClusterConfig):
         super().__init__(cluster_name, **kwargs)
         self.scheduling = scheduling
         self.login_nodes = login_nodes
+        if self.login_nodes:
+            for pool in self.login_nodes.pools:
+                if pool.ssh and not pool.ssh.key_name:
+                    pool.ssh.key_name = self.head_node.ssh.key_name
+                elif not pool.ssh:
+                    pool.ssh = LoginNodesSsh(key_name=self.head_node.ssh.key_name)
         self.__image_dict = None
         # Cache capacity reservations information together to reduce number of boto3 calls.
         # Since this cache is only used for validation, if AWSClientError happens

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1340,7 +1340,7 @@ class LoginNodesPoolSchema(BaseSchema):
         ),
         metadata={"update_policy": UpdatePolicy.SUPPORTED},
     )
-    ssh = fields.Nested(LoginNodesSshSchema, required=True, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
+    ssh = fields.Nested(LoginNodesSshSchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
     iam = fields.Nested(LoginNodesIamSchema, metadata={"update_policy": UpdatePolicy.LOGIN_NODES_STOP})
     gracetime_period = fields.Int(
         validate=validate.Range(

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -13,6 +13,7 @@ from pcluster.config.cluster_config import (
     HeadNode,
     HeadNodeImage,
     HeadNodeNetworking,
+    HeadNodeSsh,
     HealthChecks,
     Image,
     LoginNodes,
@@ -547,6 +548,70 @@ class TestBaseClusterConfig:
     def test_job_exclusive_allocation_defaults(self, queue, expected_value):
         queue = SlurmQueue(**queue)
         assert_that(queue.job_exclusive_allocation).is_equal_to(expected_value)
+
+    @pytest.mark.parametrize(
+        "head_node_ssh, login_node_ssh, expected_value",
+        [
+            (
+                HeadNodeSsh(key_name="head-node-key"),
+                LoginNodesSsh(key_name="login-node-key"),
+                "login-node-key",
+            ),
+            (HeadNodeSsh(key_name="head-node-key"), None, "head-node-key"),
+            (
+                None,
+                LoginNodesSsh(key_name="login-node-key"),
+                "login-node-key",
+            ),
+            (
+                HeadNodeSsh(key_name="head-node-key"),
+                LoginNodesSsh(key_name=None),
+                "head-node-key",
+            ),
+            (
+                None,
+                None,
+                None,
+            ),
+        ],
+    )
+    def test_login_nodes_ssh_key_default_value(self, head_node_ssh, login_node_ssh, expected_value, mocker):
+        cluster_config = SlurmClusterConfig(
+            cluster_name="clustername",
+            login_nodes=LoginNodes(
+                [
+                    LoginNodesPool(
+                        name="test_pool",
+                        instance_type="t3.xlarge",
+                        image=LoginNodesImage(custom_ami="ami-12345678"),
+                        networking=LoginNodesNetworking(subnet_ids=["subnet-12345678"]),
+                        ssh=login_node_ssh,
+                    )
+                ]
+            ),
+            image=Image("alinux2"),
+            head_node=HeadNode("c5.xlarge", HeadNodeNetworking("subnet"), ssh=head_node_ssh),
+            scheduling=SlurmScheduling(
+                [
+                    SlurmQueue(
+                        name="queue0",
+                        networking=SlurmQueueNetworking(subnet_ids=["subnet"]),
+                        compute_resources=[
+                            SlurmComputeResource(name="compute_resource_1", instance_type="c5.xlarge"),
+                            SlurmFlexibleComputeResource(
+                                [FlexibleInstanceType(instance_type="c5.xlarge")], name="compute_resource_2"
+                            ),
+                            SlurmFlexibleComputeResource(
+                                [FlexibleInstanceType(instance_type="c5n.18xlarge")], name="compute_resource_3"
+                            ),
+                        ],
+                    )
+                ],
+            ),
+        )
+        print(cluster_config.head_node.ssh.key_name)
+        print(cluster_config.login_nodes.pools[0].ssh.key_name)
+        assert_that(cluster_config.login_nodes.pools[0].ssh.key_name).is_equal_to(expected_value)
 
 
 class TestSharedEbs:

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -423,6 +423,26 @@ class LoginNodeLTAssertion:
                 InstanceTypeLTAssertion(has_instance_type=True),
             ],
         ),
+        (
+            "test-login-nodes-stack-without-ssh.yaml",
+            [
+                LoginNodeLTAssertion(
+                    pool_name="testloginnodespool1",
+                    instance_type="t2.micro",
+                    count=2,
+                    subnet_ids=["subnet-12345678"],
+                    key_name="ec2-key-name",
+                    gracetime_period=120,
+                    security_groups=[
+                        "sg-34567891",
+                        "sg-34567892",
+                        "sg-34567893",
+                    ],
+                ),
+                NetworkInterfaceLTAssertion(no_of_network_interfaces=3, subnet_id="subnet-12345678"),
+                InstanceTypeLTAssertion(has_instance_type=True),
+            ],
+        ),
     ],
 )
 def test_login_nodes_launch_template_properties(

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_login_nodes_launch_template_properties/test-login-nodes-stack-without-ssh.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_login_nodes_launch_template_properties/test-login-nodes-stack-without-ssh.yaml
@@ -1,0 +1,34 @@
+Region: eu-west-1
+Image:
+  Os: alinux2
+LoginNodes:
+  Pools:
+  - Name: testloginnodespool1
+    InstanceType: t2.micro
+    Count: 2
+    GracetimePeriod: 120
+    Networking:
+      SubnetIds:
+      - subnet-12345678
+      SecurityGroups:
+      - sg-34567891
+      - sg-34567892
+      - sg-34567893
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue1
+    ComputeResources:
+    - Name: testcomputeresource
+      InstanceType: c4.xlarge
+      MinCount: 0
+      MaxCount: 10
+    Networking:
+      SubnetIds:
+      - subnet-12345678


### PR DESCRIPTION
### Description of changes
* Modify cluster_config.py
  * Modify SlurmClusterConfig to give LoginNodes' ssh keyname a default value as HeadNode's keyname
* Modify cluster_schema.py
  * Make LoginNodes Ssh section not required
* Modify test_cluster_stack.py
  * Add unit test of creating cluster without LoginNodes' ssh section

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.
