### PR TITLE
[develop] While testing LoginNodes in private subnet accept Ssh connections from anywhere

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/pcluster.config.yaml
@@ -15,6 +15,7 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+    AllowedIps: 0.0.0.0/0
 Scheduling:
   Scheduler: slurm
   SlurmSettings:

--- a/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/pcluster.update.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_slurm/test_slurm_from_login_nodes_in_private_network/pcluster.update.config.yaml
@@ -15,6 +15,7 @@ HeadNode:
     SubnetId: {{ public_subnet_id }}
   Ssh:
     KeyName: {{ key_name }}
+    AllowedIps: 0.0.0.0/0
 Scheduling:
   Scheduler: slurm
   SlurmSettings:


### PR DESCRIPTION
### Description of changes
* Force `AllowedIps=0.0.0.0/0` in the test config

In a private network instances have only private IPs and can interact with other instances in the same VPC.
To reach them it is required to have a bastion instance with a public IP that can 
Since the test is running in a private network this is an acceptable setting. This change is required to avoid the override of this setting that will limit the SSH connection only from Jenkins instance IP.

### Tests
* Test completed in our internal Jenkins pipeline

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
