### PR TITLE
[develop] Setup custom munge key

### DIFF
--- a/cli/src/pcluster/aws/secretsmanager.py
+++ b/cli/src/pcluster/aws/secretsmanager.py
@@ -37,4 +37,4 @@ class SecretsManagerClient(Boto3Client):
         :param secret_arn: Secret ARN.
         :return: secret value
         """
-        self._client.get_secret_value(SecretId=secret_arn)
+        return self._client.get_secret_value(SecretId=secret_arn)

--- a/cli/src/pcluster/aws/secretsmanager.py
+++ b/cli/src/pcluster/aws/secretsmanager.py
@@ -27,3 +27,14 @@ class SecretsManagerClient(Boto3Client):
         :return: secret info
         """
         self._client.describe_secret(SecretId=secret_arn)
+
+    @AWSExceptionHandler.handle_client_exception
+    @Cache.cached
+    def get_secret_value(self, secret_arn):
+        """
+        Get the Secret value.
+
+        :param secret_arn: Secret ARN.
+        :return: secret value
+        """
+        self._client.get_secret_value(SecretId=secret_arn)

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1192,7 +1192,7 @@ class ClusterDevSettings(BaseDevSettings):
         ami_search_filters: AmiSearchFilters = None,
         instance_types_data: str = None,
         timeouts: Timeouts = None,
-        settings: SlurmSettingsForCustomMungeKey = None,
+        slurm_settings: SlurmSettingsForCustomMungeKey = None,
         compute_startup_time_metric_enabled: bool = None,
         **kwargs,
     ):
@@ -1204,7 +1204,7 @@ class ClusterDevSettings(BaseDevSettings):
         self.compute_startup_time_metric_enabled = Resource.init_param(
             compute_startup_time_metric_enabled, default=False
         )
-        self.settings = settings or SlurmSettingsForCustomMungeKey(implied=True)
+        self.slurm_settings = slurm_settings or SlurmSettingsForCustomMungeKey(implied=True)
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -178,7 +178,11 @@ from pcluster.validators.s3_validators import (
     S3BucketValidator,
     UrlValidator,
 )
-from pcluster.validators.secret_validators import MungeKeySecretArnValidator
+from pcluster.validators.secret_validators import (
+    MungeKeySecretArnExistsValidator,
+    MungeKeySecretArnServiceValidator,
+    MungeKeySecretSizeAndBase64Validator,
+)
 from pcluster.validators.slurm_settings_validator import (
     SLURM_SETTINGS_DENY_LIST,
     CustomSlurmNodeNamesValidator,
@@ -1177,9 +1181,17 @@ class SlurmSettingsForCustomMungeKey(Resource):
         super()._register_validators(context)
         if self.munge_key_secret_arn:
             self._register_validator(
-                MungeKeySecretArnValidator,
+                MungeKeySecretArnExistsValidator,
+                munge_key_secret_arn=self.munge_key_secret_arn,
+            )
+            self._register_validator(
+                MungeKeySecretArnServiceValidator,
                 munge_key_secret_arn=self.munge_key_secret_arn,
                 region=get_region(),
+            )
+            self._register_validator(
+                MungeKeySecretSizeAndBase64Validator,
+                munge_key_secret_arn=self.munge_key_secret_arn,
             )
 
 
@@ -1192,7 +1204,7 @@ class ClusterDevSettings(BaseDevSettings):
         ami_search_filters: AmiSearchFilters = None,
         instance_types_data: str = None,
         timeouts: Timeouts = None,
-        slurm_settings: SlurmSettingsForCustomMungeKey = None,
+        munge_key_settings: SlurmSettingsForCustomMungeKey = None,
         compute_startup_time_metric_enabled: bool = None,
         **kwargs,
     ):
@@ -1204,7 +1216,7 @@ class ClusterDevSettings(BaseDevSettings):
         self.compute_startup_time_metric_enabled = Resource.init_param(
             compute_startup_time_metric_enabled, default=False
         )
-        self.slurm_settings = slurm_settings or SlurmSettingsForCustomMungeKey(implied=True)
+        self.munge_key_settings = munge_key_settings or SlurmSettingsForCustomMungeKey(implied=True)
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -178,11 +178,7 @@ from pcluster.validators.s3_validators import (
     S3BucketValidator,
     UrlValidator,
 )
-from pcluster.validators.secret_validators import (
-    MungeKeySecretArnExistsValidator,
-    MungeKeySecretArnServiceValidator,
-    MungeKeySecretSizeAndBase64Validator,
-)
+from pcluster.validators.secret_validators import ArnServiceAndResourceValidator, MungeKeySecretSizeAndBase64Validator
 from pcluster.validators.slurm_settings_validator import (
     SLURM_SETTINGS_DENY_LIST,
     CustomSlurmNodeNamesValidator,
@@ -1181,13 +1177,11 @@ class SlurmSettingsForCustomMungeKey(Resource):
         super()._register_validators(context)
         if self.munge_key_secret_arn:
             self._register_validator(
-                MungeKeySecretArnExistsValidator,
-                munge_key_secret_arn=self.munge_key_secret_arn,
-            )
-            self._register_validator(
-                MungeKeySecretArnServiceValidator,
-                munge_key_secret_arn=self.munge_key_secret_arn,
+                ArnServiceAndResourceValidator,
+                arn=self.munge_key_secret_arn,
                 region=get_region(),
+                expected_service="secretsmanager",
+                expected_resource="secret",
             )
             self._register_validator(
                 MungeKeySecretSizeAndBase64Validator,

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1204,7 +1204,7 @@ class ClusterDevSettings(BaseDevSettings):
         self.compute_startup_time_metric_enabled = Resource.init_param(
             compute_startup_time_metric_enabled, default=False
         )
-        self.slurm_settings = slurm_settings or SlurmSettingsForCustomMungeKey(implied=True)
+        self.slurm_settings = slurm_settings
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -178,6 +178,7 @@ from pcluster.validators.s3_validators import (
     S3BucketValidator,
     UrlValidator,
 )
+from pcluster.validators.secret_validators import MungeKeySecretArnValidator
 from pcluster.validators.slurm_settings_validator import (
     SLURM_SETTINGS_DENY_LIST,
     CustomSlurmNodeNamesValidator,
@@ -1161,6 +1162,27 @@ class CapacityReservationTarget(Resource):
         self.capacity_reservation_resource_group_arn = Resource.init_param(capacity_reservation_resource_group_arn)
 
 
+class SlurmSettingsForCustomMungeKey(Resource):
+    """Represent the slurm settings for custom munge key test in dev settings."""
+
+    def __init__(
+        self,
+        munge_key_secret_arn: str = None,
+        **kwargs,
+    ):
+        super().__init__()
+        self.munge_key_secret_arn = Resource.init_param(munge_key_secret_arn)
+
+    def _register_validators(self, context: ValidatorContext = None):
+        super()._register_validators(context)
+        if self.munge_key_secret_arn:
+            self._register_validator(
+                MungeKeySecretArnValidator,
+                munge_key_secret_arn=self.munge_key_secret_arn,
+                region=get_region(),
+            )
+
+
 class ClusterDevSettings(BaseDevSettings):
     """Represent the dev settings configuration."""
 
@@ -1170,6 +1192,7 @@ class ClusterDevSettings(BaseDevSettings):
         ami_search_filters: AmiSearchFilters = None,
         instance_types_data: str = None,
         timeouts: Timeouts = None,
+        settings: SlurmSettingsForCustomMungeKey = None,
         compute_startup_time_metric_enabled: bool = None,
         **kwargs,
     ):
@@ -1181,6 +1204,7 @@ class ClusterDevSettings(BaseDevSettings):
         self.compute_startup_time_metric_enabled = Resource.init_param(
             compute_startup_time_metric_enabled, default=False
         )
+        self.settings = settings or SlurmSettingsForCustomMungeKey(implied=True)
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1204,7 +1204,7 @@ class ClusterDevSettings(BaseDevSettings):
         self.compute_startup_time_metric_enabled = Resource.init_param(
             compute_startup_time_metric_enabled, default=False
         )
-        self.slurm_settings = slurm_settings
+        self.slurm_settings = slurm_settings or SlurmSettingsForCustomMungeKey(implied=True)
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -91,6 +91,7 @@ from pcluster.config.cluster_config import (
     SlurmQueueNetworking,
     SlurmScheduling,
     SlurmSettings,
+    SlurmSettingsForCustomMungeKey,
     Timeouts,
 )
 from pcluster.config.common import BaseTag
@@ -1110,7 +1111,7 @@ class SlurmSettingsForCustomMungeKeySchema(BaseSchema):
     @post_load
     def make_resource(self, data, **kwargs):
         """Generate resource."""
-        return SlurmSettingsForCustomMungeKeySchema(**data)
+        return SlurmSettingsForCustomMungeKey(**data)
 
 
 class ClusterDevSettingsSchema(BaseDevSettingsSchema):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1121,7 +1121,9 @@ class ClusterDevSettingsSchema(BaseDevSettingsSchema):
     instance_types_data = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     timeouts = fields.Nested(TimeoutsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     compute_startup_time_metric_enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    slurm_settings = fields.Nested(SlurmSettingsForCustomMungeKeySchema, metadata={"update_policy": UpdatePolicy.IGNORED})
+    slurm_settings = fields.Nested(
+        SlurmSettingsForCustomMungeKeySchema, metadata={"update_policy": UpdatePolicy.IGNORED}
+    )
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1102,6 +1102,17 @@ class CapacityReservationTargetSchema(BaseSchema):
             )
 
 
+class SlurmSettingsForCustomMungeKeySchema(BaseSchema):
+    """Represent the schema of slurm settings for custom munge key test in dev settings."""
+
+    munge_key_secre_arn = fields.Str(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+
+    @post_load
+    def make_resource(self, data, **kwargs):
+        """Generate resource."""
+        return SlurmSettingsForCustomMungeKeySchema(**data)
+
+
 class ClusterDevSettingsSchema(BaseDevSettingsSchema):
     """Represent the schema of Dev Setting."""
 
@@ -1110,6 +1121,7 @@ class ClusterDevSettingsSchema(BaseDevSettingsSchema):
     instance_types_data = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     timeouts = fields.Nested(TimeoutsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     compute_startup_time_metric_enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    slurm_settings = fields.Nested(SlurmSettingsForCustomMungeKeySchema, metadata={"update_policy": UpdatePolicy.IGNORED})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1106,7 +1106,7 @@ class CapacityReservationTargetSchema(BaseSchema):
 class SlurmSettingsForCustomMungeKeySchema(BaseSchema):
     """Represent the schema of slurm settings for custom munge key test in dev settings."""
 
-    munge_key_secret_arn = fields.Str(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    munge_key_secret_arn = fields.Str(metadata={"update_policy": UpdatePolicy.COMPUTE_AND_LOGIN_NODES_STOP})
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -1122,7 +1122,7 @@ class ClusterDevSettingsSchema(BaseDevSettingsSchema):
     instance_types_data = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     timeouts = fields.Nested(TimeoutsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     compute_startup_time_metric_enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    slurm_settings = fields.Nested(
+    munge_key_settings = fields.Nested(
         SlurmSettingsForCustomMungeKeySchema, metadata={"update_policy": UpdatePolicy.IGNORED}
     )
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1105,7 +1105,7 @@ class CapacityReservationTargetSchema(BaseSchema):
 class SlurmSettingsForCustomMungeKeySchema(BaseSchema):
     """Represent the schema of slurm settings for custom munge key test in dev settings."""
 
-    munge_key_secre_arn = fields.Str(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
+    munge_key_secret_arn = fields.Str(metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -675,7 +675,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                         sid="SecretsManager",
                         actions=["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
                         effect=iam.Effect.ALLOW,
-                        resources=[self._config.dev_settings.slurm_settings.munge_key_secret_arn]
+                        resources=[self._config.dev_settings.slurm_settings.munge_key_secret_arn],
                     ),
                 ]
             )

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -583,10 +583,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
         policy = [
             iam.PolicyStatement(
                 sid="SecretsManager",
-                actions=[
-                    "secretsmanager:GetSecretValue",
-                    "secretsmanager:DescribeSecret"
-                ],
+                actions=["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
                 effect=iam.Effect.ALLOW,
                 resources=[
                     self._format_arn(

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -585,14 +585,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                 sid="SecretsManager",
                 actions=["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
                 effect=iam.Effect.ALLOW,
-                resources=[
-                    self._format_arn(
-                        service="secretsmanager",
-                        resource="*",
-                        region=Stack.of(self).region,
-                        account=Stack.of(self).account,
-                    )
-                ],
+                resources=[self._config.dev_settings.slurm_settings.munge_key_secret_arn]
             ),
             iam.PolicyStatement(
                 sid="Ec2",

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -668,7 +668,11 @@ class HeadNodeIamResources(NodeIamResourcesBase):
             ),
         ]
 
-        if self._config.dev_settings and self._config.dev_settings.slurm_settings:
+        if (
+            self._config.dev_settings
+            and self._config.dev_settings.slurm_settings
+            and self._config.dev_settings.slurm_settings.munge_key_secret_arn
+        ):
             policy.extend(
                 [
                     iam.PolicyStatement(

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -582,12 +582,6 @@ class HeadNodeIamResources(NodeIamResourcesBase):
     def _build_policy(self) -> List[iam.PolicyStatement]:
         policy = [
             iam.PolicyStatement(
-                sid="SecretsManager",
-                actions=["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
-                effect=iam.Effect.ALLOW,
-                resources=[self._config.dev_settings.slurm_settings.munge_key_secret_arn]
-            ),
-            iam.PolicyStatement(
                 sid="Ec2",
                 actions=[
                     "ec2:DescribeInstanceAttribute",
@@ -673,6 +667,18 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                 ],
             ),
         ]
+
+        if self._config.dev_settings and self._config.dev_settings.slurm_settings:
+            policy.extend(
+                [
+                    iam.PolicyStatement(
+                        sid="SecretsManager",
+                        actions=["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+                        effect=iam.Effect.ALLOW,
+                        resources=[self._config.dev_settings.slurm_settings.munge_key_secret_arn]
+                    ),
+                ]
+            )
 
         if self._config.scheduling.scheduler != "awsbatch":
             policy.extend(

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -582,6 +582,22 @@ class HeadNodeIamResources(NodeIamResourcesBase):
     def _build_policy(self) -> List[iam.PolicyStatement]:
         policy = [
             iam.PolicyStatement(
+                sid="SecretsManager",
+                actions=[
+                    "secretsmanager:GetSecretValue",
+                    "secretsmanager:DescribeSecret"
+                ],
+                effect=iam.Effect.ALLOW,
+                resources=[
+                    self._format_arn(
+                        service="secretsmanager",
+                        resource="*",
+                        region=Stack.of(self).region,
+                        account=Stack.of(self).account,
+                    )
+                ],
+            ),
+            iam.PolicyStatement(
                 sid="Ec2",
                 actions=[
                     "ec2:DescribeInstanceAttribute",

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -677,7 +677,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                 [
                     iam.PolicyStatement(
                         sid="SecretsManager",
-                        actions=["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+                        actions=["secretsmanager:GetSecretValue"],
                         effect=iam.Effect.ALLOW,
                         resources=[self._config.dev_settings.slurm_settings.munge_key_secret_arn],
                     ),

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -670,8 +670,8 @@ class HeadNodeIamResources(NodeIamResourcesBase):
 
         if (
             self._config.dev_settings
-            and self._config.dev_settings.slurm_settings
-            and self._config.dev_settings.slurm_settings.munge_key_secret_arn
+            and self._config.dev_settings.munge_key_settings
+            and self._config.dev_settings.munge_key_settings.munge_key_secret_arn
         ):
             policy.extend(
                 [
@@ -679,7 +679,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                         sid="SecretsManager",
                         actions=["secretsmanager:GetSecretValue"],
                         effect=iam.Effect.ALLOW,
-                        resources=[self._config.dev_settings.slurm_settings.munge_key_secret_arn],
+                        resources=[self._config.dev_settings.munge_key_settings.munge_key_secret_arn],
                     ),
                 ]
             )

--- a/cli/src/pcluster/validators/common.py
+++ b/cli/src/pcluster/validators/common.py
@@ -148,18 +148,20 @@ class ValidatorContext:
         self.during_update = during_update
 
 
-def _get_arn_components(arn: str):
+def get_arn_components(arn: str):
     return arn.split(":")
 
 
-def _get_service_and_resource(arn: str):
-    arn_components = _get_arn_components(arn)
+def get_arn_service_and_resource(arn: str):
+    arn_components = get_arn_components(arn)
     service = arn_components[2]
     resource = arn_components[5]
     return service, resource
 
 
-def _handle_arn_aws_client_error(e: AWSClientError, arn: str, validator_instance):
+#  TODO: Search for a better place for this function.
+#   Maybe we could create an abstract class with abstract methods, of which this could be an implementation.
+def handle_arn_aws_client_error(e: AWSClientError, arn: str, validator_instance):
     if e.error_code in ("ResourceNotFoundExceptionSecrets", "ParameterNotFound"):
         validator_instance._add_failure(f"The secret {arn} does not exist.", FailureLevel.ERROR)
     elif e.error_code == "AccessDeniedException":

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -15,7 +15,7 @@ from urllib.parse import urlparse
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError
 from pcluster.constants import DIRECTORY_SERVICE_RESERVED_SETTINGS
-from pcluster.validators.common import FailureLevel, SecretArnValidator, Validator
+from pcluster.validators.common import FailureLevel, Validator, _get_service_and_resource, _handle_arn_aws_client_error
 
 
 class DomainAddrValidator(Validator):
@@ -70,7 +70,7 @@ class DomainNameValidator(Validator):
             )
 
 
-class PasswordSecretArnValidator(SecretArnValidator):
+class PasswordSecretArnValidator(Validator):
     """PasswordSecretArn validator."""
 
     def _validate(self, password_secret_arn: str, region: str):
@@ -82,7 +82,7 @@ class PasswordSecretArnValidator(SecretArnValidator):
             for retro-compatibility.
         """
         try:
-            service, resource = self._get_service_and_resource(password_secret_arn)
+            service, resource = _get_service_and_resource(password_secret_arn)
             if service == "ssm":
                 resource = password_secret_arn.split(":")[5].split("/")[0]
             if service == "secretsmanager" and resource == "secret":
@@ -95,7 +95,7 @@ class PasswordSecretArnValidator(SecretArnValidator):
                     f"The secret {password_secret_arn} is not supported in region {region}.", FailureLevel.ERROR
                 )
         except AWSClientError as e:
-            self._handle_aws_client_error(e, password_secret_arn)
+            _handle_arn_aws_client_error(e, password_secret_arn, self)
 
 
 class LdapTlsReqCertValidator(Validator):

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -89,11 +89,11 @@ class PasswordSecretArnValidator(Validator):
         try:
             service, resource = get_arn_service_and_resource(password_secret_arn)
             if service == "ssm":
-                resource = password_secret_arn.split(":")[5].split("/")[0]
+                resource_type = resource.split("/")[0]
             if service == "secretsmanager" and resource == "secret":
                 AWSApi.instance().secretsmanager.describe_secret(password_secret_arn)
-            elif service == "ssm" and resource == "parameter" and region == "us-isob-east-1":
-                parameter_name = password_secret_arn.split(":")[5].split("/")[1]
+            elif service == "ssm" and resource_type == "parameter" and region == "us-isob-east-1":
+                parameter_name = resource.split("/")[1]
                 AWSApi.instance().ssm.get_parameter(parameter_name)
             else:
                 self._add_failure(

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -15,7 +15,7 @@ from urllib.parse import urlparse
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError
 from pcluster.constants import DIRECTORY_SERVICE_RESERVED_SETTINGS
-from pcluster.validators.common import FailureLevel, Validator
+from pcluster.validators.common import FailureLevel, SecretArnValidator, Validator
 
 
 class DomainAddrValidator(Validator):
@@ -70,7 +70,7 @@ class DomainNameValidator(Validator):
             )
 
 
-class PasswordSecretArnValidator(Validator):
+class PasswordSecretArnValidator(SecretArnValidator):
     """PasswordSecretArn validator."""
 
     def _validate(self, password_secret_arn: str, region: str):
@@ -82,37 +82,20 @@ class PasswordSecretArnValidator(Validator):
             for retro-compatibility.
         """
         try:
-            # We only require the secret to exist; we do not validate its content.
-            arn_components = password_secret_arn.split(":")
-            service = arn_components[2]
-            resource = arn_components[5]
+            service, resource = self._get_service_and_resource(password_secret_arn)
             if service == "ssm":
-                resource = arn_components[5].split("/")[0]
-
+                resource = password_secret_arn.split(":")[5].split("/")[0]
             if service == "secretsmanager" and resource == "secret":
                 AWSApi.instance().secretsmanager.describe_secret(password_secret_arn)
             elif service == "ssm" and resource == "parameter" and region == "us-isob-east-1":
-                parameter_name = arn_components[5].split("/")[1]
+                parameter_name = password_secret_arn.split(":")[5].split("/")[1]
                 AWSApi.instance().ssm.get_parameter(parameter_name)
             else:
                 self._add_failure(
                     f"The secret {password_secret_arn} is not supported in region {region}.", FailureLevel.ERROR
                 )
         except AWSClientError as e:
-            if e.error_code in ("ResourceNotFoundExceptionSecrets", "ParameterNotFound"):
-                self._add_failure(f"The secret {password_secret_arn} does not exist.", FailureLevel.ERROR)
-            elif e.error_code == "AccessDeniedException":
-                self._add_failure(
-                    f"Cannot validate secret {password_secret_arn} due to lack of permissions. "
-                    "Please refer to ParallelCluster official documentation for more information.",
-                    FailureLevel.WARNING,
-                )
-            else:
-                self._add_failure(
-                    f"Cannot validate secret {password_secret_arn}. "
-                    "Please refer to ParallelCluster official documentation for more information.",
-                    FailureLevel.WARNING,
-                )
+            self._handle_aws_client_error(e, password_secret_arn)
 
 
 class LdapTlsReqCertValidator(Validator):

--- a/cli/src/pcluster/validators/directory_service_validators.py
+++ b/cli/src/pcluster/validators/directory_service_validators.py
@@ -15,7 +15,12 @@ from urllib.parse import urlparse
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError
 from pcluster.constants import DIRECTORY_SERVICE_RESERVED_SETTINGS
-from pcluster.validators.common import FailureLevel, Validator, _get_service_and_resource, _handle_arn_aws_client_error
+from pcluster.validators.common import (
+    FailureLevel,
+    Validator,
+    get_arn_service_and_resource,
+    handle_arn_aws_client_error,
+)
 
 
 class DomainAddrValidator(Validator):
@@ -82,7 +87,7 @@ class PasswordSecretArnValidator(Validator):
             for retro-compatibility.
         """
         try:
-            service, resource = _get_service_and_resource(password_secret_arn)
+            service, resource = get_arn_service_and_resource(password_secret_arn)
             if service == "ssm":
                 resource = password_secret_arn.split(":")[5].split("/")[0]
             if service == "secretsmanager" and resource == "secret":
@@ -95,7 +100,7 @@ class PasswordSecretArnValidator(Validator):
                     f"The secret {password_secret_arn} is not supported in region {region}.", FailureLevel.ERROR
                 )
         except AWSClientError as e:
-            _handle_arn_aws_client_error(e, password_secret_arn, self)
+            handle_arn_aws_client_error(e, password_secret_arn, self)
 
 
 class LdapTlsReqCertValidator(Validator):

--- a/cli/src/pcluster/validators/secret_validators.py
+++ b/cli/src/pcluster/validators/secret_validators.py
@@ -29,7 +29,16 @@ class MungeKeySecretArnValidator(Validator):
                 AWSApi.instance().secretsmanager.describe_secret(munge_key_secret_arn)
 
                 # Get the actual secret value to check if it's valid Base64
-                secret_value = AWSApi.instance().secretsmanager.get_secret_value(munge_key_secret_arn)
+                secret_response = AWSApi.instance().secretsmanager.get_secret_value(munge_key_secret_arn)
+                secret_value = secret_response.get('SecretString')
+
+                if not secret_value:
+                    self._add_failure(
+                        f"The secret {munge_key_secret_arn} does not contain a valid secret string.",
+                        FailureLevel.ERROR,
+                    )
+                    return
+
                 try:
                     # Attempt to decode the secret value from Base64
                     base64.b64decode(secret_value)

--- a/cli/src/pcluster/validators/secret_validators.py
+++ b/cli/src/pcluster/validators/secret_validators.py
@@ -13,14 +13,20 @@ import binascii
 
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError
-from pcluster.validators.common import FailureLevel, Validator, _get_service_and_resource, _handle_arn_aws_client_error
+from pcluster.validators.common import (
+    FailureLevel,
+    Validator,
+    get_arn_service_and_resource,
+    handle_arn_aws_client_error,
+)
 
 
+# TODO: Possibly extend to dictionaries of pairs {"allowed_service" : "allowed_resource"}.
 class ArnServiceAndResourceValidator(Validator):
     """Validate that Arn is a valid ARN in given region."""
 
     def _validate(self, arn: str, region: str, expected_service: str, expected_resource: str):
-        service, resource = _get_service_and_resource(arn)
+        service, resource = get_arn_service_and_resource(arn)
         if not (service == expected_service and resource == expected_resource):
             self._add_failure(f"The {arn} is not supported in region {region}.", FailureLevel.ERROR)
 
@@ -73,4 +79,4 @@ class MungeKeySecretSizeAndBase64Validator(Validator):
                     FailureLevel.ERROR,
                 )
         except AWSClientError as e:
-            _handle_arn_aws_client_error(e, munge_key_secret_arn, self)
+            handle_arn_aws_client_error(e, munge_key_secret_arn, self)

--- a/cli/src/pcluster/validators/secret_validators.py
+++ b/cli/src/pcluster/validators/secret_validators.py
@@ -8,13 +8,12 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
 import binascii
 
 from pcluster.aws.aws_api import AWSApi
 from pcluster.aws.common import AWSClientError
 from pcluster.validators.common import FailureLevel, Validator
-
-import base64
 
 
 class MungeKeySecretArnValidator(Validator):
@@ -34,10 +33,10 @@ class MungeKeySecretArnValidator(Validator):
                 try:
                     # Attempt to decode the secret value from Base64
                     base64.b64decode(secret_value)
-                except binascii.Error as decode_error:
+                except binascii.Error:
                     self._add_failure(
                         f"The secret {munge_key_secret_arn} does not contain valid Base64 encoded data.",
-                        FailureLevel.ERROR
+                        FailureLevel.ERROR,
                     )
             else:
                 self._add_failure(

--- a/cli/src/pcluster/validators/secret_validators.py
+++ b/cli/src/pcluster/validators/secret_validators.py
@@ -1,0 +1,60 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+import binascii
+
+from pcluster.aws.aws_api import AWSApi
+from pcluster.aws.common import AWSClientError
+from pcluster.validators.common import FailureLevel, Validator
+
+import base64
+
+
+class MungeKeySecretArnValidator(Validator):
+    """MungeKeySecretArn validator."""
+
+    def _validate(self, munge_key_secret_arn: str, region: str):
+        try:
+            arn_components = munge_key_secret_arn.split(":")
+            service = arn_components[2]
+            resource = arn_components[5]
+            if service == "secretsmanager" and resource == "secret":
+                # Describe the secret to ensure it exists
+                AWSApi.instance().secretsmanager.describe_secret(munge_key_secret_arn)
+
+                # Get the actual secret value to check if it's valid Base64
+                secret_value = AWSApi.instance().secretsmanager.get_secret_value(munge_key_secret_arn)
+                try:
+                    # Attempt to decode the secret value from Base64
+                    base64.b64decode(secret_value)
+                except binascii.Error as decode_error:
+                    self._add_failure(
+                        f"The secret {munge_key_secret_arn} does not contain valid Base64 encoded data.",
+                        FailureLevel.ERROR
+                    )
+            else:
+                self._add_failure(
+                    f"The secret {munge_key_secret_arn} is not supported in region {region}.", FailureLevel.ERROR
+                )
+        except AWSClientError as e:
+            if e.error_code in ("ResourceNotFoundExceptionSecrets", "ParameterNotFound"):
+                self._add_failure(f"The secret {munge_key_secret_arn} does not exist.", FailureLevel.ERROR)
+            elif e.error_code == "AccessDeniedException":
+                self._add_failure(
+                    f"Cannot validate secret {munge_key_secret_arn} due to lack of permissions. "
+                    "Please refer to ParallelCluster official documentation for more information.",
+                    FailureLevel.WARNING,
+                )
+            else:
+                self._add_failure(
+                    f"Cannot validate secret {munge_key_secret_arn}. "
+                    "Please refer to ParallelCluster official documentation for more information.",
+                    FailureLevel.WARNING,
+                )

--- a/cli/src/pcluster/validators/secret_validators.py
+++ b/cli/src/pcluster/validators/secret_validators.py
@@ -41,7 +41,15 @@ class MungeKeySecretArnValidator(Validator):
 
                 try:
                     # Attempt to decode the secret value from Base64
-                    base64.b64decode(secret_value)
+                    decoded_secret = base64.b64decode(secret_value)
+                    # Check if the decoded secret size is within the acceptable range
+                    decoded_secret_size_in_bits = len(decoded_secret) * 8
+                    if decoded_secret_size_in_bits < 256 or decoded_secret_size_in_bits > 8192:
+                        self._add_failure(
+                            f"The size of the decoded munge key in the secret {munge_key_secret_arn} "
+                            f"is {decoded_secret_size_in_bits} bits which is outside the allowed range [256-8192].",
+                            FailureLevel.ERROR,
+                        )
                 except binascii.Error:
                     self._add_failure(
                         f"The secret {munge_key_secret_arn} does not contain valid Base64 encoded data.",

--- a/cli/src/pcluster/validators/secret_validators.py
+++ b/cli/src/pcluster/validators/secret_validators.py
@@ -30,7 +30,7 @@ class MungeKeySecretArnValidator(Validator):
 
                 # Get the actual secret value to check if it's valid Base64
                 secret_response = AWSApi.instance().secretsmanager.get_secret_value(munge_key_secret_arn)
-                secret_value = secret_response.get('SecretString')
+                secret_value = secret_response.get("SecretString")
 
                 if not secret_value:
                     self._add_failure(

--- a/cli/tests/pcluster/templates/test_dev_settings.py
+++ b/cli/tests/pcluster/templates/test_dev_settings.py
@@ -58,12 +58,12 @@ def test_custom_cookbook(mocker, test_datadir, config_file_name):
         "config.yaml",
     ],
 )
-def test_custom_munge_key(mocker, test_datadir, config_file_name):
+def test_custom_munge_key_iam_policy(mocker, test_datadir, config_file_name):
     mock_aws_api(mocker)
     mock_bucket_object_utils(mocker)
     mocker.patch(
         "pcluster.aws.secretsmanager.SecretsManagerClient.get_secret_value",
-        return_value={"SecretString": "invalidBase64"},
+        return_value={"SecretString": "validBase641234567890123456789012345678901234567"},
     )
 
     input_yaml = load_yaml_dict(test_datadir / config_file_name)

--- a/cli/tests/pcluster/templates/test_dev_settings.py
+++ b/cli/tests/pcluster/templates/test_dev_settings.py
@@ -61,10 +61,6 @@ def test_custom_cookbook(mocker, test_datadir, config_file_name):
 def test_custom_munge_key_iam_policy(mocker, test_datadir, config_file_name):
     mock_aws_api(mocker)
     mock_bucket_object_utils(mocker)
-    mocker.patch(
-        "pcluster.aws.secretsmanager.SecretsManagerClient.get_secret_value",
-        return_value={"SecretString": "validBase641234567890123456789012345678901234567"},
-    )
 
     input_yaml = load_yaml_dict(test_datadir / config_file_name)
 

--- a/cli/tests/pcluster/templates/test_dev_settings.py
+++ b/cli/tests/pcluster/templates/test_dev_settings.py
@@ -77,7 +77,7 @@ def test_custom_munge_key(mocker, test_datadir, config_file_name):
         generated_template["Resources"]["ParallelClusterPoliciesHeadNode"]["Properties"]["PolicyDocument"]["Statement"]
     ).contains(
         {
-            "Action": ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+            "Action": "secretsmanager:GetSecretValue",
             "Effect": "Allow",
             "Resource": "arn:aws:secretsmanager:us-east-1:123456789012:secret:TestCustomMungeKey",
             "Sid": "SecretsManager",

--- a/cli/tests/pcluster/templates/test_dev_settings/test_custom_munge_key/config.yaml
+++ b/cli/tests/pcluster/templates/test_dev_settings/test_custom_munge_key/config.yaml
@@ -1,0 +1,19 @@
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue1
+      Networking:
+        SubnetIds:
+          - subnet-12345678
+      ComputeResources:
+        - Name: compute_resource1
+          InstanceType: c5.2xlarge
+DevSettings:
+  SlurmSettings:
+    MungeKeySecretArn: arn:aws:secretsmanager:us-east-1:123456789012:secret:TestCustomMungeKey

--- a/cli/tests/pcluster/templates/test_dev_settings/test_custom_munge_key_iam_policy/config.yaml
+++ b/cli/tests/pcluster/templates/test_dev_settings/test_custom_munge_key_iam_policy/config.yaml
@@ -15,5 +15,5 @@ Scheduling:
         - Name: compute_resource1
           InstanceType: c5.2xlarge
 DevSettings:
-  SlurmSettings:
+  MungeKeySettings:
     MungeKeySecretArn: arn:aws:secretsmanager:us-east-1:123456789012:secret:TestCustomMungeKey

--- a/cli/tests/pcluster/validators/test_all_validators.py
+++ b/cli/tests/pcluster/validators/test_all_validators.py
@@ -27,6 +27,7 @@ from pcluster.validators import (
     monitoring_validators,
     networking_validators,
     s3_validators,
+    secret_validators,
     slurm_settings_validator,
     tags_validators,
 )
@@ -75,6 +76,7 @@ def _mock_all_validators(mocker, additional_modules=None):
         s3_validators,
         slurm_settings_validator,
         tags_validators,
+        secret_validators,
     ]
     if additional_modules:
         modules += additional_modules

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -229,7 +229,7 @@ DevSettings:
       {"cluster": {"scheduler_slots": "cores"}}
   AwsBatchCliPackage: s3://test/aws-parallelcluster-batch-3.0.tgz
   NodePackage: s3://test/aws-parallelcluster-node-3.0.tgz
-  SlurmSettings:
+  MungeKeySettings:
     MungeKeySecretArn: arn:aws:secretsmanager:us-east-1:123456789012:secret:TestMungeKey
 DeploymentSettings:
   LambdaFunctionsVpcConfig:

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -229,6 +229,8 @@ DevSettings:
       {"cluster": {"scheduler_slots": "cores"}}
   AwsBatchCliPackage: s3://test/aws-parallelcluster-batch-3.0.tgz
   NodePackage: s3://test/aws-parallelcluster-node-3.0.tgz
+  SlurmSettings:
+    MungeKeySecretArn: arn:aws:secretsmanager:us-east-1:123456789012:secret:TestMungeKey
 DeploymentSettings:
   LambdaFunctionsVpcConfig:
     SecurityGroupIds: ["sg-028d73ae220157d96"]

--- a/cli/tests/pcluster/validators/test_secret_validators.py
+++ b/cli/tests/pcluster/validators/test_secret_validators.py
@@ -29,19 +29,22 @@ from tests.pcluster.validators.utils import assert_failure_messages
             "arn:aws:otherService:us-west-2:123456789012:secret:testSecret",
             "us-west-2",
             {"SecretString": "validBase64Value"},
-            "The secret arn:aws:otherService:us-west-2:123456789012:secret:testSecret is not supported in region us-west-2.",
+            "The secret arn:aws:otherService:us-west-2:123456789012:secret:testSecret is not supported "
+            "in region us-west-2.",
         ),
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret",
             "us-west-2",
             {"SecretString": "validBase64Value"},
-            "The secret arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret is not supported in region us-west-2.",
+            "The secret arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret is not supported"
+            " in region us-west-2.",
         ),
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
             "us-west-2",
             {"SecretString": "invalidBase64"},
-            "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not contain valid Base64 encoded data.",
+            "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not contain"
+            " valid Base64 encoded data.",
         ),
     ],
 )

--- a/cli/tests/pcluster/validators/test_secret_validators.py
+++ b/cli/tests/pcluster/validators/test_secret_validators.py
@@ -1,0 +1,60 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+# with the License. A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from pcluster.validators.secret_validators import MungeKeySecretArnValidator
+from tests.pcluster.aws.dummy_aws_api import mock_aws_api
+from tests.pcluster.validators.utils import assert_failure_messages
+
+
+@pytest.mark.parametrize(
+    "munge_key_secret_arn, region, mock_response, expected_response",
+    [
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            "us-west-2",
+            {"SecretString": "validBase64Value"},
+            "",
+        ),
+        (
+            "arn:aws:otherService:us-west-2:123456789012:secret:testSecret",
+            "us-west-2",
+            {"SecretString": "validBase64Value"},
+            "The secret arn:aws:otherService:us-west-2:123456789012:secret:testSecret is not supported in region us-west-2.",
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret",
+            "us-west-2",
+            {"SecretString": "validBase64Value"},
+            "The secret arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret is not supported in region us-west-2.",
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            "us-west-2",
+            {"SecretString": "invalidBase64"},
+            "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not contain valid Base64 encoded data.",
+        ),
+    ],
+)
+def test_munge_key_secret_arn_validator(
+    munge_key_secret_arn,
+    region,
+    mock_response,
+    expected_response,
+    mocker,
+):
+    # Setting up the mock of secretsmanager
+    mock_aws_api(mocker)
+    mocker.patch("pcluster.aws.secretsmanager.SecretsManagerClient.get_secret_value", return_value=mock_response)
+
+    actual_response = MungeKeySecretArnValidator().execute(munge_key_secret_arn, region)
+    assert_failure_messages(actual_response, expected_response)

--- a/cli/tests/pcluster/validators/test_secret_validators.py
+++ b/cli/tests/pcluster/validators/test_secret_validators.py
@@ -23,15 +23,25 @@ from tests.pcluster.validators.utils import assert_failure_level, assert_failure
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
             "us-west-2",
-            {"SecretString": "validBase64Value"},
+            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
             "",
             None,
             None,
         ),
         (
-            "arn:aws:otherService:us-west-2:123456789012:secret:testSecret",
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
             "us-west-2",
             {"SecretString": "validBase64Value"},
+            "The size of the decoded munge key in the secret "
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is 96 bits "
+            "which is outside the allowed range [256-8192].",
+            None,
+            FailureLevel.ERROR,
+        ),
+        (
+            "arn:aws:otherService:us-west-2:123456789012:secret:testSecret",
+            "us-west-2",
+            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
             "The secret arn:aws:otherService:us-west-2:123456789012:secret:testSecret is not supported "
             "in region us-west-2.",
             None,
@@ -40,7 +50,7 @@ from tests.pcluster.validators.utils import assert_failure_level, assert_failure
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret",
             "us-west-2",
-            {"SecretString": "validBase64Value"},
+            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
             "The secret arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret is not supported"
             " in region us-west-2.",
             None,
@@ -49,7 +59,7 @@ from tests.pcluster.validators.utils import assert_failure_level, assert_failure
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
             "us-west-2",
-            {"SecretString": "invalidBase64"},
+            {"SecretString": "invalidBase64MakeItInRange[256,8192]MakeItInRange[256,8192]"},
             "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not contain"
             " valid Base64 encoded data.",
             None,
@@ -58,7 +68,7 @@ from tests.pcluster.validators.utils import assert_failure_level, assert_failure
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
             "us-west-2",
-            {"SecretString": "validBase64Value"},
+            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
             "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not exist.",
             "ResourceNotFoundExceptionSecrets",
             FailureLevel.ERROR,
@@ -66,7 +76,7 @@ from tests.pcluster.validators.utils import assert_failure_level, assert_failure
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
             "us-west-2",
-            {"SecretString": "validBase64Value"},
+            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
             "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret due to "
             "lack of permissions. Please refer to ParallelCluster official documentation for more information.",
             "AccessDeniedException",
@@ -75,7 +85,7 @@ from tests.pcluster.validators.utils import assert_failure_level, assert_failure
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
             "us-west-2",
-            {"SecretString": "validBase64Value"},
+            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
             "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret. "
             "Please refer to ParallelCluster official documentation for more information.",
             "ANOTHER_ERROR",

--- a/cli/tests/pcluster/validators/test_secret_validators.py
+++ b/cli/tests/pcluster/validators/test_secret_validators.py
@@ -9,125 +9,144 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
+# import pytest
+#
+# from pcluster.aws.common import AWSClientError
+# from pcluster.validators.common import FailureLevel
+# from tests.pcluster.validators.utils import assert_failure_level, assert_failure_messages
 
-from pcluster.aws.common import AWSClientError
-from pcluster.validators.common import FailureLevel
-from pcluster.validators.secret_validators import MungeKeySecretArnValidator
-from tests.pcluster.validators.utils import assert_failure_level, assert_failure_messages
-
-
-@pytest.mark.parametrize(
-    "munge_key_secret_arn, region, mock_response, expected_response, error_from_aws_service, expected_failure_level",
-    [
-        (
-            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-            "us-west-2",
-            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
-            "",
-            None,
-            None,
-        ),
-        (
-            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-            "us-west-2",
-            {"SecretString": "validBase64Value"},
-            "The size of the decoded munge key in the secret "
-            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is 96 bits "
-            "which is outside the allowed range [256-8192].",
-            None,
-            FailureLevel.ERROR,
-        ),
-        (
-            "arn:aws:otherService:us-west-2:123456789012:secret:testSecret",
-            "us-west-2",
-            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
-            "The secret arn:aws:otherService:us-west-2:123456789012:secret:testSecret is not supported "
-            "in region us-west-2.",
-            None,
-            FailureLevel.ERROR,
-        ),
-        (
-            "arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret",
-            "us-west-2",
-            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
-            "The secret arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret is not supported"
-            " in region us-west-2.",
-            None,
-            FailureLevel.ERROR,
-        ),
-        (
-            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-            "us-west-2",
-            {"SecretString": "invalidBase64MakeItInRange[256,8192]MakeItInRange[256,8192]"},
-            "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not contain"
-            " valid Base64 encoded data.",
-            None,
-            FailureLevel.ERROR,
-        ),
-        (
-            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-            "us-west-2",
-            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
-            "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not exist.",
-            "ResourceNotFoundExceptionSecrets",
-            FailureLevel.ERROR,
-        ),
-        (
-            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-            "us-west-2",
-            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
-            "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret due to "
-            "lack of permissions. Please refer to ParallelCluster official documentation for more information.",
-            "AccessDeniedException",
-            FailureLevel.WARNING,
-        ),
-        (
-            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-            "us-west-2",
-            {"SecretString": "validBase64ValueMakeItInRange[256,8192]MakeItInRange[256,8192]"},
-            "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret. "
-            "Please refer to ParallelCluster official documentation for more information.",
-            "ANOTHER_ERROR",
-            FailureLevel.WARNING,
-        ),
-    ],
-)
-def test_munge_key_secret_arn_validator(
-    munge_key_secret_arn,
-    region,
-    mock_response,
-    expected_response,
-    error_from_aws_service,
-    expected_failure_level,
-    mocker,
-):
-    # Setting up the mock of secretsmanager
-    mocker.patch("boto3.client")
-
-    mocker.patch("pcluster.aws.secretsmanager.SecretsManagerClient.get_secret_value", return_value=mock_response)
-    if error_from_aws_service:
-        mocker.patch(
-            "pcluster.aws.secretsmanager.SecretsManagerClient.describe_secret",
-            side_effect=AWSClientError(
-                function_name="A_FUNCTION_NAME", error_code=str(error_from_aws_service), message="AN_ERROR_MESSAGE"
-            ),
-        )
-    else:
-        mocker.patch(
-            "pcluster.aws.secretsmanager.SecretsManagerClient.describe_secret",
-            return_value={
-                "ARN": "arn:aws:secretsmanager:us-east-1:111111111111:secret:Secret-xxxxxxxx-xxxxx",
-                "Name": "dummy_secret",
-                "Description": "Dummy Secret",
-                "LastChangedDate": "2022-08-01T10:00:00+00:00",
-                "LastAccessedDate": "2022-08-02T02:00:00+00:00",
-                "Tags": [],
-                "VersionIdsToStages": {"12345678-1234-abcd-1234-567890abcdef": ["AWSCURRENT"]},
-                "CreatedDate": "2022-08-01T10:00:00+00:00",
-            },
-        )
-
-    actual_response = MungeKeySecretArnValidator().execute(munge_key_secret_arn, region)
-    assert_failure_messages(actual_response, expected_response)
-    assert_failure_level(actual_response, expected_failure_level)
+#
+# @pytest.mark.parametrize(
+#     "munge_key_secret_arn, region, mock_response, expected_response, error_from_aws_service, expected_failure_level",
+#     [
+#         (
+#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+#             "us-west-2",
+#             # In Base64 encoding:
+#             # - Every 3 bytes of input are represented as 4 characters in the encoded string.
+#             # - The length of the encoded string must be a multiple of 4.
+#             # - Valid Base64 characters include upper/lowercase letters,
+#             #   numbers, '+', '/', and possibly trailing '=' padding chars.
+#             # - The '=' padding is used if the number of bytes being encoded is not divisible by 3.
+#             # Given these rules:
+#             # - "validBase64" is valid because its length is a multiple of 4 and uses valid Base64 characters.
+#             # - "invalidBase64" is invalid because its length is not a multiple of 4.
+#             {"SecretString": "validBase641234567890123456789012345678901234567"},
+#             "",
+#             None,
+#             None,
+#         ),
+#         (
+#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+#             "us-west-2",
+#             {"SecretString": "validBase64Value"},
+#             "The size of the decoded munge key in the secret "
+#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is 96 bits. "
+#             "Please use a key with a size between 256 and 8192 bits.",
+#             None,
+#             FailureLevel.ERROR,
+#         ),
+#         (
+#             "arn:aws:otherService:us-west-2:123456789012:secret:testSecret",
+#             "us-west-2",
+#             {"SecretString": "validBase641234567890123456789012345678901234567"},
+#             "The secret arn:aws:otherService:us-west-2:123456789012:secret:testSecret is not supported "
+#             "in region us-west-2.",
+#             None,
+#             FailureLevel.ERROR,
+#         ),
+#         (
+#             "arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret",
+#             "us-west-2",
+#             {"SecretString": "validBase641234567890123456789012345678901234567"},
+#             "The secret arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret is not supported"
+#             " in region us-west-2.",
+#             None,
+#             FailureLevel.ERROR,
+#         ),
+#         (
+#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+#             "us-west-2",
+#             {"SecretString": "invalidBase641234567890123456789012345678901234567"},
+#             "The content of the secret "
+#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is not a valid Base64 encoded string. "
+#             "Please refer to the ParallelCluster official documentation for more information.",
+#             None,
+#             FailureLevel.ERROR,
+#         ),
+#         (
+#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+#             "us-west-2",
+#             {"SecretString": "invalidBase641234567890123456789012345678901234567[]"},
+#             "The content of the secret "
+#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is not a valid Base64 encoded string. "
+#             "Please refer to the ParallelCluster official documentation for more information.",
+#             None,
+#             FailureLevel.ERROR,
+#         ),
+#         (
+#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+#             "us-west-2",
+#             {"SecretString": "validBase641234567890123456789012345678901234567"},
+#             "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not exist.",
+#             "ResourceNotFoundExceptionSecrets",
+#             FailureLevel.ERROR,
+#         ),
+#         (
+#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+#             "us-west-2",
+#             {"SecretString": "validBase641234567890123456789012345678901234567"},
+#             "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret due to "
+#             "lack of permissions. Please refer to ParallelCluster official documentation for more information.",
+#             "AccessDeniedException",
+#             FailureLevel.WARNING,
+#         ),
+#         (
+#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+#             "us-west-2",
+#             {"SecretString": "validBase641234567890123456789012345678901234567"},
+#             "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret. "
+#             "Please refer to ParallelCluster official documentation for more information.",
+#             "ANOTHER_ERROR",
+#             FailureLevel.WARNING,
+#         ),
+#     ],
+# )
+# def test_munge_key_secret_arn_validator(
+#     munge_key_secret_arn,
+#     region,
+#     mock_response,
+#     expected_response,
+#     error_from_aws_service,
+#     expected_failure_level,
+#     mocker,
+# ):
+#     # Setting up the mock of secretsmanager
+#     mocker.patch("boto3.client")
+#
+#     mocker.patch("pcluster.aws.secretsmanager.SecretsManagerClient.get_secret_value", return_value=mock_response)
+#     if error_from_aws_service:
+#         mocker.patch(
+#             "pcluster.aws.secretsmanager.SecretsManagerClient.describe_secret",
+#             side_effect=AWSClientError(
+#                 function_name="A_FUNCTION_NAME", error_code=str(error_from_aws_service), message="AN_ERROR_MESSAGE"
+#             ),
+#         )
+#     else:
+#         mocker.patch(
+#             "pcluster.aws.secretsmanager.SecretsManagerClient.describe_secret",
+#             return_value={
+#                 "ARN": "arn:aws:secretsmanager:us-east-1:111111111111:secret:Secret-xxxxxxxx-xxxxx",
+#                 "Name": "dummy_secret",
+#                 "Description": "Dummy Secret",
+#                 "LastChangedDate": "2022-08-01T10:00:00+00:00",
+#                 "LastAccessedDate": "2022-08-02T02:00:00+00:00",
+#                 "Tags": [],
+#                 "VersionIdsToStages": {"12345678-1234-abcd-1234-567890abcdef": ["AWSCURRENT"]},
+#                 "CreatedDate": "2022-08-01T10:00:00+00:00",
+#             },
+#         )
+#
+#     actual_response = MungeKeySecretArnValidator().execute(munge_key_secret_arn, region)
+#     assert_failure_messages(actual_response, expected_response)
+#     assert_failure_level(actual_response, expected_failure_level)

--- a/cli/tests/pcluster/validators/test_secret_validators.py
+++ b/cli/tests/pcluster/validators/test_secret_validators.py
@@ -8,22 +8,27 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest.mock import MagicMock
 
 import pytest
 
+from pcluster.aws.common import AWSClientError
+from pcluster.validators.common import FailureLevel
 from pcluster.validators.secret_validators import MungeKeySecretArnValidator
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
-from tests.pcluster.validators.utils import assert_failure_messages
+from tests.pcluster.validators.utils import assert_failure_messages, assert_failure_level
 
 
 @pytest.mark.parametrize(
-    "munge_key_secret_arn, region, mock_response, expected_response",
+    "munge_key_secret_arn, region, mock_response, expected_response, error_from_aws_service, expected_failure_level",
     [
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
             "us-west-2",
             {"SecretString": "validBase64Value"},
             "",
+            None,
+            None,
         ),
         (
             "arn:aws:otherService:us-west-2:123456789012:secret:testSecret",
@@ -31,6 +36,8 @@ from tests.pcluster.validators.utils import assert_failure_messages
             {"SecretString": "validBase64Value"},
             "The secret arn:aws:otherService:us-west-2:123456789012:secret:testSecret is not supported "
             "in region us-west-2.",
+            None,
+            FailureLevel.ERROR,
         ),
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret",
@@ -38,6 +45,8 @@ from tests.pcluster.validators.utils import assert_failure_messages
             {"SecretString": "validBase64Value"},
             "The secret arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret is not supported"
             " in region us-west-2.",
+            None,
+            FailureLevel.ERROR,
         ),
         (
             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
@@ -45,6 +54,34 @@ from tests.pcluster.validators.utils import assert_failure_messages
             {"SecretString": "invalidBase64"},
             "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not contain"
             " valid Base64 encoded data.",
+            None,
+            FailureLevel.ERROR,
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            "us-west-2",
+            {"SecretString": "validBase64Value"},
+            "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not exist.",
+            "ResourceNotFoundExceptionSecrets",
+            FailureLevel.ERROR,
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            "us-west-2",
+            {"SecretString": "validBase64Value"},
+            "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret due to "
+            "lack of permissions. Please refer to ParallelCluster official documentation for more information.",
+            "AccessDeniedException",
+            FailureLevel.WARNING,
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            "us-west-2",
+            {"SecretString": "validBase64Value"},
+            "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret. "
+            "Please refer to ParallelCluster official documentation for more information.",
+            "ANOTHER_ERROR",
+            FailureLevel.WARNING,
         ),
     ],
 )
@@ -53,11 +90,36 @@ def test_munge_key_secret_arn_validator(
     region,
     mock_response,
     expected_response,
+    error_from_aws_service,
+    expected_failure_level,
     mocker,
 ):
     # Setting up the mock of secretsmanager
-    mock_aws_api(mocker)
+    mocker.patch("boto3.client")
+
     mocker.patch("pcluster.aws.secretsmanager.SecretsManagerClient.get_secret_value", return_value=mock_response)
+    if error_from_aws_service:
+        mocker.patch(
+            "pcluster.aws.secretsmanager.SecretsManagerClient.describe_secret",
+            side_effect=AWSClientError(
+                function_name="A_FUNCTION_NAME", error_code=str(error_from_aws_service), message="AN_ERROR_MESSAGE"
+            ),
+        )
+    else:
+        mocker.patch(
+            "pcluster.aws.secretsmanager.SecretsManagerClient.describe_secret",
+            return_value={
+                "ARN": "arn:aws:secretsmanager:us-east-1:111111111111:secret:Secret-xxxxxxxx-xxxxx",
+                "Name": "dummy_secret",
+                "Description": "Dummy Secret",
+                "LastChangedDate": "2022-08-01T10:00:00+00:00",
+                "LastAccessedDate": "2022-08-02T02:00:00+00:00",
+                "Tags": [],
+                "VersionIdsToStages": {"12345678-1234-abcd-1234-567890abcdef": ["AWSCURRENT"]},
+                "CreatedDate": "2022-08-01T10:00:00+00:00",
+            }
+        )
 
     actual_response = MungeKeySecretArnValidator().execute(munge_key_secret_arn, region)
     assert_failure_messages(actual_response, expected_response)
+    assert_failure_level(actual_response, expected_failure_level)

--- a/cli/tests/pcluster/validators/test_secret_validators.py
+++ b/cli/tests/pcluster/validators/test_secret_validators.py
@@ -8,15 +8,13 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import MagicMock
 
 import pytest
 
 from pcluster.aws.common import AWSClientError
 from pcluster.validators.common import FailureLevel
 from pcluster.validators.secret_validators import MungeKeySecretArnValidator
-from tests.pcluster.aws.dummy_aws_api import mock_aws_api
-from tests.pcluster.validators.utils import assert_failure_messages, assert_failure_level
+from tests.pcluster.validators.utils import assert_failure_level, assert_failure_messages
 
 
 @pytest.mark.parametrize(
@@ -117,7 +115,7 @@ def test_munge_key_secret_arn_validator(
                 "Tags": [],
                 "VersionIdsToStages": {"12345678-1234-abcd-1234-567890abcdef": ["AWSCURRENT"]},
                 "CreatedDate": "2022-08-01T10:00:00+00:00",
-            }
+            },
         )
 
     actual_response = MungeKeySecretArnValidator().execute(munge_key_secret_arn, region)

--- a/cli/tests/pcluster/validators/test_secret_validators.py
+++ b/cli/tests/pcluster/validators/test_secret_validators.py
@@ -21,25 +21,26 @@ from tests.pcluster.validators.utils import assert_failure_level, assert_failure
     "arn, region, expected_service, expected_resource, expected_response",
     [
         (
-            "arn:aws:validate_service:us-west-2:123456789012:validate_resource",
+            "arn:aws:valid_service:us-west-2:123456789012:valid_resource:valid_resource_name",
             "us-west-2",
-            "validate_service",
-            "validate_resource",
+            "valid_service",
+            "valid_resource",
             None,
         ),
         (
-            "arn:aws:s3:us-west-2:123456789012:bucket:my-bucket",
+            "arn:aws:valid_service:us-west-2:123456789012:invalid_resource:valid_resource_name",
             "us-west-2",
-            "validate_service",
-            "validate_resource",
-            "The arn:aws:s3:us-west-2:123456789012:bucket:my-bucket is not supported in region us-west-2.",
+            "valid_service",
+            "valid_resource",
+            "The arn:aws:valid_service:us-west-2:123456789012:invalid_resource:valid_resource_name "
+            "is not supported in region us-west-2.",
         ),
         (
-            "arn:aws:secretsmanager:us-west-2:123456789012:bucket:my-bucket",
+            "arn:aws:invalid_service:us-west-2:123456789012:valid_resource:valid_resource_name",
             "us-west-2",
-            "validate_service",
-            "validate_resource",
-            "The arn:aws:secretsmanager:us-west-2:123456789012:bucket:my-bucket "
+            "valid_service",
+            "valid_resource",
+            "The arn:aws:invalid_service:us-west-2:123456789012:valid_resource:valid_resource_name "
             "is not supported in region us-west-2.",
         ),
     ],

--- a/cli/tests/pcluster/validators/test_secret_validators.py
+++ b/cli/tests/pcluster/validators/test_secret_validators.py
@@ -9,144 +9,149 @@
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
 
-# import pytest
-#
-# from pcluster.aws.common import AWSClientError
-# from pcluster.validators.common import FailureLevel
-# from tests.pcluster.validators.utils import assert_failure_level, assert_failure_messages
+import pytest
 
-#
-# @pytest.mark.parametrize(
-#     "munge_key_secret_arn, region, mock_response, expected_response, error_from_aws_service, expected_failure_level",
-#     [
-#         (
-#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-#             "us-west-2",
-#             # In Base64 encoding:
-#             # - Every 3 bytes of input are represented as 4 characters in the encoded string.
-#             # - The length of the encoded string must be a multiple of 4.
-#             # - Valid Base64 characters include upper/lowercase letters,
-#             #   numbers, '+', '/', and possibly trailing '=' padding chars.
-#             # - The '=' padding is used if the number of bytes being encoded is not divisible by 3.
-#             # Given these rules:
-#             # - "validBase64" is valid because its length is a multiple of 4 and uses valid Base64 characters.
-#             # - "invalidBase64" is invalid because its length is not a multiple of 4.
-#             {"SecretString": "validBase641234567890123456789012345678901234567"},
-#             "",
-#             None,
-#             None,
-#         ),
-#         (
-#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-#             "us-west-2",
-#             {"SecretString": "validBase64Value"},
-#             "The size of the decoded munge key in the secret "
-#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is 96 bits. "
-#             "Please use a key with a size between 256 and 8192 bits.",
-#             None,
-#             FailureLevel.ERROR,
-#         ),
-#         (
-#             "arn:aws:otherService:us-west-2:123456789012:secret:testSecret",
-#             "us-west-2",
-#             {"SecretString": "validBase641234567890123456789012345678901234567"},
-#             "The secret arn:aws:otherService:us-west-2:123456789012:secret:testSecret is not supported "
-#             "in region us-west-2.",
-#             None,
-#             FailureLevel.ERROR,
-#         ),
-#         (
-#             "arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret",
-#             "us-west-2",
-#             {"SecretString": "validBase641234567890123456789012345678901234567"},
-#             "The secret arn:aws:secretsmanager:us-west-2:123456789012:otherResource:testSecret is not supported"
-#             " in region us-west-2.",
-#             None,
-#             FailureLevel.ERROR,
-#         ),
-#         (
-#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-#             "us-west-2",
-#             {"SecretString": "invalidBase641234567890123456789012345678901234567"},
-#             "The content of the secret "
-#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is not a valid Base64 encoded string. "
-#             "Please refer to the ParallelCluster official documentation for more information.",
-#             None,
-#             FailureLevel.ERROR,
-#         ),
-#         (
-#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-#             "us-west-2",
-#             {"SecretString": "invalidBase641234567890123456789012345678901234567[]"},
-#             "The content of the secret "
-#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is not a valid Base64 encoded string. "
-#             "Please refer to the ParallelCluster official documentation for more information.",
-#             None,
-#             FailureLevel.ERROR,
-#         ),
-#         (
-#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-#             "us-west-2",
-#             {"SecretString": "validBase641234567890123456789012345678901234567"},
-#             "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not exist.",
-#             "ResourceNotFoundExceptionSecrets",
-#             FailureLevel.ERROR,
-#         ),
-#         (
-#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-#             "us-west-2",
-#             {"SecretString": "validBase641234567890123456789012345678901234567"},
-#             "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret due to "
-#             "lack of permissions. Please refer to ParallelCluster official documentation for more information.",
-#             "AccessDeniedException",
-#             FailureLevel.WARNING,
-#         ),
-#         (
-#             "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
-#             "us-west-2",
-#             {"SecretString": "validBase641234567890123456789012345678901234567"},
-#             "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret. "
-#             "Please refer to ParallelCluster official documentation for more information.",
-#             "ANOTHER_ERROR",
-#             FailureLevel.WARNING,
-#         ),
-#     ],
-# )
-# def test_munge_key_secret_arn_validator(
-#     munge_key_secret_arn,
-#     region,
-#     mock_response,
-#     expected_response,
-#     error_from_aws_service,
-#     expected_failure_level,
-#     mocker,
-# ):
-#     # Setting up the mock of secretsmanager
-#     mocker.patch("boto3.client")
-#
-#     mocker.patch("pcluster.aws.secretsmanager.SecretsManagerClient.get_secret_value", return_value=mock_response)
-#     if error_from_aws_service:
-#         mocker.patch(
-#             "pcluster.aws.secretsmanager.SecretsManagerClient.describe_secret",
-#             side_effect=AWSClientError(
-#                 function_name="A_FUNCTION_NAME", error_code=str(error_from_aws_service), message="AN_ERROR_MESSAGE"
-#             ),
-#         )
-#     else:
-#         mocker.patch(
-#             "pcluster.aws.secretsmanager.SecretsManagerClient.describe_secret",
-#             return_value={
-#                 "ARN": "arn:aws:secretsmanager:us-east-1:111111111111:secret:Secret-xxxxxxxx-xxxxx",
-#                 "Name": "dummy_secret",
-#                 "Description": "Dummy Secret",
-#                 "LastChangedDate": "2022-08-01T10:00:00+00:00",
-#                 "LastAccessedDate": "2022-08-02T02:00:00+00:00",
-#                 "Tags": [],
-#                 "VersionIdsToStages": {"12345678-1234-abcd-1234-567890abcdef": ["AWSCURRENT"]},
-#                 "CreatedDate": "2022-08-01T10:00:00+00:00",
-#             },
-#         )
-#
-#     actual_response = MungeKeySecretArnValidator().execute(munge_key_secret_arn, region)
-#     assert_failure_messages(actual_response, expected_response)
-#     assert_failure_level(actual_response, expected_failure_level)
+from pcluster.aws.common import AWSClientError
+from pcluster.validators.common import FailureLevel
+from pcluster.validators.secret_validators import ArnServiceAndResourceValidator, MungeKeySecretSizeAndBase64Validator
+from tests.pcluster.validators.utils import assert_failure_level, assert_failure_messages
+
+
+@pytest.mark.parametrize(
+    "arn, region, expected_service, expected_resource, expected_response",
+    [
+        (
+            "arn:aws:validate_service:us-west-2:123456789012:validate_resource",
+            "us-west-2",
+            "validate_service",
+            "validate_resource",
+            None,
+        ),
+        (
+            "arn:aws:s3:us-west-2:123456789012:bucket:my-bucket",
+            "us-west-2",
+            "validate_service",
+            "validate_resource",
+            "The arn:aws:s3:us-west-2:123456789012:bucket:my-bucket is not supported in region us-west-2.",
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:bucket:my-bucket",
+            "us-west-2",
+            "validate_service",
+            "validate_resource",
+            "The arn:aws:secretsmanager:us-west-2:123456789012:bucket:my-bucket "
+            "is not supported in region us-west-2.",
+        ),
+    ],
+)
+def test_arn_service_and_resource_validator(
+    arn,
+    region,
+    expected_service,
+    expected_resource,
+    expected_response,
+):
+    actual_response = ArnServiceAndResourceValidator().execute(
+        arn,
+        region,
+        expected_service,
+        expected_resource,
+    )
+    assert_failure_messages(actual_response, expected_response)
+
+
+@pytest.mark.parametrize(
+    "munge_key_secret_arn, mock_response, expected_response, error_from_aws_service, expected_failure_level",
+    [
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            # In Base64 encoding:
+            # - Every 3 bytes of input are represented as 4 characters in the encoded string.
+            # - The length of the encoded string must be a multiple of 4.
+            # - Valid Base64 characters include upper/lowercase letters,
+            #   numbers, '+', '/', and possibly trailing '=' padding chars.
+            # - The '=' padding is used if the number of bytes being encoded is not divisible by 3.
+            # Given these rules:
+            # - "validBase64" is valid because its length is a multiple of 4 and uses valid Base64 characters.
+            # - "invalidBase64" is invalid because its length is not a multiple of 4.
+            {"SecretString": "validBase641234567890123456789012345678901234567"},
+            "",
+            None,
+            None,
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            {"SecretString": "validBase64Value"},
+            "The size of the decoded munge key in the secret "
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is 96 bits. "
+            "Please use a key with a size between 256 and 8192 bits.",
+            None,
+            FailureLevel.ERROR,
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            {"SecretString": "invalidBase641234567890123456789012345678901234567"},
+            "The content of the secret "
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is not a valid Base64 encoded string. "
+            "Please refer to the ParallelCluster official documentation for more information.",
+            None,
+            FailureLevel.ERROR,
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            {"SecretString": "invalidBase641234567890123456789012345678901234567[]"},
+            "The content of the secret "
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret is not a valid Base64 encoded string. "
+            "Please refer to the ParallelCluster official documentation for more information.",
+            None,
+            FailureLevel.ERROR,
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            {"SecretString": "validBase641234567890123456789012345678901234567"},
+            "The secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret does not exist.",
+            "ResourceNotFoundExceptionSecrets",
+            FailureLevel.ERROR,
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            {"SecretString": "validBase641234567890123456789012345678901234567"},
+            "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret due to "
+            "lack of permissions. Please refer to ParallelCluster official documentation for more information.",
+            "AccessDeniedException",
+            FailureLevel.WARNING,
+        ),
+        (
+            "arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret",
+            {"SecretString": "validBase641234567890123456789012345678901234567"},
+            "Cannot validate secret arn:aws:secretsmanager:us-west-2:123456789012:secret:testSecret. "
+            "Please refer to ParallelCluster official documentation for more information.",
+            "ANOTHER_ERROR",
+            FailureLevel.WARNING,
+        ),
+    ],
+)
+def test_munge_key_secret_arn_validator(
+    munge_key_secret_arn,
+    mock_response,
+    expected_response,
+    error_from_aws_service,
+    expected_failure_level,
+    mocker,
+):
+    # Setting up the mock of secretsmanager
+    mocker.patch("boto3.client")
+
+    if error_from_aws_service:
+        mocker.patch(
+            "pcluster.aws.secretsmanager.SecretsManagerClient.get_secret_value",
+            side_effect=AWSClientError(
+                function_name="A_FUNCTION_NAME", error_code=str(error_from_aws_service), message="AN_ERROR_MESSAGE"
+            ),
+        )
+    else:
+        mocker.patch("pcluster.aws.secretsmanager.SecretsManagerClient.get_secret_value", return_value=mock_response)
+
+    actual_response = MungeKeySecretSizeAndBase64Validator().execute(munge_key_secret_arn)
+    assert_failure_messages(actual_response, expected_response)
+    assert_failure_level(actual_response, expected_failure_level)


### PR DESCRIPTION
### Description of changes
* Add a DevSetting to specify a Secret Arn for the custom munge key and related functions
* Add related IAM policy
* Add a validator for custom munge key secret Arn
  * The CLI session does not have permission to read the content of the secret - warning
  * Generic error in accessing the secret from the CLI session - warning
  * The content of the secret is not a vaild Base64 encoded text - error

### Tests
* munge key secret validator related test
* creating cluster with custom munge key test

### Relate Pull Request
* See the PR of Setup custom munge key in cookbook: 
  * [[develop] Add custom munge key config logic](https://github.com/aws/aws-parallelcluster-cookbook/pull/2451)
  * [[develop] Add custom munge key update logic](https://github.com/aws/aws-parallelcluster-cookbook/pull/2452)
  * [[develop] Add custom munge key rotation script](https://github.com/aws/aws-parallelcluster-cookbook/pull/2453)


### New sample YAML configuration

```
DevSettings:
  SlurmSettings:
    MungeKeySecretArn: Str
```
