### PR TITLE
[release-3.7] Add AD test for LoginNodes

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/NLB_SimpleAD.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/NLB_SimpleAD.yaml
@@ -1,0 +1,118 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: |-
+  LDAPS NLB Stack from https://aws.amazon.com/blogs/security/how-to-configure-ldaps-endpoint-for-simple-ad/
+Parameters:
+  LDAPSCertificateARN:
+    Description: ARN of SSL Certificate provided as ACM Certificate or IAM Server Certificate
+    AllowedPattern: "arn:aws.*:(acm|iam):.*:.*:(certificate|server-certificate)/.*"
+    Type: String
+  VPCId:
+    Description: Please provide a VPC to deploy the solution into.
+    Type: AWS::EC2::VPC::Id
+  SubnetId1:
+    Description: Please provide the first Simple AD private subnet id with outbound connectivity within the VPC you selected above.
+    Type: AWS::EC2::Subnet::Id
+  SubnetId2:
+    Description: Please provide the second Simple AD private subnet id with outbound connectivity within the VPC you selected above.
+    Type: AWS::EC2::Subnet::Id
+  SimpleADPriIP:
+    Description: IP Address of primary Simple AD instance
+    AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
+    Type: String
+  SimpleADSecIP:
+    Description: IP Address of secondary Simple AD instance
+    AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
+    Type: String
+  CertificateSecretArn:
+    Description: The Arn of the secret storing the certificate
+    Type: String
+  DomainName:
+    Description: The domain name of the certificate in the CertificateSecretArn
+    Type: String
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: Network Configuration
+      Parameters:
+      - VPCId
+      - SubnetId1
+      - SubnetId2
+      - SimpleADPriIP
+      - SimpleADSecIP
+      - LDAPSCertificateARN
+    ParameterLabels:
+      VPCId:
+        default: Target VPC for solution
+      SubnetId1:
+        default: Simple AD Primary Subnet
+      SubnetId2:
+        default: Simple AD Secondary Subnet
+      SimpleADPriIP:
+        default: Primary Simple AD Server IP
+      SimpleADSecIP:
+        default: Secondary Simple AD Server IP
+      LDAPSCertificateARN:
+        default: ARN for SSL Certificate
+Resources:
+  NetworkLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Scheme: internal
+      Subnets:
+        - !Ref SubnetId1
+        - !Ref SubnetId2
+      Type: network
+  NetworkLoadBalancerTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Port: 389
+      Protocol: TCP
+      VpcId: !Ref VPCId
+      HealthCheckEnabled: True
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPort: 389
+      HealthCheckProtocol: TCP
+      HealthCheckTimeoutSeconds: 10
+      HealthyThresholdCount: 3
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+      Targets:
+        - Id: !Ref SimpleADPriIP
+          Port: 389
+        - Id: !Ref SimpleADSecIP
+          Port: 389
+      TargetType: ip
+  NetworkLoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref NetworkLoadBalancerTargetGroup
+      LoadBalancerArn: !Ref NetworkLoadBalancer
+      Port: '636'
+      Protocol: TLS
+      SslPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
+      Certificates:
+        - CertificateArn: !Ref LDAPSCertificateARN
+  DNS:
+    Type: AWS::Route53::HostedZone
+    Properties:
+      Name: !Ref DomainName
+      VPCs:
+        - VPCId: !Ref VPCId
+          VPCRegion: !Ref AWS::Region
+  DNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref DNS
+      Name: !Ref DomainName
+      AliasTarget:
+        DNSName: !GetAtt NetworkLoadBalancer.DNSName
+        HostedZoneId: !GetAtt NetworkLoadBalancer.CanonicalHostedZoneID
+      Type: A
+Outputs:
+  LDAPSURL:
+    Description: LDAPS Route53 Alias Target
+    Value: !GetAtt NetworkLoadBalancer.DNSName

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/ad_stack.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/ad_stack.yaml
@@ -1,0 +1,326 @@
+Parameters:
+  Vpc:
+    Description: VPC ID.
+    Type: String
+  PrivateSubnetOne:
+    Description: Subnet ID of the first subnet.
+    Type: String
+  PrivateSubnetTwo:
+    Description: Subnet ID of the second subnet. This subnet should be in another availability zone
+    Type: String
+  PublicSubnetOne:
+    Description: Subnet ID of the public subnet.
+    Type: String
+Resources:
+  DisableImdsv1LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpPutResponseHopLimit: 4
+          HttpTokens: required
+  AdDomainAdminNodeSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow SSH access
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          FromPort: -1
+          IpProtocol: "-1"
+          ToPort: -1
+      SecurityGroupIngress:
+        - CidrIp: 0.0.0.0/0
+          FromPort: 22
+          IpProtocol: tcp
+          ToPort: 22
+      VpcId:
+        Ref: Vpc
+  Directory:
+    Type: AWS::DirectoryService::{{ directory_type }}
+    Properties:
+      Name: {{ ad_domain_name }}
+      Password: {{ ad_admin_password }}
+      VpcSettings:
+        SubnetIds:
+          - Ref: PrivateSubnetOne
+          - Ref: PrivateSubnetTwo
+        VpcId:
+          Ref: Vpc
+      {% if directory_type == "SimpleAD" %}
+      Size: Small
+      {% endif %}
+      {% if directory_type == "MicrosoftAD" %}
+      Edition: Standard
+      {% endif %}
+      ShortName: {{ ad_domain_short_name }}
+  AdDomainAdminNodeWaitConditionHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+  AdDomainAdminNodeWaitCondition:
+    Type: AWS::CloudFormation::WaitCondition
+    Properties:
+      Count: 1
+      Handle:
+        Ref: AdDomainAdminNodeWaitConditionHandle
+      Timeout: "1800"
+    DependsOn:
+      - Directory
+  JoinRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: ec2.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/AmazonSSMDirectoryServiceAccess
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - ds:ResetUserPassword
+                Effect: Allow
+                Resource:
+                  - Fn::Join:
+                      - ""
+                      - - "arn:"
+                        - Ref: AWS::Partition
+                        - :ds:{{ region }}:{{ account }}:directory/
+                        - Ref: Directory
+          PolicyName:
+            Fn::Join:
+              - ""
+              - - Ref: AWS::StackName
+                - resetuserpassword
+  JoinProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - Ref: JoinRole
+    DependsOn:
+      - JoinRole
+  AdDomainAdminNode:
+    Type: AWS::EC2::Instance
+    Properties:
+      IamInstanceProfile:
+        Ref: JoinProfile
+      ImageId: {{ admin_node_ami_id }}
+      InstanceType: {{ admin_node_instance_type }}
+      KeyName: {{ admin_node_key_name }}
+      LaunchTemplate:
+        LaunchTemplateId: !Ref 'DisableImdsv1LaunchTemplate'
+        Version: !GetAtt 'DisableImdsv1LaunchTemplate.LatestVersionNumber'
+      SecurityGroupIds:
+        - Ref: AdDomainAdminNodeSecurityGroup
+      SubnetId:
+        Ref: PublicSubnetOne
+      UserData:
+        Fn::Base64:
+          Fn::Join:
+            - ""
+            - - |-
+                #!/bin/bash
+
+                set -ex
+                DIRECTORY_DNS_SERVER_IPS=
+              - Fn::Join:
+                - ","
+                - Fn::GetAtt:
+                  - Directory
+                  - DnsIpAddresses
+              - |-
+
+                DNS_IP_ONE=$(echo $DIRECTORY_DNS_SERVER_IPS | cut -d ',' -f 1)
+                DNS_IP_TWO=$(echo $DIRECTORY_DNS_SERVER_IPS | cut -d ',' -f 2)
+
+                AD_ADMIN_PASSWORD='{{ ad_admin_password }}'
+                AD_DOMAIN='{{ ad_domain_name }}'
+                AD_ADMIN_USER='{{ ad_admin_user }}'
+                AD_USERS_BASE_SEARCH='{{ ad_users_base_search }}'
+                DEFAULT_EC2_DOMAIN={{ default_ec2_domain }}
+
+                cat << EOF > /etc/resolv.conf
+                domain           $AD_DOMAIN $DEFAULT_EC2_DOMAIN
+                nameserver       $DNS_IP_ONE
+                nameserver       $DNS_IP_TWO
+                EOF
+
+                SSSD_CONFIG_PATH=/etc/sssd/sssd.conf
+                SSHD_CONFIG_PATH=/etc/ssh/sshd_config
+
+                # Install dependencies
+                yum -y install sssd realmd samba-common samba-common-tools openldap-clients krb5-workstation adcli
+
+                # Join realm
+                echo "$AD_ADMIN_PASSWORD" | realm join -U "${AD_ADMIN_USER}@${AD_DOMAIN}" "$AD_DOMAIN"
+
+                # Configure SSSD
+                # SSSD: don't use full hostnames for the AD domain
+                sed -i 's/use_fully_qualified_names = True/use_fully_qualified_names = False/g' $SSSD_CONFIG_PATH
+                grep use_fully_qualified_names "$SSSD_CONFIG_PATH"
+                # SSSD: modify default home directory path
+                sed -ri 's/fallback_homedir =.*$/fallback_homedir = \/home\/%u/g' "$SSSD_CONFIG_PATH"
+                grep fallback_homedir "$SSSD_CONFIG_PATH"
+                systemctl restart sssd
+
+                # Script to add a number of users
+                cat << EOF > /usr/local/bin/add_a_number_of_users.sh
+                #!/bin/bash
+                DIRECTORY_ID=\$1
+                NUM_USERS_TO_CREATE=\$2
+                if [ -z "\${DIRECTORY_ID}" ]; then
+                    echo 1>&2 "DIRECTORY_ID must be passed as first arg"
+                    exit 1
+                fi
+                if [ -z "\${NUM_USERS_TO_CREATE}" ]; then
+                    echo 1>&2 "NUM_USERS_TO_CREATE must be passed as second arg"
+                    exit 1
+                fi
+                for i in \$(seq 0 "\$((NUM_USERS_TO_CREATE - 1))"); do
+                    NEW_USER_ALIASES="\${NEW_USER_ALIASES} PclusterUser\${i}"
+                done
+
+                # Create LDIF file to create users
+                LDIF_FILE="adusers.ldif"
+                rm -rf \${LDIF_FILE}
+                for NEW_USER_ALIAS in \${NEW_USER_ALIASES}; do
+                  echo "dn: CN=\${NEW_USER_ALIAS},${AD_USERS_BASE_SEARCH}" >> \${LDIF_FILE}
+                  echo "objectClass: top" >> \${LDIF_FILE}
+                  echo "objectClass: person" >> \${LDIF_FILE}
+                  echo "objectClass: organizationalPerson" >> \${LDIF_FILE}
+                  echo "objectClass: user" >> \${LDIF_FILE}
+                  echo "userAccountControl: 514" >> \${LDIF_FILE}
+                  echo "accountExpires: 0" >> \${LDIF_FILE}
+                  echo "sAMAccountName: \${NEW_USER_ALIAS}" >> \${LDIF_FILE}
+                  echo "" >> \${LDIF_FILE}
+                done
+                echo "Wrote LDIF file: \${LDIF_FILE}"
+                cat \${LDIF_FILE}
+
+                # Create users in directory
+                # TODO: add ability to trigger this via lambda
+                MAX_ATTEMPTS=5
+                for ATTEMPT in \$(seq 1 \${MAX_ATTEMPTS}); do
+                  echo "Creating users from LDIF file \${LDIF_FILE} (attempt \${ATTEMPT}/\${MAX_ATTEMPTS})"
+                  ldapadd -f "\${LDIF_FILE}" -x -h "${DNS_IP_ONE}" -D "CN=${AD_ADMIN_USER},${AD_USERS_BASE_SEARCH}" -w "${AD_ADMIN_PASSWORD}" && break
+                  if [ \${ATTEMPT} -ge \${MAX_ATTEMPTS} ]; then
+                    echo "ERROR: Cannot create users"
+                    exit 1
+                  else
+                    SLEEP_TIME=\${ATTEMPT}
+                    echo "WARNING: Cannot create users. Will retry in \${SLEEP_TIME} seconds"
+                    sleep \${SLEEP_TIME}
+                  fi
+                done
+
+                # Change user passwords
+                # TODO: put this in a lambda that can be triggered by users
+                for NEW_USER_ALIAS in \${NEW_USER_ALIASES}; do
+                    MAX_ATTEMPTS=5
+                    for ATTEMPT in \$(seq 1 \${MAX_ATTEMPTS}); do
+                      echo "Setting password for user \${NEW_USER_ALIAS} (attempt \${ATTEMPT}/\${MAX_ATTEMPTS})"
+                      aws ds reset-user-password \
+                          --region {{ region }} \
+                          --directory-id "\${DIRECTORY_ID}" \
+                          --user-name "\${NEW_USER_ALIAS}" \
+                          --new-password "{{ ad_user_password }}" && break
+                      if [ \${ATTEMPT} -ge \${MAX_ATTEMPTS} ]; then
+                        echo "ERROR: Cannot set password for user \${NEW_USER_ALIAS}"
+                        exit 1
+                      else
+                        SLEEP_TIME=\${ATTEMPT}
+                        echo "WARNING: Cannot set password for user \${NEW_USER_ALIAS}. Will retry in \${SLEEP_TIME} seconds"
+                        sleep \${SLEEP_TIME}
+                      fi
+                    done
+                done
+                EOF
+                chmod +x /usr/local/bin/add_a_number_of_users.sh
+
+                # Signal success
+                # TODO: don't assumed this is installed (in case non-AL2 AMI used)
+                /opt/aws/bin/cfn-signal --exit-code=0 --reason="admin node setup complete" '
+              - Ref: AdDomainAdminNodeWaitConditionHandle
+              - "'"
+    DependsOn:
+      - Directory
+      - JoinProfile
+Outputs:
+  VpcId:
+    Value:
+      Ref: Vpc
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - VpcId
+  PrivateSubnetIds:
+    Value:
+      Fn::Join:
+        - ","
+        - - Ref: PrivateSubnetOne
+          - Ref: PrivateSubnetTwo
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - PrivateSubnetIds
+  DomainName:
+    Value: {{ ad_domain_name }}
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - DomainName
+  DomainShortName:
+    Value: {{ ad_domain_short_name }}
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - DomainShortName
+  AdminPassword:
+    Value: {{ ad_admin_password }}
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - AdminPassword
+  UserPassword:
+    Value: {{ ad_user_password }}
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - UserPassword
+  ReadOnlyUserName:
+    Value: {{ ad_admin_user }}
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - ReadOnlyUserName
+  DirectoryDnsIpAddresses:
+    Value:
+      Fn::Join:
+        - ","
+        - Fn::GetAtt:
+          - Directory
+          - DnsIpAddresses
+    Export:
+      Name:
+        Fn::Join:
+          - ""
+          - - Ref: AWS::StackName
+            - DirectoryDnsIpAddresses

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/pcluster.config.yaml
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration/test_ad_integration_on_login_nodes/pcluster.config.yaml
@@ -1,0 +1,75 @@
+Image:
+  Os: {{ os }}
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: {{ instance }}
+      Count: 1
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      Ssh:
+        KeyName: {{ key_name }}
+HeadNode:
+  InstanceType: {{ head_node_instance_type }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: compute
+      ComputeResources:
+        - Name: cit
+          Instances:
+            - InstanceType: {{ compute_instance_type }}
+          MinCount: 2
+          MaxCount: 150
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+Monitoring:
+  Logs:
+    CloudWatch:
+      Enabled: true
+      RetentionInDays: 14
+SharedStorage:
+  - MountDir: /shared
+    Name: ebs
+    StorageType: Ebs
+  - MountDir: /efs
+    Name: efs
+    StorageType: Efs
+  {% if fsx_supported %}
+  - MountDir: /fsxlustre
+    Name: fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: 2400
+  - MountDir: /fsxopenzfs
+    Name: existingopenzfs
+    StorageType: FsxOpenZfs
+    FsxOpenZfsSettings:
+      VolumeId: {{ fsx_open_zfs_volume_id }}
+  - MountDir: /fsxontap
+    Name: existingontap
+    StorageType: FsxOntap
+    FsxOntapSettings:
+      VolumeId: {{ fsx_ontap_volume_id }}
+  {% endif %}
+DirectoryService:
+  DomainName: {{ ldap_search_base }}
+  DomainAddr: {{ ldap_uri }}
+  PasswordSecretArn: {{ password_secret_arn }}
+  DomainReadOnlyUser: {{ ldap_default_bind_dn }}
+  LdapTlsCaCert: {{ ldap_tls_ca_cert }}
+  LdapTlsReqCert: {{ ldap_tls_req_cert }}
+  GenerateSshKeysForUsers: true
+  AdditionalSssdConfigs:
+    debug_level: "0x1ff"
+    {% if directory_protocol == "ldap" %}
+    ldap_auth_disable_tls_never_use_in_production: True
+    {% endif %}


### PR DESCRIPTION
### Description of changes
Porting in release-3.7 branch of a PR already merged in develop.

Test AD integration in LoginNodes with SimpleAD
and MicrosoftAD with certification validation.

Checks that AD users can log into the nodes,
their home and ssh keys created and their posix
permissions correctly set.

### Tests
* Successful manual launch of the integration test

### References 
* [PR for develop branch](https://github.com/aws/aws-parallelcluster/pull/5619)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
