### PR TITLE
[develop][Performance Test] Add scaling test to validate scale out to 1000 nodes.

### DIFF
--- a/tests/integration-tests/configs/scaling.yaml
+++ b/tests/integration-tests/configs/scaling.yaml
@@ -1,0 +1,8 @@
+test-suites:
+  performance_tests:
+    test_scaling.py::test_scaling:
+      dimensions:
+        - regions: ["us-east-1", "eu-west-1"]
+          instances: ["c5.large"]
+          oss: ["alinux2"]
+          schedulers: ["slurm"]

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -1,0 +1,56 @@
+import logging
+
+import pytest
+from remote_command_executor import RemoteCommandExecutor
+
+from tests.common.assertions import assert_no_msg_in_logs
+
+
+@pytest.mark.parametrize(
+    "max_nodes",
+    [1000],
+)
+def test_scaling(
+    vpc_stack,
+    instance,
+    os,
+    region,
+    scheduler,
+    pcluster_config_reader,
+    clusters_factory,
+    test_datadir,
+    scheduler_commands_factory,
+    max_nodes,
+):
+    cluster_config = pcluster_config_reader(max_nodes=max_nodes)
+    cluster = clusters_factory(cluster_config)
+
+    logging.info("Cluster Created")
+
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+
+    logging.info(f"Submitting an array of {max_nodes} jobs on {max_nodes} nodes")
+    job_id = scheduler_commands.submit_command_and_assert_job_accepted(
+        submit_command_args={
+            "command": "srun sleep 10",
+            "partition": "queue-0",
+            "nodes": max_nodes,
+            "slots": max_nodes,
+        }
+    )
+
+    logging.info(f"Waiting for job to be running: {job_id}")
+    scheduler_commands.wait_job_running(job_id)
+    logging.info(f"Job {job_id} is running")
+
+    logging.info(f"Cancelling job: {job_id}")
+    scheduler_commands.cancel_job(job_id)
+    logging.info(f"Job {job_id} cancelled")
+
+    logging.info("Verifying no bootstrap errors in logs")
+    assert_no_msg_in_logs(
+        remote_command_executor,
+        log_files=["/var/log/parallelcluster/clustermgtd"],
+        log_msg=["Found the following bootstrap failure nodes"],
+    )

--- a/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling/pcluster.config.yaml
@@ -1,0 +1,27 @@
+Region: {{ region }}
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: c5.24xlarge
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    AdditionalIamPolicies:
+      - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue-0
+      ComputeResources:
+        - Name: compute-resource-0
+          InstanceType: {{ instance }}
+          MinCount: 0
+          MaxCount: {{ max_nodes }}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      Iam:
+        AdditionalIamPolicies:
+          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status


### PR DESCRIPTION
The test is executed in 2 regions to collect more data.

With `-N 1000` we are sure to have 1000 nodes and using `srun` the job won't run in the first available node available and it will wait for all the nodes.`

The test checks that clustermgtd logs does not contain bootstrap errors for compute nodes.

There are no static nodes to avoid a failure at cluster creation time.

