### PR TITLE
[release-3.8] Add custom munge key integration tests

### DIFF
--- a/tests/integration-tests/configs/common/common.yaml
+++ b/tests/integration-tests/configs/common/common.yaml
@@ -522,6 +522,12 @@ schedulers:
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
         oss: ["ubuntu2004"]
         schedulers: ["slurm"]
+  test_custom_munge_key.py::test_custom_munge_key:
+    dimensions:
+      - regions: ["eu-west-1"]
+        instances: {{ common.INSTANCES_DEFAULT_X86 }}
+        oss: ["alinux2"]
+        schedulers: ["slurm"]
 spot:
   test_spot.py::test_spot_default:
     dimensions:

--- a/tests/integration-tests/remote_command_executor.py
+++ b/tests/integration-tests/remote_command_executor.py
@@ -34,7 +34,9 @@ class RemoteCommandExecutor:
         """
         Initiate SSH connection
 
-        By default, commands are executed on head node. If `compute_node_ip` is specified, execute commands on compute.
+        By default, commands are executed on head node.
+        If `compute_node_ip` is specified, execute commands on compute.
+        If `use_login_node` is set to True, execute commands on login node.
         """
         if not username:
             username = get_username_for_os(cluster.os)

--- a/tests/integration-tests/tests/ad_integration/test_ad_integration.py
+++ b/tests/integration-tests/tests/ad_integration/test_ad_integration.py
@@ -148,37 +148,6 @@ def zip_dir(path):
     return file_out
 
 
-@pytest.fixture(scope="class")
-def store_secret_in_secret_manager(request, cfn_stacks_factory):
-    secret_arns = {}
-
-    def _store_secret(region, secret_string=None, secret_binary=None):
-        secrets_manager_client = boto3.client("secretsmanager")
-        if secret_string is None and secret_binary is None:
-            logging.error("secret string and scecret binary can not both be empty")
-        secret_name = generate_stack_name("integ-tests-secret", request.config.getoption("stackname_suffix"))
-        if secret_string:
-            secret_arn = secrets_manager_client.create_secret(Name=secret_name, SecretString=secret_string)["ARN"]
-        else:
-            secret_arn = secrets_manager_client.create_secret(Name=secret_name, SecretBinary=secret_binary)["ARN"]
-        if secret_arns.get(region):
-            secret_arns[region].append(secret_arn)
-        else:
-            secret_arns[region] = [secret_arn]
-        return secret_arn
-
-    yield _store_secret
-
-    if request.config.getoption("no_delete"):
-        logging.info("Not deleting stack secrets because --no-delete option was specified")
-    else:
-        for region, secrets in secret_arns.items():
-            secrets_manager_client = boto3.client("secretsmanager", region_name=region)
-            for secret_arn in secrets:
-                logging.info("Deleting secret %s", secret_arn)
-                secrets_manager_client.delete_secret(SecretId=secret_arn)
-
-
 def _create_directory_stack(
     cfn_stacks_factory, request, directory_type, test_resources_dir, region, vpc_stack: CfnVpcStack
 ):

--- a/tests/integration-tests/tests/schedulers/test_custom_munge_key.py
+++ b/tests/integration-tests/tests/schedulers/test_custom_munge_key.py
@@ -1,0 +1,187 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "LICENSE.txt" file accompanying this file.
+# This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+import base64
+import os
+import random
+
+import boto3
+import pytest
+from assertpy import assert_that
+from remote_command_executor import RemoteCommandExecutor
+from retrying import retry
+from time_utils import minutes, seconds
+from utils import wait_for_computefleet_changed
+
+
+@pytest.mark.usefixtures("instance", "os")
+def test_custom_munge_key(
+    region,
+    pcluster_config_reader,
+    clusters_factory,
+    scheduler_commands_factory,
+    store_secret_in_secret_manager,
+    test_datadir,
+    s3_bucket_factory,
+):
+    """
+    Test custom munge key config, rotate, update, remove and roll back.
+
+    This test is focused on the scenario with LoginNodes.
+    Because this scenario covers all the logic covered by the test without login nodes。
+
+    Test phases summary:
+    1. Deployment verification: Confirm munge key is successfully shared across head, compute and login nodes, and jobs
+       can be submitted.
+    2. Rotation prep: Attempt munge key rotation without stopping compute and login nodes, expecting error messages.
+    3. Compute fleet shutdown: Prepare for munge key rotation scenario.
+    4. Key rotation without login node stop: Attempt rotation, checking for expected failure and error messages.
+    5. Login node stoppage and munge key rotation: Update cluster to stop login nodes, then execute munge key rotation.
+    6. Munge key removal: Update cluster to remove the custom munge key. Test Munge Key has been changed
+    7. Roll back with failure: Update cluster to add back the custom munge key. But let the cluster update fail after
+       the custom munge key has been added. Trigger cluster roll back. Test if munge key is fully functional.
+    """
+    encoded_custom_munge_key = create_base64_encoded_key()
+    custom_munge_key_arn = store_secret_in_secret_manager(
+        region,
+        secret_string=encoded_custom_munge_key,
+    )
+    cluster_config = pcluster_config_reader(custom_munge_key_arn=custom_munge_key_arn)
+    cluster = clusters_factory(cluster_config, upper_case_cluster_name=True)
+
+    # 1. Deployment verification: Confirm munge key is successfully shared across head, compute and login nodes,
+    # and jobs can be submitted.
+
+    # Test if the munge key was successfully fetched, decoded and shared in HeadNode and LoginNodes
+    remote_command_executor = RemoteCommandExecutor(cluster)
+    _check_encoded_munge_key(remote_command_executor, encoded_custom_munge_key)
+    _test_munge_key_shared(remote_command_executor)
+
+    remote_command_executor_login = RemoteCommandExecutor(cluster, use_login_node=True)
+    _check_encoded_munge_key(remote_command_executor_login, encoded_custom_munge_key)
+    job_command_args = {
+        "command": "srun sleep 1",
+        "nodes": 2,
+    }
+    # Test if compute node can run jobs from LoginNodes and HeadNode, indicating the munge key was successfully fetched.
+    scheduler_commands = scheduler_commands_factory(remote_command_executor_login)
+    scheduler_commands.submit_command_and_assert_job_succeeded(job_command_args)
+    remote_command_executor_login.close_connection()
+
+    scheduler_commands = scheduler_commands_factory(remote_command_executor)
+    scheduler_commands.submit_command_and_assert_job_succeeded(job_command_args)
+
+    # 2. Rotation prep: Attempt munge key rotation without stopping compute and login nodes, expecting error messages.
+    _test_update_munge_key_without_stop_login_or_compute(remote_command_executor)
+
+    # 3. Compute fleet shutdown: Prepare for munge key rotation scenario.
+    cluster.stop()
+    wait_for_computefleet_changed(cluster, "STOPPED")
+
+    # 4. Key rotation without login node stop: Attempt rotation, checking for expected failure and error messages.
+    _test_update_munge_key_without_stop_login_or_compute(remote_command_executor, compute_stopped=True)
+
+    # 5. Login node stop and munge key rotation: Update cluster to stop login nodes, then execute munge key rotation.
+    update_cluster_stop_login_config = pcluster_config_reader(
+        config_file="pcluster.stop_login.config.yaml",
+        custom_munge_key_arn=custom_munge_key_arn,
+    )
+    cluster.update(str(update_cluster_stop_login_config))
+
+    # wait for LoginNodes gracetime_period
+    _check_login_nodes_stopped(remote_command_executor)
+
+    # Test rotation script runs successfully
+    result = remote_command_executor.run_remote_command("sudo /opt/parallelcluster/scripts/slurm/update_munge_key.sh")
+    exit_code = result.return_code
+    assert_that(exit_code).is_equal_to(0)
+
+    # 6. Munge key removal: Update cluster to remove the custom munge key. Test Munge Key has been changed.
+    update_cluster_remove_custom_munge_key_config = pcluster_config_reader(
+        config_file="pcluster.remove_custom_munge_key.config.yaml"
+    )
+    cluster.update(str(update_cluster_remove_custom_munge_key_config))
+    _check_encoded_munge_key(remote_command_executor, encoded_custom_munge_key, use_custom_munge_key=False)
+
+    # 7. Roll back with failure: Update cluster to add back the custom munge key. But let the cluster update fail after
+    # the custom munge key has been added. Trigger cluster roll back. Test if munge key is fully functional.
+    bucket_name = s3_bucket_factory()
+    bucket = boto3.resource("s3", region_name=region).Bucket(bucket_name)
+    bucket.upload_file(str(test_datadir / "fail-on-node-updated.sh"), "fail-on-node-updated.sh")
+    update_cluster_fail_roll_back_config = pcluster_config_reader(
+        config_file="pcluster.roll_back.config.yaml",
+        custom_munge_key_arn=custom_munge_key_arn,
+        bucket_name=bucket_name,
+    )
+    cluster.update(str(update_cluster_fail_roll_back_config), raise_on_error=False)
+
+    cluster.start()
+    wait_for_computefleet_changed(cluster, "RUNNING")
+    scheduler_commands.submit_command_and_assert_job_succeeded(job_command_args)
+
+
+def create_base64_encoded_key():
+    key_length = random.randrange(32, 1024)
+    random_key = os.urandom(key_length)
+    base64_encoded_key = base64.b64encode(random_key).decode("utf-8")
+
+    return base64_encoded_key
+
+
+@retry(wait_fixed=seconds(20), stop_max_delay=minutes(15))
+def _check_login_nodes_stopped(remote_command_executor):
+    result = remote_command_executor.run_remote_command(
+        "sudo /opt/parallelcluster/scripts/slurm/check_login_nodes_stopped.sh",
+        raise_on_error=False,
+    )
+    exit_code = result.return_code
+    assert_that(exit_code).is_equal_to(0)
+
+
+def _check_encoded_munge_key(remote_command_executor, expected_encoded_munge_key, use_custom_munge_key=True):
+    """Test encoded munge key in secret manager has been successfully fetched by cluster and decode."""
+    result = remote_command_executor.run_remote_command("sudo cat /etc/munge/munge.key | base64")
+    encoded_munge_key = result.stdout.strip().replace("\n", "")
+    if use_custom_munge_key:
+        assert_that(encoded_munge_key).is_equal_to(expected_encoded_munge_key)
+    else:
+        assert_that(encoded_munge_key).is_not_equal_to(expected_encoded_munge_key)
+
+
+def _test_munge_key_shared(remote_command_executor):
+    """Test munge key has been successfully shared to shared directory."""
+    compute_node_munge_key_path = "/opt/parallelcluster/shared/.munge/.munge.key"
+    head_node_munge_key_path = "/opt/parallelcluster/shared_login_nodes/.munge/.munge.key"
+
+    assert_that(
+        remote_command_executor.run_remote_command(f"sudo test -f {compute_node_munge_key_path}").return_code,
+        f"File does not exist: {compute_node_munge_key_path}",
+    ).is_equal_to(0)
+
+    assert_that(
+        remote_command_executor.run_remote_command(f"sudo test -f {head_node_munge_key_path}").return_code,
+        f"File does not exist: {head_node_munge_key_path}",
+    ).is_equal_to(0)
+
+
+def _test_update_munge_key_without_stop_login_or_compute(remote_command_executor, compute_stopped=False):
+    result = remote_command_executor.run_remote_command(
+        "sudo /opt/parallelcluster/scripts/slurm/update_munge_key.sh",
+        raise_on_error=False,
+    )
+    command_output = result.stdout.strip()
+    exit_code = result.return_code
+    assert_that(exit_code).is_equal_to(1)
+    if compute_stopped:
+        expected_message = "Login nodes are running."
+    else:
+        expected_message = "Compute fleet is not stopped."
+    assert_that(command_output).contains(expected_message)

--- a/tests/integration-tests/tests/schedulers/test_custom_munge_key/test_custom_munge_key/fail-on-node-updated.sh
+++ b/tests/integration-tests/tests/schedulers/test_custom_munge_key/test_custom_munge_key/fail-on-node-updated.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exit 1

--- a/tests/integration-tests/tests/schedulers/test_custom_munge_key/test_custom_munge_key/pcluster.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_custom_munge_key/test_custom_munge_key/pcluster.config.yaml
@@ -1,0 +1,32 @@
+Image:
+  Os: {{ os }}
+LoginNodes:
+  Pools:
+    - Name: pool
+      InstanceType: {{ instance }}
+      Count: 1
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 3
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    MungeKeySecretArn: {{ custom_munge_key_arn }}
+  SlurmQueues:
+    - Name: queue
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: compute1
+          Instances:
+            - InstanceType: t2.medium
+          MinCount: 2
+          MaxCount: 5

--- a/tests/integration-tests/tests/schedulers/test_custom_munge_key/test_custom_munge_key/pcluster.remove_custom_munge_key.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_custom_munge_key/test_custom_munge_key/pcluster.remove_custom_munge_key.config.yaml
@@ -1,0 +1,30 @@
+Image:
+  Os: {{ os }}
+LoginNodes:
+  Pools:
+    - Name: pool
+      InstanceType: {{ instance }}
+      Count: 0
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 3
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: queue
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: compute1
+          Instances:
+            - InstanceType: t2.medium
+          MinCount: 2
+          MaxCount: 5

--- a/tests/integration-tests/tests/schedulers/test_custom_munge_key/test_custom_munge_key/pcluster.roll_back.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_custom_munge_key/test_custom_munge_key/pcluster.roll_back.config.yaml
@@ -1,0 +1,38 @@
+Image:
+  Os: {{ os }}
+LoginNodes:
+  Pools:
+    - Name: pool
+      InstanceType: {{ instance }}
+      Count: 0
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 3
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+  CustomActions:
+    OnNodeUpdated:
+      Script: s3://{{ bucket_name }}/fail-on-node-updated.sh
+  Iam:
+    S3Access:
+      - BucketName: {{ bucket_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    MungeKeySecretArn: {{ custom_munge_key_arn }}
+  SlurmQueues:
+    - Name: queue
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: compute1
+          Instances:
+            - InstanceType: t2.medium
+          MinCount: 2
+          MaxCount: 5

--- a/tests/integration-tests/tests/schedulers/test_custom_munge_key/test_custom_munge_key/pcluster.stop_login.config.yaml
+++ b/tests/integration-tests/tests/schedulers/test_custom_munge_key/test_custom_munge_key/pcluster.stop_login.config.yaml
@@ -1,0 +1,32 @@
+Image:
+  Os: {{ os }}
+LoginNodes:
+  Pools:
+    - Name: pool
+      InstanceType: {{ instance }}
+      Count: 0
+      Networking:
+        SubnetIds:
+          - {{ public_subnet_id }}
+      GracetimePeriod: 3
+HeadNode:
+  InstanceType: {{ instance }}
+  Networking:
+    SubnetId: {{ public_subnet_id }}
+  Ssh:
+    KeyName: {{ key_name }}
+Scheduling:
+  Scheduler: slurm
+  SlurmSettings:
+    MungeKeySecretArn: {{ custom_munge_key_arn }}
+  SlurmQueues:
+    - Name: queue
+      Networking:
+        SubnetIds:
+          - {{ private_subnet_id }}
+      ComputeResources:
+        - Name: compute1
+          Instances:
+            - InstanceType: t2.medium
+          MinCount: 2
+          MaxCount: 5


### PR DESCRIPTION
### Description of changes
* Test custom munge key config, rotate, update and roll back.
```
  Test phases summary:
  1. Deployment verification: Confirm munge key is successfully shared across head, compute and login nodes, and jobs
     can be submitted.
  2. Rotation prep: Attempt munge key rotation without stopping compute and login nodes, expecting error messages.
  3. Compute fleet shutdown: Prepare for munge key rotation scenario.
  4. Key rotation without login node stop: Attempt rotation, checking for expected failure and error messages.
  5. Login node stoppage and munge key rotation: Update cluster to stop login nodes, then execute munge key rotation.
  6. Munge key removal: Update cluster to remove the custom munge key. Test Munge Key has been changed
  7. Roll back with failure: Update cluster to add back the custom munge key. But let the cluster update fail after
     the custom munge key has been added. Trigger cluster roll back. Test if munge key is fully functional.
```

### Tests
* Locally running pass successfully

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
