### PR TITLE
Fix test_intel_hpc integration test by disable checking expired gpg k…

### DIFF
--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/install_clck.sh
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/install_clck.sh
@@ -8,4 +8,9 @@ set -e
 sudo rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
 sudo yum-config-manager --add-repo https://yum.repos.intel.com/clck/2019/setup/intel-clck-2019.repo
 sudo yum-config-manager --add-repo https://yum.repos.intel.com/clck-ext/2019/setup/intel-clck-ext-2019.repo
+# Disable the verification of the gpg key since it is expired on 2023-09-30 and intel-clck-2019 is an unsupported version
+sudo sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/intel-clck-ext-2019.repo
+sudo sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/intel-clck-ext-2019.repo
+sudo sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/intel-clck-2019.repo
+sudo sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/intel-clck-2019.repo
 sudo yum -y install intel-clck-2019.9-056


### PR DESCRIPTION
…ey when running integ test

The gpg key is a valid keyt but expired on 2023-9-30 and intel-clck-2019 is an unsupported version now

curl -fsSL https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | gpg2 --import [ec2-user@ip-172-31-47-208 ~]$ curl -fsSL -O https://yum.repos.intel.com/clck/2019/repodata/repomd.xml.asc [root@ip-172-31-45-34 ~]# gpg --verify repomd.xml.asc gpg: Signature made Fri 23 Oct 2020 02:46:46 PM UTC using RSA key ID 7E6C5DBE gpg: Good signature from "Intel(R) Software Development Products" gpg: Note: This key has expired!
Primary key fingerprint: 52AB D6E8 7E42 1793 9718  73FF ACFA 9FC5 7E6C 5DBE

Disable the key verification when running integration test to download intel-clck-2019


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

### Tests
```
[ec2-user@ip-172-31-47-208 yum.repos.d]$ sudo bash test4.sh
Loaded plugins: dkms-build-requires, extras_suggestions, langpacks, priorities, update-motd, versionlock
adding repo from: https://yum.repos.intel.com/clck/2019/setup/intel-clck-2019.repo
grabbing file https://yum.repos.intel.com/clck/2019/setup/intel-clck-2019.repo to /etc/yum.repos.d/intel-clck-2019.repo
repo saved to /etc/yum.repos.d/intel-clck-2019.repo
Loaded plugins: dkms-build-requires, extras_suggestions, langpacks, priorities, update-motd, versionlock
adding repo from: https://yum.repos.intel.com/clck-ext/2019/setup/intel-clck-ext-2019.repo
grabbing file https://yum.repos.intel.com/clck-ext/2019/setup/intel-clck-ext-2019.repo to /etc/yum.repos.d/intel-clck-ext-2019.repo
repo saved to /etc/yum.repos.d/intel-clck-ext-2019.repo
Loaded plugins: dkms-build-requires, extras_suggestions, langpacks, priorities, update-motd, versionlock
amzn2-core                                                                                                                                                             | 3.6 kB  00:00:00
amzn2extra-R3.4                                                                                                                                                        | 3.0 kB  00:00:00
amzn2extra-docker                                                                                                                                                      | 2.9 kB  00:00:00
amzn2extra-epel                                                                                                                                                        | 3.0 kB  00:00:00
amzn2extra-kernel-5.10                                                                                                                                                 | 3.0 kB  00:00:00
amzn2extra-lustre                                                                                                                                                      | 3.0 kB  00:00:00
epel/x86_64/metalink                                                                                                                                                   |  27 kB  00:00:00
intel-clck-2019-repo                                                                                                                                                   | 1.1 kB  00:00:00
intel-clck-ext-2019-repo                                                                                                                                               | 1.1 kB  00:00:00
(1/2): intel-clck-2019-repo/primary                                                                                                                                    | 4.1 kB  00:00:00
(2/2): intel-clck-ext-2019-repo/primary                                                                                                                                | 1.1 kB  00:00:00
intel-clck-2019-repo                                                                                                                                                                    30/30
intel-clck-ext-2019-repo                                                                                                                                                                  3/3
253 packages excluded due to repository priority protections
Resolving Dependencies
--> Running transaction check
---> Package intel-clck-2019.9-056.x86_64 0:2019.9-056 will be installed
--> Processing Dependency: intel-clck-2019.9-20200609 = 2019.9-20200609 for package: intel-clck-2019.9-056-2019.9-056.x86_64
--> Processing Dependency: intel-clck-support-2019.9-20200609 = 2019.9-20200609 for package: intel-clck-2019.9-056-2019.9-056.x86_64
--> Running transaction check
---> Package intel-clck-2019.9-20200609.x86_64 0:2019.9-20200609 will be installed
---> Package intel-clck-support-2019.9-20200609.noarch 0:2019.9-20200609 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

==============================================================================================================================================================================================
 Package                                                      Arch                             Version                                   Repository                                      Size
==============================================================================================================================================================================================
Installing:
 intel-clck-2019.9-056                                        x86_64                           2019.9-056                                intel-clck-2019-repo                           2.1 k
Installing for dependencies:
 intel-clck-2019.9-20200609                                   x86_64                           2019.9-20200609                           intel-clck-2019-repo                            33 M
 intel-clck-support-2019.9-20200609                           noarch                           2019.9-20200609                           intel-clck-2019-repo                           8.5 k

Transaction Summary
==============================================================================================================================================================================================
Install  1 Package (+2 Dependent packages)

Total download size: 33 M
Installed size: 124 M
Downloading packages:
(1/3): intel-clck-2019.9-056-2019.9-056.x86_64.rpm                                                                                                                     | 2.1 kB  00:00:00
(2/3): intel-clck-support-2019.9-20200609-2019.9-20200609.noarch.rpm                                                                                                   | 8.5 kB  00:00:00
(3/3): intel-clck-2019.9-20200609-2019.9-20200609.x86_64.rpm                                                                                                           |  33 MB  00:00:14
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                         2.2 MB/s |  33 MB  00:00:15
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : intel-clck-2019.9-20200609-2019.9-20200609.x86_64                                                                                                                          1/3
  Installing : intel-clck-support-2019.9-20200609-2019.9-20200609.noarch                                                                                                                  2/3
  Installing : intel-clck-2019.9-056-2019.9-056.x86_64                                                                                                                                    3/3
  Verifying  : intel-clck-support-2019.9-20200609-2019.9-20200609.noarch                                                                                                                  1/3
  Verifying  : intel-clck-2019.9-056-2019.9-056.x86_64                                                                                                                                    2/3
  Verifying  : intel-clck-2019.9-20200609-2019.9-20200609.x86_64                                                                                                                          3/3

Installed:
  intel-clck-2019.9-056.x86_64 0:2019.9-056

Dependency Installed:
  intel-clck-2019.9-20200609.x86_64 0:2019.9-20200609                                       intel-clck-support-2019.9-20200609.noarch 0:2019.9-20200609

Complete!
```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
