### PR TITLE
[Directory Service] Remove redundant tests, keeping only SimpleAD with LDAP and MicrosoftAD with LDAPS.

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -663,8 +663,8 @@ def _check_ssh_key(user, ssh_generation_enabled, remote_command_executor, schedu
     [
         ("SimpleAD", "ldap", False),
         # ("SimpleAD", "ldaps", False),
-        ("SimpleAD", "ldaps", True),
-        ("MicrosoftAD", "ldap", False),
+        # ("SimpleAD", "ldaps", True),
+        # ("MicrosoftAD", "ldap", False),
         # ("MicrosoftAD", "ldaps", False),
         ("MicrosoftAD", "ldaps", True),
     ],


### PR DESCRIPTION
### Description of changes
Remove redundant tests, keeping only:
1. SimpleAD with LDAP, which is the simplest case
2. MicrosoftAD with LDAPS, which is the most complete case

### Tests
Not needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
