### PR TITLE
Remove api/client folder from codeQL scanning and resolve other codeQL findings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,11 @@ name: "CodeQL"
 
 on:
   push:
+    paths-ignore:
+      - api/client
   pull_request:
+    paths-ignore:
+      - api/client
   schedule:
     - cron: '0 10 * * 2'
 

--- a/awsbatch-cli/src/awsbatch/awsbhosts.py
+++ b/awsbatch-cli/src/awsbatch/awsbhosts.py
@@ -185,6 +185,7 @@ class AWSBhostsCommand:
             )
         except KeyError as e:
             fail("Error building Host item. Key (%s) not found." % e)
+            return None
 
     @staticmethod
     def __get_instance_attribute(attributes, attribute_name):

--- a/awsbatch-cli/src/awsbatch/awsbqueues.py
+++ b/awsbatch-cli/src/awsbatch/awsbqueues.py
@@ -127,6 +127,7 @@ class AWSBqueuesCommand:
             )
         except KeyError as e:
             fail("Error building Queue item. Key (%s) not found." % e)
+            return None
 
 
 def main():

--- a/cli/src/pcluster/cli/commands/configure/utils.py
+++ b/cli/src/pcluster/cli/commands/configure/utils.py
@@ -33,6 +33,7 @@ def handle_client_exception(func):
             print(f"Failed with error: {e}")
             if isinstance(e, ClientError) and "credentials" in str(e):
                 print("To set the credentials, run 'aws configure' or set them as environment variables")
+                return None
 
     return wrapper
 

--- a/cli/src/pcluster/cli/commands/ssh.py
+++ b/cli/src/pcluster/cli/commands/ssh.py
@@ -21,8 +21,7 @@ from builtins import str
 from functools import partial
 from typing import List
 
-import argparse
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 
 from pcluster import utils
 from pcluster.cli.commands.common import CliCommand, to_bool
@@ -96,7 +95,7 @@ Returns an ssh command with the cluster username and IP address pre-populated:
             help=self.help,
             description=self.description,
             epilog=self.epilog,
-            formatter_class=argparse.RawDescriptionHelpFormatter,
+            formatter_class=RawDescriptionHelpFormatter,
             expects_extra_args=True,
         )
 

--- a/cli/src/pcluster3_config_converter/pcluster3_config_converter.py
+++ b/cli/src/pcluster3_config_converter/pcluster3_config_converter.py
@@ -717,6 +717,7 @@ class Pcluster3ConfigConverter(object):
             queue = self.convert_single_slurm_queue(queue_label)
             _append_if(slurm_queues, queue)
         _add_if(scheduling, param, slurm_queues)
+        return None
 
     def convert_single_slurm_queue(self, queue_label):
         """Convert single SlurmQueue."""

--- a/cli/tests/pcluster/models/test_cluster.py
+++ b/cli/tests/pcluster/models/test_cluster.py
@@ -436,7 +436,7 @@ class TestCluster:
                     "ResourceType": "AWS::CloudFormation::Stack",
                     "StackId": "arn:aws:cloudformation:us-east-1:000000000000:stack/pc",
                     "StackName": "pc",
-                    "Timestamp": datetime.datetime(2021, 7, 13, 2, 20, 20, 000000, tzinfo=tz.tzutc()),
+                    "Timestamp": datetime.datetime(2021, 7, 13, 2, 20, 20, 0o00000, tzinfo=tz.tzutc()),
                 }
             ],
         }

--- a/tests/integration-tests/clusters_factory.py
+++ b/tests/integration-tests/clusters_factory.py
@@ -40,6 +40,7 @@ def suppress_and_log_exception(func):
             return func(*args, **kwargs)
         except Exception as e:
             logging.error("Failed when running function %s. Ignoring exception. Error: %s", func.__name__, e)
+            return None
 
     return wrapper
 

--- a/tests/integration-tests/conftest_resource_bucket.py
+++ b/tests/integration-tests/conftest_resource_bucket.py
@@ -105,7 +105,7 @@ def get_resource_map():
 def resource_bucket_shared(request, s3_bucket_factory_shared, lambda_layer_source):
     root = Path(pkg_resources.resource_filename(__name__, "/../.."))
     if request.config.getoption("resource_bucket"):
-        return  # short-circuit this fixture if a resource-bucket is provided
+        return None  # short-circuit this fixture if a resource-bucket is provided
 
     for region, s3_bucket in s3_bucket_factory_shared.items():
         logger.info(f"Uploading artifacts to: {s3_bucket}[{region}]")

--- a/tests/integration-tests/s3_common_utils.py
+++ b/tests/integration-tests/s3_common_utils.py
@@ -54,3 +54,4 @@ def get_policy_resources(config, enable_write_access):
             else:
                 return [f"{bucket_name}", f"{bucket_name}/*"]
     logging.error("Bucket name couldn't be found in the configuration file.")
+    return None

--- a/tests/integration-tests/tests/common/schedulers_common.py
+++ b/tests/integration-tests/tests/common/schedulers_common.py
@@ -122,7 +122,7 @@ class SchedulerCommands(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_nodes_status(self):
+    def get_nodes_status(self, filter_by_nodes=None):
         """Retrieve node state/status from scheduler"""
         pass
 
@@ -189,7 +189,7 @@ class AWSBatchCommands(SchedulerCommands):
         """Not implemented."""
         raise NotImplementedError
 
-    def get_nodes_status(self):
+    def get_nodes_status(self, filter_by_nodes=None):
         """Not implemented."""
         raise NotImplementedError
 
@@ -670,7 +670,7 @@ class TorqueCommands(SchedulerCommands):
         """Not implemented."""
         raise NotImplementedError
 
-    def get_nodes_status(self):
+    def get_nodes_status(self, filter_by_nodes=None):
         """Not implemented."""
         raise NotImplementedError
 

--- a/tests/integration-tests/tests/storage/test_ebs.py
+++ b/tests/integration-tests/tests/storage/test_ebs.py
@@ -205,6 +205,7 @@ def _get_ebs_settings_by_name(config, name):
     for shared_storage in config["SharedStorage"]:
         if shared_storage["Name"] == name:
             return shared_storage["EbsSettings"]
+    return None
 
 
 @pytest.mark.usefixtures("os", "instance")

--- a/tests/integration-tests/utils.py
+++ b/tests/integration-tests/utils.py
@@ -418,6 +418,7 @@ def get_instance_ids_compute_hostnames_conversion_dict(instance_ids, id_to_hostn
         return conversion_dict
     except Exception as e:
         logging.error("Failed retrieving hostnames for instances {} with exception: {}".format(instance_ids, e))
+        return None
 
 
 def to_snake_case(input):

--- a/util/generate-ami-list.py
+++ b/util/generate-ami-list.py
@@ -173,6 +173,7 @@ def get_images_ec2_credential(filters, main_region, credential):
         return get_latest_images(images)
     except ClientError:
         print("Warning: non authorized in region '{0}', skipping".format(credential_region))
+        return None
 
 
 def get_images_ec2(filters, owner, region_name):
@@ -187,6 +188,7 @@ def get_images_ec2(filters, owner, region_name):
         return get_latest_images(images)
     except ClientError:
         print("Warning: non authorized in region '{0}', skipping".format(region_name))
+        return None
 
 
 def get_latest_images(images):

--- a/util/s3_factory.py
+++ b/util/s3_factory.py
@@ -106,6 +106,7 @@ class S3DocumentManager:
                 logging.warning("No Object Exists to rollback too... Continuing without rollback data.")
             else:
                 raise e
+            return None
 
     def copy(self, s3_src_bucket, s3_dest_bucket, s3_object, s3_object_version=None, dryrun=True, public_read=True):
         """


### PR DESCRIPTION
### Description of changes
* The api/client folder is automatically generated so codeQL scanning alerts from the folder can not be fixed.
* Fix explicit returns mixed with implicit, mismatch between signature and use of an overridden method, and confusing octal

### References
* https://github.com/aws/aws-parallelcluster/security/code-scanning/1604
* https://github.com/aws/aws-parallelcluster/security/code-scanning/1211
* https://github.com/aws/aws-parallelcluster/security/code-scanning/580

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
