### PR TITLE
[Test] Generate HTML report as a self-contained HTML.

### DIFF
--- a/tests/integration-tests/test_runner.py
+++ b/tests/integration-tests/test_runner.py
@@ -548,6 +548,7 @@ def _get_pytest_args(args, regions, log_file, out_dir):  # noqa: C901
 
     if "html" in args.reports:
         pytest_args.append("--html={0}/{1}/results.html".format(args.output_dir, out_dir))
+        pytest_args.append("--self-contained-html")
 
     _set_custom_packages_args(args, pytest_args)
     _set_ami_args(args, pytest_args)


### PR DESCRIPTION
### Description of changes
Generate HTML report as a self-contained HTML.
This is useful for a testing automation solution we are working on so that the operator only needs to download one HTML file from S3 rather than downloading also the CSS assets folder.

### Tests
Tested locally by running pytest runner with option `--reports html` and verified that the HTML was self contained.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
