### PR TITLE
Add the SSM Managed Instance Policy to the networking bastion instance used in tests

### DIFF
--- a/tests/integration-tests/cfn_stacks_factory.py
+++ b/tests/integration-tests/cfn_stacks_factory.py
@@ -80,6 +80,8 @@ class CfnVpcStack(CfnStack):
         self.az_override = None
         self.__public_subnet_ids = None
         self.__private_subnet_ids = None
+        if "CAPABILITY_NAMED_IAM" not in self.capabilities:
+            self.capabilities.append("CAPABILITY_NAMED_IAM")
 
     def set_az_override(self, az_override):
         """Sets the az_id to override the default AZ used to pick the subnets."""


### PR DESCRIPTION
### Description of changes
* Networking bastion instance lacks the AmazonSSMManagedInstanceCore SSM Policy 
* The host is thus unable to send information to association documents
* These changes ensure that the bastion instance has a profile/role with the Managed SSM Policy

### Tests
* Created stack

### References
* https://troposphere.readthedocs.io/en/latest/_modules/troposphere/iam.html
* http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [ ] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
