### PR TITLE
[develop] [integ-tests] Use a fixed time MPI job to test job cancellation of MPI processes

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/mpi_job.sh
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm/mpi_job.sh
@@ -7,4 +7,4 @@
 #SBATCH --output=runscript.out
 
 module load intelmpi
-mpirun -n 6 IMB-MPI1 Alltoall -npmin 2
+mpirun -n 6 bash -c 'sleep 300' -npmin 2


### PR DESCRIPTION
- Cherry-picked from: https://github.com/aws/aws-parallelcluster/pull/5665


### Description of changes
* One of the test assertions (`_test_mpi_job_termination`) checks if cancellation of an MPI process does not leave any stray processes
* The MPI job executed is an All-to-All MPI job. Timing when the job is running in order to cancel it is hard to predict.
* These code changes use a simple sleep process instead with a deterministic runtime (5 mins). This way the test's check intervals have a higher guarantee of catching the MPI process while it's running.
* The test also separates the clean up step (removing the shared file) from the retry steps

### Tests
* Ran the test (`test_slurm::test_slurm`) with Ubuntu2204

### References
* https://github.com/aws/aws-parallelcluster/pull/5654

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
