### PR TITLE
Remove inclusion of not_released_oss.yaml from develop.yaml

### DIFF
--- a/tests/integration-tests/configs/develop.yaml
+++ b/tests/integration-tests/configs/develop.yaml
@@ -4,7 +4,6 @@ test-suites:
 {{- common.OSS_COMMERCIAL_ARM.append("centos7") or "" -}}
 {% filter indent(2) %}
 {% include 'common/common.yaml' %}
-{% include 'common/not_released_osses.yaml' %} # FIXME: Overrides sections from common.yaml for Rocky8
 {% endfilter %}
   efa:
     test_efa.py::test_efa:


### PR DESCRIPTION
### Description of changes
* The inclusion was overriding most sections defined in common.yaml, with an impact on the development workflow.

### References
* https://github.com/aws/aws-parallelcluster/pull/5802

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
