### PR TITLE
[release-3.7] Re-enable createami test for RHEL8

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -162,8 +162,7 @@ createami:
     dimensions:
       - regions: ["eu-west-3"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        # TODO re-enable rhel8 after a suitable image is found
-        oss: ["ubuntu2204", "alinux2"]
+        oss: ["ubuntu2204", "alinux2", "rhel8"]
   test_createami.py::test_kernel4_build_image_run_cluster:
     dimensions:
       - regions: ["eu-south-1"]


### PR DESCRIPTION
### Description of changes
We improved the Lustre code to avoid build failures when Lustre is not compatible with 8.7 kernel.

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2442
* Rollback of: https://github.com/aws/aws-parallelcluster/pull/5676

