### PR TITLE
Disable test_intel_hpc on CentOS 7

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -302,13 +302,6 @@ iam:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: [ "alinux2" ]
         schedulers: [ "slurm" ]
-intel_hpc:
-  test_intel_hpc.py::test_intel_hpc:
-    dimensions:
-      - regions: ["us-east-2"]
-        instances: ["c5.18xlarge"]
-        oss: ["centos7"]
-        schedulers: ["slurm"]
 networking:
   test_cluster_networking.py::test_cluster_in_private_subnet:
     dimensions:


### PR DESCRIPTION
### Description of changes
* Disable test_intel_hpc on CentOS 7 due to constant failures in retrieving packages from Intel repositories.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
