### PR TITLE
[develop] Allow executing commands on LoginNodes through RemoteCommandExecutor

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -62,6 +62,7 @@ class Cluster:
         self.__cfn_resources = None
         self.__cfn_stack_arn = None
         self.custom_cli_credentials = custom_cli_credentials
+        self.cluster_info = None
 
     def __repr__(self):
         attrs = ", ".join(["{key}={value}".format(key=key, value=repr(value)) for key, value in self.__dict__.items()])
@@ -187,15 +188,19 @@ class Cluster:
 
     def describe_cluster(self):
         """Run pcluster describe-cluster and return the result."""
-        cmd_args = ["pcluster", "describe-cluster", "--cluster-name", self.name]
-        try:
-            result = run_pcluster_command(cmd_args, log_error=False, custom_cli_credentials=self.custom_cli_credentials)
-            response = json.loads(result.stdout)
-            logging.info("Get cluster {0} status successfully".format(self.name))
-            return response
-        except subprocess.CalledProcessError as e:
-            logging.error("Failed when getting cluster status with error:\n%s\nand output:\n%s", e.stderr, e.stdout)
-            raise
+        if self.cluster_info:
+            return self.cluster_info
+        else:
+            cmd_args = ["pcluster", "describe-cluster", "--cluster-name", self.name]
+            try:
+                result = run_pcluster_command(cmd_args, log_error=False, custom_cli_credentials=self.custom_cli_credentials)
+                response = json.loads(result.stdout)
+                logging.info("Get cluster {0} status successfully".format(self.name))
+                self.cluster_info = response
+                return self.cluster_info
+            except subprocess.CalledProcessError as e:
+                logging.error("Failed when getting cluster status with error:\n%s\nand output:\n%s", e.stderr, e.stdout)
+                raise
 
     def describe_compute_fleet(self):
         """Run pcluster describe-compute-fleet and return the result."""
@@ -384,6 +389,7 @@ class Cluster:
         self.__cfn_parameters = None
         self.__cfn_outputs = None
         self.__cfn_resources = None
+        self.cluster_info = None
 
     def delete_resource_by_stack_id_tag(self):
         """Delete resources by stack id tag."""

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -28,7 +28,9 @@ class RemoteCommandExecutionError(Exception):
 class RemoteCommandExecutor:
     """Execute remote commands on the cluster head node."""
 
-    def __init__(self, cluster, compute_node_ip=None, username=None, bastion=None, alternate_ssh_key=None):
+    def __init__(
+        self, cluster, compute_node_ip=None, username=None, bastion=None, alternate_ssh_key=None, use_login_node=False
+    ):
         """
         Initiate SSH connection
 
@@ -40,8 +42,13 @@ class RemoteCommandExecutor:
             # Since compute nodes may not be publicly accessible, always use head node as the bastion.
             node_ip = compute_node_ip
             bastion = f"{username}@{cluster.head_node_ip}"
+        elif use_login_node:
+            node_ip = cluster.get_login_node_public_ip()
+            if node_ip is None:
+                raise RemoteCommandExecutionError("No healthy LoginNode found in the cluster.")
         else:
             node_ip = cluster.head_node_ip
+
         connection_kwargs = {
             "host": node_ip,
             "user": username,


### PR DESCRIPTION
### Description of changes
Porting in develop a PR already tested on `release-3.7` branch.
* Extend Cluster object to retrieve and cache information about LoginNodes 
* Extend RemoteCommandExecutor to retrieve a LoginNode IP, if exists, and run commands on it

With these changes existing tests can be easily adapted to run both on LoginNodes and HeadNode

```
@pytest.mark.parametrize(
    "run_on_login_node", [(False), (True)],
)
def my_test(run_on_login_node):
    remote_command_executor = RemoteCommandExecutor(cluster, use_login_node=run_on_login_node)
    remote_command_executor.run_remote_command("cat /etc/fstab")
```

### Tests
* Temporarily changed an existing integration test and launched a few commands on a LoginNode

### References
* [Corresponding PR for release-3.7 branch](https://github.com/aws/aws-parallelcluster/pull/5535)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
