### PR TITLE
[Develop] Add the CLI option to select the type of internal storage to use, EBS (default) or EFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 - Add `Scheduling/SlurmSettings/Database/DatabaseName` parameter to allow users to specify a custom name for the database on the database server to be used for Slurm accounting.
 - Add `Monitoring/Alarms/Enabled` parameter to toggle Amazon CloudWatch Alarms for the cluster.
 - Add head node alarms to monitor EC2 health checks, CPU utilization and the overall status of the head node.
+- Add the option to use EFS storage instead of NFS exports from the head node root volume for intra-cluster shared ParallelCluster, Intel, Slurm, and login node data.
 
 **CHANGES**
 - Changed cluster alarms naming convention to '[cluster-name]-[component-name]-[metric]'.

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1391,6 +1391,7 @@ class HeadNode(Resource):
         ssh: HeadNodeSsh = None,
         disable_simultaneous_multithreading: bool = None,
         local_storage: LocalStorage = None,
+        internal_shared_storage_type: str = None,
         dcv: Dcv = None,
         custom_actions: CustomActions = None,
         iam: Iam = None,
@@ -1405,6 +1406,10 @@ class HeadNode(Resource):
         self.networking = networking
         self.ssh = ssh or HeadNodeSsh(implied=True)
         self.local_storage = local_storage or LocalStorage(implied=True)
+        self.internal_shared_storage_type = Resource.init_param(
+            internal_shared_storage_type,
+            default="Ebs",
+        )
         self.dcv = dcv
         self.custom_actions = custom_actions
         self.iam = iam or Iam(implied=True)

--- a/cli/src/pcluster/resources/compute_node/user_data.sh
+++ b/cli/src/pcluster/resources/compute_node/user_data.sh
@@ -72,6 +72,7 @@ write_files:
           "raid_type": "${RAIDType}",
           "base_os": "${BaseOS}",
           "region": "${AWS::Region}",
+          "internal_shared_storage_type": "${InternalSharedStorageType}",
           "efs_fs_ids": "${EFSIds}",
           "efs_shared_dirs": "${EFSSharedDirs}",
           "efs_encryption_in_transits": "${EFSEncryptionInTransits}",

--- a/cli/src/pcluster/resources/login_node/user_data.sh
+++ b/cli/src/pcluster/resources/login_node/user_data.sh
@@ -64,6 +64,7 @@ write_files:
             "domain_read_only_user": "${DirectoryServiceReadOnlyUser}",
             "generate_ssh_keys_for_users": "${DirectoryServiceGenerateSshKeys}"
           },
+          "internal_shared_storage_type": "${InternalSharedStorageType}",
           "ebs_shared_dirs": "${EbsSharedDirs}",
           "efs_fs_ids": "${EFSIds}",
           "efs_shared_dirs": "${EFSSharedDirs}",

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1328,6 +1328,11 @@ class HeadNodeSchema(BaseSchema):
     )
     ssh = fields.Nested(HeadNodeSshSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     local_storage = fields.Nested(HeadNodeStorageSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    internal_shared_storage_type = fields.Str(
+        required=False,
+        metadata={"update_policy": UpdatePolicy.UNSUPPORTED},
+        validate=validate.OneOf(["Ebs", "Efs"]),
+    )
     dcv = fields.Nested(DcvSchema, metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
     custom_actions = fields.Nested(HeadNodeCustomActionsSchema, metadata={"update_policy": UpdatePolicy.IGNORED})
     iam = fields.Nested(HeadNodeIamSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -259,6 +259,17 @@ class ClusterCdkStack:
         # Head Node ENI
         self._head_eni = self._add_head_eni()
 
+        # Add the internal use shared storage to the stack
+        # This FS will be mounted, the shared dirs will be added,
+        # then it will be unmounted and the shared dirs will be
+        # mounted.  We need to create the additional mount points first.
+        if self.config.head_node.internal_shared_storage_type.lower() == SharedStorageType.EFS.value:
+            internal_efs_storage_shared = SharedEfs(
+                mount_dir="/opt/parallelcluster/init_shared", name="internal_pcluster_shared"
+            )
+            self._add_shared_storage(internal_efs_storage_shared)
+
+        # Add user configured shared storage
         if self.config.shared_storage:
             for storage in self.config.shared_storage:
                 self._add_shared_storage(storage)
@@ -1229,6 +1240,7 @@ class ClusterCdkStack:
                     ),
                     "base_os": self.config.image.os,
                     "region": self.stack.region,
+                    "internal_shared_storage_type": self.config.head_node.internal_shared_storage_type.lower(),
                     "efs_fs_ids": get_shared_storage_ids_by_type(self.shared_storage_infos, SharedStorageType.EFS),
                     "efs_shared_dirs": to_comma_separated_string(self.shared_storage_mount_dirs[SharedStorageType.EFS]),
                     "efs_encryption_in_transits": to_comma_separated_string(

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -141,6 +141,7 @@ class Pool(Construct):
                                 "DirectoryServiceEnabled": str(ds_config is not None).lower(),
                                 "DirectoryServiceReadOnlyUser": ds_config.domain_read_only_user if ds_config else "",
                                 "DirectoryServiceGenerateSshKeys": ds_generate_keys,
+                                "InternalSharedStorageType": self._config.head_node.internal_shared_storage_type.lower(),  # noqa: E501  pylint: disable=line-too-long
                                 "EbsSharedDirs": to_comma_separated_string(
                                     self._shared_storage_mount_dirs[SharedStorageType.EBS]
                                 ),

--- a/cli/src/pcluster/templates/queues_stack.py
+++ b/cli/src/pcluster/templates/queues_stack.py
@@ -221,6 +221,7 @@ class QueuesStack(NestedStack):
                                 if compute_resource.disable_simultaneous_multithreading_manually
                                 else "false",
                                 "BaseOS": self._config.image.os,
+                                "InternalSharedStorageType": self._config.head_node.internal_shared_storage_type.lower(),  # noqa: E501  pylint: disable=line-too-long
                                 "EFSIds": get_shared_storage_ids_by_type(
                                     self._shared_storage_infos, SharedStorageType.EFS
                                 ),

--- a/cli/tests/pcluster/example_configs/awsbatch.full.yaml
+++ b/cli/tests/pcluster/example_configs/awsbatch.full.yaml
@@ -36,6 +36,7 @@ HeadNode:
       DeleteOnTermination: true
     EphemeralVolume:
       MountDir: /scratch
+  InternalSharedStorageType: Ebs  # Efs
   Dcv:
     Enabled: true
     Port: 8443

--- a/cli/tests/pcluster/example_configs/slurm.full.yaml
+++ b/cli/tests/pcluster/example_configs/slurm.full.yaml
@@ -42,6 +42,7 @@ HeadNode:
       DeleteOnTermination: true
     EphemeralVolume:
       MountDir: /test
+  InternalSharedStorageType: Efs  # Ebs
   Dcv:
     Enabled: true
     Port: 8443

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -904,7 +904,7 @@ def test_head_node_tags_from_launch_template(mocker, config_file_name, expected_
                 "parallelcluster:cluster-name": "clustername",
                 "parallelcluster:node-type": "HeadNode",
                 "parallelcluster:attributes": "centos7, slurm, [0-9\\.A-Za-z]+, x86_64",
-                "parallelcluster:filesystem": "efs=1, multiebs=1, raid=0, fsx=3",
+                "parallelcluster:filesystem": "efs=2, multiebs=1, raid=0, fsx=3",
                 "parallelcluster:networking": "EFA=NONE",
                 # TODO The tag 'parallelcluster:version' is actually included within head node volume tags,
                 #  but some refactoring is required to check it within this test.

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full.all_resources.yaml
@@ -47,6 +47,7 @@ HeadNode:
       DeleteOnTermination: true
     EphemeralVolume:
       MountDir: /test
+  InternalSharedStorageType: Efs  # Ebs
   Dcv:
     Enabled: true
     Port: 8443

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -43,6 +43,7 @@ HeadNode:
   Imds:
     Secured: true
   InstanceType: t2.micro
+  InternalSharedStorageType: Efs
   LocalStorage:
     EphemeralVolume:
       MountDir: /test

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/head_node_default.dna.json
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_head_node_dna_json/head_node_default.dna.json
@@ -29,6 +29,7 @@
     "head_node_imds_secured": "true",
     "instance_types_data_s3_key": "parallelcluster/clusters/dummy-cluster-randomstring123/configs/instance-types-data.json",
     "instance_types_data_version": "",
+    "internal_shared_storage_type": "ebs",
     "log_group_name": "/aws/parallelcluster/clustername-202101010101",
     "log_rotation_enabled": "true",
     "node_type": "HeadNode",


### PR DESCRIPTION
### Description of changes
* Add the CLI option to select the type of internal storage to use, EBS (default) or EFSvolume

### Tests
* Deployed a cluster and verified the fses were included when using the efs option
* Deployed a cluster and verified EBS was still the storage type when no option was selected

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2480

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
