### PR TITLE
[release-3.7] Allow restricted SSH access to LoginNodes

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -125,6 +125,7 @@ from pcluster.schemas.common_schema import ImdsSchema as TopLevelImdsSchema
 from pcluster.schemas.common_schema import (
     TagSchema,
     get_field_validator,
+    is_cidr_or_prefix_list,
     validate_no_duplicate_tag,
     validate_no_reserved_tag,
 )
@@ -734,7 +735,7 @@ class BaseSshSchema(BaseSchema):
 class HeadNodeSshSchema(BaseSshSchema):
     """Represent the schema of the HeadNodeSsh."""
 
-    allowed_ips = fields.Str(validate=get_field_validator("cidr"), metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    allowed_ips = fields.Str(validate=is_cidr_or_prefix_list, metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -747,7 +748,7 @@ class DcvSchema(BaseSchema):
 
     enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     port = fields.Int(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
-    allowed_ips = fields.Str(validate=get_field_validator("cidr"), metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    allowed_ips = fields.Str(validate=is_cidr_or_prefix_list, metadata={"update_policy": UpdatePolicy.SUPPORTED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -229,22 +229,42 @@ def test_dcv_validator(section_dict, expected_message):
 @pytest.mark.parametrize(
     "section_dict, expected_message",
     [
-        ({"AllowedIps": "wrong_value"}, "does not match expected patter"),
-        ({"AllowedIps": ""}, "does not match expected pattern"),
-        ({"AllowedIps": "wrong_value"}, "does not match expected pattern"),
-        ({"AllowedIps": "111.111.111.111"}, "does not match expected pattern"),
-        ({"AllowedIps": "111.111.111.111/222"}, "does not match expected pattern"),
-        ({"AllowedIps": "NONE"}, "does not match expected pattern"),
+        (
+            {"AllowedIps": "wrong_value"},
+            "Invalid value: 'wrong_value' is neither a valid CIDR nor a valid prefix-list.",
+        ),
+        ({"AllowedIps": ""}, "Invalid value: '' is neither a valid CIDR nor a valid prefix-list."),
+        (
+            {"AllowedIps": "wrong_value"},
+            "Invalid value: 'wrong_value' is neither a valid CIDR nor a valid prefix-list.",
+        ),
+        (
+            {"AllowedIps": "111.111.111.111"},
+            "Invalid value: '111.111.111.111' is neither a valid CIDR nor a valid prefix-list.",
+        ),
+        (
+            {"AllowedIps": "111.111.111.111/222"},
+            "Invalid value: '111.111.111.111/222' is neither a valid CIDR nor a valid prefix-list.",
+        ),
+        ({"AllowedIps": "NONE"}, "Invalid value: 'NONE' is neither a valid CIDR nor a valid prefix-list."),
         ({"AllowedIps": "0.0.0.0/0"}, None),
         ({"AllowedIps": "1.1.1.1/0"}, None),
         ({"AllowedIps": "1.1.1.1/8"}, None),
         ({"AllowedIps": "1.1.1.1/15"}, None),
         ({"AllowedIps": "1.1.1.1/32"}, None),
-        ({"AllowedIps": "1.1.1.1/33"}, "does not match expected pattern"),
+        ({"AllowedIps": "1.1.1.1/33"}, "Invalid value: '1.1.1.1/33' is neither a valid CIDR nor a valid prefix-list."),
         ({"AllowedIps": "11.11.11.11/32"}, None),
         ({"AllowedIps": "111.111.111.111/22"}, None),
         ({"AllowedIps": "255.255.255.255/32"}, None),
-        ({"AllowedIps": "255.255.255.256/32"}, "does not match expected pattern"),
+        ({"AllowedIps": "pl-123abcDEF"}, None),
+        (
+            {"AllowedIps": "prefix-list"},
+            "Invalid value: 'prefix-list' is neither a valid CIDR nor a valid prefix-list.",
+        ),
+        (
+            {"AllowedIps": "255.255.255.256/32"},
+            "Invalid value: '255.255.255.256/32' is neither a valid CIDR nor a valid prefix-list.",
+        ),
     ],
 )
 def test_cidr_validator(section_dict, expected_message):

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_security_group_with_restricted_ssh_access/config_restricted_ssh_cidr.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_security_group_with_restricted_ssh_access/config_restricted_ssh_cidr.yaml
@@ -1,0 +1,32 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+    AllowedIps: 1.2.3.4/19
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: t3.small
+      Count: 1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+        AdditionalSecurityGroups:
+          - sg-12345678
+      Ssh:
+        KeyName: kn-12345678
+

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_security_group_with_restricted_ssh_access/config_restricted_ssh_invalid.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_security_group_with_restricted_ssh_access/config_restricted_ssh_invalid.yaml
@@ -1,0 +1,31 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+    AllowedIps: invalid-cidr
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: t3.small
+      Count: 1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+        AdditionalSecurityGroups:
+          - sg-12345678
+      Ssh:
+        KeyName: kn-12345678

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_security_group_with_restricted_ssh_access/config_restricted_ssh_prefix_list.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_security_group_with_restricted_ssh_access/config_restricted_ssh_prefix_list.yaml
@@ -1,0 +1,31 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+    AllowedIps: pl-012345abcdABCD
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: t3.small
+      Count: 1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+        AdditionalSecurityGroups:
+          - sg-12345678
+      Ssh:
+        KeyName: kn-12345678


### PR DESCRIPTION
### Description of changes
* Allow to use prefix-lists in HeadNode `AllowedIPs` fields used to restrict SSH access
* Use SSH access restrictions used for the HeadNode in the LoginNodes SecurityGroup ingress rules

### Tests
* Added a specific unit test to validate this behavior (for both HeadNode and LoginNodes)

### References
* Porting of [changes committed in develop](https://github.com/aws/aws-parallelcluster/pull/5589)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

