### PR TITLE
[release-3.7] Reduce wait-time while checking mpi jobs

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -1431,7 +1431,7 @@ def _test_mpi_job_termination(remote_command_executor, test_datadir, slurm_comma
 
     # Wait for compute node to start and check that mpi processes are started
     _wait_computefleet_running(region, cluster, remote_command_executor)
-    retry(wait_fixed=seconds(30), stop_max_delay=seconds(500))(_assert_job_state)(
+    retry(wait_fixed=seconds(10), stop_max_delay=seconds(500))(_assert_job_state)(
         slurm_commands, job_id, job_state="RUNNING"
     )
     _check_mpi_process(remote_command_executor, slurm_commands, num_nodes=2, after_completion=False)


### PR DESCRIPTION
### Description of changes
While testing slurm we also test mpi job submission. The wait time to check the mpi job started was of
comparable size with the time requested to complete the job itself. This lead to flacky results.
By reducing this wait time the chances of failures should be greatly reduced.

* wait-time to check that mpi-job is running reduced from 30s to 10s

### Tests
* Manually launched the test with Login Nodes and Ubuntu2204

### References
N/A

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
