### PR TITLE
Allow configuration of Cloudwatch log collection on login nodes

### DIFF
--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -58,7 +58,7 @@ write_files:
           "cluster_user": "${OSUser}",
           "custom_node_package": "${CustomNodePackage}",
           "custom_awsbatchcli_package": "${CustomAwsBatchCliPackage}",
-          "cw_logging_enabled": "false",
+          "cw_logging_enabled": "${CWLoggingEnabled}",
           "directory_service": {
             "enabled": "${DirectoryServiceEnabled}",
             "generate_ssh_keys_for_users": "${DirectoryServiceGenerateSshKeys}"
@@ -79,6 +79,7 @@ write_files:
           "head_node_private_ip": "${HeadNodePrivateIp}",
           "dns_domain": "${ClusterDNSDomain}",
           "hosted_zone": "${ClusterHostedZone}",
+          "log_group_name": "${LogGroupName}",
           "log_rotation_enabled": "${LogRotationEnabled}",
           "node_type": "LoginNode",
           "proxy": "${ProxyServer}",

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -431,6 +431,7 @@ class ClusterCdkStack:
                 scope=self.stack,
                 id="LoginNodes",
                 cluster_config=self.config,
+                log_group=self.log_group,
                 shared_storage_infos=self.shared_storage_infos,
                 shared_storage_mount_dirs=self.shared_storage_mount_dirs,
                 shared_storage_attributes=self.shared_storage_attributes,


### PR DESCRIPTION
### Description of changes
* Allow configuration of CloudWatch log collection on login nodes

### Tests
* PENDING adding unit tests for the login stack dna.json generation (to be done in a separate PR)
* manually created a cluster with login nodes and verified that selected logs were uploaded to the CW log group.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2363

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
