### PR TITLE
Restrict access to /tmp/wait_condition_handle.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ CHANGELOG
 - Upgrade Slurm to version 23.02.4.
 - Deprecate Ubuntu 18.
 - Update the default root volume size to 40 GB to account for limits on Centos 7.
+- Restrict permission on file `/tmp/wait_condition_handle.txt` within the head node so that only root can read it.
 
 **BUG FIXES**
 - Add validation to `ScaledownIdletime` value, to prevent setting a value lower than `-1`.

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1295,7 +1295,7 @@ class ClusterCdkStack:
                     # The file is needed by the product
                     # [B108:hardcoded_tmp_directory] Probable insecure usage of temp file/directory.
                     "/tmp/wait_condition_handle.txt": {  # nosec B108
-                        "mode": "000644",
+                        "mode": "000600",
                         "owner": "root",
                         "group": "root",
                         "content": self.wait_condition_handle.ref,


### PR DESCRIPTION
cherry picked from https://github.com/aws/aws-parallelcluster/pull/5601

### Description of changes
Restrict access to /tmp/wait_condition_handle.txt by changing permission mask from 644 to 600 with root owner.
The file contains the presigned URL of the CloudFormation WaitCondition and it is used only in the head node user data to send a signal to CloudFormation in case the node bootstrap/update succeeds.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
