### PR TITLE
[integ-tests] Fix failures of test_ad_integration

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -525,6 +525,7 @@ def _check_ssh_key_generation(user, remote_command_executor, scheduler_commands,
     # Remove user's home directory to ensure public SSH key doesn't exist
     user.cleanup()
     user.ssh_connect()
+    time.sleep(3)
     _check_home_directory(user, remote_command_executor)
     _check_ssh_key(user, generate_ssh_keys_for_user, remote_command_executor, scheduler_commands)
     logging.info(


### PR DESCRIPTION
Prior to this change, there were consistent failure on CentOS 7, but consistent success on Ubuntu and Amazon Linux. After this change, the tests on CentOS 7 do not fail.

We use [Pluggable Authentication Module](https://en.wikipedia.org/wiki/Pluggable_authentication_module) to create home directory (and SSH key) upon SSH login. My guess is that there might be some delay in PAM execution.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
