### PR TITLE
[Test] Add cloudwatch:PutCompositeAlarm to permissions boundary policy.

### DIFF
--- a/tests/iam_policies/user-role.cfn.yaml
+++ b/tests/iam_policies/user-role.cfn.yaml
@@ -1089,6 +1089,7 @@ Resources:
               - cloudwatch:DeleteDashboards
               - cloudwatch:GetDashboard
               - cloudwatch:PutMetricAlarm
+              - cloudwatch:PutCompositeAlarm
               - cloudwatch:DeleteAlarms
               - cloudwatch:DescribeAlarms
             Resource: "*"


### PR DESCRIPTION
### Description of changes
Add `cloudwatch:PutCompositeAlarm` to permissions boundary policy.
This change fixes the integ test `test_iam_resource_prefix` that is currenrtly failing due to lack of the above permission.

### Tests
* [ONGOING] Local execution of test `test_iam_resource_prefix`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
