### PR TITLE
[Disable Sudo] Add Config Option to disable Sudo access for default users in supported OSSes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
   - Critical Update for Intel oneAPI DPC++/C++ Compiler: 2023.2.1
   - Critical Update for Intel Fortran Compiler & Intel® Fortran Compiler Classic: 2023.2.1
   - Remove `CommunicationParameters` from the Custom Slurm Settings deny list.
+  - Add `DisableSudoAccessForDefaultUser` parameter to disable sudo access of default user in supported OSes.
 
 **CHANGES**
 - Upgrade Slurm to 23.11.1.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1557,7 +1557,7 @@ class BaseClusterConfig(Resource):
         self.managed_compute_security_group = None
         self.instance_types_data_version = ""
         self._set_default_head_node_root_volume_size()
-        self.disable_sudo_access_default_user = Resource.init_param(disable_sudo_access_default_user)
+        self.disable_sudo_access_default_user = Resource.init_param(disable_sudo_access_default_user, default=False)
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(RegionValidator, region=self.region)
@@ -2027,11 +2027,6 @@ class BaseClusterConfig(Resource):
     def get_instance_types_data(self) -> dict:
         """Get instance type infos for all instance types used in the configuration file."""
         return {}
-
-    @property
-    def is_default_user_sudo_access_enabled(self):
-        """Return True if DisableSudoAccessForDefaultUser is True."""
-        return bool(self.disable_sudo_access_default_user)
 
 
 class AwsBatchComputeResource(BaseComputeResource):

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -103,6 +103,7 @@ from pcluster.validators.cluster_validators import (
     RootVolumeEncryptionConsistencyValidator,
     RootVolumeSizeValidator,
     SchedulableMemoryValidator,
+    SchedulerDisableSudoAccessForDefaultUserValidator,
     SchedulerOsValidator,
     SchedulerValidator,
     SharedFileCacheNotHomeValidator,
@@ -1557,7 +1558,7 @@ class BaseClusterConfig(Resource):
         self.managed_compute_security_group = None
         self.instance_types_data_version = ""
         self._set_default_head_node_root_volume_size()
-        self.disable_sudo_access_default_user = Resource.init_param(disable_sudo_access_default_user, default=False)
+        self.disable_sudo_access_default_user = Resource.init_param(disable_sudo_access_default_user)
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         self._register_validator(RegionValidator, region=self.region)
@@ -1600,13 +1601,21 @@ class BaseClusterConfig(Resource):
                 os=self.image.os,
                 architecture=self.head_node.architecture,
             )
-        if (
-            self.additional_packages
-            and self.additional_packages.intel_software
-            and self.additional_packages.intel_software.intel_hpc_platform
-        ):
-            self._register_validator(IntelHpcOsValidator, os=self.image.os)
-            self._register_validator(IntelHpcArchitectureValidator, architecture=self.head_node.architecture)
+        feature_requiring_additional_space = []
+        if self.additional_packages and self.additional_packages.intel_software:
+            if self.additional_packages.intel_software.intel_hpc_platform:
+                self._register_validator(IntelHpc2018OsValidator, os=self.image.os)
+                self._register_validator(IntelHpcArchitectureValidator, architecture=self.head_node.architecture)
+            if (
+                self.additional_packages.intel_software.one_api
+                and self.additional_packages.intel_software.one_api.base_toolkit
+            ):
+                feature_requiring_additional_space.append(Feature.INTEL_ONE_API_BASE_TOOLKIT)
+                self._register_validator(IntelOneApiToolkitsOsValidator, os=self.image.os)
+                self._register_validator(IntelOneApiToolkitsBootstrapTimeValidator)
+            if self.additional_packages.intel_software.python:
+                self._register_validator(IntelPythonOsValidator, os=self.image.os)
+
         if self.custom_s3_bucket:
             self._register_validator(S3BucketValidator, bucket=self.custom_s3_bucket)
             self._register_validator(S3BucketRegionValidator, bucket=self.custom_s3_bucket, region=self.region)
@@ -1624,6 +1633,7 @@ class BaseClusterConfig(Resource):
             RootVolumeSizeValidator,
             root_volume_size=root_volume_size,
             ami_volume_size=ami_volume_size,
+            additional_space=self._additional_space_for_features(),
         )
         self._register_validator(
             EbsVolumeTypeSizeValidator, volume_type=root_volume.volume_type, volume_size=root_volume_size
@@ -1635,6 +1645,7 @@ class BaseClusterConfig(Resource):
             volume_iops=root_volume.iops,
         )
         self._register_validator(KeyPairValidator, key_name=self.head_node.ssh.key_name, os=self.image.os)
+        self._register_validator(SchedulerDisableSudoAccessForDefaultUserValidator, scheduler=self.scheduling.scheduler)
 
     def _register_storage_validators(self):  # noqa: C901 FIXME: function too complex
         if self.shared_storage:
@@ -1781,6 +1792,44 @@ class BaseClusterConfig(Resource):
                 volume_ids.append(storage.volume_id)
         if volume_ids:
             AWSApi.instance().fsx.describe_volumes(volume_ids)
+
+    def _set_default_head_node_root_volume_size(self):
+        root_volume = self.head_node.local_storage.root_volume
+        if root_volume.size is None:
+            root_volume.size = Resource.init_param(
+                None,
+                default=AWSApi.instance().ec2.describe_image(self.head_node_ami).volume_size
+                + self._additional_space_for_features(),
+            )
+
+    def _additional_space_for_features(self):
+        feature_requiring_additional_space = []
+        if (
+            self.additional_packages
+            and self.additional_packages.intel_software
+            and self.additional_packages.intel_software.one_api
+            and self.additional_packages.intel_software.one_api.base_toolkit
+        ):
+            feature_requiring_additional_space.append(Feature.INTEL_ONE_API_BASE_TOOLKIT)
+        additional_space = 0
+        for feature in feature_requiring_additional_space:
+            additional_space += FEATURE_REQUIRING_ADDITION_SPACE[feature]
+        return additional_space
+
+    def additional_bootstrap_time_for_features(self):
+        """Calculate total additional bootstrap time for enabled features."""
+        feature_requiring_additional_bootstrap_time = []
+        if (
+            self.additional_packages
+            and self.additional_packages.intel_software
+            and self.additional_packages.intel_software.one_api
+            and self.additional_packages.intel_software.one_api.base_toolkit
+        ):
+            feature_requiring_additional_bootstrap_time.append(Feature.INTEL_ONE_API_BASE_TOOLKIT)
+        additional_bootstrap_time = 0
+        for feature in feature_requiring_additional_bootstrap_time:
+            additional_bootstrap_time += FEATURE_REQUIRING_ADDITION_BOOTSTRAP_TIME[feature]
+        return additional_bootstrap_time
 
     @property
     def region(self):
@@ -1932,6 +1981,11 @@ class BaseClusterConfig(Resource):
             if self.monitoring and self.monitoring.dashboards and self.monitoring.dashboards.cloud_watch
             else False
         )
+
+    @property
+    def are_alarms_enabled(self):
+        """Return False if Monitoring/Alarms/Enabled is False. True otherwise."""
+        return self.monitoring.alarms.enabled if self.monitoring and self.monitoring.alarms else True
 
     @property
     def is_detailed_monitoring_enabled(self):
@@ -2173,6 +2227,11 @@ class _BaseSlurmComputeResource(BaseComputeResource):
         self.static_node_priority = Resource.init_param(static_node_priority, default=1)
         self.dynamic_node_priority = Resource.init_param(dynamic_node_priority, default=1000)
 
+    @abstractmethod
+    def is_flexible(self) -> bool:
+        """Return True if the ComputeResource can contain multiple instance types, False otherwise."""
+        pass
+
     @staticmethod
     def fetch_instance_type_info(instance_type) -> InstanceTypeInfo:
         """Return instance type information."""
@@ -2243,11 +2302,7 @@ class FlexibleInstanceType(Resource):
 class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
     """Represents a Slurm Compute Resource with Multiple Instance Types."""
 
-    def __init__(
-        self,
-        instances: List[FlexibleInstanceType],
-        **kwargs,
-    ):
+    def __init__(self, instances: List[FlexibleInstanceType], **kwargs):
         super().__init__(**kwargs)
         self.instances = Resource.init_param(instances)
 
@@ -2273,6 +2328,10 @@ class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
             ec2memory=min_memory,
             instance_type=smallest_type,
         )
+
+    def is_flexible(self):
+        """Return True because the ComputeResource can contain multiple instance types."""
+        return True
 
     @property
     def disable_simultaneous_multithreading_manually(self) -> bool:
@@ -2318,28 +2377,23 @@ class SlurmFlexibleComputeResource(_BaseSlurmComputeResource):
 class SlurmComputeResource(_BaseSlurmComputeResource):
     """Represents a Slurm Compute Resource with a Single Instance Type."""
 
-    def __init__(
-        self,
-        instance_type,
-        **kwargs,
-    ):
+    def __init__(self, instance_type=None, **kwargs):
         super().__init__(**kwargs)
-        self.instance_type = Resource.init_param(instance_type)
+        _instance_type = instance_type if instance_type else self._instance_type_from_capacity_reservation()
+        self.instance_type = Resource.init_param(_instance_type)
         self.__instance_type_info = None
+
+    def is_flexible(self):
+        """Return False because the ComputeResource can not contain multiple instance types."""
+        return False
 
     @property
     def instance_types(self) -> List[str]:
         """List of instance types under this compute resource."""
         return [self.instance_type]
 
-    @property
-    def instance_type_info(self) -> InstanceTypeInfo:
-        """Return instance type information."""
-        return AWSApi.instance().ec2.get_instance_type_info(self.instance_type)
-
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
-        self._register_validator(ComputeResourceSizeValidator, min_count=self.min_count, max_count=self.max_count)
         self._register_validator(
             SchedulableMemoryValidator,
             schedulable_memory=self.schedulable_memory,
@@ -2377,7 +2431,19 @@ class SlurmComputeResource(_BaseSlurmComputeResource):
     @property
     def disable_simultaneous_multithreading_manually(self) -> bool:
         """Return true if simultaneous multithreading must be disabled with a cookbook script."""
-        return self.disable_simultaneous_multithreading and self.instance_type_info.default_threads_per_core() > 1
+        return self.disable_simultaneous_multithreading and self._instance_type_info.default_threads_per_core() > 1
+
+    def _instance_type_from_capacity_reservation(self):
+        """Return the instance type from the configured CapacityReservationId, if any."""
+        instance_type = None
+        capacity_reservation_id = (
+            self.capacity_reservation_target.capacity_reservation_id if self.capacity_reservation_target else None
+        )
+        if capacity_reservation_id:
+            capacity_reservations = AWSApi.instance().ec2.describe_capacity_reservations([capacity_reservation_id])
+            if capacity_reservations:
+                instance_type = capacity_reservations[0].instance_type()
+        return instance_type
 
 
 class _CommonQueue(BaseQueue):
@@ -2478,7 +2544,7 @@ class _CommonQueue(BaseQueue):
             if isinstance(compute_resource, SlurmComputeResource):
                 self._register_validator(
                     EfaValidator,
-                    instance_type=compute_resource.instance_type,
+                    instance_type=compute_resource.instance_types[0],
                     efa_enabled=compute_resource.efa.enabled,
                     gdr_support=compute_resource.efa.gdr_support,
                     multiaz_enabled=self.multi_az_enabled,
@@ -2520,10 +2586,11 @@ class SlurmQueue(_CommonQueue):
         if any(
             isinstance(compute_resource, SlurmFlexibleComputeResource) for compute_resource in self.compute_resources
         ):
+            default_allocation_strategy = None if self.is_capacity_block() else AllocationStrategy.LOWEST_PRICE
             self.allocation_strategy = (
                 AllocationStrategy[to_snake_case(allocation_strategy).upper()]
                 if allocation_strategy
-                else AllocationStrategy.LOWEST_PRICE
+                else default_allocation_strategy
             )
 
     @property
@@ -2600,6 +2667,12 @@ class SlurmQueue(_CommonQueue):
                 is False,
                 multi_az_enabled=self.multi_az_enabled,
             )
+            self._register_validator(
+                ComputeResourceSizeValidator,
+                min_count=compute_resource.min_count,
+                max_count=compute_resource.max_count,
+                capacity_type=self.capacity_type,
+            )
             if compute_resource.custom_slurm_settings:
                 self._register_validator(
                     CustomSlurmSettingsValidator,
@@ -2608,11 +2681,14 @@ class SlurmQueue(_CommonQueue):
                     settings_level=CustomSlurmSettingLevel.COMPUTE_RESOURCE,
                 )
             for instance_type in compute_resource.instance_types:
+                cr_target = compute_resource.capacity_reservation_target or self.capacity_reservation_target
                 self._register_validator(
                     CapacityTypeValidator,
                     capacity_type=self.capacity_type,
                     instance_type=instance_type,
+                    capacity_reservation_id=cr_target.capacity_reservation_id if cr_target else None,
                 )
+                self._register_validator(FeatureRegionValidator, feature=self.capacity_type, region=None)
 
 
 class Dns(Resource):
@@ -2635,12 +2711,14 @@ class Database(Resource):
         uri: str = None,
         user_name: str = None,
         password_secret_arn: str = None,
+        database_name: str = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.uri = Resource.init_param(uri)
         self.user_name = Resource.init_param(user_name)
         self.password_secret_arn = Resource.init_param(password_secret_arn)
+        self.database_name = Resource.init_param(database_name)
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         region = get_region()
@@ -2667,6 +2745,7 @@ class SlurmSettings(Resource):
         database: Database = None,
         custom_slurm_settings: List[Dict] = None,
         custom_slurm_settings_include_file: str = None,
+        munge_key_secret_arn: str = None,
         **kwargs,
     ):
         super().__init__()
@@ -2679,6 +2758,7 @@ class SlurmSettings(Resource):
         self.database = database
         self.custom_slurm_settings = Resource.init_param(custom_slurm_settings)
         self.custom_slurm_settings_include_file = Resource.init_param(custom_slurm_settings_include_file)
+        self.munge_key_secret_arn = Resource.init_param(munge_key_secret_arn)
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
@@ -2704,6 +2784,18 @@ class SlurmSettings(Resource):
                 custom_settings=self.custom_slurm_settings,
                 include_file_url=self.custom_slurm_settings_include_file,
             )
+        if self.munge_key_secret_arn:
+            self._register_validator(
+                ArnServiceAndResourceValidator,
+                arn=self.munge_key_secret_arn,
+                region=get_region(),
+                expected_service="secretsmanager",
+                expected_resource="secret",
+            )
+            self._register_validator(
+                MungeKeySecretSizeAndBase64Validator,
+                munge_key_secret_arn=self.munge_key_secret_arn,
+            )
 
 
 class QueueUpdateStrategy(Enum):
@@ -2717,9 +2809,10 @@ class QueueUpdateStrategy(Enum):
 class SlurmScheduling(Resource):
     """Represent a slurm Scheduling resource."""
 
-    def __init__(self, queues: List[SlurmQueue], settings: SlurmSettings = None):
+    def __init__(self, queues: List[SlurmQueue], settings: SlurmSettings = None, scaling_strategy: str = None):
         super().__init__()
         self.scheduler = "slurm"
+        self.scaling_strategy = Resource.init_param(scaling_strategy, default="all-or-nothing")
         self.queues = queues
         self.settings = settings or SlurmSettings(implied=True)
 
@@ -2883,6 +2976,7 @@ class SlurmClusterConfig(BaseClusterConfig):
         instance_types_data = self.get_instance_types_data()
         self._register_validator(MultiNetworkInterfacesInstancesValidator, queues=self.scheduling.queues)
         checked_images = []
+        capacity_reservation_id_max_count_map = {}
         for index, queue in enumerate(self.scheduling.queues):
             queue_image = self.image_dict[queue.name]
             if index == 0:
@@ -2915,6 +3009,7 @@ class SlurmClusterConfig(BaseClusterConfig):
             if queue_image not in checked_images and queue.queue_ami:
                 checked_images.append(queue_image)
                 self._register_validator(AmiOsCompatibleValidator, os=self.image.os, image_id=queue_image)
+
             for compute_resource in queue.compute_resources:
                 self._register_validator(
                     InstanceArchitectureCompatibilityValidator,
@@ -2931,11 +3026,22 @@ class SlurmClusterConfig(BaseClusterConfig):
                 # to make sure the subnet APIs are cached by previous validations.
                 cr_target = compute_resource.capacity_reservation_target or queue.capacity_reservation_target
                 if cr_target:
+                    if cr_target.capacity_reservation_id:
+                        # increment counter of number of instances used for a given capacity reservation
+                        # to verify to not exceed instance count when considering all the configured compute resources
+                        num_of_instances_in_capacity_reservation = capacity_reservation_id_max_count_map.get(
+                            cr_target.capacity_reservation_id, 0
+                        )
+                        capacity_reservation_id_max_count_map[cr_target.capacity_reservation_id] = (
+                            num_of_instances_in_capacity_reservation + compute_resource.max_count
+                        )
                     self._register_validator(
                         CapacityReservationValidator,
                         capacity_reservation_id=cr_target.capacity_reservation_id,
-                        instance_type=getattr(compute_resource, "instance_type", None),
+                        instance_types=compute_resource.instance_types,
+                        is_flexible=compute_resource.is_flexible(),
                         subnet=queue.networking.subnet_ids[0],
+                        capacity_type=queue.capacity_type,
                     )
                     self._register_validator(
                         CapacityReservationResourceGroupValidator,
@@ -3011,6 +3117,13 @@ class SlurmClusterConfig(BaseClusterConfig):
                     compute_resource_tags=compute_resource.get_tags(),
                 )
 
+        for capacity_reservation_id, num_of_instances in capacity_reservation_id_max_count_map.items():
+            self._register_validator(
+                CapacityReservationSizeValidator,
+                capacity_reservation_id=capacity_reservation_id,
+                num_of_instances=num_of_instances,
+            )
+
     @property
     def image_dict(self):
         """Return image dict of queues, key is queue name, value is image id."""
@@ -3048,7 +3161,7 @@ class SlurmClusterConfig(BaseClusterConfig):
     def capacity_reservation_arns(self):
         """Return a list of capacity reservation ARNs specified in the config."""
         return [
-            capacity_reservation["CapacityReservationArn"]
+            capacity_reservation.capacity_reservation_arn()
             for capacity_reservation in AWSApi.instance().ec2.describe_capacity_reservations(
                 self.capacity_reservation_ids
             )

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -339,3 +339,6 @@ MAX_TAGS_COUNT = 40  # Tags are limited to 50, reserve some tags for parallelclu
 IAM_ROLE_REGEX = "^arn:.*:role/"
 IAM_INSTANCE_PROFILE_REGEX = "^arn:.*:instance-profile/"
 IAM_POLICY_REGEX = "^arn:.*:policy/"
+
+# Section of Cloud-Init(cloud-config) which will be added for Disabling the Sudo access of Default user
+DISABLE_SUDO_ACCESS_FOR_DEFAULT_USER_CONFIG = {"system_info": {"default_user": {"sudo": ["ALL=(ALL) !ALL"]}}}

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -55,6 +55,9 @@ package_upgrade: false
 repo_upgrade: none
 
 datasource_list: [ Ec2, None ]
+
+${DisableSudoAccessForDefaultUserConfig}
+
 output:
   all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"
 write_files:

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -35,6 +35,10 @@ export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
 PROXY
 fi
 
+if [ "${DisableSudoAccessForDefault}" == "true" ]; then
+  sed -n -i "/"${OSUser}" ALL=(ALL) NOPASSWD:ALL/d" /etc/sudoers
+fi
+
 --==BOUNDARY==
 Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -56,6 +56,8 @@ repo_upgrade: none
 
 datasource_list: [ Ec2, None ]
 
+${DisableSudoAccessForDefaultUserConfig}
+
 --==BOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"
 MIME-Version: 1.0

--- a/cli/src/pcluster/resources/head_node/user_data.sh
+++ b/cli/src/pcluster/resources/head_node/user_data.sh
@@ -35,6 +35,10 @@ export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
 PROXY
 fi
 
+if [ "${DisableSudoAccessForDefault}" == "true" ]; then
+  sed -n -i "/"${OSUser}" ALL=(ALL) NOPASSWD:ALL/d" /etc/sudoers
+fi
+
 --==BOUNDARY==
 Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -44,6 +44,9 @@ package_upgrade: false
 repo_upgrade: none
 
 datasource_list: [ Ec2, None ]
+
+${DisableSudoAccessForDefaultUserConfig}
+
 output:
   all: "| tee -a /var/log/cloud-init-output.log | logger -t user-data -s 2>/dev/console"
 write_files:

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -35,6 +35,10 @@ export NO_PROXY="localhost,127.0.0.1,169.254.169.254"
 PROXY
 fi
 
+if [ "${DisableSudoAccessForDefault}" == "true" ]; then
+  sed -n -i "/"${OSUser}" ALL=(ALL) NOPASSWD:ALL/d" /etc/sudoers
+fi
+
 --==BOUNDARY==
 Content-Type: text/cloud-config; charset=us-ascii
 MIME-Version: 1.0

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1914,6 +1914,9 @@ class ClusterSchema(BaseSchema):
     additional_resources = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     dev_settings = fields.Nested(ClusterDevSettingsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     deployment_settings = fields.Nested(DeploymentSettingsSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
+    disable_sudo_access_default_user = fields.Bool(
+        data_key="DisableSudoAccessForDefaultUser", default=False, metadata={"update_policy": UpdatePolicy.UNSUPPORTED}
+    )
 
     def __init__(self, cluster_name: str):
         super().__init__()

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -133,7 +133,7 @@ def get_directory_service_dna_json_for_head_node(config: BaseClusterConfig) -> d
 
 
 def get_cloud_config_for_default_user(disable_sudo_access_default_user: bool):
-    """Return Cloud-Init Section (cloud-config) in YAML format if DisableSudoAccessForDefaultUser is enabled."""
+    """Return Cloud-Init Section (cloud-config) in YAML format if DisableSudoAccessForDefaultUser is True."""
     return yaml.dump(DISABLE_SUDO_ACCESS_FOR_DEFAULT_USER_CONFIG) if disable_sudo_access_default_user else ""
 
 

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -15,6 +15,7 @@ from hashlib import sha1, sha256
 from typing import List, Union
 
 import pkg_resources
+import yaml
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_lambda as awslambda
@@ -36,6 +37,7 @@ from pcluster.config.cluster_config import (
 from pcluster.constants import (
     COOKBOOK_PACKAGES_VERSIONS,
     CW_LOGS_RETENTION_DAYS_DEFAULT,
+    DISABLE_SUDO_ACCESS_FOR_DEFAULT_USER_CONFIG,
     IAM_ROLE_PATH,
     LAMBDA_VPC_ACCESS_MANAGED_POLICY,
     PCLUSTER_CLUSTER_NAME_TAG,
@@ -128,6 +130,11 @@ def get_directory_service_dna_json_for_head_node(config: BaseClusterConfig) -> d
         if directory_service
         else {}
     )
+
+
+def get_cloud_config_for_default_user(disable_sudo_access_default_user: bool):
+    """Return Cloud-Init Section (cloud-config) in YAML format if DisableSudoAccessForDefaultUser is enabled."""
+    return yaml.dump(DISABLE_SUDO_ACCESS_FOR_DEFAULT_USER_CONFIG) if disable_sudo_access_default_user else ""
 
 
 def to_comma_separated_string(list, use_lower_case=False):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -1217,6 +1217,10 @@ class ClusterCdkStack:
                                 "DisableSudoAccessForDefaultUserConfig": get_cloud_config_for_default_user(
                                     self.config.disable_sudo_access_default_user
                                 ),
+                                "OSUser": OS_MAPPING[self.config.image.os]["user"],
+                                "DisableSudoAccessForDefault": "true"
+                                if self.config.disable_sudo_access_default_user
+                                else "false",
                             },
                             **get_common_user_data_env(head_node, self.config),
                         },

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -86,6 +86,7 @@ from pcluster.templates.cdk_builder_utils import (
     apply_permissions_boundary,
     convert_deletion_policy,
     create_hash_suffix,
+    get_cloud_config_for_default_user,
     get_cloud_watch_logs_policy_statement,
     get_cloud_watch_logs_retention_days,
     get_common_user_data_env,
@@ -1213,6 +1214,9 @@ class ClusterCdkStack:
                                 if head_node.disable_simultaneous_multithreading_manually
                                 else "false",
                                 "CloudFormationUrl": cloudformation_url,
+                                "DisableSudoAccessForDefaultUserConfig": get_cloud_config_for_default_user(
+                                    self.config.disable_sudo_access_default_user
+                                ),
                             },
                             **get_common_user_data_env(head_node, self.config),
                         },

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -18,6 +18,7 @@ from pcluster.templates.cdk_builder_utils import (
     CdkLaunchTemplateBuilder,
     LoginNodesIamResources,
     _get_resource_combination_name,
+    get_cloud_config_for_default_user,
     get_common_user_data_env,
     get_custom_tags,
     get_default_instance_tags,
@@ -206,6 +207,9 @@ class Pool(Construct):
                                 "AutoScalingGroupName": f"{self._login_nodes_stack_id}-AutoScalingGroup",
                                 "LaunchingLifecycleHookName": (
                                     f"{self._login_nodes_stack_id}-LoginNodesLaunchingLifecycleHook"
+                                ),
+                                "DisableSudoAccessForDefaultUserConfig": get_cloud_config_for_default_user(
+                                    self._config.disable_sudo_access_default_user
                                 ),
                             },
                             **get_common_user_data_env(self._pool, self._config),

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -211,6 +211,9 @@ class Pool(Construct):
                                 "DisableSudoAccessForDefaultUserConfig": get_cloud_config_for_default_user(
                                     self._config.disable_sudo_access_default_user
                                 ),
+                                "DisableSudoAccessForDefault": "true"
+                                if self._config.disable_sudo_access_default_user
+                                else "false",
                             },
                             **get_common_user_data_env(self._pool, self._config),
                         },

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -19,6 +19,7 @@ from pcluster.templates.cdk_builder_utils import (
     ComputeNodeIamResources,
     create_hash_suffix,
     dict_to_cfn_tags,
+    get_cloud_config_for_default_user,
     get_common_user_data_env,
     get_custom_tags,
     get_default_instance_tags,
@@ -303,6 +304,9 @@ class QueuesStack(NestedStack):
                                         "dev_settings.compute_startup_time_metric_enabled",
                                         default=False,
                                     )
+                                ),
+                                "DisableSudoAccessForDefaultUserConfig": get_cloud_config_for_default_user(
+                                    self._config.disable_sudo_access_default_user
                                 ),
                             },
                             **get_common_user_data_env(queue, self._config),

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -308,6 +308,9 @@ class QueuesStack(NestedStack):
                                 "DisableSudoAccessForDefaultUserConfig": get_cloud_config_for_default_user(
                                     self._config.disable_sudo_access_default_user
                                 ),
+                                "DisableSudoAccessForDefault": "true"
+                                if self._config.disable_sudo_access_default_user
+                                else "false",
                             },
                             **get_common_user_data_env(queue, self._config),
                         },

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -125,6 +125,21 @@ class RegionValidator(Validator):
             )
 
 
+class SchedulerDisableSudoAccessForDefaultUserValidator(Validator):
+    """
+    Validator for DisableSudoAccessForDefaultUser and AWS Batch Scheduler.
+
+    Fail if using AWS Batch and DisableSudoAccessForDefaultUser is not supported.
+    """
+
+    def _validate(self, scheduler):
+        if scheduler == "awsbatch":
+            self._add_failure(
+                "DisableSudoAccessForDefaultUser is not supported when using AWS Batch as scheduler.",
+                FailureLevel.ERROR,
+            )
+
+
 class SchedulerOsValidator(Validator):
     """
     scheduler - os validator.

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -279,3 +279,4 @@ DevSettings:
     HeadNodeBootstrapTimeout: 1201  # Default 1800 (seconds)
     ComputeNodeBootstrapTimeout: 1001  # Default 1800 (seconds)
   ComputeStartupTimeMetricEnabled: false
+DisableSudoAccessForDefaultUser: True

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -19,6 +19,7 @@ DirectoryService:
   LdapTlsCaCert: string
   LdapTlsReqCert: never
   PasswordSecretArn: arn:aws:secretsmanager:us-east-1:111111111111:secret:Secret-xxxxxxxx-xxxxx
+DisableSudoAccessForDefaultUser: null
 HeadNode:
   CustomActions:
     OnNodeConfigured:

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_compute_launch_template_properties/cluster-using-flexible-instance-types.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_compute_launch_template_properties/cluster-using-flexible-instance-types.yaml
@@ -23,3 +23,4 @@ Scheduling:
     Networking:
       SubnetIds:
       - subnet-12345678
+DisableSudoAccessForDefaultUser: {{ disable_sudo_access_default_user }}

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_compute_launch_template_properties/cluster-using-single-instance-type.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_compute_launch_template_properties/cluster-using-single-instance-type.yaml
@@ -21,3 +21,4 @@ Scheduling:
     Networking:
       SubnetIds:
       - subnet-12345678
+DisableSudoAccessForDefaultUser: {{ disable_sudo_access_default_user }}

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_login_nodes_launch_template_properties/test-login-nodes-stack-with-custom-tags.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_login_nodes_launch_template_properties/test-login-nodes-stack-with-custom-tags.yaml
@@ -35,3 +35,4 @@ Tags:
     Value: development
   - Key: rs:project
     Value: solutions
+DisableSudoAccessForDefaultUser: {{ disable_sudo_access_default_user }}

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_login_nodes_launch_template_properties/test-login-nodes-stack-without-ssh.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_login_nodes_launch_template_properties/test-login-nodes-stack-without-ssh.yaml
@@ -32,3 +32,4 @@ Scheduling:
     Networking:
       SubnetIds:
       - subnet-12345678
+DisableSudoAccessForDefaultUser: {{ disable_sudo_access_default_user }}

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_login_nodes_launch_template_properties/test-login-nodes-stack.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_login_nodes_launch_template_properties/test-login-nodes-stack.yaml
@@ -40,3 +40,4 @@ Scheduling:
     Networking:
       SubnetIds:
       - subnet-12345678
+DisableSudoAccessForDefaultUser: {{ disable_sudo_access_default_user }}

--- a/cli/tests/pcluster/validators/test_cluster_validators.py
+++ b/cli/tests/pcluster/validators/test_cluster_validators.py
@@ -70,6 +70,7 @@ from pcluster.validators.cluster_validators import (
     RootVolumeEncryptionConsistencyValidator,
     RootVolumeSizeValidator,
     SchedulableMemoryValidator,
+    SchedulerDisableSudoAccessForDefaultUserValidator,
     SchedulerOsValidator,
     SharedFileCacheNotHomeValidator,
     SharedStorageMountDirValidator,
@@ -482,6 +483,23 @@ def test_region_validator(region, expected_message):
 def test_scheduler_os_validator(os, scheduler, expected_message):
     actual_failures = SchedulerOsValidator().execute(os, scheduler)
     assert_failure_messages(actual_failures, expected_message)
+
+
+@pytest.mark.parametrize(
+    "scheduler, expected_message, expected_failure_level",
+    [
+        ("slurm", None, None),
+        (
+            "awsbatch",
+            "DisableSudoAccessForDefaultUser is not supported when using AWS Batch as scheduler.",
+            FailureLevel.ERROR,
+        ),
+    ],
+)
+def test_scheduler_disable_sudo_access_for_default_user_validator(scheduler, expected_message, expected_failure_level):
+    actual_failures = SchedulerDisableSudoAccessForDefaultUserValidator().execute(scheduler)
+    assert_failure_messages(actual_failures, expected_message)
+    assert_failure_level(actual_failures, expected_failure_level)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -151,6 +151,12 @@ create:
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
         schedulers: ["slurm"]
         oss: ["ubuntu2004"]
+  test_create.py::test_create_disable_sudo_access_for_default_user:
+    dimensions:
+      - regions: [ "ap-northeast-2" ]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        schedulers: ["slurm"]
+        oss: [ "rocky8", "ubuntu2204" ]
 createami:
   test_createami.py::test_invalid_config:
     dimensions:

--- a/tests/integration-tests/tests/create/test_create/test_create_disable_sudo_access_for_default_user/pcluster.config.yaml
+++ b/tests/integration-tests/tests/create/test_create/test_create_disable_sudo_access_for_default_user/pcluster.config.yaml
@@ -1,0 +1,33 @@
+Image:
+  Os: {{ os }}
+LoginNodes:
+  Pools:
+    - Name: login
+      InstanceType: t2.micro
+      Count: 1
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      Ssh:
+        KeyName: {{ key_name }}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  SlurmQueues:
+    - Name: compute
+      ComputeResources:
+        - Name: compute-i1
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+DisableSudoAccessForDefaultUser: {{ disable_sudo_access_default_user }}


### PR DESCRIPTION
### Description of changes
* Add Config Option so that users can disable sudo access for [default users](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/managing-users.html)
* Adding support for only Slurm schedulers
* Disable Sudo access using cloud-config section of cloud-init
      * Remove policy for Rocky8 ( only OS) which has a policy override in /etc/sudoers file
* Add Unit Tests to check the Output/content of Launch Templates for HeadNode, LoginNode and ComputeFleet.
* Add Integ test 


### Tests
* Added Unit Tests 
* Tested Integration Tests Manually


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
