### PR TITLE
[Head Node Reporting] Add head node alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 **ENHANCEMENTS**
 - Add support for Data Repository Associations when using PERSISTENT_2 as DeploymentType for a managed FSx for Lustre.
 - Add `Scheduling/SlurmSettings/Database/DatabaseName` parameter to allow users to specify a custom name for the database on the database server to be used for Slurm accounting.
+- Add head node alarms to monitor EC2 health checks, CPU utilization and the overall status of the head node.
 
 **CHANGES**
 

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -216,12 +216,20 @@ def test_add_alarms(mocker, config_file_name):
     )
     output_yaml = yaml.dump(generated_template, width=float("inf"))
 
+    head_node_alarms = [
+        "HeadNodeAlarm",
+        "HeadNodeHealthAlarm",
+        "HeadNodeCpuAlarm",
+        "HeadNodeMemAlarm",
+        "HeadNodeDiskAlarm",
+    ]
+
     if cluster.is_cw_dashboard_enabled:
-        assert_that(output_yaml).contains("HeadNodeDiskAlarm")
-        assert_that(output_yaml).contains("HeadNodeMemAlarm")
+        for alarm in head_node_alarms:
+            assert_that(output_yaml).contains(alarm)
     else:
-        assert_that(output_yaml).does_not_contain("HeadNodeDiskAlarm")
-        assert_that(output_yaml).does_not_contain("HeadNodeMemAlarm")
+        for alarm in head_node_alarms:
+            assert_that(output_yaml).does_not_contain(alarm)
 
 
 def _mock_instance_type_info(instance_type):

--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -370,6 +370,7 @@ Resources:
               - cloudwatch:DeleteDashboards
               - cloudwatch:GetDashboard
               - cloudwatch:PutMetricAlarm
+              - cloudwatch:PutCompositeAlarm
               - cloudwatch:DeleteAlarms
               - cloudwatch:DescribeAlarms
             Resource: '*'


### PR DESCRIPTION
### Description of changes
1. Add the following new head node alarms: 
    1. EC2 Health Checks, 
    1. CPU Utilization
    1. a composite alarm including every head node alarm.
 1. Updated unit tests
 2. Updated integ tests, but added a TODO to evaluate replacement of such integ tests with unit/kitchen.

**Notes**
With reference to the feature design, the following items are out of scope for this PR:
1. alarms renaming
2. decouple alarms and dashboards
3. add alarms to dashboards

### Tests
* Manually verified creation of expected alarms
* Unit tests
* Integ tests: test_monitoring

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
