### PR TITLE
[develop]Create lifecycle hook the same time as ASG and correct wrong instance IAM policy resource of autoscaling:CompleteLifecycleAction

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -883,7 +883,7 @@ class LoginNodesIamResources(NodeIamResourcesBase):
                 resources=[
                     self._format_arn(
                         service="autoscaling",
-                        resource=f"autoScalingGroupName/{self._auto_scaling_group_name}",
+                        resource=f"autoScalingGroup:*:autoScalingGroupName/{self._auto_scaling_group_name}",
                     )
                 ],
             ),

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -599,7 +599,8 @@ class IamPolicyAssertion:
                                         {"Ref": "AWS::Region"},
                                         ":",
                                         {"Ref": "AWS::AccountId"},
-                                        ":autoScalingGroupName/clustername-testloginnodespool1-AutoScalingGroup",
+                                        ":autoScalingGroup:*:autoScalingGroupName/clustername-"
+                                        "testloginnodespool1-AutoScalingGroup",
                                     ],
                                 ]
                             },


### PR DESCRIPTION
### Description of changes
* Modify cdk_builder_utils.py to correct wrong instance IAM policy resource of autoscaling:CompleteLifecycleAction
* Modify login_nodes_stack.py to create lifecycle hook the same time as ASG
* Fix related unit tests

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.