### PR TITLE
[integ-tests-3.6.1] Fix logic in test_queue_parameters_update and test_efa integration tests

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -21,6 +21,6 @@ flask>=2.2.5,==2.2.*
 jinja2~=3.0
 jmespath~=0.10
 marshmallow~=3.10
-PyYAML~=5.3
+PyYAML==5.3.1
 tabulate>=0.8.8,<=0.8.10
 werkzeug~=2.0

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -26,7 +26,7 @@ REQUIRES = [
     "setuptools",
     "boto3>=1.16.14",
     "tabulate>=0.8.8,<=0.8.10",
-    "PyYAML~=5.3",
+    "PyYAML==5.3.1",
     "jinja2~=3.0",
     "marshmallow~=3.10",
     "aws-cdk.core~=" + CDK_VERSION,

--- a/cloudformation/tests/requirements.txt
+++ b/cloudformation/tests/requirements.txt
@@ -1,7 +1,7 @@
-pytest
-jinja2~=3.0
-cfn-lint
-cfn-flip
 assertpy
 boto3
-PyYAML~=5.3
+cfn-flip
+cfn-lint
+jinja2~=3.0
+pytest
+PyYAML==5.3.1

--- a/tests/integration-tests/tests/common/assertions.py
+++ b/tests/integration-tests/tests/common/assertions.py
@@ -35,6 +35,7 @@ def assert_instance_replaced_or_terminating(instance_id, region):
 
 def assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=False):
     __tracebackhide__ = True
+    ice_patterns = ["InsufficientInstanceCapacity", "Failed to launch instances due to limited EC2 capacity"]
     if scheduler == "slurm":
         log_files = [
             "/var/log/parallelcluster/clustermgtd",
@@ -53,7 +54,7 @@ def assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=False)
     for log_file in log_files:
         log = remote_command_executor.run_remote_command("sudo cat {0}".format(log_file), hide=True).stdout
         if skip_ice:
-            log = "\n".join([line for line in log.splitlines() if "InsufficientInstanceCapacity" not in line])
+            log = "\n".join([line for line in log.splitlines() if not any(pattern in line for pattern in ice_patterns)])
         for error_level in ["CRITICAL", "ERROR"]:
             assert_that(log).does_not_contain(error_level)
 

--- a/tests/integration-tests/tests/common/mpi_common.py
+++ b/tests/integration-tests/tests/common/mpi_common.py
@@ -3,7 +3,7 @@ import pathlib
 
 from assertpy import assert_that
 
-from tests.common.assertions import assert_no_errors_in_logs, assert_scaling_worked
+from tests.common.assertions import assert_scaling_worked
 
 MPI_COMMON_DATADIR = pathlib.Path(__file__).parent / "data/mpi/"
 
@@ -80,5 +80,3 @@ def _test_mpi(
     )
     assert_that(mpi_out).contains("Process 0 received token -1 from process 1")
     assert_that(mpi_out).contains("Process 1 received token -1 from process 0")
-
-    assert_no_errors_in_logs(remote_command_executor, scheduler, skip_ice=True)

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -29,12 +29,7 @@ from time_utils import minutes, seconds
 from utils import describe_cluster_instances, is_fsx_supported, retrieve_cfn_resources, wait_for_computefleet_changed
 
 from tests.common.assertions import assert_lines_in_logs, assert_no_msg_in_logs
-from tests.common.hit_common import (
-    assert_compute_node_reasons,
-    assert_compute_node_states,
-    assert_initial_conditions,
-    wait_for_compute_nodes_states,
-)
+from tests.common.hit_common import assert_compute_node_states, assert_initial_conditions, wait_for_compute_nodes_states
 from tests.common.scaling_common import get_batch_ce, get_batch_ce_max_size, get_batch_ce_min_size
 from tests.common.schedulers_common import SlurmCommands
 from tests.common.storage.assertions import assert_storage_existence
@@ -860,8 +855,6 @@ def _test_update_queue_strategy_with_running_job(
         remote_command_executor.run_remote_command(f"scontrol requeue {queue2_job_id}")
     elif queue_update_strategy == "TERMINATE":
         scheduler_commands.assert_job_state(queue2_job_id, "PENDING")
-        expected_reason = "updating node state during cluster update"
-        assert_compute_node_reasons(scheduler_commands, queue2_nodes, expected_reason=expected_reason)
 
     # Be sure the queue2 job is running even after the forced termination: we need the nodes active so that we
     # can check the AMI id on the instances

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -774,7 +774,9 @@ def _test_update_queue_strategy_without_running_job(
         ],
     )
     queue1_nodes = scheduler_commands.get_compute_nodes("queue1")
-    wait_for_compute_nodes_states(scheduler_commands, queue1_nodes, expected_states=["idle", "idle~"])
+    wait_for_compute_nodes_states(
+        scheduler_commands, queue1_nodes, expected_states=["idle", "idle~"], stop_max_delay_secs=600
+    )
     # test volume size are expected after update
     instances = cluster.get_cluster_instance_ids(node_type="Compute", queue_name="queue1")
     for instance in instances:


### PR DESCRIPTION
### Description of changes
* Increase timeout in one of the functions of the `test_queue_parameters_update` integration test to wait a longer time for nodes to come back after queue parameter update strategy action;
* include CreateFleet limited capacity log pattern when skipping ICE errors in the ParallelCluster logs within `assert_no_errors_in_logs` (used by `test_efa`).
* Remove usage of `assert_no_errors_in_logs` within a `_test_mpi()` function called by the `test_efa` integration test.
* Fix the logic of the `test_queue_parameters_update` test, which was relying on the submission of job arrays instead of multi-node jobs, which caused several issues.

### Tests
* Successful manual run of modified integration tests

### References
* https://github.com/aws/aws-parallelcluster/pull/5512

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [ ] ~Make sure **to have added unit tests or integration tests** to cover the new/modified code.~
- [ ] ~Check if documentation is impacted by this change.~

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

