### PR TITLE
[develop] Move MungeKeySecretArn to Scheduling SlurmSettings

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1179,33 +1179,6 @@ class CapacityReservationTarget(Resource):
         self.capacity_reservation_resource_group_arn = Resource.init_param(capacity_reservation_resource_group_arn)
 
 
-class SlurmSettingsForCustomMungeKey(Resource):
-    """Represent the slurm settings for custom munge key test in dev settings."""
-
-    def __init__(
-        self,
-        munge_key_secret_arn: str = None,
-        **kwargs,
-    ):
-        super().__init__()
-        self.munge_key_secret_arn = Resource.init_param(munge_key_secret_arn)
-
-    def _register_validators(self, context: ValidatorContext = None):
-        super()._register_validators(context)
-        if self.munge_key_secret_arn:
-            self._register_validator(
-                ArnServiceAndResourceValidator,
-                arn=self.munge_key_secret_arn,
-                region=get_region(),
-                expected_service="secretsmanager",
-                expected_resource="secret",
-            )
-            self._register_validator(
-                MungeKeySecretSizeAndBase64Validator,
-                munge_key_secret_arn=self.munge_key_secret_arn,
-            )
-
-
 class ClusterDevSettings(BaseDevSettings):
     """Represent the dev settings configuration."""
 
@@ -1215,7 +1188,6 @@ class ClusterDevSettings(BaseDevSettings):
         ami_search_filters: AmiSearchFilters = None,
         instance_types_data: str = None,
         timeouts: Timeouts = None,
-        munge_key_settings: SlurmSettingsForCustomMungeKey = None,
         compute_startup_time_metric_enabled: bool = None,
         **kwargs,
     ):
@@ -1227,7 +1199,6 @@ class ClusterDevSettings(BaseDevSettings):
         self.compute_startup_time_metric_enabled = Resource.init_param(
             compute_startup_time_metric_enabled, default=False
         )
-        self.munge_key_settings = munge_key_settings or SlurmSettingsForCustomMungeKey(implied=True)
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
@@ -2637,6 +2608,7 @@ class SlurmSettings(Resource):
         database: Database = None,
         custom_slurm_settings: List[Dict] = None,
         custom_slurm_settings_include_file: str = None,
+        munge_key_secret_arn: str = None,
         **kwargs,
     ):
         super().__init__()
@@ -2649,6 +2621,7 @@ class SlurmSettings(Resource):
         self.database = database
         self.custom_slurm_settings = Resource.init_param(custom_slurm_settings)
         self.custom_slurm_settings_include_file = Resource.init_param(custom_slurm_settings_include_file)
+        self.munge_key_secret_arn = Resource.init_param(munge_key_secret_arn)
 
     def _register_validators(self, context: ValidatorContext = None):
         super()._register_validators(context)
@@ -2673,6 +2646,18 @@ class SlurmSettings(Resource):
                 CustomSlurmSettingsIncludeFileOnlyValidator,
                 custom_settings=self.custom_slurm_settings,
                 include_file_url=self.custom_slurm_settings_include_file,
+            )
+        if self.munge_key_secret_arn:
+            self._register_validator(
+                ArnServiceAndResourceValidator,
+                arn=self.munge_key_secret_arn,
+                region=get_region(),
+                expected_service="secretsmanager",
+                expected_resource="secret",
+            )
+            self._register_validator(
+                MungeKeySecretSizeAndBase64Validator,
+                munge_key_secret_arn=self.munge_key_secret_arn,
             )
 
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -92,7 +92,6 @@ from pcluster.config.cluster_config import (
     SlurmQueueNetworking,
     SlurmScheduling,
     SlurmSettings,
-    SlurmSettingsForCustomMungeKey,
     Timeouts,
 )
 from pcluster.config.common import BaseTag
@@ -1116,17 +1115,6 @@ class CapacityReservationTargetSchema(BaseSchema):
             )
 
 
-class SlurmSettingsForCustomMungeKeySchema(BaseSchema):
-    """Represent the schema of slurm settings for custom munge key test in dev settings."""
-
-    munge_key_secret_arn = fields.Str(metadata={"update_policy": UpdatePolicy.COMPUTE_AND_LOGIN_NODES_STOP})
-
-    @post_load
-    def make_resource(self, data, **kwargs):
-        """Generate resource."""
-        return SlurmSettingsForCustomMungeKey(**data)
-
-
 class ClusterDevSettingsSchema(BaseDevSettingsSchema):
     """Represent the schema of Dev Setting."""
 
@@ -1135,9 +1123,6 @@ class ClusterDevSettingsSchema(BaseDevSettingsSchema):
     instance_types_data = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
     timeouts = fields.Nested(TimeoutsSchema, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     compute_startup_time_metric_enabled = fields.Bool(metadata={"update_policy": UpdatePolicy.SUPPORTED})
-    munge_key_settings = fields.Nested(
-        SlurmSettingsForCustomMungeKeySchema, metadata={"update_policy": UpdatePolicy.IGNORED}
-    )
 
     @post_load
     def make_resource(self, data, **kwargs):
@@ -1725,6 +1710,7 @@ class SlurmSettingsSchema(BaseSchema):
     database = fields.Nested(DatabaseSchema, metadata={"update_policy": UpdatePolicy.COMPUTE_FLEET_STOP})
     custom_slurm_settings = fields.List(fields.Dict, metadata={"update_policy": UpdatePolicy.SUPPORTED})
     custom_slurm_settings_include_file = fields.Str(metadata={"update_policy": UpdatePolicy.SUPPORTED})
+    munge_key_secret_arn = fields.Str(metadata={"update_policy": UpdatePolicy.COMPUTE_AND_LOGIN_NODES_STOP})
 
     @post_load
     def make_resource(self, data, **kwargs):

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -669,9 +669,9 @@ class HeadNodeIamResources(NodeIamResourcesBase):
         ]
 
         if (
-            self._config.dev_settings
-            and self._config.dev_settings.munge_key_settings
-            and self._config.dev_settings.munge_key_settings.munge_key_secret_arn
+            self._config.scheduling.scheduler == "slurm"
+            and self._config.scheduling.settings
+            and self._config.scheduling.settings.munge_key_secret_arn
         ):
             policy.extend(
                 [
@@ -679,7 +679,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                         sid="SecretsManager",
                         actions=["secretsmanager:GetSecretValue"],
                         effect=iam.Effect.ALLOW,
-                        resources=[self._config.dev_settings.munge_key_settings.munge_key_secret_arn],
+                        resources=[self._config.scheduling.settings.munge_key_secret_arn],
                     ),
                 ]
             )

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_cluster_config_limits/slurm.full_config.snapshot.yaml
@@ -3793,6 +3793,7 @@ Scheduling:
       HostedZoneId: null
       UseEc2Hostnames: false
     EnableMemoryBasedScheduling: false
+    MungeKeySecretArn: null
     QueueUpdateStrategy: TERMINATE
     ScaledownIdletime: 10
 SharedStorage:

--- a/cli/tests/pcluster/templates/test_dev_settings/test_custom_munge_key_iam_policy/config.yaml
+++ b/cli/tests/pcluster/templates/test_dev_settings/test_custom_munge_key_iam_policy/config.yaml
@@ -14,6 +14,5 @@ Scheduling:
       ComputeResources:
         - Name: compute_resource1
           InstanceType: c5.2xlarge
-DevSettings:
-  MungeKeySettings:
+  SlurmSettings:
     MungeKeySecretArn: arn:aws:secretsmanager:us-east-1:123456789012:secret:TestCustomMungeKey

--- a/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
+++ b/cli/tests/pcluster/validators/test_all_validators/test_slurm_all_validators_are_called/slurm_1.yaml
@@ -56,6 +56,7 @@ Scheduling:
       DisableManagedDns: false
       HostedZoneId: 12345ABC
     CustomSlurmSettingsIncludeFile: https://test.conf
+    MungeKeySecretArn: arn:aws:secretsmanager:us-east-1:123456789012:secret:TestMungeKey
   SlurmQueues:
     - Name: queue1
       CapacityType: ONDEMAND
@@ -229,8 +230,6 @@ DevSettings:
       {"cluster": {"scheduler_slots": "cores"}}
   AwsBatchCliPackage: s3://test/aws-parallelcluster-batch-3.0.tgz
   NodePackage: s3://test/aws-parallelcluster-node-3.0.tgz
-  MungeKeySettings:
-    MungeKeySecretArn: arn:aws:secretsmanager:us-east-1:123456789012:secret:TestMungeKey
 DeploymentSettings:
   LambdaFunctionsVpcConfig:
     SecurityGroupIds: ["sg-028d73ae220157d96"]


### PR DESCRIPTION
### Description of changes
* Move MungeKeySecretArn to Scheduling SlurmSettings instead of DevSettings MungeKeySettings
* Modify related unit tests

### New YAML example
```
Scheduling:
  Scheduler: slurm
  SlurmSettings:
    MungeKeySecretArn: arn:aws:secretsmanager:region:account-id:secret:secret-name
```

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.