### PR TITLE
[Release 3.7] Update SSH keypair vaildator to include a check for ed2…

### DIFF
--- a/cli/src/pcluster/aws/aws_api.py
+++ b/cli/src/pcluster/aws/aws_api.py
@@ -201,3 +201,12 @@ class AWSApi:
     def reset():
         """Reset the instance to clear all caches."""
         AWSApi._instance = None
+
+
+class KeyPairInfo:
+    """Object to store Ec2 Keypair information, initialized with the key name."""
+
+    def __init__(self, key_name: str):
+        self.key_name = key_name
+        self.key_data = AWSApi.instance().ec2.describe_key_pair(key_name)
+        self.key_type = self.key_data["KeyPairs"][0]["KeyType"]

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -759,9 +759,6 @@ class _BaseSsh(Resource):
         super().__init__(**kwargs)
         self.key_name = Resource.init_param(key_name)
 
-    def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
-        self._register_validator(KeyPairValidator, key_name=self.key_name)
-
 
 class HeadNodeSsh(_BaseSsh):
     """Represent the SSH configuration for HeadNode."""
@@ -1535,6 +1532,7 @@ class BaseClusterConfig(Resource):
             volume_size=root_volume_size,
             volume_iops=root_volume.iops,
         )
+        self._register_validator(KeyPairValidator, key_name=self.head_node.ssh.key_name, os=self.image.os)
 
     def _register_storage_validators(self):  # noqa: C901 FIXME: function too complex
         if self.shared_storage:

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -303,7 +303,7 @@ def test_slurm_validators_are_called_with_correct_argument(test_datadir, mocker)
         ],
         any_order=True,
     )
-    key_pair_validator.assert_has_calls([call(key_name="ec2-key-name")])
+    key_pair_validator.assert_has_calls([call(key_name="ec2-key-name", os="alinux2")])
     instance_type_validator.assert_has_calls([call(instance_type="c5d.xlarge")])
     instance_type_base_ami_compatible_validator.assert_has_calls(
         [


### PR DESCRIPTION
…5519 keys on Ubuntu 22.04

Adds a KeyPairInfo class to encapsulate the data retrieved from AWS. It needs to be defined in aws_api because the aws_resources is a dependency for the API. Adds unit tests for all supported OSes for the keypair validator

### Tests
* Ran pytest for unit tests on the validator

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
