### PR TITLE
Update the AD integration test to use the new ED25519 keys that are generated in the cookbook

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -26,7 +26,7 @@ from assertpy import assert_that
 from cfn_stacks_factory import CfnStack, CfnVpcStack
 from OpenSSL import crypto
 from OpenSSL.crypto import FILETYPE_PEM, TYPE_RSA, X509, dump_certificate, dump_privatekey
-from paramiko import RSAKey
+from paramiko import Ed25519Key
 from remote_command_executor import RemoteCommandExecutor
 from retrying import retry
 from time_utils import seconds
@@ -636,7 +636,7 @@ def _check_ssh_key(user, ssh_generation_enabled, remote_command_executor, schedu
         key_content = result.stdout
         assert_that(key_content).is_not_empty()
 
-        user_command_executor = user.ssh_connect(pkey=RSAKey.from_private_key(io.StringIO(key_content)))
+        user_command_executor = user.ssh_connect(pkey=Ed25519Key.from_private_key(io.StringIO(key_content)))
         logging.info(
             "Verified SSH key usable for SSH login to the head node for user %s (expected to exist: %s)",
             user.alias,


### PR DESCRIPTION
### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2350/files.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
