### PR TITLE
Added support for Data Repository Associations with Pcluster Managed FSx for Lustre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ------
 
 **ENHANCEMENTS**
-
+- Add support for Data Repository Associations when using PERSISTENT_2 as DeploymentType for a managed FSx for Lustre.
 **CHANGES**
 
 **BUG FIXES**

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -139,10 +139,10 @@ from pcluster.validators.ec2_validators import (
 from pcluster.validators.efs_validators import EfsMountOptionsValidator
 from pcluster.validators.feature_validators import FeatureRegionValidator
 from pcluster.validators.fsx_validators import (
-    DraValidator,
     FsxAutoImportValidator,
     FsxBackupIdValidator,
     FsxBackupOptionsValidator,
+    FsxDraValidator,
     FsxPersistentOptionsValidator,
     FsxS3Validator,
     FsxStorageCapacityValidator,
@@ -189,7 +189,6 @@ from pcluster.validators.slurm_settings_validator import (
 from pcluster.validators.tags_validators import ComputeResourceTagsValidator
 
 LOGGER = logging.getLogger(__name__)
-
 
 # pylint: disable=C0302
 
@@ -434,12 +433,14 @@ class BaseSharedFsx(Resource):
 
 
 class DataRepositoryAssociation(Resource):
+    """Represent the Data Repository Association resource."""
+
     def __init__(
         self,
-        name: str = None,
-        batch_import_metadata_on_create: bool = None,
-        data_repository_path: str = None,
-        file_system_path: str = None,
+        name: str,
+        data_repository_path: str,
+        file_system_path: str,
+        batch_import_meta_data_on_create: bool = None,
         imported_file_chunk_size: int = None,
         auto_export_policy: List[str] = None,
         auto_import_policy: List[str] = None,
@@ -447,10 +448,10 @@ class DataRepositoryAssociation(Resource):
     ):
         super().__init__(**kwargs)
         self.name = Resource.init_param(name)
-        self.batch_import_metadata_on_create = Resource.init_param(batch_import_metadata_on_create, default=False)
+        self.batch_import_meta_data_on_create = Resource.init_param(batch_import_meta_data_on_create, default=False)
         self.data_repository_path = Resource.init_param(data_repository_path)
         self.file_system_path = Resource.init_param(file_system_path)
-        self.imported_file_chunk_size = Resource.init_param(imported_file_chunk_size)
+        self.imported_file_chunk_size = Resource.init_param(imported_file_chunk_size, default=1024)
         self.auto_export_policy = Resource.init_param(auto_export_policy)
         self.auto_import_policy = Resource.init_param(auto_import_policy)
 
@@ -519,7 +520,7 @@ class SharedFsxLustre(BaseSharedFsx):
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
         self._register_validator(
-            DraValidator,
+            FsxDraValidator,
             data_repository_associations=self.data_repository_associations,
             import_path=self.import_path,
             export_path=self.export_path,

--- a/cli/src/pcluster/config/config_patch.py
+++ b/cli/src/pcluster/config/config_patch.py
@@ -189,18 +189,19 @@ class ConfigPatch:
                     )
                 )
         # Then, compare all non visited base sections vs target config.
-        for base_nested_section in base_section.get(data_key, []):
-            if not base_nested_section.get("visited", False):
-                self.changes.append(
-                    Change(
-                        param_path,
-                        data_key,
-                        base_nested_section,
-                        None,
-                        change_update_policy,
-                        is_list=True,
+        if base_section:
+            for base_nested_section in base_section.get(data_key, []):
+                if not base_nested_section.get("visited", False):
+                    self.changes.append(
+                        Change(
+                            param_path,
+                            data_key,
+                            base_nested_section,
+                            None,
+                            change_update_policy,
+                            is_list=True,
+                        )
                     )
-                )
 
     @property
     def update_policy_level(self):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -962,6 +962,18 @@ class ClusterCdkStack:
             ) = convert_deletion_policy(shared_fsx.deletion_policy)
 
             fsx_id = fsx_resource.ref
+
+            for dra in shared_fsx.data_repository_associations:
+                fsx.CfnDataRepositoryAssociation(
+                    batch_import_metadata_on_create=dra.batch_import_metadata_on_create,
+                    data_repository_path=dra.data_repository_path,
+                    file_system_id=fsx_id,
+                    file_system_path=dra.file_system_path,
+                    imported_file_chunk_size=dra.imported_file_chunk_size,
+                    s3=[dra.auto_export_policy, dra.auto_import_policy],
+                    tags=[CfnTag(key="Name", value=dra.name)],
+                )
+
             # Get MountName for new filesystem. DNSName cannot be retrieved from CFN and will be generated in cookbook
             mount_name = fsx_resource.attr_lustre_mount_name
 

--- a/cli/src/pcluster/validators/fsx_validators.py
+++ b/cli/src/pcluster/validators/fsx_validators.py
@@ -48,6 +48,22 @@ class FsxS3Validator(Validator):
             )
 
 
+class DraValidator(Validator):
+    def _validate(self, data_repository_associations, import_path, export_path):
+        if data_repository_associations and (import_path or export_path):
+            self._add_failure(
+                "When specifying data repository associations, import and export path "
+                "can not be used on the same file system.",
+                FailureLevel.ERROR,
+            )
+
+        if len(data_repository_associations) > 8:
+            self._add_failure(
+                "The number of data repository association used for one file system cannot be greater that 8.",
+                FailureLevel.ERROR,
+            )
+
+
 class FsxPersistentOptionsValidator(Validator):
     """
     FSX persistent options validator.

--- a/cli/src/pcluster/validators/fsx_validators.py
+++ b/cli/src/pcluster/validators/fsx_validators.py
@@ -48,7 +48,13 @@ class FsxS3Validator(Validator):
             )
 
 
-class DraValidator(Validator):
+class FsxDraValidator(Validator):
+    """
+    FSX Dra validator.
+
+    Verify compatibility of given S3 association options for FSX.
+    """
+
     def _validate(self, data_repository_associations, import_path, export_path):
         if data_repository_associations and (import_path or export_path):
             self._add_failure(
@@ -57,7 +63,7 @@ class DraValidator(Validator):
                 FailureLevel.ERROR,
             )
 
-        if len(data_repository_associations) > 8:
+        if data_repository_associations and len(data_repository_associations) > 8:
             self._add_failure(
                 "The number of data repository association used for one file system cannot be greater that 8.",
                 FailureLevel.ERROR,

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -182,10 +182,10 @@ SharedStorage:
     FsxLustreSettings:
       StorageCapacity: 3600
       DeploymentType: PERSISTENT_1  # PERSISTENT_1 | PERSISTENT_2 | SCRATCH_1 | SCRATCH_2
-      ImportedFileChunkSize: 1024
+      # ImportedFileChunkSize: 1024 # ImportedFileChunkSize cannot coexist with some of the fields
       DataCompressionType: LZ4
-      ExportPath: s3://bucket/folder
-      ImportPath: s3://bucket
+      # ExportPath: s3://bucket/folder # ExportPath cannot coexist with some of the fields
+      # ImportPath: s3://bucket # ImportPath cannot coexist with some of the fields
       WeeklyMaintenanceStartTime: "1:00:00"
       AutomaticBackupRetentionDays: 0
       CopyTagsToBackups: true
@@ -194,9 +194,17 @@ SharedStorage:
       # BackupId: backup-fedcba98 # BackupId cannot coexist with some of the fields
       KmsKeyId: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
       # FileSystemId: fs-12345678123456789 # FileSystemId cannot coexist with other fields
-      AutoImportPolicy: NEW  # NEW | NEW_CHANGED | NEW_CHANGED_DELETED
+      # AutoImportPolicy: NEW  # NEW | NEW_CHANGED | NEW_CHANGED_DELETED # AutoImportPolicy cannot coexist with some of the fields
       DriveCacheType: READ  # READ
       StorageType: HDD  # HDD | SSD
+      DataRepositoryAssociations:
+        - Name: dra
+          BatchImportMetaDataOnCreate: false
+          DataRepositoryPath: s3://bucket/folder
+          FileSystemPath: /
+          ImportedFileChunkSize: 1024
+          AutoExportPolicy: [ NEW, CHANGED, DELETED ]
+          AutoImportPolicy: [ NEW, CHANGED, DELETED ]
   - MountDir: /my/mount/point4
     Name: name4
     StorageType: FsxOpenZfs

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -4143,6 +4143,7 @@ SharedStorage:
     CopyTagsToBackups: true
     DailyAutomaticBackupStartTime: 01:03
     DataCompressionType: LZ4
+    DataRepositoryAssociations: null
     DeletionPolicy: Delete
     DeploymentType: PERSISTENT_1
     DriveCacheType: READ
@@ -4175,6 +4176,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4197,6 +4199,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4219,6 +4222,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4241,6 +4245,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4263,6 +4268,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4285,6 +4291,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4307,6 +4314,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4329,6 +4337,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4351,6 +4360,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4373,6 +4383,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4395,6 +4406,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4417,6 +4429,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4439,6 +4452,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4461,6 +4475,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4483,6 +4498,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4505,6 +4521,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4527,6 +4544,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null
@@ -4549,6 +4567,7 @@ SharedStorage:
     CopyTagsToBackups: null
     DailyAutomaticBackupStartTime: null
     DataCompressionType: null
+    DataRepositoryAssociations: null
     DeletionPolicy: null
     DeploymentType: null
     DriveCacheType: null

--- a/cli/tests/pcluster/validators/test_fsx_validators.py
+++ b/cli/tests/pcluster/validators/test_fsx_validators.py
@@ -17,6 +17,7 @@ from pcluster.validators.fsx_validators import (
     FsxAutoImportValidator,
     FsxBackupIdValidator,
     FsxBackupOptionsValidator,
+    FsxDraValidator,
     FsxPersistentOptionsValidator,
     FsxS3Validator,
     FsxStorageCapacityValidator,
@@ -71,6 +72,35 @@ def test_fsx_s3_validator(import_path, imported_file_chunk_size, export_path, au
         export_path,
         auto_import_policy,
     )
+    assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "data_repository_associations, import_path, export_path, expected_message",
+    [
+        (
+            ["dra-1"],
+            "s3://test",
+            None,
+            "When specifying data repository associations, import and export path "
+            "can not be used on the same file system.",
+        ),
+        (
+            ["dra-1", "dra-2", "dra-3", "dra-4", "dra-5", "6", "dra-7", "dra-8", "dra-9"],
+            None,
+            None,
+            "The number of data repository association used for one file system cannot be greater that 8.",
+        ),
+        (
+            None,
+            "s3://test",
+            "s3://test",
+            None,
+        ),
+    ],
+)
+def test_fsx_dra_validator(data_repository_associations, import_path, export_path, expected_message):
+    actual_failures = FsxDraValidator().execute(data_repository_associations, import_path, export_path)
     assert_failure_messages(actual_failures, expected_message)
 
 

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -540,12 +540,18 @@ storage:
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: ["ubuntu2204"]
         schedulers: ["slurm"]
-  test_fsx_lustre.py::test_file_cache:
+  test_fsx_lustre.py::test_fsx_lustre_dra:
     dimensions:
       - regions: [ "eu-west-2" ]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: [ "alinux2" ]
         schedulers: [ "slurm" ]
+      - regions: [ "eu-north-1" ]
+        instances: {{ common.INSTANCES_DEFAULT_ARM }}
+        oss: [ "ubuntu2204" ]
+        schedulers: [ "slurm" ]
+  test_fsx_lustre.py::test_file_cache:
+    dimensions:
       - regions: [ "eu-north-1" ]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         oss: [ "ubuntu2204" ]

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.update.yaml
@@ -1,0 +1,53 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket_name }}
+        EnableWriteAccess: False
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue-0
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}
+            EnableWriteAccess: False
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+SharedStorage:
+  - MountDir: {{ mount_dir }}
+    Name: fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: {{ storage_capacity }}
+      DeploymentType: PERSISTENT_2
+      PerUnitStorageThroughput: 125
+      DataRepositoryAssociations:
+        - Name: dra
+          BatchImportMetaDataOnCreate: True
+          DataRepositoryPath: s3://{{ bucket_name }}/test1
+          FileSystemPath: /test1
+          ImportedFileChunkSize: 1024
+          AutoExportPolicy: [ NEW, CHANGED, DELETED ]
+          AutoImportPolicy: [ NEW, CHANGED ]
+        - Name: dra_2
+          BatchImportMetaDataOnCreate: True
+          DataRepositoryPath: s3://{{ bucket_name }}/test2
+          FileSystemPath: /test2
+          ImportedFileChunkSize: 1024
+          AutoExportPolicy: [ NEW, CHANGED, DELETED ]
+          AutoImportPolicy: [ NEW ]

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/pcluster.config.yaml
@@ -1,0 +1,46 @@
+Image:
+  Os: {{ os }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket_name }}
+        EnableWriteAccess: False
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue-0
+      Iam:
+        S3Access:
+          - BucketName: {{ bucket_name }}
+            EnableWriteAccess: False
+      ComputeResources:
+        - Name: compute-resource-0
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+SharedStorage:
+  - MountDir: {{ mount_dir }}
+    Name: fsx
+    StorageType: FsxLustre
+    FsxLustreSettings:
+      StorageCapacity: {{ storage_capacity }}
+      DeploymentType: PERSISTENT_2
+      PerUnitStorageThroughput: 125
+      DataRepositoryAssociations:
+        - Name: dra
+          BatchImportMetaDataOnCreate: True
+          DataRepositoryPath: s3://{{ bucket_name }}/test1
+          FileSystemPath: /test1
+          ImportedFileChunkSize: 1024
+          AutoExportPolicy: [ NEW, CHANGED, DELETED ]
+          AutoImportPolicy: [ NEW ]

--- a/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/s3_test_file
+++ b/tests/integration-tests/tests/storage/test_fsx_lustre/test_fsx_lustre_dra/s3_test_file
@@ -1,0 +1,1 @@
+Downloaded by FSx Lustre


### PR DESCRIPTION
### Description of changes
* FSx released Persistent_2 which no longer supports the use of ExportPath and ImportPath. Instead, it uses DRAs to configure S3 association. 
* The possibility to configure DRAs for managed FSx for Lustre file systems when configuring a cluster will now be supported.

### Tests
- Integration Tests
   -The addition, removal, and update of DRAs was tested
* Unit Tests
  -The new schema and validators were tested

### References
* https://github.com/aws/aws-parallelcluster/issues/4499

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
