### PR TITLE
[Release 3.8] Add integ test for shared /home

### DIFF
--- a/tests/integration-tests/tests/storage/test_shared_home.py
+++ b/tests/integration-tests/tests/storage/test_shared_home.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import logging
+
+import pytest
+from remote_command_executor import RemoteCommandExecutor
+
+from tests.storage.storage_common import (
+    test_directory_correctly_shared_between_ln_and_hn,
+    test_efs_correctly_mounted,
+    verify_directory_correctly_shared,
+)
+
+
+@pytest.mark.usefixtures("os", "scheduler", "instance")
+def test_shared_home(
+    region, scheduler, pcluster_config_reader, clusters_factory, vpc_stack, scheduler_commands_factory
+):
+    """Verify the internal shared storage fs is available when set to Efs"""
+    mount_dir = "/home"
+    cluster_config = pcluster_config_reader(mount_dir=mount_dir)
+    cluster = clusters_factory(cluster_config)
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    remote_command_executor_login_node = RemoteCommandExecutor(cluster, use_login_node=True)
+
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+    test_efs_correctly_mounted(remote_command_executor, mount_dir)
+    _test_efs_correctly_shared_compute(remote_command_executor, mount_dir, scheduler_commands)
+    test_efs_correctly_mounted(remote_command_executor_login_node, mount_dir)
+    test_directory_correctly_shared_between_ln_and_hn(
+        remote_command_executor, remote_command_executor_login_node, mount_dir, run_sudo=True
+    )
+
+
+def _test_efs_correctly_shared_compute(remote_command_executor, mount_dir, scheduler_commands):
+    logging.info("Testing efs correctly mounted on compute nodes")
+    verify_directory_correctly_shared(remote_command_executor, mount_dir, scheduler_commands, run_sudo=True)

--- a/tests/integration-tests/tests/storage/test_shared_home/test_shared_home/pcluster.config.yaml
+++ b/tests/integration-tests/tests/storage/test_shared_home/test_shared_home/pcluster.config.yaml
@@ -1,0 +1,44 @@
+Image:
+  Os: {{ os }}
+  {% if scheduler == "slurm" %}
+LoginNodes:
+  Pools:
+    - Name: login-node-pool-0
+      InstanceType: {{ instance }}
+      Count: 2
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 60
+  {% endif %}
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  Imds:
+    Secured: {{ imds_secured }}
+Scheduling:
+  Scheduler: {{ scheduler }}
+  {% if scheduler == "awsbatch" %}AwsBatchQueues:{% else %}SlurmQueues:{% endif %}
+  - Name: queue-0
+    ComputeResources:
+      - Name: compute-resource-0
+        {% if scheduler == "awsbatch" %}
+        InstanceTypes:
+          - {{ instance }}
+        MinvCpus: 4
+        DesiredvCpus: 4
+        {% else %}
+        Instances:
+          - InstanceType: {{ instance }}
+        MinCount: 1
+        {% endif %}
+    Networking:
+      SubnetIds:
+        - {{ private_subnet_id }}
+SharedStorage:
+  - MountDir: {{ mount_dir }}
+    Name: efs
+    StorageType: Efs


### PR DESCRIPTION
Added the test_shared_home integ test to check that the shared /home directory is available on all nodes

### Tests
* Ran the integ test test_shared_home

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
