### PR TITLE
[Test] Add cloudwatch:PutCompositeAlarm to permissions boundary policy created at runtime.

### DIFF
--- a/tests/integration-tests/tests/iam/test_iam.py
+++ b/tests/integration-tests/tests/iam/test_iam.py
@@ -590,6 +590,7 @@ def _create_permission_boundary(permission_boundary_name):
                         "cloudwatch:DeleteDashboards",
                         "cloudwatch:GetDashboard",
                         "cloudwatch:PutMetricAlarm",
+                        "cloudwatch:PutCompositeAlarm",
                         "cloudwatch:DeleteAlarms",
                         "cloudwatch:DescribeAlarms",
                     ],


### PR DESCRIPTION
### Description of changes
Add `cloudwatch:PutCompositeAlarm` to permissions boundary policy created at runtime to fix failure in `test_iam_resource_prefix`

### Tests
Test `test_iam_resource_prefix` succeeded.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
