### PR TITLE
[Integ] Adding default value for architecture param used in `inject_additional_config_settings`

### DIFF
--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -659,7 +659,7 @@ def _inject_additional_iam_policies_for_nodes(
             _inject_additional_iam_policies(pool, policies)
 
 
-def inject_additional_config_settings(cluster_config, request, region, architecture, benchmarks=None):  # noqa C901
+def inject_additional_config_settings(cluster_config, request, region, architecture=None, benchmarks=None):  # noqa C901
     with open(cluster_config, encoding="utf-8") as conf_file:
         config_content = yaml.safe_load(conf_file)
 


### PR DESCRIPTION
### Description of changes
* Adding default value for architecture for handling the failing Integration tests
 

### Tests
* Locally tested `test_slurm_cli_commands`
* Locally tested `test_pcluster_configure`

### References
* https://github.com/aws/aws-parallelcluster/pull/5749

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
