### PR TITLE
[release-3.7][integ-test] Use alinux2 to test mpi job cancellation

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -415,7 +415,7 @@ schedulers:
     dimensions:
       - regions: ["eu-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["ubuntu2204"]
+        oss: ["alinux2"]  # TODO: Check why retry intervals in the test differ in Ubuntu2204
         schedulers: ["slurm"]
   test_slurm.py::test_slurm_pmix:  # TODO: include in main test_slurm to reduce number of created clusters
     dimensions:


### PR DESCRIPTION
* Created in preference of: https://github.com/aws/aws-parallelcluster/pull/5665

### Description of changes
* One of the test assertions (`_test_mpi_job_termination`) checks if cancellation of an MPI process does not leave any stray processes
* The MPI job completes before the test can cancel it on Ubuntu2204 (but the test runs successfully with more granular intervals)
* The timing issue is non-existent in `alinux2`
* These changes switch the test to running on `alinux2` and follow up with an investigation on why the timing differs on Ubuntu2204 (and possibly improve this test to be less influenced by timing issues)

### Tests
* Ran the test (`test_slurm::test_slurm`)

### References
* https://github.com/aws/aws-parallelcluster/pull/5654

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
