### PR TITLE
[Integ]Adding instance fixture so that it can be used by architecture fixture when creating the cluster config file

### DIFF
--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1440,7 +1440,7 @@ def _test_shared_storage_rollback(
             boto3.client("fsx", region).describe_file_systems(FileSystemIds=managed_fsx)
 
 
-@pytest.mark.usefixtures("os")
+@pytest.mark.usefixtures("os", "instance")
 def test_multi_az_create_and_update(
     region, pcluster_config_reader, clusters_factory, odcr_stack, scheduler_commands_factory, test_datadir
 ):


### PR DESCRIPTION
Adding instance fixture so that it can be used by architecture fixture when creating the cluster config file.

### Tests
* Local `test_multi_az_create_and_update`

### References
* https://github.com/aws/aws-parallelcluster/pull/5759
* https://github.com/aws/aws-parallelcluster/pull/5749

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
