### PR TITLE
Modify message to check in Cinc log at the end of the update

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1390,7 +1390,7 @@ def _test_shared_storage_rollback(
     retry(wait_fixed=seconds(20), stop_max_delay=minutes(5))(assert_lines_in_logs)(
         remote_command_executor,
         ["/var/log/chef-client.log"],
-        ["Cinc Client finished"],
+        ["Infra Phase complete"],
     )
 
     # Check shared storages are not on headnode


### PR DESCRIPTION
### Description of changes

"Cinc Client finished" is no longer available within Cinc 18.2.7. It has been replaced by "Infra Phase complete".
We updated cinc as part of https://github.com/aws/aws-parallelcluster-cookbook/pull/2405 and missed to fix this test.

### Tests

3.7.0 cluster:

```
[ec2-user@ip-10-0-0-16 ~]$ grep -e "Cinc Client Run complete" /var/log/chef-client.log
[2023-10-03T09:23:52+00:00] INFO: Cinc Client Run complete in 57.658527347 seconds
[2023-10-03T09:24:38+00:00] INFO: Cinc Client Run complete in 42.456784199 seconds
[2023-10-03T09:28:25+00:00] INFO: Cinc Client Run complete in 223.018415679 seconds

[ec2-user@ip-10-0-0-16 ~]$ grep -e "Cinc Client finished" /var/log/chef-client.log
Cinc Client finished, 51/60 resources updated in 01 minutes 23 seconds
Cinc Client finished, 139/168 resources updated in 44 seconds
Cinc Client finished, 6/7 resources updated in 03 minutes 45 seconds

[ec2-user@ip-10-0-0-16 ~]$ grep -e "Infra Phase complete" /var/log/chef-client.log
[ec2-user@ip-10-0-0-16 ~]$
```

3.8.0 cluster:
```
[ec2-user@ip-10-0-0-213 ~]$ grep -e "Cinc Client Run complete" /var/log/chef-client.log
[2023-10-05T08:14:52+00:00] INFO: Cinc Client Run complete in 21.967250328 seconds
[2023-10-05T08:15:19+00:00] INFO: Cinc Client Run complete in 22.762820192 seconds
[2023-10-05T08:15:46+00:00] INFO: Cinc Client Run complete in 22.953907467 seconds

[ec2-user@ip-10-0-0-213 ~]$ grep -e "Cinc Client finished" /var/log/chef-client.log
[ec2-user@ip-10-0-0-213 ~]$

[ec2-user@ip-10-0-0-213 ~]$ grep -e "Infra Phase complete" /var/log/chef-client.log
Infra Phase complete, 51/60 resources updated in 34 seconds
Infra Phase complete, 141/171 resources updated in 24 seconds
Infra Phase complete, 6/7 resources updated in 25 seconds
```

