### PR TITLE
[release-3.8] Rename LoginNodes Stack Target Group resource to specific schema

### DIFF
--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -54,6 +54,14 @@ from pcluster.utils import (
 PCLUSTER_LAMBDA_PREFIX = "pcluster-"
 
 
+def _get_resource_combination_name(*resource_names, partial_length=7, hash_length=16):
+    combined_name = "".join(resource_names)
+    hash_value = sha256(combined_name.encode()).hexdigest()[:hash_length]
+    prefix = "-".join(name[:partial_length] for name in resource_names)
+
+    return f"{prefix}-{hash_value}"
+
+
 def create_hash_suffix(string_to_hash: str):
     """Create 16digit hash string."""
     return (
@@ -688,10 +696,8 @@ class HeadNodeIamResources(NodeIamResourcesBase):
                 policy.extend(
                     [
                         iam.PolicyStatement(
-                            sid="ElasticLoadBalancingDescribe",
+                            sid="TargetGroupDescribe",
                             actions=[
-                                "elasticloadbalancing:DescribeLoadBalancers",
-                                "elasticloadbalancing:DescribeTags",
                                 "elasticloadbalancing:DescribeTargetGroups",
                                 "elasticloadbalancing:DescribeTargetHealth",
                             ],

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -17,6 +17,7 @@ from pcluster.constants import (
 from pcluster.templates.cdk_builder_utils import (
     CdkLaunchTemplateBuilder,
     LoginNodesIamResources,
+    _get_resource_combination_name,
     get_common_user_data_env,
     get_default_instance_tags,
     get_default_volume_tags,
@@ -280,6 +281,12 @@ class Pool(Construct):
             protocol=elbv2.Protocol.TCP,
             target_type=elbv2.TargetType.INSTANCE,
             vpc=self._vpc,
+            target_group_name=_get_resource_combination_name(
+                self._config.cluster_name,
+                self._pool.name,
+                partial_length=7,
+                hash_length=16,
+            ),
         )
 
     def _add_login_nodes_pool_load_balancer(


### PR DESCRIPTION
### Description of changes
* Rename LoginNodes Stack Target Group resource to specific schema
* So that we can strict the IAM policy. Delete two related to the NLB and strict one related to TG.
* Also we will be able to modify the check_login_stopped.sh script to directly use TG name to query to reduce script running time

### Tests
* Manually tests done, passed successfully.

### References
* The cookbook modify the check_login_stopped.sh script to directly use TG name to query PR is [here](https://github.com/aws/aws-parallelcluster-cookbook/pull/2525).

### Checklist
- Make sure you are pointing to **the right branch**.
- If you're creating a patch for a branch other than `develop` add the branch name as prefix in the PR title (e\.g\. `[release-3.6]`).
- Check all commits' messages are clear, describing what and why vs how.
- Make sure **to have added unit tests or integration tests** to cover the new/modified code.
- Check if documentation is impacted by this change.

Please review the [guidelines for contributing](../CONTRIBUTING.md) and [Pull Request Instructions](https://github.com/aws/aws-parallelcluster/wiki/Git-Pull-Request-Instructions).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.