### PR TITLE
Bump version of awsbatch-cli to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 **CHANGES**
 - Changed cluster alarms naming convention to '[cluster-name]-[component-name]-[metric]'.
 - Add head node alarms to cluster dashboard.
+- Add support for Python 3.10 in aws-parallelcluster-batch-cli.
 
 **BUG FIXES**
 - Fix inconsistent configuration after cluster update rollback when modifying the list of instance types declared in the Compute Resources.

--- a/awsbatch-cli/setup.py
+++ b/awsbatch-cli/setup.py
@@ -20,7 +20,7 @@ def readme():
         return f.read()
 
 
-VERSION = "1.1.0"
+VERSION = "1.2.0"
 REQUIRES = [
     "setuptools",
     "boto3>=1.16.14",


### PR DESCRIPTION
### Description of changes
* Bump version of awsbatch-cli to 1.2.0

### References
* https://github.com/aws/aws-parallelcluster/pull/5768

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
