### PR TITLE
Add read_only user in LoginNode dna.json

### DIFF
--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -61,6 +61,7 @@ write_files:
           "cw_logging_enabled": "${CWLoggingEnabled}",
           "directory_service": {
             "enabled": "${DirectoryServiceEnabled}",
+            "domain_read_only_user": "${DirectoryServiceReadOnlyUser}",
             "generate_ssh_keys_for_users": "${DirectoryServiceGenerateSshKeys}"
           },
           "ebs_shared_dirs": "${EbsSharedDirs}",

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -132,6 +132,7 @@ class Pool(Construct):
                                 "CustomAwsBatchCliPackage": self._config.custom_aws_batch_cli_package or "",
                                 "CWLoggingEnabled": "true" if self._config.is_cw_logging_enabled else "false",
                                 "DirectoryServiceEnabled": str(ds_config is not None).lower(),
+                                "DirectoryServiceReadOnlyUser": ds_config.domain_read_only_user if ds_config else "",
                                 "DirectoryServiceGenerateSshKeys": ds_generate_keys,
                                 "EbsSharedDirs": to_comma_separated_string(
                                     self._shared_storage_mount_dirs[SharedStorageType.EBS]


### PR DESCRIPTION



### Description of changes
* Add read_only user in LoginNode dna.json
  * This parameter is required to check the connection with the remote directory service and sync the user db.

### Tests
* N/A
* unit test will be added in a following PR

### References
* [Check AD connection](https://github.com/aws/aws-parallelcluster-cookbook/pull/2372)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
