### PR TITLE
Use DatabaseName in Slurm Accounting integ test

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm_accounting/test_slurm_accounting/pcluster.config.update.yaml
@@ -20,6 +20,7 @@ Scheduling:
       Uri: {{ database_host }}
       UserName: {{ database_admin_user }}
       PasswordSecretArn: {{ database_secret_arn }}
+      DatabaseName: {{ custom_database_name }}
   SlurmQueues:
     - Name: compute
       ComputeResources:


### PR DESCRIPTION
### Description of changes
* Modify one of the integration tests for Slurm Accounting to use DatabaseName at cluster update to add integ test coverage for the DatabaseName configuration parameter.

### Tests
* Modified and run (successfully) one of the Slurm Accounting integration tests

### References
* See:
  * https://github.com/aws/aws-parallelcluster/pull/5718
  * https://github.com/aws/aws-parallelcluster-cookbook/pull/2470

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
