### PR TITLE
Pass value of AssignPublicIp config param to LT associate_public_ip_address property

### DIFF
--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -149,9 +149,7 @@ class QueuesStack(NestedStack):
         compute_lt_nw_interfaces = [
             ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
                 device_index=0,
-                associate_public_ip_address=queue.networking.assign_public_ip
-                if compute_resource.max_network_interface_count == 1
-                else None,  # parameter not supported for instance types with multiple network interfaces
+                associate_public_ip_address=queue.networking.assign_public_ip,
                 interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
                 groups=queue_lt_security_groups,
                 subnet_id=queue.networking.subnet_ids[0]
@@ -165,6 +163,7 @@ class QueuesStack(NestedStack):
                 ec2.CfnLaunchTemplate.NetworkInterfaceProperty(
                     device_index=0,
                     network_card_index=network_interface_index,
+                    associate_public_ip_address=False,
                     interface_type="efa" if compute_resource.efa and compute_resource.efa.enabled else None,
                     groups=queue_lt_security_groups,
                     subnet_id=queue.networking.subnet_ids[0]

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -3146,6 +3146,16 @@ def test_root_volume_encryption_consistency_validator(
             id="Test with single nic queue with assigned public ip and subnet with public ip",
         ),
         pytest.param(
+            1,
+            False,
+            [
+                {"SubnetId": "subnet_1", "MapPublicIpOnLaunch": True},
+                {"SubnetId": "subnet_2", "MapPublicIpOnLaunch": False},
+            ],
+            None,
+            id="Test with single nic queue with not assigned public ip and subnet with public ip",
+        ),
+        pytest.param(
             2,
             False,
             [


### PR DESCRIPTION
### Description of changes

We have the `MultiNetworkInterfacesInstancesValidator` that doesn't permit to set `AssignPublicIp: true` when using a multi-NIC instance type, so this change does not have an impact in the default behaviour.

Anyway, this change permits to pass `AssignPublicIp: false` and this is useful in cases where the user has a very strict PermissionsBoundary that explicitly forbids the creation of EC2 instances unless you have in the request an explicit `associate_public_ip_address=false`.

### Tests

`AssignPublicIp: true`:
* standard instance type --> no changes
* multi-nic instance type --> blocked by `MultiNetworkInterfacesInstancesValidator` --> no changes

`AssignPublicIp: false`:
* standard instance type --> `associate_public_ip_address=False` (previously it was `None`) --> no changes in the default behaviour
* multi-nic instance type --> `associate_public_ip_address=False` (previously it was `None`) --> no changes in the default behaviour

