### PR TITLE
[release-3.7] Add scaffolding to test login nodes dna_json

### DIFF
--- a/cli/tests/pcluster/templates/test_cluster_stack/test_login_node_dna_json/login-basic-config.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_login_node_dna_json/login-basic-config.yaml
@@ -1,0 +1,32 @@
+Image:
+  Os: alinux2
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: t2.micro
+      Count: 1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      Ssh:
+        KeyName: ec2-key-name
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+  Imds:
+    Secured: True
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+        - Name: compute_resource2
+          InstanceType: c4.2xlarge

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_login_node_dna_json/login-with-directory-service.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_login_node_dna_json/login-with-directory-service.yaml
@@ -1,0 +1,39 @@
+Image:
+  Os: alinux2
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: t2.micro
+      Count: 1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      Ssh:
+        KeyName: ec2-key-name
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+  Imds:
+    Secured: True
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+        - Name: compute_resource2
+          InstanceType: c4.2xlarge
+DirectoryService:
+  DomainName: corp.sirena.com
+  DomainAddr: ldaps://corp.sirena.com
+  PasswordSecretArn: arn:aws:secretsmanager:eu-west-1:161767479707:secret:PasswordSecret-ad-test-CbpuId
+  DomainReadOnlyUser: cn=ReadOnlyUser,ou=Users,ou=CORP,dc=corp,dc=sirena,dc=com
+  LdapTlsReqCert: never
+  GenerateSshKeysForUsers: true


### PR DESCRIPTION
### Description of changes
Porting of a PR merged in Develop (see References)

* Add scaffolding to test login nodes dna_json
* Add utility functions to render the user_data generated by CF and to check that it contains a set of fields expected in the dna.json file.
* Provide a simple test for dna.json fields.
* It may be used also for ComputeNodes.

### Tests
* Unit tests successfully executed locally.

### References
* [Develop PR](https://github.com/aws/aws-parallelcluster/pull/5526) 

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
