### PR TITLE
[develop] Remove pin of pytest library

### DIFF
--- a/tests/integration-tests/requirements.txt
+++ b/tests/integration-tests/requirements.txt
@@ -13,7 +13,7 @@ matplotlib
 pexpect
 pykwalify
 pyOpenSSL
-pytest~=7.3.2
+pytest
 pytest-datadir
 pytest-html
 pytest-rerunfailures

--- a/tests/integration-tests/tox.ini
+++ b/tests/integration-tests/tox.ini
@@ -14,3 +14,6 @@ skip_install = true
 deps = -r requirements.txt
 commands =
     python -m framework.tests_configuration.config_generator --output-file {posargs} --tests-root-dir tests/
+
+[pytest]
+# No options, section required to define pytest root dir.


### PR DESCRIPTION
We pinned pytest because usage of custom args stopped to work with pytest 3.7.4. At the end it was a configuration issue: we were missing to specify which is the pytest root dir. Adding a `[pytest]` section in the `tox.ini` file permits pytest to discover the right root dir and so to use custom arguments.

### Tests

Without the pin and before this patch tests were failing with:
```
ERROR: usage: test_runner.py [options] [file_or_dir] [file_or_dir] [...]
test_runner.py: error: unrecognized arguments: --tests-log-file=/tmp//...eu-west-1.log --output-dir=/tmp/...eu-west-1
    --key-name=... --key-path=...usai-common.pem --stackname-suffix --tests-config-file=/tmp/...tests_config.yaml --regions eu-west-1
    --ami-owner ... --vpc-stack integ-tests-vpc-...-360 --no-delete ...
  inifile: None
  rootdir: .../aws-parallelcluster/tests/integration-tests/tests
```

Now tests are executed correctly.

### References
* https://github.com/pytest-dev/pytest/issues/11134
* https://docs.pytest.org/en/stable/reference/customize.html#finding-the-rootdir
