### PR TITLE
Update integ tests for the new minimum volume size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ CHANGELOG
 - Change the default value of `Imds/ImdsSupport` from `v1.0` to `v2.0`.
 - Upgrade Slurm to version 23.02.4.
 - Deprecate Ubuntu 18.
+- Update the default root volume size to 40 GB to account for limits on Centos 7.
 
 **BUG FIXES**
 - Add validation to `ScaledownIdletime` value, to prevent setting a value lower than `-1`.

--- a/tests/integration-tests/tests/iam/test_iam_image/test_iam_roles/image.config.yaml
+++ b/tests/integration-tests/tests/iam/test_iam_image/test_iam_roles/image.config.yaml
@@ -3,7 +3,7 @@ Image:
         - Key: dummyImageTag
           Value: dummyImageTag
     RootVolume:
-        Size: 35
+        Size: 40
 
 Build:
     Iam:

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -656,8 +656,8 @@ def test_queue_parameters_update(
 ):
     """Test update cluster with drain strategy."""
     # Create cluster with initial configuration
-    initial_compute_root_volume_size = 35
-    updated_compute_root_volume_size = 40
+    initial_compute_root_volume_size = 40
+    updated_compute_root_volume_size = 45
     # If you are running this test in your personal account, then you must have
     # ParallelCluster AMIs following the official naming convention
     # and set allow_private_ami to True.
@@ -1279,7 +1279,7 @@ def _test_shared_storages_mount_on_headnode(
     """Check storages are mounted on headnode."""
     # ebs
     for ebs_dir in ebs_mount_dirs:
-        volume_size = "9.[7,8]" if "existing" in ebs_dir else "35"
+        volume_size = "9.[7,8]" if "existing" in ebs_dir else "40"
         test_ebs_correctly_mounted(remote_command_executor, ebs_dir, volume_size=volume_size)
     # check raid
     test_raid_correctly_configured(remote_command_executor, raid_type="0", volume_size=75, raid_devices=5)


### PR DESCRIPTION
### Description of changes
* Our integ tests update.test_update.test_dynamic_file_systems_update, update.test_update.test_queue_parameters_update, and iam.test_iam_image.test_iam_roles referenced hard coded values for the root volume size that needed to be updated to the new minimum
Also update the changelog for the new root volume size

### References
* https://github.com/aws/aws-parallelcluster/pull/5581

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
