### PR TITLE
[develop] Fix code-quality issue in RemoteCommandExecutor

### DIFF
--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -74,6 +74,10 @@ class RemoteCommandExecutor:
         self.__user_at_hostname = "{0}@{1}".format(username, node_ip)
 
     def __del__(self):
+        self.close_connection()
+
+    def close_connection(self):
+        """Close SSH connection."""
         try:
             self.__connection.close()
         except Exception as e:
@@ -82,7 +86,7 @@ class RemoteCommandExecutor:
 
     def reset_connection(self):
         """Reset SSH connection."""
-        self.__del__()
+        self.close_connection()
         if self.__connection_kwargs:
             self.__connection = Connection(**self.__connection_kwargs)
 


### PR DESCRIPTION
### Description of changes
The __del__ special method is designed to be called by the Python virtual machine when an object is no longer reachable, but before it is destroyed.
Calling a __del__ method explicitly may cause an object to enter an unsafe state.

### Tests
* N/(A

### References
* [RemoteCommandExecutor change](https://github.com/aws/aws-parallelcluster/pull/5544)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
