### PR TITLE
Remove PyYAML pin

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -22,6 +22,6 @@ jinja2~=3.0
 jmespath~=0.10
 jsii==1.85.0
 marshmallow~=3.10
-PyYAML==6.0.1
+PyYAML>=5.3.1,!=5.4
 tabulate>=0.8.8,<=0.8.10
 werkzeug~=2.0

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -26,7 +26,7 @@ REQUIRES = [
     "setuptools",
     "boto3>=1.16.14",
     "tabulate>=0.8.8,<=0.8.10",
-    "PyYAML==6.0.1",
+    "PyYAML>=5.3.1,!=5.4",
     "jinja2~=3.0",
     "marshmallow~=3.10",
     "aws-cdk.core~=" + CDK_VERSION,

--- a/cloudformation/tests/requirements.txt
+++ b/cloudformation/tests/requirements.txt
@@ -4,4 +4,4 @@ cfn-flip
 cfn-lint
 jinja2~=3.0
 pytest
-PyYAML==6.0.1
+PyYAML>=5.3.1,!=5.4


### PR DESCRIPTION

### Description of changes
Remove PyYAML pin added in https://github.com/aws/aws-parallelcluster/pull/5503, that was then bumped in https://github.com/aws/aws-parallelcluster/pull/5509

Restoring the version requirements to the one present when PCluster 3.0.0 was released

Resolve https://github.com/aws/aws-parallelcluster/issues/5714

### Tests
manual tested installation in a clean virtualenv

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
