### PR TITLE
[release-3.8]Removing rocky8 from Testing for ARM instances

### DIFF
--- a/tests/integration-tests/configs/common/not_released_osses.yaml
+++ b/tests/integration-tests/configs/common/not_released_osses.yaml
@@ -420,7 +420,7 @@ storage:
               collective: ["osu_alltoall"]
       - regions: ["eu-west-2"]
         instances: {{ common.INSTANCES_DEFAULT_ARM }}
-        oss: {{ common.NOT_RELEASED_OSES }}
+        oss: ["ubuntu2004"]
         schedulers: ["slurm"]
       - regions: ["cn-north-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
@@ -428,7 +428,7 @@ storage:
         schedulers: ["slurm"]
       - regions: ["us-gov-west-1"]
         instances: {{ common.INSTANCES_DEFAULT_X86 }}
-        oss: ["alinux2"]
+        oss: ["rocky8"]
         schedulers: ["slurm"]
   test_fsx_lustre.py::test_multi_az_fsx:
     dimensions:


### PR DESCRIPTION
Removing Rocky8 from the ARM OSses to be tested. Since in previous patch we are only able to retrieve the x86 AMI to avoid impacting other tests which have hardcoded the instances.

https://github.com/aws/aws-parallelcluster/pull/5777

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
