### PR TITLE
[Integ]Removing rocky8 from Testing for ARM instances 

### DIFF
--- a/tests/integration-tests/configs/common.jinja2
+++ b/tests/integration-tests/configs/common.jinja2
@@ -8,9 +8,9 @@
 {%- set OSS_COMMERCIAL_X86 = ["alinux2", "centos7", "ubuntu2004", "ubuntu2204", "rhel8", "rocky8"] -%}
 {%- set OSS_CHINA_X86 = ["alinux2", "ubuntu2004", "ubuntu2204", "rhel8", "rocky8"] -%}
 {%- set OSS_GOVCLOUD_X86 = ["alinux2", "ubuntu2004", "ubuntu2204", "rhel8", "rocky8"] -%}
-{%- set OSS_COMMERCIAL_ARM = ["alinux2", "ubuntu2004", "ubuntu2204", "rhel8", "rocky8"] -%}
-{%- set OSS_CHINA_ARM = ["alinux2", "ubuntu2004", "ubuntu2204", "rhel8", "rocky8"] -%}
-{%- set OSS_GOVCLOUD_ARM = ["alinux2", "ubuntu2004", "ubuntu2204", "rhel8", "rocky8"] -%}
+{%- set OSS_COMMERCIAL_ARM = ["alinux2", "ubuntu2004", "ubuntu2204", "rhel8"] -%}
+{%- set OSS_CHINA_ARM = ["alinux2", "ubuntu2004", "ubuntu2204", "rhel8"] -%}
+{%- set OSS_GOVCLOUD_ARM = ["alinux2", "ubuntu2004", "ubuntu2204", "rhel8"] -%}
 {%- set OSS_ONE_PER_DISTRO = ["centos7", "alinux2", "ubuntu2004", "rhel8", "rocky8"] -%}
 {%- set INSTANCES_DEFAULT_X86 = ["c5.xlarge"] -%}
 {%- set INSTANCES_DEFAULT_ARM = ["m6g.xlarge"] -%} # m6g.xlarge is not supported in af-south-1, eu-south-1, eu-west-3, me-south-1


### PR DESCRIPTION
### Description of changes
* Removing Rocky8 from the ARM OSses to be tested. Since in previous patch we are only able to retrieve the x86 AMI to avoid impacting other tests which have hardcoded the instances.
* Will add the rocky8 AMI again after we make changes to retrieve the ARM AMI without impacting other tests.

### References
* https://github.com/aws/aws-parallelcluster/pull/5763

Release-3.8 -> https://github.com/aws/aws-parallelcluster/pull/5777

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
