### PR TITLE
[Head Node Reporting] Fix regression in test_monitoring causing cluster creation failure.

### DIFF
--- a/tests/integration-tests/tests/monitoring/test_monitoring.py
+++ b/tests/integration-tests/tests/monitoring/test_monitoring.py
@@ -40,6 +40,7 @@ def test_monitoring(
     cluster_config = pcluster_config_reader(
         dashboard_enabled=str(dashboard_enabled).lower(),
         cw_log_enabled=str(cw_log_enabled).lower(),
+        alarms_enabled=str(alarms_enabled).lower(),
     )
     cluster = clusters_factory(cluster_config)
     cw_client = boto3.client("cloudwatch", region_name=region)


### PR DESCRIPTION
### Description of changes
Fix regression in `test_monitoring` introduced by https://github.com/aws/aws-parallelcluster/pull/5732, that started causing cluster creation failure due to invalid cluster config.

The test was failing because the cluster config used by the test was expecting the variable `alarms_enabled` to be injected but it was not.

### Tests
Verified that cluster config is now valid in test_monitoring integ test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
