### PR TITLE
Add more semgrep rulesets

### DIFF
--- a/awsbatch-cli/tox.ini
+++ b/awsbatch-cli/tox.ini
@@ -155,10 +155,6 @@ commands =
 
 # semgrep is used to check for security issues
 # https://semgrep.dev/
-# The Dockerfile for Batch clusters is currently excluded for the because it
-# violates the last-user-is-root rule from https://semgrep.dev/p/dockerfile.
-# There doesn't appear to be a way to either disable this one rule without
-# using a custom set of rules.
 [testenv:semgrep]
 basepython = python3
 deps =
@@ -167,8 +163,10 @@ commands =
     semgrep \
         --config p/r2c-security-audit \
         --config p/secrets \
+        --config p/default \
+        --config p/owasp-top-ten \
+        --config p/dockerfile \
         --exclude 'tests/**' \
-        --exclude 'Dockerfile' \
         --error
 
 # Target that groups all code linters to run in Travis.

--- a/cli/src/pcluster/cli/model.py
+++ b/cli/src/pcluster/cli/model.py
@@ -22,7 +22,7 @@ from pcluster.utils import to_kebab_case, to_snake_case, yaml_load
 
 # For importing package resources
 try:
-    import importlib.resources as pkg_resources  # pylint: disable=ungrouped-imports
+    import importlib.resources as pkg_resources  # pylint: disable=ungrouped-imports # nosem
 except ImportError:
     import importlib_resources as pkg_resources
 
@@ -170,7 +170,8 @@ def get_function_from_name(function_name):
 
     while not module:
         try:
-            module = importlib.import_module(module_name)
+            # TODO: Fix semgrep finding in line below. https://sg.run/y6Jk
+            module = importlib.import_module(module_name)  # nosem
         except ImportError as import_error:
             last_import_error = import_error
             if "." in module_name:

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1226,7 +1226,8 @@ class OneOrManyCustomActionField(fields.Nested):
             )
             globals()[class_name] = schema_class_type
         else:
-            schema_class_type = globals()[class_name]
+            # TODO: Fix semgrep finding in line below. https://sg.run/jNzn
+            schema_class_type = globals()[class_name]  # nosem
         return schema_class_type
 
     def _deserialize(self, value, attr, data, **kwargs):

--- a/cli/src/pcluster/validators/common.py
+++ b/cli/src/pcluster/validators/common.py
@@ -136,7 +136,8 @@ def get_async_timed_validator_type_for(validator_type: type) -> AsyncValidator:
         schema_class_type = type(class_name, class_bases, class_dict)
         globals()[class_name] = schema_class_type
     else:
-        schema_class_type = globals()[class_name]
+        # TODO: Fix semgrep finding in line below. https://sg.run/jNzn
+        schema_class_type = globals()[class_name]  # nosem
     return schema_class_type
 
 

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -170,10 +170,6 @@ commands =
 
 # semgrep is used to check for security issues
 # https://semgrep.dev/
-# The Dockerfile for Batch clusters is currently excluded for the because it
-# violates the last-user-is-root rule from https://semgrep.dev/p/dockerfile.
-# There doesn't appear to be a way to either disable this one rule without
-# using a custom set of rules.
 [testenv:semgrep]
 basepython = python3
 deps =
@@ -182,8 +178,10 @@ commands =
     semgrep \
         --config p/r2c-security-audit \
         --config p/secrets \
+        --config p/default \
+        --config p/owasp-top-ten \
+        --config p/dockerfile \
         --exclude 'tests/**' \
-        --exclude 'Dockerfile' \
         --error
 
 # Target that groups all code linters to run in Travis.


### PR DESCRIPTION
### Description of changes
* Added default, owasp-top-ten, and dockerfile semgrep rulesets to add more security coverage
* Adding these rulesets introduces 4 semgrep findings
* 1 is safe because we only use python versions 3.7+
* The other 3 don't seem to be release-blocking, so added `# nosem` for now to ignore those findings but created tasks for next release to fix the underlying issues.
* Deleted the dockerfile comments because there aren't any more dockerfile semgrep findings.

### Tests
* Ran tox with these new semgrep rulesets

### References
* [Default semgrep ruleset](https://semgrep.dev/p/default)
* [Dockerfile semgrep ruleset](https://semgrep.dev/p/dockerfile)
* [owasp-top-ten semgrep ruleset](https://semgrep.dev/p/owasp-top-ten)

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
