### PR TITLE
Use ED25519 keys for cluster_user.py in integ tests

### DIFF
--- a/tests/integration-tests/tests/ad_integration/cluster_user.py
+++ b/tests/integration-tests/tests/ad_integration/cluster_user.py
@@ -40,7 +40,7 @@ class ClusterUser:
         self._configure_public_ssh_keys()
 
     def _generate_ssh_keypair(self):
-        """Create an RSA SSH keypair for the user."""
+        """Create an ED25519 SSH keypair for the user."""
         logging.info("Creating SSH keypair for user %s", self.alias)
         cmd = [
             "ssh-keygen",
@@ -48,7 +48,7 @@ class ClusterUser:
             "-f",
             self.ssh_keypair_path_prefix,
             "-t",
-            "rsa",
+            "ed25519",
             "-N",
             "",
             "-C",


### PR DESCRIPTION
### References
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
