### PR TITLE
Reset ssh connection before checking remote files

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -574,6 +574,8 @@ def _check_home_directory(user, remote_command_executor):
     """
     logging.info("Checking home directory for user %s", user.alias)
 
+    # Reset underlying ssh connection to prevent occasional `file not found` issues
+    remote_command_executor.reset_connection()
     check_existence = f"sudo ls {user.home_dir}"
     result = remote_command_executor.run_remote_command(check_existence)
     assert_that(result.failed).is_false()
@@ -596,6 +598,9 @@ def _check_ssh_key(user, ssh_generation_enabled, remote_command_executor, schedu
     logging.info("Checking SSH key for user %s (expected to exist: %s)", user.alias, ssh_generation_enabled)
 
     ssh_key_path = f"{user.home_dir}/.ssh/id_ed25519"
+
+    # Reset underlying ssh connection to prevent occasional `file not found` issues
+    remote_command_executor.reset_connection()
 
     # Check existence
     check_existence = f"sudo ls {ssh_key_path}"


### PR DESCRIPTION
### Description of changes

During AD test execution we had sporadic failures
due to `file not found` issues.
Resetting the underlying SSH connection prevent them.

### Tests
* While working on AD integration test on LoginNodes some check passed reliably while running in debug and they consistently failed when run as tests.

* Invoking the reset_connection method solved the issue and made all the tests pass successfully.

### References
* [PR for develop](https://github.com/aws/aws-parallelcluster/pull/5546)
* [RemoteCommandExecutor change](https://github.com/aws/aws-parallelcluster/pull/5545)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
