### PR TITLE
[Head Node Reporting] Change cluster alarms naming convention to '[cluster-name]-[component-name]-[metric]'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
 - Add head node alarms to monitor EC2 health checks, CPU utilization and the overall status of the head node.
 
 **CHANGES**
+- Changed cluster alarms naming convention to '[cluster-name]-[component-name]-[metric]'.
 
 **BUG FIXES**
 - Fix inconsistent configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -345,7 +345,7 @@ class ClusterCdkStack:
 
         for metric_key, metric in metrics_for_alarms.items():
             alarm_id = f"HeadNode{metric_key}Alarm"
-            alarm_name = f"{self.stack.stack_name}_{metric_key}Alarm_HeadNode"
+            alarm_name = f"{self.stack.stack_name}-HeadNode-{metric_key}"
             threshold = 0 if metric_key == "Health" else CW_ALARM_PERCENT_THRESHOLD_DEFAULT
             self.head_node_alarms.append(
                 cloudwatch.Alarm(
@@ -364,7 +364,7 @@ class ClusterCdkStack:
             cloudwatch.CompositeAlarm(
                 scope=self.stack,
                 id="HeadNodeAlarm",
-                composite_alarm_name=f"{self.stack.stack_name}_HeadNode",
+                composite_alarm_name=f"{self.stack.stack_name}-HeadNode",
                 alarm_rule=cloudwatch.AlarmRule.any_of(*self.head_node_alarms),
             )
         )

--- a/tests/integration-tests/tests/monitoring/test_monitoring.py
+++ b/tests/integration-tests/tests/monitoring/test_monitoring.py
@@ -109,10 +109,10 @@ def _test_dashboard(cw_client, cluster_name, region, dashboard_enabled, cw_log_e
 def _test_alarms(cw_client, cluster_name, headnode_instance_id, alarms_enabled):
     alarm_response = cw_client.describe_alarms(AlarmNamePrefix=cluster_name)
     if alarms_enabled:
-        health_alarm_name = f"{cluster_name}_HealthAlarm_HeadNode"
-        cpu_alarm_name = f"{cluster_name}_CpuAlarm_HeadNode"
-        mem_alarm_name = f"{cluster_name}_MemAlarm_HeadNode"
-        disk_alarm_name = f"{cluster_name}_DiskAlarm_HeadNode"
+        health_alarm_name = f"{cluster_name}-HeadNode-Health"
+        cpu_alarm_name = f"{cluster_name}-HeadNode-Cpu"
+        mem_alarm_name = f"{cluster_name}-HeadNode-Mem"
+        disk_alarm_name = f"{cluster_name}-HeadNode-Disk"
 
         health_alarms = _get_alarm_records(alarm_response, health_alarm_name)
         cpu_alarms = _get_alarm_records(alarm_response, cpu_alarm_name)


### PR DESCRIPTION
### Description of changes
Change cluster alarms naming convention to '[cluster-name]-[component-name]-[metric]'.
Took the chance to improve correctness of the corresponding unit test.

### Tests
* Unit tests
* Integ tests will be validate by the dev pipelines

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
