### PR TITLE
[release-3.8] Remove mpi job termination check from test in private network

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_slurm.py
+++ b/tests/integration-tests/tests/schedulers/test_slurm.py
@@ -203,9 +203,6 @@ def test_slurm_from_login_nodes_in_private_network(
     scaledown_idletime = 3
     gpu_instance_type = "g3.4xlarge"
     gpu_instance_type_info = get_instance_info(gpu_instance_type, region)
-    # For OSs running _test_mpi_job_termination, spin up 2 compute nodes at cluster creation to run test
-    # Else do not spin up compute node and start running regular slurm tests
-    supports_impi = architecture == "x86_64"
     compute_node_bootstrap_timeout = 1600
     cluster_config = pcluster_config_reader(
         scaledown_idletime=scaledown_idletime,
@@ -220,9 +217,6 @@ def test_slurm_from_login_nodes_in_private_network(
     slurm_root_path = _retrieve_slurm_root_path(remote_command_executor)
     assert "/opt/slurm" == slurm_root_path
     slurm_commands = scheduler_commands_factory(remote_command_executor)
-
-    if supports_impi:
-        _test_mpi_job_termination(remote_command_executor, test_datadir, slurm_commands, region, cluster)
 
     _assert_no_node_in_cluster(region, cluster.cfn_name, slurm_commands)
     _test_job_dependencies(slurm_commands, region, cluster.cfn_name, scaledown_idletime)


### PR DESCRIPTION
### Description of changes
_Porting in 3.8 change made in develop_

* Remove mpi job termination check from test in private network
This is a flacky check that is randomly failing
when testing LoginNodes in a private network.
Since this test in unrelated to the behavior under test we can safely remove this check from the test.

### Tests
* Test succeeded in our team's Jenkins pipeline.

### References
* [develop PR](https://github.com/aws/aws-parallelcluster/pull/5780)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
