### PR TITLE
[release-3.7] Reduce Login nodes gracetime period in test_ebs_existing

### DIFF
--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -10,6 +10,7 @@
 # This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 import logging
+import time
 
 import boto3
 import pytest
@@ -255,6 +256,10 @@ def test_ebs_existing(
 
     # delete the cluster before detaching the EBS volume
     cluster.delete()
+
+    # Wait a little longer than 3 minutes to let the LN GracetimePeriod expire (3min)
+    # Note: double check if it is needed. It seems that LN are terminated before the cluster deletion is completed.
+    time.sleep(200)
     # check the volume still exists after deleting the cluster
     _assert_volume_exist(volume_id, region)
 

--- a/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_ebs/test_ebs_existing/pcluster.config.yaml
@@ -9,7 +9,7 @@ LoginNodes:
       Networking:
         SubnetIds:
           - {{ public_subnet_id }}
-      GracetimePeriod: 60
+      GracetimePeriod: 3
 {% endif %}
 HeadNode:
   InstanceType: {{ instance }}


### PR DESCRIPTION
### Description of changes
Previously the config set the gracetime period to 1h 
This lead to a timeout when deleting the cluster and consequently the test failed.

* Reduced the gracetime period to 3min
* Added an extra wait time of little more than 3min after the cluster deletion

### Tests
* Manually launched the test 

### References
N/A

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
