### PR TITLE
[Release 3.7] Update additional integ tests that hardcode references …

### DIFF
--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -53,7 +53,7 @@ def test_ebs_single(
     scheduler_commands = scheduler_commands_factory(remote_command_executor_head_node)
     volume_id = get_ebs_volume_ids(cluster, region)[0]
 
-    test_ebs_correctly_mounted(remote_command_executor_head_node, mount_dir, volume_size=35)
+    test_ebs_correctly_mounted(remote_command_executor_head_node, mount_dir, volume_size=40)
     # Test ebs correctly shared between HeadNode and ComputeNodes
     _test_ebs_correctly_shared(remote_command_executor_head_node, mount_dir, scheduler_commands)
 

--- a/tests/integration-tests/tests/storage/test_raid.py
+++ b/tests/integration-tests/tests/storage/test_raid.py
@@ -42,8 +42,8 @@ def test_raid_fault_tolerance_mode(pcluster_config_reader, clusters_factory, sch
 
     scheduler_commands = scheduler_commands_factory(remote_command_executor)
     mount_dir = "/raid_dir"
-    test_raid_correctly_configured(remote_command_executor, raid_type="1", volume_size=35, raid_devices=2)
-    test_raid_correctly_mounted(remote_command_executor, mount_dir, volume_size=35)
+    test_raid_correctly_configured(remote_command_executor, raid_type="1", volume_size=40, raid_devices=2)
+    test_raid_correctly_mounted(remote_command_executor, mount_dir, volume_size=40)
     _test_raid_correctly_shared(remote_command_executor, mount_dir, scheduler_commands)
 
 


### PR DESCRIPTION
…to default volume size

### Description of changes
test_ebs and test_raid also reference the volume size default

### References
https://github.com/aws/aws-parallelcluster/pull/5581

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
