### PR TITLE
[Integ-tests] Relax intel MPI Allgather base number

### DIFF
--- a/tests/integration-tests/tests/efa/test_efa.py
+++ b/tests/integration-tests/tests/efa/test_efa.py
@@ -258,14 +258,8 @@ def _check_osu_benchmarks_results(test_datadir, instance, mpi_version, benchmark
                 tolerated_value = float(previous_result) - (float(previous_result) * 0.2)
                 is_failure = int(value) < tolerated_value
             else:
-                # Use a tolerance of 10us for 2 digits values.
-                # For 3+ digits values use a 20% tolerance, except for the higher-variance latency benchmark.
-                if len(previous_result) <= 2:
-                    accepted_tolerance = 10
-                else:
-                    multiplier = 0.3 if benchmark_name == "osu_latency" else 0.2
-                    accepted_tolerance = float(previous_result) * multiplier
-                tolerated_value = float(previous_result) + accepted_tolerance
+                multiplier = 0.3 if benchmark_name == "osu_latency" else 0.2
+                tolerated_value = float(previous_result) + max(float(previous_result) * multiplier, 10)
 
                 is_failure = int(value) > tolerated_value
 

--- a/tests/integration-tests/tests/efa/test_efa/test_efa/osu_benchmarks/results/c5n.18xlarge/intelmpi/osu_allgather
+++ b/tests/integration-tests/tests/efa/test_efa/test_efa/osu_benchmarks/results/c5n.18xlarge/intelmpi/osu_allgather
@@ -1,10 +1,11 @@
 # OSU MPI Allgather Latency Test v5.7.1
+# The first four latencies were retrieved as the average of four OSU benchmarks during August twenty twenty three
 # Size       Avg Latency(us)
-1                     244.22
-2                     221.93
-4                     219.47
-8                     223.62
-16                    230.11
+1                     205.00
+2                     225.00
+4                     226.00
+8                     259.00
+16                    300.00
 32                    371.38
 64                    416.95
 128                   555.10


### PR DESCRIPTION
### Description of changes
As agreed by Usai, we are going to relax the base number used by OSU benchmark. We also created https://github.com/aws/aws-parallelcluster/pull/5567 to better understand the change in performance.

### Tests
With this PR, test_efa is consistently passing

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
