### PR TITLE
Fix test_intel_hpc integration test by disable checking expired gpg k…

### DIFF
--- a/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/install_clck.sh
+++ b/tests/integration-tests/tests/intel_hpc/test_intel_hpc/test_intel_hpc/install_clck.sh
@@ -8,4 +8,9 @@ set -e
 sudo rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
 sudo yum-config-manager --add-repo https://yum.repos.intel.com/clck/2019/setup/intel-clck-2019.repo
 sudo yum-config-manager --add-repo https://yum.repos.intel.com/clck-ext/2019/setup/intel-clck-ext-2019.repo
+# Disable the verification of the gpg key since it is expired on 2023-09-30 and intel-clck-2019 is an unsupported version
+sudo sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/intel-clck-ext-2019.repo
+sudo sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/intel-clck-ext-2019.repo
+sudo sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/intel-clck-2019.repo
+sudo sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/intel-clck-2019.repo
 sudo yum -y install intel-clck-2019.9-056


### PR DESCRIPTION
…ey when running integ test

The gpg key is a valid keyt but expired on 2023-9-30 and intel-clck-2019 is an unsupported version now

curl -fsSL https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | gpg2 --import [ec2-user@ip-172-31-47-208 ~]$ curl -fsSL -O https://yum.repos.intel.com/clck/2019/repodata/repomd.xml.asc [root@ip-172-31-45-34 ~]# gpg --verify repomd.xml.asc gpg: Signature made Fri 23 Oct 2020 02:46:46 PM UTC using RSA key ID 7E6C5DBE gpg: Good signature from "Intel(R) Software Development Products" gpg: Note: This key has expired!
Primary key fingerprint: 52AB D6E8 7E42 1793 9718  73FF ACFA 9FC5 7E6C 5DBE

Disable the key verification when running integration test to download intel-clck-2019


### Description of changes
* Describe *what* you're changing and *why* you're doing these changes.

### Tests
* Describe the automated and/or manual tests executed to validate the patch.
* Describe the added/modified tests.

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
