### PR TITLE
[Release 3.8] Use elastic throughput for internal shared EFS when used

### DIFF
--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -265,7 +265,7 @@ class ClusterCdkStack:
         # mounted.  We need to create the additional mount points first.
         if self.config.head_node.internal_shared_storage_type.lower() == SharedStorageType.EFS.value:
             internal_efs_storage_shared = SharedEfs(
-                mount_dir="/opt/parallelcluster/init_shared", name="internal_pcluster_shared"
+                mount_dir="/opt/parallelcluster/init_shared", name="internal_pcluster_shared", throughput_mode="elastic"
             )
             self._add_shared_storage(internal_efs_storage_shared)
 


### PR DESCRIPTION
### Tests
* Ran manual tests using elastic throughput which will guarantee throughput for the filesystem no matter the total size of storage based on workload needs.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
