### PR TITLE
Remove dangling IAM policies resources when CustomLambdaRole is specified in cfn custom resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ CHANGELOG
 
 **BUG FIXES**
 - Add validation to `ScaledownIdletime` value, to prevent setting a value lower than `-1`.
+- Fix issue causing dangling IAM policies to be created when creating ParallelCluster CloudFormation custom resource provider with `CustomLambdaRole`.
 
 3.6.1
 ------

--- a/cloudformation/custom_resource/cluster.yaml
+++ b/cloudformation/custom_resource/cluster.yaml
@@ -68,6 +68,7 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${PclusterCfnFunction}
 
   EventsPolicy:
+    Condition: UsePCPolicies
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
@@ -82,6 +83,7 @@ Resources:
               - events:RemoveTargets
             Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*
   S3Policy:
+    Condition: UsePCPolicies
     Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:


### PR DESCRIPTION
### Description of changes
When `CustomLambdaRole` is specified, `cluster.yaml` does not create another Lambda role. Prior to this change dangling IAM policies were created. They were dangling because they were not used by any roles.

### Tests
Add a check in integration test to make sure no IAM resources are created when `CustomLambdaRole` is specified.
The following tests have been passed:
```
{%- import 'common.jinja2' as common with context -%}
---
test-suites:
  custom_resource:
    test_cluster_custom_resource.py::test_cluster_create:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_create_invalid:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_update:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_update_invalid:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_update_tag_propagation:
      dimensions:
        - oss: [ "alinux2" ]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_delete_out_of_band:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_delete_retain:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
    test_cluster_custom_resource.py::test_cluster_create_with_custom_policies:
      dimensions:
        - oss: ["alinux2"]
          regions: ["us-east-2"]
          instances: {{ common.INSTANCES_DEFAULT_X86 }}
```

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
