### PR TITLE
[Release 3.8] Add internal use EFS tests to common and develop

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -692,6 +692,12 @@ storage:
         instances: ["m5d.xlarge"]  # SSD based instance
         oss: ["alinux2"]
         schedulers: ["slurm"]
+  test_internal_efs.py::test_internal_efs:
+    dimensions:
+      - regions: [ "us-west-2" ]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: [ "ubuntu2204" ]
+        schedulers: [ "slurm" ]
 tags:
   test_tag_propagation.py::test_tag_propagation:
     dimensions:

--- a/tests/integration-tests/tests/storage/test_internal_efs.py
+++ b/tests/integration-tests/tests/storage/test_internal_efs.py
@@ -1,0 +1,51 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+
+import pytest
+from remote_command_executor import RemoteCommandExecutor
+
+from tests.storage.storage_common import (
+    test_directory_correctly_shared_between_ln_and_hn,
+    test_efs_correctly_mounted,
+    verify_directory_correctly_shared,
+)
+
+
+@pytest.mark.usefixtures("os", "scheduler", "instance")
+def test_internal_efs(
+    region, scheduler, pcluster_config_reader, clusters_factory, vpc_stack, scheduler_commands_factory
+):
+    """Verify the internal shared storage fs is available when set to Efs"""
+    compute_shared_dirs = ["/opt/parallelcluster/shared", "/opt/slurm", "/opt/intel"]
+    login_shared_dirs = ["/opt/parallelcluster/shared_login_nodes", "/opt/slurm", "/opt/intel"]
+    cluster_config = pcluster_config_reader()
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    remote_command_executor_login_node = RemoteCommandExecutor(cluster, use_login_node=True)
+
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+    for directory in compute_shared_dirs:
+        test_efs_correctly_mounted(remote_command_executor, directory)
+        _test_efs_correctly_shared_compute(remote_command_executor, directory, scheduler_commands)
+
+    for directory in login_shared_dirs:
+        test_efs_correctly_mounted(remote_command_executor, directory)
+        test_efs_correctly_mounted(remote_command_executor_login_node, directory)
+        test_directory_correctly_shared_between_ln_and_hn(
+            remote_command_executor, remote_command_executor_login_node, directory, run_sudo=True
+        )
+
+
+def _test_efs_correctly_shared_compute(remote_command_executor, mount_dir, scheduler_commands):
+    logging.info("Testing efs correctly mounted on compute nodes")
+    verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands, run_sudo=True)

--- a/tests/integration-tests/tests/storage/test_internal_efs/test_internal_efs/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_internal_efs/test_internal_efs/pcluster.config.yaml
@@ -1,0 +1,41 @@
+Image:
+  Os: {{ os }}
+{% if scheduler == "slurm" %}
+LoginNodes:
+  Pools:
+    - Name: login-node-pool-0
+      InstanceType: {{ instance }}
+      Count: 2
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 60
+{% endif %}
+HeadNode:
+  InternalSharedStorageType: Efs
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
+    - Name: queue-0
+      ComputeResources:
+        - Name: compute-resource-0
+          {% if scheduler == "awsbatch" %}
+          InstanceTypes:
+            - {{ instance }}
+          MinvCpus: 4
+          DesiredvCpus: 4
+          {% else %}
+          Instances:
+            - InstanceType: {{ instance }}
+          MinCount: 1
+          {% endif %}
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}


### PR DESCRIPTION
Adds the test_internal_efs integration test to verify the internal shared dirs are available on the head node and compute nodes

### Tests
* integ test test_internal_efs test is passing

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
