### PR TITLE
Remove api/client from directories to scan

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,7 @@
+name: "CodeQL config"
+
+queries:
+  - uses: security-and-quality
+
+paths-ignore:
+  - '/api/client'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,11 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    paths-ignore:
-      - api/client
   pull_request:
-    paths-ignore:
-      - api/client
   schedule:
     - cron: '0 10 * * 2'
 
@@ -29,6 +25,6 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        queries: +security-and-quality
+        config-file: ./.github/codeql/codeql-config.yml
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
### Description of changes
* Add config file in order to remove api/client from directories to scan

### References
* https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
* Patch for: https://github.com/aws/aws-parallelcluster/pull/5703

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
