### PR TITLE
[release-3.8] Add wait to give nodes the time to mount NFS share

### DIFF
--- a/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/test_mpi_job.sh
+++ b/tests/integration-tests/tests/schedulers/test_awsbatch/test_awsbatch/test_mpi_job.sh
@@ -58,6 +58,9 @@ EOF
     echo "Compiling..."
     /usr/lib64/openmpi/bin/mpicc -o "${_job_dir}/mpi_hello_world" "${_shared_dir}/mpi_hello_world.c"
 
+    echo "Sleeping here 10 sec to see if all nodes have established NFS connection"
+    sleep 10
+
     echo "Running..."
     /usr/lib64/openmpi/bin/mpirun --mca btl_tcp_if_include eth0 --allow-run-as-root --machinefile "${HOME}/hostfile" "${_job_dir}/mpi_hello_world"
 


### PR DESCRIPTION
### Description of changes
* Add wait to give compute nodes the time to mount the NFS share

### Tests
* tested launching the test locally

Job output
```
  | 2023-11-02T14:52:16.737+01:00 | Job id: 6367a2d9-d373-4d2a-8420-91bf1d280c21#0
  | 2023-11-02T14:52:16.737+01:00 | Initializing the environment...
  | 2023-11-02T14:52:16.737+01:00 | Starting ssh agents...
  | 2023-11-02T14:52:16.740+01:00 | Agent pid 9
  | 2023-11-02T14:52:16.744+01:00 | Identity added: /root/.ssh/id_rsa (/root/.ssh/id_rsa)
  | 2023-11-02T14:52:16.749+01:00 | Mounting /home...
  | 2023-11-02T14:52:16.926+01:00 | Mounting shared file system...
  | 2023-11-02T14:52:17.105+01:00 | Detected 1/4 compute nodes. Waiting for all compute nodes to start.
  | 2023-11-02T14:52:32.107+01:00 | Detected 1/4 compute nodes. Waiting for all compute nodes to start.
  | 2023-11-02T14:52:47.119+01:00 | Detected 4/4 compute nodes. Waiting for all compute nodes to start.
  | 2023-11-02T14:53:02.124+01:00 | Starting the job...
  | 2023-11-02T14:53:02.654+01:00 | ip container: 192.168.124.91
  | 2023-11-02T14:53:02.678+01:00 | ip host: 192.168.122.247
  | 2023-11-02T14:53:02.679+01:00 | Hello I'm the main node ip-192-168-124-91.ec2.internal! I run the mpi job!
  | 2023-11-02T14:53:02.683+01:00 | Writing mpi code...
  | 2023-11-02T14:53:02.687+01:00 | Compiling...
  | 2023-11-02T14:53:02.739+01:00 | Sleeping here 10 sec to see if all nodes have established NFS connection
  | 2023-11-02T14:53:12.739+01:00 | Running...
  | 2023-11-02T14:53:12.909+01:00 | Warning: Permanently added '192.168.126.18' (RSA) to the list of known hosts.
  | 2023-11-02T14:53:12.917+01:00 | Warning: Permanently added '192.168.127.20' (RSA) to the list of known hosts.
  | 2023-11-02T14:53:12.917+01:00 | Warning: Permanently added '192.168.127.200' (RSA) to the list of known hosts.
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-124-91.ec2.internal, rank 0 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-124-91.ec2.internal, rank 3 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-127-20.ec2.internal, rank 9 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-124-91.ec2.internal, rank 1 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-124-91.ec2.internal, rank 2 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-127-20.ec2.internal, rank 8 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-127-20.ec2.internal, rank 11 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-127-200.ec2.internal, rank 12 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-127-20.ec2.internal, rank 10 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-127-200.ec2.internal, rank 14 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-126-18.ec2.internal, rank 4 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-126-18.ec2.internal, rank 5 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-126-18.ec2.internal, rank 6 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-127-200.ec2.internal, rank 13 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-126-18.ec2.internal, rank 7 out of 16 processors
  | 2023-11-02T14:53:13.592+01:00 | Hello world from processor ip-192-168-127-200.ec2.internal, rank 15 out of 16 processors


```

### References
* Link to impacted open issues.
* Link to related PRs in other packages (i.e. cookbook, node).
* Link to documentation useful to understand the changes.

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
