### PR TITLE
[develop] Rename LoginNodes Stack Target Group resource to specific schema

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -694,34 +694,16 @@ class HeadNodeIamResources(NodeIamResourcesBase):
             )
 
             if self._config.login_nodes:
-                target_group_name = _get_target_group_name(
-                    self._config.cluster_name,
-                    self._config.login_nodes.pools[0].name,
-                )
                 policy.extend(
                     [
                         iam.PolicyStatement(
                             sid="TargetGroupDescribe",
                             actions=[
                                 "elasticloadbalancing:DescribeTargetGroups",
-                            ],
-                            effect=iam.Effect.ALLOW,
-                            resources=["*"],
-                        ),
-                        iam.PolicyStatement(
-                            sid="TargetHealthDescribe",
-                            actions=[
                                 "elasticloadbalancing:DescribeTargetHealth",
                             ],
                             effect=iam.Effect.ALLOW,
-                            resources=[
-                                self._format_arn(
-                                    service="elasticloadbalancing",
-                                    resource=f"targetgroup/{target_group_name}/*",
-                                    region=Stack.of(self).region,
-                                    account=Stack.of(self).account,
-                                ),
-                            ],
+                            resources=["*"],
                         ),
                     ]
                 )

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -44,7 +44,6 @@ from pcluster.constants import (
 )
 from pcluster.launch_template_utils import _LaunchTemplateBuilder
 from pcluster.models.s3_bucket import S3Bucket, parse_bucket_url
-from pcluster.templates.login_nodes_stack import _get_target_group_name
 from pcluster.utils import (
     get_installed_version,
     get_resource_name_from_resource_arn,
@@ -53,6 +52,15 @@ from pcluster.utils import (
 )
 
 PCLUSTER_LAMBDA_PREFIX = "pcluster-"
+
+
+def _get_target_group_name(cluster_name, pool_name):
+    partial_cluster_name = cluster_name[:7]
+    partial_pool_name = pool_name[:7]
+    combined_name = cluster_name + pool_name
+    hash_value = sha256(combined_name.encode()).hexdigest()[:16]
+
+    return f"{partial_cluster_name}-{partial_pool_name}-{hash_value}"
 
 
 def create_hash_suffix(string_to_hash: str):

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -54,13 +54,12 @@ from pcluster.utils import (
 PCLUSTER_LAMBDA_PREFIX = "pcluster-"
 
 
-def _get_resource_combination_name(resource_name_1, resource_name_2, partial_length, hash_length):
-    partial_resource_name_1 = resource_name_1[:partial_length]
-    partial_resource_name_2 = resource_name_2[:partial_length]
-    combined_name = resource_name_1 + resource_name_2
+def _get_resource_combination_name(*resource_names, partial_length=7, hash_length=16):
+    combined_name = "".join(resource_names)
     hash_value = sha256(combined_name.encode()).hexdigest()[:hash_length]
+    prefix = "-".join(name[:partial_length] for name in resource_names)
 
-    return f"{partial_resource_name_1}-{partial_resource_name_2}-{hash_value}"
+    return f"{prefix}-{hash_value}"
 
 
 def create_hash_suffix(string_to_hash: str):

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -54,13 +54,13 @@ from pcluster.utils import (
 PCLUSTER_LAMBDA_PREFIX = "pcluster-"
 
 
-def _get_target_group_name(cluster_name, pool_name):
-    partial_cluster_name = cluster_name[:7]
-    partial_pool_name = pool_name[:7]
-    combined_name = cluster_name + pool_name
-    hash_value = sha256(combined_name.encode()).hexdigest()[:16]
+def _get_resource_combination_name(resource_name_1, resource_name_2, partial_length, hash_length):
+    partial_resource_name_1 = resource_name_1[:partial_length]
+    partial_resource_name_2 = resource_name_2[:partial_length]
+    combined_name = resource_name_1 + resource_name_2
+    hash_value = sha256(combined_name.encode()).hexdigest()[:hash_length]
 
-    return f"{partial_cluster_name}-{partial_pool_name}-{hash_value}"
+    return f"{partial_resource_name_1}-{partial_resource_name_2}-{hash_value}"
 
 
 def create_hash_suffix(string_to_hash: str):

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -18,6 +18,7 @@ from pcluster.constants import (
 from pcluster.templates.cdk_builder_utils import (
     CdkLaunchTemplateBuilder,
     LoginNodesIamResources,
+    _get_target_group_name,
     get_common_user_data_env,
     get_default_instance_tags,
     get_default_volume_tags,
@@ -27,15 +28,6 @@ from pcluster.templates.cdk_builder_utils import (
     to_comma_separated_string,
 )
 from pcluster.utils import get_attr, get_http_tokens_setting
-
-
-def _get_target_group_name(cluster_name, pool_name):
-    partial_cluster_name = cluster_name[:7]
-    partial_pool_name = pool_name[:7]
-    combined_name = cluster_name + pool_name
-    hash_value = hashlib.sha256(combined_name.encode()).hexdigest()[:16]
-
-    return f"{partial_cluster_name}-{partial_pool_name}-{hash_value}"
 
 
 class Pool(Construct):

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -282,8 +282,8 @@ class Pool(Construct):
             target_type=elbv2.TargetType.INSTANCE,
             vpc=self._vpc,
             target_group_name=_get_resource_combination_name(
-                resource_name_1=self._config.cluster_name,
-                resource_name_2=self._pool.name,
+                self._config.cluster_name,
+                self._pool.name,
                 partial_length=7,
                 hash_length=16,
             ),

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -1,4 +1,3 @@
-import hashlib
 from typing import Dict
 
 from aws_cdk import aws_autoscaling as autoscaling

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -17,7 +17,7 @@ from pcluster.constants import (
 from pcluster.templates.cdk_builder_utils import (
     CdkLaunchTemplateBuilder,
     LoginNodesIamResources,
-    _get_target_group_name,
+    _get_resource_combination_name,
     get_common_user_data_env,
     get_default_instance_tags,
     get_default_volume_tags,
@@ -281,7 +281,12 @@ class Pool(Construct):
             protocol=elbv2.Protocol.TCP,
             target_type=elbv2.TargetType.INSTANCE,
             vpc=self._vpc,
-            target_group_name=_get_target_group_name(self._config.cluster_name, self._pool.name),
+            target_group_name=_get_resource_combination_name(
+                resource_name_1=self._config.cluster_name,
+                resource_name_2=self._pool.name,
+                partial_length=7,
+                hash_length=16,
+            ),
         )
 
     def _add_login_nodes_pool_load_balancer(

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -1138,10 +1138,7 @@ def test_custom_munge_key_iam_policy(mocker, test_datadir, config_file_name):
         ]["Statement"]
         assert_that(iam_policies).contains(
             {
-                "Action": [
-                    "elasticloadbalancing:DescribeTargetGroups",
-                    "elasticloadbalancing:DescribeTargetHealth"
-                ],
+                "Action": ["elasticloadbalancing:DescribeTargetGroups", "elasticloadbalancing:DescribeTargetHealth"],
                 "Effect": "Allow",
                 "Resource": "*",
                 "Sid": "TargetGroupDescribe",

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -1159,8 +1159,8 @@ def test_resource_combination_name(
     resource_name_1, resource_name_2, partial_length, hash_length, expected_combination_name
 ):
     combination_name = _get_resource_combination_name(
-        resource_name_1=resource_name_1,
-        resource_name_2=resource_name_2,
+        resource_name_1,
+        resource_name_2,
         partial_length=partial_length,
         hash_length=hash_length,
     )

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -1133,20 +1133,35 @@ def test_custom_munge_key_iam_policy(mocker, test_datadir, config_file_name):
     )
 
     if config_file_name == "config_with_login_nodes.yaml":
-        assert_that(
-            generated_template["Resources"]["ParallelClusterPoliciesHeadNode"]["Properties"]["PolicyDocument"][
-                "Statement"
-            ]
-        ).contains(
+        iam_policies = generated_template["Resources"]["ParallelClusterPoliciesHeadNode"]["Properties"][
+            "PolicyDocument"
+        ]["Statement"]
+        assert_that(iam_policies).contains(
             {
-                "Action": [
-                    "elasticloadbalancing:DescribeLoadBalancers",
-                    "elasticloadbalancing:DescribeTags",
-                    "elasticloadbalancing:DescribeTargetGroups",
-                    "elasticloadbalancing:DescribeTargetHealth",
-                ],
+                "Action": "elasticloadbalancing:DescribeTargetGroups",
                 "Effect": "Allow",
                 "Resource": "*",
-                "Sid": "ElasticLoadBalancingDescribe",
+                "Sid": "TargetGroupDescribe",
             }
+        )
+        assert_that(iam_policies).contains(
+            {
+                "Action": "elasticloadbalancing:DescribeTargetHealth",
+                "Effect": "Allow",
+                "Resource": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "arn:",
+                            {"Ref": "AWS::Partition"},
+                            ":elasticloadbalancing:",
+                            {"Ref": "AWS::Region"},
+                            ":",
+                            {"Ref": "AWS::AccountId"},
+                            ":targetgroup/cluster-pool-bd8a861086ff7b00/*",
+                        ],
+                    ]
+                },
+                "Sid": "TargetHealthDescribe",
+            },
         )

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -33,6 +33,7 @@ from pcluster.constants import (
 from pcluster.models.s3_bucket import S3FileFormat, format_content
 from pcluster.schemas.cluster_schema import ClusterSchema
 from pcluster.templates.cdk_builder import CDKTemplateBuilder
+from pcluster.templates.cdk_builder_utils import _get_resource_combination_name
 from pcluster.utils import load_json_dict, load_yaml_dict
 from tests.pcluster.aws.dummy_aws_api import mock_aws_api
 from tests.pcluster.models.dummy_s3_bucket import dummy_cluster_bucket, mock_bucket, mock_bucket_object_utils
@@ -1144,3 +1145,23 @@ def test_custom_munge_key_iam_policy(mocker, test_datadir, config_file_name):
                 "Sid": "TargetGroupDescribe",
             }
         )
+
+
+@pytest.mark.parametrize(
+    "resource_name_1, resource_name_2, partial_length, hash_length, expected_combination_name",
+    [
+        ("test-cluster", "test-pool", 7, 16, "test-cl-test-po-18c74b16dfbc78ac"),
+        ("abcdefghijk", "lmnopqrst", 8, 14, "abcdefgh-lmnopqrs-dd65eea0329dcb"),
+        ("a", "b", 7, 16, "a-b-fb8e20fc2e4c3f24"),
+    ],
+)
+def test_resource_combination_name(
+    resource_name_1, resource_name_2, partial_length, hash_length, expected_combination_name
+):
+    combination_name = _get_resource_combination_name(
+        resource_name_1=resource_name_1,
+        resource_name_2=resource_name_2,
+        partial_length=partial_length,
+        hash_length=hash_length,
+    )
+    assert_that(combination_name).is_equal_to(expected_combination_name)

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -1138,30 +1138,12 @@ def test_custom_munge_key_iam_policy(mocker, test_datadir, config_file_name):
         ]["Statement"]
         assert_that(iam_policies).contains(
             {
-                "Action": "elasticloadbalancing:DescribeTargetGroups",
+                "Action": [
+                    "elasticloadbalancing:DescribeTargetGroups",
+                    "elasticloadbalancing:DescribeTargetHealth"
+                ],
                 "Effect": "Allow",
                 "Resource": "*",
                 "Sid": "TargetGroupDescribe",
             }
-        )
-        assert_that(iam_policies).contains(
-            {
-                "Action": "elasticloadbalancing:DescribeTargetHealth",
-                "Effect": "Allow",
-                "Resource": {
-                    "Fn::Join": [
-                        "",
-                        [
-                            "arn:",
-                            {"Ref": "AWS::Partition"},
-                            ":elasticloadbalancing:",
-                            {"Ref": "AWS::Region"},
-                            ":",
-                            {"Ref": "AWS::AccountId"},
-                            ":targetgroup/cluster-pool-bd8a861086ff7b00/*",
-                        ],
-                    ]
-                },
-                "Sid": "TargetHealthDescribe",
-            },
         )


### PR DESCRIPTION
### Description of changes
* Rename LoginNodes Stack Target Group resource to specific schema
* So that we can strict the IAM policy. Delete two related to the NLB and strict one related to TG.
* Also we will be able to modify the check_login_stopped.sh script to directly use TG name to query to reduce script running time

### Tests
* Manually tests done, passed successfully.

### References
* The cookbook modify the check_login_stopped.sh script to directly use TG name to query PR is [here](https://github.com/aws/aws-parallelcluster-cookbook/pull/2524).

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.