### PR TITLE
[release-3.7] Add reset_connection method to RemoteCommandExecutor

### DIFF
--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -69,6 +69,7 @@ class RemoteCommandExecutor:
             f"Connecting to {connection_kwargs['host']} as {connection_kwargs['user']} with "
             f"{connection_kwargs['connect_kwargs']['key_filename']}"
         )
+        self.__connection_kwargs = connection_kwargs
         self.__connection = Connection(**connection_kwargs)
         self.__user_at_hostname = "{0}@{1}".format(username, node_ip)
 
@@ -78,6 +79,12 @@ class RemoteCommandExecutor:
         except Exception as e:
             # Catch all exceptions if we fail to close the clients
             logging.warning("Exception raised when closing remote ssh client: {0}".format(e))
+
+    def reset_connection(self):
+        """Reset SSH connection."""
+        self.__del__()
+        if self.__connection_kwargs:
+            self.__connection = Connection(**self.__connection_kwargs)
 
     @retry(wait_exponential_multiplier=1000, stop_max_attempt_number=5)
     def _run_command(self, command, **kwargs):


### PR DESCRIPTION
### Description of changes
(Porting from develop)

Add `reset_connection` method to Remote Command Executor.

AD integration test has sporadic failures due to `remote file not found`
Resetting the underlying SSH connection seems to resolve the issue.

### Tests
* While working on AD integration test on LoginNodes some check passed reliably while running in debug and they consistently failed when run as tests.

* Invoking the reset_connection method solved the issue and made all the tests pass successfully.

### References 
* [Same PR for develop](https://github.com/aws/aws-parallelcluster/pull/5544)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
