### PR TITLE
[Rocky8] Removing Rocky8 from test_create_wrong_pcluster_version 

### DIFF
--- a/awsbatch-cli/.flake8
+++ b/awsbatch-cli/.flake8
@@ -18,7 +18,8 @@ ignore =
     F821,
     # B028: Consider replacing f"'{foo}'" with f"{foo!r}".
     # Currently being disabled by flake8-bugbear. See https://github.com/PyCQA/flake8-bugbear/pull/333
-    B028
+    B028,
+    T499
 # D101 Missing docstring in public class
 # D102 Missing docstring in public method
 per-file-ignores =

--- a/cli/.flake8
+++ b/cli/.flake8
@@ -20,7 +20,8 @@ ignore =
     N818,
     # B028: Consider replacing f"'{foo}'" with f"{foo!r}".
     # Currently being disabled by flake8-bugbear. See https://github.com/PyCQA/flake8-bugbear/pull/333
-    B028
+    B028,
+    T499
 # D101 Missing docstring in public class
 # D102 Missing docstring in public method
 # D202 No blank lines allowed after function docstring

--- a/tests/integration-tests/configs/common/not_released_osses.yaml
+++ b/tests/integration-tests/configs/common/not_released_osses.yaml
@@ -48,13 +48,13 @@ create:
     dimensions:
       - regions: ["ca-central-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{ common.NOT_RELEASED_OSES }}
+        oss: ["alinux2"]
         schedulers: ["slurm"]
   test_create.py::test_create_imds_secured:
     dimensions:
       - regions: ["eu-south-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: {{common.OSS_COMMERCIAL_X86}}
+        oss: {{ common.OSS_COMMERCIAL_X86 }}
         schedulers: ["slurm"]
   test_create.py::test_cluster_creation_with_problematic_preinstall_script:
     dimensions:


### PR DESCRIPTION
### Description of changes
* Removing Rocky8 from `test_create_wrong_pcluster_version` as it checks for Rocky8 Image with PC 3.5.1 and fails.



### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
