### PR TITLE
Avoid injecting AdditionalIAMPolicies if using InstanceRole or InstanceProfile

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -629,7 +629,12 @@ def _inject_additional_iam_policies(node_config, additional_iam_policies):
             if policy not in node_config["Iam"]["AdditionalIamPolicies"]:
                 node_config["Iam"]["AdditionalIamPolicies"] += [copy.deepcopy(policy)]
     else:
-        dict_add_nested_key(node_config, additional_iam_policies, ("Iam", "AdditionalIamPolicies"))
+        # InstanceProfile, InstanceRole or AdditionalIamPolicies can not be configured together.
+        if not (
+            dict_has_nested_key(node_config, ("Iam", "InstanceRole"))
+            or dict_has_nested_key(node_config, ("Iam", "InstanceProfile"))
+        ):
+            dict_add_nested_key(node_config, additional_iam_policies, ("Iam", "AdditionalIamPolicies"))
 
 
 def _inject_additional_iam_policies_for_nodes(

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -627,7 +627,7 @@ def _inject_additional_iam_policies(node_config, additional_iam_policies):
     if dict_has_nested_key(node_config, ("Iam", "AdditionalIamPolicies")):
         for policy in additional_iam_policies:
             if policy not in node_config["Iam"]["AdditionalIamPolicies"]:
-                node_config["Iam"]["AdditionalIamPolicies"] += copy.deepcopy(policy)
+                node_config["Iam"]["AdditionalIamPolicies"] += [copy.deepcopy(policy)]
     else:
         dict_add_nested_key(node_config, additional_iam_policies, ("Iam", "AdditionalIamPolicies"))
 
@@ -636,21 +636,21 @@ def _inject_additional_iam_policies_for_nodes(
     config_content, scheduler: str, node_types: List[NodeType], policies: List[Dict]
 ):
     if NodeType.HEAD_NODE in node_types:
-        _inject_additional_iam_policies(config_content["HeadNode"], copy.deepcopy(policies))
+        _inject_additional_iam_policies(config_content["HeadNode"], policies)
     if (
         scheduler == "slurm"
         and dict_has_nested_key(config_content, ("Scheduling", "SlurmQueues"))
         and NodeType.COMPUTE_NODES in node_types
     ):
         for queue in config_content["Scheduling"]["SlurmQueues"]:
-            _inject_additional_iam_policies(queue, copy.deepcopy(policies))
+            _inject_additional_iam_policies(queue, policies)
     if (
         scheduler == "slurm"
         and dict_has_nested_key(config_content, ("LoginNodes", "Pools"))
         and NodeType.LOGIN_NODES in node_types
     ):
         for pool in config_content["LoginNodes"]["Pools"]:
-            _inject_additional_iam_policies(pool, copy.deepcopy(policies))
+            _inject_additional_iam_policies(pool, policies)
 
 
 def inject_additional_config_settings(cluster_config, request, region, benchmarks=None):  # noqa C901

--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -668,7 +668,8 @@ def _create_permission_boundary(permission_boundary_name):
                     ],
                     "Effect": "Allow",
                     "Resource": [
-                        {"Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${CustomIamNamePrefix}*"}
+                        {"Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${CustomIamNamePrefix}*"},
+                        {"Fn::Sub": "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"},
                     ],
                 },
             ],


### PR DESCRIPTION
### Description of changes
* Fix integration test failures, namely:
    * Avoid use of `AdditionalIamPolicies` alongside `InstanceRole` or `InstanceProfile` (which is not supported)
    * Add the `SSMManagedInstanceCore` policy to the permission boundary of one of the tests that provide an explicit permissions boundary (`test_iam`)

### Tests
* Ran subset of failing tests to confirm fix

### References
* N/A

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
