### PR TITLE
[Integ] Reverting the change made to make AD Integ test Pass due to failure in Spack file Permission

### DIFF
--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -449,10 +449,9 @@ def _check_whoami(users):
     logging.info("Checking whoami")
     for user in users:
         result = user.run_remote_command("whoami").stdout
-        # TODO: Change the assertion to check the output is just the Username
-        assert_that(result).contains(user.alias)
+        assert_that(result).is_equal_to(user.alias)
         result = user.run_remote_command("srun whoami").stdout
-        assert_that(result).contains(user.alias)
+        assert_that(result).is_equal_to(user.alias)
 
 
 def _check_files_permissions(users, shared_storage_mount_dirs):


### PR DESCRIPTION
Reverting the change made to make AD Integ test Pass due to failure in Spack file Permission

This reverts commit dbf07072f64bfb911fb411dc5096d06a68808e0f.


### Tests
* Successfully tested on Personal jenkins

Spack Changes -> https://github.com/aws/aws-parallelcluster-cookbook/pull/2494

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
