### PR TITLE
Ignore describe-cluster exceptions when getting information about login nodes

### DIFF
--- a/cli/src/pcluster/api/controllers/cluster_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/cluster_operations_controller.py
@@ -252,13 +252,13 @@ def describe_cluster(cluster_name, region=None):
             state=InstanceState.from_dict(head_node.state),
             private_ip_address=head_node.private_ip,
         )
+        login_nodes = _get_login_nodes(cluster)
+        if login_nodes:
+            response.login_nodes = login_nodes
     except ClusterActionError as e:
-        # This should not be treated as a failure cause head node might not be running in some cases
+        # This should not be treated as a failure cause head node and login node might not be running in some cases.
+        # e.g. when the cluster is in DELETE_IN_PROGRESS
         LOGGER.info(e)
-
-    login_nodes = _get_login_nodes(cluster)
-    if login_nodes:
-        response.login_nodes = login_nodes
 
     return response
 


### PR DESCRIPTION
Login node and/or S3 bucket might not be available in some cases. e.g. when the cluster is in DELETE_IN_PROGRESS

### Tests
The following integration tests have been passed, which were failing intermittently prior to this change
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  custom_resource:
    test_cluster_custom_resource.py::test_cluster_create:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_create_invalid:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_update:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_update_invalid:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_update_tag_propagation:
      dimensions:
        - oss: [ "alinux2" ]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_delete_out_of_band:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_delete_retain:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
```


### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
