### PR TITLE
[Develop] Test Slurm with LoginNodes in a private network

### DIFF
--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -246,11 +246,22 @@ class Cluster:
         return self.describe_cluster_instances(node_type="LoginNode")
 
     def get_login_node_public_ip(self):
-        """Return the ip address of the first healthy login node if exists."""
+        """Return the public ip address of the first healthy login node if exists."""
+        return self._get_login_node_ip(private=False)
+
+    def get_login_node_private_ip(self):
+        """Return the private ip address of the first healthy login node if exists."""
+        return self._get_login_node_ip(private=True)
+
+    def _get_login_node_ip(self, private=False):
+        key = "publicIpAddress"
+        if private:
+            key = "privateIpAddress"
+
         login_nodes = self.describe_login_nodes()
-        for login in login_nodes:
-            if "running" == login["state"]:
-                return login["publicIpAddress"]
+        for node in login_nodes:
+            if "running" == node["state"] and key in node:
+                return node[key]
 
         return None
 

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -416,6 +416,12 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2204"]
         schedulers: ["slurm"]
+  test_slurm.py::test_slurm_from_login_nodes_in_private_network:
+    dimensions:
+      - regions: ["eu-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
   test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
     dimensions:
       - regions: ["ap-south-1"]

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -45,9 +45,12 @@ class RemoteCommandExecutor:
             bastion = f"{username}@{cluster.head_node_ip}"
         elif use_login_node:
             self.target = "LoginNode"
-            node_ip = cluster.get_login_node_public_ip()
+            if bastion:
+                node_ip = cluster.get_login_node_private_ip()
+            else:
+                node_ip = cluster.get_login_node_public_ip()
             if node_ip is None:
-                raise RemoteCommandExecutionError("No healthy LoginNode found in the cluster.")
+                raise RemoteCommandExecutionError("Unable to retrieve a valid LoginNode IP Address.")
         else:
             self.target = "HeadNode"
             node_ip = cluster.head_node_ip
@@ -68,6 +71,7 @@ class RemoteCommandExecutor:
             )
             connection_kwargs["gateway"] = f"ssh -W %h:%p -A {bastion}"
             connection_kwargs["forward_agent"] = True
+            connection_kwargs["connect_kwargs"]["banner_timeout"] = 60
         logging.info(
             f"Connecting to {connection_kwargs['host']} as {connection_kwargs['user']} with "
             f"{connection_kwargs['connect_kwargs']['key_filename']}"

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/mpi_job.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/mpi_job.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#SBATCH --export=ALL
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=3
+#SBATCH --job-name=imb2
+#SBATCH --output=runscript.out
+
+module load intelmpi
+mpirun -n 6 IMB-MPI1 Alltoall -npmin 2

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/pcluster.config.yaml
@@ -1,0 +1,52 @@
+Image:
+  Os: {{ os }}
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: {{ instance }}
+      Count: 1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      GracetimePeriod: 5
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    ScaledownIdletime: {{ scaledown_idletime }}
+  SlurmQueues:
+    - Name: ondemand
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: ondemand-i1
+          Instances:
+            - InstanceType: c4.xlarge
+        - Name: same-name-diff-queue
+          Instances:
+            - InstanceType: c5.xlarge
+          MaxCount: 5
+    - Name: gpu
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      CapacityType: ONDEMAND
+      ComputeResources:
+        - Name: same-name-diff-queue
+          Instances:
+            - InstanceType: {{ gpu_instance_type }}
+          MaxCount: 5
+SharedStorage:
+  - MountDir: /shared  # Test comment
+    Name: name1
+    StorageType: Ebs
+DevSettings:
+  Timeouts:
+    HeadNodeBootstrapTimeout: 1700
+    ComputeNodeBootstrapTimeout: {{compute_node_bootstrap_timeout}}

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/pcluster.update.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/pcluster.update.config.yaml
@@ -1,0 +1,54 @@
+Image:
+  Os: {{ os }}
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: {{ instance }}
+      Count: 1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      GracetimePeriod: 5
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    ScaledownIdletime: {{ scaledown_idletime }}
+  SlurmQueues:
+    - Name: ondemand
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: ondemand-i1
+          Instances:
+            - InstanceType: c5.large
+        - Name: same-name-diff-queue
+          Instances:
+            - InstanceType: c5.xlarge
+          MinCount: 1
+          MaxCount: 5
+    - Name: gpu
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      CapacityType: ONDEMAND
+      ComputeResources:
+        - Name: same-name-diff-queue
+          Instances:
+            - InstanceType: {{ gpu_instance_type }}
+          MaxCount: 5
+SharedStorage:
+  - MountDir: /shared  # Test comment
+    Name: name1
+    StorageType: Ebs
+DevSettings:
+  Timeouts:
+    HeadNodeBootstrapTimeout: 1700
+    ComputeNodeBootstrapTimeout: {{compute_node_bootstrap_timeout}}
+

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/torque_job.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/torque_job.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "qsub executed successfully"


### PR DESCRIPTION
### Description of changes
* Cluster class provides private IP
* RemoteCommandExecutor retrieves and uses  LoginNode private IP when bastion is defined
* Test common Slurm tasks with LoginNodes in a private network

### Tests
* Manual launch of the test was successful

### References
N/A

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
