### PR TITLE
Fixes usage of instance types data file during rollback and adds an integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 **CHANGES**
 
 **BUG FIXES**
+- Fix inconsistent scaling configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.
 
 3.7.0
 ------

--- a/cli/src/pcluster/api/converters.py
+++ b/cli/src/pcluster/api/converters.py
@@ -28,6 +28,7 @@ def cloud_formation_status_to_cluster_status(cfn_status):
     return mapping.get(cfn_status, cfn_status)
 
 
+
 def cloud_formation_status_to_image_status(cfn_status):
     mapping = {
         CloudFormationStackStatus.CREATE_IN_PROGRESS: ImageBuildStatus.BUILD_IN_PROGRESS,

--- a/cli/src/pcluster/api/converters.py
+++ b/cli/src/pcluster/api/converters.py
@@ -28,7 +28,6 @@ def cloud_formation_status_to_cluster_status(cfn_status):
     return mapping.get(cfn_status, cfn_status)
 
 
-
 def cloud_formation_status_to_image_status(cfn_status):
     mapping = {
         CloudFormationStackStatus.CREATE_IN_PROGRESS: ImageBuildStatus.BUILD_IN_PROGRESS,

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1461,6 +1461,7 @@ class BaseClusterConfig(Resource):
         self.deployment_settings = deployment_settings
         self.managed_head_node_security_group = None
         self.managed_compute_security_group = None
+        self.instance_types_data_version = ""
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(RegionValidator, region=self.region)

--- a/cli/src/pcluster/models/cluster.py
+++ b/cli/src/pcluster/models/cluster.py
@@ -76,7 +76,6 @@ from pcluster.validators.common import FailureLevel, ValidationResult, Validator
 
 LOGGER = logging.getLogger(__name__)
 
-
 # pylint: disable=C0302
 
 
@@ -369,7 +368,7 @@ class Cluster:
                 validator_suppressors, validation_failure_level
             )
 
-            LOGGER.info("Generating artifact dir and uploading config and instance types data...")
+            LOGGER.info("Generating artifact dir, uploading config and instance types data...")
             self._add_tags()
             self._generate_artifact_dir()
             artifact_dir_generated = True
@@ -477,7 +476,7 @@ class Cluster:
             raise BadRequestClusterActionError(f"Cluster {self.name} already exists.")
 
     def _validate_and_parse_config(
-            self, validator_suppressors, validation_failure_level, config_text=None, context: ValidatorContext = None
+        self, validator_suppressors, validation_failure_level, config_text=None, context: ValidatorContext = None
     ):
         """
         Perform syntactic and semantic validation and return parsed config.
@@ -536,14 +535,13 @@ class Cluster:
 
                 # original config version will be stored in CloudFormation Parameters
                 self.config.original_config_version = result.get("VersionId")
-
         except Exception as e:
             raise _cluster_error_mapper(
                 e, f"Unable to upload cluster config to the S3 bucket {self.bucket.name} due to exception: {e}"
             )
 
     def _upload_instance_types_data(self):
-        """Upload source config and save config version."""
+        """Upload instance types data and version id."""
         self._check_bucket_existence()
         try:
             # Upload instance types data
@@ -727,7 +725,7 @@ class Cluster:
         return filters
 
     def describe_instances(
-            self, node_type: NodeType = None, next_token: str = None, queue_name: str = None
+        self, node_type: NodeType = None, next_token: str = None, queue_name: str = None
     ) -> Tuple[List[ClusterInstance], str]:
         """Return the cluster instances filtered by node type."""
         try:
@@ -744,7 +742,7 @@ class Cluster:
                 self.__has_running_capacity = self.get_running_capacity() > 0
             else:
                 self.__has_running_capacity = (
-                        self.compute_fleet_status_manager.get_status() != ComputeFleetStatus.STOPPED
+                    self.compute_fleet_status_manager.get_status() != ComputeFleetStatus.STOPPED
                 )
         return self.__has_running_capacity
 
@@ -911,6 +909,7 @@ class Cluster:
 
             self._add_tags()
             self._upload_config()
+            self._upload_instance_types_data()
             self._upload_change_set(changes)
 
             # Create template if not provided by the user

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1232,6 +1232,7 @@ class ClusterCdkStack:
                         self.bucket.artifact_directory, PCLUSTER_S3_ARTIFACTS_DICT.get("config_name")
                     ),
                     "cluster_config_version": self.config.config_version,
+                    "instance_types_data_version": self.config.instance_types_data_version,
                     "change_set_s3_key": f"{self.bucket.artifact_directory}/configs/"
                     f"{PCLUSTER_S3_ARTIFACTS_DICT.get('change_set_name')}",
                     "instance_types_data_s3_key": f"{self.bucket.artifact_directory}/configs/"

--- a/cli/tests/pcluster/cli/test_commands.py
+++ b/cli/tests/pcluster/cli/test_commands.py
@@ -295,6 +295,7 @@ def test_setup_bucket_with_resources_upload_failure(
     upload_fileobj_awsclient_error = AWSClientError(
         function_name="upload_fileobj", message="Unable to upload file to the S3 bucket"
     )
+    upload_instance_types_data_action_error = "Unable to upload instance types data to the S3 bucket"
 
     mock_aws_api(mocker)
 
@@ -327,5 +328,8 @@ def test_setup_bucket_with_resources_upload_failure(
 
     with pytest.raises(ClusterActionError, match=upload_resource_cluster_action_error):
         cluster._upload_artifacts()
+
+    with pytest.raises(ClusterActionError, match=upload_instance_types_data_action_error):
+        cluster._upload_instance_types_data()
 
     check_bucket_mock.assert_called_with()

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -677,6 +677,22 @@ class TestCluster:
 
         assert_that(bucket_object_utils_dict.get("upload_config").call_count).is_equal_to(2)
 
+    def test_upload_instance_types_data(self, mocker, cluster):
+        mock_aws_api(mocker)
+        mock_bucket(mocker)
+        mock_bucket_utils(mocker)
+        bucket_object_utils_dict = mock_bucket_object_utils(mocker)
+        cluster.config = dummy_slurm_cluster_config(mocker)
+        cluster._upload_instance_types_data()
+
+        bucket_object_utils_dict.get("upload_config").assert_any_call(
+            cluster.config.get_instance_types_data(),
+            "instance-types-data.json",
+            format=S3FileFormat.JSON,
+        )
+
+        assert_that(bucket_object_utils_dict.get("upload_config").call_count).is_equal_to(1)
+
     @pytest.mark.parametrize(
         "changes, change_set",
         [

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/head_node_default.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/head_node_default.dna.json
@@ -28,6 +28,7 @@
     "fsx_volume_junction_paths": "",
     "head_node_imds_secured": "true",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",
+    "instance_types_data_version": "",
     "log_group_name": "/aws/parallelcluster/clustername-202101010101",
     "log_rotation_enabled": "true",
     "node_type": "HeadNode",

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/failing_post_install.sh
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/failing_post_install.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 1

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.remove.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.remove.yaml
@@ -2,10 +2,16 @@ Image:
   Os: {{ os }}
 HeadNode:
   InstanceType: {{ instance }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket_name }}
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+  CustomActions:
+    OnNodeUpdated:
+      Script: s3://{{ bucket_name }}/failing_post_install.sh
 Scheduling:
   Scheduler: slurm
   SlurmQueues:
@@ -13,9 +19,16 @@ Scheduling:
       ComputeResources:
         - Name: queue1-i1
           Instances:
-            - InstanceType: c5.xlarge
+            - InstanceType: m5.xlarge
           MinCount: 1
           MaxCount: 2
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}
+DevSettings:
+  Cookbook:
+    ChefCookbook: https://github.com/hgreebe/aws-parallelcluster-cookbook/tarball/develop
+

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.update.yaml
@@ -2,6 +2,9 @@ Image:
   Os: {{ os }}
 HeadNode:
   InstanceType: {{ instance }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket_name }}
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:
@@ -20,3 +23,10 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}
+DevSettings:
+  Cookbook:
+    ChefCookbook: https://github.com/hgreebe/aws-parallelcluster-cookbook/tarball/develop
+

--- a/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
+++ b/tests/integration-tests/tests/update/test_update/test_update_instance_list/pcluster.config.yaml
@@ -2,6 +2,9 @@ Image:
   Os: {{ os }}
 HeadNode:
   InstanceType: {{ instance }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket_name }}
   Networking:
     SubnetId: {{ public_subnet_id }}
   Ssh:
@@ -19,3 +22,10 @@ Scheduling:
       Networking:
         SubnetIds:
           - {{ private_subnet_id }}
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}
+DevSettings:
+  Cookbook:
+    ChefCookbook: https://github.com/hgreebe/aws-parallelcluster-cookbook/tarball/develop
+


### PR DESCRIPTION
### Description of changes
* It saves a instance_types_data_version so that when an update rollback occurs, we can restore the previous instance_type_data

### Tests
* Integration Test and Manual Test that recreates the scenario that caused the bug

### References
* PR for cookbook: https://github.com/aws/aws-parallelcluster-cookbook/pull/2432
* Github known issue: https://github.com/aws/aws-parallelcluster/wiki/(3.0.0%E2%80%903.6.1)-Cluster-update-rollback-can-fail-when-modifying-the-list-of-instance-types-declared-in-the-Compute-Resources

Dev-Settings that were incorrectly added were removed from test files in this PR:
https://github.com/aws/aws-parallelcluster/pull/5684

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
