### PR TITLE
Add Integration test of testing external FS(ebs and efs) access on LoginNodes -- release-3.7 branch

### DIFF
--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -40,13 +40,16 @@ class RemoteCommandExecutor:
             username = get_username_for_os(cluster.os)
         if compute_node_ip:
             # Since compute nodes may not be publicly accessible, always use head node as the bastion.
+            self.target = "ComputeNode"
             node_ip = compute_node_ip
             bastion = f"{username}@{cluster.head_node_ip}"
         elif use_login_node:
+            self.target = "LoginNode"
             node_ip = cluster.get_login_node_public_ip()
             if node_ip is None:
                 raise RemoteCommandExecutionError("No healthy LoginNode found in the cluster.")
         else:
+            self.target = "HeadNode"
             node_ip = cluster.head_node_ip
 
         connection_kwargs = {
@@ -83,6 +86,10 @@ class RemoteCommandExecutor:
         except Exception as e:
             # Catch all exceptions if we fail to close the clients
             logging.warning("Exception raised when closing remote ssh client: {0}".format(e))
+
+    def get_target_host_type(self):
+        """Get target host type. ComputeNode, LoginNode or HeadNode."""
+        return self.target
 
     def reset_connection(self):
         """Reset SSH connection."""

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -55,6 +55,21 @@ def get_cluster_subnet_ids_groups(cluster: Cluster, scheduler: str, include_head
 def test_directory_correctly_shared_between_ln_and_hn(
     remote_command_executor_head_node, remote_command_executor_login_node, mount_dir
 ):
+    """
+    This test verifies if a shared directory is correctly shared between the HeadNode and the LoginNode.
+
+    Preconditions:
+    - An EBS volume is expected to be mounted at <HN_folder> on the HeadNode and exported through NFS.
+    - The EBS volume is expected to be mounted at <LN_folder> on the LoginNode through NFS.
+
+    Test Steps:
+    1. Writes a file from the HeadNode to the shared volume.
+    2. Writes a file from the LoginNode to the shared volume.
+    3. Reads both files from both the HeadNode and the LoginNode to validate that the shared volume is working correctly.
+
+    Expected Result:
+    - Both files can be successfully read from both the HeadNode and the LoginNode, proving that the shared volume is correctly shared between the two nodes.
+    """
     logging.info("Testing FS correctly mounted on login nodes")
     head_node_file = random_alphanumeric()
     logging.info(f"Writing HeadNode File: {head_node_file}")
@@ -98,7 +113,7 @@ def verify_directory_correctly_shared(remote_command_executor, mount_dir, schedu
         "B" reads files: ["A-<random_alphanumeric_characters>", "B-<random_alphanumeric_characters>"]
     """
     executor_node_file = random_alphanumeric()
-    logging.info(f"Writing ExecutorNode File: {executor_node_file}")
+    logging.info(f"{remote_command_executor.get_target_host_type()}: Writing File: {executor_node_file}")
     remote_command_executor.run_remote_command(
         "touch {mount_dir}/{executor_node_file} && cat {mount_dir}/{executor_node_file}".format(
             mount_dir=mount_dir, executor_node_file=executor_node_file
@@ -126,7 +141,7 @@ def verify_directory_correctly_shared(remote_command_executor, mount_dir, schedu
         files_to_read=" ".join([f"{mount_dir}/{target_file}" for target_file in files_to_read]),
     )
     # Attempt reading files from executor node
-    logging.info(f"Reading Files: {files_to_read} from executor node")
+    logging.info(f"{remote_command_executor.get_target_host_type()}: Reading Files: {files_to_read}")
     remote_command_executor.run_remote_command(read_all_files_command)
 
     # Submit a "Read" job to each partition

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -65,10 +65,11 @@ def test_directory_correctly_shared_between_ln_and_hn(
     Test Steps:
     1. Writes a file from the HeadNode to the shared volume.
     2. Writes a file from the LoginNode to the shared volume.
-    3. Reads both files from both the HeadNode and the LoginNode to validate that the shared volume is working correctly.
+    3. Reads both files from both the HeadNode and the LoginNode to validate that shared volume is working correctly.
 
     Expected Result:
-    - Both files can be successfully read from both the HeadNode and the LoginNode, proving that the shared volume is correctly shared between the two nodes.
+    - Both files can be successfully read from both the HeadNode and the LoginNode,
+      proving that the shared volume is correctly shared between the two nodes.
     """
     logging.info("Testing FS correctly mounted on login nodes")
     head_node_file = random_alphanumeric()

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -64,16 +64,16 @@ def verify_directory_correctly_shared(remote_command_executor, mount_dir, schedu
         "A" reads files: ["A-<random_alphanumeric_characters>", "B-<random_alphanumeric_characters>"]
         "B" reads files: ["A-<random_alphanumeric_characters>", "B-<random_alphanumeric_characters>"]
     """
-    head_node_file = random_alphanumeric()
-    logging.info(f"Writing HeadNode File: {head_node_file}")
+    executor_node_file = random_alphanumeric()
+    logging.info(f"Writing ExecutorNode File: {executor_node_file}")
     remote_command_executor.run_remote_command(
-        "touch {mount_dir}/{head_node_file} && cat {mount_dir}/{head_node_file}".format(
-            mount_dir=mount_dir, head_node_file=head_node_file
+        "touch {mount_dir}/{executor_node_file} && cat {mount_dir}/{executor_node_file}".format(
+            mount_dir=mount_dir, executor_node_file=executor_node_file
         )
     )
 
     # Submit a "Write" job to each partition
-    files_to_read = [head_node_file]
+    files_to_read = [executor_node_file]
     partitions = (
         partitions or scheduler_commands.get_partitions() if isinstance(scheduler_commands, SlurmCommands) else [None]
     )
@@ -92,8 +92,8 @@ def verify_directory_correctly_shared(remote_command_executor, mount_dir, schedu
     read_all_files_command = "cat {files_to_read}".format(
         files_to_read=" ".join([f"{mount_dir}/{target_file}" for target_file in files_to_read]),
     )
-    # Attempt reading files from HeadNode
-    logging.info(f"Reading Files: {files_to_read} from HeadNode")
+    # Attempt reading files from executor node
+    logging.info(f"Reading Files: {files_to_read} from executor node")
     remote_command_executor.run_remote_command(read_all_files_command)
 
     # Submit a "Read" job to each partition

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -55,7 +55,7 @@ def get_cluster_subnet_ids_groups(cluster: Cluster, scheduler: str, include_head
 def test_directory_correctly_shared_between_ln_and_hn(
     remote_command_executor_head_node, remote_command_executor_login_node, mount_dir
 ):
-    logging.info("Testing efs correctly mounted on login nodes")
+    logging.info("Testing FS correctly mounted on login nodes")
     head_node_file = random_alphanumeric()
     logging.info(f"Writing HeadNode File: {head_node_file}")
     remote_command_executor_head_node.run_remote_command(

--- a/tests/integration-tests/tests/storage/storage_common.py
+++ b/tests/integration-tests/tests/storage/storage_common.py
@@ -55,6 +55,7 @@ def get_cluster_subnet_ids_groups(cluster: Cluster, scheduler: str, include_head
 def test_directory_correctly_shared_between_ln_and_hn(
     remote_command_executor_head_node, remote_command_executor_login_node, mount_dir
 ):
+    logging.info("Testing efs correctly mounted on login nodes")
     head_node_file = random_alphanumeric()
     logging.info(f"Writing HeadNode File: {head_node_file}")
     remote_command_executor_head_node.run_remote_command(

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
@@ -1,5 +1,16 @@
 Image:
   Os: {{ os }}
+{% if scheduler == "slurm" and use_login_node %}
+LoginNodes:
+  Pools:
+    - Name: login-node-pool-0
+      InstanceType: {{ instance }}
+      Count: 2
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 60
+{% endif %}
 HeadNode:
   InstanceType: {{ instance }}
   Networking:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
@@ -1,6 +1,6 @@
 Image:
   Os: {{ os }}
-{% if scheduler == "slurm" and use_login_node %}
+{% if scheduler == "slurm" %}
 LoginNodes:
   Pools:
     - Name: login-node-pool-0

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -1,5 +1,16 @@
 Image:
   Os: {{ os }}
+{% if scheduler == "slurm" and use_login_node %}
+LoginNodes:
+  Pools:
+    - Name: login-node-pool-0
+      InstanceType: {{ instance }}
+      Count: 2
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 60
+{% endif %}
 HeadNode:
   InstanceType: {{ instance }}
   Networking:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -1,6 +1,6 @@
 Image:
   Os: {{ os }}
-{% if scheduler == "slurm" and use_login_node %}
+{% if scheduler == "slurm" %}
 LoginNodes:
   Pools:
     - Name: login-node-pool-0

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -1,5 +1,16 @@
 Image:
   Os: {{ os }}
+{% if scheduler == "slurm" and use_login_node %}
+LoginNodes:
+  Pools:
+    - Name: login-node-pool-0
+      InstanceType: {{ instance }}
+      Count: 2
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 60
+{% endif %}
 HeadNode:
   InstanceType: {{ instance }}
   Networking:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_single/pcluster.config.yaml
@@ -1,6 +1,6 @@
 Image:
   Os: {{ os }}
-{% if scheduler == "slurm" and use_login_node %}
+{% if scheduler == "slurm" %}
 LoginNodes:
   Pools:
     - Name: login-node-pool-0

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
@@ -1,5 +1,16 @@
 Image:
   Os: {{ os }}
+{% if scheduler == "slurm" and use_login_node %}
+LoginNodes:
+  Pools:
+    - Name: login-node-pool-0
+      InstanceType: {{ instance }}
+      Count: 2
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 60
+{% endif %}
 HeadNode:
   InstanceType: {{ instance }}
   Networking:

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_snapshot/pcluster.config.yaml
@@ -1,6 +1,6 @@
 Image:
   Os: {{ os }}
-{% if scheduler == "slurm" and use_login_node %}
+{% if scheduler == "slurm" %}
 LoginNodes:
   Pools:
     - Name: login-node-pool-0

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -39,7 +39,7 @@ def test_efs_use_login_nodes(
     The efs correctly mounted on LoginNodes and compute.
     """
     if scheduler != "slurm":
-        return
+        pytest.skip(f"Skipping test because scheduler: {scheduler} is not supported for login nodes. Please use Slurm.")
 
     mount_dir = "efs_mount_dir"
     cluster_config = pcluster_config_reader(mount_dir=mount_dir)

--- a/tests/integration-tests/tests/storage/test_efs.py
+++ b/tests/integration-tests/tests/storage/test_efs.py
@@ -52,7 +52,6 @@ def test_efs_use_login_nodes(
     _test_efs_correctly_shared(remote_command_executor_head_node, mount_dir, scheduler_commands)
 
     remote_command_executor_login_node = RemoteCommandExecutor(cluster, use_login_node=True)
-    test_efs_correctly_mounted(remote_command_executor_login_node, mount_dir)
     _test_efs_correctly_shared(remote_command_executor_login_node, mount_dir, scheduler_commands)
     test_directory_correctly_shared_between_ln_and_hn(
         remote_command_executor_head_node, remote_command_executor_login_node, mount_dir

--- a/tests/integration-tests/tests/storage/test_efs/test_efs_use_login_nodes/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_efs/test_efs_use_login_nodes/pcluster.config.yaml
@@ -1,0 +1,44 @@
+Image:
+  Os: {{ os }}
+{% if scheduler == "slurm" %}
+LoginNodes:
+  Pools:
+    - Name: login-node-pool-0
+      InstanceType: {{ instance }}
+      Count: 2
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 60
+{% endif %}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
+    - Name: queue-0
+      ComputeResources:
+        - Name: compute-resource-0
+          {% if scheduler == "awsbatch" %}
+          InstanceTypes:
+            - {{ instance }}
+          MinvCpus: 4
+          DesiredvCpus: 4
+          {% else %}
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          {% endif %}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+SharedStorage:
+  - MountDir: {{ mount_dir }}
+    Name: efs
+    StorageType: Efs


### PR DESCRIPTION
### Description of changes
* Add Integration test of testing external FS(ebs) access on LoginNodes and related support
  * Add LoginNodes section in related yaml file when `use_login_nodes` is true and `scheduler == "slurm"`
  * Test ebs correctly mounted on LoginNodes
  * Test ebs correctly shared between LoginNode and ComputeNodes
  * Test ebs correctly shared between HeadNode and LoginNode
  
* Add Integration test of testing external FS(efs) access on LoginNodes and related support
  * Test efs correctly mounted on LoginNodes
  * Test efs correctly shared between LoginNode and ComputeNodes
  * Test efs correctly shared between HeadNode and LoginNode

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.