### PR TITLE
Add support for Database/DatabaseName in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 **ENHANCEMENTS**
 - Add support for Data Repository Associations when using PERSISTENT_2 as DeploymentType for a managed FSx for Lustre.
+- Add `Scheduling/SlurmSettings/Database/DatabaseName` parameter to allow users to specify a custom name for the database on the database server to be used for Slurm accounting.
 
 **CHANGES**
 

--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -2551,12 +2551,14 @@ class Database(Resource):
         uri: str = None,
         user_name: str = None,
         password_secret_arn: str = None,
+        database_name: str = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.uri = Resource.init_param(uri)
         self.user_name = Resource.init_param(user_name)
         self.password_secret_arn = Resource.init_param(password_secret_arn)
+        self.database_name = Resource.init_param(database_name)
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
         region = get_region()

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1666,6 +1666,14 @@ class DatabaseSchema(BaseSchema):
         validate=validate.Regexp(r"^arn:.*:secret"),
         metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP},
     )
+    database_name = fields.Str(
+        required=False,
+        validate=validate.And(
+            validate.Regexp(r"^[0-9a-z_]+$"),
+            validate.Length(min=1, max=64),
+        ),
+        metadata={"update_policy": UpdatePolicy.SUPPORTED},
+    )
 
     @post_load
     def make_resource(self, data, **kwargs):


### PR DESCRIPTION
### Description of changes
* Add support for `DatabaseName` in the `Scheduling/SlurmSettings/Database` structure. This allows users to select the name of the database ([`StorageLoc`](https://slurm.schedmd.com/slurmdbd.conf.html#OPT_StorageLoc) in the slurmdbd configuration) on the database server to be used for Slurm accounting.

### Tests
* Manual test of the Marshmallow parameter validation (no unit test needed).

### References
* https://github.com/aws/aws-parallelcluster-cookbook/pull/2470

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
