### PR TITLE
[develop] Add possibility to pass a custom cinc URL during AMI build

### DIFF
--- a/cli/src/pcluster/config/imagebuilder_config.py
+++ b/cli/src/pcluster/config/imagebuilder_config.py
@@ -197,6 +197,7 @@ class ImagebuilderDevSettings(BaseDevSettings):
         distribution_configuration: DistributionConfiguration = None,
         terminate_instance_on_failure: bool = None,
         disable_validate_and_test: bool = None,
+        cinc_installer_url: str = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -204,6 +205,7 @@ class ImagebuilderDevSettings(BaseDevSettings):
         self.distribution_configuration = distribution_configuration
         self.terminate_instance_on_failure = Resource.init_param(terminate_instance_on_failure, default=True)
         self.disable_validate_and_test = Resource.init_param(disable_validate_and_test, default=True)
+        self.cinc_installer_url = Resource.init_param(cinc_installer_url, default="")
 
 
 # ---------------------- ImageBuilder ---------------------- #

--- a/cli/src/pcluster/schemas/imagebuilder_schema.py
+++ b/cli/src/pcluster/schemas/imagebuilder_schema.py
@@ -203,6 +203,7 @@ class ImagebuilderDevSettingsSchema(BaseDevSettingsSchema):
     distribution_configuration = fields.Nested(DistributionConfigurationSchema)
     terminate_instance_on_failure = fields.Bool()
     disable_validate_and_test = fields.Bool()
+    cinc_installer_url = fields.Str()
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/imagebuilder_stack.py
+++ b/cli/src/pcluster/templates/imagebuilder_stack.py
@@ -183,7 +183,16 @@ class ImageBuilderCdkStack(Stack):
         CfnParameter(
             self, "CfnParamChefCookbook", type="String", default=custom_chef_cookbook, description="ChefCookbook"
         )
-        CfnParameter(self, "CfnParamCincInstaller", type="String", default="", description="CincInstaller")
+
+        custom_cinc_installer_url = (
+            self.config.dev_settings.cinc_installer_url
+            if self.config.dev_settings and self.config.dev_settings.cinc_installer_url
+            else ""
+        )
+        CfnParameter(
+            self, "CfnParamCincInstaller", type="String", default=custom_cinc_installer_url, description="CincInstaller"
+        )
+
         CfnParameter(
             self,
             "CfnParamChefDnaJson",


### PR DESCRIPTION
### Description of changes

This change permits to pass a custom installer url to test new cinc version at AMI build time.

Example:
```
DevSettings:
  CincInstallerUrl: https://raw.githubusercontent.com/aws/aws-parallelcluster-cookbook/develop/util/cinc-install.sh
```

### Tests
* Tested with CI/CD
