### PR TITLE
[develop] Add DeleteLifecycleHook to test UserRole

### DIFF
--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -799,6 +799,7 @@ Resources:
           - Action:
               - autoscaling:CreateAutoScalingGroup
               - autoscaling:DeleteAutoScalingGroup
+              - autoscaling:DeleteLifecycleHook
               - autoscaling:DescribeAutoScalingGroups
               - autoscaling:DescribeLifecycleHooks
               - autoscaling:DescribeScalingActivities


### PR DESCRIPTION
### Description of changes
UserRole created for integ-test requires permissions to DeleteLifecycleHook when using cluster with LoginNodes

### Tests
* Deletion of a LoginNode stack failed when launching an integ-test with the following error 

```
arn:aws:sts::249582277112:assumed-role/integ-tests-iam-user-role-ParallelClusterUserRole-1B2DAS9RUXABL/us-east-2_integration_tests_session is not authorized to perform: autoscaling:DeleteLifecycleHook on resource: arn:aws:autoscaling:us-east-2:249582277112:autoScalingGroup:fa708016-3f3c-4f24-9e1d-90f3c5a7b9b3:autoScalingGroupName/integ-tests-575mcroubwumxaed-login-node-pool-0-AutoScalingGroup because no identity-based policy allows the autoscaling:DeleteLifecycleHook action
```

### References
* [PR related to the test](https://github.com/aws/aws-parallelcluster/pull/5539/)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
