### PR TITLE
[release-3.7] gracetime period

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1264,7 +1264,7 @@ class LoginNodesPool(Resource):
         self.count = Resource.init_param(count, default=1)
         self.ssh = ssh
         self.iam = iam or LoginNodesIam(implied=True)
-        self.gracetime_period = Resource.init_param(gracetime_period, default=60)
+        self.gracetime_period = Resource.init_param(gracetime_period, default=10)
 
     @property
     def instance_profile(self):

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -511,7 +511,7 @@ class TestBaseClusterConfig:
 
         login_nodes = LoginNodes(pools=[login_node_pool])
         assert_that(login_nodes.pools[0].count).is_equal_to(1)
-        assert_that(login_nodes.pools[0].gracetime_period).is_equal_to(60)
+        assert_that(login_nodes.pools[0].gracetime_period).is_equal_to(10)
 
     @pytest.mark.parametrize(
         "queue, expected_value",

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -9,7 +9,7 @@ LoginNodes:
   - Name: test
     InstanceType: t2.micro
     Count: 1
-    GracetimePeriod: 60
+    GracetimePeriod: 10
     Image:
       CustomAmi: ami-12345678
     Networking:

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -86,7 +86,7 @@ Imds:
 LoginNodes:
   Pools:
   - Count: 1
-    GracetimePeriod: 60
+    GracetimePeriod: 10
     Iam:
       AdditionalIamPolicies:
       - Policy: arn:aws:iam::aws:policy/AdministratorAccess

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_multiple/pcluster.config.yaml
@@ -9,7 +9,7 @@ LoginNodes:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
-      GracetimePeriod: 60
+      GracetimePeriod: 10
 {% endif %}
 HeadNode:
   InstanceType: {{ instance }}


### PR DESCRIPTION
### Description of changes
* CherryPick from [develop](https://github.com/aws/aws-parallelcluster/pull/5643)
* Reduce default value for LoginNode GracetimePeriod to 10 minutes.
* Adapt existing tests to new default value.

## Tests
* Manually launched unit tests.

### References
* [PR in develop](https://github.com/aws/aws-parallelcluster/pull/5643)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
