### PR TITLE
[release-3.7][Performance Test] Improve scaling test to validate scale out to 1000 nodes

### DIFF
--- a/tests/integration-tests/configs/scaling.yaml
+++ b/tests/integration-tests/configs/scaling.yaml
@@ -2,7 +2,7 @@ test-suites:
   performance_tests:
     test_scaling.py::test_scaling:
       dimensions:
-        - regions: ["us-east-1"]
+        - regions: ["us-east-1", "eu-west-1"]
           instances: ["c5.large"]
           oss: ["alinux2"]
           schedulers: ["slurm"]

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -33,9 +33,10 @@ def test_scaling(
     logging.info(f"Submitting an array of {max_nodes} jobs on {max_nodes} nodes")
     job_id = scheduler_commands.submit_command_and_assert_job_accepted(
         submit_command_args={
-            "command": "sleep 1800",
+            "command": "srun sleep 10",
             "partition": "queue-1",
-            "other_options": f"--array [1-{max_nodes}] --exclusive",
+            "nodes": max_nodes,
+            "slots": max_nodes,
         }
     )
 

--- a/tests/integration-tests/tests/performance_tests/test_scaling.py
+++ b/tests/integration-tests/tests/performance_tests/test_scaling.py
@@ -34,7 +34,7 @@ def test_scaling(
     job_id = scheduler_commands.submit_command_and_assert_job_accepted(
         submit_command_args={
             "command": "srun sleep 10",
-            "partition": "queue-1",
+            "partition": "queue-0",
             "nodes": max_nodes,
             "slots": max_nodes,
         }

--- a/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling/pcluster.config.yaml
+++ b/tests/integration-tests/tests/performance_tests/test_scaling/test_scaling/pcluster.config.yaml
@@ -17,18 +17,6 @@ Scheduling:
       ComputeResources:
         - Name: compute-resource-0
           InstanceType: {{ instance }}
-          MinCount: {{ max_nodes }}
-          MaxCount: {{ max_nodes }}
-      Networking:
-        SubnetIds:
-          - {{ private_subnet_id }}
-      Iam:
-        AdditionalIamPolicies:
-          - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore #Required to report patching status
-    - Name: queue-1
-      ComputeResources:
-        - Name: compute-resource-0
-          InstanceType: {{ instance }}
           MinCount: 0
           MaxCount: {{ max_nodes }}
       Networking:


### PR DESCRIPTION
### Description of changes
The test is executed in 2 regions to collect more date.

With `-N 1000` we are sure to have 1000 nodes and using `srun` the job won't run in the first available node available and it will wait for all the nodes.`

The test checks that clustermgtd logs does not contain bootstrap errors for compute nodes.

There are no static nodes to avoid a failure at cluster creation time.

### References
* https://github.com/aws/aws-parallelcluster/pull/5600