### PR TITLE
[develop] Increase trigger_slurm_reconfigure_race_condition of 1 minute

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -2695,7 +2695,7 @@ def _test_scontrol_reboot_nodes(
     )
 
 
-@retry(wait_fixed=seconds(10), stop_max_delay=minutes(5))
+@retry(wait_fixed=seconds(10), stop_max_delay=minutes(6))
 def trigger_slurm_reconfigure_race_condition(remote_command_executor):
     # trigger slurmctld restart and scontrol reconfigure until they are executed in the same timestamp second
     remote_command_executor.run_remote_command("sudo -i systemctl restart slurmctld && sudo -i scontrol reconfigure")


### PR DESCRIPTION
### Description of changes
Increase the retries on trigger_slurm_reconfigure_race_condition of 1 minute, so that we try to increase the chance to trigger slurmctld restart and scontrol reconfigure in the same timestamp second

### Tests
* integ test already present

### References
n/a

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
