### PR TITLE
Improve Marshmallow validation message for DatabaseName

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1687,7 +1687,7 @@ class DatabaseSchema(BaseSchema):
     database_name = fields.Str(
         required=False,
         validate=validate.And(
-            validate.Regexp(r"^[0-9a-z_]+$"),
+            validate.Regexp(r"^[0-9a-z_]+$", error="String does not match expected regex pattern: ^[0-9a-z_]+$"),
             validate.Length(min=1, max=64),
         ),
         metadata={"update_policy": UpdatePolicy.SUPPORTED},


### PR DESCRIPTION
### Description of changes
* Improve Marshmallow validation message for DatabaseName.
  * By default, the validation error for Marshmallow's Regexp validator does not print the regexp being used for the validation. Adding a custom error message to the validator.

### Tests
* Manually tested the new validation message.

### References
* 3.8 PR: https://github.com/aws/aws-parallelcluster/pull/5795

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
