### PR TITLE
Remove tox dependency on `pytest-travis-fold`

### DIFF
--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -14,7 +14,6 @@ usedevelop =
     nocov: false
 deps =
     -rtests/requirements.txt
-    pytest-travis-fold
 commands =
     nocov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --ignore=src tests/
     cov: python setup.py clean --all build_ext --force --inplace

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -17,7 +17,6 @@ allowlist_externals =
     bash
 deps =
     -rtests/requirements.txt
-    pytest-travis-fold
 extras =
     awslambda
 commands =


### PR DESCRIPTION
### Description of changes
- Tests run using Github actions now, not TravisCI.
- The pytest-travis-fold module is no longer necessary.

### Tests
* Current Github Actions Succeed
* Before these changes: https://github.com/aws/aws-parallelcluster/actions/runs/6075753710/job/16482877413?pr=5672

### References
* https://github.com/abusalimov/pytest-travis-fold/issues/11

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
