### PR TITLE
Retrieve Login Nodes pool based on its name in the describe cluster

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -287,7 +287,9 @@ class Cluster:
         """Status of the login nodes pool."""
         login_nodes_status = LoginNodesStatus(self.stack_name)
         if self.stack.scheduler == "slurm" and self.config.login_nodes:
-            login_nodes_status.retrieve_data()
+            # This approach works since by design we have now only one pool.
+            # We should fix this if we want to add more than a login nodes pool per cluster.
+            login_nodes_status.retrieve_data(self.config.login_nodes.pools[0].name)
         return login_nodes_status
 
     @property

--- a/cli/src/pcluster/models/login_nodes_status.py
+++ b/cli/src/pcluster/models/login_nodes_status.py
@@ -33,6 +33,7 @@ class LoginNodesStatus:
 
     def __init__(self, stack_name):
         self._stack_name = stack_name
+        self._login_nodes_pool_name = None
         self._login_nodes_pool_available = False
         self._load_balancer_arn = None
         self._target_group_arn = None
@@ -72,8 +73,9 @@ class LoginNodesStatus:
         """Return the number of unhealthy nodes of a login nodes fleet."""
         return self._unhealthy_nodes
 
-    def retrieve_data(self):
+    def retrieve_data(self, login_nodes_pool_name):
         """Initialize the class with the information related to the login nodes pool."""
+        self._login_nodes_pool_name = login_nodes_pool_name
         self._retrieve_assigned_load_balancer()
         if self._load_balancer_arn:
             self._login_nodes_pool_available = True
@@ -82,14 +84,8 @@ class LoginNodesStatus:
 
     def _retrieve_assigned_load_balancer(self):
         load_balancers = AWSApi.instance().elb.list_load_balancers()
-        tags = self._retrieve_all_tags([o.get("LoadBalancerArn") for o in load_balancers])
-        for tag in tags:
-            if any(
-                "parallelcluster:cluster-name" == kv.get("Key") and kv.get("Value") == self._stack_name
-                for kv in tag.get("Tags")
-            ):
-                self._load_balancer_arn = tag.get("ResourceArn")
-                break
+        tags_list = self._retrieve_all_tags([o.get("LoadBalancerArn") for o in load_balancers])
+        self._load_balancer_arn_from_tags(tags_list)
         if self._load_balancer_arn:
             for load_balancer in load_balancers:
                 if load_balancer.get("LoadBalancerArn") == self._load_balancer_arn:
@@ -97,6 +93,19 @@ class LoginNodesStatus:
                     self._dns_name = load_balancer.get("DNSName")
                     self._scheme = load_balancer.get("Scheme")
                     break
+
+    def _load_balancer_arn_from_tags(self, tags_list):
+        for tags in tags_list:
+            if self._key_value_tag_found(
+                tags, "parallelcluster:cluster-name", self._stack_name
+            ) and self._key_value_tag_found(tags, "parallelcluster:login-nodes-pool", self._login_nodes_pool_name):
+                self._load_balancer_arn = tags.get("ResourceArn")
+                break
+
+    def _key_value_tag_found(self, tags, key, value):
+        if any(key == kv.get("Key") and kv.get("Value") == value for kv in tags.get("Tags")):
+            return True
+        return False
 
     def _retrieve_all_tags(self, load_balancers):
         tags = []

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -38,6 +38,7 @@ from aws_cdk.core import (
     Duration,
     Fn,
     Stack,
+    Tags,
 )
 
 from pcluster.aws.aws_api import AWSApi
@@ -411,6 +412,12 @@ class ClusterCdkStack:
                 login_security_group=self._login_security_group,
                 head_eni=self._head_eni,
                 cluster_hosted_zone=self.scheduler_resources.cluster_hosted_zone if self.scheduler_resources else None,
+            )
+            Tags.of(self.login_nodes_stack).add(
+                # This approach works since by design we have now only one pool.
+                # We should fix this if we want to add more than a login nodes pool per cluster.
+                "parallelcluster:login-nodes-pool",
+                self.config.login_nodes.pools[0].name,
             )
             # Add dependency on the Head Node construct
             self.login_nodes_stack.node.add_dependency(self.head_node_instance)

--- a/cli/tests/pcluster/models/test_login_nodes_status.py
+++ b/cli/tests/pcluster/models/test_login_nodes_status.py
@@ -8,6 +8,7 @@ class TestLoginNodesStatus:
     dummy_stack_name = "dummy_cluster_name"
     dummy_load_balancer_arn = "dummy_load_balancer_arn"
     dummy_load_balancer_arn_2 = "dummy_load_balancer_arn_2"
+    dummy_pool_name = "dummy_pool_name"
     dummy_scheme = "internet-facing"
     dummy_status = "active"
     dummy_dns_name = "dummy_dns_name"
@@ -36,14 +37,22 @@ class TestLoginNodesStatus:
                     "Key": "parallelcluster:cluster-name",
                     "Value": dummy_stack_name,
                 },
+                {
+                    "Key": "parallelcluster:login-nodes-pool",
+                    "Value": dummy_pool_name,
+                },
             ],
         },
         {
             "ResourceArn": "another_dummy_load_balancer_arn",
             "Tags": [
                 {
-                    "Key": dummy_load_balancer_arn_2,
+                    "Key": "parallelcluster:cluster-name",
                     "Value": "pcluster-name-2",
+                },
+                {
+                    "Key": "parallelcluster:login-nodes-pool",
+                    "Value": "dummy_pool_name_2",
                 },
             ],
         },
@@ -100,7 +109,7 @@ class TestLoginNodesStatus:
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_groups", return_value=self.dummy_target_groups)
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_health", return_value=self.dummy_targets_health)
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data()
+        login_nodes_status.retrieve_data(self.dummy_pool_name)
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_true()
         assert_that(login_nodes_status.get_status()).is_equal_to(LoginNodesPoolState.ACTIVE)
         assert_that(login_nodes_status.get_address()).is_equal_to(self.dummy_dns_name)
@@ -121,7 +130,7 @@ class TestLoginNodesStatus:
         mocker.patch("pcluster.aws.elb.ElbClient.__init__", return_value=None)
         mocker.patch("pcluster.aws.elb.ElbClient.list_load_balancers", return_value=[])
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data()
+        login_nodes_status.retrieve_data(self.dummy_pool_name)
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_false()
 
     def test_wrong_load_balancer_available(self, mocker):
@@ -140,7 +149,7 @@ class TestLoginNodesStatus:
         ]
         mocker.patch("pcluster.aws.elb.ElbClient.describe_tags", return_value=dummy_tags_description)
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data()
+        login_nodes_status.retrieve_data(self.dummy_pool_name)
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_false()
 
     def test_target_group_arn_not_available(self, mocker):
@@ -154,7 +163,7 @@ class TestLoginNodesStatus:
             "pcluster.aws.elb.ElbClient.describe_target_groups", side_effect=Exception("Target Group Not Available")
         )
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data()
+        login_nodes_status.retrieve_data(self.dummy_pool_name)
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_true()
         assert_that(login_nodes_status.get_healthy_nodes()).is_none()
         assert_that(login_nodes_status.get_unhealthy_nodes()).is_none()
@@ -171,7 +180,7 @@ class TestLoginNodesStatus:
             "pcluster.aws.elb.ElbClient.describe_target_health", side_effect=Exception("Target Group Not Available")
         )
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data()
+        login_nodes_status.retrieve_data(self.dummy_pool_name)
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_true()
         assert_that(login_nodes_status.get_healthy_nodes()).is_none()
         assert_that(login_nodes_status.get_unhealthy_nodes()).is_none()
@@ -202,6 +211,6 @@ class TestLoginNodesStatus:
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_groups", return_value=self.dummy_target_groups)
         mocker.patch("pcluster.aws.elb.ElbClient.describe_target_health", return_value=self.dummy_targets_health)
         login_nodes_status = LoginNodesStatus(self.dummy_stack_name)
-        login_nodes_status.retrieve_data()
+        login_nodes_status.retrieve_data(self.dummy_pool_name)
         assert_that(login_nodes_status.get_login_nodes_pool_available()).is_true()
         assert_that(login_nodes_status.get_status()).is_equal_to(expected_status)


### PR DESCRIPTION
### Description of changes
* Add a tag to all resources related to the login nodes
* Retrieve Login Nodes pool based on its name in the describe cluster

### Tests
* Unit tests updated
* Manual tests with debug completed. Verified multiple clusters with several login nodes pools and cluster without login nodes: the _describe cluster_ works as expected.

### Checklist
- [X] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [X] Check all commits' messages are clear, describing what and why vs how.
- [X] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [X] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
