### PR TITLE
[Login Nodes] Fix logic that checks number of healthy/unhealthy login nodes

### DIFF
--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -738,7 +738,9 @@ class Cluster:
         """Return True if the cluster has running login nodes. Note: the value will be cached."""
         if self.__has_running_login_nodes is None or updated_value:
             self.__has_running_login_nodes = (
-                self.login_nodes_status.get_healthy_nodes() + self.login_nodes_status.get_unhealthy_nodes() != 0
+                self.login_nodes_status.get_healthy_nodes() is not None
+                and self.login_nodes_status.get_unhealthy_nodes() is not None
+                and self.login_nodes_status.get_healthy_nodes() + self.login_nodes_status.get_unhealthy_nodes() != 0
             )
         return self.__has_running_login_nodes
 


### PR DESCRIPTION
### Description of changes
Fix logic that checks number of healthy/unhealthy login nodes,
to cover the case when login nodes are not deployed at all.

### Tests
Manually tested DFSM with debugger.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
