### PR TITLE
Removing Instances from config file and replacing it with InstanceTypes when using --force-run-instances option

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -725,8 +725,8 @@ def inject_additional_config_settings(cluster_config, request, region, benchmark
                 for compute_resources in queues["ComputeResources"]:
                     if dict_has_nested_key(compute_resources, ["Instances"]):
                         instance_type = compute_resources["Instances"][0]["InstanceType"]
-                    compute_resources.pop("Instances")
-                    compute_resources["InstanceType"] = instance_type
+                        compute_resources.pop("Instances")
+                        compute_resources["InstanceType"] = instance_type
 
     with open(cluster_config, "w", encoding="utf-8") as conf_file:
         yaml.dump(config_content, conf_file)


### PR DESCRIPTION
Removing `Instances` from config file and replacing it with `InstanceTypes` when using --force-run-instances option




### References
https://github.com/aws/aws-parallelcluster/pull/5427

### Checklist
- [ ] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [ ] Check all commits' messages are clear, describing what and why vs how.
- [ ] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
