### PR TITLE
[develop] Strip string configuration values

### DIFF
--- a/cli/src/pcluster/config/common.py
+++ b/cli/src/pcluster/config/common.py
@@ -88,7 +88,7 @@ class Resource:
                 self.__value = default
                 self.__implied = True
             else:
-                self.__value = value
+                self.__value = value.strip() if isinstance(value, str) else value
                 self.__implied = False
             self.__default = default
             self.__update_policy = update_policy

--- a/cli/tests/pcluster/config/test_common.py
+++ b/cli/tests/pcluster/config/test_common.py
@@ -329,6 +329,7 @@ def test_nested_resource_validate():
 @pytest.mark.parametrize(
     "value, default, expected_value, expected_implied",
     [
+        ("abc ", "default_value", "abc", False),
         ("abc", "default_value", "abc", False),
         (None, "default_value", "default_value", True),
         (5, 10, 5, False),


### PR DESCRIPTION
### Description of changes

When using line folding AND there is an extra space at the end some parameters like `PasswordSecretArn` are failing on both validation and cluster creation case.

### Tests

Before the patch (extra space at the end):
```
  PasswordSecretArn: >-
    arn:aws:secretsmanager:eu-west-1:xxx:secret:PasswordSecret-pcluster-ad-7WCRBu
```
it is failing with:
```
    {
      "level": "WARNING",
      "type": "PasswordSecretArnValidator",
      "message": "Cannot validate secret arn:aws:secretsmanager:eu-west-1:xxx:secret:PasswordSecret-pcluster-ad-7WCRBu . Please refer to ParallelCluster official documentation for more information."
    }
```
and cluster creation is failing with:
```
Expected process to exit with [0], but received '255'
---- Begin output of aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:eu-west-1:xxx:secret:pcluster-ad-7WCRBu  --region eu-west --query 'SecretString' --output text ----
STDOUT:
STDERR: An error occurred (AccessDeniedException) when calling the GetSecretValue operation: User: arn:aws:sts::xxx:assumed-role/cluster-3-second-line-RoleHeadNode-yyy/i-xxx is not authorized to perform: secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:eu-west:xxx:secret:ReadOnly-xTbzmS because no identity-based policy allows the secretsmanager:GetSecretValue action
```

After the patch the validation is passing and creation succeeding.

### References
* https://yaml.org/spec/1.2.2/#65-line-folding

