### PR TITLE
[Integ]Handling failures caused by fixture `instance` not found

### DIFF
--- a/tests/integration-tests/configs/common/not_released_osses.yaml
+++ b/tests/integration-tests/configs/common/not_released_osses.yaml
@@ -15,15 +15,15 @@ cloudwatch_logging:
       # 2) run the test for all OSes with slurm
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: ["ubuntu2204"]
         schedulers: ["slurm"]
-      - regions: [ "ap-east-1" ]
-        instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.NOT_RELEASED_OSES }}
-        schedulers: [ "slurm" ]
+        oss: ["ubuntu2204", "rhel8"]
       - regions: ["ap-east-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["rhel8", "centos7"]
+        oss: ["centos7"]
+        schedulers: ["slurm"]
+      - regions: ["ap-east-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: {{ common.NOT_RELEASED_OSES }}
         schedulers: ["slurm"]
   test_compute_console_output_logging.py::test_console_output_with_monitoring_disabled:
     dimensions:

--- a/tests/integration-tests/conftest.py
+++ b/tests/integration-tests/conftest.py
@@ -565,7 +565,7 @@ def test_datadir(request, datadir):
 
 
 @pytest.fixture()
-def pcluster_config_reader(test_datadir, vpc_stack, request, region, architecture):
+def pcluster_config_reader(test_datadir, vpc_stack, request, region):
     """
     Define a fixture to render pcluster config templates associated to the running test.
 
@@ -592,7 +592,7 @@ def pcluster_config_reader(test_datadir, vpc_stack, request, region, architectur
         rendered_template = env.get_template(config_file).render(**{**default_values, **kwargs})
         output_file_path.write_text(rendered_template)
         if not config_file.endswith("image.config.yaml"):
-            inject_additional_config_settings(output_file_path, request, region, architecture, benchmarks)
+            inject_additional_config_settings(output_file_path, request, region, benchmarks)
         else:
             inject_additional_image_configs_settings(output_file_path, request)
         return output_file_path
@@ -659,7 +659,7 @@ def _inject_additional_iam_policies_for_nodes(
             _inject_additional_iam_policies(pool, policies)
 
 
-def inject_additional_config_settings(cluster_config, request, region, architecture=None, benchmarks=None):  # noqa C901
+def inject_additional_config_settings(cluster_config, request, region, benchmarks=None):  # noqa C901
     with open(cluster_config, encoding="utf-8") as conf_file:
         config_content = yaml.safe_load(conf_file)
 
@@ -694,7 +694,6 @@ def inject_additional_config_settings(cluster_config, request, region, architect
             retrieve_latest_ami(
                 region,
                 config_content["Image"]["Os"],
-                architecture=architecture,
                 ami_type="pcluster",
             ),
             ("Image", "CustomAmi"),

--- a/tests/integration-tests/tests/update/test_update.py
+++ b/tests/integration-tests/tests/update/test_update.py
@@ -1440,7 +1440,7 @@ def _test_shared_storage_rollback(
             boto3.client("fsx", region).describe_file_systems(FileSystemIds=managed_fsx)
 
 
-@pytest.mark.usefixtures("os", "instance")
+@pytest.mark.usefixtures("os")
 def test_multi_az_create_and_update(
     region, pcluster_config_reader, clusters_factory, odcr_stack, scheduler_commands_factory, test_datadir
 ):


### PR DESCRIPTION
### Description of changes
* Reverting the addition of Instance in test_update test.
* Handling failure caused by fixture 'instance' not found by not using the architecture fixture, which is required only when I am testing the ARM architecture instances.

### Tests
* Running below tests in Personal Jenkins. Some of which fail due to have CR.
* test_on_demand_capacity_reservation
* test_region_without_t2micro
* test_pcluster_configure
* test_trainium
* test_update
* test_create_wrong_os

### References
* https://github.com/aws/aws-parallelcluster/pull/5761
* https://github.com/aws/aws-parallelcluster/pull/5759
* https://github.com/aws/aws-parallelcluster/pull/5749

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
