### PR TITLE
[Login Nodes] Add 'dns_domain' and 'hosted_zone' to dna.json in login nodes

### DIFF
--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -77,6 +77,8 @@ write_files:
           "fsx_fs_types": "${FSXFileSystemTypes}",
           "fsx_shared_dirs": "${FSXSharedDirs}",
           "head_node_private_ip": "${HeadNodePrivateIp}",
+          "dns_domain": "${ClusterDNSDomain}",
+          "hosted_zone": "${ClusterHostedZone}",
           "log_rotation_enabled": "${LogRotationEnabled}",
           "node_type": "LoginNode",
           "proxy": "${ProxyServer}",

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -410,6 +410,7 @@ class ClusterCdkStack:
                 shared_storage_attributes=self.shared_storage_attributes,
                 login_security_group=self._login_security_group,
                 head_eni=self._head_eni,
+                cluster_hosted_zone=self.scheduler_resources.cluster_hosted_zone if self.scheduler_resources else None,
             )
             # Add dependency on the Head Node construct
             self.login_nodes_stack.node.add_dependency(self.head_node_instance)


### PR DESCRIPTION
### Description of changes
Add 'dns_domain' and 'hosted_zone' to dna.json in login nodes, so that the cookbook has all the info to configure the DNS in login nodes.

the lack of this info was causing the cookbook to skip some DNs configuration steps. In particular it was skipping the configuration of `/etc/dhcp/dhclient.conf` which is responsible to add the cluster domain name to the search patterns for domain resolution.

### Tests
Manual test: without this change, the login nodes did not have the DNS properly configured, causing the srun command to fail when executed from login nodes due to hostname resolution failure.
With this change the DNS is properly configured in login nodes:

```
[ec2-user@ip-3-5-59-73 ~]$ sudo cat /etc/dhcp/dhclient.conf
timeout 300;

# Enable the DHCPv6 Client FQDN Option in our DHCPv6 requests:
also request dhcp6.fqdn;

# Fill in the Client FQDN Option flags field. The EC2 DHCPv6 server
# will override our settings if they don't match what it supports, so
# the exact value here does not matter, but this is configured to
# match what it would set:
send fqdn.server-update true;
send fqdn.no-client-update false;
append domain-name " login-20230714-3.pcluster.";
```
and both batch and interactive jobs can be executed:

```
[ec2-user@ip-3-5-59-73 ~]$ srun -n1 -N1 hostname
q1-st-t3medium-1

[ec2-user@ip-3-5-59-73 ~]$ sbatch --wrap hostname
Submitted batch job 2
[ec2-user@ip-3-5-59-73 ~]$ cat /home/ec2-user/slurm-2.out 
q1-st-t3medium-1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
