### PR TITLE
Remove print of func names and param from pcluster CLI log

### DIFF
--- a/cli/src/pcluster/cli/entrypoint.py
+++ b/cli/src/pcluster/cli/entrypoint.py
@@ -258,7 +258,7 @@ def run(sys_args, model=None):
         os.environ["AWS_DEFAULT_REGION"] = args.region
 
     LOGGER.info("Handling CLI command %s", args.operation)
-    LOGGER.info("Parsed CLI arguments: args(%s), extra_args(%s)", args, extra_args)
+    LOGGER.debug("Parsed CLI arguments: args(%s), extra_args(%s)", args, extra_args)
     return _run_operation(model, args, extra_args)
 
 

--- a/cli/tests/pcluster/cli/test_entrypoint.py
+++ b/cli/tests/pcluster/cli/test_entrypoint.py
@@ -5,6 +5,9 @@
 #  or in the "LICENSE.txt" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 #  OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and
 #  limitations under the License.
+import os
+
+from assertpy import assert_that
 
 
 class TestParallelClusterCli:
@@ -19,3 +22,19 @@ class TestParallelClusterCli:
         run_cli(command, expect_failure=True)
 
         assert_out_err(expected_out="", expected_err=(test_datadir / "pcluster-command-error.txt").read_text().strip())
+
+    def test_logger(self, test_datadir, run_cli, assert_out_err):
+        home = os.path.expanduser("~")
+        cli_log = home + "/.parallelcluster/pcluster-cli.log"
+        log = open(cli_log, "r")
+        log.readlines()
+
+        command = ["pcluster", "version"]
+        run_cli(command, expect_failure=False)
+
+        new = log.readlines()
+
+        log.close()
+
+        assert_that(new[0]).contains("Handling CLI command")
+        assert_that(len(new)).is_equal_to(1)


### PR DESCRIPTION
### Description of changes
* Remove print of func names and param from pcluster CLI log
*  There are a lot of useless information that are polluting the log file, like the list of functions and accepted parameters available, that information has now been moved to the debug level

### Tests
* Unit test created to check that the appropriate information is in the logs



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
