### PR TITLE
Add version checks to custom image commands

### DIFF
--- a/cli/src/pcluster/api/controllers/image_logs_controller.py
+++ b/cli/src/pcluster/api/controllers/image_logs_controller.py
@@ -12,6 +12,7 @@ from pcluster.api.controllers.common import (
     assert_supported_operation,
     configure_aws_region,
     convert_errors,
+    validate_image,
     validate_timestamp,
 )
 from pcluster.api.errors import BadRequestException
@@ -78,6 +79,8 @@ def get_image_log_events(
         raise BadRequestException("'limit' must be a positive integer.")
 
     imagebuilder = ImageBuilder(image_id=image_id)
+    validate_image(imagebuilder)
+
     log_events = imagebuilder.get_log_events(
         log_stream_name,
         start_time=start_dt,
@@ -115,6 +118,7 @@ def get_image_stack_events(image_id, region=None, next_token=None):
     """
     assert_supported_operation(operation=Operation.GET_IMAGE_STACK_EVENTS, region=region)
     imagebuilder = ImageBuilder(image_id=image_id)
+    validate_image(imagebuilder)
     stack_events = imagebuilder.get_stack_events(next_token=next_token)
 
     def convert_event(event):
@@ -152,6 +156,7 @@ def list_image_log_streams(image_id, region=None, next_token=None):
 
     assert_supported_operation(operation=Operation.LIST_IMAGE_LOG_STREAMS, region=region)
     imagebuilder = ImageBuilder(image_id=image_id)
+    validate_image(imagebuilder)
     logs = imagebuilder.list_log_streams(next_token=next_token)
     log_streams = [convert_log(log) for log in logs.log_streams]
     next_token = logs.next_token

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -17,6 +17,7 @@ from pcluster.api.controllers.common import (
     convert_errors,
     get_validator_suppressors,
     http_success_status_code,
+    validate_image
 )
 from pcluster.api.converters import (
     cloud_formation_status_to_image_status,
@@ -130,6 +131,8 @@ def build_image(
             validation_failure_level=FailureLevel[validation_failure_level],
         )
 
+        validate_image(imagebuilder, exact_match=True)
+
         return BuildImageResponseContent(
             image=_imagebuilder_stack_to_image_info_summary(imagebuilder.stack),
             validation_messages=validation_results_to_config_validation_errors(suppressed_validation_failures) or None,
@@ -164,6 +167,7 @@ def delete_image(image_id, region=None, force=None):
     force = force or False
     imagebuilder = ImageBuilder(image_id=image_id)
     image, stack = _get_underlying_image_or_stack(imagebuilder)
+    validate_image(imagebuilder)
 
     imagebuilder.delete(force=force)
 
@@ -209,6 +213,7 @@ def describe_image(image_id, region=None):
     """
     assert_supported_operation(operation=Operation.DESCRIBE_IMAGE, region=region)
     imagebuilder = ImageBuilder(image_id=image_id)
+    validate_image(imagebuilder)
 
     try:
         return _image_to_describe_image_response(imagebuilder)

--- a/cli/src/pcluster/api/controllers/image_operations_controller.py
+++ b/cli/src/pcluster/api/controllers/image_operations_controller.py
@@ -17,7 +17,7 @@ from pcluster.api.controllers.common import (
     convert_errors,
     get_validator_suppressors,
     http_success_status_code,
-    validate_image
+    validate_image,
 )
 from pcluster.api.converters import (
     cloud_formation_status_to_image_status,

--- a/cli/src/pcluster/cli/commands/image_logs.py
+++ b/cli/src/pcluster/cli/commands/image_logs.py
@@ -13,7 +13,7 @@ from typing import List
 from argparse import ArgumentParser, Namespace
 
 from pcluster import utils
-from pcluster.api.controllers.common import assert_supported_operation
+from pcluster.api.controllers.common import assert_supported_operation, validate_image
 from pcluster.aws.common import get_region
 from pcluster.cli.commands.common import CliCommand, ExportLogsCommand
 from pcluster.constants import Operation
@@ -70,6 +70,7 @@ class ExportImageLogsCommand(ExportLogsCommand, CliCommand):
 
         # retrieve imagebuilder config and generate model
         imagebuilder = ImageBuilder(image_id=args.image_id)
+        validate_image(imagebuilder)
         url = imagebuilder.export_logs(
             bucket=args.bucket,
             bucket_prefix=args.bucket_prefix,

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -303,7 +303,7 @@ def mock_cluster_stack(mocker, cfn_describe_stack_mock_response):
 
 @pytest.fixture()
 def mock_image_stack(mocker):
-    def _mock_image_stack(image_id: str = "image", stack_exists: bool = True):
+    def _mock_image_stack(image_id: str = "image", stack_exists: bool = True, version="3.0.0"):
         uid = "00000000-ffff-1111-9999-000000000000"
         stack_data = {
             "Capabilities": ["CAPABILITY_NAMED_IAM"],
@@ -315,13 +315,13 @@ def mock_image_stack(mocker):
             "StackName": image_id,
             "StackStatus": "CREATE_COMPLETE",
             "Tags": [
-                {"Key": "parallelcluster:version", "Value": "3.0.0"},
+                {"Key": "parallelcluster:version", "Value": version},
                 {"Key": "parallelcluster:image_name", "Value": image_id},
                 {"Key": "parallelcluster:image_id", "Value": image_id},
                 {"Key": "parallelcluster:s3_bucket", "Value": "parallelcluster-0000000000000000-v1-do-not-delete"},
                 {
                     "Key": "parallelcluster:s3_image_dir",
-                    "Value": f"parallelcluster/3.0.0/images/{image_id}-aaaaaaaaaaaaaaaa",
+                    "Value": f"parallelcluster/{version}/images/{image_id}-aaaaaaaaaaaaaaaa",
                 },
                 {
                     "Key": "parallelcluster:build_log",
@@ -334,7 +334,7 @@ def mock_image_stack(mocker):
                     "Key": "parallelcluster:build_config",
                     "Value": (
                         "s3://parallelcluster-0cd54f8004a2e0af-v1-do-not-delete/parallelcluster/"
-                        "3.0.0/images/custom-image-0-pgdlow92odu5dbvv/configs/image-config.yaml"
+                        "{version}/images/custom-image-0-pgdlow92odu5dbvv/configs/image-config.yaml"
                     ),
                 },
             ],

--- a/cli/tests/pcluster/api/controllers/test_image_logs_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_logs_controller.py
@@ -5,15 +5,36 @@
 # or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 # limitations under the License.
+from datetime import datetime
 
 import pytest
 from assertpy import assert_that
 
+from pcluster.api.models import Ec2AmiState
+from pcluster.aws.aws_resources import ImageInfo
 from pcluster.aws.common import AWSClientError
 from pcluster.constants import Operation
 from pcluster.models.common import LogStream
 from pcluster.utils import to_utc_datetime
 from tests.pcluster.api.controllers.utils import mock_assert_supported_operation, verify_unsupported_operation
+
+
+def _create_image_info(image_id: str = "image", version="3.0.0"):
+    return ImageInfo(
+        {
+            "Name": image_id,
+            "ImageId": image_id,
+            "State": Ec2AmiState.AVAILABLE,
+            "Architecture": "x86_64",
+            "CreationDate": datetime(2021, 4, 12),
+            "Description": "description",
+            "Tags": [
+                {"Key": "parallelcluster:image_id", "Value": image_id},
+                {"Key": "parallelcluster:version", "Value": version},
+                {"Key": "parallelcluster:build_config", "Value": "s3://bucket/key"},
+            ],
+        }
+    )
 
 
 class TestGetImageLogEvents:

--- a/cli/tests/pcluster/api/controllers/test_image_logs_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_logs_controller.py
@@ -12,10 +12,10 @@ from assertpy import assert_that
 
 from pcluster.api.models import Ec2AmiState
 from pcluster.aws.aws_resources import ImageInfo
-from pcluster.aws.common import AWSClientError, StackNotFoundError, ImageNotFoundError
+from pcluster.aws.common import AWSClientError, ImageNotFoundError, StackNotFoundError
 from pcluster.constants import Operation
 from pcluster.models.common import LogStream
-from pcluster.models.imagebuilder import LimitExceededImageError, BadRequestImageError, ImageError
+from pcluster.models.imagebuilder import BadRequestImageError, ImageError, LimitExceededImageError
 from pcluster.utils import to_utc_datetime
 from tests.pcluster.api.controllers.utils import mock_assert_supported_operation, verify_unsupported_operation
 
@@ -216,16 +216,16 @@ class TestGetImageLogEvents:
         )
 
     @pytest.mark.parametrize(
-        ("error", "error_code"),
-        [(LimitExceededImageError, 429), (BadRequestImageError, 400), (ImageError, 500)]
+        ("error", "error_code"), [(LimitExceededImageError, 429), (BadRequestImageError, 400), (ImageError, 500)]
     )
     def test_image_error(self, client, mocker, error, error_code):
         mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", side_effect=error("image error"))
         mocker.patch(
             "pcluster.aws.cfn.CfnClient.describe_stack", side_effect=StackNotFoundError("describe_stack", "stack_name")
         )
-        response = self._send_test_request(client, "nonExistentImage", "logstream", "us-east-2",
-                                           None, None, None, None, None)
+        response = self._send_test_request(
+            client, "nonExistentImage", "logstream", "us-east-2", None, None, None, None, None
+        )
         expected_response = "image error"
         if error == BadRequestImageError:
             expected_response = "Bad Request: " + expected_response
@@ -236,18 +236,24 @@ class TestGetImageLogEvents:
         image = _create_image_info("image1", version=version)
         mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", return_value=image)
         response = self._send_test_request(client, "image1", "logstream", "us-east-2", None, None, None, None, None)
-        expected_response = "Bad Request: Image or stack associated with image id 'image1' belongs to an " \
-                            "incompatible ParallelCluster major version."
+        expected_response = (
+            "Bad Request: Image or stack associated with image id 'image1' belongs to an "
+            "incompatible ParallelCluster major version."
+        )
         self._assert_invalid_response(response, expected_response)
 
     @pytest.mark.parametrize("version", ["2.0.0", "5.0.0"])
     def test_stack_incompatible_version(self, client, mocker, mock_image_stack, version):
-        mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
-                     side_effect=ImageNotFoundError("describe_image_by_id_tag"))
+        mocker.patch(
+            "pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
+            side_effect=ImageNotFoundError("describe_image_by_id_tag"),
+        )
         mock_image_stack(image_id="image1", version=version)
         response = self._send_test_request(client, "image1", "logstream", "us-east-2", None, None, None, None, None)
-        expected_response = "Bad Request: Image or stack associated with image id 'image1' belongs to an " \
-                            "incompatible ParallelCluster major version."
+        expected_response = (
+            "Bad Request: Image or stack associated with image id 'image1' belongs to an "
+            "incompatible ParallelCluster major version."
+        )
         self._assert_invalid_response(response, expected_response)
 
     @staticmethod
@@ -367,8 +373,7 @@ class TestGetImageStackEvents:
         )
 
     @pytest.mark.parametrize(
-        ("error", "error_code"),
-        [(LimitExceededImageError, 429), (BadRequestImageError, 400), (ImageError, 500)]
+        ("error", "error_code"), [(LimitExceededImageError, 429), (BadRequestImageError, 400), (ImageError, 500)]
     )
     def test_image_error(self, client, mocker, error, error_code):
         mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", side_effect=error("image error"))
@@ -386,18 +391,24 @@ class TestGetImageStackEvents:
         image = _create_image_info("image1", version=version)
         mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", return_value=image)
         response = self._send_test_request(client, "image1", "us-east-2", None)
-        expected_response = "Bad Request: Image or stack associated with image id 'image1' belongs to an " \
-                            "incompatible ParallelCluster major version."
+        expected_response = (
+            "Bad Request: Image or stack associated with image id 'image1' belongs to an "
+            "incompatible ParallelCluster major version."
+        )
         self._assert_invalid_response(response, expected_response)
 
     @pytest.mark.parametrize("version", ["2.0.0", "5.0.0"])
     def test_stack_incompatible_version(self, client, mocker, mock_image_stack, version):
-        mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
-                     side_effect=ImageNotFoundError("describe_image_by_id_tag"))
+        mocker.patch(
+            "pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
+            side_effect=ImageNotFoundError("describe_image_by_id_tag"),
+        )
         mock_image_stack(image_id="image1", version=version)
         response = self._send_test_request(client, "image1", "us-east-2", None)
-        expected_response = "Bad Request: Image or stack associated with image id 'image1' belongs to an " \
-                            "incompatible ParallelCluster major version."
+        expected_response = (
+            "Bad Request: Image or stack associated with image id 'image1' belongs to an "
+            "incompatible ParallelCluster major version."
+        )
         self._assert_invalid_response(response, expected_response)
 
     @staticmethod
@@ -541,8 +552,7 @@ class TestListImageLogStreams:
         )
 
     @pytest.mark.parametrize(
-        ("error", "error_code"),
-        [(LimitExceededImageError, 429), (BadRequestImageError, 400), (ImageError, 500)]
+        ("error", "error_code"), [(LimitExceededImageError, 429), (BadRequestImageError, 400), (ImageError, 500)]
     )
     def test_image_error(self, client, mocker, error, error_code):
         mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", side_effect=error("image error"))
@@ -560,18 +570,24 @@ class TestListImageLogStreams:
         image = _create_image_info("image1", version=version)
         mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag", return_value=image)
         response = self._send_test_request(client, "image1", "us-east-2", None)
-        expected_response = "Bad Request: Image or stack associated with image id 'image1' belongs to an " \
-                            "incompatible ParallelCluster major version."
+        expected_response = (
+            "Bad Request: Image or stack associated with image id 'image1' belongs to an "
+            "incompatible ParallelCluster major version."
+        )
         self._assert_invalid_response(response, expected_response)
 
     @pytest.mark.parametrize("version", ["2.0.0", "5.0.0"])
     def test_stack_incompatible_version(self, client, mocker, mock_image_stack, version):
-        mocker.patch("pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
-                     side_effect=ImageNotFoundError("describe_image_by_id_tag"))
+        mocker.patch(
+            "pcluster.aws.ec2.Ec2Client.describe_image_by_id_tag",
+            side_effect=ImageNotFoundError("describe_image_by_id_tag"),
+        )
         mock_image_stack(image_id="image1", version=version)
         response = self._send_test_request(client, "image1", "us-east-2", None)
-        expected_response = "Bad Request: Image or stack associated with image id 'image1' belongs to an " \
-                            "incompatible ParallelCluster major version."
+        expected_response = (
+            "Bad Request: Image or stack associated with image id 'image1' belongs to an "
+            "incompatible ParallelCluster major version."
+        )
         self._assert_invalid_response(response, expected_response)
 
     @staticmethod

--- a/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
+++ b/cli/tests/pcluster/api/controllers/test_image_operations_controller.py
@@ -38,7 +38,7 @@ from pcluster.models.imagebuilder import (
     LimitExceededImageError,
 )
 from pcluster.models.imagebuilder_resources import BadRequestStackError, LimitExceededStackError
-from pcluster.utils import to_iso_timestr, to_utc_datetime, get_installed_version
+from pcluster.utils import get_installed_version, to_iso_timestr, to_utc_datetime
 from pcluster.validators.common import FailureLevel, ValidationResult
 from tests.pcluster.api.controllers.utils import mock_assert_supported_operation, verify_unsupported_operation
 
@@ -593,8 +593,9 @@ class TestBuildImage:
         )
         mocker.patch(
             "pcluster.aws.cfn.CfnClient.describe_stack",
-            return_value=_create_stack("image1", CloudFormationStackStatus.CREATE_IN_PROGRESS,
-                                       version=get_installed_version()),
+            return_value=_create_stack(
+                "image1", CloudFormationStackStatus.CREATE_IN_PROGRESS, version=get_installed_version()
+            ),
         )
         mocker.patch("pcluster.aws.cfn.CfnClient.describe_stack_resource", return_value=None)
 

--- a/cli/tests/pcluster/cli/test_export_image_logs.py
+++ b/cli/tests/pcluster/cli/test_export_image_logs.py
@@ -63,13 +63,14 @@ class TestExportImageLogsCommand:
             },
         ],
     )
-    def test_execute(self, mocker, set_env, args):
+    def test_execute(self, mocker, mock_image_stack, set_env, args):
         mocked_assert_supported_operation = mocker.patch("pcluster.cli.commands.image_logs.assert_supported_operation")
         export_logs_mock = mocker.patch(
             "pcluster.cli.commands.image_logs.ImageBuilder.export_logs",
             return_value=args.get("output_file", "https://u.r.l."),
         )
         set_env("AWS_DEFAULT_REGION", "us-east-1")
+        mock_image_stack()
 
         command = ["export-image-logs"] + self._build_cli_args({**REQUIRED_ARGS, **args})
         out = run(command)
@@ -101,7 +102,7 @@ class TestExportImageLogsCommand:
         mocked_assert_supported_operation.assert_called_with(operation=Operation.EXPORT_IMAGE_LOGS, region="us-east-1")
 
     @pytest.mark.parametrize("is_operation_supported", [True, False])
-    def test_operation_support(self, mocker, set_env, is_operation_supported):
+    def test_operation_support(self, mocker, mock_image_stack, set_env, is_operation_supported):
         set_env("AWS_DEFAULT_REGION", "us-east-1")
 
         mocked_assert_supported_operation = mocker.patch(
@@ -110,6 +111,8 @@ class TestExportImageLogsCommand:
         )
 
         mocked_export_logs = mocker.patch("pcluster.cli.commands.image_logs.ImageBuilder.export_logs")
+
+        mock_image_stack()
 
         command = ["export-image-logs"] + self._build_cli_args(
             {**REQUIRED_ARGS},

--- a/cli/tests/pcluster/cli/test_get_image_log_events.py
+++ b/cli/tests/pcluster/cli/test_get_image_log_events.py
@@ -81,7 +81,7 @@ class TestGetImageLogEventsCommand:
             ),
         ],
     )
-    def test_execute(self, mocker, set_env, test_datadir, args):
+    def test_execute(self, mocker, mock_image_stack, set_env, test_datadir, args):
         mocked_result = [
             LogStream(
                 FAKE_ID,
@@ -122,6 +122,7 @@ class TestGetImageLogEventsCommand:
         get_image_log_events_mock = mocker.patch(
             "pcluster.api.controllers.image_logs_controller.ImageBuilder.get_log_events", side_effect=mocked_result
         )
+        mock_image_stack()
         set_env("AWS_DEFAULT_REGION", "us-east-1")
         base_args = ["get-image-log-events"]
         command = base_args + self._build_cli_args({**REQUIRED_ARGS, **args})

--- a/cli/tests/pcluster/cli/test_list_image_log_streams.py
+++ b/cli/tests/pcluster/cli/test_list_image_log_streams.py
@@ -33,7 +33,7 @@ class TestListImageLogStreamsCommand:
         assert_that(out + err).contains(error_message)
 
     @pytest.mark.parametrize("args", [{}, {"next_token": "123"}])
-    def test_execute(self, mocker, set_env, args):
+    def test_execute(self, mocker, mock_image_stack, set_env, args):
         logs = LogStreams()
         logs.log_streams = [
             {
@@ -70,6 +70,8 @@ class TestListImageLogStreamsCommand:
             "pcluster.api.controllers.image_logs_controller.ImageBuilder.list_log_streams", return_value=logs
         )
         set_env("AWS_DEFAULT_REGION", "us-east-1")
+
+        mock_image_stack()
 
         base_args = ["list-image-log-streams"]
         command = base_args + self._build_cli_args({**REQUIRED_ARGS, **args})


### PR DESCRIPTION
### Description of changes
* Added version check functions to pcluster/api/controllers/common.py
* Added calls to the version checks in each image command, as described in associated decision doc
* Edited existing unit tests for the image commands with appropriate mockers to pass with the added version checks
* Added unit tests to ensure appropriate behavior for each image command 

For the version check, I try to get the version of the image. If image throws error, I try to get the stack associated with the image_id. Depending on the error thrown, I throw either the image or stack error.

### Tests
* Added unit tests to test_image_logs_controller.py and test_image_operations_controller.py
* Edited unit tests in test_image_logs_controller.py, test_image_operations_controller.py, test_export_image_logs.py, test_get_image_log_events.py, and test_list_image_log_streams.py

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
