### PR TITLE
[Performance Test] Add scaling test to validate scale out to 1000 nodes.

### DIFF
--- a/tests/integration-tests/configs/scaling.yaml
+++ b/tests/integration-tests/configs/scaling.yaml
@@ -1,0 +1,8 @@
+test-suites:
+  performance_tests:
+    test_scaling.py::test_scaling:
+      dimensions:
+        - regions: ["us-east-1"]
+          instances: ["c5.large"]
+          oss: ["alinux2"]
+          schedulers: ["slurm"]

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -1,0 +1,46 @@
+import logging
+
+import pytest
+from remote_command_executor import RemoteCommandExecutor
+
+
+@pytest.mark.parametrize(
+    "max_nodes",
+    [1000],
+)
+def test_scaling(
+    vpc_stack,
+    instance,
+    os,
+    region,
+    scheduler,
+    pcluster_config_reader,
+    clusters_factory,
+    test_datadir,
+    scheduler_commands_factory,
+    max_nodes,
+):
+    cluster_config = pcluster_config_reader(max_nodes=max_nodes)
+    cluster = clusters_factory(cluster_config)
+
+    logging.info("Cluster Created")
+
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+
+    logging.info(f"Submitting an array of {max_nodes} jobs on {max_nodes} nodes")
+    job_id = scheduler_commands.submit_command_and_assert_job_accepted(
+        submit_command_args={
+            "command": "sleep 1800",
+            "partition": "queue-1",
+            "other_options": f"--array [1-{max_nodes}] --exclusive",
+        }
+    )
+
+    logging.info(f"Waiting for job to be running: {job_id}")
+    scheduler_commands.wait_job_running(job_id)
+    logging.info(f"Job {job_id} is running")
+
+    logging.info(f"Cancelling job: {job_id}")
+    scheduler_commands.cancel_job(job_id)
+    logging.info(f"Job {job_id} cancelled")

--- a/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling/pcluster.config.yaml
@@ -1,0 +1,39 @@
+Region: {{ region }}
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: c5.24xlarge
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue-0
+      ComputeResources:
+        - Name: compute-resource-0
+          InstanceType: {{ instance }}
+          MinCount: {{ max_nodes }}
+          MaxCount: {{ max_nodes }}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
+    - Name: queue-1
+      ComputeResources:
+        - Name: compute-resource-0
+          InstanceType: {{ instance }}
+          MinCount: 0
+          MaxCount: {{ max_nodes }}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status


### PR DESCRIPTION
### Description of changes
Add an integration tests to validate the scale up of a cluster to 1K static nodes and 1K dynamic nodes.

### Tests
Test succeeded with the most recent 3.7.0b1 AMI in eu-west-1 alinux2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
