### PR TITLE
[develop] Change flask version constrain format

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -17,7 +17,7 @@ aws_cdk.aws-cloudwatch~=1.164
 aws_cdk.aws-lambda~=1.164
 boto3>=1.16.14
 connexion~=2.13.0
-flask>=2.2.5,==2.2.*
+flask>=2.2.5,<2.3
 jinja2~=3.0
 jmespath~=0.10
 jsii==1.85.0

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -48,7 +48,7 @@ REQUIRES = [
     "aws-cdk.aws-cloudformation~=" + CDK_VERSION,
     "werkzeug~=2.0",
     "connexion~=2.13.0",
-    "flask>=2.2.5,==2.2.*",
+    "flask>=2.2.5,<2.3",
     "jmespath~=0.10",
     "jsii==1.85.0",
 ]


### PR DESCRIPTION
The version constraints are the same from the perspective of Python. But Conda only correctly parses the constraint after this commit.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
