### PR TITLE
[Rocky8] Add Validator to check CustomAMI is provided when Private OSSes are used

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -93,6 +93,7 @@ from pcluster.validators.cluster_validators import (
     MultiNetworkInterfacesInstancesValidator,
     NameValidator,
     NumberOfStorageValidator,
+    OsCustomAmiValidator,
     OverlappingMountDirValidator,
     RegionValidator,
     RootVolumeEncryptionConsistencyValidator,
@@ -1218,6 +1219,7 @@ class Image(Resource):
         self.custom_ami = Resource.init_param(custom_ami)
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
+        self._register_validator(OsCustomAmiValidator, os=self.os, custom_ami=self.custom_ami)
         if self.custom_ami:
             self._register_validator(CustomAmiTagValidator, custom_ami=self.custom_ami)
             self._register_validator(AmiOsCompatibleValidator, os=self.os, image_id=self.custom_ami)

--- a/cli/src/pcluster/constants.py
+++ b/cli/src/pcluster/constants.py
@@ -51,6 +51,8 @@ OS_TO_IMAGE_NAME_PART_MAP = {
     "rhel8": "rhel8-hvm",
     "rocky8": "rocky8-hvm",
 }
+# We do not publicly publish/release Parallelcluster AMI of below OSSes
+PRIVATE_OSES = ["rocky8"]
 
 IMAGE_NAME_PART_TO_OS_MAP = {value: key for key, value in OS_TO_IMAGE_NAME_PART_MAP.items()}
 

--- a/cli/src/pcluster/validators/cluster_validators.py
+++ b/cli/src/pcluster/validators/cluster_validators.py
@@ -31,6 +31,7 @@ from pcluster.constants import (
     PCLUSTER_NAME_REGEX,
     PCLUSTER_TAG_VALUE_REGEX,
     PCLUSTER_VERSION_TAG,
+    PRIVATE_OSES,
     RETAIN_POLICY,
     SCHEDULERS_SUPPORTING_IMDS_SECURED,
     SUPPORTED_OSES,
@@ -133,6 +134,22 @@ class SchedulerOsValidator(Validator):
         if os not in supported_os:
             self._add_failure(
                 f"{scheduler} scheduler supports the following operating systems: {supported_os}.", FailureLevel.ERROR
+            )
+
+
+class OsCustomAmiValidator(Validator):
+    """For some OSes we don't publish official AMIs, so CustomAmi parameter is required."""
+
+    def _validate(self, os: str, custom_ami: str):
+        if not custom_ami and os in PRIVATE_OSES:
+            self._add_failure(
+                (
+                    f"ParallelCluster has no official AMI for {os}. "
+                    "Please build your own AMI using pcluster build-image command, "
+                    "as explained in the documentation: "
+                    "https://docs.aws.amazon.com/parallelcluster/latest/ug/building-custom-ami-v3.html"
+                ),
+                FailureLevel.ERROR,
             )
 
 

--- a/tests/integration-tests/tests/common/osu_common.py
+++ b/tests/integration-tests/tests/common/osu_common.py
@@ -20,6 +20,7 @@ from utils import render_jinja_template
 
 OSU_COMMON_DATADIR = pathlib.Path(__file__).parent / "data/osu/"
 SUPPORTED_MPIS = ["openmpi", "intelmpi"]
+PRIVATE_OSES = ["rocky8"]
 
 
 def compile_osu(mpi_variant, remote_command_executor):


### PR DESCRIPTION
### Description of changes
* Adding Validation for checking if CustomAMI is provided when we have Rocky8 ( Private OSSes) that we dont publicly Publish/release.
* Changed the Integ Test code to get the latest internal Parallelcluster AMI for rocky8.

### Tests
* Local Unit Test
* Custom Resource Integ Test for x86 and ARM instances

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
