### PR TITLE
Disable deprecated flake8-mypy Python tox check

### DIFF
--- a/.github/.pre-commit-config.yaml
+++ b/.github/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-docstrings, flake8-bugbear, flake8-mypy, flake8-colors, pep8-naming]
+        additional_dependencies: [flake8-docstrings, flake8-bugbear, flake8-colors, pep8-naming]
         args: ['--config=cli/.flake8']
 
   - repo: https://github.com/timothycrosley/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-docstrings, flake8-bugbear, flake8-mypy, flake8-colors, pep8-naming]
+        additional_dependencies: [flake8-docstrings, flake8-bugbear, flake8-colors, pep8-naming]
         # If flake8 isn't run from the CLI directory it doesn't read in its configuration in the same way.
         # Paths are relative to the top-level of the repo so the nested shell handles that.
         entry: bash -c 'cd cli && flake8 $(for arg in $@; do echo -n "../$arg " ; done)'

--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -96,7 +96,6 @@ deps =
     flake8
     flake8-docstrings
     flake8-bugbear
-    flake8-mypy
     # flake8-import-order # delegated to isort
     flake8-colors
     pep8-naming

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -106,7 +106,6 @@ deps =
     flake8
     flake8-docstrings
     flake8-bugbear
-    flake8-mypy
     # flake8-import-order # delegated to isort
     flake8-colors
     pep8-naming


### PR DESCRIPTION
### Description of changes
- Disable deprecated flake8-mypy Python tox check, which caused problems in the GitHub actions on the repository.

### References
- https://github.com/aws/aws-parallelcluster-cookbook/pull/2492
- https://github.com/aws/aws-parallelcluster-node/pull/571

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
