### PR TITLE
[develop] [POC] Add new DebugLevel DevSetting parameter

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1121,6 +1121,7 @@ class ClusterDevSettings(BaseDevSettings):
         instance_types_data: str = None,
         timeouts: Timeouts = None,
         compute_startup_time_metric_enabled: bool = None,
+        debug_level: str = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -1131,6 +1132,7 @@ class ClusterDevSettings(BaseDevSettings):
         self.compute_startup_time_metric_enabled = Resource.init_param(
             compute_startup_time_metric_enabled, default=False
         )
+        self.debug_level = Resource.init_param(debug_level, default="info")
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1070,6 +1070,7 @@ class ClusterDevSettingsSchema(BaseDevSettingsSchema):
     instance_types_data = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     timeouts = fields.Nested(TimeoutsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     compute_startup_time_metric_enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    debug_level = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -87,6 +87,7 @@ def get_common_user_data_env(node: Union[HeadNode, SlurmQueue, LoginNodesPool], 
         "CookbookVersion": COOKBOOK_PACKAGES_VERSIONS["cookbook"],
         "ChefVersion": COOKBOOK_PACKAGES_VERSIONS["chef"],
         "BerkshelfVersion": COOKBOOK_PACKAGES_VERSIONS["berkshelf"],
+        "DebugLevel": config.dev_settings.debug_level,
     }
 
 

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1362,7 +1362,8 @@ class ClusterCdkStack:
                 "commands": {
                     "chef": {
                         "command": (
-                            "cinc-client --local-mode --config /etc/chef/client.rb --log_level info "
+                            "cinc-client --local-mode --config /etc/chef/client.rb "
+                            f"--log_level {self.config.dev_settings.debug_level} "
                             "--logfile /var/log/chef-client.log --force-formatter --no-color "
                             "--chef-zero-port 8889 --json-attributes /etc/chef/dna.json "
                             "--override-runlist aws-parallelcluster-entrypoints::init"
@@ -1378,7 +1379,8 @@ class ClusterCdkStack:
                 "commands": {
                     "chef": {
                         "command": (
-                            "cinc-client --local-mode --config /etc/chef/client.rb --log_level info "
+                            "cinc-client --local-mode --config /etc/chef/client.rb "
+                            f"--log_level {self.config.dev_settings.debug_level} "
                             "--logfile /var/log/chef-client.log --force-formatter --no-color "
                             "--chef-zero-port 8889 --json-attributes /etc/chef/dna.json "
                             "--override-runlist aws-parallelcluster-entrypoints::config"
@@ -1394,7 +1396,8 @@ class ClusterCdkStack:
                 "commands": {
                     "chef": {
                         "command": (
-                            "cinc-client --local-mode --config /etc/chef/client.rb --log_level info "
+                            "cinc-client --local-mode --config /etc/chef/client.rb "
+                            f"--log_level {self.config.dev_settings.debug_level} "
                             "--logfile /var/log/chef-client.log --force-formatter --no-color "
                             "--chef-zero-port 8889 --json-attributes /etc/chef/dna.json "
                             "--override-runlist aws-parallelcluster-entrypoints::finalize"
@@ -1414,7 +1417,8 @@ class ClusterCdkStack:
                     "chef": {
                         "command": (
                             ". /etc/profile.d/pcluster.sh; "
-                            "cinc-client --local-mode --config /etc/chef/client.rb --log_level info"
+                            "cinc-client --local-mode --config /etc/chef/client.rb "
+                            f"--log_level {self.config.dev_settings.debug_level}"
                             " --logfile /var/log/chef-client.log --force-formatter --no-color"
                             " --chef-zero-port 8889 --json-attributes /etc/chef/dna.json"
                             " --override-runlist aws-parallelcluster-entrypoints::update &&"

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -198,7 +198,9 @@ class QueuesStack(NestedStack):
                 instance_market_options=self._launch_template_builder.get_instance_market_options(
                     queue, compute_resource
                 ),
-                instance_initiated_shutdown_behavior="terminate",
+                instance_initiated_shutdown_behavior="stop"
+                if self._config.dev_settings.debug_level != "info"
+                else "terminate",
                 capacity_reservation_specification=self._launch_template_builder.get_capacity_reservation(
                     queue,
                     compute_resource,


### PR DESCRIPTION
This new parameter permits to:
* Change cinc-client log_level
* Avoid to terminate compute nodes if there are bootstrap issues

This must be a valid cinc-client `log_level` value: debug, error, fatal, info, trace, or warn.

In future, when introducing it as a feature, we can split the shutdown termination behaviour from the cinc client log level setup.

### References
* https://docs.chef.io/debug/
