### PR TITLE
[Integ Tests]Change the assertion for AD Integ Tests for checking the content of command

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -480,9 +480,10 @@ def _check_whoami(users):
     logging.info("Checking whoami")
     for user in users:
         result = user.run_remote_command("whoami").stdout
-        assert_that(result).is_equal_to(user.alias)
+        # TODO: Change the assertion to check the output is just the Username
+        assert_that(result).contains(user.alias)
         result = user.run_remote_command("srun whoami").stdout
-        assert_that(result).is_equal_to(user.alias)
+        assert_that(result).contains(user.alias)
 
 
 def _check_files_permissions(users, shared_storage_mount_dirs):


### PR DESCRIPTION
### Description of changes

Change the assertion for AD Integ Tests for checking the content of the `whoami` command *contains* the user name to avoid the failure of Spack setup file Permission Denied Error Message

```
 </etc/profile.d/spack.sh: line 2: /home/ec2-user/spack/share/spack/setup-env.sh: Permission denied
/etc/profile.d/spack.sh: line 2: /home/ec2-user/spack/share/spack/setup-env.sh: Permission denied
PclusterUser0
```


### Tests
* Integ tests


### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
