### PR TITLE
[Release3.7] Add DeleteLifecycleHook to test UserRole

### DIFF
--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -799,6 +799,7 @@ Resources:
           - Action:
               - autoscaling:CreateAutoScalingGroup
               - autoscaling:DeleteAutoScalingGroup
+              - autoscaling:DeleteLifecycleHook
               - autoscaling:DescribeAutoScalingGroups
               - autoscaling:DescribeLifecycleHooks
               - autoscaling:DescribeScalingActivities


### PR DESCRIPTION
### Description of changes
Porting from develop
UserRole created for integ-test requires permissions to DeleteLifecycleHook when using cluster with LoginNodes

### References
* [Develop PR](https://github.com/aws/aws-parallelcluster/pull/5562)

### Checklist
- [x] Make sure you are pointing to **the right branch** and add a label in the PR title (i.e. **2.x** vs **3.x**)
- [x] Check all commits' messages are clear, describing what and why vs how.
- [x] Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- [x] Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
