### PR TITLE
[Release-3.7] Upgrade Slurm version to 23.02.05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+3.7.1
+------
+**CHANGES**
+- Upgrade Slurm to 23.02.5 (from 23.02.4).
+  - Upgrade Pmix to 4.2.6 (from 3.2.3).
+  - Upgrade libjwt to 1.15.3 (from 1.12.0).
+
 3.7.0
 ------
 

--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -14,7 +14,6 @@ usedevelop =
     nocov: false
 deps =
     -rtests/requirements.txt
-    pytest-travis-fold
 commands =
     nocov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --ignore=src tests/
     cov: python setup.py clean --all build_ext --force --inplace

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -17,7 +17,6 @@ allowlist_externals =
     bash
 deps =
     -rtests/requirements.txt
-    pytest-travis-fold
 extras =
     awslambda
 commands =

--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -229,7 +229,7 @@ def test_slurm_pmix(pcluster_config_reader, scheduler, clusters_factory, use_log
     remote_command_executor = RemoteCommandExecutor(cluster, use_login_node=use_login_node)
 
     # Ensure the expected PMIx version is listed when running `srun --mpi=list`.
-    # Since we're installing PMIx v3.1.5, we expect to see pmix and pmix_v3 in the output.
+    # Since we're installing PMIx v4.2.6, we expect to see pmix and pmix_v4 in the output.
     # Sample output:
     # [ec2-user@ip-172-31-33-187 ~]$ srun 2>&1 --mpi=list
     # srun: MPI types are...
@@ -237,10 +237,10 @@ def test_slurm_pmix(pcluster_config_reader, scheduler, clusters_factory, use_log
     # srun: openmpi
     # srun: pmi2
     # srun: pmix
-    # srun: pmix_v3
+    # srun: pmix_v4
     mpi_list_output = remote_command_executor.run_remote_command("srun 2>&1 --mpi=list").stdout
     assert_that(mpi_list_output).matches(r"\s+pmix($|\s+)")
-    assert_that(mpi_list_output).matches(r"\s+pmix_v3($|\s+)")
+    assert_that(mpi_list_output).matches(r"\s+pmix_v4($|\s+)")
 
     # Compile and run an MPI program interactively
     mpi_module = "openmpi"
@@ -1711,7 +1711,7 @@ def _gpu_resource_check(slurm_commands, partition, instance_type, instance_type_
 def _test_slurm_version(remote_command_executor):
     logging.info("Testing Slurm Version")
     version = remote_command_executor.run_remote_command("sinfo -V").stdout
-    assert_that(version).is_equal_to("slurm 23.02.4")
+    assert_that(version).is_equal_to("slurm 23.02.5")
 
 
 def _test_job_dependencies(slurm_commands, region, stack_name, scaledown_idletime):


### PR DESCRIPTION


### Description of changes
* Upgrade Slurm version to 23.02.05
* Also update test for pmix upgrade to 4.2.6

### Tests
* Adapt existing integration test to check for the new version.
* Launched scheduler test suite in internal Jenkins: all tests completed successfully.

### References
* [Changes in Cookbook.](https://github.com/aws/aws-parallelcluster-cookbook/pull/2450/files)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
