### PR TITLE
[integ-tests-3.7.0][integ-tests] Improve _get_resources_with_image_resource

### DIFF
--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -14,7 +14,6 @@ usedevelop =
     nocov: false
 deps =
     -rtests/requirements.txt
-    pytest-travis-fold
 commands =
     nocov: pytest -n auto -l -v --basetemp={envtmpdir} --html=report.html --ignore=src tests/
     cov: python setup.py clean --all build_ext --force --inplace

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -17,7 +17,6 @@ allowlist_externals =
     bash
 deps =
     -rtests/requirements.txt
-    pytest-travis-fold
 extras =
     awslambda
 commands =

--- a/tests/integration-tests/tests/iam/test_iam_image.py
+++ b/tests/integration-tests/tests/iam/test_iam_image.py
@@ -93,7 +93,7 @@ def _get_resources_with_image_resource(cfn_client, stack_name):
     image_resource_exists = False
     logging.info("Checking image resource")
     for resource in resources:
-        if resource["ResourceType"] == "AWS::ImageBuilder::Image":
+        if resource["ResourceType"] == "AWS::ImageBuilder::Image" and resource.get("PhysicalResourceId"):
             image_resource_exists = True
             logging.info("The image resource exists!")
             break


### PR DESCRIPTION
When the resource first appears, the PhysicalResourceId might not be available. Therefore, this commit improves the function to wait until PhysicalResourceId is available.

This PR also cherry picks https://github.com/aws/aws-parallelcluster/pull/5685

### Tests
test_iam_roles integration test has been passed

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
