### PR TITLE
Use wget for failure cases in test_dcv to avoid the change in behavio…

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -218,7 +218,7 @@ dcv:
       # DCV in gov-cloud regions and non GPU enabled instance
       - regions: ["us-gov-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2004"]
+        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
   test_dcv.py::test_dcv_with_remote_access:
     dimensions:

--- a/tests/integration-tests/tests/dcv/test_dcv.py
+++ b/tests/integration-tests/tests/dcv/test_dcv.py
@@ -85,17 +85,20 @@ def _test_dcv_configuration(
     _check_auth_ko(
         remote_command_executor,
         dcv_authenticator_port,
-        "-d action=requestToken -d authUser=centos -d sessionID=invalidSessionId",
+        "action=requestToken&authUser=centos&sessionID=invalidSessionId",
         "The given session does not exists",
     )
     _check_auth_ko(
-        remote_command_executor, dcv_authenticator_port, "-d action=test", "The action specified 'test' is not valid"
+        remote_command_executor,
+        dcv_authenticator_port,
+        "action=test",
+        "The action specified 'test' is not valid",
     )
     _check_auth_ko(
-        remote_command_executor, dcv_authenticator_port, "-d action=requestToken -d authUser=centos", "Wrong parameters"
-    )
-    _check_auth_ko(
-        remote_command_executor, dcv_authenticator_port, "-d action=sessionToken -d authUser=centos", "Wrong parameters"
+        remote_command_executor,
+        dcv_authenticator_port,
+        "action=requestToken&authUser=centos",
+        "Wrong parameters",
     )
 
     shared_dir = f"/home/{get_username_for_os(os)}"
@@ -133,7 +136,8 @@ def _test_dcv_configuration(
 def _check_auth_ko(remote_command_executor, dcv_authenticator_port, params, expected_message):
     assert_that(
         remote_command_executor.run_remote_command(
-            f"curl -s -k -X GET -G {SERVER_URL}:{dcv_authenticator_port} {params}"
+            "wget --no-check-certificate --output-document - --quiet "
+            f"'{SERVER_URL}:{dcv_authenticator_port}?{params}'"
         ).stdout
     ).contains(expected_message)
 


### PR DESCRIPTION

…r for curl with OpenSSL 3.0 when running on Ubuntu 22.04

Curl exits with a code of 56 when executing the test command for error cases, but returns 0 for the same on Ubuntu 20.
Otherwise all positive tests for DCV are passing on Ubuntu 22.04.  Able to launch clusters and open the web portal
for DCV via dcv-connect.


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

### Tests
* Ran test_dcv integ tests locally and on dev jenkins for Ubuntu 20 and 22.
* Added ubuntu 2204 to the common integ test config.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
